### PR TITLE
Change HTTP/gRPC server init order

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -211,14 +211,14 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 		log.Warnf("failed to build HTTP pipeline: %s", err)
 	}
 
-	a.startHTTPServer(a.runtimeConfig.HTTPPort, a.runtimeConfig.ProfilePort, a.runtimeConfig.AllowedOrigins, pipeline)
-	log.Infof("http server is running on port %v", a.runtimeConfig.HTTPPort)
-
 	err = a.startGRPCServer(a.runtimeConfig.GRPCPort)
 	if err != nil {
 		log.Fatalf("failed to start gRPC server: %s", err)
 	}
 	log.Infof("gRPC server is running on port %v", a.runtimeConfig.GRPCPort)
+
+	a.startHTTPServer(a.runtimeConfig.HTTPPort, a.runtimeConfig.ProfilePort, a.runtimeConfig.AllowedOrigins, pipeline)
+	log.Infof("http server is running on port %v", a.runtimeConfig.HTTPPort)
 
 	if a.runtimeConfig.EnableMetrics {
 		a.startMetricsServer()


### PR DESCRIPTION
This PR starts the Dapr HTTP server after the gRPC server to allow for Dapr to authenticate with Sentry and spin up its internal invocation mechanism prior to receiving external requests.

Closes #1185 