### PR TITLE
Adding initial injector service metrics

### DIFF
--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dapr/dapr/pkg/injector"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/dapr/dapr/pkg/metrics"
+	"github.com/dapr/dapr/pkg/sentry/monitoring"
 	"github.com/dapr/dapr/pkg/signals"
 	"github.com/dapr/dapr/pkg/version"
 	"github.com/dapr/dapr/utils"
@@ -58,6 +59,11 @@ func init() {
 
 	// Initialize dapr metrics exporter
 	if err := metricsExporter.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Initialize injector service metrics
+	if err := monitoring.InitMetrics(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -121,7 +121,6 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 			http.StatusUnsupportedMediaType,
 		)
 
-		monitoring.RecordFailedSidecarInjectionCount()
 		return
 	}
 

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -167,7 +167,7 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 	var id string
 
 	if ar.Request != nil {
-		err := json.Unmarshal(ar.Request.Object.Raw, &pod)
+		err = json.Unmarshal(ar.Request.Object.Raw, &pod)
 		if err != nil {
 			log.Errorf("could not unmarshal raw object: %v", err)
 		} else {

--- a/pkg/injector/monitoring/metrics.go
+++ b/pkg/injector/monitoring/metrics.go
@@ -20,14 +20,20 @@ const (
 )
 
 var (
+	sidecarInjectionRequestsTotal = stats.Int64(
+		"injector/sidecar_injection/requests_total",
+		"The total number of sidecar injection requests.",
+		stats.UnitDimensionless)
 	succeededSidecarInjectedTotal = stats.Int64(
-		"injector/sidecar_injection_succeeded_total",
+		"injector/sidecar_injection/succeeded_total",
 		"The total number of successful sidecar injections.",
 		stats.UnitDimensionless)
 	failedSidecarInjectedTotal = stats.Int64(
-		"injector/sidecar_injection_failed_total",
+		"injector/sidecar_injection/failed_total",
 		"The total number of failed sidecar injections.",
 		stats.UnitDimensionless)
+
+	noKeys = []tag.Key{}
 
 	// appIDKey is a tag key for App ID
 	appIDKey = tag.MustNewKey(appID)
@@ -35,6 +41,11 @@ var (
 	// failedReasonKey is a tag key for failed reason
 	failedReasonKey = tag.MustNewKey(failedReason)
 )
+
+// RecordSidecarInjectionRequestsCount records the total number of sidecar injection requests
+func RecordSidecarInjectionRequestsCount() {
+	stats.Record(context.Background(), sidecarInjectionRequestsTotal.M(1))
+}
 
 // RecordSuccessfulSidecarInjectionCount records the number of successful sidecar injections
 func RecordSuccessfulSidecarInjectionCount(appID string) {
@@ -49,6 +60,7 @@ func RecordFailedSidecarInjectionCount(appID, reason string) {
 // InitMetrics initialize the injector service metrics
 func InitMetrics() error {
 	err := view.Register(
+		diag_utils.NewMeasureView(sidecarInjectionRequestsTotal, noKeys, view.Count()),
 		diag_utils.NewMeasureView(succeededSidecarInjectedTotal, []tag.Key{appIDKey}, view.Count()),
 		diag_utils.NewMeasureView(failedSidecarInjectedTotal, []tag.Key{appIDKey, failedReasonKey}, view.Count()),
 	)

--- a/pkg/injector/monitoring/metrics.go
+++ b/pkg/injector/monitoring/metrics.go
@@ -8,77 +8,49 @@ package monitoring
 import (
 	"context"
 
+	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 )
 
 const (
-	appID   = "app_id"
-	podName = "pod_name"
+	appID        = "app_id"
+	failedReason = "reason"
 )
 
 var (
-	successfulAdmissionReviewResponseTotal = stats.Int64(
-		"injector/successful_admissionreview_response_total",
-		"The total number of successful admission review responses.",
+	succeededSidecarInjectedTotal = stats.Int64(
+		"injector/sidecar_injection_succeeded_total",
+		"The total number of successful sidecar injections.",
 		stats.UnitDimensionless)
-	failedAdmissionReviewResponseTotal = stats.Int64(
-		"injector/failed_admissionreview_response_total",
-		"The total number of failed admission review responses.",
+	failedSidecarInjectedTotal = stats.Int64(
+		"injector/sidecar_injection_failed_total",
+		"The total number of failed sidecar injections.",
 		stats.UnitDimensionless)
 
 	// appIDKey is a tag key for App ID
 	appIDKey = tag.MustNewKey(appID)
 
-	// podNameKey is a tag key for Pod name
-	podNameKey = tag.MustNewKey(podName)
+	// failedReasonKey is a tag key for failed reason
+	failedReasonKey = tag.MustNewKey(failedReason)
 )
 
-// RecordSuccessfulAdmissionReviewResponseCount records the number of successful admission review responses
-func RecordSuccessfulAdmissionReviewResponseCount(appID, podname string) {
-	stats.RecordWithTags(context.Background(), withTags(appIDKey, appID, podNameKey, podname), successfulAdmissionReviewResponseTotal.M(1))
+// RecordSuccessfulSidecarInjectionCount records the number of successful sidecar injections
+func RecordSuccessfulSidecarInjectionCount(appID string) {
+	stats.RecordWithTags(context.Background(), diag_utils.WithTags(appIDKey, appID), succeededSidecarInjectedTotal.M(1))
 }
 
-// RecordFailedAdmissionReviewResponseCount records the number of failed admission review responses
-func RecordFailedAdmissionReviewResponseCount(appID, podname string) {
-	stats.RecordWithTags(context.Background(), withTags(appIDKey, appID, podNameKey, podname), failedAdmissionReviewResponseTotal.M(1))
-}
-
-// withTags converts tag key and value pairs to tag.Mutator array.
-// withTags(key1, value1, key2, value2) returns
-// []tag.Mutator{tag.Upsert(key1, value1), tag.Upsert(key2, value2)}
-func withTags(opts ...interface{}) []tag.Mutator {
-	tagMutators := []tag.Mutator{}
-	for i := 0; i < len(opts)-1; i += 2 {
-		key, ok := opts[i].(tag.Key)
-		if !ok {
-			break
-		}
-		value, ok := opts[i+1].(string)
-		if !ok {
-			break
-		}
-		tagMutators = append(tagMutators, tag.Upsert(key, value))
-	}
-	return tagMutators
-}
-
-func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
-	return &view.View{
-		Name:        measure.Name(),
-		Description: measure.Description(),
-		Measure:     measure,
-		TagKeys:     keys,
-		Aggregation: aggregation,
-	}
+// RecordFailedSidecarInjectionCount records the number of failed sidecar injections
+func RecordFailedSidecarInjectionCount(appID, reason string) {
+	stats.RecordWithTags(context.Background(), diag_utils.WithTags(appIDKey, appID, failedReasonKey, reason), failedSidecarInjectedTotal.M(1))
 }
 
 // InitMetrics initialize the injector service metrics
 func InitMetrics() error {
 	err := view.Register(
-		newView(successfulAdmissionReviewResponseTotal, []tag.Key{appIDKey, podNameKey}, view.Count()),
-		newView(failedAdmissionReviewResponseTotal, []tag.Key{appIDKey, podNameKey}, view.Count()),
+		diag_utils.NewMeasureView(succeededSidecarInjectedTotal, []tag.Key{appIDKey}, view.Count()),
+		diag_utils.NewMeasureView(failedSidecarInjectedTotal, []tag.Key{appIDKey, failedReasonKey}, view.Count()),
 	)
 
 	return err

--- a/pkg/injector/monitoring/metrics.go
+++ b/pkg/injector/monitoring/metrics.go
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package monitoring
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+const (
+	appID   = "app_id"
+	podName = "pod_name"
+)
+
+var (
+	successfulAdmissionReviewResponseTotal = stats.Int64(
+		"injector/successful_admissionreview_response_total",
+		"The total number of successful admission review responses.",
+		stats.UnitDimensionless)
+	failedAdmissionReviewResponseTotal = stats.Int64(
+		"injector/failed_admissionreview_response_total",
+		"The total number of failed admission review responses.",
+		stats.UnitDimensionless)
+
+	// appIDKey is a tag key for App ID
+	appIDKey = tag.MustNewKey(appID)
+
+	// podNameKey is a tag key for Pod name
+	podNameKey = tag.MustNewKey(podName)
+)
+
+// RecordSuccessfulAdmissionReviewResponseCount records the number of successful admission review responses
+func RecordSuccessfulAdmissionReviewResponseCount(appID, podname string) {
+	stats.RecordWithTags(context.Background(), withTags(appIDKey, appID, podNameKey, podname), successfulAdmissionReviewResponseTotal.M(1))
+}
+
+// RecordFailedAdmissionReviewResponseCount records the number of failed admission review responses
+func RecordFailedAdmissionReviewResponseCount(appID, podname string) {
+	stats.RecordWithTags(context.Background(), withTags(appIDKey, appID, podNameKey, podname), failedAdmissionReviewResponseTotal.M(1))
+}
+
+// withTags converts tag key and value pairs to tag.Mutator array.
+// withTags(key1, value1, key2, value2) returns
+// []tag.Mutator{tag.Upsert(key1, value1), tag.Upsert(key2, value2)}
+func withTags(opts ...interface{}) []tag.Mutator {
+	tagMutators := []tag.Mutator{}
+	for i := 0; i < len(opts)-1; i += 2 {
+		key, ok := opts[i].(tag.Key)
+		if !ok {
+			break
+		}
+		value, ok := opts[i+1].(string)
+		if !ok {
+			break
+		}
+		tagMutators = append(tagMutators, tag.Upsert(key, value))
+	}
+	return tagMutators
+}
+
+func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		Measure:     measure,
+		TagKeys:     keys,
+		Aggregation: aggregation,
+	}
+}
+
+// InitMetrics initialize the injector service metrics
+func InitMetrics() error {
+	err := view.Register(
+		newView(successfulAdmissionReviewResponseTotal, []tag.Key{appIDKey, podNameKey}, view.Count()),
+		newView(failedAdmissionReviewResponseTotal, []tag.Key{appIDKey, podNameKey}, view.Count()),
+	)
+
+	return err
+}


### PR DESCRIPTION
# Description

Adding initial set of metrics in injector service.

injector/sidecar_injection/requests_total: The total number of sidecar injection requests.
injector/sidecar_injection/succeeded_total: The total number of successful sidecar injections.
injector/sidecar_injection/failed_total:The total number of failed sidecar injections.

## Issue reference

#971

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
