### PR TITLE
Migrate from helm-2 to helm-3

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -18,8 +18,8 @@ jobs:
       GOPROXY: https://proxy.golang.org
       DAPR_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       DAPR_TEST_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
-      HELMVER: v2.16.1
-      HELM_NAMESPACE: dapr-tests
+      HELMVER: v3.0.2
+      DAPR_NAMESPACE: dapr-tests
       MAX_TEST_TIMEOUT: 5400
     steps:
       - name: Parse test payload

--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,11 @@ DOCKERFILE:=Dockerfile
 # Helm template and install setting
 HELM:=helm
 RELEASE_NAME?=dapr
-HELM_NAMESPACE?=dapr-system
+DAPR_NAMESPACE?=dapr-system
 HELM_CHART_ROOT:=./charts
 HELM_CHART_DIR:=$(HELM_CHART_ROOT)/dapr
 HELM_OUT_DIR:=$(OUT_DIR)/install
-HELM_MANIFEST_FILE:=$(HELM_CHART_ROOT)/manifest/$(RELEASE_NAME).yaml
+HELM_MANIFEST_FILE:=$(HELM_OUT_DIR)/$(RELEASE_NAME).yaml
 
 ################################################################################
 # Go build details                                                             #
@@ -211,10 +211,7 @@ endif
 # Generate helm chart manifest
 manifest-gen: dapr.yaml
 
-$(HOME)/.helm:
-	$(HELM) init --client-only
-
-dapr.yaml: check-docker-env $(HOME)/.helm
+dapr.yaml: check-docker-env
 	$(info Generating helm manifest $(HELM_MANIFEST_FILE)...)
 	@mkdir -p $(HELM_OUT_DIR)
 	$(HELM) template \
@@ -224,10 +221,10 @@ dapr.yaml: check-docker-env $(HOME)/.helm
 # Target: docker-deploy-k8s                                                    #
 ################################################################################
 
-docker-deploy-k8s: check-docker-env $(HOME)/.helm
+docker-deploy-k8s: check-docker-env
 	$(info Deploying ${DAPR_REGISTRY}/${RELEASE_NAME}:${DAPR_TAG} to the current K8S context...)
 	$(HELM) install \
-		--name=$(RELEASE_NAME) --namespace=$(HELM_NAMESPACE) \
+		$(RELEASE_NAME) --namespace=$(DAPR_NAMESPACE) \
 		--set-string global.tag=$(DAPR_TAG) --set-string global.registry=$(DAPR_REGISTRY) $(HELM_CHART_DIR)
 
 ################################################################################

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -13,7 +13,7 @@ E2E_TESTAPP_DIR=./tests/apps
 KUBECTL=kubectl
 
 ifeq ($(DAPR_TEST_NAMESPACE),)
-DAPR_TEST_NAMESPACE=$(HELM_NAMESPACE)
+DAPR_TEST_NAMESPACE=$(DAPR_NAMESPACE)
 endif
 
 ifeq ($(DAPR_TEST_REGISTRY),)
@@ -74,18 +74,18 @@ test-e2e-all: check-e2e-env
 	DAPR_TEST_NAMESPACE=$(DAPR_TEST_NAMESPACE) DAPR_TEST_TAG=$(DAPR_TEST_TAG) DAPR_TEST_REGISTRY=$(DAPR_TEST_REGISTRY) DAPR_TEST_MINIKUBE_IP=$(MINIKUBE_NODE_IP) go test -count=1 -v -tags=e2e ./tests/e2e/...
 
 # add required helm repo
-setup-helm-init: $(HOME)/.helm
+setup-helm-init:
 	$(HELM) repo add stable https://kubernetes-charts.storage.googleapis.com/
 	$(HELM) repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
 	$(HELM) repo update
 
 # install redis to the cluster without password
 setup-test-env-redis:
-	$(HELM) install --wait --timeout 1000 --name dapr-redis --set usePassword=false stable/redis --namespace $(DAPR_TEST_NAMESPACE)
+	$(HELM) install dapr-redis stable/redis --wait --timeout 5m0s --set usePassword=false --namespace $(DAPR_TEST_NAMESPACE)
 
 # install kafka to the cluster
 setup-test-env-kafka:
-	$(HELM) install -f ./tests/config/kafka_override.yaml --wait --timeout 1000 --name dapr-kafka --namespace $(DAPR_TEST_NAMESPACE) incubator/kafka
+	$(HELM) install dapr-kafka incubator/kafka --wait --timeout 10m0s --namespace $(DAPR_TEST_NAMESPACE) -f ./tests/config/kafka_override.yaml 
 
 # Install redis and kafka to test cluster
 setup-test-env: setup-test-env-redis setup-test-env-kafka

--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -16,7 +16,7 @@ E2E tests are designed for verifying the functional correctness by replicating e
     ```bash
     export DAPR_REGISTRY=docker.io/your_dockerhub_id
     export DAPR_TAG=dev
-    export HELM_NAMESPACE=dapr-tests
+    export DAPR_NAMESPACE=dapr-tests
 
     # Do not set DAPR_TEST_ENV if you do not use minikube
     export DAPR_TEST_ENV=minikube

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -22,8 +22,8 @@ testclusterpool=(
 [ -z "$DAPR_TEST_RESOURCE_GROUP" ] && DAPR_TEST_RESOURCE_GROUP="dapre2e"
 
 if [ -z "$DAPR_TEST_NAMESPACE" ]; then
-    if [ ! -z "$HELM_NAMESPACE" ]; then
-        DAPR_TEST_NAMESPACE=$HELM_NAMESPACE
+    if [ ! -z "$DAPR_NAMESPACE" ]; then
+        DAPR_TEST_NAMESPACE=$DAPR_NAMESPACE
     else
         DAPR_TEST_NAMESPACE="dapr-tests"
     fi


### PR DESCRIPTION
# Description

This PR migrates from helm 2 to helm 3 for development environment.

* Use the latest helm 3.0.2 for e2e test
* Use helm 3 commands for developing commands in makefile
* Rename HELM_NAMESPACE to DAPR_NAMESPACE
* Update docs.

## Issue reference

#964 
#963 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
