### PR TITLE
Disable docker image build and push step for PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,11 @@ jobs:
     - publish_edge_binaries
     - release_environment
   condition: |
-    eq(dependencies.publish_edge_binaries.result, 'Succeeded')
+    and
+    (
+      eq(dependencies.publish_edge_binaries.result, 'Succeeded'),
+      ne(variables['Build.Reason'], 'PullRequest')
+    )
   variables:
     REL_VERSION: $[ dependencies.release_environment.outputs['env_var_step.REL_VERSION'] ]
   steps:


### PR DESCRIPTION
Interesting. Azure pipeline suddenly runs docker image build and push step for pr build even if we didn't change anything. 

* Disable docker image build and push step explicitly for PR build