### PR TITLE
E2E test runner can manage dapr component object automatically

### DIFF
--- a/tests/e2e/hellodapr_test.go
+++ b/tests/e2e/hellodapr_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 		},
 	}
 
-	tr = runner.NewTestRunner("hellodapr", testApps)
+	tr = runner.NewTestRunner("hellodapr", testApps, nil)
 	os.Exit(tr.Start(m))
 }
 

--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package kubernetes
 
 // AppDescription holds the deployment information of test app

--- a/tests/platforms/kubernetes/client.go
+++ b/tests/platforms/kubernetes/client.go
@@ -8,6 +8,8 @@ package kubernetes
 import (
 	"path/filepath"
 
+	daprclient "github.com/dapr/dapr/pkg/client/clientset/versioned"
+	componentsv1alpha1 "github.com/dapr/dapr/pkg/client/clientset/versioned/typed/components/v1alpha1"
 	"k8s.io/client-go/kubernetes"
 	appv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	apiv1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -19,7 +21,8 @@ import (
 // KubeClient holds instances of Kubernetes clientset
 // TODO: Add cluster management methods to clean up the old test apps
 type KubeClient struct {
-	ClientSet kubernetes.Interface
+	ClientSet     kubernetes.Interface
+	DaprClientSet daprclient.Interface
 }
 
 // NewKubeClient creates KubeClient instance
@@ -29,12 +32,17 @@ func NewKubeClient(configPath string, clusterName string) (*KubeClient, error) {
 		return nil, err
 	}
 
-	clientset, err := kubernetes.NewForConfig(config)
+	kubecs, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
 
-	return &KubeClient{ClientSet: clientset}, nil
+	daprcs, err := daprclient.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KubeClient{ClientSet: kubecs, DaprClientSet: daprcs}, nil
 }
 
 func clientConfig(kubeConfigPath string, clusterName string) (*rest.Config, error) {
@@ -73,4 +81,9 @@ func (c *KubeClient) Pods(namespace string) apiv1.PodInterface {
 // Namespaces gets Namespace client
 func (c *KubeClient) Namespaces() apiv1.NamespaceInterface {
 	return c.ClientSet.CoreV1().Namespaces()
+}
+
+// DaprComponents gets Dapr component client for namespace
+func (c *KubeClient) DaprComponents(namespace string) componentsv1alpha1.ComponentInterface {
+	return c.DaprClientSet.ComponentsV1alpha1().Components(namespace)
 }

--- a/tests/platforms/kubernetes/component_description.go
+++ b/tests/platforms/kubernetes/component_description.go
@@ -11,6 +11,6 @@ type ComponentDescription struct {
 	Name string
 	// Type contains component types (<type>.<component_name>)
 	TypeName string
-	// MetaData contains the meta data for dapr component
+	// MetaData contains the metadata for dapr component
 	MetaData map[string]string
 }

--- a/tests/platforms/kubernetes/component_description.go
+++ b/tests/platforms/kubernetes/component_description.go
@@ -1,0 +1,16 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+// ComponentDescription holds dapr component description
+type ComponentDescription struct {
+	// Name is the name of dapr component
+	Name string
+	// Type contains component types (<type>.<component_name>)
+	TypeName string
+	// MetaData contains the meta data for dapr component
+	MetaData map[string]string
+}

--- a/tests/platforms/kubernetes/daprcomponent.go
+++ b/tests/platforms/kubernetes/daprcomponent.go
@@ -1,0 +1,61 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	v1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DaprComponent holds kubernetes client and component information
+type DaprComponent struct {
+	namespace  string
+	kubeClient *KubeClient
+	component  ComponentDescription
+}
+
+// NewDaprComponent creates DaprComponent instance
+func NewDaprComponent(client *KubeClient, ns string, comp ComponentDescription) *DaprComponent {
+	return &DaprComponent{
+		namespace:  ns,
+		kubeClient: client,
+		component:  comp,
+	}
+}
+
+func (do *DaprComponent) addComponent() (*v1alpha1.Component, error) {
+	client := do.kubeClient.DaprComponents(DaprTestKubeNameSpace)
+
+	metadata := []v1alpha1.MetadataItem{}
+
+	for k, v := range do.component.MetaData {
+		metadata = append(metadata, v1alpha1.MetadataItem{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	obj := buildDaprComponentObject(do.component.Name, do.component.TypeName, metadata)
+	return client.Create(obj)
+}
+
+func (do *DaprComponent) deleteComponent() error {
+	client := do.kubeClient.DaprComponents(DaprTestKubeNameSpace)
+	return client.Delete(do.component.Name, &metav1.DeleteOptions{})
+}
+
+func (do *DaprComponent) Name() string {
+	return do.component.Name
+}
+
+func (do *DaprComponent) Init() error {
+	_, err := do.addComponent()
+	return err
+}
+
+func (do *DaprComponent) Dispose() error {
+	return do.deleteComponent()
+}

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -8,6 +8,7 @@ package kubernetes
 import (
 	"fmt"
 
+	v1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,9 @@ const (
 	DefaultContainerPort = 3000
 	// DefaultExternalPort is the default external port exposed by load balancer ingress
 	DefaultExternalPort = 3000
+
+	// DaprComponentsKind is component kind
+	DaprComponentsKind = "components.dapr.io"
 )
 
 // buildDeploymentObject creates the Kubernetes Deployment object for dapr test app
@@ -108,6 +112,22 @@ func buildServiceObject(namespace string, appDesc AppDescription) *apiv1.Service
 				},
 			},
 			Type: serviceType,
+		},
+	}
+}
+
+// buildDaprComponentObject creates dapr component object
+func buildDaprComponentObject(componentName string, typeName string, metaData []v1alpha1.MetadataItem) *v1alpha1.Component {
+	return &v1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			Kind: DaprComponentsKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: componentName,
+		},
+		Spec: v1alpha1.ComponentSpec{
+			Type:     typeName,
+			Metadata: metaData,
 		},
 	}
 }

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -60,10 +60,8 @@ func (c *KubeTestPlatform) addComponents(comps []kube.ComponentDescription) erro
 		return fmt.Errorf("kubernetes cluster needs to be setup")
 	}
 
-	if comps != nil {
-		for _, comp := range comps {
-			c.ComponentResources.Add(kube.NewDaprComponent(c.kubeClient, kube.DaprTestKubeNameSpace, comp))
-		}
+	for _, comp := range comps {
+		c.ComponentResources.Add(kube.NewDaprComponent(c.kubeClient, kube.DaprTestKubeNameSpace, comp))
 	}
 
 	// setup component resources
@@ -80,18 +78,16 @@ func (c *KubeTestPlatform) addApps(apps []kube.AppDescription) error {
 		return fmt.Errorf("kubernetes cluster needs to be setup before calling BuildAppResources")
 	}
 
-	if apps != nil {
-		for _, app := range apps {
-			if app.RegistryName == "" {
-				app.RegistryName = c.imageRegistry()
-			}
-			if app.ImageName == "" {
-				return fmt.Errorf("%s app doesn't have imagename property", app.AppName)
-			}
-			app.ImageName = fmt.Sprintf("%s:%s", app.ImageName, c.imageTag())
-
-			c.AppResources.Add(kube.NewAppManager(c.kubeClient, kube.DaprTestKubeNameSpace, app))
+	for _, app := range apps {
+		if app.RegistryName == "" {
+			app.RegistryName = c.imageRegistry()
 		}
+		if app.ImageName == "" {
+			return fmt.Errorf("%s app doesn't have imagename property", app.AppName)
+		}
+		app.ImageName = fmt.Sprintf("%s:%s", app.ImageName, c.imageTag())
+
+		c.AppResources.Add(kube.NewAppManager(c.kubeClient, kube.DaprTestKubeNameSpace, app))
 	}
 
 	// installApps installs the apps in AppResource queue sequentially

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -60,8 +60,10 @@ func (c *KubeTestPlatform) addComponents(comps []kube.ComponentDescription) erro
 		return fmt.Errorf("kubernetes cluster needs to be setup")
 	}
 
-	for _, comp := range comps {
-		c.ComponentResources.Add(kube.NewDaprComponent(c.kubeClient, kube.DaprTestKubeNameSpace, comp))
+	if comps != nil {
+		for _, comp := range comps {
+			c.ComponentResources.Add(kube.NewDaprComponent(c.kubeClient, kube.DaprTestKubeNameSpace, comp))
+		}
 	}
 
 	// setup component resources
@@ -78,16 +80,18 @@ func (c *KubeTestPlatform) addApps(apps []kube.AppDescription) error {
 		return fmt.Errorf("kubernetes cluster needs to be setup before calling BuildAppResources")
 	}
 
-	for _, app := range apps {
-		if app.RegistryName == "" {
-			app.RegistryName = c.imageRegistry()
-		}
-		if app.ImageName == "" {
-			return fmt.Errorf("%s app doesn't have imagename property", app.AppName)
-		}
-		app.ImageName = fmt.Sprintf("%s:%s", app.ImageName, c.imageTag())
+	if apps != nil {
+		for _, app := range apps {
+			if app.RegistryName == "" {
+				app.RegistryName = c.imageRegistry()
+			}
+			if app.ImageName == "" {
+				return fmt.Errorf("%s app doesn't have imagename property", app.AppName)
+			}
+			app.ImageName = fmt.Sprintf("%s:%s", app.ImageName, c.imageTag())
 
-		c.AppResources.Add(kube.NewAppManager(c.kubeClient, kube.DaprTestKubeNameSpace, app))
+			c.AppResources.Add(kube.NewAppManager(c.kubeClient, kube.DaprTestKubeNameSpace, app))
+		}
 	}
 
 	// installApps installs the apps in AppResource queue sequentially

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -42,11 +42,11 @@ func (c *KubeTestPlatform) setup() (err error) {
 
 func (c *KubeTestPlatform) tearDown() error {
 	if err := c.AppResources.tearDown(); err != nil {
-		log.Errorf("Failed to tearDown AppResources. got: %q", err)
+		log.Errorf("failed to tear down AppResources. got: %q", err)
 	}
 
 	if err := c.ComponentResources.tearDown(); err != nil {
-		log.Errorf("Failed to tearDown ComponentResources. got: %q", err)
+		log.Errorf("failed to tear down ComponentResources. got: %q", err)
 	}
 
 	// TODO: clean up kube cluster

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -20,14 +20,16 @@ const (
 
 // KubeTestPlatform includes K8s client for testing cluster and kubernetes testing apps
 type KubeTestPlatform struct {
-	AppResources *TestResources
-	kubeClient   *kube.KubeClient
+	AppResources       *TestResources
+	ComponentResources *TestResources
+	kubeClient         *kube.KubeClient
 }
 
 // NewKubeTestPlatform creates KubeTestPlatform instance
 func NewKubeTestPlatform() *KubeTestPlatform {
 	return &KubeTestPlatform{
-		AppResources: new(TestResources),
+		AppResources:       new(TestResources),
+		ComponentResources: new(TestResources),
 	}
 }
 
@@ -43,7 +45,29 @@ func (c *KubeTestPlatform) tearDown() error {
 		log.Errorf("Failed to tearDown AppResources. got: %q", err)
 	}
 
+	if err := c.ComponentResources.tearDown(); err != nil {
+		log.Errorf("Failed to tearDown ComponentResources. got: %q", err)
+	}
+
 	// TODO: clean up kube cluster
+
+	return nil
+}
+
+// addComponents adds component to disposable Resource queues
+func (c *KubeTestPlatform) addComponents(comps []kube.ComponentDescription) error {
+	if c.kubeClient == nil {
+		return fmt.Errorf("kubernetes cluster needs to be setup")
+	}
+
+	for _, comp := range comps {
+		c.ComponentResources.Add(kube.NewDaprComponent(c.kubeClient, kube.DaprTestKubeNameSpace, comp))
+	}
+
+	// setup component resources
+	if err := c.ComponentResources.setup(); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -66,6 +90,11 @@ func (c *KubeTestPlatform) addApps(apps []kube.AppDescription) error {
 		c.AppResources.Add(kube.NewAppManager(c.kubeClient, kube.DaprTestKubeNameSpace, app))
 	}
 
+	// installApps installs the apps in AppResource queue sequentially
+	if err := c.AppResources.setup(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -83,14 +112,6 @@ func (c *KubeTestPlatform) imageTag() string {
 		return defaultImageTag
 	}
 	return tag
-}
-
-// installApps installs the apps in AppResource queue sequentially
-func (c *KubeTestPlatform) installApps() error {
-	if err := c.AppResources.setup(); err != nil {
-		return err
-	}
-	return nil
 }
 
 // AcquireAppExternalURL returns the external url for 'name'

--- a/tests/runner/testrunner.go
+++ b/tests/runner/testrunner.go
@@ -21,8 +21,8 @@ type runnable interface {
 type PlatformInterface interface {
 	setup() error
 	tearDown() error
+	addComponents(comps []kube.ComponentDescription) error
 	addApps(apps []kube.AppDescription) error
-	installApps() error
 
 	AcquireAppExternalURL(name string) string
 }
@@ -32,6 +32,8 @@ type PlatformInterface interface {
 type TestRunner struct {
 	// id is test runner id which will be used for logging
 	id string
+
+	components []kube.ComponentDescription
 	// TODO: Needs to define kube.AppDescription more general struct for Dapr app
 	initialApps []kube.AppDescription
 
@@ -40,9 +42,10 @@ type TestRunner struct {
 }
 
 // NewTestRunner returns TestRunner instance for e2e test
-func NewTestRunner(id string, apps []kube.AppDescription) *TestRunner {
+func NewTestRunner(id string, apps []kube.AppDescription, comps []kube.ComponentDescription) *TestRunner {
 	return &TestRunner{
 		id:          id,
+		components:  comps,
 		initialApps: apps,
 		Platform:    NewKubeTestPlatform(),
 	}
@@ -59,11 +62,13 @@ func (tr *TestRunner) Start(m runnable) int {
 		return runnerFailExitCode
 	}
 
-	// Install apps
-	if err := tr.Platform.addApps(tr.initialApps); err != nil {
+	// install components
+	if err := tr.Platform.addComponents(tr.components); err != nil {
 		return runnerFailExitCode
 	}
-	if err := tr.Platform.installApps(); err != nil {
+
+	// Install apps
+	if err := tr.Platform.addApps(tr.initialApps); err != nil {
 		return runnerFailExitCode
 	}
 


### PR DESCRIPTION
# Description

This PR is to manage dapr component objects(e.g. redis statestore component) automatically, which resolves the effort to install and clean up components during the test.

## Issue reference

#798 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
