### PR TITLE
Propagate REL_VERSION to the build processes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
     targetOS: darwin
     targetArch: amd64
     binaryExtension: ''
-    dependsOn: release_environment
+    dependStep: release_environment
     relVersion: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
 - template: 'build-binary-template.yml'
   parameters:
@@ -72,7 +72,7 @@ jobs:
     targetOS: linux
     targetArch: arm
     binaryExtension: ''
-    dependsOn: release_environment
+    dependStep: release_environment
     relVersion: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
 - template: 'build-binary-template.yml'
   parameters:
@@ -80,7 +80,7 @@ jobs:
     targetOS: linux
     targetArch: amd64
     binaryExtension: ''
-    dependsOn: release_environment
+    dependStep: release_environment
     relVersion: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
 - template: 'build-binary-template.yml'
   parameters:
@@ -88,7 +88,7 @@ jobs:
     targetOS: windows
     targetArch: amd64
     binaryExtension: '.exe'
-    dependsOn: release_environment
+    dependStep: release_environment
     relVersion: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
 - job: publish_edge_binaries
   pool:

--- a/build-binary-template.yml
+++ b/build-binary-template.yml
@@ -3,11 +3,12 @@ parameters:
   targetOS: 'darwin'
   targetArch: 'amd64'
   binaryExtension: ''
-  dependsOn: 'release_environment'
+  dependStep: 'release_environment'
   relVersion: ''
 jobs:
 - job: build_${{ parameters.targetOS }}_${{ parameters.targetArch }}
-  dependsOn: ${{ parameters.dependsStep }}
+  dependsOn:
+    ${{ parameters.dependStep }}
   variables:
     GOOS: ${{ parameters.targetOS }}
     GOARCH: ${{ parameters.targetArch }}


### PR DESCRIPTION
I realized that makefile uses `REL_VERSION` now. This pr will propagate REL_VERSION to each build step.