### PR TITLE
Use modified key for gRPC deletion

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -280,7 +280,7 @@ func (a *api) DeleteState(ctx context.Context, in *dapr_pb.DeleteStateEnvelope) 
 	}
 
 	req := state.DeleteRequest{
-		Key:  in.Key,
+		Key:  a.getModifiedStateKey(in.Key),
 		ETag: in.Etag,
 	}
 	if in.Options != nil {


### PR DESCRIPTION
# Description

This is to bring gRPC protocol to use the same modified key for deletion as in HTTP implementation

