### PR TITLE
Hotfix: Parse header's Request URI

### DIFF
--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -76,13 +76,14 @@ func TraceSpanFromFastHTTPRequest(r *fasthttp.Request, spec config.TracingSpec) 
 	var spanc *trace.Span
 
 	corID := string(r.Header.Peek(CorrelationID))
+	uriSpanName := string(r.Header.RequestURI())
 	if corID != "" {
 		spanContext := DeserializeSpanContext(corID)
-		ctx, span = trace.StartSpanWithRemoteParent(context.Background(), string(r.RequestURI()), spanContext, trace.WithSpanKind(trace.SpanKindServer))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(string(r.RequestURI())), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span = trace.StartSpanWithRemoteParent(context.Background(), uriSpanName, spanContext, trace.WithSpanKind(trace.SpanKindServer))
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(uriSpanName), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient))
 	} else {
-		ctx, span = trace.StartSpan(context.Background(), string(r.RequestURI()), trace.WithSpanKind(trace.SpanKindServer))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(string(r.RequestURI())), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span = trace.StartSpan(context.Background(), uriSpanName, trace.WithSpanKind(trace.SpanKindServer))
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(uriSpanName), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient))
 	}
 
 	addAnnotations(r, span, spec.ExpandParams, spec.IncludeBody)


### PR DESCRIPTION
# Description

**Problem:**

TL;DR; when tracing is enabled, service invocation doesn't work. 

**Root cause:**

Without tracing, `Host` field in HTTP request header should include user app's server address and port.

![image](https://user-images.githubusercontent.com/11863108/77029402-d7654c00-6958-11ea-86b0-b4effb5d3a5c.png)

With tracing, `Host` field in http request header has unexpected address and port(localhost:51887). So user app's http server returns 404 because it is invalid. 

![image](https://user-images.githubusercontent.com/11863108/77029300-90775680-6958-11ea-9db6-91e67b43c370.png)

**How to fix:**

Using fast http request header's Request URI for trace span name resolves this problem.

**Actions items:**

* Add E2E test to validate tracing configuration (#1171)

## Issue reference

#1274 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
