### PR TITLE
Adds PUT Metadata API + appCommand metadata.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/tidwall/pretty v1.0.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20200122045848-3419fae592fc // indirect
 	github.com/valyala/fasthttp v1.6.0
+	go.etcd.io/etcd v3.3.17+incompatible
 	go.opencensus.io v0.22.3
 	google.golang.org/grpc v1.26.0
 	gopkg.in/couchbase/gocbcore.v7 v7.1.16 // indirect

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -612,8 +612,9 @@ func TestV1MetadataEndpoint(t *testing.T) {
 	fakeServer.StartServer(testAPI.constructMetadataEndpoints())
 
 	expectedBody := map[string]interface{}{
-		"id":     "xyz",
-		"actors": []map[string]interface{}{{"type": "abcd", "count": 10}, {"type": "xyz", "count": 5}},
+		"id":         "xyz",
+		"actors":     []map[string]interface{}{{"type": "abcd", "count": 10}, {"type": "xyz", "count": 5}},
+		"appCommand": "",
 	}
 	expectedBodyBytes, _ := json.Marshal(expectedBody)
 


### PR DESCRIPTION
# Description

New API to allow modification of mutable metadata attributes.
Adds appCommand as first mutable metadata attribute.

This is useful to link external state into the sidecar metadata.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/cli/issues/249 https://github.com/dapr/cli/issues/273

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
