### PR TITLE
allow redelivery of event to rejecting consumer

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -679,7 +679,8 @@ func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
 
 	resp, err := a.appChannel.InvokeMethod(&req)
 	if err != nil || http.GetStatusCodeFromMetadata(resp.Metadata) != 200 {
-		log.Debugf("error from app: %s", err)
+		err = fmt.Errorf("error from app consumer: %s", err)
+		log.Debug(err)
 		return err
 	}
 	return nil
@@ -711,7 +712,8 @@ func (a *DaprRuntime) publishMessageGRPC(msg *pubsub.NewMessage) error {
 	client := daprclient_pb.NewDaprClientClient(a.grpc.AppClient)
 	_, err = client.OnTopicEvent(context.Background(), envelope)
 	if err != nil {
-		log.Debugf("error from app: %s", err)
+		err = fmt.Errorf("error from consumer app: %s", err)
+		log.Debug(err)
 		return err
 	}
 	return nil

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -6,6 +6,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -398,14 +399,16 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
 		rt.appChannel = mockAppChannel
 
+		clientError := errors.New("Internal Error")
+
 		fakeHttpResponse := &channel.InvokeResponse{
 			Metadata: map[string]string{http_channel.HTTPStatusCode: "500"},
-			Data:     []byte("Internal Error"),
+			Data:     []byte(clientError.Error()),
 		}
 
-		expectedClientError := fmt.Errorf("Internal Error")
+		expectedClientError := fmt.Errorf("error from app consumer: Internal Error")
 
-		mockAppChannel.On("InvokeMethod", expectedRequest).Return(fakeHttpResponse, expectedClientError)
+		mockAppChannel.On("InvokeMethod", expectedRequest).Return(fakeHttpResponse, clientError)
 
 		// act
 		err := rt.publishMessageHTTP(testPubSubMessage)


### PR DESCRIPTION
Pub-Sub: When receiving an error from an HTTP consumer, the error returned to the message bus is nil, and therefor does not count for redelivery.

This allows for redelivery to the rejecting consumer.