### PR TITLE
Make input bindings retry-able 

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -458,7 +458,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 		}
 
 		resp, err := a.appChannel.InvokeMethod(&req)
-		if err != nil {
+		if err != nil || http.GetStatusCodeFromMetadata(resp.Metadata) != 200 {
 			return fmt.Errorf("error invoking app: %s", err)
 		}
 
@@ -487,7 +487,8 @@ func (a *DaprRuntime) readFromBinding(name string, binding bindings.InputBinding
 		if resp != nil {
 			err := a.sendBindingEventToApp(name, resp.Data, resp.Metadata)
 			if err != nil {
-				log.Debugf("binding error [%s]: %s", name, err)
+				log.Debugf("error from app consumer for binding [%s]: %s", name, err)
+				return err
 			}
 		}
 		return nil


### PR DESCRIPTION
This PR enables returning an error to an input binding from user app error.

Fixes #1189.

This PR also adds test coverage for the area fixed, plus an additional data validation test.