### PR TITLE
Disable publishing binaries for pr build

### DIFF
--- a/build-binary-template.yml
+++ b/build-binary-template.yml
@@ -60,7 +60,6 @@ jobs:
         failOnStderr: true
     - task: ArchiveFiles@2
       displayName: 'Build $(GOARCH)/${{ parameters.binaryName }}_${{ parameters.targetOS }}.zip'
-      condition: ne(variables['Build.Reason'], 'PullRequest')
       inputs:
         rootFolderOrFile: '$(modulePath)/dist/${{ parameters.targetOS }}_$(GOARCH)'
         includeRootFolder: false
@@ -69,7 +68,6 @@ jobs:
         replaceExistingArchive: true
     - task: PublishBuildArtifacts@1
       displayName: 'Publish build artifacts'
-      condition: ne(variables['Build.Reason'], 'PullRequest')
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)/${{ parameters.targetOS }}_$(GOARCH)'
         ArtifactName: 'drop'


### PR DESCRIPTION
* Disable publishing binaries for pr build which will make pr build faster ( 8.x mins -> 4.x mins )