### PR TITLE
Use Trace Sampling Rate as configuration with probabilistic trace sampler 

### DIFF
--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -64,9 +64,7 @@ type SelectorField struct {
 
 // TracingSpec is the spec object in ConfigurationSpec
 type TracingSpec struct {
-	Enabled      bool `json:"enabled"`
-	IncludeBody  bool `json:"includeBody"`
-	ExpandParams bool `json:"expandParams"`
+	SamplingRate string `json:"samplingRate"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
 	tracing "github.com/dapr/dapr/pkg/diagnostics"
+	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	daprclient_pb "github.com/dapr/dapr/pkg/proto/daprclient"
 	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/grpc"
@@ -74,7 +75,7 @@ func (g *Channel) InvokeMethod(req *channel.InvokeRequest) (*channel.InvokeRespo
 	var span tracing.TracerSpan
 	var spanc tracing.TracerSpan
 
-	if g.tracingSpec.Enabled {
+	if diag_utils.IsTracingEnabled(g.tracingSpec.SamplingRate) {
 		span, spanc = tracing.TracingSpanFromGRPCContext(ctx, nil, req.Method, g.tracingSpec)
 
 		defer span.Span.End()
@@ -83,7 +84,7 @@ func (g *Channel) InvokeMethod(req *channel.InvokeRequest) (*channel.InvokeRespo
 
 	resp, err := c.OnInvoke(ctx, &msg)
 
-	if g.tracingSpec.Enabled {
+	if diag_utils.IsTracingEnabled(g.tracingSpec.SamplingRate) {
 		tracing.UpdateSpanPairStatusesFromError(span, spanc, err, req.Method)
 	}
 

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/valyala/fasthttp"
 )
 
@@ -99,7 +100,7 @@ func (h *Channel) InvokeMethod(invokeRequest *channel.InvokeRequest) (*channel.I
 	var span diag.TracerSpan
 	var spanc diag.TracerSpan
 
-	if h.tracingSpec.Enabled {
+	if diag_utils.IsTracingEnabled(h.tracingSpec.SamplingRate) {
 		span, spanc = diag.TraceSpanFromFastHTTPRequest(req, h.tracingSpec)
 
 		defer span.Span.End()
@@ -157,7 +158,7 @@ func (h *Channel) InvokeMethod(invokeRequest *channel.InvokeRequest) (*channel.I
 		metadata["headers"] = strings.Join(headers, "&__header_delim__&")
 	}
 
-	if h.tracingSpec.Enabled {
+	if diag_utils.IsTracingEnabled(h.tracingSpec.SamplingRate) {
 		diag.UpdateSpanPairStatusesFromHTTPResponse(span, spanc, resp)
 	}
 

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -81,7 +81,7 @@ func TestInvokeMethod(t *testing.T) {
 			baseAddress: server.URL,
 			client:      &fasthttp.Client{},
 			tracingSpec: config.TracingSpec{
-				Enabled: false,
+				SamplingRate: "0",
 			},
 		}
 		th.serverURL = server.URL[len("http://"):]
@@ -98,7 +98,7 @@ func TestInvokeMethod(t *testing.T) {
 			baseAddress: server.URL,
 			client:      &fasthttp.Client{},
 			tracingSpec: config.TracingSpec{
-				Enabled: true,
+				SamplingRate: "1",
 			},
 		}
 		th.serverURL = server.URL[len("http://"):]

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -53,7 +53,7 @@ type SelectorField struct {
 }
 
 type TracingSpec struct {
-	Enabled bool `json:"enabled" yaml:"enabled"`
+	SamplingRate string `json:"samplingRate" yaml:"samplingRate"`
 }
 
 type MTLSSpec struct {
@@ -67,7 +67,7 @@ func LoadDefaultConfiguration() *Configuration {
 	return &Configuration{
 		Spec: ConfigurationSpec{
 			TracingSpec: TracingSpec{
-				Enabled: false,
+				SamplingRate: "0.0",
 			},
 		},
 	}

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -69,19 +69,19 @@ func DeserializeSpanContextPointer(ctx string) *trace.SpanContext {
 	return context
 }
 
-// TraceSpanFromFastHTTPRequest creates a tracing span form a fasthttp request
+// TraceSpanFromFastHTTPRequest creates a tracing span from a fasthttp request
 func TraceSpanFromFastHTTPRequest(r *fasthttp.Request, spec config.TracingSpec) (TracerSpan, TracerSpan) {
 	uri := string(r.Header.RequestURI())
 	return getTraceSpan(r, uri, spec)
 }
 
-// TraceSpanFromFastHTTPContext creates a tracing span form a fasthttp request context
+// TraceSpanFromFastHTTPContext creates a tracing span from a fasthttp request context
 func TraceSpanFromFastHTTPContext(c *fasthttp.RequestCtx, spec config.TracingSpec) (TracerSpan, TracerSpan) {
 	uri := string(c.Path())
 	return getTraceSpan(&c.Request, uri, spec)
 }
 
-// getTraceSpan creates a tracing span from a fasthttp request
+// getTraceSpan creates a tracing span from a fasthttp request and given tracing spec
 func getTraceSpan(r *fasthttp.Request, uri string, spec config.TracingSpec) (TracerSpan, TracerSpan) {
 	var ctx context.Context
 	var span *trace.Span

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -81,13 +81,17 @@ func TraceSpanFromFastHTTPRequest(r *fasthttp.Request, spec config.TracingSpec) 
 	rate := diag_utils.GetTraceSamplingRate(spec.SamplingRate)
 
 	// TODO : Continue using ProbabilitySampler till Go SDK starts supporting RateLimiting sampler
+	probSamplerOption := trace.WithSampler(trace.ProbabilitySampler(rate))
+	serverKindOption := trace.WithSpanKind(trace.SpanKindServer)
+	clientKindOption := trace.WithSpanKind(trace.SpanKindClient)
+	spanName := createSpanName(uriSpanName)
 	if corID != "" {
 		spanContext := DeserializeSpanContext(corID)
-		ctx, span = trace.StartSpanWithRemoteParent(context.Background(), uriSpanName, spanContext, trace.WithSpanKind(trace.SpanKindServer), trace.WithSampler(trace.ProbabilitySampler(rate)))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(uriSpanName), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient), trace.WithSampler(trace.ProbabilitySampler(rate)))
+		ctx, span = trace.StartSpanWithRemoteParent(context.Background(), uriSpanName, spanContext, serverKindOption, probSamplerOption)
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, spanName, span.SpanContext(), clientKindOption, probSamplerOption)
 	} else {
-		ctx, span = trace.StartSpan(context.Background(), uriSpanName, trace.WithSpanKind(trace.SpanKindServer), trace.WithSampler(trace.ProbabilitySampler(rate)))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(uriSpanName), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient), trace.WithSampler(trace.ProbabilitySampler(rate)))
+		ctx, span = trace.StartSpan(context.Background(), uriSpanName, serverKindOption, probSamplerOption)
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, spanName, span.SpanContext(), clientKindOption, probSamplerOption)
 	}
 
 	addAnnotationsFromHTTPMetadata(r, span)
@@ -108,13 +112,18 @@ func TraceSpanFromFastHTTPContext(c *fasthttp.RequestCtx, spec config.TracingSpe
 	rate := diag_utils.GetTraceSamplingRate(spec.SamplingRate)
 
 	// TODO : Continue using ProbabilitySampler till Go SDK starts supporting RateLimiting sampler
+	probSamplerOption := trace.WithSampler(trace.ProbabilitySampler(rate))
+	path := string(c.Path())
+	serverKindOption := trace.WithSpanKind(trace.SpanKindServer)
+	clientKindOption := trace.WithSpanKind(trace.SpanKindClient)
+	spanName := createSpanName(path)
 	if corID != "" {
 		spanContext := DeserializeSpanContext(corID)
-		ctx, span = trace.StartSpanWithRemoteParent(context.Background(), string(c.Path()), spanContext, trace.WithSpanKind(trace.SpanKindServer), trace.WithSampler(trace.ProbabilitySampler(rate)))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(string(c.Path())), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient), trace.WithSampler(trace.ProbabilitySampler(rate)))
+		ctx, span = trace.StartSpanWithRemoteParent(context.Background(), path, spanContext, serverKindOption, probSamplerOption)
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, spanName, span.SpanContext(), clientKindOption, probSamplerOption)
 	} else {
-		ctx, span = trace.StartSpan(context.Background(), string(c.Path()), trace.WithSpanKind(trace.SpanKindServer), trace.WithSampler(trace.ProbabilitySampler(rate)))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(string(c.Path())), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient), trace.WithSampler(trace.ProbabilitySampler(rate)))
+		ctx, span = trace.StartSpan(context.Background(), path, serverKindOption, probSamplerOption)
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, spanName, span.SpanContext(), clientKindOption, probSamplerOption)
 	}
 
 	addAnnotationsFromHTTPMetadata(&c.Request, span)
@@ -226,13 +235,17 @@ func TracingSpanFromGRPCContext(c context.Context, req interface{}, method strin
 	rate := diag_utils.GetTraceSamplingRate(spec.SamplingRate)
 
 	// TODO : Continue using ProbabilitySampler till Go SDK starts supporting RateLimiting sampler
+	probSamplerOption := trace.WithSampler(trace.ProbabilitySampler(rate))
+	serverKindOption := trace.WithSpanKind(trace.SpanKindServer)
+	clientKindOption := trace.WithSpanKind(trace.SpanKindClient)
+	spanName := createSpanName(method)
 	if corID != "" {
 		spanContext := DeserializeSpanContext(corID)
-		ctx, span = trace.StartSpanWithRemoteParent(c, method, spanContext, trace.WithSpanKind(trace.SpanKindServer), trace.WithSampler(trace.ProbabilitySampler(rate)))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(method), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient), trace.WithSampler(trace.ProbabilitySampler(rate)))
+		ctx, span = trace.StartSpanWithRemoteParent(c, method, spanContext, serverKindOption, probSamplerOption)
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, spanName, span.SpanContext(), clientKindOption, probSamplerOption)
 	} else {
-		ctx, span = trace.StartSpan(context.Background(), method, trace.WithSpanKind(trace.SpanKindServer), trace.WithSampler(trace.ProbabilitySampler(rate)))
-		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, createSpanName(method), span.SpanContext(), trace.WithSpanKind(trace.SpanKindClient), trace.WithSampler(trace.ProbabilitySampler(rate)))
+		ctx, span = trace.StartSpan(context.Background(), method, serverKindOption, probSamplerOption)
+		ctxc, spanc = trace.StartSpanWithRemoteParent(ctx, spanName, span.SpanContext(), clientKindOption, probSamplerOption)
 	}
 
 	addAnnotationsFromGRPCMetadata(md, span)

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -18,14 +18,14 @@ import (
 
 func TestTraceSpanFromFastHTTPRequest(t *testing.T) {
 	req := getTestHTTPRequest()
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 
 	TraceSpanFromFastHTTPRequest(req, spec)
 }
 
 func TestTraceSpanFromFastHTTPContext(t *testing.T) {
 	req := getTestHTTPRequest()
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 	ctx := &fasthttp.RequestCtx{}
 	req.CopyTo(&ctx.Request)
 
@@ -57,7 +57,7 @@ func getTestHTTPRequest() *fasthttp.Request {
 
 func TestTracingSpanFromGRPCContext(t *testing.T) {
 	req := &channel.InvokeRequest{}
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 	ctx := context.Background()
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{"dapr-headerKey": {"v3", "v4"}})
 

--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -10,14 +10,14 @@ import (
 )
 
 const (
-	defaultTraceSamplingRate = 0.001
+	defaultSamplingRate = 1e-4
 )
 
 // GetTraceSamplingRate parses the given rate and returns the parsed rate
 func GetTraceSamplingRate(rate string) float64 {
 	f, err := strconv.ParseFloat(rate, 64)
 	if err != nil {
-		return defaultTraceSamplingRate
+		return defaultSamplingRate
 	}
 	return f
 }

--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -12,10 +12,7 @@ import (
 // IsTracingEnabled checks for tracing enabled or not based on given sampling rate
 func IsTracingEnabled(rate string) bool {
 	f, _ := strconv.ParseFloat(rate, 64)
-	if f != 0 {
-		return true
-	}
-	return false
+	return f != 0
 }
 
 // GetTraceSamplingRate parses the given rate and returns the parsed rate

--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package utils
+
+import (
+	"strconv"
+)
+
+// IsTracingEnabled checks for tracing enabled or not based on given sampling rate
+func IsTracingEnabled(rate string) bool {
+	f, _ := strconv.ParseFloat(rate, 64)
+	if f != 0 {
+		return true
+	}
+	return false
+}
+
+// GetTraceSamplingRate parses the given rate and returns the parsed rate
+func GetTraceSamplingRate(rate string) float64 {
+	f, err := strconv.ParseFloat(rate, 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}

--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -9,17 +9,15 @@ import (
 	"strconv"
 )
 
-// IsTracingEnabled checks for tracing enabled or not based on given sampling rate
-func IsTracingEnabled(rate string) bool {
-	f, _ := strconv.ParseFloat(rate, 64)
-	return f != 0
-}
+const (
+	defaultTraceSamplingRate = 0.001
+)
 
 // GetTraceSamplingRate parses the given rate and returns the parsed rate
 func GetTraceSamplingRate(rate string) float64 {
 	f, err := strconv.ParseFloat(rate, 64)
 	if err != nil {
-		return 0
+		return defaultTraceSamplingRate
 	}
 	return f
 }

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -78,7 +78,7 @@ func TestCallActorWithTracing(t *testing.T) {
 	assert.NoError(t, err)
 
 	buffer := ""
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "1"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,
@@ -125,7 +125,7 @@ func TestCallRemoteAppWithTracing(t *testing.T) {
 	assert.NoError(t, err)
 
 	buffer := ""
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "1"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
-	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/dapr/dapr/pkg/logger"
 	dapr_pb "github.com/dapr/dapr/pkg/proto/dapr"
 	daprinternal_pb "github.com/dapr/dapr/pkg/proto/daprinternal"
@@ -126,13 +125,11 @@ func (s *server) generateWorkloadCert() error {
 func (s *server) getMiddlewareOptions() []grpc_go.ServerOption {
 	opts := []grpc_go.ServerOption{}
 
-	if diag_utils.IsTracingEnabled(s.tracingSpec.SamplingRate) {
-		s.logger.Infof("enabled tracing grpc middleware")
-		opts = append(
-			opts,
-			grpc_go.StreamInterceptor(diag.TracingGRPCMiddlewareStream(s.tracingSpec)),
-			grpc_go.UnaryInterceptor(diag.TracingGRPCMiddlewareUnary(s.tracingSpec)))
-	}
+	s.logger.Infof("enabled tracing grpc middleware")
+	opts = append(
+		opts,
+		grpc_go.StreamInterceptor(diag.TracingGRPCMiddlewareStream(s.tracingSpec)),
+		grpc_go.UnaryInterceptor(diag.TracingGRPCMiddlewareUnary(s.tracingSpec)))
 
 	s.logger.Infof("enabled metrics grpc middleware")
 	opts = append(opts, grpc_go.StatsHandler(diag.DefaultGRPCMonitoring.ServerStatsHandler))

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/dapr/dapr/pkg/logger"
 	dapr_pb "github.com/dapr/dapr/pkg/proto/dapr"
 	daprinternal_pb "github.com/dapr/dapr/pkg/proto/daprinternal"
@@ -125,7 +126,7 @@ func (s *server) generateWorkloadCert() error {
 func (s *server) getMiddlewareOptions() []grpc_go.ServerOption {
 	opts := []grpc_go.ServerOption{}
 
-	if s.tracingSpec.Enabled {
+	if diag_utils.IsTracingEnabled(s.tracingSpec.SamplingRate) {
 		s.logger.Infof("enabled tracing grpc middleware")
 		opts = append(
 			opts,

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -34,7 +34,7 @@ func TestGetMiddlewareOptions(t *testing.T) {
 		fakeServer := &server{
 			config: ServerConfig{},
 			tracingSpec: config.TracingSpec{
-				Enabled: true,
+				SamplingRate: "1",
 			},
 			renewMutex: &sync.Mutex{},
 			logger:     logger.NewLogger("dapr.runtime.grpc.test"),
@@ -49,7 +49,7 @@ func TestGetMiddlewareOptions(t *testing.T) {
 		fakeServer := &server{
 			config: ServerConfig{},
 			tracingSpec: config.TracingSpec{
-				Enabled: false,
+				SamplingRate: "0",
 			},
 			renewMutex: &sync.Mutex{},
 			logger:     logger.NewLogger("dapr.runtime.grpc.test"),

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -45,7 +45,7 @@ func TestGetMiddlewareOptions(t *testing.T) {
 		assert.Equal(t, 3, len(serverOption))
 	})
 
-	t.Run("should disable middlewares", func(t *testing.T) {
+	t.Run("should not disable middlewares even when SamplingRate is 0", func(t *testing.T) {
 		fakeServer := &server{
 			config: ServerConfig{},
 			tracingSpec: config.TracingSpec{
@@ -57,6 +57,6 @@ func TestGetMiddlewareOptions(t *testing.T) {
 
 		serverOption := fakeServer.getMiddlewareOptions()
 
-		assert.Equal(t, 1, len(serverOption))
+		assert.Equal(t, 3, len(serverOption))
 	})
 }

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttputil"
+	"go.opencensus.io/trace"
 )
 
 var retryCounter = 0
@@ -105,7 +106,7 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	buffer := ""
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,
@@ -114,7 +115,7 @@ func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 		},
 	}
 	createExporters(meta)
-
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 	testAPI := &api{
 		sendToOutputBindingFn: func(name string, req *bindings.WriteRequest) error { return nil },
 		json:                  jsoniter.ConfigFastest,
@@ -256,7 +257,7 @@ func TestV1DirectMessagingEndpointsWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,
@@ -645,7 +646,7 @@ func TestV1ActorEndpointsWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,
@@ -956,7 +957,7 @@ func TestEmptyPipelineWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 	pipe := http_middleware.Pipeline{}
 
 	meta := exporters.Metadata{
@@ -1038,7 +1039,7 @@ func TestSinglePipelineWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{Enabled: true}
+	spec := config.TracingSpec{SamplingRate: "0.5"}
 
 	pipeline := buildHTTPPineline(config.PipelineSpec{
 		Handlers: []config.HandlerSpec{

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttputil"
-	"go.opencensus.io/trace"
 )
 
 var retryCounter = 0
@@ -106,7 +105,7 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	buffer := ""
-	spec := config.TracingSpec{SamplingRate: "0.5"}
+	spec := config.TracingSpec{SamplingRate: "1"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,
@@ -115,7 +114,7 @@ func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 		},
 	}
 	createExporters(meta)
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
 	testAPI := &api{
 		sendToOutputBindingFn: func(name string, req *bindings.WriteRequest) error { return nil },
 		json:                  jsoniter.ConfigFastest,
@@ -257,7 +256,7 @@ func TestV1DirectMessagingEndpointsWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{SamplingRate: "0.5"}
+	spec := config.TracingSpec{SamplingRate: "1"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,
@@ -646,7 +645,7 @@ func TestV1ActorEndpointsWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{SamplingRate: "0.5"}
+	spec := config.TracingSpec{SamplingRate: "1"}
 
 	meta := exporters.Metadata{
 		Buffer: &buffer,
@@ -957,7 +956,7 @@ func TestEmptyPipelineWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{SamplingRate: "0.5"}
+	spec := config.TracingSpec{SamplingRate: "1.0"}
 	pipe := http_middleware.Pipeline{}
 
 	meta := exporters.Metadata{
@@ -1039,7 +1038,7 @@ func TestSinglePipelineWithTracer(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 
 	buffer := ""
-	spec := config.TracingSpec{SamplingRate: "0.5"}
+	spec := config.TracingSpec{SamplingRate: "1.0"}
 
 	pipeline := buildHTTPPineline(config.PipelineSpec{
 		Handlers: []config.HandlerSpec{
@@ -1088,6 +1087,74 @@ func TestSinglePipelineWithTracer(t *testing.T) {
 		// assert
 		mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 1)
 		assert.Equal(t, "0", buffer, "failed to generate proper traces with invoke")
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+}
+
+func TestSinglePipelineWithNoTracing(t *testing.T) {
+	fakeHeader := "Host&__header_equals__&localhost&__header_delim__&Content-Length&__header_equals__&8&__header_delim__&Content-Type&__header_equals__&application/json&__header_delim__&User-Agent&__header_equals__&Go-http-client/1.1&__header_delim__&Accept-Encoding&__header_equals__&gzip"
+	fakeDirectMessageResponse := &messaging.DirectMessageResponse{
+		Data: []byte("fakeDirectMessageResponse"),
+		Metadata: map[string]string{
+			"http.status_code": "200",
+			"headers":          fakeHeader,
+		},
+	}
+
+	mockDirectMessaging := new(daprt.MockDirectMessaging)
+
+	fakeServer := newFakeHTTPServer()
+
+	buffer := ""
+	spec := config.TracingSpec{SamplingRate: "0"}
+
+	pipeline := buildHTTPPineline(config.PipelineSpec{
+		Handlers: []config.HandlerSpec{
+			{
+				Type: "middleware.http.uppercase",
+				Name: "middleware.http.uppercase",
+			},
+		},
+	})
+
+	meta := exporters.Metadata{
+		Buffer: &buffer,
+		Properties: map[string]string{
+			"Enabled": "true",
+		},
+	}
+	createExporters(meta)
+
+	testAPI := &api{
+		directMessaging: mockDirectMessaging,
+	}
+	fakeServer.StartServerWithTracingAndPipeline(spec, pipeline, testAPI.constructDirectMessagingEndpoints())
+
+	t.Run("Invoke direct messaging without querystring - 200 OK", func(t *testing.T) {
+		buffer = ""
+		apiPath := "v1.0/invoke/fakeDaprID/method/fakeMethod"
+		fakeData := []byte("fakeData")
+
+		mockDirectMessaging.Calls = nil // reset call count
+		mockDirectMessaging.On(
+			"Invoke",
+			&messaging.DirectMessageRequest{
+				Data:   []byte("FAKEDATA"),
+				Method: "fakeMethod",
+				Metadata: map[string]string{
+					"headers":        fakeHeader,
+					http.HTTPVerb:    "POST",
+					http.QueryString: "", // without query string
+				},
+				Target: "fakeDaprID",
+			}).Return(fakeDirectMessageResponse, nil).Once()
+
+		// act
+		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil)
+
+		// assert
+		mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 1)
+		assert.Equal(t, "", buffer, "failed to generate proper traces with invoke")
 		assert.Equal(t, 200, resp.StatusCode)
 	})
 }

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dapr/dapr/pkg/logger"
 
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 	routing "github.com/qiangxue/fasthttp-routing"
 	"github.com/valyala/fasthttp"
@@ -54,7 +55,7 @@ func (s *server) StartNonBlocking() {
 
 	handler = s.useMetrics(handler)
 
-	if isTracingEnabled(s.tracingSpec.SamplingRate) {
+	if diag_utils.IsTracingEnabled(s.tracingSpec.SamplingRate) {
 		handler = s.useTracing(handler)
 	}
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -54,7 +54,7 @@ func (s *server) StartNonBlocking() {
 
 	handler = s.useMetrics(handler)
 
-	if s.tracingSpec.Enabled {
+	if isTracingEnabled(s.tracingSpec.SamplingRate) {
 		handler = s.useTracing(handler)
 	}
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/dapr/dapr/pkg/logger"
 
 	diag "github.com/dapr/dapr/pkg/diagnostics"
-	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 	routing "github.com/qiangxue/fasthttp-routing"
 	"github.com/valyala/fasthttp"
@@ -54,10 +53,7 @@ func (s *server) StartNonBlocking() {
 					s.useRouter())))
 
 	handler = s.useMetrics(handler)
-
-	if diag_utils.IsTracingEnabled(s.tracingSpec.SamplingRate) {
-		handler = s.useTracing(handler)
-	}
+	handler = s.useTracing(handler)
 
 	go func() {
 		log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.Port), handler))


### PR DESCRIPTION
# Description
- Adding the Tracing Sampling Rate Config in the TracingSpec. Removed "Enabled" property.
- Sampling Rate 0 signifies, tracing is disabled because sampler will turned off sampling. Proababilistic Sampler is used with configured sampling rate.
- Using the Default Sampling Rate as 0.001 
- Adding the trace utils to have trace helper methods.
- Changes to gRPC and HTTP server and API packages.

## Issue reference

#1395 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
