### PR TITLE
Simplify tracing options - Remove expandParams and includeBody

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -53,9 +53,7 @@ type SelectorField struct {
 }
 
 type TracingSpec struct {
-	Enabled      bool `json:"enabled" yaml:"enabled"`
-	ExpandParams bool `json:"expandParams" yaml:"expandParams"`
-	IncludeBody  bool `json:"includeBody" yaml:"includeBody"`
+	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
 type MTLSSpec struct {
@@ -69,9 +67,7 @@ func LoadDefaultConfiguration() *Configuration {
 	return &Configuration{
 		Spec: ConfigurationSpec{
 			TracingSpec: TracingSpec{
-				Enabled:      false,
-				ExpandParams: false,
-				IncludeBody:  false,
+				Enabled: false,
 			},
 		},
 	}

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -237,7 +237,6 @@ func addAnnotationsFromGRPCMetadata(md map[string][]string, span *trace.Span) {
 	// md metadata must only have dapr prefixed headers metadata
 	// still extra check for dapr headers to avoid, it might be micro performance hit but that is ok
 	for k, vv := range md {
-
 		if !strings.HasPrefix(strings.ToLower(k), headerPrefix) {
 			continue
 		}
@@ -301,7 +300,7 @@ func extractDaprMetadata(ctx context.Context) map[string][]string {
 		return daprMetadata
 	}
 
-	for k, _ := range md {
+	for k := range md {
 		k = strings.ToLower(k)
 		if strings.HasPrefix(k, headerPrefix) {
 			daprMetadata[k] = md[k]

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -28,9 +28,9 @@ type key string
 
 const (
 	// CorrelationID is the header key name of correlation id for trace
-	CorrelationID      = "X-Correlation-ID"
-	correlationKey key = CorrelationID
-	headerPrefix       = "dapr-"
+	CorrelationID        = "X-Correlation-ID"
+	correlationKey   key = CorrelationID
+	daprHeaderPrefix     = "dapr-"
 )
 
 // TracerSpan defines a tracing span that a tracer users to keep track of call scopes
@@ -121,7 +121,7 @@ func addAnnotationsFromHTTPMetadata(req *fasthttp.Request, span *trace.Span) {
 	req.Header.VisitAll(func(key []byte, value []byte) {
 		headerKey := string(key)
 		headerKey = strings.ToLower(headerKey)
-		if strings.HasPrefix(headerKey, headerPrefix) {
+		if strings.HasPrefix(headerKey, daprHeaderPrefix) {
 			span.AddAttributes(trace.StringAttribute(headerKey, string(value)))
 		}
 	})
@@ -236,7 +236,7 @@ func addAnnotationsFromGRPCMetadata(md map[string][]string, span *trace.Span) {
 	// md metadata must only have dapr prefixed headers metadata
 	// still extra check for dapr headers to avoid, it might be micro performance hit but that is ok
 	for k, vv := range md {
-		if !strings.HasPrefix(strings.ToLower(k), headerPrefix) {
+		if !strings.HasPrefix(strings.ToLower(k), daprHeaderPrefix) {
 			continue
 		}
 
@@ -301,7 +301,7 @@ func extractDaprMetadata(ctx context.Context) map[string][]string {
 
 	for k, v := range md {
 		k = strings.ToLower(k)
-		if strings.HasPrefix(k, headerPrefix) {
+		if strings.HasPrefix(k, daprHeaderPrefix) {
 			daprMetadata[k] = v
 		}
 	}

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -299,10 +299,10 @@ func extractDaprMetadata(ctx context.Context) map[string][]string {
 		return daprMetadata
 	}
 
-	for k := range md {
+	for k, v := range md {
 		k = strings.ToLower(k)
 		if strings.HasPrefix(k, headerPrefix) {
-			daprMetadata[k] = md[k]
+			daprMetadata[k] = v
 		}
 	}
 

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -21,7 +21,6 @@ import (
 	"github.com/valyala/fasthttp"
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc"
-	grpc_go "google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -141,7 +140,7 @@ func TracingHTTPMiddleware(spec config.TracingSpec, next fasthttp.RequestHandler
 }
 
 // TracingGRPCMiddlewareStream plugs tracer into gRPC stream
-func TracingGRPCMiddlewareStream(spec config.TracingSpec) grpc_go.StreamServerInterceptor {
+func TracingGRPCMiddlewareStream(spec config.TracingSpec) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		span, spanc := TracingSpanFromGRPCContext(stream.Context(), nil, info.FullMethod, spec)
 		wrappedStream := grpc_middleware.WrapServerStream(stream)
@@ -190,7 +189,7 @@ func UpdateSpanPairStatusesFromError(span, spanc TracerSpan, err error, method s
 }
 
 // TracingGRPCMiddlewareUnary plugs tracer into gRPC unary calls
-func TracingGRPCMiddlewareUnary(spec config.TracingSpec) grpc_go.UnaryServerInterceptor {
+func TracingGRPCMiddlewareUnary(spec config.TracingSpec) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		span, spanc := TracingSpanFromGRPCContext(ctx, req, info.FullMethod, spec)
 		defer span.Span.End()

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -23,7 +23,10 @@ func TestTraceSpanFromFastHTTPRequest(t *testing.T) {
 func TestTraceSpanFromFastHTTPContext(t *testing.T) {
 	req := getTestHTTPRequest()
 	spec := config.TracingSpec{Enabled: true}
-	ctx := &fasthttp.RequestCtx{Request: *req}
+
+	var r = fasthttp.Request{}
+	req.CopyTo(&r)
+	ctx := &fasthttp.RequestCtx{Request: r}
 
 	TraceSpanFromFastHTTPContext(ctx, spec)
 }

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -6,11 +6,14 @@
 package diagnostics
 
 import (
+	"context"
 	"testing"
 
+	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/valyala/fasthttp"
 	"go.opencensus.io/trace"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestTraceSpanFromFastHTTPRequest(t *testing.T) {
@@ -50,4 +53,13 @@ func getTestHTTPRequest() *fasthttp.Request {
 	req.Header.Set(CorrelationID, corID)
 
 	return req
+}
+
+func TestTracingSpanFromGRPCContext(t *testing.T) {
+	req := &channel.InvokeRequest{}
+	spec := config.TracingSpec{Enabled: true}
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"dapr-headerKey": {"v3", "v4"}})
+
+	TracingSpanFromGRPCContext(ctx, req, "invoke", spec)
 }

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -1,0 +1,39 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/dapr/dapr/pkg/config"
+	"github.com/valyala/fasthttp"
+	"go.opencensus.io/trace"
+)
+
+func TestTraceSpanFromFastHTTPRequest(t *testing.T) {
+	req := &fasthttp.Request{}
+	req.Header.Set("dapr-testheaderkey", "dapr-testheadervalue")
+	req.Header.Set("x-testheaderkey1", "dapr-testheadervalue")
+	req.Header.Set("daprd-testheaderkey2", "dapr-testheadervalue")
+
+	var (
+		tid = trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 4, 8, 16, 32, 64, 128}
+		sid = trace.SpanID{1, 2, 4, 8, 16, 32, 64, 128}
+	)
+
+	sc := trace.SpanContext{
+		TraceID:      tid,
+		SpanID:       sid,
+		TraceOptions: 0x0,
+	}
+
+	corID := SerializeSpanContext(sc)
+	req.Header.Set(CorrelationID, corID)
+
+	spec := config.TracingSpec{Enabled: true}
+
+	TraceSpanFromFastHTTPRequest(req, spec)
+}

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -14,6 +14,21 @@ import (
 )
 
 func TestTraceSpanFromFastHTTPRequest(t *testing.T) {
+	req := getTestHTTPRequest()
+	spec := config.TracingSpec{Enabled: true}
+
+	TraceSpanFromFastHTTPRequest(req, spec)
+}
+
+func TestTraceSpanFromFastHTTPContext(t *testing.T) {
+	req := getTestHTTPRequest()
+	spec := config.TracingSpec{Enabled: true}
+	ctx := &fasthttp.RequestCtx{Request: *req}
+
+	TraceSpanFromFastHTTPContext(ctx, spec)
+}
+
+func getTestHTTPRequest() *fasthttp.Request {
 	req := &fasthttp.Request{}
 	req.Header.Set("dapr-testheaderkey", "dapr-testheadervalue")
 	req.Header.Set("x-testheaderkey1", "dapr-testheadervalue")
@@ -33,7 +48,5 @@ func TestTraceSpanFromFastHTTPRequest(t *testing.T) {
 	corID := SerializeSpanContext(sc)
 	req.Header.Set(CorrelationID, corID)
 
-	spec := config.TracingSpec{Enabled: true}
-
-	TraceSpanFromFastHTTPRequest(req, spec)
+	return req
 }

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -23,10 +23,8 @@ func TestTraceSpanFromFastHTTPRequest(t *testing.T) {
 func TestTraceSpanFromFastHTTPContext(t *testing.T) {
 	req := getTestHTTPRequest()
 	spec := config.TracingSpec{Enabled: true}
-
-	var r = fasthttp.Request{}
-	req.CopyTo(&r)
-	ctx := &fasthttp.RequestCtx{Request: r}
+	ctx := &fasthttp.RequestCtx{}
+	req.CopyTo(&ctx.Request)
 
 	TraceSpanFromFastHTTPContext(ctx, spec)
 }


### PR DESCRIPTION
# Description
- Simplify tracing options  - Removed expandParams and includeBody
- Extracting only dapr- prefixed metadata from gRPC metadata. This will avoid any potential issues coming from parsing reserved gRPC headers .
- Adding annotations only for dapr- prefixed headers

## Issue reference
Epic :  #1317 
Closes #1394 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
