### PR TITLE
Refactor host_ip env var usage

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
+	"github.com/dapr/dapr/pkg/runtime"
 	"github.com/dapr/dapr/pkg/sentry/certs"
 	sentry_config "github.com/dapr/dapr/pkg/sentry/config"
 	log "github.com/sirupsen/logrus"
@@ -265,7 +266,7 @@ func getSidecarContainer(applicationPort, applicationProtocol, id, config, daprS
 			},
 		},
 		Command: []string{"/daprd"},
-		Env:     []corev1.EnvVar{{Name: "HOST_IP", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}}, {Name: "NAMESPACE", Value: namespace}},
+		Env:     []corev1.EnvVar{{Name: runtime.HostIPEnvVar, ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}}, {Name: "NAMESPACE", Value: namespace}},
 		Args:    []string{"--mode", "kubernetes", "--dapr-http-port", fmt.Sprintf("%v", sidecarHTTPPort), "--dapr-grpc-port", fmt.Sprintf("%v", sidecarGRPCPORT), "--app-port", applicationPort, "--dapr-id", id, "--control-plane-address", controlPlaneAddress, "--protocol", applicationProtocol, "--placement-address", placementServiceAddress, "--config", config, "--enable-profiling", enableProfiling, "--log-level", logLevel, "--max-concurrency", maxConcurrency, "--sentry-address", sentryAddress},
 	}
 

--- a/pkg/runtime/host.go
+++ b/pkg/runtime/host.go
@@ -1,0 +1,32 @@
+package runtime
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"errors"
+)
+
+const (
+	HostIPEnvVar        = "DAPR_HOST_IP"
+)
+
+func GetHostAddress() (string, error) {
+	if val, ok := os.LookupEnv(HostIPEnvVar); ok && val != "" {
+		return val, nil
+	}
+	
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", fmt.Errorf("error getting interface addresses: %s", err)
+	}
+
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String(), nil
+			}
+		}
+	}
+	return "", errors.New("could not determine non-loopback host address")
+}

--- a/pkg/runtime/host_test.go
+++ b/pkg/runtime/host_test.go
@@ -1,0 +1,26 @@
+package runtime
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHostAdress(t *testing.T) {
+	t.Run("DAPR_HOST_IP present", func(t *testing.T) {
+		hostIP := "test.local"
+		os.Setenv(HostIPEnvVar, hostIP)
+		defer os.Clearenv()
+
+		address, err := GetHostAddress()
+		assert.Nil(t, err)
+		assert.Equal(t, hostIP, address)
+	})
+
+	t.Run("DAPR_HOST_IP not present, non-empty response", func(t *testing.T) {
+		address, err := GetHostAddress()
+		assert.Nil(t, err)
+		assert.NotEmpty(t, address)
+	})
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -56,7 +56,6 @@ import (
 
 const (
 	appConfigEndpoint   = "dapr/config"
-	hostIPEnvVar        = "HOST_IP"
 	parallelConcurrency = "parallel"
 	actorStateStore     = "actorStateStore"
 )
@@ -152,9 +151,9 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 
 	a.blockUntilAppIsReady()
 
-	err = a.setHostAddress()
+	a.hostAddress, err = GetHostAddress()
 	if err != nil {
-		log.Warnf("failed to set host address: %s", err)
+		return fmt.Errorf("failed to determine host address: %s", err)
 	}
 
 	err = a.createAppChannel()
@@ -508,26 +507,6 @@ func (a *DaprRuntime) startGRPCServer(port int) error {
 	server := grpc.NewServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.authenticator)
 	err := server.StartNonBlocking()
 	return err
-}
-
-func (a *DaprRuntime) setHostAddress() error {
-	a.hostAddress = os.Getenv(hostIPEnvVar)
-	if a.hostAddress == "" {
-		addrs, err := net.InterfaceAddrs()
-		if err != nil {
-			return err
-		}
-
-		for _, addr := range addrs {
-			if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-				if ipnet.IP.To4() != nil {
-					a.hostAddress = ipnet.IP.String()
-					return nil
-				}
-			}
-		}
-	}
-	return nil
 }
 
 func (a *DaprRuntime) getSubscribedBindingsGRPC() []string {


### PR DESCRIPTION
Part of #1087.

This PR changes the environment variable `HOST_IP` to `DAPR_HOST_IP` in both the runtime and the sidecar injector.

Other changes:

1. Puts logic of getting host address in separate file
2. Adds unit tests
3. Removes duplicate declaration for `DAPR_HOST_IP` in Sidecar Injector
4. Treats being unable to get host address as an error that halts the runtime instead of a warning