### PR TITLE
gRPC generation updates

### DIFF
--- a/tools/proto/generate.sh
+++ b/tools/proto/generate.sh
@@ -48,6 +48,14 @@ file="protoc-${VERSION}-${OS}-x86_64.zip"
 wget "https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/${file}" \
   -O ${root}/${file}
 
+# Download Java gRPC plugin
+java_grpc_plugin_file="protoc-gen-grpc-java-1.24.0-${OS}-x86_64.exe"
+java_grpc_plugin_path=${root}/${java_grpc_plugin_file}
+
+wget "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.24.0/${java_grpc_plugin_file}" \
+  -O ${java_grpc_plugin_path}
+
+chmod +x ${java_grpc_plugin_path}
 unzip ${root}/${file} -d ${root}
 
 # find grpc_tools_node_protoc_plugin location
@@ -57,7 +65,7 @@ PROTOC_PLUGIN=$(which grpc_tools_node_protoc_plugin)
 generate javascript js src 'import_style=commonjs' '--plugin=protoc-gen-grpc='${PROTOC_PLUGIN} --grpc_out=${top_root}/../dapr-javascript/src
 
 # generate java
-generate java java src/main/java '' --grpc-java_out=${top_root}/../dapr-java/src/main/java 
+generate java java src/main/java '' --plugin=protoc-gen-grpc-java=${java_grpc_plugin_path} --grpc-java_out=${top_root}/../dapr-java/src/main/java 
 
 # generate dotnet
 # dotnet generates their own via dotnet build...
@@ -72,4 +80,4 @@ python3 -m grpc.tools.protoc -I${top_root}/pkg/proto \
    daprclient/daprclient.proto
 
 # cleanup
-rm -r ${root}/include ${root}/bin ${root}/${file} ${root}/readme.txt
+rm -r ${root}/include ${root}/bin ${root}/${file} ${root}/readme.txt ${java_grpc_plugin_path}


### PR DESCRIPTION
This PR does the following:

* Add support for darwin in addition to linux
* Fixes Python generation error for non existent directory
* Uses installed location for `grpc_tools_node_protoc_plugin` instead of `/usr/bin/grpc_tools_node_protoc_plugin`
* Downloads Java gRPC plugin - needed for java client generation