### PR TITLE
Remove duplicated dapr protoclient imports

### DIFF
--- a/tests/apps/service_invocation/Dockerfile
+++ b/tests/apps/service_invocation/Dockerfile
@@ -3,11 +3,14 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM golang:1.14
+FROM golang:1.14 as build_env
 
 WORKDIR /app
 COPY app.go .
 RUN go get -d -v
 RUN go build -o app .
 
-CMD ["./app"]
+FROM debian:buster-slim
+WORKDIR /
+COPY --from=build_env /app/app /
+CMD ["/app"]

--- a/tests/apps/service_invocation/app.go
+++ b/tests/apps/service_invocation/app.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/dapr/dapr/pkg/proto/dapr"
-	daprsdk "github.com/dapr/go-sdk/dapr"
 
 	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/grpc"
@@ -234,7 +233,7 @@ func grpcToGrpcTest(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close()
 
 	// Create the client
-	client := daprsdk.NewDaprClient(conn)
+	client := dapr.NewDaprClient(conn)
 
 	testMessage := guuid.New().String()
 	b, err := json.Marshal(testMessage)
@@ -245,7 +244,7 @@ func grpcToGrpcTest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fmt.Printf("grpcToGrpcTest calling with message %s\n", string(b))
-	resp, err := client.InvokeService(context.Background(), &daprsdk.InvokeServiceEnvelope{
+	resp, err := client.InvokeService(context.Background(), &dapr.InvokeServiceEnvelope{
 		Id:     commandBody.RemoteApp,
 		Data:   &any.Any{Value: b},
 		Method: "grpcToGrpcTest",


### PR DESCRIPTION
# Description

service_invocation app imports the duplicated grpc client from dapr/dapr and dapr/go-sdk repo. this pr will import only dapr/dapr. 

additionally, it will use multi-stage docker build to reduce the size of the final image.

## Issue reference

#1406 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
