### PR TITLE
Update .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 5m
+  deadline: 10m
 
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1


### PR DESCRIPTION
Windows linting takes longer and causes build tests to time out every other build.
This PR raises the deadline timeout.