### PR TITLE
Break after actor deactivation

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -576,6 +576,7 @@ func (a *actorsRuntime) drainRebalancedActors() {
 						if err != nil {
 							log.Warnf("failed to deactivate actor %s: %s", actorKey, err)
 						}
+						break
 					}
 					time.Sleep(time.Millisecond * 500)
 				}


### PR DESCRIPTION
This PR introduces a missing break condition for the actor deactivation loop when draining actors that have been rebalanced.