### PR TITLE
fix dns on windows

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbp
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
-github.com/dapr/components-contrib v0.0.0-20200407184158-1ab1a86a60ef h1:PYfpBLqMdRZ3wEGyCqb/TecoOh+PztQKvOdE20e5/Jo=
-github.com/dapr/components-contrib v0.0.0-20200407184158-1ab1a86a60ef/go.mod h1:c3KXN49vGYGeccF7i1Hq7T8a0VzV/r8891Yi2HmulC8=
+github.com/dapr/components-contrib v0.0.0-20200423045401-ebf31ef7c585 h1:ZZqdJRyeTPFUMI3OpnRWIe3kbaq2Lw2tDzrHYsU4j3Q=
 github.com/dapr/components-contrib v0.0.0-20200423045401-ebf31ef7c585/go.mod h1:+puDxKOdbUEf9HbmzBhGFic+Az2zBB2Os/zThRied28=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad h1:RKWoYovBc+B9ltvjtZLMnbu49stSucH8rZze3MeqyvQ=

--- a/pkg/grpc/dial.go
+++ b/pkg/grpc/dial.go
@@ -2,6 +2,8 @@ package grpc
 
 import "github.com/dapr/dapr/pkg/modes"
 
+// GetDialAddressPrefix returns a dial prefix for a gRPC client connections
+// For a given DaprMode.
 func GetDialAddressPrefix(mode modes.DaprMode) string {
 	switch mode {
 	case modes.KubernetesMode:

--- a/pkg/grpc/dial.go
+++ b/pkg/grpc/dial.go
@@ -1,0 +1,12 @@
+package grpc
+
+import "github.com/dapr/dapr/pkg/modes"
+
+func GetDialAddressPrefix(mode modes.DaprMode) string {
+	switch mode {
+	case modes.KubernetesMode:
+		return "dns:///"
+	default:
+		return ""
+	}
+}

--- a/pkg/grpc/dial_test.go
+++ b/pkg/grpc/dial_test.go
@@ -1,0 +1,20 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/dapr/dapr/pkg/modes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDialAddress(t *testing.T) {
+	t.Run("kubernetes mode", func(t *testing.T) {
+		m := GetDialAddressPrefix(modes.KubernetesMode)
+		assert.Equal(t, "dns:///", m)
+	})
+
+	t.Run("self hosted mode", func(t *testing.T) {
+		m := GetDialAddressPrefix(modes.StandaloneMode)
+		assert.Equal(t, "", m)
+	})
+}

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -14,6 +14,7 @@ import (
 	grpc_channel "github.com/dapr/dapr/pkg/channel/grpc"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/runtime/security"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -30,13 +31,15 @@ type Manager struct {
 	lock           *sync.Mutex
 	connectionPool map[string]*grpc.ClientConn
 	auth           security.Authenticator
+	mode           modes.DaprMode
 }
 
 // NewGRPCManager returns a new grpc manager
-func NewGRPCManager() *Manager {
+func NewGRPCManager(mode modes.DaprMode) *Manager {
 	return &Manager{
 		lock:           &sync.Mutex{},
 		connectionPool: map[string]*grpc.ClientConn{},
+		mode:           mode,
 	}
 }
 
@@ -92,7 +95,8 @@ func (g *Manager) GetGRPCConnection(address, id string, skipTLS, recreateIfExist
 		opts = append(opts, grpc.WithInsecure())
 	}
 
-	conn, err := grpc.Dial("dns:///"+address, opts...)
+	dialPrefix := GetDialAddressPrefix(g.mode)
+	conn, err := grpc.Dial(dialPrefix+address, opts...)
 	if err != nil {
 		g.lock.Unlock()
 		return nil, err

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -106,7 +106,7 @@ func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration) *
 	return &DaprRuntime{
 		runtimeConfig:            runtimeConfig,
 		globalConfig:             globalConfig,
-		grpc:                     grpc.NewGRPCManager(),
+		grpc:                     grpc.NewGRPCManager(runtimeConfig.Mode),
 		json:                     jsoniter.ConfigFastest,
 		inputBindings:            map[string]bindings.InputBinding{},
 		outputBindings:           map[string]bindings.OutputBinding{},


### PR DESCRIPTION
Reported by @LMWF, this PR fixes the `dns:///` address prefix for gRPC Dial not working on Windows.

Closed #1457 