### PR TITLE
Bi-di bindings: missing operation fix

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -190,7 +190,8 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 
 func (a *api) InvokeBinding(ctx context.Context, in *runtimev1pb.InvokeBindingRequest) (*runtimev1pb.InvokeBindingResponse, error) {
 	req := &bindings.InvokeRequest{
-		Metadata: in.Metadata,
+		Metadata:  in.Metadata,
+		Operation: bindings.OperationKind(in.Operation),
 	}
 	if in.Data != nil {
 		req.Data = in.Data

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -297,8 +297,9 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	resp, err := a.sendToOutputBindingFn(name, &bindings.InvokeRequest{
-		Metadata: req.Metadata,
-		Data:     b,
+		Metadata:  req.Metadata,
+		Data:      b,
+		Operation: bindings.OperationKind(req.Operation),
 	})
 	if err != nil {
 		errMsg := fmt.Sprintf("error invoking output binding %s: %s", name, err)


### PR DESCRIPTION
This PR assigns the operation from the user request to the bindings function.