### PR TITLE
Add healthz server for control plane

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -22,6 +22,20 @@ spec:
     spec:
       containers:
       - name: dapr-operator
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -23,6 +23,20 @@ spec:
     spec:
       containers:
       - name: dapr-placement
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -33,6 +33,20 @@ spec:
     spec:
       containers:
       - name: dapr-sentry
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -23,6 +23,20 @@ spec:
       serviceAccountName: dapr-operator
       containers:
       - name: dapr-sidecar-injector
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          failureThreshold: 5
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}

--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"time"
 
@@ -44,7 +43,7 @@ func main() {
 		healthzServer := health.NewServer(log)
 		healthzServer.Ready()
 
-		err := healthzServer.Run(context.Background(), healthzPort)
+		err := healthzServer.Run(ctx, healthzPort)
 		if err != nil {
 			log.Fatalf("failed to start healhz server: %s", err)
 		}

--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -45,7 +45,7 @@ func main() {
 
 		err := healthzServer.Run(ctx, healthzPort)
 		if err != nil {
-			log.Fatalf("failed to start healhz server: %s", err)
+			log.Fatalf("failed to start healthz server: %s", err)
 		}
 	}()
 

--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -6,10 +6,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"time"
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
+	"github.com/dapr/dapr/pkg/health"
 	"github.com/dapr/dapr/pkg/injector"
 	"github.com/dapr/dapr/pkg/injector/monitoring"
 	"github.com/dapr/dapr/pkg/logger"
@@ -20,6 +22,10 @@ import (
 )
 
 var log = logger.NewLogger("dapr.injector")
+
+const (
+	healthzPort = 8080
+)
 
 func main() {
 	log.Infof("starting Dapr Sidecar Injector -- version %s -- commit %s", version.Version(), version.Commit())
@@ -33,6 +39,16 @@ func main() {
 	kubeClient := utils.GetKubeClient()
 	conf := utils.GetConfig()
 	daprClient, _ := scheme.NewForConfig(conf)
+
+	go func() {
+		healthzServer := health.NewServer(log)
+		healthzServer.Ready()
+
+		err := healthzServer.Run(context.Background(), healthzPort)
+		if err != nil {
+			log.Fatalf("failed to start healhz server: %s", err)
+		}
+	}()
 
 	injector.NewInjector(cfg, daprClient, kubeClient).Run(ctx)
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"time"
 
@@ -30,7 +29,7 @@ var certChainPath string
 
 const (
 	defaultCredentialsPath = "/var/run/dapr/credentials"
-	healthzPort            = 8081
+	healthzPort            = 8080
 )
 
 func main() {
@@ -58,7 +57,7 @@ func main() {
 		healthzServer := health.NewServer(log)
 		healthzServer.Ready()
 
-		err := healthzServer.Run(context.Background(), healthzPort)
+		err := healthzServer.Run(ctx, healthzPort)
 		if err != nil {
 			log.Fatalf("failed to start healhz server: %s", err)
 		}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -11,7 +11,6 @@ import (
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	"github.com/dapr/dapr/pkg/credentials"
-	"github.com/dapr/dapr/pkg/health"
 	k8s "github.com/dapr/dapr/pkg/kubernetes"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/dapr/dapr/pkg/metrics"
@@ -29,7 +28,6 @@ var certChainPath string
 
 const (
 	defaultCredentialsPath = "/var/run/dapr/credentials"
-	healthzPort            = 8080
 )
 
 func main() {
@@ -52,16 +50,6 @@ func main() {
 		log.Fatal(err)
 	}
 	config.Credentials = credentials.NewTLSCredentials(certChainPath)
-
-	go func() {
-		healthzServer := health.NewServer(log)
-		healthzServer.Ready()
-
-		err := healthzServer.Run(ctx, healthzPort)
-		if err != nil {
-			log.Fatalf("failed to start healthz server: %s", err)
-		}
-	}()
 
 	operator.NewOperator(kubeAPI, config).Run(ctx)
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -59,7 +59,7 @@ func main() {
 
 		err := healthzServer.Run(ctx, healthzPort)
 		if err != nil {
-			log.Fatalf("failed to start healhz server: %s", err)
+			log.Fatalf("failed to start healthz server: %s", err)
 		}
 	}()
 

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/credentials"
 	"github.com/dapr/dapr/pkg/fswatcher"
+	"github.com/dapr/dapr/pkg/health"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/dapr/dapr/pkg/metrics"
 	"github.com/dapr/dapr/pkg/placement"
@@ -26,6 +27,7 @@ var tlsEnabled bool
 
 const (
 	defaultCredentialsPath = "/var/run/dapr/credentials"
+	healthzPort            = 8080
 )
 
 func main() {
@@ -95,5 +97,16 @@ func main() {
 	go p.Run(*port, certChain)
 
 	log.Infof("placement Service started on port %s", *port)
+
+	go func() {
+		healthzServer := health.NewServer(log)
+		healthzServer.Ready()
+
+		err := healthzServer.Run(context.Background(), healthzPort)
+		if err != nil {
+			log.Fatalf("failed to start healhz server: %s", err)
+		}
+	}()
+
 	<-stop
 }

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -104,7 +104,7 @@ func main() {
 
 		err := healthzServer.Run(context.Background(), healthzPort)
 		if err != nil {
-			log.Fatalf("failed to start healhz server: %s", err)
+			log.Fatalf("failed to start healthz server: %s", err)
 		}
 	}()
 

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"os"
 	"os/signal"
@@ -106,7 +105,7 @@ func main() {
 		healthzServer := health.NewServer(log)
 		healthzServer.Ready()
 
-		err := healthzServer.Run(context.Background(), healthzPort)
+		err := healthzServer.Run(ctx, healthzPort)
 		if err != nil {
 			log.Fatalf("failed to start healhz server: %s", err)
 		}

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -107,7 +107,7 @@ func main() {
 
 		err := healthzServer.Run(ctx, healthzPort)
 		if err != nil {
-			log.Fatalf("failed to start healhz server: %s", err)
+			log.Fatalf("failed to start healthz server: %s", err)
 		}
 	}()
 

--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -1,0 +1,92 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dapr/dapr/pkg/logger"
+)
+
+// Server is the interface for the healthz server
+type Server interface {
+	Run(context.Context, int) error
+	Ready()
+	Unready()
+}
+
+type server struct {
+	ready bool
+	log   logger.Logger
+}
+
+// NewServer returns a new healthz server
+func NewServer(log logger.Logger) Server {
+	return &server{
+		log: log,
+	}
+}
+
+// Ready sets a ready state for the endpoint handlers
+func (s *server) Ready() {
+	s.ready = true
+}
+
+// Unready sets unready state for the endpoint handlers
+func (s *server) Unready() {
+	s.ready = false
+}
+
+// Run starts a net/http server with a healthz endpoint
+func (s *server) Run(ctx context.Context, port int) error {
+	router := http.NewServeMux()
+	router.Handle("/healthz", s.healthz())
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: router,
+	}
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.log.Info("Healthz server is shutting down")
+			shutdownCtx, cancel := context.WithTimeout(
+				context.Background(),
+				time.Second*5,
+			)
+			defer cancel()
+			srv.Shutdown(shutdownCtx) // nolint: errcheck
+		case <-doneCh:
+		}
+	}()
+
+	s.log.Infof("Healthz server is listening on %s", srv.Addr)
+	err := srv.ListenAndServe()
+	if err != http.ErrServerClosed {
+		s.log.Errorf("Healthz server error: %s", err)
+	}
+	close(doneCh)
+	return err
+}
+
+// healthz is a health endpoint handler
+func (s *server) healthz() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var status int
+		if s.ready {
+			status = http.StatusOK
+		} else {
+			status = http.StatusServiceUnavailable
+		}
+		w.WriteHeader(status)
+	})
+}

--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -18,7 +18,7 @@ import (
 type Server interface {
 	Run(context.Context, int) error
 	Ready()
-	Unready()
+	NotReady()
 }
 
 type server struct {
@@ -38,8 +38,8 @@ func (s *server) Ready() {
 	s.ready = true
 }
 
-// Unready sets unready state for the endpoint handlers
-func (s *server) Unready() {
+// NotReady sets a not ready state for the endpoint handlers
+func (s *server) NotReady() {
 	s.ready = false
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -12,6 +12,7 @@ import (
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	"github.com/dapr/dapr/pkg/credentials"
 	"github.com/dapr/dapr/pkg/fswatcher"
+	"github.com/dapr/dapr/pkg/health"
 	k8s "github.com/dapr/dapr/pkg/kubernetes"
 	"github.com/dapr/dapr/pkg/logger"
 	"github.com/dapr/dapr/pkg/operator/api"
@@ -23,6 +24,10 @@ import (
 )
 
 var log = logger.NewLogger("dapr.operator")
+
+const (
+	healthzPort = 8080
+)
 
 // Operator is an Dapr Kubernetes Operator for managing components and sidecar lifecycle
 type Operator interface {
@@ -145,6 +150,16 @@ func (o *operator) Run(ctx context.Context) {
 		certChain = chain
 		log.Info("tls certificates loaded successfully")
 	}
+
+	go func() {
+		healthzServer := health.NewServer(log)
+		healthzServer.Ready()
+
+		err := healthzServer.Run(ctx, healthzPort)
+		if err != nil {
+			log.Fatalf("failed to start healthz server: %s", err)
+		}
+	}()
 
 	o.apiServer.Run(certChain)
 	cancel()


### PR DESCRIPTION
This PR adds a healthz server to every control plane component and update the Helm charts to put sane defaults for readiness and liveness probes.

Closes #1512 