### PR TITLE
Skip empty tag value

### DIFF
--- a/pkg/diagnostics/metrics.go
+++ b/pkg/diagnostics/metrics.go
@@ -55,7 +55,10 @@ func withTags(opts ...interface{}) []tag.Mutator {
 		if !ok {
 			break
 		}
-		tagMutators = append(tagMutators, tag.Upsert(key, value))
+		// skip if value is empty
+		if value != "" {
+			tagMutators = append(tagMutators, tag.Upsert(key, value))
+		}
 	}
 	return tagMutators
 }

--- a/pkg/diagnostics/metrics_test.go
+++ b/pkg/diagnostics/metrics_test.go
@@ -234,4 +234,12 @@ func TestWithTags(t *testing.T) {
 		mutators := withTags(appKey, "test", operationKey, 1)
 		assert.Equal(t, 1, len(mutators))
 	})
+
+	t.Run("skip empty value key", func(t *testing.T) {
+		var appKey = tag.MustNewKey("app_id")
+		var operationKey = tag.MustNewKey("operation")
+		var methodKey = tag.MustNewKey("method")
+		mutators := withTags(appKey, "", operationKey, "op", methodKey, "method")
+		assert.Equal(t, 2, len(mutators))
+	})
 }


### PR DESCRIPTION
# Description

Skip empty tag value. for example, if grpc metrics handlers are used in system processes such as operator, injector, sentry, then appID is not given and is unnecessary.

## Issue reference

#971 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
