### PR TITLE
Specify namespace for helm 3 uninstall

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -100,5 +100,5 @@ setup-test-components:
 	$(KUBECTL) get components --namespace $(DAPR_TEST_NAMESPACE)
 
 # Clean up test environment
-clean-test-env: $(HOME)/.helm
+clean-test-env:
 	./tests/test-infra/clean_up.sh $(DAPR_TEST_NAMESPACE)

--- a/tests/test-infra/clean_up.sh
+++ b/tests/test-infra/clean_up.sh
@@ -7,10 +7,11 @@
 
 [ -z "$1" ] && echo "Namespace must be specified" && exit 0
 
-installed_apps=$(helm list -q)
+installed_apps=$(helm list -q -n $1)
+echo $installed_apps
 
 for app in $installed_apps; do
-    helm delete --purge $app
+    helm uninstall $app -n $1
 done
 
 echo "Trying to delete namespace..."


### PR DESCRIPTION
# Description

Helm 3 requires to specify namespace when app is uninstalled

## Issue reference

#965 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
