### PR TITLE
Add internal invoke request and response helpers

### DIFF
--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -1,0 +1,156 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package v1
+
+import (
+	"net/url"
+	"strings"
+
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/daprinternal/v1"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+)
+
+const (
+	// DefaultAPIVersion is the default Dapr API version
+	DefaultAPIVersion = internalv1pb.APIVersion_V1
+)
+
+// InvokeMethodRequest holds InternalInvokeRequest protobuf message
+// and provides the helpers to manage it.
+type InvokeMethodRequest struct {
+	r *internalv1pb.InternalInvokeRequest
+	m *commonv1pb.InvokeRequest
+}
+
+// NewInvokeMethodRequest creates InvokeMethodRequest object for method
+func NewInvokeMethodRequest(method string) *InvokeMethodRequest {
+	return &InvokeMethodRequest{
+		r: &internalv1pb.InternalInvokeRequest{
+			Ver: DefaultAPIVersion,
+		},
+		m: &commonv1pb.InvokeRequest{
+			Method: method,
+		},
+	}
+
+}
+
+// FromInvokeRequestMessage creates InvokeMethodRequest object from InvokeRequest pb object
+func FromInvokeRequestMessage(pb *commonv1pb.InvokeRequest) *InvokeMethodRequest {
+	return &InvokeMethodRequest{
+		r: &internalv1pb.InternalInvokeRequest{
+			Ver: DefaultAPIVersion,
+		},
+		m: pb,
+	}
+}
+
+// InternalInvokeRequest creates InvokeMethodRequest object from InternalInvokeRequest pb object
+func InternalInvokeRequest(pb *internalv1pb.InternalInvokeRequest) (*InvokeMethodRequest, error) {
+	req := &InvokeMethodRequest{r: pb}
+	req.m = &commonv1pb.InvokeRequest{}
+	if pb.Message != nil {
+		if err := ptypes.UnmarshalAny(pb.Message, req.m); err != nil {
+			return nil, err
+		}
+		pb.Message = nil
+	}
+
+	return req, nil
+}
+
+// WithMetadata sets metadata
+func (imr *InvokeMethodRequest) WithMetadata(md map[string][]string) *InvokeMethodRequest {
+	imr.r.Metadata = GrpcMetadataToInternalMetadata(md)
+	return imr
+}
+
+// WithRawData sets message data and content_type
+func (imr *InvokeMethodRequest) WithRawData(data []byte, contentType string) *InvokeMethodRequest {
+	d := &commonv1pb.DataWithContentType{ContentType: contentType, Body: data}
+	if contentType == "" {
+		d.ContentType = JSONContentType
+	}
+	imr.m.Data, _ = ptypes.MarshalAny(d)
+	return imr
+}
+
+// WithHTTPExtension sets new HTTP extension with verb and querystring
+func (imr *InvokeMethodRequest) WithHTTPExtension(verb string, querystring string) *InvokeMethodRequest {
+	httpMethod, ok := commonv1pb.HTTPExtension_Verb_value[strings.ToUpper(verb)]
+	if !ok {
+		httpMethod = int32(commonv1pb.HTTPExtension_POST)
+	}
+
+	var metadata = map[string]string{}
+	if querystring != "" {
+		params, _ := url.ParseQuery(querystring)
+
+		for k, v := range params {
+			metadata[k] = v[0]
+		}
+	}
+
+	imr.m.HttpExtension = &commonv1pb.HTTPExtension{
+		Verb:        commonv1pb.HTTPExtension_Verb(httpMethod),
+		Querystring: metadata,
+	}
+
+	return imr
+}
+
+// EncodeHTTPQueryString generates querystring for http using http extension object
+func (imr *InvokeMethodRequest) EncodeHTTPQueryString() string {
+	if imr.m.GetHttpExtension() == nil {
+		return ""
+	}
+
+	qs := imr.m.GetHttpExtension().Querystring
+	if len(qs) == 0 {
+		return ""
+	}
+
+	params := url.Values{}
+	for k, v := range qs {
+		params.Add(k, v)
+	}
+	return params.Encode()
+}
+
+// APIVersion gets API version of InvokeMethodRequest
+func (imr *InvokeMethodRequest) APIVersion() internalv1pb.APIVersion {
+	return imr.r.GetVer()
+}
+
+// Metadata gets Metadata of InvokeMethodRequest
+func (imr *InvokeMethodRequest) Metadata() map[string]*structpb.ListValue {
+	return imr.r.GetMetadata()
+}
+
+// Proto returns InternalInvokeRequest Proto object
+func (imr *InvokeMethodRequest) Proto() *internalv1pb.InternalInvokeRequest {
+	p := proto.Clone(imr.r).(*internalv1pb.InternalInvokeRequest)
+	if imr.m != nil {
+		p.Message, _ = ptypes.MarshalAny(imr.m)
+	}
+	return p
+}
+
+// Message gets InvokeRequest Message object
+func (imr *InvokeMethodRequest) Message() *commonv1pb.InvokeRequest {
+	return imr.m
+}
+
+// RawData returns content_type and byte array body
+func (imr *InvokeMethodRequest) RawData() (string, []byte) {
+	if imr.m == nil {
+		return "", nil
+	}
+	return extractRawData(imr.m.GetData())
+}

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -38,7 +38,6 @@ func NewInvokeMethodRequest(method string) *InvokeMethodRequest {
 			Method: method,
 		},
 	}
-
 }
 
 // FromInvokeRequestMessage creates InvokeMethodRequest object from InvokeRequest pb object

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package v1
+
+import (
+	"testing"
+
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/daprinternal/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvokeRequest(t *testing.T) {
+	req := NewInvokeMethodRequest("test_method")
+
+	assert.Equal(t, internalv1pb.APIVersion_V1, req.r.GetVer())
+	assert.Equal(t, "test_method", req.m.GetMethod())
+}
+
+func TestFromInvokeRequestMessage(t *testing.T) {
+	pb := &commonv1pb.InvokeRequest{Method: "frominvokerequestmessage"}
+	req := FromInvokeRequestMessage(pb)
+
+	assert.Equal(t, internalv1pb.APIVersion_V1, req.r.GetVer())
+	assert.Equal(t, "frominvokerequestmessage", req.m.GetMethod())
+}
+
+func TestInternalInvokeRequest(t *testing.T) {
+	d := commonv1pb.DataWithContentType{
+		ContentType: "application/json",
+		Body:        []byte("test"),
+	}
+	ds, _ := ptypes.MarshalAny(&d)
+	m := commonv1pb.InvokeRequest{
+		Method: "invoketest",
+		Data:   ds,
+	}
+	ms, _ := ptypes.MarshalAny(&m)
+	pb := internalv1pb.InternalInvokeRequest{
+		Ver:     internalv1pb.APIVersion_V1,
+		Message: ms,
+	}
+
+	ir, err := InternalInvokeRequest(&pb)
+	assert.NoError(t, err)
+	assert.NotNil(t, ir.m)
+	assert.Equal(t, "invoketest", ir.m.GetMethod())
+	assert.NotNil(t, ir.m.GetData())
+}
+
+func TestMetadata(t *testing.T) {
+	req := NewInvokeMethodRequest("test_method")
+	md := map[string][]string{
+		"test1": {"val1", "val2"},
+		"test2": {"val3", "val4"},
+	}
+	req.WithMetadata(md)
+	mdata := req.Metadata()
+
+	assert.Equal(t, "val1", mdata["test1"].GetValues()[0].GetStringValue())
+	assert.Equal(t, "val2", mdata["test1"].GetValues()[1].GetStringValue())
+	assert.Equal(t, "val3", mdata["test2"].GetValues()[0].GetStringValue())
+	assert.Equal(t, "val4", mdata["test2"].GetValues()[1].GetStringValue())
+}
+
+func TestData(t *testing.T) {
+	req := NewInvokeMethodRequest("test_method")
+	req.WithRawData([]byte("test"), "application/json")
+	contentType, bData := req.RawData()
+	assert.Equal(t, "application/json", contentType)
+	assert.Equal(t, []byte("test"), bData)
+}
+
+func TestHTTPExtension(t *testing.T) {
+	req := NewInvokeMethodRequest("test_method")
+	req.WithHTTPExtension("POST", "query1=value1&query2=value2")
+	assert.Equal(t, commonv1pb.HTTPExtension_POST, req.Message().GetHttpExtension().GetVerb())
+	assert.Equal(t, "query1=value1&query2=value2", req.EncodeHTTPQueryString())
+}
+
+func TestProto(t *testing.T) {
+	d := commonv1pb.DataWithContentType{
+		ContentType: "application/json",
+		Body:        []byte("test"),
+	}
+	ds, _ := ptypes.MarshalAny(&d)
+	m := commonv1pb.InvokeRequest{
+		Method: "invoketest",
+		Data:   ds,
+	}
+	ms, _ := ptypes.MarshalAny(&m)
+	pb := internalv1pb.InternalInvokeRequest{
+		Ver:     internalv1pb.APIVersion_V1,
+		Message: ms,
+	}
+
+	ir, err := InternalInvokeRequest(&pb)
+	assert.NoError(t, err)
+	req2 := ir.Proto()
+
+	m2 := commonv1pb.InvokeRequest{}
+	err = ptypes.UnmarshalAny(req2.GetMessage(), &m2)
+
+	d2 := commonv1pb.DataWithContentType{}
+	err = ptypes.UnmarshalAny(m2.Data, &d2)
+
+	assert.Equal(t, "application/json", d2.GetContentType())
+	assert.Equal(t, []byte("test"), d2.GetBody())
+}

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -104,9 +104,11 @@ func TestProto(t *testing.T) {
 
 	m2 := commonv1pb.InvokeRequest{}
 	err = ptypes.UnmarshalAny(req2.GetMessage(), &m2)
+	assert.NoError(t, err)
 
 	d2 := commonv1pb.DataWithContentType{}
 	err = ptypes.UnmarshalAny(m2.Data, &d2)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "application/json", d2.GetContentType())
 	assert.Equal(t, []byte("test"), d2.GetBody())

--- a/pkg/messaging/v1/invoke_method_response.go
+++ b/pkg/messaging/v1/invoke_method_response.go
@@ -61,7 +61,7 @@ func (imr *InvokeMethodResponse) WithRawData(data []byte, contentType string) *I
 	return imr
 }
 
-// WithHeaders sets gRPC repsonse header metadata
+// WithHeaders sets gRPC response header metadata
 func (imr *InvokeMethodResponse) WithHeaders(headers metadata.MD) *InvokeMethodResponse {
 	imr.r.Headers = GrpcMetadataToInternalMetadata(headers)
 	return imr

--- a/pkg/messaging/v1/invoke_method_response.go
+++ b/pkg/messaging/v1/invoke_method_response.go
@@ -1,0 +1,135 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package v1
+
+import (
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/daprinternal/v1"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	any "github.com/golang/protobuf/ptypes/any"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/valyala/fasthttp"
+	"google.golang.org/grpc/metadata"
+)
+
+// InvokeMethodResponse holds InternalInvokeResponse protobuf message
+// and provides the helpers to manage it.
+type InvokeMethodResponse struct {
+	r *internalv1pb.InternalInvokeResponse
+	m *commonv1pb.InvokeResponse
+}
+
+// NewInvokeMethodResponse returns new InvokeMethodResponse object with status
+func NewInvokeMethodResponse(statusCode int32, statusMessage string, statusDetails []*any.Any) *InvokeMethodResponse {
+	return &InvokeMethodResponse{
+		r: &internalv1pb.InternalInvokeResponse{
+			Status: &internalv1pb.Status{Code: statusCode, Message: statusMessage, Details: statusDetails},
+		},
+		m: &commonv1pb.InvokeResponse{},
+	}
+}
+
+// InternalInvokeResponse returns InvokeMethodResponse for InternalInvokeResponse pb to use the helpers
+func InternalInvokeResponse(resp *internalv1pb.InternalInvokeResponse) (*InvokeMethodResponse, error) {
+	rsp := &InvokeMethodResponse{r: resp}
+	rsp.m = &commonv1pb.InvokeResponse{}
+	if resp.Message != nil {
+		if err := ptypes.UnmarshalAny(resp.Message, rsp.m); err != nil {
+			return nil, err
+		}
+		resp.Message = nil
+	}
+
+	return rsp, nil
+}
+
+// WithMessage sets InvokeResponse pb object to Message field
+func (imr *InvokeMethodResponse) WithMessage(pb *commonv1pb.InvokeResponse) *InvokeMethodResponse {
+	imr.m = pb
+	return imr
+}
+
+// WithRawData sets Message using byte data and content type
+func (imr *InvokeMethodResponse) WithRawData(data []byte, contentType string) *InvokeMethodResponse {
+	d := &commonv1pb.DataWithContentType{ContentType: contentType, Body: data}
+	imr.m.Data, _ = ptypes.MarshalAny(d)
+
+	return imr
+}
+
+// WithHeaders sets gRPC repsonse header metadata
+func (imr *InvokeMethodResponse) WithHeaders(headers metadata.MD) *InvokeMethodResponse {
+	imr.r.Headers = GrpcMetadataToInternalMetadata(headers)
+	return imr
+}
+
+// WithFastHTTPHeaders populates fasthttp response header to gRPC header metadata
+func (imr *InvokeMethodResponse) WithFastHTTPHeaders(header *fasthttp.ResponseHeader) *InvokeMethodResponse {
+	var md = map[string]*structpb.ListValue{}
+	header.VisitAll(func(key []byte, value []byte) {
+		md[string(key)] = &structpb.ListValue{
+			Values: []*structpb.Value{
+				{Kind: &structpb.Value_StringValue{StringValue: string(value)}},
+			},
+		}
+	})
+	if len(md) > 0 {
+		imr.r.Headers = md
+	}
+	return imr
+}
+
+// WithTrailers sets Trailer in internal InvokeMethodResponse
+func (imr *InvokeMethodResponse) WithTrailers(trailer metadata.MD) *InvokeMethodResponse {
+	imr.r.Trailers = GrpcMetadataToInternalMetadata(trailer)
+	return imr
+}
+
+// Status gets Response status
+func (imr *InvokeMethodResponse) Status() *internalv1pb.Status {
+	return imr.r.GetStatus()
+}
+
+// IsHTTPResponse returns true if response status code is http response status
+func (imr *InvokeMethodResponse) IsHTTPResponse() bool {
+	// gRPC status code <= 15 - https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+	// HTTP status code >= 100 - https://tools.ietf.org/html/rfc2616#section-10
+	return imr.r.GetStatus().Code >= 100
+}
+
+// Proto clones the internal InvokeMethodResponse pb object
+func (imr *InvokeMethodResponse) Proto() *internalv1pb.InternalInvokeResponse {
+	p := proto.Clone(imr.r).(*internalv1pb.InternalInvokeResponse)
+	if imr.m != nil {
+		p.Message, _ = ptypes.MarshalAny(imr.m)
+	}
+	return p
+}
+
+// Headers gets Headers metadata
+func (imr *InvokeMethodResponse) Headers() map[string]*structpb.ListValue {
+	return imr.r.Headers
+}
+
+// Trailers gets Trailers metadata
+func (imr *InvokeMethodResponse) Trailers() map[string]*structpb.ListValue {
+	return imr.r.Trailers
+}
+
+// Message returns message field in InvokeMethodResponse
+func (imr *InvokeMethodResponse) Message() *commonv1pb.InvokeResponse {
+	return imr.m
+}
+
+// RawData returns content_type and byte array body
+func (imr *InvokeMethodResponse) RawData() (string, []byte) {
+	if imr.m == nil {
+		return "", nil
+	}
+
+	return extractRawData(imr.m.GetData())
+}

--- a/pkg/messaging/v1/invoke_method_response_test.go
+++ b/pkg/messaging/v1/invoke_method_response_test.go
@@ -1,0 +1,114 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package v1
+
+import (
+	"net/http"
+	"testing"
+
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/daprinternal/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+	"google.golang.org/grpc/codes"
+)
+
+func TestInvocationResponse(t *testing.T) {
+	req := NewInvokeMethodResponse(0, "OK", nil)
+
+	assert.Equal(t, int32(0), req.r.GetStatus().Code)
+	assert.Equal(t, "OK", req.r.GetStatus().Message)
+	assert.NotNil(t, req.m)
+}
+
+func TestInternalInvocationResponse(t *testing.T) {
+	d := commonv1pb.DataWithContentType{
+		ContentType: "application/json",
+		Body:        []byte("response"),
+	}
+	ds, _ := ptypes.MarshalAny(&d)
+	m := commonv1pb.InvokeResponse{
+		Data: ds,
+	}
+	ms, _ := ptypes.MarshalAny(&m)
+	pb := internalv1pb.InternalInvokeResponse{
+		Status:  &internalv1pb.Status{Code: 0},
+		Message: ms,
+	}
+
+	ir, err := InternalInvokeResponse(&pb)
+	assert.NoError(t, err)
+	assert.NotNil(t, ir.m)
+	assert.Equal(t, int32(0), ir.r.GetStatus().GetCode())
+}
+
+func TestResponseData(t *testing.T) {
+	resp := NewInvokeMethodResponse(0, "OK", nil)
+	resp.WithRawData([]byte("test"), "application/json")
+	contentType, bData := resp.RawData()
+	assert.Equal(t, "application/json", contentType)
+	assert.Equal(t, []byte("test"), bData)
+}
+
+func TestResponseHeader(t *testing.T) {
+	t.Run("gRPC headers", func(t *testing.T) {
+		resp := NewInvokeMethodResponse(0, "OK", nil)
+		md := map[string][]string{
+			"test1": {"val1", "val2"},
+			"test2": {"val3", "val4"},
+		}
+		resp.WithHeaders(md)
+		mheader := resp.Headers()
+
+		assert.Equal(t, "val1", mheader["test1"].GetValues()[0].GetStringValue())
+		assert.Equal(t, "val2", mheader["test1"].GetValues()[1].GetStringValue())
+		assert.Equal(t, "val3", mheader["test2"].GetValues()[0].GetStringValue())
+		assert.Equal(t, "val4", mheader["test2"].GetValues()[1].GetStringValue())
+	})
+
+	t.Run("HTTP headers", func(t *testing.T) {
+		var resp = fasthttp.AcquireResponse()
+		resp.Header.Set("Header1", "Value1")
+		resp.Header.Set("Header2", "Value2")
+		resp.Header.Set("Header3", "Value3")
+
+		re := NewInvokeMethodResponse(0, "OK", nil)
+		re.WithFastHTTPHeaders(&resp.Header)
+		mheader := re.Headers()
+
+		assert.Equal(t, "Value1", mheader["Header1"].GetValues()[0].GetStringValue())
+		assert.Equal(t, "Value2", mheader["Header2"].GetValues()[0].GetStringValue())
+		assert.Equal(t, "Value3", mheader["Header3"].GetValues()[0].GetStringValue())
+	})
+}
+
+func TestResponseTrailer(t *testing.T) {
+	resp := NewInvokeMethodResponse(0, "OK", nil)
+	md := map[string][]string{
+		"test1": {"val1", "val2"},
+		"test2": {"val3", "val4"},
+	}
+	resp.WithTrailers(md)
+	mheader := resp.Trailers()
+
+	assert.Equal(t, "val1", mheader["test1"].GetValues()[0].GetStringValue())
+	assert.Equal(t, "val2", mheader["test1"].GetValues()[1].GetStringValue())
+	assert.Equal(t, "val3", mheader["test2"].GetValues()[0].GetStringValue())
+	assert.Equal(t, "val4", mheader["test2"].GetValues()[1].GetStringValue())
+}
+
+func TestIsHTTPResponse(t *testing.T) {
+	t.Run("gRPC response status", func(t *testing.T) {
+		grpcResp := NewInvokeMethodResponse(int32(codes.OK), "OK", nil)
+		assert.False(t, grpcResp.IsHTTPResponse())
+	})
+
+	t.Run("HTTP response status", func(t *testing.T) {
+		httpResp := NewInvokeMethodResponse(http.StatusOK, "OK", nil)
+		assert.True(t, httpResp.IsHTTPResponse())
+	})
+}

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -47,7 +47,7 @@ func GrpcMetadataToInternalMetadata(md metadata.MD) map[string]*structpb.ListVal
 }
 
 // isPermanentHTTPHeader checks whether hdr belongs to the list of
-// permenant request headers maintained by IANA.
+// permanent request headers maintained by IANA.
 // http://www.iana.org/assignments/message-headers/message-headers.xml
 func isPermanentHTTPHeader(hdr string) bool {
 	switch hdr {

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -1,0 +1,211 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package v1
+
+import (
+	"net/http"
+	"strings"
+
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// JSONContentType is the MIME media type for JSON
+	JSONContentType = "application/json"
+	// ProtobufContentType is the MIME media type for Protobuf
+	ProtobufContentType = "application/x-protobuf"
+
+	// DaprHeaderPrefix is the prefix if metadata is defined by non user-defined http headers
+	DaprHeaderPrefix = "dapr-"
+
+	// gRPCBinaryMetadata is the suffix of grpc metadata binary value
+	gRPCBinaryMetadata = "-bin"
+)
+
+// GrpcMetadataToInternalMetadata converts gRPC metadata to dapr internal metadata map
+func GrpcMetadataToInternalMetadata(md metadata.MD) map[string]*structpb.ListValue {
+	var internalMD = map[string]*structpb.ListValue{}
+	for k, values := range md {
+		var listValue = structpb.ListValue{}
+		for _, v := range values {
+			listValue.Values = append(listValue.Values, &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: v},
+			})
+		}
+		internalMD[k] = &listValue
+	}
+
+	return internalMD
+}
+
+// isPermanentHTTPHeader checks whether hdr belongs to the list of
+// permenant request headers maintained by IANA.
+// http://www.iana.org/assignments/message-headers/message-headers.xml
+func isPermanentHTTPHeader(hdr string) bool {
+	switch hdr {
+	case
+		"Accept",
+		"Accept-Charset",
+		"Accept-Language",
+		"Accept-Ranges",
+		// "Authorization",
+		"Cache-Control",
+		"Content-Type",
+		"Cookie",
+		"Date",
+		"Expect",
+		"From",
+		"Host",
+		"If-Match",
+		"If-Modified-Since",
+		"If-None-Match",
+		"If-Schedule-Tag-Match",
+		"If-Unmodified-Since",
+		"Max-Forwards",
+		"Origin",
+		"Pragma",
+		"Referer",
+		"User-Agent",
+		"Via",
+		"Warning":
+		return true
+	}
+	return false
+}
+
+// InternalMetadataToGrpcMetadata converts internal metadata map to gRPC metadata
+func InternalMetadataToGrpcMetadata(internalMD map[string]*structpb.ListValue, httpHeaderConversion bool) metadata.MD {
+	var md = metadata.MD{}
+	for k, listVal := range internalMD {
+		keyName := strings.ToLower(k)
+		if httpHeaderConversion && isPermanentHTTPHeader(k) {
+			keyName = strings.ToLower(DaprHeaderPrefix + keyName)
+		}
+		for _, v := range listVal.Values {
+			if _, ok := md[keyName]; !ok {
+				md[keyName] = []string{v.GetStringValue()}
+			} else {
+				md[keyName] = append(md[keyName], v.GetStringValue())
+			}
+		}
+	}
+	return md
+}
+
+// InternalMetadataToHTTPHeader converts internal metadata pb to HTTP headers
+func InternalMetadataToHTTPHeader(internalMD map[string]*structpb.ListValue, setHeader func(string, string)) {
+	for k, listVal := range internalMD {
+		// Skip if the header key has -bin suffix
+		if len(listVal.Values) == 0 || strings.HasSuffix(k, gRPCBinaryMetadata) {
+			continue
+		}
+		setHeader(k, listVal.Values[0].GetStringValue())
+	}
+}
+
+// HTTPStatusFromCode converts a gRPC error code into the corresponding HTTP response status.
+// https://github.com/grpc-ecosystem/grpc-gateway/blob/master/runtime/errors.go#L15
+// See: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+func HTTPStatusFromCode(code codes.Code) int {
+	switch code {
+	case codes.OK:
+		return http.StatusOK
+	case codes.Canceled:
+		return http.StatusRequestTimeout
+	case codes.Unknown:
+		return http.StatusInternalServerError
+	case codes.InvalidArgument:
+		return http.StatusBadRequest
+	case codes.DeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case codes.NotFound:
+		return http.StatusNotFound
+	case codes.AlreadyExists:
+		return http.StatusConflict
+	case codes.PermissionDenied:
+		return http.StatusForbidden
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
+	case codes.FailedPrecondition:
+		// Note, this deliberately doesn't translate to the similarly named '412 Precondition Failed' HTTP response status.
+		return http.StatusBadRequest
+	case codes.Aborted:
+		return http.StatusConflict
+	case codes.OutOfRange:
+		return http.StatusBadRequest
+	case codes.Unimplemented:
+		return http.StatusNotImplemented
+	case codes.Internal:
+		return http.StatusInternalServerError
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable
+	case codes.DataLoss:
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusInternalServerError
+}
+
+// CodeFromHTTPStatus converts http status code to gRPC status code
+// See: https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
+func CodeFromHTTPStatus(httpStatusCode int) codes.Code {
+	switch httpStatusCode {
+	case http.StatusOK:
+		return codes.OK
+	case http.StatusRequestTimeout:
+		return codes.Canceled
+	case http.StatusInternalServerError:
+		return codes.Unknown
+	case http.StatusBadRequest:
+		return codes.Internal
+	case http.StatusGatewayTimeout:
+		return codes.DeadlineExceeded
+	case http.StatusNotFound:
+		return codes.NotFound
+	case http.StatusConflict:
+		return codes.AlreadyExists
+	case http.StatusForbidden:
+		return codes.PermissionDenied
+	case http.StatusUnauthorized:
+		return codes.Unauthenticated
+	case http.StatusTooManyRequests:
+		return codes.ResourceExhausted
+	case http.StatusNotImplemented:
+		return codes.Unimplemented
+	case http.StatusServiceUnavailable:
+		return codes.Unavailable
+	}
+
+	return codes.Unknown
+}
+
+func isDataWithContentType(data *any.Any) bool {
+	if data == nil {
+		return false
+	}
+
+	return ptypes.Is(data, &commonv1pb.DataWithContentType{})
+}
+
+func extractRawData(data *any.Any) (string, []byte) {
+	if !isDataWithContentType(data) {
+		return "", nil
+	}
+
+	d := &commonv1pb.DataWithContentType{}
+	if err := ptypes.UnmarshalAny(data, d); err != nil {
+		return "", nil
+	}
+
+	return d.GetContentType(), d.GetBody()
+}


### PR DESCRIPTION
# Description

Add internal invoke request and response helpers.

* Encapsulate pb definitions as a helper struct and expose helper methods
* Add more tests

Next PR: 
* Support service invocation v1 in direct_messaging and http/grpc channels

## Issue reference

https://github.com/dapr/dapr/issues/1409

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
