### PR TITLE
Correcting the E2E test suit name to TestActorFeatures.

### DIFF
--- a/tests/e2e/actor_features/actor_features_test.go
+++ b/tests/e2e/actor_features/actor_features_test.go
@@ -120,7 +120,7 @@ func TestMain(m *testing.M) {
 	os.Exit(tr.Start(m))
 }
 
-func TestServiceInvocation(t *testing.T) {
+func TestActorFeatures(t *testing.T) {
 	externalURL := tr.Platform.AcquireAppExternalURL(appName)
 	require.NotEmpty(t, externalURL, "external URL must not be empty!")
 


### PR DESCRIPTION
# Description

Currently the E2E test suit name for ActorFeatures is ServiceInvocation. Correcting it to TestActorFeatures.

## Issue reference

Closes #1323 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
