### PR TITLE
change direct invoke endpoint

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -122,15 +122,9 @@ func (a *api) constructDirectMessagingEndpoints() []Endpoint {
 	return []Endpoint{
 		{
 			Methods: []string{http.Get, http.Post, http.Delete, http.Put},
-			Route:   "actions/<id>/<method>",
+			Route:   "invoke/<id>/method/*",
 			Version: apiVersionV1,
 			Handler: a.onDirectMessage,
-		},
-		{
-			Methods: []string{http.Post},
-			Route:   "invoke/*",
-			Version: apiVersionV1,
-			Handler: a.onInvokeLocal,
 		},
 	}
 }
@@ -331,7 +325,8 @@ func (a *api) setHeaders(c *routing.Context, metadata map[string]string) {
 
 func (a *api) onDirectMessage(c *routing.Context) error {
 	targetID := c.Param(idParam)
-	method := c.Param(methodParam)
+	path := string(c.Path())
+	method := path[strings.Index(path, "method/")+7:]
 	body := c.PostBody()
 	verb := string(c.Method())
 	queryString := string(c.QueryArgs().QueryString())

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -153,7 +153,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 	fakeServer.StartServer(testAPI.constructDirectMessagingEndpoints())
 
 	t.Run("Invoke direct messaging without querystring - 200 OK", func(t *testing.T) {
-		apiPath := "v1.0/actions/fakeActionsID/fakeMethod"
+		apiPath := "v1.0/invoke/fakeActionsID/method/fakeMethod"
 		fakeData := []byte("fakeData")
 
 		mockDirectMessaging.Calls = nil // reset call count
@@ -179,7 +179,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 	})
 
 	t.Run("Invoke direct messaging with querystring - 200 OK", func(t *testing.T) {
-		apiPath := "v1.0/actions/fakeActionsID/fakeMethod?param1=val1&param2=val2"
+		apiPath := "v1.0/invoke/fakeActionsID/method/fakeMethod?param1=val1&param2=val2"
 		fakeData := []byte("fakeData")
 
 		mockDirectMessaging.Calls = nil // reset call count
@@ -232,7 +232,7 @@ func TestV1DirectMessagingEndpointsWithTracer(t *testing.T) {
 
 	t.Run("Invoke direct messaging without querystring - 200 OK", func(t *testing.T) {
 		buffer = ""
-		apiPath := "v1.0/actions/fakeActionsID/fakeMethod"
+		apiPath := "v1.0/invoke/fakeActionsID/method/fakeMethod"
 		fakeData := []byte("fakeData")
 
 		mockDirectMessaging.Calls = nil // reset call count
@@ -260,7 +260,7 @@ func TestV1DirectMessagingEndpointsWithTracer(t *testing.T) {
 
 	t.Run("Invoke direct messaging with querystring - 200 OK", func(t *testing.T) {
 		buffer = ""
-		apiPath := "v1.0/actions/fakeActionsID/fakeMethod?param1=val1&param2=val2"
+		apiPath := "v1.0/invoke/fakeActionsID/method/fakeMethod?param1=val1&param2=val2"
 		fakeData := []byte("fakeData")
 
 		mockDirectMessaging.Calls = nil // reset call count

--- a/samples/1.hello-world/README.md
+++ b/samples/1.hello-world/README.md
@@ -104,12 +104,12 @@ Now that Actions and our Node.js app are running, let's POST messages against it
 You can do this using `curl` with:
 
 ```sh
-curl -XPOST -d @sample.json http://localhost:3500/v1.0/actions/mynode/neworder
+curl -XPOST -d @sample.json http://localhost:3500/v1.0/invoke/mynode/method/neworder
 ```
 
 Or you can use the Postman GUI
 
-Open Postman and create a POST request against `http://localhost:3500/v1.0/actions/mynode/neworder`
+Open Postman and create a POST request against `http://localhost:3500/v1.0/invoke/mynode/method/neworder`
 ![Postman Screenshot](./img/postman1.jpg)
 In your terminal window, you should see logs indicating that the message was received and state was updated:
 ```bash
@@ -119,10 +119,10 @@ In your terminal window, you should see logs indicating that the message was rec
 
 ## Step 5 - Confirm Successful Persistence
 
-Now, let's just make sure that our order was successfully persisted to our state store. Create a GET request against: `http://localhost:3500/v1.0/actions/mynode/order`
+Now, let's just make sure that our order was successfully persisted to our state store. Create a GET request against: `http://localhost:3500/v1.0/invoke/mynode/method/order`
 
 ```sh
-curl http://localhost:3500/v1.0/actions/mynode/order
+curl http://localhost:3500/v1.0/invoke/mynode/method/order
 ```
 
 Or use the Postman GUI

--- a/samples/2.hello-kubernetes/README.md
+++ b/samples/2.hello-kubernetes/README.md
@@ -115,10 +115,10 @@ export NODE_APP=$(kubectl get svc nodeapp --output 'jsonpath={.status.loadBalanc
 ## Step 5 - Deploy the Python App with the Actions Sidecar
 Next, let's take a quick look at our python app. Navigate to the python app in the kubernetes sample: `cd samples/2.hello-kubernetes/python/app.py`.
 
-At a quick glance, this is a basic python app that posts JSON messages to ```localhost:3500```, which is the default listening port for Actions. We invoke our Node.js application's `neworder` endpoint by posting to `v1.0/actions/nodeapp/neworder`. Our message contains some `data` with an orderId that increments once per second:
+At a quick glance, this is a basic python app that posts JSON messages to ```localhost:3500```, which is the default listening port for Actions. We invoke our Node.js application's `neworder` endpoint by posting to `v1.0/invoke/nodeapp/method/neworder`. Our message contains some `data` with an orderId that increments once per second:
 
 ```python
-actions_url = "http://localhost:3500/v1.0/actions/nodeapp/neworder"
+actions_url = "http://localhost:3500/v1.0/invoke/nodeapp/method/neworder"
 n = 0
 while True:
     n += 1

--- a/samples/2.hello-kubernetes/python/app.py
+++ b/samples/2.hello-kubernetes/python/app.py
@@ -2,7 +2,7 @@ import time
 import requests
 import os
 
-actions_url = "http://localhost:3500/v1.0/actions/nodeapp/neworder"
+actions_url = "http://localhost:3500/v1.0/invoke/nodeapp/method/neworder"
 n = 0
 while True:
     n += 1

--- a/samples/3.distributed-calculator/README.md
+++ b/samples/3.distributed-calculator/README.md
@@ -106,15 +106,15 @@ When our front-end server calls the respective operation services (see `server.j
 
 The code below shows calls to the “add” and “subtract” services via the Actions URLs:
 ```js
-const actionsUrl = `http://localhost:3500/v1.0/actions`;
+const actionsUrl = `http://localhost:3500/v1.0/invoke`;
 
 app.post('/calculate/add', async (req, res) => {
-  const addUrl = `${actionsUrl}/addapp/add`;
+  const addUrl = `${actionsUrl}/addapp/method/add`;
   req.pipe(request(addUrl)).pipe(res);
 });
 
 app.post('/calculate/subtract', async (req, res) => {
-  const subtractUrl = `${actionsUrl}/subtractapp/subtract`;
+  const subtractUrl = `${actionsUrl}/subtractapp/method/subtract`;
   req.pipe(request(subtractUrl)).pipe(res);
 });
 ...

--- a/samples/3.distributed-calculator/react-calculator/server.js
+++ b/samples/3.distributed-calculator/react-calculator/server.js
@@ -5,30 +5,30 @@ const request = require('request');
 const app = express();
 
 const port = 8080;
-const actionsUrl = "http://localhost:3500/v1.0/actions";
+const actionsUrl = "http://localhost:3500/v1.0/invoke";
 const stateUrl = "http://localhost:3500/v1.0/state";
 
 /**
-The following routes forward requests (using pipe) from our React client to our actions-enabled services. Our actions sidecar lives on localhost:3500. We invoke other actions enabled services by calling /v1.0/actions/<ACTION_ID>/<SERVICE'S_ROUTE>.
+The following routes forward requests (using pipe) from our React client to our actions-enabled services. Our actions sidecar lives on localhost:3500. We invoke other actions enabled services by calling /v1.0/invoke/<ACTIONS_ID>/method/<SERVICE'S_ROUTE>.
 */
 
 app.post('/calculate/add', async (req, res) => {
-  const addUrl = `${actionsUrl}/addapp/add`;
+  const addUrl = `${actionsUrl}/addapp/method/add`;
   req.pipe(request(addUrl)).pipe(res);
 });
 
 app.post('/calculate/subtract', async (req, res) => {
-  const subtractUrl = `${actionsUrl}/subtractapp/subtract`;
+  const subtractUrl = `${actionsUrl}/subtractapp/method/subtract`;
   req.pipe(request(subtractUrl)).pipe(res);
 });
 
 app.post('/calculate/multiply', async (req, res) => {
-  const multiplyUrl = `${actionsUrl}/multiplyapp/multiply`;
+  const multiplyUrl = `${actionsUrl}/multiplyapp/method/multiply`;
   req.pipe(request(multiplyUrl)).pipe(res);
 });
 
 app.post('/calculate/divide', async (req, res) => {
-  const divideUrl = `${actionsUrl}/divideapp/divide`;
+  const divideUrl = `${actionsUrl}/divideapp/method/divide`;
   req.pipe(request(divideUrl)).pipe(res);
 });
 


### PR DESCRIPTION
# Description

This PR changes the direct invoke endpoint from `v1.0/actions/<id>/<method>` to `v1.0/invoke/<id>/method/<method>`.

## Issue reference

https://github.com/actionscore/actions/issues/420

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation
* [x] Specification has been updated
* [x] Provided sample for the feature
