### PR TITLE
[E2E] Split e2e package to each e2e test

### DIFF
--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -9,7 +9,8 @@ E2E tests are designed for verifying the functional correctness by replicating e
 
 ### Prerequisites
 
-* Set up your kubernetes environment and install the latest helm v2 by following [this setup doc](https://github.com/dapr/docs/blob/master/getting-started/environment-setup.md#installing-dapr-on-a-kubernetes-cluster).
+* Set up [Dapr development environment](https://github.com/dapr/dapr/blob/master/docs/development/setup-dapr-development-env.md)
+  - [Install the latest helm v2](https://github.com/dapr/docs/blob/master/getting-started/environment-setup.md#installing-dapr-on-a-kubernetes-cluster).
 * Create your DockerHub ID
 * Set the environment variables
     ```bash
@@ -24,7 +25,6 @@ E2E tests are designed for verifying the functional correctness by replicating e
     # export DAPR_TEST_REGISTRY=docker.io/your_dockerhub_id
     # export DARP_TEST_TAG=dev
     ```
-
 * Install redis and kafka for state, pubsub, and binding building block
     ```bash
     make setup-helm-init
@@ -51,6 +51,12 @@ make docker-push
 make docker-deploy-k8s
 ```
 
+### Register the default component configurations for testing
+
+```bash
+make setup-test-components
+```
+
 ### Build and push test apps to docker hub
 
 Build docker images from apps and push the images to test docker hub
@@ -61,12 +67,6 @@ make build-e2e-app-all
 
 # push e2e apps docker image to docker hub
 make push-e2e-app-all
-```
-
-### Register the default component configurations for testing
-
-```bash
-make setup-test-components
 ```
 
 ### Run end-to-end test

--- a/tests/docs/writing-e2e-test.md
+++ b/tests/docs/writing-e2e-test.md
@@ -49,19 +49,21 @@ kubectl delete -f service.yaml
 
 ## Add test driver
 
-A test driver is a typical Go test with `e2e` build tag in [/tests/e2e/](../e2e/). It can deploy test apps to a test cluster, run the tests, and clean up all test apps and any resources. We provides test runner framework to manage the test app's lifecycle during the test so that you do not need to manage the test apps by yourself. We plan to add more functionalities to test runner later, such as the log collection of test app POD.
+A test driver is a typical Go test with `e2e` build tag under [/tests/e2e/](../e2e/). It can deploy test apps to a test cluster, run the tests, and clean up all test apps and any resources. We provides test runner framework to manage the test app's lifecycle during the test so that you do not need to manage the test apps by yourself. We plan to add more functionalities to test runner later, such as the log collection of test app POD.
 
 ### Writing test app
 
+1. Create new test directory under [/tests/e2e/](../e2e).
 1. Create go test file based on the below example:
    - `// +build e2e` must be placed at the first line of test code
    - `TestMain(m *testing.M)` defines the list of test apps and component, which will be used in `TestXxx(t *testing.T)`
+   - Define new package for the test
    - Use Go test best practice
 
 ```go
 // +build e2e
 
-package e2e
+package hellodapr_e2e
 
 import (
     "testing"

--- a/tests/e2e/hellodapr/hellodapr_test.go
+++ b/tests/e2e/hellodapr/hellodapr_test.go
@@ -86,7 +86,7 @@ func TestHelloDapr(t *testing.T) {
 			require.NotEmpty(t, externalURL, "external URL must not be empty")
 
 			// Check if test app endpoint is available
-			resp, err := utils.httpGet(externalURL)
+			resp, err := utils.HTTPGet(externalURL)
 			require.NoError(t, err)
 
 			// Trigger test
@@ -95,7 +95,7 @@ func TestHelloDapr(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			resp, err = utils.httpPost(fmt.Sprintf("%s/tests/%s", externalURL, tt.testCommand), body)
+			resp, err = utils.HTTPPost(fmt.Sprintf("%s/tests/%s", externalURL, tt.testCommand), body)
 			require.NoError(t, err)
 
 			var appResp appResponse

--- a/tests/e2e/hellodapr/hellodapr_test.go
+++ b/tests/e2e/hellodapr/hellodapr_test.go
@@ -16,7 +16,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/stretchr/testify/require"
-	utils "github.com/dapr/dapr/tests/e2e/utils"
+	"github.com/dapr/dapr/tests/e2e/utils"
 )
 
 type testCommandRequest struct {

--- a/tests/e2e/hellodapr/hellodapr_test.go
+++ b/tests/e2e/hellodapr/hellodapr_test.go
@@ -5,7 +5,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package e2e
+package hellodapr_e2e
 
 import (
 	"encoding/json"
@@ -16,6 +16,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/stretchr/testify/require"
+	utils "github.com/dapr/dapr/tests/e2e/utils"
 )
 
 type testCommandRequest struct {
@@ -85,7 +86,7 @@ func TestHelloDapr(t *testing.T) {
 			require.NotEmpty(t, externalURL, "external URL must not be empty")
 
 			// Check if test app endpoint is available
-			resp, err := httpGet(externalURL)
+			resp, err := utils.httpGet(externalURL)
 			require.NoError(t, err)
 
 			// Trigger test
@@ -94,7 +95,7 @@ func TestHelloDapr(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			resp, err = httpPost(fmt.Sprintf("%s/tests/%s", externalURL, tt.testCommand), body)
+			resp, err = utils.httpPost(fmt.Sprintf("%s/tests/%s", externalURL, tt.testCommand), body)
 			require.NoError(t, err)
 
 			var appResp appResponse

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -5,7 +5,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package e2e
+package utils
 
 import (
 	"bytes"

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -30,7 +30,7 @@ func newHTTPClient() http.Client {
 // HTTPGet is a helper to make GET request call to url
 func HTTPGet(url string) ([]byte, error) {
 	client := newHTTPClient()
-	resp, err := client.Get(sanitizeHTTPURL(url))
+	resp, err := client.Get(sanitizeHTTPURL(url)) //nolint
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func HTTPGet(url string) ([]byte, error) {
 // HTTPPost is a helper to make POST request call to url
 func HTTPPost(url string, data []byte) ([]byte, error) {
 	client := newHTTPClient()
-	resp, err := client.Post(sanitizeHTTPURL(url), "application/json", bytes.NewBuffer(data))
+	resp, err := client.Post(sanitizeHTTPURL(url), "application/json", bytes.NewBuffer(data)) //nolint
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 // ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
@@ -18,7 +16,7 @@ import (
 	"time"
 )
 
-func newHttpClient() http.Client {
+func newHTTPClient() http.Client {
 	return http.Client{
 		Transport: &http.Transport{
 			// Sometimes, the first connection to ingress endpoint takes longer than 1 minute (e.g. AKS)
@@ -29,9 +27,10 @@ func newHttpClient() http.Client {
 	}
 }
 
-func httpGet(url string) ([]byte, error) {
-	client := newHttpClient()
-	resp, err := client.Get(sanitizeHttpUrl(url))
+// HTTPGet is a helper to make GET request call to url
+func HTTPGet(url string) ([]byte, error) {
+	client := newHTTPClient()
+	resp, err := client.Get(sanitizeHTTPURL(url))
 	if err != nil {
 		return nil, err
 	}
@@ -39,9 +38,10 @@ func httpGet(url string) ([]byte, error) {
 	return extractBody(resp.Body)
 }
 
-func httpPost(url string, data []byte) ([]byte, error) {
-	client := newHttpClient()
-	resp, err := client.Post(sanitizeHttpUrl(url), "application/json", bytes.NewBuffer(data))
+// HTTPPost is a helper to make POST request call to url
+func HTTPPost(url string, data []byte) ([]byte, error) {
+	client := newHTTPClient()
+	resp, err := client.Post(sanitizeHTTPURL(url), "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func httpPost(url string, data []byte) ([]byte, error) {
 	return extractBody(resp.Body)
 }
 
-func sanitizeHttpUrl(url string) string {
+func sanitizeHTTPURL(url string) string {
 	if !strings.Contains(url, "http") {
 		url = fmt.Sprintf("http://%s", url)
 	}


### PR DESCRIPTION
# Description

TestMain() is called once in the entire package so that we could not create the multiple go test files having TestMain(). This pr is to separate e2e package to each test package and update the docs.

## Issue reference

#846 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
