### PR TITLE
Pub Sub: Don't allow allowedTopics to override

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -867,7 +867,7 @@ func (a *DaprRuntime) Publish(req *pubsub.PublishRequest) error {
 	return a.pubSub.Publish(req)
 }
 
-func (a *DaprRuntime) isPubSubOperationAllowed(topic string, topicsList []string) bool {
+func (a *DaprRuntime) isPubSubOperationAllowed(topic string, scopedTopics []string) bool {
 	inAllowedTopics := false
 
 	// first check if allowedTopics contain it
@@ -881,20 +881,18 @@ func (a *DaprRuntime) isPubSubOperationAllowed(topic string, topicsList []string
 		if !inAllowedTopics {
 			return false
 		}
-	} else if len(topicsList) == 0 {
+	}
+	if len(scopedTopics) == 0 {
 		return true
 	}
 
 	// check if a granular scope has been applied
 	allowedScope := false
-	for _, t := range topicsList {
+	for _, t := range scopedTopics {
 		if t == topic {
 			allowedScope = true
 			break
 		}
-	}
-	if inAllowedTopics && !allowedScope {
-		return true
 	}
 	return allowedScope
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -363,29 +363,28 @@ func TestInitPubSub(t *testing.T) {
 		assert.True(t, a)
 	})
 
-	t.Run("topic is in allowed topics, not in existing publishing scopes, operation allowed", func(t *testing.T) {
+	t.Run("topic in allowed topics, not in existing publishing scopes, operation not allowed", func(t *testing.T) {
 		rt.allowedTopics = []string{"topic1"}
 		rt.scopedPublishings = []string{"topic2"}
-		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
-		assert.True(t, a)
-	})
-
-	t.Run("topic in allowed topics, no in publishing scopes, operation allowed", func(t *testing.T) {
-		rt.allowedTopics = []string{"topic1"}
-		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
-		assert.True(t, a)
-	})
-
-	t.Run("topic is not in allowed topics, in publishing scopes, operation not allowed", func(t *testing.T) {
-		rt.allowedTopics = []string{}
 		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
 		assert.False(t, a)
 	})
 
-	t.Run("topic is not in allowed topics, not in publishing scopes, operation allowed", func(t *testing.T) {
-		rt.allowedTopics = []string{}
-		a := rt.isPubSubOperationAllowed("topic1", []string{})
+	t.Run("topic in allowed topics, not in publishing scopes, operation allowed", func(t *testing.T) {
+		rt.allowedTopics = []string{"topic1"}
+		rt.scopedPublishings = []string{}
+		a := rt.isPubSubOperationAllowed("topic1", rt.scopedPublishings)
 		assert.True(t, a)
+	})
+
+	t.Run("topics A and B in allowed topics, A in publishing scopes, operation allowed for A only", func(t *testing.T) {
+		rt.allowedTopics = []string{"A", "B"}
+		rt.scopedPublishings = []string{"A"}
+		a := rt.isPubSubOperationAllowed("A", rt.scopedPublishings)
+		assert.True(t, a)
+
+		b := rt.isPubSubOperationAllowed("B", rt.scopedPublishings)
+		assert.False(t, b)
 	})
 }
 


### PR DESCRIPTION
This PR aligns scoped topics with the correct behavior of taking granular scopes into consideration if the topic exists in `allowedTopics`.

/cc @RicardoNiepel 