### PR TITLE
Added pub/sub scopes

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -802,7 +802,7 @@ func (a *DaprRuntime) isPubSubOperationAllowed(topic string, topicsList []string
 			}
 		}
 		if !inAllowedTopics {
-			return inAllowedTopics
+			return false
 		}
 	} else if len(topicsList) == 0 {
 		return true

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -774,6 +774,7 @@ func (a *DaprRuntime) initPubSub() error {
 				}
 			}
 			if !allowed {
+				log.Warnf("subscription to topic %s is not allowed", t)
 				continue
 			}
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -791,32 +791,35 @@ func (a *DaprRuntime) Publish(req *pubsub.PublishRequest) error {
 }
 
 func (a *DaprRuntime) isPubSubOperationAllowed(topic string, topicsList []string) bool {
-	allowed := false
+	inAllowedTopics := false
 
 	// first check if allowedTopics contain it
 	if len(a.allowedTopics) > 0 {
 		for _, t := range a.allowedTopics {
 			if t == topic {
-				allowed = true
+				inAllowedTopics = true
 				break
 			}
 		}
-		if !allowed {
-			return allowed
+		if !inAllowedTopics {
+			return inAllowedTopics
 		}
 	} else if len(topicsList) == 0 {
 		return true
 	}
 
 	// check if a granular scope has been applied
-	allowed = false
+	allowedScope := false
 	for _, t := range topicsList {
 		if t == topic {
-			allowed = true
+			allowedScope = true
 			break
 		}
 	}
-	return allowed
+	if inAllowedTopics && !allowedScope {
+		return true
+	}
+	return allowedScope
 }
 
 func (a *DaprRuntime) initServiceDiscovery() error {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -805,15 +805,16 @@ func (a *DaprRuntime) isPubSubOperationAllowed(topic string, topicsList []string
 			return allowed
 		}
 	}
+	if len(topicsList) == 0 {
+		return true
+	}
 
 	// check if a granular scope has been applied
 	allowed = false
-	if len(topicsList) > 0 {
-		for _, t := range topicsList {
-			if t == topic {
-				allowed = true
-				break
-			}
+	for _, t := range topicsList {
+		if t == topic {
+			allowed = true
+			break
 		}
 	}
 	return allowed

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -804,8 +804,7 @@ func (a *DaprRuntime) isPubSubOperationAllowed(topic string, topicsList []string
 		if !allowed {
 			return allowed
 		}
-	}
-	if len(topicsList) == 0 {
+	} else if len(topicsList) == 0 {
 		return true
 	}
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -47,6 +47,7 @@ import (
 	"github.com/dapr/dapr/pkg/modes"
 	daprclient_pb "github.com/dapr/dapr/pkg/proto/daprclient"
 	"github.com/dapr/dapr/pkg/runtime/security"
+	"github.com/dapr/dapr/pkg/scopes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
 	jsoniter "github.com/json-iterator/go"
@@ -89,6 +90,7 @@ type DaprRuntime struct {
 	actorStateStoreCount     int
 	authenticator            security.Authenticator
 	namespace                string
+	allowedPublishings       []string
 }
 
 // NewDaprRuntime returns a new runtime with the given runtime config and global config
@@ -490,7 +492,7 @@ func (a *DaprRuntime) readFromBinding(name string, binding bindings.InputBinding
 }
 
 func (a *DaprRuntime) startHTTPServer(port, profilePort int, allowedOrigins string, pipeline http_middleware.Pipeline) {
-	api := http.NewAPI(a.runtimeConfig.ID, a.appChannel, a.directMessaging, a.stateStores, a.secretStores, a.pubSub, a.actor, a.sendToOutputBinding)
+	api := http.NewAPI(a.runtimeConfig.ID, a.appChannel, a.directMessaging, a.stateStores, a.secretStores, a.getPublishAdapter(), a.actor, a.sendToOutputBinding)
 	serverConf := http.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, profilePort, allowedOrigins, a.runtimeConfig.EnableProfiling)
 
 	server := http.NewServer(api, serverConf, a.globalConfig.Spec.TracingSpec, pipeline)
@@ -498,11 +500,18 @@ func (a *DaprRuntime) startHTTPServer(port, profilePort int, allowedOrigins stri
 }
 
 func (a *DaprRuntime) startGRPCServer(port int) error {
-	api := grpc.NewAPI(a.runtimeConfig.ID, a.appChannel, a.stateStores, a.secretStores, a.pubSub, a.directMessaging, a.actor, a.sendToOutputBinding, a)
+	api := grpc.NewAPI(a.runtimeConfig.ID, a.appChannel, a.stateStores, a.secretStores, a.getPublishAdapter(), a.directMessaging, a.actor, a.sendToOutputBinding, a)
 	serverConf := grpc.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port)
 	server := grpc.NewServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.authenticator)
 	err := server.StartNonBlocking()
 	return err
+}
+
+func (a *DaprRuntime) getPublishAdapter() func(*pubsub.PublishRequest) error {
+	if a.pubSub == nil {
+		return nil
+	}
+	return a.Publish
 }
 
 func (a *DaprRuntime) getSubscribedBindingsGRPC() []string {
@@ -709,6 +718,8 @@ func (a *DaprRuntime) initExporters() error {
 }
 
 func (a *DaprRuntime) initPubSub() error {
+	var allowedSubscriptions []string
+
 	for _, c := range a.components {
 		if strings.Index(c.Spec.Type, "pubsub") == 0 {
 			pubSub, err := a.pubSubRegistry.Create(c.Spec.Type)
@@ -730,6 +741,9 @@ func (a *DaprRuntime) initPubSub() error {
 				continue
 			}
 
+			allowedSubscriptions = scopes.GetScopedTopics(scopes.SubscriptionScopes, a.runtimeConfig.ID, properties)
+			a.allowedPublishings = scopes.GetScopedTopics(scopes.SubscriptionScopes, a.runtimeConfig.ID, properties)
+
 			a.pubSub = pubSub
 			diag.DefaultMonitoring.ComponentInitialized(c.Spec.Type)
 			break
@@ -747,6 +761,22 @@ func (a *DaprRuntime) initPubSub() error {
 	if a.pubSub != nil && a.appChannel != nil {
 		topics := a.getSubscribedTopicsFromApp()
 		for _, t := range topics {
+			allowed := false
+
+			if len(allowedSubscriptions) == 0 {
+				allowed = true
+			} else {
+				for _, s := range allowedSubscriptions {
+					if s == t {
+						allowed = true
+						break
+					}
+				}
+			}
+			if !allowed {
+				continue
+			}
+
 			err := a.pubSub.Subscribe(pubsub.SubscribeRequest{
 				Topic: t,
 			}, publishFunc)
@@ -756,6 +786,25 @@ func (a *DaprRuntime) initPubSub() error {
 		}
 	}
 	return nil
+}
+
+// Publish is an adapter method for the runtime to pre-validate publish requests
+// And then forward them to the Pub/Sub component.
+// This method is used by the HTTP and gRPC APIs.
+func (a *DaprRuntime) Publish(req *pubsub.PublishRequest) error {
+	if len(a.allowedPublishings) > 0 {
+		allowed := false
+		for _, t := range a.allowedPublishings {
+			if t == req.Topic {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("topic %s is not allowed for app id %s", req.Topic, a.runtimeConfig.ID)
+		}
+	}
+	return a.pubSub.Publish(req)
 }
 
 func (a *DaprRuntime) initServiceDiscovery() error {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -344,27 +344,27 @@ func TestInitPubSub(t *testing.T) {
 
 	t.Run("test allowed topics, no scopes, operation allowed", func(t *testing.T) {
 		rt.allowedTopics = []string{"topic1"}
-		a := rt.isPubSubOperationAllowed("topic1", rt.allowedPublishings)
+		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
 		assert.True(t, a)
 	})
 
 	t.Run("test allowed topics, no scopes, operation not allowed", func(t *testing.T) {
 		rt.allowedTopics = []string{"topic1"}
-		a := rt.isPubSubOperationAllowed("topic2", rt.allowedPublishings)
+		a := rt.isPubSubOperationAllowed("topic2", rt.scopedPublishings)
 		assert.False(t, a)
 	})
 
 	t.Run("test allowed topics, with scopes, operation allowed", func(t *testing.T) {
 		rt.allowedTopics = []string{"topic1"}
-		rt.allowedPublishings = []string{"topic1"}
-		a := rt.isPubSubOperationAllowed("topic1", rt.allowedPublishings)
+		rt.scopedPublishings = []string{"topic1"}
+		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
 		assert.True(t, a)
 	})
 
 	t.Run("test allowed topics, with scopes, operation not allowed", func(t *testing.T) {
 		rt.allowedTopics = []string{"topic1"}
-		rt.allowedPublishings = []string{"topic2"}
-		a := rt.isPubSubOperationAllowed("topic1", rt.allowedPublishings)
+		rt.scopedPublishings = []string{"topic2"}
+		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
 		assert.False(t, a)
 	})
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -361,11 +361,29 @@ func TestInitPubSub(t *testing.T) {
 		assert.True(t, a)
 	})
 
-	t.Run("test allowed topics, with scopes, operation not allowed", func(t *testing.T) {
+	t.Run("topic is in allowed topics, not in existing publishing scopes, operation allowed", func(t *testing.T) {
 		rt.allowedTopics = []string{"topic1"}
 		rt.scopedPublishings = []string{"topic2"}
 		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
+		assert.True(t, a)
+	})
+
+	t.Run("topic in allowed topics, no in publishing scopes, operation allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{"topic1"}
+		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
+		assert.True(t, a)
+	})
+
+	t.Run("topic is not in allowed topics, in publishing scopes, operation not allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{}
+		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
 		assert.False(t, a)
+	})
+
+	t.Run("topic is not in allowed topics, not in publishing scopes, operation allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{}
+		a := rt.isPubSubOperationAllowed("topic1", []string{})
+		assert.True(t, a)
 	})
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -160,13 +160,13 @@ func TestInitPubSub(t *testing.T) {
 	})
 
 	t.Run("publish adapter is nil, no pub sub component", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt = NewTestDaprRuntime(modes.StandaloneMode)
 		a := rt.getPublishAdapter()
 		assert.Nil(t, a)
 	})
 
 	t.Run("publish adapter not nil, with pub sub component", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt = NewTestDaprRuntime(modes.StandaloneMode)
 		rt.pubSub = initMockPubSubForRuntime(rt)
 		a := rt.getPublishAdapter()
 		assert.NotNil(t, a)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -341,6 +341,32 @@ func TestInitPubSub(t *testing.T) {
 		})
 		assert.NotNil(t, err)
 	})
+
+	t.Run("test allowed topics, no scopes, operation allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{"topic1"}
+		a := rt.isPubSubOperationAllowed("topic1", rt.allowedPublishings)
+		assert.True(t, a)
+	})
+
+	t.Run("test allowed topics, no scopes, operation not allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{"topic1"}
+		a := rt.isPubSubOperationAllowed("topic2", rt.allowedPublishings)
+		assert.False(t, a)
+	})
+
+	t.Run("test allowed topics, with scopes, operation allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{"topic1"}
+		rt.allowedPublishings = []string{"topic1"}
+		a := rt.isPubSubOperationAllowed("topic1", rt.allowedPublishings)
+		assert.True(t, a)
+	})
+
+	t.Run("test allowed topics, with scopes, operation not allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{"topic1"}
+		rt.allowedPublishings = []string{"topic2"}
+		a := rt.isPubSubOperationAllowed("topic1", rt.allowedPublishings)
+		assert.False(t, a)
+	})
 }
 
 func TestInitSecretStores(t *testing.T) {

--- a/pkg/scopes/scopes.go
+++ b/pkg/scopes/scopes.go
@@ -19,17 +19,17 @@ func GetScopedTopics(scope, appID string, metadata map[string]string) []string {
 		apps := strings.Split(val, appsSeperator)
 		for _, a := range apps {
 			appTopics := strings.Split(a, appSeperator)
-			if len(appTopics) > 1 {
-				app := appTopics[0]
-				if app != appID {
-					continue
-				}
-
-				topics = strings.Split(appTopics[1], topicSeperator)
-				break
-			} else {
-				break
+			if len(appTopics) == 0 {
+				continue
 			}
+
+			app := appTopics[0]
+			if app != appID {
+				continue
+			}
+
+			topics = strings.Split(appTopics[1], topicSeperator)
+			break
 		}
 	}
 	return topics

--- a/pkg/scopes/scopes.go
+++ b/pkg/scopes/scopes.go
@@ -5,6 +5,7 @@ import "strings"
 const (
 	SubscriptionScopes = "subscriptionScopes"
 	PublishingScopes   = "publishingScopes"
+	AllowedTopics      = "allowedTopics"
 	appsSeperator      = ";"
 	appSeperator       = "="
 	topicSeperator     = ","
@@ -31,6 +32,15 @@ func GetScopedTopics(scope, appID string, metadata map[string]string) []string {
 			topics = strings.Split(appTopics[1], topicSeperator)
 			break
 		}
+	}
+	return topics
+}
+
+func GetAllowedTopics(metadata map[string]string) []string {
+	topics := []string{}
+
+	if val, ok := metadata[AllowedTopics]; ok && val != "" {
+		topics = strings.Split(val, topicSeperator)
 	}
 	return topics
 }

--- a/pkg/scopes/scopes.go
+++ b/pkg/scopes/scopes.go
@@ -1,0 +1,36 @@
+package scopes
+
+import "strings"
+
+const (
+	SubscriptionScopes = "subscriptionScopes"
+	PublishingScopes   = "publishingScopes"
+	appsSeperator      = ";"
+	appSeperator       = "="
+	topicSeperator     = ","
+)
+
+// GetScopedTopics returns a list of scoped topics for a given application from a Pub/Sub
+// Component properties
+func GetScopedTopics(scope, appID string, metadata map[string]string) []string {
+	topics := []string{}
+
+	if val, ok := metadata[scope]; ok && val != "" {
+		apps := strings.Split(val, appsSeperator)
+		for _, a := range apps {
+			appTopics := strings.Split(a, appSeperator)
+			if len(appTopics) > 1 {
+				app := appTopics[0]
+				if app != appID {
+					continue
+				}
+
+				topics = strings.Split(appTopics[1], topicSeperator)
+				break
+			} else {
+				break
+			}
+		}
+	}
+	return topics
+}

--- a/pkg/scopes/scopes_test.go
+++ b/pkg/scopes/scopes_test.go
@@ -1,0 +1,54 @@
+package scopes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowedTopics(t *testing.T) {
+	t.Run("subscriptions: no scopes", func(t *testing.T) {
+		topics := GetScopedTopics(SubscriptionScopes, "test", map[string]string{})
+		assert.Len(t, topics, 0)
+	})
+
+	t.Run("publications: no scopes", func(t *testing.T) {
+		topics := GetScopedTopics(PublishingScopes, "test", map[string]string{})
+		assert.Len(t, topics, 0)
+	})
+
+	t.Run("subscriptions: allowed 1 topic", func(t *testing.T) {
+		topics := GetScopedTopics(SubscriptionScopes, "test", map[string]string{SubscriptionScopes: "test=topic1"})
+		assert.Len(t, topics, 1)
+		assert.Equal(t, topics[0], "topic1")
+	})
+
+	t.Run("publications: allowed 1 topic", func(t *testing.T) {
+		topics := GetScopedTopics(PublishingScopes, "test", map[string]string{PublishingScopes: "test=topic1"})
+		assert.Len(t, topics, 1)
+		assert.Equal(t, topics[0], "topic1")
+	})
+
+	t.Run("allowed 2 publication, 2 subscriptions", func(t *testing.T) {
+		p := map[string]string{SubscriptionScopes: "test=topic1,topic2", PublishingScopes: "test=topic3,topic4"}
+		subTopics := GetScopedTopics(SubscriptionScopes, "test", p)
+		assert.Len(t, subTopics, 2)
+		assert.Equal(t, subTopics[0], "topic1")
+		assert.Equal(t, subTopics[1], "topic2")
+
+		pubTopics := GetScopedTopics(PublishingScopes, "test", p)
+		assert.Len(t, pubTopics, 2)
+		assert.Equal(t, pubTopics[0], "topic3")
+		assert.Equal(t, pubTopics[1], "topic4")
+	})
+
+	t.Run("publications: allowed all, different app-id", func(t *testing.T) {
+		topics := GetScopedTopics(PublishingScopes, "test", map[string]string{PublishingScopes: "test1=topic1"})
+		assert.Len(t, topics, 0)
+	})
+
+	t.Run("subscriptions: allowed all, different app-id", func(t *testing.T) {
+		topics := GetScopedTopics(SubscriptionScopes, "test", map[string]string{SubscriptionScopes: "test1=topic1"})
+		assert.Len(t, topics, 0)
+	})
+}

--- a/pkg/scopes/scopes_test.go
+++ b/pkg/scopes/scopes_test.go
@@ -51,4 +51,9 @@ func TestAllowedTopics(t *testing.T) {
 		topics := GetScopedTopics(SubscriptionScopes, "test", map[string]string{SubscriptionScopes: "test1=topic1"})
 		assert.Len(t, topics, 0)
 	})
+
+	t.Run("get 2 allowed topics", func(t *testing.T) {
+		topics := GetAllowedTopics(map[string]string{AllowedTopics: "topic1,topic2"})
+		assert.Len(t, topics, 2)
+	})
 }


### PR DESCRIPTION
This PR adds granular scoping for Pub/Sub, enabling operators to limit an application to a set of pre-configured topics for both subscribing and publishing.

Closes #1294 
Closes #1035 

The PR includes the following:

* Adds inspection of special metadata properties to get a list of whitelisted subscriptions/publishings
* Changes Pub/Sub component injected into HTTP and gRPC APIs into an adapter function that performs pre-validation
* Adds test coverage