### PR TITLE
Create dapr runtime docker image separately

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,8 @@ RUN if [ $TARGETPLATFORM = linux/arm/v7 ]; then mkdir -p /dist/linux/arm/v7 && m
 
 FROM scratch
 ARG TARGETPLATFORM
+ARG PKG_FILES
 ENTRYPOINT []
 WORKDIR /
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=alpine /dist/$TARGETPLATFORM/release /
+COPY --from=alpine /dist/$TARGETPLATFORM/release/$PKG_FILES /

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,9 +1,10 @@
 FROM golang:latest
 ARG TARGETPLATFORM
+ARG PKG_FILES
 ADD . /dist
 RUN if [ $TARGETPLATFORM = linux/amd64 ]; then mkdir -p /dist/linux/amd64 && mv /dist/linux_amd64/debug /dist/linux/amd64/; fi
 RUN if [ $TARGETPLATFORM = linux/arm/v7 ]; then mkdir -p /dist/linux/arm/v7 && mv /dist/linux_arm/debug /dist/linux/arm/v7/; fi
-RUN cp /dist/$TARGETPLATFORM/debug/* /
+RUN cp /dist/$TARGETPLATFORM/debug/$PKG_FILES /
 RUN rm -rf /dist
 
 WORKDIR /

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -8,6 +8,9 @@
 DOCKER:=docker
 DOCKERFILE_DIR?=./docker
 
+DAPR_SYSTEM_IMAGE_NAME=$(RELEASE_NAME)
+DAPR_RUNTIME_IMAGE_NAME=daprd
+
 ifeq ($(origin DEBUG), undefined)
   DOCKERFILE:=Dockerfile
 else ifeq ($(DEBUG),0)
@@ -24,10 +27,12 @@ DOCKERMUTI_ARCH=linux/amd64,linux/arm/v7
 ################################################################################
 
 LINUX_BINS_OUT_DIR=$(OUT_DIR)/linux_$(GOARCH)
-DOCKER_IMAGE_TAG=$(DAPR_REGISTRY)/$(RELEASE_NAME):$(DAPR_TAG)
+DOCKER_IMAGE_TAG=$(DAPR_REGISTRY)/$(DAPR_SYSTEM_IMAGE_NAME):$(DAPR_TAG)
+DAPR_RUNTIME_DOCKER_IMAGE_TAG=$(DAPR_REGISTRY)/$(DAPR_RUNTIME_IMAGE_NAME):$(DAPR_TAG)
 
 ifeq ($(LATEST_RELEASE),true)
-DOCKER_IMAGE_LATEST_TAG=$(DAPR_REGISTRY)/$(RELEASE_NAME):$(LATEST_TAG)
+DOCKER_IMAGE_LATEST_TAG=$(DAPR_REGISTRY)/$(DAPR_SYSTEM_IMAGE_NAME):$(LATEST_TAG)
+DAPR_RUNTIME_DOCKER_IMAGE_LATEST_TAG=$(DAPR_REGISTRY)/$(DAPR_RUNTIME_IMAGE_NAME):$(LATEST_TAG)
 endif
 
 # To use buildx: https://github.com/docker/buildx#docker-ce
@@ -45,22 +50,26 @@ endif
 # build docker image for linux
 docker-build: check-docker-env
 	$(info Building $(DOCKER_IMAGE_TAG) docker image ...)
-	$(DOCKER) build --build-arg TARGETPLATFORM=linux/amd64 -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(OUT_DIR)/. -t $(DOCKER_IMAGE_TAG)
+	$(DOCKER) build --build-arg TARGETPLATFORM=linux/amd64 --build-arg PKG_FILES=* -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(OUT_DIR)/. -t $(DOCKER_IMAGE_TAG)
+	$(DOCKER) build --build-arg TARGETPLATFORM=linux/amd64 --build-arg PKG_FILES=daprd -f $(DOCKERFILE_DIR)/$(DOCKERFILE) $(OUT_DIR)/. -t $(DAPR_RUNTIME_DOCKER_IMAGE_TAG)
 
 # push docker image to the registry
 docker-push: docker-build
 	$(info Pushing $(DOCKER_IMAGE_TAG) docker image ...)
 	$(DOCKER) push $(DOCKER_IMAGE_TAG)
+	$(DOCKER) push $(DAPR_RUNTIME_DOCKER_IMAGE_TAG)
 
 # publish muti-arch docker image to the registry
 docker-publish: check-docker-env
 	-$(DOCKER) buildx create --use --name daprbuild
 	-$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	$(info Pushing $(DOCKER_IMAGE_TAG) docker image ...)
-	$(DOCKER) buildx build --platform $(DOCKERMUTI_ARCH) -t $(DOCKER_IMAGE_TAG) $(OUT_DIR) -f $(DOCKERFILE_DIR)/$(DOCKERFILE) --push
+	$(DOCKER) buildx build --build-arg PKG_FILES=* --platform $(DOCKERMUTI_ARCH) -t $(DOCKER_IMAGE_TAG) $(OUT_DIR) -f $(DOCKERFILE_DIR)/$(DOCKERFILE) --push
+	$(DOCKER) buildx build --build-arg PKG_FILES=daprd --platform $(DOCKERMUTI_ARCH) -t $(DAPR_RUNTIME_DOCKER_IMAGE_TAG) $(OUT_DIR) -f $(DOCKERFILE_DIR)/$(DOCKERFILE) --push
 ifeq ($(LATEST_RELEASE),true)
 	$(info Pushing $(DOCKER_IMAGE_LATEST_TAG) docker image ...)
-	$(DOCKER) buildx build --platform $(DOCKERMUTI_ARCH) -t $(DOCKER_IMAGE_LATEST_TAG) $(OUT_DIR) -f $(DOCKERFILE_DIR)/$(DOCKERFILE) --push
+	$(DOCKER) buildx build --build-arg PKG_FILES=* --platform $(DOCKERMUTI_ARCH) -t $(DOCKER_IMAGE_LATEST_TAG) $(OUT_DIR) -f $(DOCKERFILE_DIR)/$(DOCKERFILE) --push
+	$(DOCKER) buildx build --build-arg PKG_FILES=daprd --platform $(DOCKERMUTI_ARCH) -t $(DAPR_RUNTIME_DOCKER_IMAGE_LATEST_TAG) $(OUT_DIR) -f $(DOCKERFILE_DIR)/$(DOCKERFILE) --push
 endif
 
 ################################################################################


### PR DESCRIPTION
# Description

Create dapr runtime image separately.
- Create `daprd` image including only daprd binary
- Keep daprd in dapr image for the backward compat.

Next PR:
- change operator to pull daprd image. 

## Issue reference

#633 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
