### PR TITLE
Check if metrics enabled for HTTP middleware and gRPC interceptors

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -552,9 +552,12 @@ func (a *actorsRuntime) getPlacementClientPersistently(placementAddress, hostAdd
 			log.Errorf("failed to establish TLS credentials for actor placement service: %s", err)
 			return nil
 		}
-		opts = append(
-			opts,
-			grpc.WithUnaryInterceptor(diag.DefaultGRPCMonitoring.UnaryClientInterceptor()))
+
+		if diag.DefaultGRPCMonitoring.IsEnabled() {
+			opts = append(
+				opts,
+				grpc.WithUnaryInterceptor(diag.DefaultGRPCMonitoring.UnaryClientInterceptor()))
+		}
 
 		conn, err := grpc.Dial(
 			placementAddress,

--- a/pkg/diagnostics/grpc_monitoring.go
+++ b/pkg/diagnostics/grpc_monitoring.go
@@ -135,6 +135,10 @@ func (g *grpcMetrics) Init(appID string) error {
 	return view.Register(views...)
 }
 
+func (g *grpcMetrics) IsEnabled() bool {
+	return g.enabled
+}
+
 func (g *grpcMetrics) ServerRequestReceived(ctx context.Context, method string, contentSize int64) time.Time {
 	if g.enabled {
 		stats.RecordWithTags(

--- a/pkg/diagnostics/http_monitoring.go
+++ b/pkg/diagnostics/http_monitoring.go
@@ -83,6 +83,10 @@ func newHTTPMetrics() *httpMetrics {
 	}
 }
 
+func (h *httpMetrics) IsEnabled() bool {
+	return h.enabled
+}
+
 func (h *httpMetrics) ServerRequestReceived(ctx context.Context, method, path string, contentSize int64) {
 	if h.enabled {
 		stats.RecordWithTags(

--- a/pkg/diagnostics/metrics.go
+++ b/pkg/diagnostics/metrics.go
@@ -23,9 +23,9 @@ var (
 
 	// DefaultMonitoring holds service monitoring metrics definitions
 	DefaultMonitoring = newServiceMetrics()
-	// DefaultGRPCMonitoring holds default gRPC monitoring handlers and middleswares
+	// DefaultGRPCMonitoring holds default gRPC monitoring handlers and middlewares
 	DefaultGRPCMonitoring = newGRPCMetrics()
-	// DefaultHTTPMonitoring holds default HTTP monitoring handlers and middleswares
+	// DefaultHTTPMonitoring holds default HTTP monitoring handlers and middlewares
 	DefaultHTTPMonitoring = newHTTPMetrics()
 )
 

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -74,8 +74,11 @@ func (g *Manager) GetGRPCConnection(address, id string, skipTLS, recreateIfExist
 
 	opts := []grpc.DialOption{
 		grpc.WithBlock(),
-		grpc.WithUnaryInterceptor(diag.DefaultGRPCMonitoring.UnaryClientInterceptor()),
 		grpc.WithDefaultServiceConfig(grpcServiceConfig),
+	}
+
+	if diag.DefaultGRPCMonitoring.IsEnabled() {
+		opts = append(opts, grpc.WithUnaryInterceptor(diag.DefaultGRPCMonitoring.UnaryClientInterceptor()))
 	}
 
 	if !skipTLS && g.auth != nil {

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -73,7 +73,10 @@ func (s *server) useTracing(next fasthttp.RequestHandler) fasthttp.RequestHandle
 }
 
 func (s *server) useMetrics(next fasthttp.RequestHandler) fasthttp.RequestHandler {
-	return diag.DefaultHTTPMonitoring.FastHTTPMiddleware(next)
+	if diag.DefaultHTTPMonitoring.IsEnabled() {
+		return diag.DefaultHTTPMonitoring.FastHTTPMiddleware(next)
+	}
+	return next
 }
 
 func (s *server) useRouter() fasthttp.RequestHandler {


### PR DESCRIPTION
# Description

This PR adds a check if metrics is enabled before adding middleware for HTTP and interceptor for gRPC server/client.

## Issue reference

This PR addresses Issue: https://github.com/dapr/dapr/issues/1535

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dapr/dapr/1538)
<!-- Reviewable:end -->
