### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ git clone https://github.com/actionscore/actions.git github.com/actionscore/acti
 #### Build the action binary
 
 ```
-cd $GOPATH/src/github.com/actionscore/actions/cmd/action
+cd $GOPATH/src/github.com/actionscore/actions/cmd/actionsrt
 go build -o action
 ```
 


### PR DESCRIPTION
Doc is out of date, the folder is `actionsrt` instead of `action` 

Is the name of build output supposed to be `action`? or should that change too?