### PR TITLE
fix x-correlation-id matching to ignore case

### DIFF
--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -170,7 +170,7 @@ func TracingSpanFromGRPCContext(c context.Context, req interface{}, method strin
 	headers := extractHeaders(req)
 	re := regexp.MustCompile(`(?i)(&__header_delim__&)?X-Correlation-ID&__header_equals__&[0-9a-fA-F]+;[0-9a-fA-F]+;[0-9a-fA-F]+`)
 	corID := strings.Replace(re.FindString(headers), "&__header_delim__&", "", 1)
-	if len(corID) > 35 {
+	if len(corID) > 35 { //to remove the prefix "X-Correlation-Id&__header_equals__&", which may in different casing
 		corID = corID[35:]
 	}
 


### PR DESCRIPTION
relax regular expression to ignore casing when searching for X-Correlation-ID, which gets normalized by fasthttp to X-Correlation-Id.