### PR TITLE
Fix unpopulated metadata for input bindings for HTTP app channel

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -573,6 +573,12 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 		req.WithHTTPExtension(nethttp.MethodPost, "")
 		req.WithRawData(data, invokev1.JSONContentType)
 
+		reqMetadata := map[string][]string{}
+		for k, v := range metadata {
+			reqMetadata[k] = []string{v}
+		}
+		req.WithMetadata(reqMetadata)
+
 		ctx := context.Background()
 		spanName := fmt.Sprintf("Binding: %s", bindingName)
 		// context.Background() can be considered as GRPC context and so using StartTracingServerSpanFromGRPCContext to generate span

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -865,6 +865,7 @@ func TestReadInputBindings(t *testing.T) {
 		fakeReq := invokev1.NewInvokeMethodRequest("test")
 		fakeReq.WithHTTPExtension(http.MethodPost, "")
 		fakeReq.WithRawData([]byte("test"), "application/json")
+		fakeReq.WithMetadata(map[string][]string{})
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil)
@@ -888,6 +889,7 @@ func TestReadInputBindings(t *testing.T) {
 		fakeReq := invokev1.NewInvokeMethodRequest("test")
 		fakeReq.WithHTTPExtension(http.MethodPost, "")
 		fakeReq.WithRawData([]byte("test"), "application/json")
+		fakeReq.WithMetadata(map[string][]string{})
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(500, "Internal Error", nil)
@@ -911,6 +913,7 @@ func TestReadInputBindings(t *testing.T) {
 		fakeReq := invokev1.NewInvokeMethodRequest("test")
 		fakeReq.WithHTTPExtension(http.MethodPost, "")
 		fakeReq.WithRawData([]byte("test"), "application/json")
+		fakeReq.WithMetadata(map[string][]string{})
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil)


### PR DESCRIPTION
# Description

This PR fixes the regression bug in which `metadata` is not populated to HTTP request header for input bindings

@youngbupark Could you please review this PR? 

## Issue reference

This PR will close: https://github.com/dapr/dapr/issues/1569

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dapr/dapr/1570)
<!-- Reviewable:end -->
