### PR TITLE
removed redundant event source

### DIFF
--- a/eventsources/redis.yaml
+++ b/eventsources/redis.yaml
@@ -1,9 +1,0 @@
-apiversion: actions.io/v1alpha1
-kind: EventSource
-metadata:
-  name: statestore
-spec:
-  type: actions.state.redis
-  connectioninfo:
-    redishost: localhost:6379
-    redispassword: ""


### PR DESCRIPTION
Fixes mistake made in commit #95 https://github.com/actionscore/actions/commit/f2f590d4ff528ee03ec1a1381638af8112752b8f - an ```event sources``` dir got pushed through it seems.