### PR TITLE
fix pub/sub content type

### DIFF
--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -41,6 +41,8 @@ const (
 	defaultContentType = "application/json"
 
 	httpInternalErrorCode = "500"
+	HeaderDelim           = "&__header_delim__&"
+	HeaderEquals          = "&__header_equals__&"
 )
 
 // Channel is an HTTP implementation of an AppChannel
@@ -68,9 +70,9 @@ func (h *Channel) InvokeMethod(invokeRequest *channel.InvokeRequest) (*channel.I
 	}
 	if invokeRequest.Metadata != nil {
 		if val, ok := invokeRequest.Metadata["headers"]; ok {
-			headers := strings.Split(val, "&__header_delim__&")
+			headers := strings.Split(val, HeaderDelim)
 			for _, h := range headers {
-				kv := strings.Split(h, "&__header_equals__&")
+				kv := strings.Split(h, HeaderEquals)
 				req.Header.Set(kv[0], kv[1])
 			}
 		}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -794,8 +794,8 @@ func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
 		Method:  msg.Topic,
 		Payload: msg.Data,
 		Metadata: map[string]string{http_channel.HTTPVerb: http_channel.Post,
-			http_channel.ContentType: pubsub.ContentType,
-			diag.CorrelationID:       subject},
+			"headers":          fmt.Sprintf("%s%s%s", http_channel.ContentType, http_channel.HeaderEquals, pubsub.ContentType),
+			diag.CorrelationID: subject},
 	}
 
 	resp, err := a.appChannel.InvokeMethod(&req)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -400,8 +400,10 @@ func TestOnNewPublishedMessage(t *testing.T) {
 	expectedRequest := &channel.InvokeRequest{
 		Method:  testPubSubMessage.Topic,
 		Payload: testPubSubMessage.Data,
-		Metadata: map[string]string{http_channel.HTTPVerb: http_channel.Post, http_channel.ContentType: pubsub.ContentType,
-			tracing.CorrelationID: ""},
+		Metadata: map[string]string{http_channel.HTTPVerb: http_channel.Post,
+			tracing.CorrelationID: "",
+			"headers":             fmt.Sprintf("%s%s%s", http_channel.ContentType, http_channel.HeaderEquals, pubsub.ContentType),
+		},
 	}
 
 	rt := NewTestDaprRuntime(modes.StandaloneMode)


### PR DESCRIPTION
When invoking the user app, the content type was being set wrong on the HTTP request.

This PR sets the content type on the `metadata.headers` where it should be, and changes the test to account for the correct logic.

Fixes #1248 
