### PR TITLE
Make dapr bot smarter

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -32,10 +32,20 @@ jobs:
             const isFromPulls = !!payload.issue.pull_request;
             const commentBody = payload.comment.body;
 
-            if (isFromPulls && commentBody && commentBody.indexOf("/ok-to-test") >= 0) {
+            if (isFromPulls && commentBody && commentBody.indexOf("/ok-to-test") == 0) {
               // Ignore the command unless the actor is in owner list
               if (owners.indexOf(context.actor) < 0) {
-                console.log(`${context.actor} doesn't have the permission to execute the comment`);
+                const errorMessage = `${context.actor} doesn't have the permission to execute the command`;
+
+                console.log(errorMessage);
+                
+                await github.issues.createComment({
+                  owner: issue.owner,
+                  repo: issue.repo,
+                  issue_number: issue.number,
+                  body: errorMessage
+                });
+
                 return;
               }
 


### PR DESCRIPTION
# Description

Bot adds error message if user doesn't have permission to execute

* Add comment if user doesn't have permission to execute command
* Trigger the bot only if user leaves a comment starting '/ok-to-test'

## Issue reference

N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
