### PR TITLE
Add control plane retries in daprd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
-	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/etcd v3.3.18+incompatible // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/dapr/components-contrib v0.0.0-20200325000036-1ac30f7be571

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbp
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
-github.com/dapr/components-contrib v0.0.0-20200310050752-cf077cca6569 h1:71RTMkuhIOvhk8Pjyq/IMMwlWihhlxy3b1WpSlq0yCA=
-github.com/dapr/components-contrib v0.0.0-20200310050752-cf077cca6569/go.mod h1:YAE3MtYSknwlQNQ6wNtGJOxs/MGbfkwSEe5HhXSWPeo=
 github.com/dapr/components-contrib v0.0.0-20200325000036-1ac30f7be571 h1:IMgmxn+cpG2RkuqHxCxdB2JVmqwbc3BAlWdZrc08VrM=
 github.com/dapr/components-contrib v0.0.0-20200325000036-1ac30f7be571/go.mod h1:c3KXN49vGYGeccF7i1Hq7T8a0VzV/r8891Yi2HmulC8=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
@@ -494,6 +492,7 @@ github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/pkg/components/kubernetes_loader.go
+++ b/pkg/components/kubernetes_loader.go
@@ -20,6 +20,11 @@ import (
 
 var log = logger.NewLogger("dapr.runtime.components")
 
+const (
+	operatorCallTimeout = time.Second * 5
+	operatorMaxRetries  = 100
+)
+
 // KubernetesComponents loads components in a kubernetes environment
 type KubernetesComponents struct {
 	config config.KubernetesConfig
@@ -36,7 +41,7 @@ func NewKubernetesComponents(configuration config.KubernetesConfig, operatorClie
 
 // LoadComponents returns components from a given control plane address
 func (k *KubernetesComponents) LoadComponents() ([]components_v1alpha1.Component, error) {
-	resp, err := k.client.GetComponents(context.Background(), &empty.Empty{}, grpc_retry.WithMax(100), grpc_retry.WithPerRetryTimeout(5*time.Second))
+	resp, err := k.client.GetComponents(context.Background(), &empty.Empty{}, grpc_retry.WithMax(operatorMaxRetries), grpc_retry.WithPerRetryTimeout(operatorCallTimeout))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/components/kubernetes_loader.go
+++ b/pkg/components/kubernetes_loader.go
@@ -36,21 +36,21 @@ func NewKubernetesComponents(configuration config.KubernetesConfig, operatorClie
 
 // LoadComponents returns components from a given control plane address
 func (k *KubernetesComponents) LoadComponents() ([]components_v1alpha1.Component, error) {
-	var components []components_v1alpha1.Component
 	resp, err := k.client.GetComponents(context.Background(), &empty.Empty{}, grpc_retry.WithMax(100), grpc_retry.WithPerRetryTimeout(5*time.Second))
 	if err != nil {
 		return nil, err
 	}
 	comps := resp.GetComponents()
 
+	components := []components_v1alpha1.Component{}
 	for _, c := range comps {
 		var component components_v1alpha1.Component
-		serErr := json.Unmarshal(c.Value, &component)
-		if serErr != nil {
-			log.Warnf("error deserializing component: %s", serErr)
+		err := json.Unmarshal(c.Value, &component)
+		if err != nil {
+			log.Warnf("error deserializing component: %s", err)
 			continue
 		}
 		components = append(components, component)
 	}
-	return components, err
+	return components, nil
 }

--- a/pkg/components/kubernetes_loader.go
+++ b/pkg/components/kubernetes_loader.go
@@ -18,8 +18,6 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 )
 
-const maxRetryTime = time.Second * 30
-
 var log = logger.NewLogger("dapr.runtime.components")
 
 // KubernetesComponents loads components in a kubernetes environment

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -18,6 +18,11 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const (
+	operatorCallTimeout = time.Second * 5
+	operatorMaxRetries  = 100
+)
+
 type Configuration struct {
 	Spec ConfigurationSpec `json:"spec" yaml:"spec"`
 }
@@ -98,7 +103,7 @@ func LoadKubernetesConfiguration(config, namespace string, operatorClient pb.Ope
 	resp, err := operatorClient.GetConfiguration(context.Background(), &pb.GetConfigurationRequest{
 		Name:      config,
 		Namespace: namespace,
-	}, grpc_retry.WithMax(100), grpc_retry.WithPerRetryTimeout(5*time.Second))
+	}, grpc_retry.WithMax(operatorMaxRetries), grpc_retry.WithPerRetryTimeout(operatorCallTimeout))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	pb "github.com/dapr/dapr/pkg/proto/operator"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -96,7 +98,7 @@ func LoadKubernetesConfiguration(config, namespace string, operatorClient pb.Ope
 	resp, err := operatorClient.GetConfiguration(context.Background(), &pb.GetConfigurationRequest{
 		Name:      config,
 		Namespace: namespace,
-	})
+	}, grpc_retry.WithMax(100), grpc_retry.WithPerRetryTimeout(5*time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -8,6 +8,7 @@ import (
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	pb "github.com/dapr/dapr/pkg/proto/operator"
 	"github.com/dapr/dapr/pkg/sentry/certchain"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -17,6 +18,7 @@ import (
 func GetOperatorClient(address, serverName string, certChain *certchain.CertChain) (pb.OperatorClient, *grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
 		grpc.WithStatsHandler(diag.DefaultGRPCMonitoring.ClientStatsHandler),
+		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor()),
 	}
 	if certChain != nil {
 		cp := x509.NewCertPool()

--- a/pkg/runtime/security/auth.go
+++ b/pkg/runtime/security/auth.go
@@ -24,6 +24,7 @@ const (
 	sentrySignTimeout = time.Second * 5
 	certType          = "CERTIFICATE"
 	kubeTknPath       = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	sentryMaxRetries  = 100
 )
 
 type Authenticator interface {
@@ -108,7 +109,7 @@ func (a *authenticator) CreateSignedWorkloadCert(id string) (*SignedCertificate,
 		CertificateSigningRequest: certPem,
 		Id:                        getSentryIdentifier(id),
 		Token:                     getToken(),
-	}, grpc_retry.WithMax(100), grpc_retry.WithPerRetryTimeout(sentrySignTimeout))
+	}, grpc_retry.WithMax(sentryMaxRetries), grpc_retry.WithPerRetryTimeout(sentrySignTimeout))
 	if err != nil {
 		diag.DefaultMonitoring.MTLSWorkLoadCertRotationFailed("sign")
 		return nil, fmt.Errorf("error from sentry SignCertificate: %s", err)


### PR DESCRIPTION
Fixes #1314 

This PR adds resiliency to `daprd` in case of an unavailable operator, and/or sentry, delaying the init of `daprd` until the control plane is running.

This PR uses gRPC middleware for retries and gets rid of the exponential retries custom package that was used before.