### PR TITLE
Fix gRPC pod affinity on Kubernetes

### DIFF
--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -92,7 +92,7 @@ func (g *Manager) GetGRPCConnection(address, id string, skipTLS, recreateIfExist
 		opts = append(opts, grpc.WithInsecure())
 	}
 
-	conn, err := grpc.Dial(address, opts...)
+	conn, err := grpc.Dial("dns:///"+address, opts...)
 	if err != nil {
 		g.lock.Unlock()
 		return nil, err

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	// needed to load balance requests for target services with multiple endpoints, ie. multiple instances
 	grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
 )
 

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -20,7 +20,12 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// Manager is a wrapper around gRPC connection pooling
+const (
+ gRPCServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
+)
+
+// Mana
+ger is a wrapper around gRPC connection pooling
 type Manager struct {
 	AppClient      *grpc.ClientConn
 	lock           *sync.Mutex
@@ -68,7 +73,7 @@ func (g *Manager) GetGRPCConnection(address, id string, skipTLS, recreateIfExist
 	opts := []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithStatsHandler(diag.DefaultGRPCMonitoring.ClientStatsHandler),
-		grpc.WithBalancerName(roundrobin.Name),
+		grpc.WithDefaultServiceConfig(gRPCServiceConfig),
 	}
 
 	if !skipTLS && g.auth != nil {

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -16,6 +16,7 @@ import (
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/runtime/security"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -67,6 +68,7 @@ func (g *Manager) GetGRPCConnection(address, id string, skipTLS, recreateIfExist
 	opts := []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithStatsHandler(diag.DefaultGRPCMonitoring.ClientStatsHandler),
+		grpc.WithBalancerName(roundrobin.Name),
 	}
 
 	if !skipTLS && g.auth != nil {

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -16,16 +16,14 @@ import (
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/runtime/security"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/credentials"
 )
 
 const (
- gRPCServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
+	grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
 )
 
-// Mana
-ger is a wrapper around gRPC connection pooling
+// Manager is a wrapper around gRPC connection pooling
 type Manager struct {
 	AppClient      *grpc.ClientConn
 	lock           *sync.Mutex
@@ -73,7 +71,7 @@ func (g *Manager) GetGRPCConnection(address, id string, skipTLS, recreateIfExist
 	opts := []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithStatsHandler(diag.DefaultGRPCMonitoring.ClientStatsHandler),
-		grpc.WithDefaultServiceConfig(gRPCServiceConfig),
+		grpc.WithDefaultServiceConfig(grpcServiceConfig),
 	}
 
 	if !skipTLS && g.auth != nil {

--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -27,6 +27,7 @@ const (
 	daprSidecarAPIGRPCPort          = 50001
 	daprSidecarInternalGRPCPort     = 50002
 	defaultMetricsPort              = 9090
+	clusterIPNone                   = "None"
 )
 
 var log = logger.NewLogger("dapr.operator.handlers")
@@ -69,7 +70,8 @@ func (h *DaprHandler) createDaprService(name string, deployment *appsv1.Deployme
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: deployment.Spec.Selector.MatchLabels,
+			Selector:  deployment.Spec.Selector.MatchLabels,
+			ClusterIP: clusterIPNone,
 			Ports: []corev1.ServicePort{
 				{
 					Protocol:   corev1.ProtocolTCP,


### PR DESCRIPTION
Fixes #1444 

This PR fixes the Pod affinity created with gRPC and Kubernetes Services, causing only one Pod out of multiple instances to receive traffic.

This PR changes Dapr k8s services to Headless services, which return a list of endpoint destinations on a lookup request, in combination with the gRPC Load Balancing strategy `grpc.WithBalancerName(roundrobin.Name)`.

More information here:
https://medium.com/google-cloud/loadbalancing-grpc-for-kubernetes-cluster-services-3ba9a8d8fc03