### PR TITLE
Fix pubsub crash on app channel error

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -943,9 +943,20 @@ func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
 	}
 
 	resp, err := a.appChannel.InvokeMethod(&req)
-	statusCode := http.GetStatusCodeFromMetadata(resp.Metadata)
+	statusCode := 0
+
+	if resp != nil {
+		statusCode = http.GetStatusCodeFromMetadata(resp.Metadata)
+	}
+
 	if err != nil || statusCode != 200 {
-		err = fmt.Errorf("error from app while processing pub/sub event: %s. status code returned: %v", string(resp.Data), statusCode)
+		var err error
+		if resp == nil {
+			err = fmt.Errorf("error from app channel while sending pub/sub event to app: %s", err)
+		} else {
+			err = fmt.Errorf("error returned from app while processing pub/sub event: %s. status code returned: %v", string(resp.Data), statusCode)
+		}
+
 		log.Debug(err)
 		return err
 	}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -667,7 +667,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 			Data:     []byte(clientError.Error()),
 		}
 
-		expectedClientError := fmt.Errorf("error from app while processing pub/sub event: Internal Error. status code returned: 500")
+		expectedClientError := fmt.Errorf("error returned from app while processing pub/sub event: Internal Error. status code returned: 500")
 
 		mockAppChannel.On("InvokeMethod", expectedRequest).Return(fakeHTPResponse, clientError)
 


### PR DESCRIPTION
Closed #1422 

This PR fixes a situation where the app channel timed out while waiting for a response from the app, in which case the response would come back as `nil` and trying to extract the status code from it would panic.