### PR TITLE
Exclude healthz endpoint from token authentication

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -106,7 +106,7 @@ func useAPIAuthentication(next fasthttp.RequestHandler) fasthttp.RequestHandler 
 	}
 	return func(ctx *fasthttp.RequestCtx) {
 		v := ctx.Request.Header.Peek(auth.APITokenHeader)
-		if string(v) == token {
+		if auth.ExcludedRoute(string(ctx.Request.URI().FullURI())) || string(v) == token {
 			next(ctx)
 		} else {
 			ctx.Error("invalid api token", http.StatusUnauthorized)

--- a/pkg/runtime/security/token.go
+++ b/pkg/runtime/security/token.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"os"
+	"strings"
 )
 
 /* #nosec */
@@ -12,7 +13,19 @@ const (
 	APITokenHeader = "dapr-api-token"
 )
 
+var excludedRoutes = []string{"/healthz"}
+
 // GetAPIToken returns the value of the api token from an environment variable
 func GetAPIToken() string {
 	return os.Getenv(APITokenEnvVar)
+}
+
+// ExcludedRoute returns whether a given route should be excluded from a token check
+func ExcludedRoute(route string) bool {
+	for _, r := range excludedRoutes {
+		if strings.Contains(route, r) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/runtime/security/token_test.go
+++ b/pkg/runtime/security/token_test.go
@@ -23,3 +23,17 @@ func TestAPIToken(t *testing.T) {
 		assert.Equal(t, "", token)
 	})
 }
+
+func TestExcludedRoute(t *testing.T) {
+	t.Run("healthz route is excluded", func(t *testing.T) {
+		route := "v1.0/healthz"
+		excluded := ExcludedRoute(route)
+		assert.True(t, excluded)
+	})
+
+	t.Run("custom route is not excluded", func(t *testing.T) {
+		route := "v1.0/state"
+		excluded := ExcludedRoute(route)
+		assert.False(t, excluded)
+	})
+}


### PR DESCRIPTION
When running on Kubernetes, the `/healthz` endpoint needs to be excluded from a token check when API authentication is turned on.