### PR TITLE
Passing correlationID in publishMessage and generating  server spans both in publishmessage and binding message path.

### DIFF
--- a/pkg/diagnostics/http_tracing.go
+++ b/pkg/diagnostics/http_tracing.go
@@ -7,6 +7,7 @@ package diagnostics
 
 import (
 	"context"
+	"fmt"
 	"net/textproto"
 	"regexp"
 	"strconv"
@@ -92,11 +93,11 @@ func addAnnotationsToSpan(req *fasthttp.Request, span *trace.Span) {
 	})
 }
 
-// UpdateSpanStatus updates trace span status based on HTTP response
-func UpdateSpanStatus(span *trace.Span, resp *fasthttp.Response) {
+// UpdateSpanStatus updates trace span status based on response code
+func UpdateSpanStatus(span *trace.Span, spanName string, code int) {
 	span.SetStatus(trace.Status{
-		Code:    projectStatusCode(resp.StatusCode()),
-		Message: strconv.Itoa(resp.StatusCode()),
+		Code:    projectStatusCode(code),
+		Message: fmt.Sprintf("method %s status - %s", spanName, strconv.Itoa(code)),
 	})
 }
 

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -148,10 +148,12 @@ func (a *api) PublishEvent(ctx context.Context, in *daprv1pb.PublishEventEnvelop
 		body = in.Data.Value
 	}
 
-	// TODO : Remove passing corID in NewCloudEventsEnvelope through arguments as it can be passed through context
-	sc := diag.FromContext(ctx)
-	corID := sc.TraceID.String()
+	var span *trace.Span
+	spanName := fmt.Sprintf("PublishEvent: %s", topic)
+	_, span = diag.StartTracingClientSpanFromGRPCContext(ctx, spanName, a.tracingSpec)
+	defer span.End()
 
+	corID := diag.SpanContextToString(span.SpanContext())
 	envelope := pubsub.NewCloudEventsEnvelope(uuid.New().String(), a.id, pubsub.DefaultCloudEventType, corID, body)
 	b, err := jsoniter.ConfigFastest.Marshal(envelope)
 	if err != nil {
@@ -162,11 +164,6 @@ func (a *api) PublishEvent(ctx context.Context, in *daprv1pb.PublishEventEnvelop
 		Topic: topic,
 		Data:  b,
 	}
-
-	var span *trace.Span
-	spanName := fmt.Sprintf("PublishEvent: %s", topic)
-	_, span = diag.StartTracingClientSpanFromGRPCContext(ctx, spanName, a.tracingSpec)
-	defer span.End()
 
 	err = a.publishFn(&req)
 	if err != nil {

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -206,7 +206,8 @@ func (a *api) InvokeBinding(ctx context.Context, in *daprv1pb.InvokeBindingEnvel
 	}
 
 	var span *trace.Span
-	_, span = diag.StartTracingClientSpanFromGRPCContext(ctx, "InvokeBinding", a.tracingSpec)
+	spanName := fmt.Sprintf("Binding: %s", in.Name)
+	_, span = diag.StartTracingClientSpanFromGRPCContext(ctx, spanName, a.tracingSpec)
 	defer span.End()
 
 	err := a.sendToOutputBindingFn(in.Name, req)

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -296,7 +296,7 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	var span *trace.Span
-	spanName := fmt.Sprintf("OutputBindingMessage: %s", name)
+	spanName := fmt.Sprintf("Binding: %s", name)
 	sc := diag.GetSpanContextFromRequestContext(reqCtx, a.tracingSpec)
 	ctx := diag.NewContext((context.Context)(reqCtx), sc)
 	_, span = diag.StartTracingClientSpanFromHTTPContext(ctx, &reqCtx.Request, spanName, a.tracingSpec)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -968,7 +968,7 @@ func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
 	// subject contains the correlationID which is passed span context
 	sc, _ := diag.SpanContextFromString(subject)
 	ctx := diag.NewContext(context.Background(), sc)
-	spanName := fmt.Sprintf("PublishMessage: %s", msg.Topic)
+	spanName := fmt.Sprintf("DeliveredEvent: %s", msg.Topic)
 	ctx, span := diag.StartTracingServerSpanFromGRPCContext(ctx, spanName, a.globalConfig.Spec.TracingSpec)
 	defer span.End()
 
@@ -1020,7 +1020,7 @@ func (a *DaprRuntime) publishMessageGRPC(msg *pubsub.NewMessage) error {
 	subject := cloudEvent.Subject
 	sc, _ := diag.SpanContextFromString(subject)
 	ctx := diag.NewContext(context.Background(), sc)
-	spanName := fmt.Sprintf("PublishMessage: %s", msg.Topic)
+	spanName := fmt.Sprintf("DeliveredEvent: %s", msg.Topic)
 	ctx, span := diag.StartTracingServerSpanFromGRPCContext(ctx, spanName, a.globalConfig.Spec.TracingSpec)
 	defer span.End()
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -486,7 +486,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 
 	if a.runtimeConfig.ApplicationProtocol == GRPCProtocol {
 		ctx := context.Background()
-		spanName := fmt.Sprintf("SendBindingEventToApp: %s", bindingName)
+		spanName := fmt.Sprintf("Binding: %s", bindingName)
 		ctx, span := diag.StartTracingServerSpanFromGRPCContext(ctx, spanName, a.globalConfig.Spec.TracingSpec)
 		defer span.End()
 
@@ -534,7 +534,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 		req.WithRawData(data, invokev1.JSONContentType)
 
 		ctx := context.Background()
-		spanName := fmt.Sprintf("SendBindingEventToApp: %s", bindingName)
+		spanName := fmt.Sprintf("Binding: %s", bindingName)
 		// context.Background() can be considered as GRPC context and so using StartTracingServerSpanFromGRPCContext to generate span
 		ctx, span := diag.StartTracingServerSpanFromGRPCContext(ctx, spanName, a.globalConfig.Spec.TracingSpec)
 		defer span.End()

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -615,7 +615,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil)
 		fakeResp.WithRawData([]byte("OK"), "application/json")
 
-		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.emptyCtx"), fakeReq).Return(fakeResp, nil)
+		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.valueCtx"), fakeReq).Return(fakeResp, nil)
 
 		// act
 		err := rt.publishMessageHTTP(testPubSubMessage)
@@ -633,7 +633,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		fakeResp := invokev1.NewInvokeMethodResponse(500, "Internal Error", nil)
 		fakeResp.WithRawData([]byte(clientError.Error()), "application/json")
 
-		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.emptyCtx"), fakeReq).Return(fakeResp, nil)
+		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.valueCtx"), fakeReq).Return(fakeResp, nil)
 
 		// act
 		err := rt.publishMessageHTTP(testPubSubMessage)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -779,7 +779,7 @@ func TestReadInputBindings(t *testing.T) {
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil)
 		fakeResp.WithRawData([]byte("OK"), "application/json")
 
-		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.emptyCtx"), fakeReq).Return(fakeResp, nil)
+		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.valueCtx"), fakeReq).Return(fakeResp, nil)
 
 		rt.appChannel = mockAppChannel
 
@@ -802,7 +802,7 @@ func TestReadInputBindings(t *testing.T) {
 		fakeResp := invokev1.NewInvokeMethodResponse(500, "Internal Error", nil)
 		fakeResp.WithRawData([]byte("Internal Error"), "application/json")
 
-		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.emptyCtx"), fakeReq).Return(fakeResp, nil)
+		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.valueCtx"), fakeReq).Return(fakeResp, nil)
 
 		rt.appChannel = mockAppChannel
 
@@ -825,7 +825,7 @@ func TestReadInputBindings(t *testing.T) {
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil)
 		fakeResp.WithRawData([]byte("OK"), "application/json")
 
-		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.emptyCtx"), fakeReq).Return(fakeResp, nil)
+		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.valueCtx"), fakeReq).Return(fakeResp, nil)
 		rt.appChannel = mockAppChannel
 
 		b := mockBinding{}


### PR DESCRIPTION
# Description

Passing correlationID in publishMessage and generating server spans both in publishmessage and binding message path

**Note** : This issue was known and targeted to 0.8.0 https://github.com/dapr/dapr/pull/1482

## Issue reference

#1533 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
