### PR TITLE
fix SIDECAR_IMAGE env var

### DIFF
--- a/charts/dapr-operator/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr-operator/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -36,7 +36,11 @@ spec:
         - name: TLS_KEY_FILE
           value: /dapr/cert/tls.key
         - name: SIDECAR_IMAGE
-          value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+{{- if contains "/" .Values.image.name }}
+          value: "{{ .Values.image.name }}"
+{{- else }}
+          value: "{{ $.Values.global.registry }}/dapr:{{ $.Values.global.tag }}"
+          {{- end }}
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
         ports:


### PR DESCRIPTION
Without this fix, the value for `SIDECAR_IMAGE` is `":"`.