### PR TITLE
use service discovery from components-contrib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Sirupsen/logrus v1.0.6
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/creack/pty v1.1.9 // indirect
-	github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e
+	github.com/dapr/components-contrib v0.0.0-20191115232656-5a27c138e761
 	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.2.0+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,17 @@ go 1.13
 
 require (
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
+	github.com/Azure/go-autorest v13.0.1+incompatible // indirect
+	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/Sirupsen/logrus v1.0.6
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/creack/pty v1.1.9 // indirect
-	github.com/dapr/components-contrib v0.0.0-20191108224343-bd36a6759fe4
+	github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e
+	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/evanphx/json-patch v4.2.0+incompatible // indirect
+	github.com/frankban/quicktest v1.5.0 // indirect
+	github.com/garyburd/redigo v1.6.0 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/spec v0.19.3 // indirect
@@ -17,29 +22,51 @@ require (
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/gddo v0.0.0-20190815223733-287de01127ef // indirect
 	github.com/golang/protobuf v1.3.2
+	github.com/google/pprof v0.0.0-20190908185732-236ed259b199 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gorilla/mux v1.7.1
 	github.com/grandcat/zeroconf v0.0.0-20190424104450-85eadb44205c
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
+	github.com/grpc-ecosystem/grpc-gateway v1.11.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/jcmturner/gofork v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.7
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/klauspost/compress v1.5.0 // indirect
 	github.com/klauspost/cpuid v1.2.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/mediocregopher/radix.v2 v0.0.0-20181115013041-b67df6e626f9 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5
+	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
 	github.com/qiangxue/fasthttp-routing v0.0.0-20160225050629-6ccdc2a18d87
+	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
+	github.com/rogpeppe/fastuuid v1.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.4.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/valyala/fasthttp v1.4.0
 	go.opencensus.io v0.22.1
+	golang.org/x/exp v0.0.0-20190927203820-447a159532ef // indirect
+	golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a // indirect
+	golang.org/x/mobile v0.0.0-20190923204409-d3ece3b6da5f // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
 	gonum.org/v1/gonum v0.0.0-20190911200027-40d3308efe80 // indirect
+	google.golang.org/appengine v1.6.4 // indirect
+	google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c // indirect
 	google.golang.org/grpc v1.24.0
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
+	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
@@ -48,6 +75,7 @@ require (
 	k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab // indirect
 	k8s.io/klog v0.4.0
 	k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5 // indirect
+	pack.ag/amqp v0.12.3 // indirect
 )
 
 replace k8s.io/client => github.com/kubernetes-client/go v0.0.0-20190928040339-c757968c4c36

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/dapr/components-contrib v0.0.0-20191114211457-e7e02ee05658 h1:/DL7Ro/
 github.com/dapr/components-contrib v0.0.0-20191114211457-e7e02ee05658/go.mod h1:hMtuJ1q/l7anEHgttGmic+jUVSFLc59sJroqT9YJjio=
 github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e h1:eeiNzKl1gqnE9zf0lqL6JXz5R5Wi+R+lgy4l+hM25Ic=
 github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e/go.mod h1:hMtuJ1q/l7anEHgttGmic+jUVSFLc59sJroqT9YJjio=
+github.com/dapr/components-contrib v0.0.0-20191115232656-5a27c138e761 h1:XkgS+HougkJYtZjvoj57kYauhgdSnTMdRRQDcey6/u4=
+github.com/dapr/components-contrib v0.0.0-20191115232656-5a27c138e761/go.mod h1:hMtuJ1q/l7anEHgttGmic+jUVSFLc59sJroqT9YJjio=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,10 @@ github.com/dapr/components-contrib v0.0.0-20191108201019-08e654c0cd73 h1:j8qX+N8
 github.com/dapr/components-contrib v0.0.0-20191108201019-08e654c0cd73/go.mod h1:vS1Yk3eDfvZvv95H6piES4A+SVumUGlU35O6zDuVi7U=
 github.com/dapr/components-contrib v0.0.0-20191108224343-bd36a6759fe4 h1:uakhMxnRn5lnDgylpU5qMPjZ4eIYnkZirlBv1zvFKfg=
 github.com/dapr/components-contrib v0.0.0-20191108224343-bd36a6759fe4/go.mod h1:jwdzDvJhzUP5yKPDjAPkjKeeUDAbTbRvpe3UX1odxas=
+github.com/dapr/components-contrib v0.0.0-20191114211457-e7e02ee05658 h1:/DL7Ro/iR4IcXSE6Tk+capNmPhwKudOHG18ZwtB/3rI=
+github.com/dapr/components-contrib v0.0.0-20191114211457-e7e02ee05658/go.mod h1:hMtuJ1q/l7anEHgttGmic+jUVSFLc59sJroqT9YJjio=
+github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e h1:eeiNzKl1gqnE9zf0lqL6JXz5R5Wi+R+lgy4l+hM25Ic=
+github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e/go.mod h1:hMtuJ1q/l7anEHgttGmic+jUVSFLc59sJroqT9YJjio=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -413,6 +417,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubernetes-client/go v0.0.0-20190625181339-cd8e39e789c7 h1:NZlvd1Qf3MwoRhh87iVkJSHK3R31fX3D7kQfdJy6LnQ=
 github.com/kubernetes-client/go v0.0.0-20190625181339-cd8e39e789c7/go.mod h1:ks4KCmmxdXksTSu2dlnUanEOqNd/dsoyS6/7bay2RQ8=
+github.com/kubernetes-client/go v0.0.0-20190928040339-c757968c4c36/go.mod h1:ks4KCmmxdXksTSu2dlnUanEOqNd/dsoyS6/7bay2RQ8=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -522,6 +527,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -542,6 +548,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/pkg/components/servicediscovery/loader.go
+++ b/pkg/components/servicediscovery/loader.go
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package servicediscovery
+
+import (
+	"github.com/dapr/components-contrib/servicediscovery"
+	"github.com/dapr/components-contrib/servicediscovery/kubernetes"
+	"github.com/dapr/components-contrib/servicediscovery/mdns"
+)
+
+func Load() {
+	RegisterServiceDiscovery("mdns", func() servicediscovery.Resolver {
+		return mdns.NewMDNSResolver()
+	})
+	RegisterServiceDiscovery("kubernetes", func() servicediscovery.Resolver {
+		return kubernetes.NewKubernetesResolver()
+	})
+}

--- a/pkg/components/servicediscovery/loader.go
+++ b/pkg/components/servicediscovery/loader.go
@@ -6,16 +6,12 @@
 package servicediscovery
 
 import (
-	"github.com/dapr/components-contrib/servicediscovery"
 	"github.com/dapr/components-contrib/servicediscovery/kubernetes"
 	"github.com/dapr/components-contrib/servicediscovery/mdns"
 )
 
 func Load() {
-	RegisterServiceDiscovery("mdns", func() servicediscovery.Resolver {
-		return mdns.NewMDNSResolver()
-	})
-	RegisterServiceDiscovery("kubernetes", func() servicediscovery.Resolver {
-		return kubernetes.NewKubernetesResolver()
-	})
+	RegisterServiceDiscovery("mdns", mdns.NewMDNSResolver)
+
+	RegisterServiceDiscovery("kubernetes", kubernetes.NewKubernetesResolver)
 }

--- a/pkg/components/servicediscovery/registry.go
+++ b/pkg/components/servicediscovery/registry.go
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package servicediscovery
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/dapr/components-contrib/servicediscovery"
+)
+
+type Registry interface {
+	CreateResolver(name string) (servicediscovery.Resolver, error)
+}
+
+type serviceDiscoveryRegistry struct {
+	resolvers map[string]func() servicediscovery.Resolver
+}
+
+var instance *serviceDiscoveryRegistry
+var once sync.Once
+
+func NewRegistry() Registry {
+	once.Do(func() {
+		instance = &serviceDiscoveryRegistry{
+			resolvers: map[string]func() servicediscovery.Resolver{},
+		}
+	})
+	return instance
+}
+
+func RegisterServiceDiscovery(name string, factoryMethod func() servicediscovery.Resolver) {
+	instance.resolvers[formatName(name)] = factoryMethod
+}
+
+func (s *serviceDiscoveryRegistry) CreateResolver(name string) (servicediscovery.Resolver, error) {
+	if method, ok := s.resolvers[formatName(name)]; ok {
+		return method(), nil
+	}
+	return nil, fmt.Errorf("couldn't find service resolver %s", name)
+}
+
+func formatName(s string) string {
+	return fmt.Sprintf("servicediscovery.%s", s)
+}

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -8,10 +8,7 @@ package messaging
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
-
-	"github.com/dapr/dapr/pkg/discovery"
 
 	"github.com/golang/protobuf/ptypes/any"
 
@@ -20,6 +17,7 @@ import (
 	"github.com/dapr/dapr/pkg/channel"
 	"google.golang.org/grpc"
 
+	"github.com/dapr/components-contrib/servicediscovery"
 	daprinternal_pb "github.com/dapr/dapr/pkg/proto/daprinternal"
 )
 
@@ -35,10 +33,11 @@ type directMessaging struct {
 	mode                modes.DaprMode
 	grpcPort            int
 	namespace           string
+	resolver            servicediscovery.Resolver
 }
 
 // NewDirectMessaging returns a new direct messaging api
-func NewDirectMessaging(daprID, namespace string, port int, mode modes.DaprMode, appChannel channel.AppChannel, grpcConnectionFn func(address string) (*grpc.ClientConn, error)) DirectMessaging {
+func NewDirectMessaging(daprID, namespace string, port int, mode modes.DaprMode, appChannel channel.AppChannel, grpcConnectionFn func(address string) (*grpc.ClientConn, error), resolver servicediscovery.Resolver) DirectMessaging {
 	return &directMessaging{
 		appChannel:          appChannel,
 		connectionCreatorFn: grpcConnectionFn,
@@ -46,6 +45,7 @@ func NewDirectMessaging(daprID, namespace string, port int, mode modes.DaprMode,
 		mode:                mode,
 		grpcPort:            port,
 		namespace:           namespace,
+		resolver:            resolver,
 	}
 }
 
@@ -85,7 +85,8 @@ func (d *directMessaging) invokeLocal(req *DirectMessageRequest) (*DirectMessage
 }
 
 func (d *directMessaging) invokeRemote(req *DirectMessageRequest) (*DirectMessageResponse, error) {
-	address, err := d.getAddress(req.Target)
+	request := servicediscovery.ResolveRequest{ID: req.Target, Port: d.grpcPort}
+	address, err := d.resolver.ResolveID(&request)
 	if err != nil {
 		return nil, err
 	}
@@ -114,19 +115,4 @@ func (d *directMessaging) invokeRemote(req *DirectMessageRequest) (*DirectMessag
 		Data:     resp.Data.Value,
 		Metadata: resp.Metadata,
 	}, nil
-}
-
-func (d *directMessaging) getAddress(target string) (string, error) {
-	switch d.mode {
-	case modes.KubernetesMode:
-		return fmt.Sprintf("%s-dapr.%s.svc.cluster.local:%v", target, d.namespace, d.grpcPort), nil
-	case modes.StandaloneMode:
-		port, err := discovery.LookupPortMDNS(target)
-		if err != nil {
-			return "", err
-		}
-		return fmt.Sprintf("localhost:%v", port), nil
-	default:
-		return "", fmt.Errorf("remote calls not supported for %s mode", string(d.mode))
-	}
 }

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -12,13 +12,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/any"
 
-	"github.com/dapr/dapr/pkg/modes"
-
-	"github.com/dapr/dapr/pkg/channel"
-	"google.golang.org/grpc"
-
 	"github.com/dapr/components-contrib/servicediscovery"
+	"github.com/dapr/dapr/pkg/channel"
+	"github.com/dapr/dapr/pkg/modes"
 	daprinternal_pb "github.com/dapr/dapr/pkg/proto/daprinternal"
+	"google.golang.org/grpc"
 )
 
 // DirectMessaging is the API interface for invoking a remote app
@@ -85,8 +83,8 @@ func (d *directMessaging) invokeLocal(req *DirectMessageRequest) (*DirectMessage
 }
 
 func (d *directMessaging) invokeRemote(req *DirectMessageRequest) (*DirectMessageResponse, error) {
-	request := servicediscovery.ResolveRequest{ID: req.Target, Port: d.grpcPort}
-	address, err := d.resolver.ResolveID(&request)
+	request := servicediscovery.ResolveRequest{ID: req.Target, Namespace: d.namespace, Port: d.grpcPort}
+	address, err := d.resolver.ResolveID(request)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/dapr/components-contrib/servicediscovery/kubernetes/kubernetes.go
+++ b/vendor/github.com/dapr/components-contrib/servicediscovery/kubernetes/kubernetes.go
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/dapr/components-contrib/servicediscovery"
+)
+
+type Resolver struct {
+}
+
+func NewKubernetesResolver() *Resolver {
+	return &Resolver{}
+}
+
+func (z *Resolver) ResolveID(req *servicediscovery.ResolveRequest) (string, error) {
+	// Dapr requires this formatting for Kubernetes services
+	return fmt.Sprintf("%s-dapr.%s.svc.cluster.local:%d", req.ID, req.Namespace, req.Port), nil
+}

--- a/vendor/github.com/dapr/components-contrib/servicediscovery/kubernetes/kubernetes.go
+++ b/vendor/github.com/dapr/components-contrib/servicediscovery/kubernetes/kubernetes.go
@@ -11,14 +11,14 @@ import (
 	"github.com/dapr/components-contrib/servicediscovery"
 )
 
-type Resolver struct {
+type resolver struct {
 }
 
-func NewKubernetesResolver() *Resolver {
-	return &Resolver{}
+func NewKubernetesResolver() servicediscovery.Resolver {
+	return &resolver{}
 }
 
-func (z *Resolver) ResolveID(req *servicediscovery.ResolveRequest) (string, error) {
+func (z *resolver) ResolveID(req servicediscovery.ResolveRequest) (string, error) {
 	// Dapr requires this formatting for Kubernetes services
 	return fmt.Sprintf("%s-dapr.%s.svc.cluster.local:%d", req.ID, req.Namespace, req.Port), nil
 }

--- a/vendor/github.com/dapr/components-contrib/servicediscovery/mdns/mdns.go
+++ b/vendor/github.com/dapr/components-contrib/servicediscovery/mdns/mdns.go
@@ -21,7 +21,7 @@ func NewMDNSResolver() servicediscovery.Resolver {
 type resolver struct {
 }
 
-func (z *resolver) ResolveID(req *servicediscovery.ResolveRequest) (string, error) {
+func (z *resolver) ResolveID(req servicediscovery.ResolveRequest) (string, error) {
 	port, err := LookupPortMDNS(req.ID)
 	if err != nil {
 		return "", err
@@ -30,12 +30,12 @@ func (z *resolver) ResolveID(req *servicediscovery.ResolveRequest) (string, erro
 }
 
 // LookupPortMDNS uses mdns to find the port of a given service entry on a local network
-func LookupPortMDNS(id string) (int, error) {	
+func LookupPortMDNS(id string) (int, error) {
 	resolver, err := zeroconf.NewResolver(nil)
 	if err != nil {
 		return -1, fmt.Errorf("failed to initialize resolver: %e", err)
 	}
-	
+
 	port := -1
 	entries := make(chan *zeroconf.ServiceEntry)
 

--- a/vendor/github.com/dapr/components-contrib/servicediscovery/mdns/mdns.go
+++ b/vendor/github.com/dapr/components-contrib/servicediscovery/mdns/mdns.go
@@ -1,0 +1,66 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package mdns
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dapr/components-contrib/servicediscovery"
+	"github.com/grandcat/zeroconf"
+)
+
+func NewMDNSResolver() servicediscovery.Resolver {
+	return &resolver{}
+}
+
+type resolver struct {
+}
+
+func (z *resolver) ResolveID(req *servicediscovery.ResolveRequest) (string, error) {
+	port, err := LookupPortMDNS(req.ID)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("localhost:%v", port), nil
+}
+
+// LookupPortMDNS uses mdns to find the port of a given service entry on a local network
+func LookupPortMDNS(id string) (int, error) {	
+	resolver, err := zeroconf.NewResolver(nil)
+	if err != nil {
+		return -1, fmt.Errorf("failed to initialize resolver: %e", err)
+	}
+	
+	port := -1
+	entries := make(chan *zeroconf.ServiceEntry)
+
+	go func(results <-chan *zeroconf.ServiceEntry) {
+		for entry := range results {
+			for _, text := range entry.Text {
+				if text == id {
+					port = entry.Port
+					return
+				}
+			}
+		}
+	}(entries)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancel()
+
+	err = resolver.Browse(ctx, id, "local.", entries)
+	if err != nil {
+		return -1, fmt.Errorf("failed to browse: %s", err.Error())
+	}
+
+	<-ctx.Done()
+	if port == -1 {
+		return port, fmt.Errorf("couldn't find service: %s", id)
+	}
+	return port, nil
+}

--- a/vendor/github.com/dapr/components-contrib/servicediscovery/requests.go
+++ b/vendor/github.com/dapr/components-contrib/servicediscovery/requests.go
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package servicediscovery
+
+const DefaultNamespace = "default"
+
+type ResolveRequest struct {
+	ID        string
+	Namespace string
+	Port      int
+	Data      map[string]string
+}
+
+func NewResolveRequest() *ResolveRequest {
+	return &ResolveRequest{Namespace: DefaultNamespace}
+}

--- a/vendor/github.com/dapr/components-contrib/servicediscovery/servicediscovery.go
+++ b/vendor/github.com/dapr/components-contrib/servicediscovery/servicediscovery.go
@@ -6,5 +6,5 @@
 package servicediscovery
 
 type Resolver interface {
-	ResolveID(req *ResolveRequest) (string, error)
+	ResolveID(req ResolveRequest) (string, error)
 }

--- a/vendor/github.com/dapr/components-contrib/servicediscovery/servicediscovery.go
+++ b/vendor/github.com/dapr/components-contrib/servicediscovery/servicediscovery.go
@@ -1,0 +1,10 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package servicediscovery
+
+type Resolver interface {
+	ResolveID(req *ResolveRequest) (string, error)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/coreos/etcd/raft/raftpb
 github.com/coreos/go-systemd/journal
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
-# github.com/dapr/components-contrib v0.0.0-20191108224343-bd36a6759fe4
+# github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e
 github.com/dapr/components-contrib/bindings
 github.com/dapr/components-contrib/bindings/blobstorage
 github.com/dapr/components-contrib/bindings/cosmosdb
@@ -201,6 +201,9 @@ github.com/dapr/components-contrib/secretstores
 github.com/dapr/components-contrib/secretstores/keyvault
 github.com/dapr/components-contrib/secretstores/kubernetes
 github.com/dapr/components-contrib/secretstores/vault
+github.com/dapr/components-contrib/servicediscovery
+github.com/dapr/components-contrib/servicediscovery/kubernetes
+github.com/dapr/components-contrib/servicediscovery/mdns
 github.com/dapr/components-contrib/state
 github.com/dapr/components-contrib/state/cassandra
 github.com/dapr/components-contrib/state/consul

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,7 +171,7 @@ github.com/coreos/etcd/raft/raftpb
 github.com/coreos/go-systemd/journal
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
-# github.com/dapr/components-contrib v0.0.0-20191115044052-cf2f5287fe7e
+# github.com/dapr/components-contrib v0.0.0-20191115232656-5a27c138e761
 github.com/dapr/components-contrib/bindings
 github.com/dapr/components-contrib/bindings/blobstorage
 github.com/dapr/components-contrib/bindings/cosmosdb


### PR DESCRIPTION
# Description

This is the dapr runtime side of the change to make service discovery pluggable, connecting to the change in components-contrib.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

https://github.com/dapr/dapr/issues/753

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
