### PR TITLE
upgrade helm, go, and linter to latest versions

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -15,13 +15,13 @@ jobs:
     name: end-to-end tests
     runs-on: ubuntu-latest
     env:
-      GOVER: 1.14
+      GOVER: 1.14.3
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       DAPR_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       DAPR_TEST_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
-      HELMVER: v3.0.3
+      HELMVER: v3.2.1
       DAPR_NAMESPACE: dapr-tests
       MAX_TEST_TIMEOUT: 5400
     steps:

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -21,8 +21,8 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.14
-      GOLANGCILINT_VER: 1.23.8
+      GOVER: 1.14.3
+      GOLANGCILINT_VER: 1.26.0
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -78,7 +78,7 @@ jobs:
     env:
       ARTIFACT_DIR: ./release
       DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
-      HELMVER: v3.1.2
+      HELMVER: v3.2.1
     runs-on: ubuntu-latest
     steps:
       - name: Set up Helm ${{ env.HELMVER }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -233,3 +233,7 @@ linters:
     - unparam
     - wsl
     - gomnd
+    - godot
+    - testpackage
+    - goerr113
+    - nestif

--- a/pkg/sentry/ca/certificate_authority_test.go
+++ b/pkg/sentry/ca/certificate_authority_test.go
@@ -68,6 +68,7 @@ func getTestCertAuth() CertificateAuthority {
 	return certAuth
 }
 
+// nolint:gosec
 func writeTestCredentialsToDisk() {
 	ioutil.WriteFile("ca.crt", []byte(rootCert), 0644)
 	ioutil.WriteFile("issuer.crt", []byte(issuerCert), 0644)

--- a/pkg/sentry/certs/store.go
+++ b/pkg/sentry/certs/store.go
@@ -56,6 +56,7 @@ func storeKubernetes(rootCertPem, issuerCertPem, issuerCertKey []byte) error {
 	return nil
 }
 
+/* #nosec */
 func storeSelfhosted(rootCertPem, issuerCertPem, issuerKeyPem []byte, rootCertPath, issuerCertPath, issuerKeyPath string) error {
 	err := ioutil.WriteFile(rootCertPath, rootCertPem, 0644)
 	if err != nil {

--- a/pkg/sentry/identity/selfhosted/validator.go
+++ b/pkg/sentry/identity/selfhosted/validator.go
@@ -9,7 +9,7 @@ func NewValidator() identity.Validator {
 type validator struct {
 }
 
-// no validation for self hosted
 func (v *validator) Validate(id, token string) error {
+	// no validation for self hosted.
 	return nil
 }

--- a/tests/apps/perf/tester/app.go
+++ b/tests/apps/perf/tester/app.go
@@ -15,7 +15,7 @@ import (
 	"os/exec"
 )
 
-//TODO: change to take from "github.com/dapr/dapr/tests/perf" once in repository. otherwise fails on go get step in Dockerfile
+// TODO: change to take from "github.com/dapr/dapr/tests/perf" once in repository. otherwise fails on go get step in Dockerfile.
 type TestParameters struct {
 	QPS               int    `json:"qps"`
 	ClientConnections int    `json:"clientConnections"`

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -122,7 +122,7 @@ func HTTPGetRawNTimes(url string, n int) (*http.Response, error) {
 // HTTPGetRaw is a helper to make GET request call to url
 func HTTPGetRaw(url string) (*http.Response, error) {
 	client := newHTTPClient()
-	resp, err := client.Get(sanitizeHTTPURL(url)) //nolint
+	resp, err := client.Get(sanitizeHTTPURL(url))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -19,14 +19,14 @@ const (
 	defaultImageTag      = "latest"
 )
 
-// KubeTestPlatform includes K8s client for testing cluster and kubernetes testing apps
+// KubeTestPlatform includes K8s client for testing cluster and kubernetes testing apps.
 type KubeTestPlatform struct {
 	AppResources       *TestResources
 	ComponentResources *TestResources
 	kubeClient         *kube.KubeClient
 }
 
-// NewKubeTestPlatform creates KubeTestPlatform instance
+// NewKubeTestPlatform creates KubeTestPlatform instance.
 func NewKubeTestPlatform() *KubeTestPlatform {
 	return &KubeTestPlatform{
 		AppResources:       new(TestResources),
@@ -55,7 +55,7 @@ func (c *KubeTestPlatform) tearDown() error {
 	return nil
 }
 
-// addComponents adds component to disposable Resource queues
+// addComponents adds component to disposable Resource queues.
 func (c *KubeTestPlatform) addComponents(comps []kube.ComponentDescription) error {
 	if c.kubeClient == nil {
 		return fmt.Errorf("kubernetes cluster needs to be setup")
@@ -73,7 +73,7 @@ func (c *KubeTestPlatform) addComponents(comps []kube.ComponentDescription) erro
 	return nil
 }
 
-// addApps adds test apps to disposable App Resource queues
+// addApps adds test apps to disposable App Resource queues.
 func (c *KubeTestPlatform) addApps(apps []kube.AppDescription) error {
 	if c.kubeClient == nil {
 		return fmt.Errorf("kubernetes cluster needs to be setup before calling BuildAppResources")
@@ -116,13 +116,13 @@ func (c *KubeTestPlatform) imageTag() string {
 	return tag
 }
 
-// AcquireAppExternalURL returns the external url for 'name'
+// AcquireAppExternalURL returns the external url for 'name'.
 func (c *KubeTestPlatform) AcquireAppExternalURL(name string) string {
 	app := c.AppResources.FindActiveResource(name)
 	return app.(*kube.AppManager).AcquireExternalURL()
 }
 
-// Scale changes the number of replicas of the app
+// Scale changes the number of replicas of the app.
 func (c *KubeTestPlatform) Scale(name string, replicas int32) error {
 	app := c.AppResources.FindActiveResource(name)
 	appManager := app.(*kube.AppManager)
@@ -136,7 +136,7 @@ func (c *KubeTestPlatform) Scale(name string, replicas int32) error {
 	return err
 }
 
-// Restart restarts all instances for the app
+// Restart restarts all instances for the app.
 func (c *KubeTestPlatform) Restart(name string) error {
 	// To minic the restart behavior, scale to 0 and then scale to the original replicas.
 	app := c.AppResources.FindActiveResource(name)
@@ -149,7 +149,7 @@ func (c *KubeTestPlatform) Restart(name string) error {
 	return c.Scale(name, originalReplicas)
 }
 
-// PortForwardToApp opens a new connection to the app on a the target port and returns the local port or error
+// PortForwardToApp opens a new connection to the app on a the target port and returns the local port or error.
 func (c *KubeTestPlatform) PortForwardToApp(appName string, targetPorts ...int) ([]int, error) {
 	app := c.AppResources.FindActiveResource(appName)
 	appManager := app.(*kube.AppManager)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -32,27 +32,27 @@ func initKubeConfig() {
 
 // GetConfig gets a kubernetes rest config
 func GetConfig() *rest.Config {
-	if kubeConfig == nil {
-		var kubeconfig *string
-		if home := homedir.HomeDir(); home != "" {
-			kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-		} else {
-			kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-		}
-		flag.Parse()
-
-		conf, err := rest.InClusterConfig()
-		if err != nil {
-			conf, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		return conf
+	if kubeConfig != nil {
+		return kubeConfig
 	}
 
-	return kubeConfig
+	var kubeconfig *string
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	conf, err := rest.InClusterConfig()
+	if err != nil {
+		conf, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return conf
 }
 
 // GetKubeClient gets a kubernetes client


### PR DESCRIPTION
# Description
* upgrade to latest
   - helm - v3.2.1
   - go - 1.14.3
   - linter - 1.26.0

* upgrade go and linter. below linters are disabled.

    - godot
    - testpackage
    - goerr113
    - nestif

## Issue reference

#1558 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
