### PR TITLE
Fix class name for common.proto

### DIFF
--- a/dapr/proto/common/v1/common.proto
+++ b/dapr/proto/common/v1/common.proto
@@ -10,7 +10,7 @@ package dapr.proto.common.v1;
 import "google/protobuf/any.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "CommonProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/common/v1";
 


### PR DESCRIPTION
# Description

Class name is wrong for common.proto and breaks codegen in Java SDK.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/java-sdk/issues/272
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
