### PR TITLE
Now correctly setting bindings.Metadata.Name for Output Bindings

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -596,6 +596,7 @@ func (a *DaprRuntime) initOutputBindings(registry bindings_loader.Registry) erro
 			if binding != nil {
 				err := binding.Init(bindings.Metadata{
 					Properties: a.convertMetadataItemsToProperties(c.Spec.Metadata),
+					Name:       c.ObjectMeta.Name,
 				})
 				if err != nil {
 					log.Warnf("failed to init output binding %s: %s", c.Spec.Type, err)


### PR DESCRIPTION
Fixes #1032

# Description

Now setting bindings.Metadata.Name when OutputBindings are initialized

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1032

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
