### PR TITLE
better kafka binding sync producer defaults

### DIFF
--- a/pkg/bindings/kafka/kafka.go
+++ b/pkg/bindings/kafka/kafka.go
@@ -105,9 +105,9 @@ func (k *Kafka) getKafkaMetadata(metadata bindings.Metadata) (*kafkaMetadata, er
 
 func (k *Kafka) getSyncProducer(meta *kafkaMetadata) (sarama.SyncProducer, error) {
 	config := sarama.NewConfig()
-	config.Producer.RequiredAcks = sarama.WaitForLocal
-	config.Producer.Retry.Max = 10
-	config.Producer.Return.Successes = false
+	config.Producer.RequiredAcks = sarama.WaitForAll
+	config.Producer.Retry.Max = 5
+	config.Producer.Return.Successes = true
 
 	producer, err := sarama.NewSyncProducer(meta.Brokers, config)
 	if err != nil {


### PR DESCRIPTION
changes to sync producer based on Kafka Sarama client best practices