### PR TITLE
Fix test name for state app

### DIFF
--- a/tests/e2e/stateapp/stateapp_test.go
+++ b/tests/e2e/stateapp/stateapp_test.go
@@ -217,7 +217,7 @@ func TestMain(m *testing.M) {
 	os.Exit(tr.Start(m))
 }
 
-func TestServiceInvocation(t *testing.T) {
+func TestStateApp(t *testing.T) {
 	externalURL := tr.Platform.AcquireAppExternalURL(appName)
 	require.NotEmpty(t, externalURL, "external URL must not be empty!")
 	testCases := generateTestCases()


### PR DESCRIPTION
Fix test name for state app

# Description

Test name for State App is incorrectly set to Service Invocation test

## Issue reference

Closes #898 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
