### PR TITLE
Propagating context in actor calls

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -52,17 +52,17 @@ var log = logger.NewLogger("dapr.runtime.actor")
 type Actors interface {
 	Call(ctx context.Context, req *CallRequest) (*CallResponse, error)
 	Init() error
-	GetState(req *GetStateRequest) (*StateResponse, error)
-	SaveState(req *SaveStateRequest) error
-	DeleteState(req *DeleteStateRequest) error
-	TransactionalStateOperation(req *TransactionalRequest) error
-	GetReminder(req *GetReminderRequest) (*Reminder, error)
-	CreateReminder(req *CreateReminderRequest) error
-	DeleteReminder(req *DeleteReminderRequest) error
-	CreateTimer(req *CreateTimerRequest) error
-	DeleteTimer(req *DeleteTimerRequest) error
-	IsActorHosted(req *ActorHostedRequest) bool
-	GetActiveActorsCount() []ActiveActorsCount
+	GetState(ctx context.Context, req *GetStateRequest) (*StateResponse, error)
+	SaveState(ctx context.Context, req *SaveStateRequest) error
+	DeleteState(ctx context.Context, req *DeleteStateRequest) error
+	TransactionalStateOperation(ctx context.Context, req *TransactionalRequest) error
+	GetReminder(ctx context.Context, req *GetReminderRequest) (*Reminder, error)
+	CreateReminder(ctx context.Context, req *CreateReminderRequest) error
+	DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error
+	CreateTimer(ctx context.Context, req *CreateTimerRequest) error
+	DeleteTimer(ctx context.Context, req *DeleteTimerRequest) error
+	IsActorHosted(ctx context.Context, req *ActorHostedRequest) bool
+	GetActiveActorsCount(ctx context.Context) []ActiveActorsCount
 }
 
 type actorsRuntime struct {
@@ -418,7 +418,7 @@ func (a *actorsRuntime) isActorLocal(targetActorAddress, hostAddress string, grp
 		targetActorAddress == fmt.Sprintf("%s:%v", hostAddress, grpcPort)
 }
 
-func (a *actorsRuntime) GetState(req *GetStateRequest) (*StateResponse, error) {
+func (a *actorsRuntime) GetState(ctx context.Context, req *GetStateRequest) (*StateResponse, error) {
 	if a.store == nil {
 		return nil, errors.New("actors: state store does not exist or incorrectly configured")
 	}
@@ -435,7 +435,7 @@ func (a *actorsRuntime) GetState(req *GetStateRequest) (*StateResponse, error) {
 	}, nil
 }
 
-func (a *actorsRuntime) TransactionalStateOperation(req *TransactionalRequest) error {
+func (a *actorsRuntime) TransactionalStateOperation(ctx context.Context, req *TransactionalRequest) error {
 	if a.store == nil {
 		return errors.New("actors: state store does not exist or incorrectly configured")
 	}
@@ -484,13 +484,13 @@ func (a *actorsRuntime) TransactionalStateOperation(req *TransactionalRequest) e
 	return err
 }
 
-func (a *actorsRuntime) IsActorHosted(req *ActorHostedRequest) bool {
+func (a *actorsRuntime) IsActorHosted(ctx context.Context, req *ActorHostedRequest) bool {
 	key := a.constructCompositeKey(req.ActorType, req.ActorID)
 	_, exists := a.actorsTable.Load(key)
 	return exists
 }
 
-func (a *actorsRuntime) SaveState(req *SaveStateRequest) error {
+func (a *actorsRuntime) SaveState(ctx context.Context, req *SaveStateRequest) error {
 	if a.store == nil {
 		return errors.New("actors: state store does not exist or incorrectly configured")
 	}
@@ -502,7 +502,7 @@ func (a *actorsRuntime) SaveState(req *SaveStateRequest) error {
 	return err
 }
 
-func (a *actorsRuntime) DeleteState(req *DeleteStateRequest) error {
+func (a *actorsRuntime) DeleteState(ctx context.Context, req *DeleteStateRequest) error {
 	if a.store == nil {
 		return errors.New("actors: state store does not exist or incorrectly configured")
 	}
@@ -910,7 +910,7 @@ func (a *actorsRuntime) startReminder(reminder *Reminder) error {
 				}
 			}(t, stop, reminder.ActorType, reminder.ActorID, reminder.Name, reminder.DueTime, reminder.Period, reminder.Data)
 		} else {
-			err := a.DeleteReminder(&DeleteReminderRequest{
+			err := a.DeleteReminder(context.TODO(), &DeleteReminderRequest{
 				Name:      reminder.Name,
 				ActorID:   reminder.ActorID,
 				ActorType: reminder.ActorType,
@@ -969,11 +969,11 @@ func (a *actorsRuntime) getReminder(req *CreateReminderRequest) (*Reminder, bool
 	return nil, false
 }
 
-func (a *actorsRuntime) CreateReminder(req *CreateReminderRequest) error {
+func (a *actorsRuntime) CreateReminder(ctx context.Context, req *CreateReminderRequest) error {
 	r, exists := a.getReminder(req)
 	if exists {
 		if a.reminderRequiresUpdate(req, r) {
-			err := a.DeleteReminder(&DeleteReminderRequest{
+			err := a.DeleteReminder(ctx, &DeleteReminderRequest{
 				ActorID:   req.ActorID,
 				ActorType: req.ActorType,
 				Name:      req.Name,
@@ -1031,7 +1031,7 @@ func (a *actorsRuntime) CreateReminder(req *CreateReminderRequest) error {
 	return nil
 }
 
-func (a *actorsRuntime) CreateTimer(req *CreateTimerRequest) error {
+func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest) error {
 	actorKey := a.constructCompositeKey(req.ActorType, req.ActorID)
 	timerKey := a.constructCompositeKey(actorKey, req.Name)
 
@@ -1074,7 +1074,7 @@ func (a *actorsRuntime) CreateTimer(req *CreateTimerRequest) error {
 						log.Debugf("error invoking timer on actor %s: %s", actorKey, err)
 					}
 				} else {
-					a.DeleteTimer(&DeleteTimerRequest{
+					a.DeleteTimer(ctx, &DeleteTimerRequest{
 						Name:      name,
 						ActorID:   actorID,
 						ActorType: actorType,
@@ -1133,7 +1133,7 @@ func (a *actorsRuntime) getRemindersForActorType(actorType string) ([]Reminder, 
 	return reminders, nil
 }
 
-func (a *actorsRuntime) DeleteReminder(req *DeleteReminderRequest) error {
+func (a *actorsRuntime) DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error {
 	if a.evaluationBusy {
 		select {
 		case <-time.After(time.Second * 5):
@@ -1186,7 +1186,7 @@ func (a *actorsRuntime) DeleteReminder(req *DeleteReminderRequest) error {
 	return nil
 }
 
-func (a *actorsRuntime) GetReminder(req *GetReminderRequest) (*Reminder, error) {
+func (a *actorsRuntime) GetReminder(ctx context.Context, req *GetReminderRequest) (*Reminder, error) {
 	reminders, err := a.getRemindersForActorType(req.ActorType)
 	if err != nil {
 		return nil, err
@@ -1204,7 +1204,7 @@ func (a *actorsRuntime) GetReminder(req *GetReminderRequest) (*Reminder, error) 
 	return nil, nil
 }
 
-func (a *actorsRuntime) DeleteTimer(req *DeleteTimerRequest) error {
+func (a *actorsRuntime) DeleteTimer(ctx context.Context, req *DeleteTimerRequest) error {
 	actorKey := a.constructCompositeKey(req.ActorType, req.ActorID)
 	timerKey := a.constructCompositeKey(actorKey, req.Name)
 
@@ -1217,7 +1217,7 @@ func (a *actorsRuntime) DeleteTimer(req *DeleteTimerRequest) error {
 	return nil
 }
 
-func (a *actorsRuntime) GetActiveActorsCount() []ActiveActorsCount {
+func (a *actorsRuntime) GetActiveActorsCount(ctx context.Context) []ActiveActorsCount {
 	var actorCountMap = map[string]int{}
 	a.actorsTable.Range(func(key, value interface{}) bool {
 		actorType, _ := a.getActorTypeAndIDFromKey(key.(string))

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -6,6 +6,7 @@
 package actors
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -232,7 +233,8 @@ func TestGetReminderTrack(t *testing.T) {
 func TestCreateReminder(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
-	err := testActorsRuntime.CreateReminder(&CreateReminderRequest{
+	ctx := context.Background()
+	err := testActorsRuntime.CreateReminder(ctx, &CreateReminderRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Name:      "reminder1",
@@ -244,15 +246,16 @@ func TestCreateReminder(t *testing.T) {
 }
 
 func TestOverrideReminder(t *testing.T) {
+	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
 		actorType, actorID := getTestActorTypeAndID()
 		reminder := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "a")
-		err := testActorsRuntime.CreateReminder(&reminder)
+		err := testActorsRuntime.CreateReminder(ctx, &reminder)
 		assert.Nil(t, err)
 
 		reminder2 := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "b")
-		testActorsRuntime.CreateReminder(&reminder2)
+		testActorsRuntime.CreateReminder(ctx, &reminder2)
 		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		assert.Equal(t, "b", reminders[0].Data)
@@ -262,11 +265,11 @@ func TestOverrideReminder(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
 		actorType, actorID := getTestActorTypeAndID()
 		reminder := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "")
-		err := testActorsRuntime.CreateReminder(&reminder)
+		err := testActorsRuntime.CreateReminder(ctx, &reminder)
 		assert.Nil(t, err)
 
 		reminder2 := createReminderData(actorID, actorType, "reminder1", "1s", "2s", "")
-		testActorsRuntime.CreateReminder(&reminder2)
+		testActorsRuntime.CreateReminder(ctx, &reminder2)
 		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		assert.Equal(t, "2s", reminders[0].DueTime)
@@ -276,11 +279,11 @@ func TestOverrideReminder(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
 		actorType, actorID := getTestActorTypeAndID()
 		reminder := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "")
-		err := testActorsRuntime.CreateReminder(&reminder)
+		err := testActorsRuntime.CreateReminder(ctx, &reminder)
 		assert.Nil(t, err)
 
 		reminder2 := createReminderData(actorID, actorType, "reminder1", "2s", "1s", "")
-		testActorsRuntime.CreateReminder(&reminder2)
+		testActorsRuntime.CreateReminder(ctx, &reminder2)
 		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		assert.Equal(t, "2s", reminders[0].Period)
@@ -290,10 +293,11 @@ func TestOverrideReminder(t *testing.T) {
 func TestDeleteReminder(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	reminder := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "")
-	testActorsRuntime.CreateReminder(&reminder)
+	testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.Equal(t, 1, len(testActorsRuntime.reminders[actorType]))
-	err := testActorsRuntime.DeleteReminder(&DeleteReminderRequest{
+	err := testActorsRuntime.DeleteReminder(ctx, &DeleteReminderRequest{
 		Name:      "reminder1",
 		ActorID:   actorID,
 		ActorType: actorType,
@@ -305,10 +309,11 @@ func TestDeleteReminder(t *testing.T) {
 func TestGetReminder(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	reminder := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "a")
-	testActorsRuntime.CreateReminder(&reminder)
+	testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.Equal(t, 1, len(testActorsRuntime.reminders[actorType]))
-	r, err := testActorsRuntime.GetReminder(&GetReminderRequest{
+	r, err := testActorsRuntime.GetReminder(ctx, &GetReminderRequest{
 		Name:      "reminder1",
 		ActorID:   actorID,
 		ActorType: actorType,
@@ -322,11 +327,12 @@ func TestGetReminder(t *testing.T) {
 func TestDeleteTimer(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	actorKey := testActorsRuntime.constructCompositeKey(actorType, actorID)
 	fakeCallAndActivateActor(testActorsRuntime, actorKey)
 
 	timer := createTimerData(actorID, actorType, "timer1", "100ms", "100ms", "callback", "")
-	err := testActorsRuntime.CreateTimer(&timer)
+	err := testActorsRuntime.CreateTimer(ctx, &timer)
 	assert.Nil(t, err)
 
 	timerKey := testActorsRuntime.constructCompositeKey(actorKey, timer.Name)
@@ -334,7 +340,7 @@ func TestDeleteTimer(t *testing.T) {
 	_, ok := testActorsRuntime.activeTimers.Load(timerKey)
 	assert.True(t, ok)
 
-	err = testActorsRuntime.DeleteTimer(&DeleteTimerRequest{
+	err = testActorsRuntime.DeleteTimer(ctx, &DeleteTimerRequest{
 		Name:      timer.Name,
 		ActorID:   actorID,
 		ActorType: actorType,
@@ -348,8 +354,9 @@ func TestDeleteTimer(t *testing.T) {
 func TestReminderFires(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	reminder := createReminderData(actorID, actorType, "reminder1", "100ms", "100ms", "a")
-	err := testActorsRuntime.CreateReminder(&reminder)
+	err := testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Millisecond * 250)
@@ -363,9 +370,10 @@ func TestReminderFires(t *testing.T) {
 func TestReminderDueDate(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	actorKey := testActorsRuntime.constructCompositeKey(actorType, actorID)
 	reminder := createReminderData(actorID, actorType, "reminder1", "100ms", "500ms", "a")
-	err := testActorsRuntime.CreateReminder(&reminder)
+	err := testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.Nil(t, err)
 
 	track, err := testActorsRuntime.getReminderTrack(actorKey, "reminder1")
@@ -382,9 +390,10 @@ func TestReminderDueDate(t *testing.T) {
 func TestReminderPeriod(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	actorKey := testActorsRuntime.constructCompositeKey(actorType, actorID)
 	reminder := createReminderData(actorID, actorType, "reminder1", "100ms", "100ms", "a")
-	err := testActorsRuntime.CreateReminder(&reminder)
+	err := testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Millisecond * 250)
@@ -404,9 +413,10 @@ func TestReminderPeriod(t *testing.T) {
 func TestReminderFiresOnceWithEmptyPeriod(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	actorKey := testActorsRuntime.constructCompositeKey(actorType, actorID)
 	reminder := createReminderData(actorID, actorType, "reminder1", "", "100ms", "a")
-	err := testActorsRuntime.CreateReminder(&reminder)
+	err := testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.Nil(t, err)
 
 	time.Sleep(time.Millisecond * 150)
@@ -439,6 +449,7 @@ func TestConstructActorStateKey(t *testing.T) {
 func TestSaveState(t *testing.T) {
 	testActorRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	fakeData := strconv.Quote("fakeData")
 
 	var val interface{}
@@ -448,7 +459,7 @@ func TestSaveState(t *testing.T) {
 	actorKey := testActorRuntime.constructCompositeKey(actorType, actorID)
 	fakeCallAndActivateActor(testActorRuntime, actorKey)
 
-	err := testActorRuntime.SaveState(&SaveStateRequest{
+	err := testActorRuntime.SaveState(ctx, &SaveStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -457,7 +468,7 @@ func TestSaveState(t *testing.T) {
 	assert.NoError(t, err)
 
 	// assert
-	response, err := testActorRuntime.GetState(&GetStateRequest{
+	response, err := testActorRuntime.GetState(ctx, &GetStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -470,6 +481,7 @@ func TestSaveState(t *testing.T) {
 func TestGetState(t *testing.T) {
 	testActorRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	fakeData := strconv.Quote("fakeData")
 
 	var val interface{}
@@ -478,7 +490,7 @@ func TestGetState(t *testing.T) {
 	actorKey := testActorRuntime.constructCompositeKey(actorType, actorID)
 	fakeCallAndActivateActor(testActorRuntime, actorKey)
 
-	testActorRuntime.SaveState(&SaveStateRequest{
+	testActorRuntime.SaveState(ctx, &SaveStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -486,7 +498,7 @@ func TestGetState(t *testing.T) {
 	})
 
 	// act
-	response, err := testActorRuntime.GetState(&GetStateRequest{
+	response, err := testActorRuntime.GetState(ctx, &GetStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -500,6 +512,7 @@ func TestGetState(t *testing.T) {
 func TestDeleteState(t *testing.T) {
 	testActorRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
 	fakeData := strconv.Quote("fakeData")
 
 	var val interface{}
@@ -509,7 +522,7 @@ func TestDeleteState(t *testing.T) {
 	actorKey := testActorRuntime.constructCompositeKey(actorType, actorID)
 	fakeCallAndActivateActor(testActorRuntime, actorKey)
 
-	testActorRuntime.SaveState(&SaveStateRequest{
+	testActorRuntime.SaveState(ctx, &SaveStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -517,7 +530,7 @@ func TestDeleteState(t *testing.T) {
 	})
 
 	// make sure that state is stored.
-	response, err := testActorRuntime.GetState(&GetStateRequest{
+	response, err := testActorRuntime.GetState(ctx, &GetStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -527,7 +540,7 @@ func TestDeleteState(t *testing.T) {
 	assert.Equal(t, fakeData, string(response.Data))
 
 	// act
-	err = testActorRuntime.DeleteState(&DeleteStateRequest{
+	err = testActorRuntime.DeleteState(ctx, &DeleteStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -535,7 +548,7 @@ func TestDeleteState(t *testing.T) {
 	assert.NoError(t, err)
 
 	// assert
-	response, err = testActorRuntime.GetState(&GetStateRequest{
+	response, err = testActorRuntime.GetState(ctx, &GetStateRequest{
 		ActorID:   actorID,
 		ActorType: actorType,
 		Key:       TestKeyName,
@@ -546,6 +559,7 @@ func TestDeleteState(t *testing.T) {
 }
 
 func TestTransactionalState(t *testing.T) {
+	ctx := context.Background()
 	t.Run("Single set request succeeds", func(t *testing.T) {
 		testActorRuntime := newTestActorsRuntime()
 		actorType, actorID := getTestActorTypeAndID()
@@ -553,7 +567,7 @@ func TestTransactionalState(t *testing.T) {
 		actorKey := testActorRuntime.constructCompositeKey(actorType, actorID)
 		fakeCallAndActivateActor(testActorRuntime, actorKey)
 
-		err := testActorRuntime.TransactionalStateOperation(&TransactionalRequest{
+		err := testActorRuntime.TransactionalStateOperation(ctx, &TransactionalRequest{
 			ActorType: actorType,
 			ActorID:   actorID,
 			Operations: []TransactionalOperation{
@@ -576,7 +590,7 @@ func TestTransactionalState(t *testing.T) {
 		actorKey := testActorRuntime.constructCompositeKey(actorType, actorID)
 		fakeCallAndActivateActor(testActorRuntime, actorKey)
 
-		err := testActorRuntime.TransactionalStateOperation(&TransactionalRequest{
+		err := testActorRuntime.TransactionalStateOperation(ctx, &TransactionalRequest{
 			ActorType: actorType,
 			ActorID:   actorID,
 			Operations: []TransactionalOperation{
@@ -605,7 +619,7 @@ func TestTransactionalState(t *testing.T) {
 		actorKey := testActorRuntime.constructCompositeKey(actorType, actorID)
 		fakeCallAndActivateActor(testActorRuntime, actorKey)
 
-		err := testActorRuntime.TransactionalStateOperation(&TransactionalRequest{
+		err := testActorRuntime.TransactionalStateOperation(ctx, &TransactionalRequest{
 			ActorType: actorType,
 			ActorID:   actorID,
 			Operations: []TransactionalOperation{
@@ -625,7 +639,7 @@ func TestTransactionalState(t *testing.T) {
 		actorKey := testActorRuntime.constructCompositeKey(actorType, actorID)
 		fakeCallAndActivateActor(testActorRuntime, actorKey)
 
-		err := testActorRuntime.TransactionalStateOperation(&TransactionalRequest{
+		err := testActorRuntime.TransactionalStateOperation(ctx, &TransactionalRequest{
 			ActorType: actorType,
 			ActorID:   actorID,
 			Operations: []TransactionalOperation{
@@ -641,6 +655,7 @@ func TestTransactionalState(t *testing.T) {
 }
 
 func TestActiveActorsCount(t *testing.T) {
+	ctx := context.Background()
 	t.Run("Actors Count", func(t *testing.T) {
 		expectedCounts := []ActiveActorsCount{{Type: "cat", Count: 2}, {Type: "dog", Count: 1}}
 
@@ -653,7 +668,7 @@ func TestActiveActorsCount(t *testing.T) {
 		actorKey3 := testActorRuntime.constructCompositeKey("dog", "xyz")
 		fakeCallAndActivateActor(testActorRuntime, actorKey3)
 
-		actualCounts := testActorRuntime.GetActiveActorsCount()
+		actualCounts := testActorRuntime.GetActiveActorsCount(ctx)
 		assert.ElementsMatch(t, expectedCounts, actualCounts)
 	})
 
@@ -662,7 +677,7 @@ func TestActiveActorsCount(t *testing.T) {
 
 		testActorRuntime := newTestActorsRuntime()
 
-		actualCounts := testActorRuntime.GetActiveActorsCount()
+		actualCounts := testActorRuntime.GetActiveActorsCount(ctx)
 		assert.Equal(t, expectedCounts, actualCounts)
 	})
 }

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -589,22 +589,22 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 	respond(reqCtx, statusCode, body)
 }
 
-func (a *api) onCreateActorReminder(ctx *fasthttp.RequestCtx) {
+func (a *api) onCreateActorReminder(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	name := ctx.UserValue(nameParam).(string)
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	name := reqCtx.UserValue(nameParam).(string)
 
 	var req actors.CreateReminderRequest
-	err := a.json.Unmarshal(ctx.PostBody(), &req)
+	err := a.json.Unmarshal(reqCtx.PostBody(), &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", err.Error())
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
@@ -612,31 +612,34 @@ func (a *api) onCreateActorReminder(ctx *fasthttp.RequestCtx) {
 	req.ActorType = actorType
 	req.ActorID = actorID
 
-	err = a.actor.CreateReminder(&req)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	err = a.actor.CreateReminder(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_CREATE", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 200)
+		respondEmpty(reqCtx, 200)
 	}
 }
 
-func (a *api) onCreateActorTimer(ctx *fasthttp.RequestCtx) {
+func (a *api) onCreateActorTimer(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	name := ctx.UserValue(nameParam).(string)
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	name := reqCtx.UserValue(nameParam).(string)
 
 	var req actors.CreateTimerRequest
-	err := a.json.Unmarshal(ctx.PostBody(), &req)
+	err := a.json.Unmarshal(reqCtx.PostBody(), &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", err.Error())
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
@@ -644,25 +647,28 @@ func (a *api) onCreateActorTimer(ctx *fasthttp.RequestCtx) {
 	req.ActorType = actorType
 	req.ActorID = actorID
 
-	err = a.actor.CreateTimer(&req)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	err = a.actor.CreateTimer(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_TIMER_CREATE", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 200)
+		respondEmpty(reqCtx, 200)
 	}
 }
 
-func (a *api) onDeleteActorReminder(ctx *fasthttp.RequestCtx) {
+func (a *api) onDeleteActorReminder(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	name := ctx.UserValue(nameParam).(string)
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	name := reqCtx.UserValue(nameParam).(string)
 
 	req := actors.DeleteReminderRequest{
 		Name:      name,
@@ -670,34 +676,40 @@ func (a *api) onDeleteActorReminder(ctx *fasthttp.RequestCtx) {
 		ActorType: actorType,
 	}
 
-	err := a.actor.DeleteReminder(&req)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	err := a.actor.DeleteReminder(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_DELETE", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 200)
+		respondEmpty(reqCtx, 200)
 	}
 }
 
-func (a *api) onActorStateTransaction(ctx *fasthttp.RequestCtx) {
+func (a *api) onActorStateTransaction(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	body := ctx.PostBody()
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	body := reqCtx.PostBody()
 
-	hosted := a.actor.IsActorHosted(&actors.ActorHostedRequest{
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	hosted := a.actor.IsActorHosted(ctx, &actors.ActorHostedRequest{
 		ActorType: actorType,
 		ActorID:   actorID,
 	})
 
 	if !hosted {
 		msg := NewErrorResponse("ERR_ACTOR_INSTANCE_MISSING", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
@@ -705,7 +717,7 @@ func (a *api) onActorStateTransaction(ctx *fasthttp.RequestCtx) {
 	err := a.json.Unmarshal(body, &ops)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", err.Error())
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
@@ -715,54 +727,57 @@ func (a *api) onActorStateTransaction(ctx *fasthttp.RequestCtx) {
 		Operations: ops,
 	}
 
-	err = a.actor.TransactionalStateOperation(&req)
+	err = a.actor.TransactionalStateOperation(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_STATE_TRANSACTION_SAVE", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 201)
+		respondEmpty(reqCtx, 201)
 	}
 }
 
-func (a *api) onGetActorReminder(ctx *fasthttp.RequestCtx) {
+func (a *api) onGetActorReminder(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	name := ctx.UserValue(nameParam).(string)
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	name := reqCtx.UserValue(nameParam).(string)
 
-	resp, err := a.actor.GetReminder(&actors.GetReminderRequest{
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	resp, err := a.actor.GetReminder(ctx, &actors.GetReminderRequest{
 		ActorType: actorType,
 		ActorID:   actorID,
 		Name:      name,
 	})
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_GET", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	}
 	b, err := a.json.Marshal(resp)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_GET", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondWithJSON(ctx, 200, b)
+		respondWithJSON(reqCtx, 200, b)
 	}
 }
 
-func (a *api) onDeleteActorTimer(ctx *fasthttp.RequestCtx) {
+func (a *api) onDeleteActorTimer(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	name := ctx.UserValue(nameParam).(string)
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	name := reqCtx.UserValue(nameParam).(string)
 
 	req := actors.DeleteTimerRequest{
 		Name:      name,
@@ -770,12 +785,15 @@ func (a *api) onDeleteActorTimer(ctx *fasthttp.RequestCtx) {
 		ActorType: actorType,
 	}
 
-	err := a.actor.DeleteTimer(&req)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	err := a.actor.DeleteTimer(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_TIMER_DELETE", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 200)
+		respondEmpty(reqCtx, 200)
 	}
 }
 
@@ -830,26 +848,29 @@ func (a *api) setHeadersOnRequest(metadata map[string]string, ctx *fasthttp.Requ
 	}
 }
 
-func (a *api) onSaveActorState(ctx *fasthttp.RequestCtx) {
+func (a *api) onSaveActorState(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	key := ctx.UserValue(stateKeyParam).(string)
-	body := ctx.PostBody()
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	key := reqCtx.UserValue(stateKeyParam).(string)
+	body := reqCtx.PostBody()
 
-	hosted := a.actor.IsActorHosted(&actors.ActorHostedRequest{
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	hosted := a.actor.IsActorHosted(ctx, &actors.ActorHostedRequest{
 		ActorType: actorType,
 		ActorID:   actorID,
 	})
 
 	if !hosted {
 		msg := NewErrorResponse("ERR_ACTOR_INSTANCE_MISSING", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
@@ -859,7 +880,7 @@ func (a *api) onSaveActorState(ctx *fasthttp.RequestCtx) {
 	err := a.json.Unmarshal(body, &val)
 	if err != nil {
 		msg := NewErrorResponse("ERR_DESERIALIZE_HTTP_BODY", err.Error())
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
@@ -870,25 +891,25 @@ func (a *api) onSaveActorState(ctx *fasthttp.RequestCtx) {
 		Value:     val,
 	}
 
-	err = a.actor.SaveState(&req)
+	err = a.actor.SaveState(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_STATE_SAVE", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 201)
+		respondEmpty(reqCtx, 201)
 	}
 }
 
-func (a *api) onGetActorState(ctx *fasthttp.RequestCtx) {
+func (a *api) onGetActorState(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	key := ctx.UserValue(stateKeyParam).(string)
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	key := reqCtx.UserValue(stateKeyParam).(string)
 
 	req := actors.GetStateRequest{
 		ActorType: actorType,
@@ -896,34 +917,40 @@ func (a *api) onGetActorState(ctx *fasthttp.RequestCtx) {
 		Key:       key,
 	}
 
-	resp, err := a.actor.GetState(&req)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	resp, err := a.actor.GetState(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_STATE_GET", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondWithJSON(ctx, 200, resp.Data)
+		respondWithJSON(reqCtx, 200, resp.Data)
 	}
 }
 
-func (a *api) onDeleteActorState(ctx *fasthttp.RequestCtx) {
+func (a *api) onDeleteActorState(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
-	actorType := ctx.UserValue(actorTypeParam).(string)
-	actorID := ctx.UserValue(actorIDParam).(string)
-	key := ctx.UserValue(stateKeyParam).(string)
+	actorType := reqCtx.UserValue(actorTypeParam).(string)
+	actorID := reqCtx.UserValue(actorIDParam).(string)
+	key := reqCtx.UserValue(stateKeyParam).(string)
 
-	hosted := a.actor.IsActorHosted(&actors.ActorHostedRequest{
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
+	hosted := a.actor.IsActorHosted(ctx, &actors.ActorHostedRequest{
 		ActorType: actorType,
 		ActorID:   actorID,
 	})
 
 	if !hosted {
 		msg := NewErrorResponse("ERR_ACTOR_INSTANCE_MISSING", "")
-		respondWithError(ctx, 400, msg)
+		respondWithError(reqCtx, 400, msg)
 		return
 	}
 
@@ -933,16 +960,16 @@ func (a *api) onDeleteActorState(ctx *fasthttp.RequestCtx) {
 		Key:       key,
 	}
 
-	err := a.actor.DeleteState(&req)
+	err := a.actor.DeleteState(ctx, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_STATE_DELETE", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 200)
+		respondEmpty(reqCtx, 200)
 	}
 }
 
-func (a *api) onGetMetadata(ctx *fasthttp.RequestCtx) {
+func (a *api) onGetMetadata(reqCtx *fasthttp.RequestCtx) {
 	temp := make(map[interface{}]interface{})
 
 	// Copy synchronously so it can be serialized to JSON.
@@ -951,26 +978,29 @@ func (a *api) onGetMetadata(ctx *fasthttp.RequestCtx) {
 		return true
 	})
 
+	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	ctx := diag.NewContext((context.Context)(reqCtx), sc)
+
 	mtd := metadata{
 		ID:                a.id,
-		ActiveActorsCount: a.actor.GetActiveActorsCount(),
+		ActiveActorsCount: a.actor.GetActiveActorsCount(ctx),
 		Extended:          temp,
 	}
 
 	mtdBytes, err := a.json.Marshal(mtd)
 	if err != nil {
 		msg := NewErrorResponse("ERR_METADATA_GET", err.Error())
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondWithJSON(ctx, 200, mtdBytes)
+		respondWithJSON(reqCtx, 200, mtdBytes)
 	}
 }
 
-func (a *api) onPutMetadata(ctx *fasthttp.RequestCtx) {
-	key := ctx.UserValue("key")
-	body := ctx.PostBody()
+func (a *api) onPutMetadata(reqCtx *fasthttp.RequestCtx) {
+	key := reqCtx.UserValue("key")
+	body := reqCtx.PostBody()
 	a.extendedMetadata.Store(key, string(body))
-	respondEmpty(ctx, 200)
+	respondEmpty(reqCtx, 200)
 }
 
 func (a *api) onPublish(reqCtx *fasthttp.RequestCtx) {
@@ -1028,11 +1058,11 @@ func GetStatusCodeFromMetadata(metadata map[string]string) int {
 	return 200
 }
 
-func (a *api) onGetHealthz(ctx *fasthttp.RequestCtx) {
+func (a *api) onGetHealthz(reqCtx *fasthttp.RequestCtx) {
 	if !a.readyStatus {
 		msg := NewErrorResponse("ERR_HEALTH_NOT_READY", "dapr is not ready")
-		respondWithError(ctx, 500, msg)
+		respondWithError(reqCtx, 500, msg)
 	} else {
-		respondEmpty(ctx, 200)
+		respondEmpty(reqCtx, 200)
 	}
 }

--- a/pkg/testing/actors_mock.go
+++ b/pkg/testing/actors_mock.go
@@ -43,7 +43,7 @@ func (_m *MockActors) Call(ctx context.Context, req *actors.CallRequest) (*actor
 }
 
 // CreateReminder provides a mock function with given fields: req
-func (_m *MockActors) CreateReminder(req *actors.CreateReminderRequest) error {
+func (_m *MockActors) CreateReminder(ctx context.Context, req *actors.CreateReminderRequest) error {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -57,7 +57,7 @@ func (_m *MockActors) CreateReminder(req *actors.CreateReminderRequest) error {
 }
 
 // IsActorHosted provides a mock function with given fields: req
-func (_m *MockActors) IsActorHosted(req *actors.ActorHostedRequest) bool {
+func (_m *MockActors) IsActorHosted(ctx context.Context, req *actors.ActorHostedRequest) bool {
 	ret := _m.Called(req)
 
 	var r0 bool
@@ -71,7 +71,7 @@ func (_m *MockActors) IsActorHosted(req *actors.ActorHostedRequest) bool {
 }
 
 // CreateTimer provides a mock function with given fields: req
-func (_m *MockActors) CreateTimer(req *actors.CreateTimerRequest) error {
+func (_m *MockActors) CreateTimer(ctx context.Context, req *actors.CreateTimerRequest) error {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -85,7 +85,7 @@ func (_m *MockActors) CreateTimer(req *actors.CreateTimerRequest) error {
 }
 
 // DeleteReminder provides a mock function with given fields: req
-func (_m *MockActors) DeleteReminder(req *actors.DeleteReminderRequest) error {
+func (_m *MockActors) DeleteReminder(ctx context.Context, req *actors.DeleteReminderRequest) error {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -99,7 +99,7 @@ func (_m *MockActors) DeleteReminder(req *actors.DeleteReminderRequest) error {
 }
 
 // DeleteTimer provides a mock function with given fields: req
-func (_m *MockActors) DeleteTimer(req *actors.DeleteTimerRequest) error {
+func (_m *MockActors) DeleteTimer(ctx context.Context, req *actors.DeleteTimerRequest) error {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -113,7 +113,7 @@ func (_m *MockActors) DeleteTimer(req *actors.DeleteTimerRequest) error {
 }
 
 // GetState provides a mock function with given fields: req
-func (_m *MockActors) GetState(req *actors.GetStateRequest) (*actors.StateResponse, error) {
+func (_m *MockActors) GetState(ctx context.Context, req *actors.GetStateRequest) (*actors.StateResponse, error) {
 	ret := _m.Called(req)
 
 	var r0 *actors.StateResponse
@@ -150,7 +150,7 @@ func (_m *MockActors) Init() error {
 }
 
 // SaveState provides a mock function with given fields: req
-func (_m *MockActors) SaveState(req *actors.SaveStateRequest) error {
+func (_m *MockActors) SaveState(ctx context.Context, req *actors.SaveStateRequest) error {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -164,7 +164,7 @@ func (_m *MockActors) SaveState(req *actors.SaveStateRequest) error {
 }
 
 // DeleteState provides a mock function with given fields: req
-func (_m *MockActors) DeleteState(req *actors.DeleteStateRequest) error {
+func (_m *MockActors) DeleteState(ctx context.Context, req *actors.DeleteStateRequest) error {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -178,7 +178,7 @@ func (_m *MockActors) DeleteState(req *actors.DeleteStateRequest) error {
 }
 
 // TransactionalStateOperation provides a mock function with given fields: req
-func (_m *MockActors) TransactionalStateOperation(req *actors.TransactionalRequest) error {
+func (_m *MockActors) TransactionalStateOperation(ctx context.Context, req *actors.TransactionalRequest) error {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -192,7 +192,7 @@ func (_m *MockActors) TransactionalStateOperation(req *actors.TransactionalReque
 }
 
 // GetReminder provides a mock function with given fields: req
-func (_m *MockActors) GetReminder(req *actors.GetReminderRequest) (*actors.Reminder, error) {
+func (_m *MockActors) GetReminder(ctx context.Context, req *actors.GetReminderRequest) (*actors.Reminder, error) {
 	ret := _m.Called(req)
 
 	var r0 error
@@ -206,7 +206,7 @@ func (_m *MockActors) GetReminder(req *actors.GetReminderRequest) (*actors.Remin
 }
 
 // GetActiveActorsCount provides a mock function
-func (_m *MockActors) GetActiveActorsCount() []actors.ActiveActorsCount {
+func (_m *MockActors) GetActiveActorsCount(ctx context.Context) []actors.ActiveActorsCount {
 	_m.Called()
 	return []actors.ActiveActorsCount{
 		{


### PR DESCRIPTION
# Description
This PR is in continuation of earlier PR in 0.6.0 milestone #1332. Due to various changes over the code path, to avoid fixing merge conflicts resolutions, created this PR on latest code.

This PR is in conjunction with #1373 to address remaining propagation of context in actor calls.
This PR was not checked in 0.6.0 release as the context was not populated with correlation id.
Now with issue #1373 , context is built correctly , so checking in this change now.

- [x] Call(ctx context.Context, req *CallRequest) (*CallResponse, error)
- [x] 	GetState(ctx context.Context, req *GetStateRequest) (*StateResponse, error)
- [x] 	SaveState(ctx context.Context, req *SaveStateRequest) error
- [x] 	DeleteState(ctx context.Context, req *DeleteStateRequest) error
- [x] 	TransactionalStateOperation(ctx context.Context, req *TransactionalRequest) error
- [x] 	GetReminder(ctx context.Context, req *GetReminderRequest) (*Reminder, error)
- [x] 	CreateReminder(ctx context.Context, req *CreateReminderRequest) error
- [x] 	DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error
- [x] 	CreateTimer(ctx context.Context, req *CreateTimerRequest) error
- [x] 	DeleteTimer(ctx context.Context, req *DeleteTimerRequest) error
- [x] 	IsActorHosted(ctx context.Context, req *ActorHostedRequest) bool
- [x] 	GetActiveActorsCount(ctx context.Context) []ActiveActorsCount

**Note**  The context is not passed to external components contrib calls. There are 2 reasons for not to have those changes in this PR and subject to further discussions on below 2 points :
                              1.  Changing the components APIs to have context, will break the APIs and will be 
                                   breaking change.
                              2. Having context in the components APIs, will force components API to always 
                                  honor the context . 

One approach to satisfy both the above 2 points would be to provide components APIs with 2 versions that , a) APIs taking context as parameters and b) APIs taking no context which is current case.     
             
## Issue reference
#292 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation
* [ ] Specification has been updated
* [ ] Provided sample for the feature
