### PR TITLE
Fixed HTTP middleware pipeline

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -51,10 +51,10 @@ func (s *server) StartNonBlocking() {
 	go func() {
 		if s.tracingSpec.Enabled {
 			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.Port),
-				s.pipeline.Apply(diag.TracingHTTPMiddleware(s.tracingSpec, corsHandler.CorsMiddleware(handler)))))
+				diag.TracingHTTPMiddleware(s.tracingSpec, corsHandler.CorsMiddleware(handler))))
 		} else {
 			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.Port),
-				s.pipeline.Apply(corsHandler.CorsMiddleware(handler))))
+				corsHandler.CorsMiddleware(handler)))
 		}
 	}()
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 
 	cors "github.com/AdhityaRamadhanus/fasthttpcors"
-	log "github.com/sirupsen/logrus"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 	routing "github.com/qiangxue/fasthttp-routing"
+	log "github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/pprofhandler"
 )
@@ -44,9 +44,9 @@ func NewServer(api API, config ServerConfig, tracingSpec config.TracingSpec, pip
 // StartNonBlocking starts a new server in a goroutine
 func (s *server) StartNonBlocking() {
 	handler :=
-			s.useCors(
-				s.useComponents(
-					s.useRouter()))
+		s.useCors(
+			s.useComponents(
+				s.useRouter()))
 
 	if s.tracingSpec.Enabled {
 		handler = s.useTracing(handler)

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -43,19 +43,17 @@ func NewServer(api API, config ServerConfig, tracingSpec config.TracingSpec, pip
 
 // StartNonBlocking starts a new server in a goroutine
 func (s *server) StartNonBlocking() {
-	endpoints := s.api.APIEndpoints()
-	router := s.getRouter(endpoints)
-	origins := strings.Split(s.config.AllowedOrigins, ",")
-	corsHandler := s.getCorsHandler(origins)
-	handler := s.pipeline.Apply(router.HandleRequest)
+	handler :=
+			s.useCors(
+				s.useComponents(
+					s.useRouter()))
+
+	if s.tracingSpec.Enabled {
+		handler = s.useTracing(handler)
+	}
+
 	go func() {
-		if s.tracingSpec.Enabled {
-			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.Port),
-				diag.TracingHTTPMiddleware(s.tracingSpec, corsHandler.CorsMiddleware(handler))))
-		} else {
-			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.Port),
-				corsHandler.CorsMiddleware(handler)))
-		}
+		log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.Port), handler))
 	}()
 
 	if s.config.EnableProfiling {
@@ -64,6 +62,26 @@ func (s *server) StartNonBlocking() {
 			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.ProfilePort), pprofhandler.PprofHandler))
 		}()
 	}
+}
+
+func (s *server) useTracing(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	return diag.TracingHTTPMiddleware(s.tracingSpec, next)
+}
+
+func (s *server) useRouter() fasthttp.RequestHandler {
+	endpoints := s.api.APIEndpoints()
+	router := s.getRouter(endpoints)
+	return router.HandleRequest
+}
+
+func (s *server) useComponents(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	return s.pipeline.Apply(next)
+}
+
+func (s *server) useCors(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	origins := strings.Split(s.config.AllowedOrigins, ",")
+	corsHandler := s.getCorsHandler(origins)
+	return corsHandler.CorsMiddleware(next)
 }
 
 func (s *server) getCorsHandler(allowedOrigins []string) *cors.CorsHandler {


### PR DESCRIPTION
# Description

Removed the additional `pipeline.Apply(...)` call from the HTTP server that caused the pipeline to include duplicate component based middleware.

Feels like maybe we should take this opportunity to clean up this code too - it's not super clear on the order of middleware or how it compliments the builtin middleware. Something like below: 
```
handler := s.useCors(
	        s.useComponents(
                    s.useRouter()))

if s.tracingSpec.Enabled {
	handler = s.useTracing(handler)
}

go func() {
	log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.Port), handler))
}()
...
```

## Issue reference

Please reference the issue this PR will close: #948 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
