### PR TITLE
Setting the default TraceOptions correctly

### DIFF
--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -38,3 +38,21 @@ func TestWithGRPCSpanContext(t *testing.T) {
 
 	assert.Equalf(t, gotSc, wantSc, "WithGRPCSpanContext gotSc = %v, want %v", gotSc, wantSc)
 }
+
+func TestWithGRPCWithNoSpanContext(t *testing.T) {
+	t.Run("No SpanContext with non-zero sampling rate", func(t *testing.T) {
+		ctx := context.Background()
+		spec := config.TracingSpec{SamplingRate: "1"}
+		sc := GetSpanContextFromGRPC(ctx, spec)
+		assert.NotEmpty(t, sc, "Should get default span context")
+		assert.Equal(t, 1, int(sc.TraceOptions), "Should be sampled")
+	})
+
+	t.Run("No SpanContext with zero sampling rate", func(t *testing.T) {
+		ctx := context.Background()
+		spec := config.TracingSpec{SamplingRate: "0"}
+		sc := GetSpanContextFromGRPC(ctx, spec)
+		assert.NotEmpty(t, sc, "Should get default span context")
+		assert.Equal(t, 0, int(sc.TraceOptions), "Should not be sampled")
+	})
+}

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -40,12 +40,19 @@ func TestWithGRPCSpanContext(t *testing.T) {
 }
 
 func TestWithGRPCWithNoSpanContext(t *testing.T) {
-	t.Run("No SpanContext with non-zero sampling rate", func(t *testing.T) {
+	t.Run("No SpanContext with always sampling rate", func(t *testing.T) {
 		ctx := context.Background()
 		spec := config.TracingSpec{SamplingRate: "1"}
 		sc := GetSpanContextFromGRPC(ctx, spec)
 		assert.NotEmpty(t, sc, "Should get default span context")
 		assert.Equal(t, 1, int(sc.TraceOptions), "Should be sampled")
+	})
+
+	t.Run("No SpanContext with non-zero sampling rate", func(t *testing.T) {
+		ctx := context.Background()
+		spec := config.TracingSpec{SamplingRate: "0.5"}
+		sc := GetSpanContextFromGRPC(ctx, spec)
+		assert.NotEmpty(t, sc, "Should get default span context")
 	})
 
 	t.Run("No SpanContext with zero sampling rate", func(t *testing.T) {

--- a/pkg/diagnostics/http_tracing_test.go
+++ b/pkg/diagnostics/http_tracing_test.go
@@ -113,12 +113,19 @@ func TestSpanContextToRequest(t *testing.T) {
 }
 
 func TestWithNoSpanContext(t *testing.T) {
-	t.Run("No SpanContext with non-zero sampling rate", func(t *testing.T) {
+	t.Run("No SpanContext with always sampling rate", func(t *testing.T) {
 		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
 		spec := config.TracingSpec{SamplingRate: "1"}
 		sc := GetSpanContextFromRequestContext(ctx, spec)
 		assert.NotEmpty(t, sc, "Should get default span context")
 		assert.Equal(t, 1, int(sc.TraceOptions), "Should be sampled")
+	})
+
+	t.Run("No SpanContext with non-zero sampling rate", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
+		spec := config.TracingSpec{SamplingRate: "0.5"}
+		sc := GetSpanContextFromRequestContext(ctx, spec)
+		assert.NotEmpty(t, sc, "Should get default span context")
 	})
 
 	t.Run("No SpanContext with zero sampling rate", func(t *testing.T) {

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -81,9 +81,7 @@ func GetDefaultSpanContext(spec config.TracingSpec) trace.SpanContext {
 		HasRemoteParent: false}).Sample
 
 	if sampled {
-		spanContext.TraceOptions |= 1
-	} else {
-		spanContext.TraceOptions &= ^trace.TraceOptions(1)
+		spanContext.TraceOptions = 1
 	}
 
 	return spanContext

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -181,8 +181,7 @@ func (a *api) InvokeService(ctx context.Context, in *daprv1pb.InvokeServiceReque
 	if incomingMD, ok := metadata.FromIncomingContext(ctx); ok {
 		req.WithMetadata(incomingMD)
 	}
-	sc := diag.GetSpanContextFromGRPC(ctx)
-	ctx = diag.NewContext(ctx, sc)
+
 	resp, err := a.directMessaging.Invoke(ctx, in.Id, req)
 	if err != nil {
 		return nil, err

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dapr/components-contrib/exporters"
 	"github.com/dapr/components-contrib/exporters/stringexporter"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
+	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/logger"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
@@ -104,9 +105,10 @@ func startTestServerWithTracing(port int) (*grpc_go.Server, *string) {
 		},
 	})
 
+	spec := config.TracingSpec{SamplingRate: "1"}
 	server := grpc_go.NewServer(
-		grpc_go.StreamInterceptor(grpc_middleware.ChainStreamServer(diag.SetTracingSpanContextGRPCMiddlewareStream())),
-		grpc_go.UnaryInterceptor(grpc_middleware.ChainUnaryServer(diag.SetTracingSpanContextGRPCMiddlewareUnary())),
+		grpc_go.StreamInterceptor(grpc_middleware.ChainStreamServer(diag.SetTracingSpanContextGRPCMiddlewareStream(spec))),
+		grpc_go.UnaryInterceptor(grpc_middleware.ChainUnaryServer(diag.SetTracingSpanContextGRPCMiddlewareUnary(spec))),
 	)
 
 	go func() {

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -138,8 +138,8 @@ func (s *server) getMiddlewareOptions() []grpc_go.ServerOption {
 	s.logger.Infof("enabled tracing grpc middleware")
 	opts = append(
 		opts,
-		grpc_go.StreamInterceptor(diag.SetTracingSpanContextGRPCMiddlewareStream()),
-		grpc_go.UnaryInterceptor(diag.SetTracingSpanContextGRPCMiddlewareUnary()))
+		grpc_go.StreamInterceptor(diag.SetTracingSpanContextGRPCMiddlewareStream(s.tracingSpec)),
+		grpc_go.UnaryInterceptor(diag.SetTracingSpanContextGRPCMiddlewareUnary(s.tracingSpec)))
 
 	s.logger.Infof("enabled metrics grpc middleware")
 	opts = append(opts, grpc_go.StatsHandler(diag.DefaultGRPCMonitoring.ServerStatsHandler))

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -297,7 +297,7 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 
 	var span *trace.Span
 	spanName := fmt.Sprintf("OutputBindingMessage: %s", name)
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 	_, span = diag.StartTracingClientSpanFromHTTPContext(ctx, &reqCtx.Request, spanName, a.tracingSpec)
 	diag.SpanContextToRequest(span.SpanContext(), &reqCtx.Request)
@@ -333,7 +333,7 @@ func (a *api) onGetState(reqCtx *fasthttp.RequestCtx) {
 
 	var span *trace.Span
 	spanName := fmt.Sprintf("GetState: %s", storeName)
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 	_, span = diag.StartTracingClientSpanFromHTTPContext(ctx, &reqCtx.Request, spanName, a.tracingSpec)
 	diag.SpanContextToRequest(span.SpanContext(), &reqCtx.Request)
@@ -410,7 +410,7 @@ func (a *api) onDeleteState(reqCtx *fasthttp.RequestCtx) {
 
 	var span *trace.Span
 	spanName := fmt.Sprintf("DeleteState: %s", storeName)
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 	_, span = diag.StartTracingClientSpanFromHTTPContext(ctx, &reqCtx.Request, spanName, a.tracingSpec)
 	diag.SpanContextToRequest(span.SpanContext(), &reqCtx.Request)
@@ -458,7 +458,7 @@ func (a *api) onGetSecret(reqCtx *fasthttp.RequestCtx) {
 
 	var span *trace.Span
 	spanName := fmt.Sprintf("GetSecret: %s", secretStoreName)
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 	_, span = diag.StartTracingClientSpanFromHTTPContext(ctx, &reqCtx.Request, spanName, a.tracingSpec)
 	diag.SpanContextToRequest(span.SpanContext(), &reqCtx.Request)
@@ -509,7 +509,7 @@ func (a *api) onPostState(reqCtx *fasthttp.RequestCtx) {
 
 	var span *trace.Span
 	spanName := fmt.Sprintf("SaveState: %s", storeName)
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 	_, span = diag.StartTracingClientSpanFromHTTPContext(ctx, &reqCtx.Request, spanName, a.tracingSpec)
 	diag.SpanContextToRequest(span.SpanContext(), &reqCtx.Request)
@@ -553,7 +553,7 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 	})
 	req.WithMetadata(metadata)
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 	resp, err := a.directMessaging.Invoke(ctx, targetID, req)
 	// err does not represent user application response
@@ -599,7 +599,7 @@ func (a *api) onCreateActorReminder(reqCtx *fasthttp.RequestCtx) {
 	req.ActorType = actorType
 	req.ActorID = actorID
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	err = a.actor.CreateReminder(ctx, &req)
@@ -634,7 +634,7 @@ func (a *api) onCreateActorTimer(reqCtx *fasthttp.RequestCtx) {
 	req.ActorType = actorType
 	req.ActorID = actorID
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	err = a.actor.CreateTimer(ctx, &req)
@@ -663,7 +663,7 @@ func (a *api) onDeleteActorReminder(reqCtx *fasthttp.RequestCtx) {
 		ActorType: actorType,
 	}
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	err := a.actor.DeleteReminder(ctx, &req)
@@ -686,7 +686,7 @@ func (a *api) onActorStateTransaction(reqCtx *fasthttp.RequestCtx) {
 	actorID := reqCtx.UserValue(actorIDParam).(string)
 	body := reqCtx.PostBody()
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	hosted := a.actor.IsActorHosted(ctx, &actors.ActorHostedRequest{
@@ -734,7 +734,7 @@ func (a *api) onGetActorReminder(reqCtx *fasthttp.RequestCtx) {
 	actorID := reqCtx.UserValue(actorIDParam).(string)
 	name := reqCtx.UserValue(nameParam).(string)
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	resp, err := a.actor.GetReminder(ctx, &actors.GetReminderRequest{
@@ -772,7 +772,7 @@ func (a *api) onDeleteActorTimer(reqCtx *fasthttp.RequestCtx) {
 		ActorType: actorType,
 	}
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	err := a.actor.DeleteTimer(ctx, &req)
@@ -809,7 +809,7 @@ func (a *api) onDirectActorMessage(reqCtx *fasthttp.RequestCtx) {
 	})
 	req.WithMetadata(metadata)
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	resp, err := a.actor.Call(ctx, req)
@@ -844,7 +844,7 @@ func (a *api) onSaveActorState(reqCtx *fasthttp.RequestCtx) {
 	key := reqCtx.UserValue(stateKeyParam).(string)
 	body := reqCtx.PostBody()
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	hosted := a.actor.IsActorHosted(ctx, &actors.ActorHostedRequest{
@@ -901,7 +901,7 @@ func (a *api) onGetActorState(reqCtx *fasthttp.RequestCtx) {
 		Key:       key,
 	}
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	resp, err := a.actor.GetState(ctx, &req)
@@ -924,7 +924,7 @@ func (a *api) onDeleteActorState(reqCtx *fasthttp.RequestCtx) {
 	actorID := reqCtx.UserValue(actorIDParam).(string)
 	key := reqCtx.UserValue(stateKeyParam).(string)
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	hosted := a.actor.IsActorHosted(ctx, &actors.ActorHostedRequest{
@@ -962,7 +962,7 @@ func (a *api) onGetMetadata(reqCtx *fasthttp.RequestCtx) {
 		return true
 	})
 
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 
 	mtd := metadata{
@@ -998,7 +998,7 @@ func (a *api) onPublish(reqCtx *fasthttp.RequestCtx) {
 	body := reqCtx.PostBody()
 
 	// TODO : Remove passing corID in NewCloudEventsEnvelope through arguments as it can be passed through context
-	sc := diag.GetSpanContextFromRequestContext(reqCtx)
+	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	corID := sc.TraceID.String()
 	envelope := pubsub.NewCloudEventsEnvelope(uuid.New().String(), a.id, pubsub.DefaultCloudEventType, corID, body)
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -1206,7 +1206,7 @@ func (f *fakeHTTPServer) StartServerWithTracing(spec config.TracingSpec, endpoin
 	router := f.getRouter(endpoints)
 	f.ln = fasthttputil.NewInmemoryListener()
 	go func() {
-		if err := fasthttp.Serve(f.ln, diag.SetTracingSpanContextFromHTTPContext(router.Handler)); err != nil {
+		if err := fasthttp.Serve(f.ln, diag.SetTracingSpanContextFromHTTPContext(router.Handler, spec)); err != nil {
 			panic(fmt.Errorf("failed to set tracing span context: %v", err))
 		}
 	}()
@@ -1225,7 +1225,8 @@ func (f *fakeHTTPServer) StartServerWithTracingAndPipeline(spec config.TracingSp
 	f.ln = fasthttputil.NewInmemoryListener()
 	go func() {
 		handler := pipeline.Apply(router.Handler)
-		if err := fasthttp.Serve(f.ln, diag.SetTracingSpanContextFromHTTPContext(handler)); err != nil {
+		spec := config.TracingSpec{SamplingRate: "1"}
+		if err := fasthttp.Serve(f.ln, diag.SetTracingSpanContextFromHTTPContext(handler, spec)); err != nil {
 			panic(fmt.Errorf("failed to serve tracing span context: %v", err))
 		}
 	}()

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -69,7 +69,7 @@ func (s *server) StartNonBlocking() {
 
 func (s *server) useTracing(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	log.Infof("enabled tracing http middleware")
-	return diag.SetTracingSpanContextFromHTTPContext(next)
+	return diag.SetTracingSpanContextFromHTTPContext(next, s.tracingSpec)
 }
 
 func (s *server) useMetrics(next fasthttp.RequestHandler) fasthttp.RequestHandler {


### PR DESCRIPTION
# Description

Currently default TraceOptions of span is set to 1 when not provided by client. This is not correct when parent context is provided.

## Issue reference

closes #1495

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
