### PR TITLE
Reducing the initial readiness probe delay from 5 secs to 1 sec

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -50,8 +50,8 @@ const (
 	defaultConfig                = "default"
 	defaultMetricsPort           = 9090
 	sidecarHealthzPath           = "healthz"
-	defaultHealthzProbeDelay     = 5
-	defaultHealthzProbeTimeout   = 5
+	defaultHealthzProbeDelay     = 1
+	defaultHealthzProbeTimeout   = 3
 	defaultHealthzProbeThreshold = 1
 	apiVersionV1                 = "v1.0"
 )


### PR DESCRIPTION
- Reducing the initial readiness probe delay from 5 secs to 1 sec

- Also reducing the timeout from 5 to 3 secs

## Issue reference

Closes #1362

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
