### PR TITLE
don't init input bindings if not needed

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -445,6 +445,7 @@ func (a *DaprRuntime) getSubscribedBindingsGRPC() []string {
 }
 
 func (a *DaprRuntime) isAppSubscribedToBinding(binding string, bindingsList []string) bool {
+	// if gRPC, looks for the binding in the list of bindings returned from the app
 	if a.runtimeConfig.ApplicationProtocol == GRPCProtocol {
 		for _, b := range bindingsList {
 			if b == binding {
@@ -452,6 +453,7 @@ func (a *DaprRuntime) isAppSubscribedToBinding(binding string, bindingsList []st
 			}
 		}
 	} else if a.runtimeConfig.ApplicationProtocol == HTTPProtocol {
+		// if HTTP, check if there's an endpoint listening for that binding
 		req := channel.InvokeRequest{
 			Method:   binding,
 			Metadata: map[string]string{http_channel.HTTPVerb: http_channel.Options},


### PR DESCRIPTION
This PR fixes an issue where input bindings would be initialized even if the app didn't subscribe for them.