### PR TITLE
fix content-type override

### DIFF
--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -44,13 +44,10 @@ type Channel struct {
 	ch          chan int
 }
 
-func getContentType(metadata map[string]string) string {
-	if metadata != nil {
-		if val, ok := metadata[ContentType]; ok && val != "" {
-			return val
-		}
+func applyContentTypeIfNotPresent(req *fasthttp.Request) {
+	if len(req.Header.ContentType()) == 0 {
+		req.Header.SetContentType(defaultContentType)
 	}
-	return defaultContentType
 }
 
 // InvokeMethod invokes user code via HTTP
@@ -71,8 +68,7 @@ func (h *Channel) InvokeMethod(invokeRequest *channel.InvokeRequest) (*channel.I
 			}
 		}
 	}
-	contentType := getContentType(invokeRequest.Metadata)
-	req.Header.SetContentType(contentType)
+	applyContentTypeIfNotPresent(req)
 
 	method := invokeRequest.Metadata[HTTPVerb]
 	if method == "" {
@@ -85,6 +81,7 @@ func (h *Channel) InvokeMethod(invokeRequest *channel.InvokeRequest) (*channel.I
 	if h.ch != nil {
 		h.ch <- 1
 	}
+
 	err := h.client.Do(req, resp)
 	if h.ch != nil {
 		<-h.ch

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -163,7 +163,9 @@ func TestContentType(t *testing.T) {
 		server := httptest.NewServer(handler)
 		c := Channel{baseAddress: server.URL, client: &fasthttp.Client{}}
 		request := &channel.InvokeRequest{
-			Metadata: map[string]string{ContentType: "application/json"},
+			Metadata: map[string]string{
+				"headers": "Content-Type&__header_equals__&application/json&__header_delim__&h2&__header_equals__&v2",
+			},
 		}
 		c.InvokeMethod(request)
 		assert.Equal(t, "application/json", handler.ContentType)
@@ -175,7 +177,9 @@ func TestContentType(t *testing.T) {
 		server := httptest.NewServer(handler)
 		c := Channel{baseAddress: server.URL, client: &fasthttp.Client{}}
 		request := &channel.InvokeRequest{
-			Metadata: map[string]string{ContentType: "custom"},
+			Metadata: map[string]string{
+				"headers": "Content-Type&__header_equals__&custom&__header_delim__&h2&__header_equals__&v2",
+			},
 		}
 		c.InvokeMethod(request)
 		assert.Equal(t, "custom", handler.ContentType)

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -488,7 +488,7 @@ func (a *api) onDirectMessage(c *routing.Context) error {
 	} else {
 		statusCode := GetStatusCodeFromMetadata(resp.Metadata)
 		a.setHeadersOnRequest(resp.Metadata, c)
-		respondWithJSON(c.RequestCtx, statusCode, resp.Data)
+		respond(c.RequestCtx, statusCode, resp.Data)
 	}
 
 	return nil

--- a/pkg/http/responses.go
+++ b/pkg/http/responses.go
@@ -11,24 +11,33 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const (
+	jsonContentTypeHeader = "application/json"
+	etagHeader            = "ETag"
+)
+
+// respondWithJSON overrides the content-type with application/json
 func respondWithJSON(ctx *fasthttp.RequestCtx, code int, obj []byte) {
-	ctx.Response.Header.SetContentType("application/json")
-	ctx.Response.SetStatusCode(code)
-	ctx.Response.SetBody(obj)
+	respond(ctx, code, obj)
+	ctx.Response.Header.SetContentType(jsonContentTypeHeader)
 }
 
+// respond sets a default application/json content type if content type is not present
+func respond(ctx *fasthttp.RequestCtx, code int, obj []byte) {
+	ctx.Response.SetStatusCode(code)
+	ctx.Response.SetBody(obj)
+
+	if len(ctx.Response.Header.ContentType()) == 0 {
+		ctx.Response.Header.SetContentType(jsonContentTypeHeader)
+	}
+}
+
+// respondWithETaggedJSON overrides the content-type with application/json and etag header
 func respondWithETaggedJSON(ctx *fasthttp.RequestCtx, code int, obj []byte, etag string) {
-	ctx.Response.Header.SetContentType("application/json")
-	ctx.Response.Header.Set("ETag", etag)
-	ctx.Response.SetStatusCode(code)
-	ctx.Response.SetBody(obj)
+	respond(ctx, code, obj)
+	ctx.Response.Header.SetContentType(jsonContentTypeHeader)
+	ctx.Response.Header.Set(etagHeader, etag)
 }
-
-//func respondWithString(ctx *fasthttp.RequestCtx, code int, obj string) {
-//	ctx.Response.Header.SetContentType("application/json")
-//	ctx.Response.SetStatusCode(code)
-//	ctx.Response.SetBodyString(obj)
-//}
 
 func respondWithError(ctx *fasthttp.RequestCtx, code int, resp ErrorResponse) {
 	b, _ := json.Marshal(&resp)
@@ -39,16 +48,3 @@ func respondEmpty(ctx *fasthttp.RequestCtx, code int) {
 	ctx.Response.SetBody(nil)
 	ctx.Response.SetStatusCode(code)
 }
-
-//func serializeToJSON(obj interface{}) ([]byte, error) {
-//	buffer := &bytes.Buffer{}
-//	encoder := json.NewEncoder(buffer)
-//	encoder.SetEscapeHTML(false)
-//	err := encoder.Encode(obj)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	bytes := buffer.Bytes()
-//	return bytes, nil
-//}

--- a/pkg/http/responses_test.go
+++ b/pkg/http/responses_test.go
@@ -1,0 +1,54 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func TestHeaders(t *testing.T) {
+	t.Run("Respond with JSON", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
+		respondWithJSON(ctx, 200, nil)
+
+		assert.Equal(t, "application/json", string(ctx.Response.Header.ContentType()))
+	})
+
+	t.Run("Respond with JSON overrides custom content-type", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
+		ctx.Response.Header.SetContentType("custom")
+		respondWithJSON(ctx, 200, nil)
+
+		assert.Equal(t, "application/json", string(ctx.Response.Header.ContentType()))
+	})
+
+	t.Run("Respond with ETag JSON", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
+		etagValue := "etagValue"
+		respondWithETaggedJSON(ctx, 200, nil, etagValue)
+
+		assert.Equal(t, etagValue, string(ctx.Response.Header.Peek(etagHeader)))
+	})
+
+	t.Run("Respond with custom content type", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
+		customContentType := "custom"
+		ctx.Response.Header.SetContentType(customContentType)
+		respond(ctx, 200, nil)
+
+		assert.Equal(t, customContentType, string(ctx.Response.Header.ContentType()))
+	})
+
+	t.Run("Respond with default content type", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
+		respond(ctx, 200, nil)
+
+		assert.Equal(t, "text/plain; charset=utf-8", string(ctx.Response.Header.ContentType()))
+	})
+}


### PR DESCRIPTION
Closes https://github.com/dapr/dapr/issues/1072

This PR does the following:

1. Treats content-type as any other header. Until now, it was treated in a special way and not respected in the caller side, only in the app channel side. This resulted in a custom content type not arriving to the app.

2. Fixed direct messaging API to not apply `application/json` content type on response header if one is already present from the invoke response.

3. Removes unneeded commented out code