### PR TITLE
[E2E] initial commit of find_cluster.sh to find the available cluster in the pool

### DIFF
--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -43,7 +43,7 @@ for clustername in ${testclusterpool[@]}; do
         continue
     fi
 
-    # To resolve the racing condition when multiple tests are running,
+    # To resolve the race condition when multiple tests are running,
     # this script tries to create the namespace. If it is failed, we can assume 
     # that this cluster is being used by the other tests.
     echo "Trying to create ${KUBE_TEST_NAMESPACE} namespace..."

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -16,6 +16,9 @@ testclusterpool=(
     "dapr-aks-e2e-04"
 )
 
+# Define max e2e test timeout
+MAX_TEST_TIMEOUT=3600
+
 if [ -z "$DAPR_TEST_RESOURCE_GROUP" ]; then
     DAPR_TEST_RESOURCE_GROUP="dapre2e"
 fi
@@ -35,46 +38,37 @@ for clustername in ${testclusterpool[@]}; do
     # Switch to cluster context
     az aks get-credentials -n $clustername -g $DAPR_TEST_RESOURCE_GROUP
     if [ $? -ne 0 ]; then
-        echo "Failed to switch to $clustername context. Retry to get available test cluster after 10 seconds ..."
-        sleep 10
-        continue
-    fi
-
-    echo "Checking if $KUBE_TEST_NAMESPACE namespace has any running pod ..."
-
-    running_pods=$(kubectl get pods -o=jsonpath='{.items}' -n ${KUBE_TEST_NAMESPACE})
-    if [ $? -ne 0 ]; then
-        echo "Failed to run kubectl. Retry to get available test cluster after 10 seconds."
+        echo "Failed to switch to $clustername context. Retry to get available test cluster after 5 seconds ..."
         sleep 5
         continue
     fi
 
-    # If the namespace is empty, then items array is empty
-    if [ "$running_pods" == "[]" ]; then
-        echo "Found available test cluster: $clustername"
-        exit 0
-    fi
+    # To resolve the racing condition when multiple tests are running,
+    # this script tries to create the namespace. If it is failed, we can assume 
+    # that this cluster is being used by the other tests.
+    echo "Trying to create ${KUBE_TEST_NAMESPACE} namespace..."
+    kubectl create namespace ${KUBE_TEST_NAMESPACE}
 
-    # Get the running time for one of pods in dapr-tests namespace
-    start_datetime=$(kubectl get pods -n ${KUBE_TEST_NAMESPACE} -o=jsonpath='{.items[0].status.startTime}')
+    # Get the running time of dapr-tests namespace
+    start_datetime=$(kubectl get namespace ${KUBE_TEST_NAMESPACE} -o=jsonpath='{.metadata.creationTimestamp}')
     if [ $? -ne 0 ]; then
-        echo "Cannot get startTime of the first pod with kubectl (Test cluster is being cleaned up)."
-        echo "Retry to get available test cluster after 10 seconds."
+        echo "Cannot get creation time of namespace with kubectl (Test cluster is being cleaned up)."
+        echo "Retry to get available test cluster after 5 seconds."
         sleep 5
         continue
     fi
 
     # NOTE: 'date' is GNU version date. Please use gdate on mac os
     # after installing coreutils (brew install coreutils)
-    start_sec=$(date -d "$start_datetime" +%s)
-    now_sec=$(date +%s)
+    start_sec=$(gdate -d "$start_datetime" +%s)
+    now_sec=$(gdate +%s)
     running_time=$((now_sec-start_sec))
 
-    echo "Found that the POD is running for $running_time seconds"
+    echo "Namespace is being used for $running_time seconds"
 
-    # If running time is greater than 7200 seconds (2 hours), it might be because of test failure.
-    # In this case, we can use this cluster after cleaning up the old pods
-    if [ $running_time -gt 100 ]; then
+    # If running time is greater than $MAX_TEST_TIMEOUT, it might be because of test failure.
+    # In this case, we can use this cluster.
+    if [ $running_time -gt $MAX_TEST_TIMEOUT ]; then
         echo "The previous test running in this cluster might be cancelled or failed accidently so use $clustername cluster for e2e test."
         exit 0
     fi

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+# This script scans all AKS clusters in test cluster pools to find the available test cluster
+
+# The test cluster pool for e2e test
+# TODO: Add more aks test clusters
+testclusterpool=(
+    "dapr-aks-e2e-01"
+    "dapr-aks-e2e-02"
+    "dapr-aks-e2e-03"
+    "dapr-aks-e2e-04"
+)
+
+if [ -z "$DAPR_TEST_RESOURCE_GROUP" ]; then
+    DAPR_TEST_RESOURCE_GROUP="dapre2e"
+fi
+
+if [ -z "$KUBE_TEST_NAMESPACE" ]; then
+    KUBE_TEST_NAMESPACE="dapr-tests"
+fi
+
+echo "Selected Dapr Test Resource group: $DAPR_TEST_RESOURCE_GROUP"
+echo "Selected Kubernetes Namespace: $KUBE_TEST_NAMESPACE"
+
+# Find the available cluster
+for clustername in ${testclusterpool[@]}; do
+    echo "Scanning $clustername ..."
+
+    echo "Switching to $clustername context..."
+    # Switch to cluster context
+    az aks get-credentials -n $clustername -g $DAPR_TEST_RESOURCE_GROUP
+    if [ $? -ne 0 ]; then
+        echo "Failed to switch to $clustername context. Retry to get available test cluster after 10 seconds ..."
+        sleep 10
+        continue
+    fi
+
+    echo "Checking if $KUBE_TEST_NAMESPACE namespace has any running pod ..."
+
+    running_pods=$(kubectl get pods -o=jsonpath='{.items}' -n ${KUBE_TEST_NAMESPACE})
+    if [ $? -ne 0 ]; then
+        echo "Failed to run kubectl. Retry to get available test cluster after 10 seconds."
+        sleep 5
+        continue
+    fi
+
+    # If the namespace is empty, then items array is empty
+    if [ "$running_pods" == "[]" ]; then
+        echo "Found available test cluster: $clustername"
+        exit 0
+    fi
+
+    # Get the running time for one of pods in dapr-tests namespace
+    start_datetime=$(kubectl get pods -n ${KUBE_TEST_NAMESPACE} -o=jsonpath='{.items[0].status.startTime}')
+    if [ $? -ne 0 ]; then
+        echo "Cannot get startTime of the first pod with kubectl (Test cluster is being cleaned up)."
+        echo "Retry to get available test cluster after 10 seconds."
+        sleep 5
+        continue
+    fi
+
+    # NOTE: 'date' is GNU version date. Please use gdate on mac os
+    # after installing coreutils (brew install coreutils)
+    start_sec=$(date -d "$start_datetime" +%s)
+    now_sec=$(date +%s)
+    running_time=$((now_sec-start_sec))
+
+    echo "Found that the POD is running for $running_time seconds"
+
+    # If running time is greater than 7200 seconds (2 hours), it might be because of test failure.
+    # In this case, we can use this cluster after cleaning up the old pods
+    if [ $running_time -gt 100 ]; then
+        echo "The previous test running in this cluster might be cancelled or failed accidently so use $clustername cluster for e2e test."
+        exit 0
+    fi
+
+    echo "-------------------------------------------------------"
+
+    sleep 1
+done
+
+echo "All test clusters are fully occupied."
+
+exit 1


### PR DESCRIPTION
# Description

This is the script to find the available AKS cluster in the preconfigured pool. This will be the first CI build step to select the available cluster. It will try to create test namespace to resolve the race condition by the multiple tests.

## Issue reference

#375 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
