### PR TITLE
Do not check contenttype for dapr/config

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1197,7 +1197,7 @@ func (a *DaprRuntime) getConfigurationHTTP() (*config.ApplicationConfig, error) 
 
 	contentType, body := resp.RawData()
 	if contentType != invokev1.JSONContentType {
-		return nil, fmt.Errorf("invalid content_type: %s", contentType)
+		log.Debugf("dapr/config returns invalid content_type: %s", contentType)
 	}
 
 	if err = a.json.Unmarshal(body, &config); err != nil {


### PR DESCRIPTION
# Description

Do not check content-type for dapr/config

dotnet actor sdk returns with `text/plain` content-type. it was working before service invocation change because dapr didn't check content-type. this pr will allow any content-type, but will log error as a debug level.

## Issue reference

#1409 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
