### PR TITLE
ref(chart): Fixes some chart problems

### DIFF
--- a/charts/dapr-operator/Chart.yaml
+++ b/charts/dapr-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr-operator
-version: 0.2.0
+version: 0.2.1

--- a/charts/dapr-operator/README.md
+++ b/charts/dapr-operator/README.md
@@ -48,7 +48,7 @@ For more details on initializing helm, Go [here](https://docs.helm.sh/helm/#helm
 
 2. Install the Dapr chart on your cluster in the dapr-system namespace:
     ```
-    helm install actionscore/dapr-operator --name dapr --namespace dapr-system
+    helm install dapr/dapr-operator --name dapr --namespace dapr-system
     ``` 
 
 ## Verify installation

--- a/charts/dapr-operator/charts/dapr_crd/Chart.yaml
+++ b/charts/dapr-operator/charts/dapr_crd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes CRDs
 name: dapr_crd
-version: 0.2.0
+version: 0.2.1

--- a/charts/dapr-operator/charts/dapr_crd/templates/components.yaml
+++ b/charts/dapr-operator/charts/dapr_crd/templates/components.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: components.dapr.io
-  namespace: {{ .Release.Namespace }}
 spec:
   group: dapr.io
   version: v1alpha1

--- a/charts/dapr-operator/charts/dapr_crd/templates/configuration.yaml
+++ b/charts/dapr-operator/charts/dapr_crd/templates/configuration.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: configurations.dapr.io
-  namespace: {{ .Release.Namespace }}
 spec:
   group: dapr.io
   version: v1alpha1

--- a/charts/dapr-operator/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr-operator/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: 0.2.0
+version: 0.2.1

--- a/charts/dapr-operator/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr-operator/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dapr-operator
-  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-operator
 spec:
@@ -20,12 +19,14 @@ spec:
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}
-        image: "{{ $.Values.global.registry }}/dapr:{{ $.Values.global.tag }}"
+        image: "{{ .Values.global.registry }}/dapr:{{ .Values.global.tag }}"
 {{- end }}
-        imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         env:
         - name: NAMESPACE
-          value: {{ .Release.Namespace }}
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 6500
         command:

--- a/charts/dapr-operator/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr-operator/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: dapr-api
-  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     app: dapr-operator

--- a/charts/dapr-operator/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr-operator/charts/dapr_placement/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: 0.2.0
+version: 0.2.1

--- a/charts/dapr-operator/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr-operator/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dapr-placement
-  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-placement
 spec:
@@ -21,9 +20,9 @@ spec:
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}
-        image: "{{ $.Values.global.registry }}/dapr:{{ $.Values.global.tag }}"
+        image: "{{ .Values.global.registry }}/dapr:{{ .Values.global.tag }}"
 {{- end }}
-        imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         ports:
           - containerPort: 50005
         command:

--- a/charts/dapr-operator/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr-operator/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -2,7 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: dapr-placement
-  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     app: dapr-placement

--- a/charts/dapr-operator/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr-operator/charts/dapr_rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC componentes
 name: dapr_rbac
-version: 0.2.0
+version: 0.2.1

--- a/charts/dapr-operator/charts/dapr_rbac/templates/ServiceAccount.yaml
+++ b/charts/dapr-operator/charts/dapr_rbac/templates/ServiceAccount.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dapr-operator
-  namespace: {{ .Release.Namespace }}

--- a/charts/dapr-operator/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr-operator/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: 0.2.0
+version: 0.2.1

--- a/charts/dapr-operator/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr-operator/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -20,9 +20,9 @@ spec:
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}
-        image: "{{ $.Values.global.registry }}/dapr:{{ $.Values.global.tag }}"
+        image: "{{ .Values.global.registry }}/dapr:{{ .Values.global.tag }}"
 {{- end }}
-        imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           runAsUser: 1000
         command:
@@ -39,10 +39,12 @@ spec:
 {{- if contains "/" .Values.image.name }}
           value: "{{ .Values.image.name }}"
 {{- else }}
-          value: "{{ $.Values.global.registry }}/dapr:{{ $.Values.global.tag }}"
+          value: "{{ .Values.global.registry }}/dapr:{{ .Values.global.tag }}"
           {{- end }}
         - name: NAMESPACE
-          value: {{ .Release.Namespace }}
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - name: https
           containerPort: 4000

--- a/charts/dapr-operator/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr-operator/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   metadata:
   name: dapr-sidecar-injector
-  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/dapr-operator/requirements.yaml
+++ b/charts/dapr-operator/requirements.yaml
@@ -1,6 +1,9 @@
 dependencies:
 - name: dapr_crd
   version: "0.2.0"
+  # NOTE: In Helm 2.15 and Helm 3, the repository field will no longer be
+  # necessary to require local charts in the charts/ directory, so this can be
+  # removed as soon as those are released
   repository: "file://dapr_crd"
 - name: dapr_rbac
   version: "0.2.0"
@@ -13,4 +16,4 @@ dependencies:
   repository: "file://dapr_placement"
 - name: dapr_sidecar_injector
   version: "0.2.0"
-  repository: "file://dapr_sidecar_injector"      
+  repository: "file://dapr_sidecar_injector"

--- a/charts/dapr-operator/templates/NOTES.txt
+++ b/charts/dapr-operator/templates/NOTES.txt
@@ -3,7 +3,7 @@ Thank you for installing Dapr: High-performance, lightweight serverless runtime 
 Your release is named {{ .Release.Name }}.
 
 To get started with Dapr, we recommend using our samples page:
-https://github.com/dapr/dapr/tree/master/samples/1.hello-world
+https://github.com/dapr/samples
 
 For more information on running Dapr, visit:
-https://github.com/dapr
+https://dapr.io


### PR DESCRIPTION
This fixes some documentation and less-than-ideal template usage (especially with namespaces)
that I found while giving dapr a whirl. As part of this, I have bumped the patch version
on all charts. I have both linted and tested an install of the new chart

Some other recommendations for posterity sake that are out of scope of this PR, but
would be good to make this a more production ready chart:
- Make the name and labels for objects dynamic (generally with the fullname template)
- Consider adding redis as a dependency (that can be turned off with a condition) to
  make it easier for those getting started
- Fill out `Chart.yaml` with icons/sources/etc.