### PR TITLE
Adding custom components

### DIFF
--- a/cmd/daprd/main.go
+++ b/cmd/daprd/main.go
@@ -331,6 +331,17 @@ func main() {
 				return eventgrid.NewAzureEventGrid(logContrib)
 			}),
 		),
+
+		// You can extend Dapr by creating your own Daprd binary by doing following
+		// 1. Create a Go project and copy this "main.go". Use dapr and component-contrib as library in the project
+		// 2. Uncomment below code to add your custom feature as GRPC endpoint.
+		//
+		// runtime.WithCustomComponents(
+		//		customs_loader.New("yourcomponent", func() custom.Custom {
+		//		return yourcomponent.New(logContrib)
+		//	}),
+		//),
+
 		runtime.WithHTTPMiddleware(
 			http_middleware_loader.New("uppercase", func(metadata middleware.Metadata) http_middleware.Middleware {
 				return func(h fasthttp.RequestHandler) fasthttp.RequestHandler {

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,17 @@ go 1.14
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
+	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/coreos/etcd v3.3.18+incompatible // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/dapr/components-contrib v0.0.0-20200430212123-b647397b2c81
 	github.com/fasthttp/router v1.0.4
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.4.0
-	github.com/golang/protobuf v1.3.3
+	github.com/golang/protobuf v1.3.5
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
 	github.com/grandcat/zeroconf v0.0.0-20190424104450-85eadb44205c
@@ -23,17 +26,22 @@ require (
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5
+	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/valyala/fasthttp v1.12.0
+	github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb // indirect
 	go.opencensus.io v0.22.3
 	go.uber.org/zap v1.13.0 // indirect
 	google.golang.org/genproto v0.0.0-20200122232147-0452cf42e150
 	google.golang.org/grpc v1.26.0
+	gopkg.in/couchbaselabs/gocbconnstr.v1 v1.0.4 // indirect
+	gopkg.in/couchbaselabs/jsonx.v1 v1.0.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/Azure/go-autorest/autorest v0.9.3 h1:OZEIaBbMdUE/Js+BQKlpO81XlISgipr6
 github.com/Azure/go-autorest/autorest v0.9.3/go.mod h1:GsRuLYvwzLjjjRoWEIyMUaYq8GNUx2nRB378IPt/1p0=
 github.com/Azure/go-autorest/autorest v0.10.0 h1:mvdtztBqcL8se7MdrUweNieTNi4kfNG6GOJuurQJpuY=
 github.com/Azure/go-autorest/autorest v0.10.0/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
+github.com/Azure/go-autorest/autorest v0.10.1 h1:uaB8A32IZU9YKs9v50+/LWIWTDHJk2vlGzbfd7FfESI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/adal v0.6.0 h1:UCTq22yE3RPgbU/8u4scfnnzuCW6pwQ9n+uBtV78ouo=
 github.com/Azure/go-autorest/autorest/adal v0.6.0/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
@@ -338,6 +339,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
+github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
@@ -622,6 +625,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v1.0.0 h1:3gD5McaYs9CxjyK5AXGcq8gdeCARtd/9gJDUvVeaZ0Y=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/components/custom/registry.go
+++ b/pkg/components/custom/registry.go
@@ -1,0 +1,66 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package custom
+
+import (
+	"fmt"
+
+	"github.com/dapr/components-contrib/custom"
+)
+
+type (
+	// Custom encapsulates a factory of custom components
+	Custom struct {
+		Name          string
+		FactoryMethod func() custom.Custom
+	}
+
+	// Registry is an interface for a component that returns registered custom implementations
+	Registry interface {
+		Register(components ...Custom)
+		CreateCustomComponent(name string) (custom.Custom, error)
+	}
+
+	// customRegistry implementation of Registry
+	customRegistry struct {
+		customComponents map[string]func() custom.Custom
+	}
+)
+
+// New creates a custom components factory
+func New(name string, factoryMethod func() custom.Custom) Custom {
+	return Custom{
+		Name:          name,
+		FactoryMethod: factoryMethod,
+	}
+}
+
+// NewRegistry is used to create state store registry.
+func NewRegistry() Registry {
+	return &customRegistry{
+		customComponents: map[string]func() custom.Custom{},
+	}
+}
+
+// Register registers a new factory method that creates an instance of a Custom.
+// The key is the name of the custom component, eg. custom.somefunc
+func (s *customRegistry) Register(components ...Custom) {
+	for _, component := range components {
+		s.customComponents[createFullName(component.Name)] = component.FactoryMethod
+	}
+}
+
+// Create instantiates an custom component based on `name`.
+func (s *customRegistry) CreateCustomComponent(name string) (custom.Custom, error) {
+	if method, ok := s.customComponents[name]; ok {
+		return method(), nil
+	}
+	return nil, fmt.Errorf("couldn't find custom component %s", name)
+}
+
+func createFullName(name string) string {
+	return fmt.Sprintf("custom.%s", name)
+}

--- a/pkg/components/custom/registry_test.go
+++ b/pkg/components/custom/registry_test.go
@@ -1,0 +1,74 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package custom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	grpc_go "google.golang.org/grpc"
+
+	"github.com/dapr/components-contrib/custom"
+)
+
+// custom mock object
+type mockcustom struct {
+	mock.Mock
+}
+
+// Init is a mock initialization method.
+func (m *mockcustom) Init(metadata custom.Metadata) error {
+	args := m.Called(metadata)
+	return args.Error(0)
+}
+
+// RegisterServer add service to gRPC server.
+func (m *mockcustom) RegisterServer(s *grpc_go.Server) error {
+	args := m.Called(s)
+	return args.Error(0)
+}
+func TestCreateFullName(t *testing.T) {
+	t.Run("create custom exporter key name", func(t *testing.T) {
+		assert.Equal(t, "custom.encrypt", createFullName("encrypt"))
+	})
+
+	t.Run("create string key name", func(t *testing.T) {
+		assert.Equal(t, "custom.decrypt", createFullName("decrypt"))
+	})
+}
+
+func TestCreateRegistry(t *testing.T) {
+	testRegistry := NewRegistry()
+
+	t.Run("custom component is registered", func(t *testing.T) {
+		const CustomName = "mockCustom"
+		// Initiate mock object
+		mockCustom := new(mockcustom)
+
+		// act
+		testRegistry.Register(New(CustomName, func() custom.Custom {
+			return mockCustom
+		}))
+		p, e := testRegistry.CreateCustomComponent(createFullName(CustomName))
+
+		// assert
+		assert.Equal(t, mockCustom, p)
+		assert.Nil(t, e)
+	})
+
+	t.Run("custom component is not registered", func(t *testing.T) {
+		const CustomName = "fakeCustomComponent"
+
+		// act
+		p, e := testRegistry.CreateCustomComponent(createFullName(CustomName))
+
+		// assert
+		assert.Nil(t, p)
+		assert.Equal(t, fmt.Errorf("couldn't find custom component %s", createFullName(CustomName)), e)
+	})
+}

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -1,7 +1,6 @@
 package grpc
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -31,13 +30,12 @@ func TestCertRenewal(t *testing.T) {
 
 func TestGetMiddlewareOptions(t *testing.T) {
 	t.Run("should enable two interceptors if tracing and metrics are enabled", func(t *testing.T) {
-		fakeServer := &server{
+		fakeServer := &Server{
 			config: ServerConfig{},
 			tracingSpec: config.TracingSpec{
 				SamplingRate: "1",
 			},
-			renewMutex: &sync.Mutex{},
-			logger:     logger.NewLogger("dapr.runtime.grpc.test"),
+			logger: logger.NewLogger("dapr.runtime.grpc.test"),
 		}
 
 		serverOption := fakeServer.getMiddlewareOptions()
@@ -46,13 +44,12 @@ func TestGetMiddlewareOptions(t *testing.T) {
 	})
 
 	t.Run("should not disable middlewares even when SamplingRate is 0", func(t *testing.T) {
-		fakeServer := &server{
+		fakeServer := &Server{
 			config: ServerConfig{},
 			tracingSpec: config.TracingSpec{
 				SamplingRate: "0",
 			},
-			renewMutex: &sync.Mutex{},
-			logger:     logger.NewLogger("dapr.runtime.grpc.test"),
+			logger: logger.NewLogger("dapr.runtime.grpc.test"),
 		}
 
 		serverOption := fakeServer.getMiddlewareOptions()

--- a/pkg/runtime/options.go
+++ b/pkg/runtime/options.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"github.com/dapr/dapr/pkg/components/bindings"
+	"github.com/dapr/dapr/pkg/components/custom"
 	"github.com/dapr/dapr/pkg/components/exporters"
 	"github.com/dapr/dapr/pkg/components/middleware/http"
 	"github.com/dapr/dapr/pkg/components/pubsub"
@@ -21,6 +22,7 @@ type (
 		inputBindings    []bindings.InputBinding
 		outputBindings   []bindings.OutputBinding
 		httpMiddleware   []http.Middleware
+		customComponents []custom.Custom
 	}
 
 	// Option is a function that customizes the runtime.
@@ -80,5 +82,12 @@ func WithOutputBindings(outputBindings ...bindings.OutputBinding) Option {
 func WithHTTPMiddleware(httpMiddleware ...http.Middleware) Option {
 	return func(o *runtimeOpts) {
 		o.httpMiddleware = append(o.httpMiddleware, httpMiddleware...)
+	}
+}
+
+// WithCustomComponents add Custom gRPC endpoint to the runtime.
+func WithCustomComponents(customComonents ...custom.Custom) Option {
+	return func(o *runtimeOpts) {
+		o.customComponents = append(o.customComponents, customComonents...)
 	}
 }


### PR DESCRIPTION
Co-authored-by: Phil Kedy <phil.kedy@gmail.com>

# Description

Organization may have a requirement to add custom functionality to Dapr, such as integration with propriety or legacy systems. Custom Components is a point of extension that allows third-party functionality to run alongside the existing building blocks that ship with Dapr. For example, you have an existing library for encryption and decryption that you would like to expose as a building block to your applications. Applications will connect to this custom component via a gRPC endpoint which is the same mechanism the Dapr SDKs uses.

In this feature we'll be extended Dapr by using it as a library. Simply create a new Go project and copy the original [main.go](https://github.com/dapr/dapr/blob/master/cmd/daprd/main.go) from Dapr Github source code to this new project(using Dapr as library here), next stitch together all the Components(Dapr runtime) in the same way as it was present in the original `main.go`, next register Custom component in runtime. The new binary created after compilation is a custom `Daprd` binary with a new gRPC endpoint as a custom component.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
