### PR TITLE
e2e: enable running on EKS

### DIFF
--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -269,7 +269,13 @@ func (m *AppManager) WaitUntilServiceState(isState func(*apiv1.Service, error) b
 // AcquireExternalURLFromService gets external url from Service Object.
 func (m *AppManager) AcquireExternalURLFromService(svc *apiv1.Service) string {
 	if svc.Status.LoadBalancer.Ingress != nil && len(svc.Status.LoadBalancer.Ingress) > 0 && len(svc.Spec.Ports) > 0 {
-		return fmt.Sprintf("%s:%d", svc.Status.LoadBalancer.Ingress[0].IP, svc.Spec.Ports[0].Port)
+		address := ""
+		if svc.Status.LoadBalancer.Ingress[0].Hostname != "" {
+			address = svc.Status.LoadBalancer.Ingress[0].Hostname
+		} else {
+			address = svc.Status.LoadBalancer.Ingress[0].IP
+		}
+		return fmt.Sprintf("%s:%d", address, svc.Spec.Ports[0].Port)
 	}
 
 	// TODO: Support the other local k8s clusters


### PR DESCRIPTION
This enabled the e2e tests to run on EKS by utilizing ingress hostnames.

fixes #890 