### PR TITLE
Generating span Id also in the default case like TraceID as per OC spec

### DIFF
--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -45,6 +45,8 @@ func TestWithGRPCWithNoSpanContext(t *testing.T) {
 		spec := config.TracingSpec{SamplingRate: "1"}
 		sc := GetSpanContextFromGRPC(ctx, spec)
 		assert.NotEmpty(t, sc, "Should get default span context")
+		assert.NotEmpty(t, sc.TraceID, "Should get default traceID")
+		assert.NotEmpty(t, sc.SpanID, "Should get default spanID")
 		assert.Equal(t, 1, int(sc.TraceOptions), "Should be sampled")
 	})
 
@@ -52,6 +54,8 @@ func TestWithGRPCWithNoSpanContext(t *testing.T) {
 		ctx := context.Background()
 		spec := config.TracingSpec{SamplingRate: "0.5"}
 		sc := GetSpanContextFromGRPC(ctx, spec)
+		assert.NotEmpty(t, sc.TraceID, "Should get default traceID")
+		assert.NotEmpty(t, sc.SpanID, "Should get default spanID")
 		assert.NotEmpty(t, sc, "Should get default span context")
 	})
 
@@ -60,6 +64,8 @@ func TestWithGRPCWithNoSpanContext(t *testing.T) {
 		spec := config.TracingSpec{SamplingRate: "0"}
 		sc := GetSpanContextFromGRPC(ctx, spec)
 		assert.NotEmpty(t, sc, "Should get default span context")
+		assert.NotEmpty(t, sc.TraceID, "Should get default traceID")
+		assert.NotEmpty(t, sc.SpanID, "Should get default spanID")
 		assert.Equal(t, 0, int(sc.TraceOptions), "Should not be sampled")
 	})
 }

--- a/pkg/diagnostics/http_tracing_test.go
+++ b/pkg/diagnostics/http_tracing_test.go
@@ -118,6 +118,8 @@ func TestWithNoSpanContext(t *testing.T) {
 		spec := config.TracingSpec{SamplingRate: "1"}
 		sc := GetSpanContextFromRequestContext(ctx, spec)
 		assert.NotEmpty(t, sc, "Should get default span context")
+		assert.NotEmpty(t, sc.TraceID, "Should get default traceID")
+		assert.NotEmpty(t, sc.SpanID, "Should get default spanID")
 		assert.Equal(t, 1, int(sc.TraceOptions), "Should be sampled")
 	})
 
@@ -126,6 +128,8 @@ func TestWithNoSpanContext(t *testing.T) {
 		spec := config.TracingSpec{SamplingRate: "0.5"}
 		sc := GetSpanContextFromRequestContext(ctx, spec)
 		assert.NotEmpty(t, sc, "Should get default span context")
+		assert.NotEmpty(t, sc.TraceID, "Should get default traceID")
+		assert.NotEmpty(t, sc.SpanID, "Should get default spanID")
 	})
 
 	t.Run("No SpanContext with zero sampling rate", func(t *testing.T) {
@@ -133,6 +137,8 @@ func TestWithNoSpanContext(t *testing.T) {
 		spec := config.TracingSpec{SamplingRate: "0"}
 		sc := GetSpanContextFromRequestContext(ctx, spec)
 		assert.NotEmpty(t, sc, "Should get default span context")
+		assert.NotEmpty(t, sc.TraceID, "Should get default traceID")
+		assert.NotEmpty(t, sc.SpanID, "Should get default spanID")
 		assert.Equal(t, 0, int(sc.TraceOptions), "Should not be sampled")
 	})
 }

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -134,8 +134,8 @@ func GetDefaultSpanContext(spec config.TracingSpec) trace.SpanContext {
 
 	gen := tracingConfig.Load().(*traceIDGenerator)
 
-	// Only generating TraceID. SpanID is not generated as there is no span started in the middleware.
 	spanContext.TraceID = gen.NewTraceID()
+	spanContext.SpanID = gen.NewSpanID()
 
 	rate := diag_utils.GetTraceSamplingRate(spec.SamplingRate)
 


### PR DESCRIPTION
# Description
Earlier we decided to generate just TraceID and TraceOptions and not SpanID in the case of default case when user app is not passing SpanContext. 

Now looking at the open census spec, we need to modify this behaviour and we need to generate default span ID also in the case of default.

Change is now generating span Id also in the default case like TraceOptions and TraceID as per OC spec

## Issue reference

Closes #1592

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
