### PR TITLE
fix activation check

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -214,7 +214,7 @@ func (a *actorsRuntime) actorInstanceExists(key string) bool {
 func (a *actorsRuntime) callLocalActor(actorType, actorID, actorMethod string, data []byte, metadata map[string]string) (*CallResponse, error) {
 	key := a.constructCombinedActorKey(actorType, actorID)
 
-	val, _ := a.actorsTable.LoadOrStore(key, &actor{
+	val, exists := a.actorsTable.LoadOrStore(key, &actor{
 		lock:         &sync.RWMutex{},
 		busy:         true,
 		lastUsedTime: time.Now(),
@@ -226,7 +226,6 @@ func (a *actorsRuntime) callLocalActor(actorType, actorID, actorMethod string, d
 	lock.Lock()
 	defer lock.Unlock()
 
-	exists := a.actorInstanceExists(key)
 	if !exists {
 		err := a.tryActivateActor(actorType, actorID)
 		if err != nil {

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -206,11 +206,6 @@ func (a *actorsRuntime) Call(req *CallRequest) (*CallResponse, error) {
 	return resp, nil
 }
 
-func (a *actorsRuntime) actorInstanceExists(key string) bool {
-	_, exists := a.actorsTable.Load(key)
-	return exists
-}
-
 func (a *actorsRuntime) callLocalActor(actorType, actorID, actorMethod string, data []byte, metadata map[string]string) (*CallResponse, error) {
 	key := a.constructCombinedActorKey(actorType, actorID)
 


### PR DESCRIPTION
A sync map's `LoadOrStore` is concurrently safe, and so two concurrent goroutines cannot assume a value exists or not when accessed concurrently.

The exists check is performed before the lock and evaluated after the lock and thus fixes a situation where an actor will not be activated.

cc @amanbha 