### PR TITLE
[sentry] Add the remaining metrics (final)

### DIFF
--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -87,6 +87,7 @@ func main() {
 	go watcher.StartIssuerWatcher(ctx, watchDir, issuerEvent)
 	go func() {
 		for range issuerEvent {
+			monitoring.IssuerCredentialChanged()
 			log.Warn("issuer credentials changed. reloading")
 			ca.Restart(ctx, config)
 		}

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dapr/dapr/pkg/metrics"
 	"github.com/dapr/dapr/pkg/sentry"
 	"github.com/dapr/dapr/pkg/sentry/config"
+	"github.com/dapr/dapr/pkg/sentry/monitoring"
 	"github.com/dapr/dapr/pkg/sentry/watcher"
 	"github.com/dapr/dapr/pkg/signals"
 	"github.com/dapr/dapr/pkg/version"
@@ -47,6 +48,10 @@ func main() {
 
 	// Initialize dapr metrics exporter
 	if err := metricsExporter.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := monitoring.InitMetrics(); err != nil {
 		log.Fatal(err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0
-	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.3
 	github.com/google/uuid v1.1.1
@@ -35,8 +34,6 @@ require (
 	github.com/valyala/fasthttp v1.6.0
 	go.opencensus.io v0.22.3
 	google.golang.org/grpc v1.26.0
-	gopkg.in/couchbase/gocbcore.v7 v7.1.16 // indirect
-	gopkg.in/couchbaselabs/gojcbmock.v1 v1.0.4 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,13 @@ go 1.14
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
-	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
-	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/etcd v3.3.18+incompatible // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/dapr/components-contrib v0.0.0-20200305065926-4602757a455e
 	github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.3
 	github.com/google/uuid v1.1.1
@@ -29,23 +24,16 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/qiangxue/fasthttp-routing v0.0.0-20160225050629-6ccdc2a18d87
-	github.com/russross/blackfriday v2.0.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/valyala/fasthttp v1.6.0
-	github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb // indirect
 	go.opencensus.io v0.22.3
-	go.uber.org/multierr v1.2.0 // indirect
 	google.golang.org/grpc v1.26.0
-	gopkg.in/couchbaselabs/gocbconnstr.v1 v1.0.4 // indirect
-	gopkg.in/couchbaselabs/jsonx.v1 v1.0.0 // indirect
-	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/pkg/sentry/monitoring/metrics.go
+++ b/pkg/sentry/monitoring/metrics.go
@@ -1,0 +1,61 @@
+package monitoring
+
+import (
+	"context"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	csrReceivedTotal = stats.Int64(
+		"sentry/csr/received_total",
+		"The number of CSRs received by Dapr Sentry server.",
+		stats.UnitDimensionless)
+	certIssueSuccessTotal = stats.Int64(
+		"sentry/cert/issue/success_total",
+		"The number of certificates issuances that have succeeded.",
+		stats.UnitDimensionless)
+	rootCertExpiryTimestamp = stats.Int64(
+		"sentry/rootcert/expiry_timestamp",
+		"The unix timestamp, in seconds, when root cert will expire. ",
+		stats.UnitDimensionless)
+)
+
+func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		Measure:     measure,
+		TagKeys:     keys,
+		Aggregation: aggregation,
+	}
+}
+
+// CSRRecieved counts when CSR received.
+func CSRRecieved() {
+	stats.Record(context.Background(), csrReceivedTotal.M(1))
+}
+
+// CertIssueSuceeed counts suceeded cert issuance
+func CertIssueSuceeed() {
+	stats.Record(context.Background(), certIssueSuccessTotal.M(1))
+}
+
+// RootCertExpiry records root cert expiry
+func RootCertExpiry(expiry time.Time) {
+	stats.Record(context.Background(), certIssueSuccessTotal.M(expiry.Unix()))
+}
+
+// InitMetrics initializes metrics
+func InitMetrics() error {
+	err := view.Register(
+		newView(csrReceivedTotal, []tag.Key{}, view.Count()),
+		newView(certIssueSuccessTotal, []tag.Key{}, view.Count()),
+		newView(rootCertExpiryTimestamp, []tag.Key{}, view.LastValue()),
+	)
+
+	return err
+}

--- a/pkg/sentry/monitoring/metrics.go
+++ b/pkg/sentry/monitoring/metrics.go
@@ -30,11 +30,11 @@ var (
 		"The unix timestamp, in seconds, when root cert will expire.",
 		stats.UnitDimensionless)
 	rootCertRotateTotal = stats.Int64(
-		"sentry/rootcert/rotated",
+		"sentry/rootcert/rotation_total",
 		"The number of root certificate rotated.",
 		stats.UnitDimensionless)
 	issuerCredentialChangeTotal = stats.Int64(
-		"sentry/issuer/cert/changed",
+		"sentry/issuer/cert/change_total",
 		"The number of issuer cert updates, when issuer cert or key is changed",
 		stats.UnitDimensionless)
 

--- a/pkg/sentry/monitoring/metrics.go
+++ b/pkg/sentry/monitoring/metrics.go
@@ -71,12 +71,12 @@ func CertSignRequestRecieved() {
 	stats.Record(context.Background(), csrReceivedTotal.M(1))
 }
 
-// CertSignSuceeed counts suceeded cert issuance
-func CertSignSuceeed() {
+// CertSignSucceed counts succeeded cert issuance
+func CertSignSucceed() {
 	stats.Record(context.Background(), certSignSuccessTotal.M(1))
 }
 
-// CertSignFailed counts suceeded cert issuance
+// CertSignFailed counts succeeded cert issuance
 func CertSignFailed(failure certSignErrorType) {
 	ctx, err := tag.New(context.Background(), tag.Insert(errorTypeTag, string(failure)))
 	if err != nil {

--- a/pkg/sentry/monitoring/metrics.go
+++ b/pkg/sentry/monitoring/metrics.go
@@ -2,27 +2,59 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/dapr/dapr/pkg/logger"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 )
 
 var (
+	// Metrics definitions
 	csrReceivedTotal = stats.Int64(
 		"sentry/csr/received_total",
 		"The number of CSRs received by Dapr Sentry server.",
 		stats.UnitDimensionless)
-	certIssueSuccessTotal = stats.Int64(
-		"sentry/cert/issue/success_total",
+	certSignSuccessTotal = stats.Int64(
+		"sentry/cert/sign/success_total",
 		"The number of certificates issuances that have succeeded.",
+		stats.UnitDimensionless)
+	certSignErrorTotal = stats.Int64(
+		"sentry/cert/sign/error_total",
+		"The number of errors occurred when signing the CSR.",
 		stats.UnitDimensionless)
 	rootCertExpiryTimestamp = stats.Int64(
 		"sentry/rootcert/expiry_timestamp",
-		"The unix timestamp, in seconds, when root cert will expire. ",
+		"The unix timestamp, in seconds, when root cert will expire.",
 		stats.UnitDimensionless)
+	rootCertRotateTotal = stats.Int64(
+		"sentry/rootcert/rotated",
+		"The number of root certificate rotated.",
+		stats.UnitDimensionless)
+	issuerCredentialChangeTotal = stats.Int64(
+		"sentry/issuer/cert/changed",
+		"The number of issuer cert updates, when issuer cert or key is changed",
+		stats.UnitDimensionless)
+
+	nilKey = []tag.Key{}
+
+	// Metrics Tags
+	errorTypeTag tag.Key
 )
+
+type certSignErrorType string
+
+const (
+	CertParseError        certSignErrorType = "CertParse"
+	CertValidationError   certSignErrorType = "CertValidation"
+	ReqIDError            certSignErrorType = "ReqIDValidation"
+	CertSignError         certSignErrorType = "CertSign"
+	InsufficientDataError certSignErrorType = "InsufficientData"
+)
+
+var log = logger.NewLogger("dapr.sentry.monitoring")
 
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
 	return &view.View{
@@ -34,27 +66,56 @@ func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregatio
 	}
 }
 
-// CSRRecieved counts when CSR received.
-func CSRRecieved() {
+// CertSignRequestRecieved counts when CSR received.
+func CertSignRequestRecieved() {
 	stats.Record(context.Background(), csrReceivedTotal.M(1))
 }
 
-// CertIssueSuceeed counts suceeded cert issuance
-func CertIssueSuceeed() {
-	stats.Record(context.Background(), certIssueSuccessTotal.M(1))
+// CertSignSuceeed counts suceeded cert issuance
+func CertSignSuceeed() {
+	stats.Record(context.Background(), certSignSuccessTotal.M(1))
+}
+
+// CertSignFailed counts suceeded cert issuance
+func CertSignFailed(failure certSignErrorType) {
+	ctx, err := tag.New(context.Background(), tag.Insert(errorTypeTag, string(failure)))
+	if err != nil {
+		log.Warnf("error creating monitoring context: %v", err)
+		return
+	}
+
+	stats.Record(ctx, certSignErrorTotal.M(1))
 }
 
 // RootCertExpiry records root cert expiry
 func RootCertExpiry(expiry time.Time) {
-	stats.Record(context.Background(), certIssueSuccessTotal.M(expiry.Unix()))
+	stats.Record(context.Background(), rootCertExpiryTimestamp.M(expiry.Unix()))
+}
+
+// RootCertRotationSucceed records root cert rotation
+func RootCertRotationSucceed() {
+	stats.Record(context.Background(), rootCertRotateTotal.M(1))
+}
+
+// IssuerCredentialChanged records issuer credential change
+func IssuerCredentialChanged() {
+	stats.Record(context.Background(), issuerCredentialChangeTotal.M(1))
 }
 
 // InitMetrics initializes metrics
 func InitMetrics() error {
-	err := view.Register(
-		newView(csrReceivedTotal, []tag.Key{}, view.Count()),
-		newView(certIssueSuccessTotal, []tag.Key{}, view.Count()),
-		newView(rootCertExpiryTimestamp, []tag.Key{}, view.LastValue()),
+	var err error
+	if errorTypeTag, err = tag.NewKey("error_type"); err != nil {
+		return fmt.Errorf("failed to create new key: %v", err)
+	}
+
+	err = view.Register(
+		newView(csrReceivedTotal, nilKey, view.Count()),
+		newView(certSignSuccessTotal, nilKey, view.Count()),
+		newView(certSignErrorTotal, nilKey, view.Count()),
+		newView(rootCertRotateTotal, nilKey, view.Count()),
+		newView(issuerCredentialChangeTotal, nilKey, view.Count()),
+		newView(rootCertExpiryTimestamp, nilKey, view.LastValue()),
 	)
 
 	return err

--- a/pkg/sentry/monitoring/metrics.go
+++ b/pkg/sentry/monitoring/metrics.go
@@ -34,7 +34,7 @@ var (
 		"The number of root certificate rotated.",
 		stats.UnitDimensionless)
 	issuerCredentialChangeTotal = stats.Int64(
-		"sentry/issuer/cert/changed_total",
+		"sentry/issuercert/changed_total",
 		"The number of issuer cert updates, when issuer cert or key is changed",
 		stats.UnitDimensionless)
 

--- a/pkg/sentry/monitoring/metrics.go
+++ b/pkg/sentry/monitoring/metrics.go
@@ -14,8 +14,8 @@ import (
 var (
 	// Metrics definitions
 	csrReceivedTotal = stats.Int64(
-		"sentry/csr/received_total",
-		"The number of CSRs received by Dapr Sentry server.",
+		"sentry/cert/sign/request_received_total",
+		"The number of CSRs received.",
 		stats.UnitDimensionless)
 	certSignSuccessTotal = stats.Int64(
 		"sentry/cert/sign/success_total",
@@ -30,11 +30,11 @@ var (
 		"The unix timestamp, in seconds, when root cert will expire.",
 		stats.UnitDimensionless)
 	rootCertRotateTotal = stats.Int64(
-		"sentry/rootcert/rotation_total",
+		"sentry/rootcert/rotated_total",
 		"The number of root certificate rotated.",
 		stats.UnitDimensionless)
 	issuerCredentialChangeTotal = stats.Int64(
-		"sentry/issuer/cert/change_total",
+		"sentry/issuer/cert/changed_total",
 		"The number of issuer cert updates, when issuer cert or key is changed",
 		stats.UnitDimensionless)
 

--- a/pkg/sentry/server/server.go
+++ b/pkg/sentry/server/server.go
@@ -180,7 +180,7 @@ func (s *server) SignCertificate(ctx context.Context, req *pb.SignCertificateReq
 		ValidUntil:             expiry,
 	}
 
-	monitoring.CertSignSuceeed()
+	monitoring.CertSignSucceed()
 
 	return resp, nil
 }


### PR DESCRIPTION
# Description

* Supported metrics for sentry
  - sentry/cert/sign/request_received_total : The number of CSRs received.
  - sentry/cert/sign/success_total : The number of certificates issuances that have succeeded.
  - sentry/cert/sign/error_total: The number of errors occurred when signing the CSRs
  - sentry/rootcert/expiry_timestamp: The unix timestamp, in seconds, when root cert will expire.
  - sentry/rootcert/rotated_total: The number of root certificate rotated.
  - sentry/issuercert/changed_total: The number of issuer cert updates, when issuer cert or key is changed
* Add detail errortype tag to sentry/cert/sign/error_total

## Issue reference

#971 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
