### PR TITLE
Adding GRPC span attributes as per Open Telemetry Spec for each specific RPC call

### DIFF
--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -56,7 +56,7 @@ func SetTracingInGRPCMiddlewareUnary(appID string, spec config.TracingSpec) grpc
 		resp, err = handler(newCtx, req)
 
 		// add span attributes
-		m := getSpanAttributesMapFromGRPC(req, info.FullMethod)
+		m := GetSpanAttributesMapFromGRPC(req, info.FullMethod)
 		AddAttributesToSpan(span, m)
 
 		UpdateSpanStatusFromGRPCError(span, err, method)

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -55,6 +55,10 @@ func SetTracingInGRPCMiddlewareUnary(appID string, spec config.TracingSpec) grpc
 		newCtx = NewContext(ctx, span.SpanContext())
 		resp, err = handler(newCtx, req)
 
+		// add span attributes
+		m := getSpanAttributesMapFromGRPC(req, info.FullMethod)
+		AddAttributesToSpan(span, m)
+
 		UpdateSpanStatusFromGRPCError(span, err, method)
 
 		span.End()

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -203,36 +203,26 @@ func GetSpanAttributesMapFromGRPC(req interface{}, rpcMethod string) map[string]
 }
 
 func extractComponentValueFromGRPCRequest(req interface{}) string {
-	switch req.(type) {
+	switch s := req.(type) {
 	case *internalv1pb.InternalInvokeRequest:
-		s := req.(*internalv1pb.InternalInvokeRequest)
 		return s.Message.GetMethod()
 	case *runtimev1pb.InvokeServiceRequest:
-		s := req.(*runtimev1pb.InvokeServiceRequest)
 		return s.Message.GetMethod()
 	case *runtimev1pb.PublishEventRequest:
-		s := req.(*runtimev1pb.PublishEventRequest)
 		return s.GetTopic()
 	case *runtimev1pb.InvokeBindingRequest:
-		s := req.(*runtimev1pb.InvokeBindingRequest)
 		return s.GetName()
 	case *runtimev1pb.GetStateRequest:
-		s := req.(*runtimev1pb.GetStateRequest)
 		return s.GetStoreName()
 	case *runtimev1pb.SaveStateRequest:
-		s := req.(*runtimev1pb.SaveStateRequest)
 		return s.GetStoreName()
 	case *runtimev1pb.DeleteStateRequest:
-		s := req.(*runtimev1pb.DeleteStateRequest)
 		return s.GetStoreName()
 	case *runtimev1pb.GetSecretRequest:
-		s := req.(*runtimev1pb.GetSecretRequest)
 		return s.GetStoreName()
 	case *runtimev1pb.TopicEventRequest:
-		s := req.(*runtimev1pb.TopicEventRequest)
 		return s.GetTopic()
 	case *runtimev1pb.BindingEventRequest:
-		s := req.(*runtimev1pb.BindingEventRequest)
 		return s.GetName()
 	default:
 		return ""

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -203,38 +203,38 @@ func GetSpanAttributesMapFromGRPC(req interface{}, rpcMethod string) map[string]
 }
 
 func extractComponentValueFromGRPCRequest(req interface{}) string {
-	if req == nil {
+	switch req.(type) {
+	case *internalv1pb.InternalInvokeRequest:
+		s := req.(*internalv1pb.InternalInvokeRequest)
+		return s.Message.GetMethod()
+	case *runtimev1pb.InvokeServiceRequest:
+		s := req.(*runtimev1pb.InvokeServiceRequest)
+		return s.Message.GetMethod()
+	case *runtimev1pb.PublishEventRequest:
+		s := req.(*runtimev1pb.PublishEventRequest)
+		return s.GetTopic()
+	case *runtimev1pb.InvokeBindingRequest:
+		s := req.(*runtimev1pb.InvokeBindingRequest)
+		return s.GetName()
+	case *runtimev1pb.GetStateRequest:
+		s := req.(*runtimev1pb.GetStateRequest)
+		return s.GetStoreName()
+	case *runtimev1pb.SaveStateRequest:
+		s := req.(*runtimev1pb.SaveStateRequest)
+		return s.GetStoreName()
+	case *runtimev1pb.DeleteStateRequest:
+		s := req.(*runtimev1pb.DeleteStateRequest)
+		return s.GetStoreName()
+	case *runtimev1pb.GetSecretRequest:
+		s := req.(*runtimev1pb.GetSecretRequest)
+		return s.GetStoreName()
+	case *runtimev1pb.TopicEventRequest:
+		s := req.(*runtimev1pb.TopicEventRequest)
+		return s.GetTopic()
+	case *runtimev1pb.BindingEventRequest:
+		s := req.(*runtimev1pb.BindingEventRequest)
+		return s.GetName()
+	default:
 		return ""
 	}
-	if s, ok := req.(*internalv1pb.InternalInvokeRequest); ok {
-		return s.Message.GetMethod()
-	}
-	if s, ok := req.(*runtimev1pb.PublishEventRequest); ok {
-		return s.GetTopic()
-	}
-	if s, ok := req.(*runtimev1pb.InvokeServiceRequest); ok {
-		return s.Message.GetMethod()
-	}
-	if s, ok := req.(*runtimev1pb.InvokeBindingRequest); ok {
-		return s.GetName()
-	}
-	if s, ok := req.(*runtimev1pb.GetStateRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.GetSecretRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.SaveStateRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.DeleteStateRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.TopicEventRequest); ok {
-		return s.GetTopic()
-	}
-	if s, ok := req.(*runtimev1pb.BindingEventRequest); ok {
-		return s.GetName()
-	}
-	return ""
 }

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dapr/dapr/pkg/config"
 	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"
 	"google.golang.org/grpc"
@@ -159,4 +160,81 @@ func addAnnotationsToSpanFromGRPCMetadata(ctx context.Context, span *trace.Span)
 
 func isLocalServiceInvocationMethod(method string) bool {
 	return strings.Contains(method, "/CallLocal")
+}
+
+// GetSpanAttributesMapFromGRPC builds the span trace attributes map for gRPC calls based on given parameters as per open-telemetry specs
+func GetSpanAttributesMapFromGRPC(req interface{}, rpcMethod string) map[string]string {
+	// RPC Span Attribute reference https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md
+	// gRPC method /package.service/method
+	var serviceName string
+
+	p := rpcMethod
+	if p[0] == '/' {
+		p = rpcMethod[1:]
+	}
+
+	// Split up to 3 delimiters in '/package.service/method'
+	// example for internal call : "/dapr.proto.internals.v1.ServiceInvocation/CallLocal"
+	// example for non-internal call : "/dapr.proto.runtime.v1.Dapr/InvokeService"
+	internalCall := strings.Contains(p, "dapr.proto.internals.")
+
+	tokens := strings.SplitN(p, "/", 3)
+	if len(tokens) >= 2 {
+		if internalCall {
+			if t := strings.SplitN(tokens[0], ".", 5); len(t) >= 4 {
+				serviceName = t[4]
+			}
+		} else {
+			// TODO : need to revisit /package.service/method format in runtime calls, currently service name is "Dapr"
+			// so instead of taking general "Dapr", taking method name as service name to give better insights
+			serviceName = tokens[1]
+		}
+	} else {
+		// default service name to full method name, after removing first "/"
+		serviceName = p
+	}
+
+	m := make(map[string]string)
+	m[gRPCServiceSpanAttributeKey] = serviceName
+
+	// below attribute is not as per open temetery spec, adding custom dapr attribute to have additional details
+	m[gRPCDaprInstanceSpanAttributeKey] = extractComponentValueFromGRPCRequest(req)
+	return m
+}
+
+func extractComponentValueFromGRPCRequest(req interface{}) string {
+	if req == nil {
+		return ""
+	}
+	if s, ok := req.(*internalv1pb.InternalInvokeRequest); ok {
+		return s.Message.GetMethod()
+	}
+	if s, ok := req.(*runtimev1pb.PublishEventRequest); ok {
+		return s.GetTopic()
+	}
+	if s, ok := req.(*runtimev1pb.InvokeServiceRequest); ok {
+		return s.Message.GetMethod()
+	}
+	if s, ok := req.(*runtimev1pb.InvokeBindingRequest); ok {
+		return s.GetName()
+	}
+	if s, ok := req.(*runtimev1pb.GetStateRequest); ok {
+		return s.GetStoreName()
+	}
+	if s, ok := req.(*runtimev1pb.GetSecretRequest); ok {
+		return s.GetStoreName()
+	}
+	if s, ok := req.(*runtimev1pb.SaveStateRequest); ok {
+		return s.GetStoreName()
+	}
+	if s, ok := req.(*runtimev1pb.DeleteStateRequest); ok {
+		return s.GetStoreName()
+	}
+	if s, ok := req.(*runtimev1pb.TopicEventRequest); ok {
+		return s.GetTopic()
+	}
+	if s, ok := req.(*runtimev1pb.BindingEventRequest); ok {
+		return s.GetName()
+	}
+	return ""
 }

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	"github.com/dapr/dapr/pkg/config"
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc/metadata"
@@ -68,4 +71,50 @@ func TestWithGRPCWithNoSpanContext(t *testing.T) {
 		assert.NotEmpty(t, sc.SpanID, "Should get default spanID")
 		assert.Equal(t, 0, int(sc.TraceOptions), "Should not be sampled")
 	})
+}
+
+func TestGetSpanAttributesMapFromGRPC(t *testing.T) {
+	var tests = []struct {
+		rpcMethod                    string
+		requestType                  string
+		expectedServiceNameAttribute string
+		expectedCustomAttribute      string
+	}{
+		{"/dapr.proto.internals.v1.ServiceInvocation/CallLocal", "InternalInvokeRequest", "ServiceInvocation", "mymethod"},
+		{"/dapr.proto.runtime.v1.Dapr/InvokeService", "InvokeServiceRequest", "InvokeService", "mymethod"},
+		{"/dapr.proto.runtime.v1.Dapr/GetState", "GetStateRequest", "GetState", "mystore"},
+		{"/dapr.proto.runtime.v1.Dapr/SaveState", "SaveStateRequest", "SaveState", "mystore"},
+		{"/dapr.proto.runtime.v1.Dapr/DeleteState", "DeleteStateRequest", "DeleteState", "mystore"},
+		{"/dapr.proto.runtime.v1.Dapr/GetSecret", "GetSecretRequest", "GetSecret", "mysecretstore"},
+		{"/dapr.proto.runtime.v1.Dapr/InvokeBinding", "InvokeBindingRequest", "InvokeBinding", "mybindings"},
+		{"/dapr.proto.runtime.v1.Dapr/PublishEvent", "PublishEventRequest", "PublishEvent", "mytopic"},
+		{"/invalid.rpcMethodformat", "InvokeServiceRequest", "", "mymethod"},
+	}
+	var req interface{}
+	for _, tt := range tests {
+		t.Run(tt.rpcMethod, func(t *testing.T) {
+			switch tt.requestType {
+			case "InvokeServiceRequest":
+				req = &runtimev1pb.InvokeServiceRequest{Message: &commonv1pb.InvokeRequest{Method: "mymethod"}}
+			case "GetStateRequest":
+				req = &runtimev1pb.GetStateRequest{StoreName: "mystore"}
+			case "SaveStateRequest":
+				req = &runtimev1pb.SaveStateRequest{StoreName: "mystore"}
+			case "DeleteStateRequest":
+				req = &runtimev1pb.DeleteStateRequest{StoreName: "mystore"}
+			case "GetSecretRequest":
+				req = &runtimev1pb.GetSecretRequest{StoreName: "mysecretstore"}
+			case "InvokeBindingRequest":
+				req = &runtimev1pb.InvokeBindingRequest{Name: "mybindings"}
+			case "PublishEventRequest":
+				req = &runtimev1pb.PublishEventRequest{Topic: "mytopic"}
+			case "InternalInvokeRequest":
+				req = &internalv1pb.InternalInvokeRequest{Message: &commonv1pb.InvokeRequest{Method: "mymethod"}}
+			}
+
+			got := getSpanAttributesMapFromGRPC(req, tt.rpcMethod)
+			assert.Equal(t, tt.expectedServiceNameAttribute, got[gRPCServiceSpanAttributeKey], "servicename attribute should be equal")
+			assert.Equal(t, tt.expectedCustomAttribute, got[gRPCDaprInstanceSpanAttributeKey], "custom attribute should be equal")
+		})
+	}
 }

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -88,7 +88,9 @@ func TestGetSpanAttributesMapFromGRPC(t *testing.T) {
 		{"/dapr.proto.runtime.v1.Dapr/GetSecret", "GetSecretRequest", "GetSecret", "mysecretstore"},
 		{"/dapr.proto.runtime.v1.Dapr/InvokeBinding", "InvokeBindingRequest", "InvokeBinding", "mybindings"},
 		{"/dapr.proto.runtime.v1.Dapr/PublishEvent", "PublishEventRequest", "PublishEvent", "mytopic"},
-		{"/invalid.rpcMethodformat", "InvokeServiceRequest", "", "mymethod"},
+		{"/dapr.proto.runtime.v1.Dapr/AppCallback", "TopicEventRequest", "AppCallback", "mytopic"},
+		{"/dapr.proto.runtime.v1.Dapr/AppCallback", "BindingEventRequest", "AppCallback", "mybindings"},
+		{"/invalid.rpcMethodformat", "InvokeServiceRequest", "invalid.rpcMethodformat", "mymethod"},
 	}
 	var req interface{}
 	for _, tt := range tests {
@@ -108,11 +110,15 @@ func TestGetSpanAttributesMapFromGRPC(t *testing.T) {
 				req = &runtimev1pb.InvokeBindingRequest{Name: "mybindings"}
 			case "PublishEventRequest":
 				req = &runtimev1pb.PublishEventRequest{Topic: "mytopic"}
+			case "TopicEventRequest":
+				req = &runtimev1pb.TopicEventRequest{Topic: "mytopic"}
+			case "BindingEventRequest":
+				req = &runtimev1pb.BindingEventRequest{Name: "mybindings"}
 			case "InternalInvokeRequest":
 				req = &internalv1pb.InternalInvokeRequest{Message: &commonv1pb.InvokeRequest{Method: "mymethod"}}
 			}
 
-			got := getSpanAttributesMapFromGRPC(req, tt.rpcMethod)
+			got := GetSpanAttributesMapFromGRPC(req, tt.rpcMethod)
 			assert.Equal(t, tt.expectedServiceNameAttribute, got[gRPCServiceSpanAttributeKey], "servicename attribute should be equal")
 			assert.Equal(t, tt.expectedCustomAttribute, got[gRPCDaprInstanceSpanAttributeKey], "custom attribute should be equal")
 		})

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -12,17 +12,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 
 	"github.com/dapr/dapr/pkg/config"
 	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
-	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
-	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
-	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
-	"github.com/valyala/fasthttp"
 
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc/metadata"
@@ -202,41 +197,6 @@ func extractDaprMetadata(ctx context.Context) map[string][]string {
 	return daprMetadata
 }
 
-func getSpanAttributesMapFromHTTPContext(ctx *fasthttp.RequestCtx) map[string]string {
-	// Span Attribute reference https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
-	route := string(ctx.Request.URI().Path())
-	method := string(ctx.Request.Header.Method())
-	uri := ctx.Request.URI().String()
-	statusCode := ctx.Response.StatusCode()
-	r := getAPIComponent(route)
-	return GetSpanAttributesMapFromHTTP(r.componentType, r.componentValue, method, route, uri, statusCode)
-}
-
-// GetSpanAttributesMap builds the span trace attributes map for HTTP calls based on given parameters as per open-telemetry specs
-func GetSpanAttributesMapFromHTTP(componentType, componentValue, method, route, uri string, statusCode int) map[string]string {
-	// Span Attribute reference https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
-	m := make(map[string]string)
-	switch componentType {
-	case "state", "secrets", "bindings":
-		m[dbTypeSpanAttributeKey] = componentType
-		m[dbInstanceSpanAttributeKey] = componentValue
-		// TODO: not possible currently to get the route {state_store} , so using path instead of route
-		m[dbStatementSpanAttributeKey] = fmt.Sprintf("%s %s", method, route)
-		m[dbURLSpanAttributeKey] = route
-	case "invoke", "actors":
-		m[httpMethodSpanAttributeKey] = method
-		m[httpURLSpanAttributeKey] = uri
-		code := invokev1.CodeFromHTTPStatus(statusCode)
-		m[httpStatusCodeSpanAttributeKey] = strconv.Itoa(statusCode)
-		m[httpStatusTextSpanAttributeKey] = code.String()
-	case "publish":
-		m[messagingSystemSpanAttributeKey] = componentType
-		m[messagingDestinationSpanAttributeKey] = componentValue
-		m[messagingDestinationKindSpanAttributeKey] = messagingDestinationKind
-	}
-	return m
-}
-
 // AddAttributesToSpan adds the given attributes in the span
 func AddAttributesToSpan(span *trace.Span, attributes map[string]string) {
 	if span != nil {
@@ -268,83 +228,6 @@ func getAPIComponent(apiPath string) apiComponent {
 
 	// return 'state', 'statestore' from the parsed tokens in apiComponent type
 	return apiComponent{componentType: tokens[1], componentValue: tokens[2]}
-}
-
-// GetSpanAttributesMapFromGRPC builds the span trace attributes map for gRPC calls based on given parameters as per open-telemetry specs
-func GetSpanAttributesMapFromGRPC(req interface{}, rpcMethod string) map[string]string {
-	// RPC Span Attribute reference https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md
-	// gRPC method /package.service/method
-	var serviceName string
-
-	p := rpcMethod
-	if p[0] == '/' {
-		p = rpcMethod[1:]
-	}
-
-	// Split up to 3 delimiters in '/package.service/method'
-	// example for internal call : "/dapr.proto.internals.v1.ServiceInvocation/CallLocal"
-	// example for non-internal call : "/dapr.proto.runtime.v1.Dapr/InvokeService"
-	internalCall := strings.Contains(p, "dapr.proto.internals.")
-
-	tokens := strings.SplitN(p, "/", 3)
-	if len(tokens) >= 2 {
-		if internalCall {
-			if t := strings.SplitN(tokens[0], ".", 5); len(t) >= 4 {
-				serviceName = t[4]
-			}
-		} else {
-			// TODO : need to revisit /package.service/method format in runtime calls, currently service name is "Dapr"
-			// so instead of taking general "Dapr", taking method name as service name to give better insights
-			serviceName = tokens[1]
-		}
-	} else {
-		// default service name to full method name, after removing first "/"
-		serviceName = p
-	}
-
-	m := make(map[string]string)
-	m[gRPCServiceSpanAttributeKey] = serviceName
-
-	// below attribute is not as per open temetery spec, adding custom dapr attribute to have additional details
-	m[gRPCDaprInstanceSpanAttributeKey] = extractComponentValueFromGRPCRequest(req)
-	return m
-}
-
-func extractComponentValueFromGRPCRequest(req interface{}) string {
-	if req == nil {
-		return ""
-	}
-	if s, ok := req.(*internalv1pb.InternalInvokeRequest); ok {
-		return s.Message.GetMethod()
-	}
-	if s, ok := req.(*runtimev1pb.PublishEventRequest); ok {
-		return s.GetTopic()
-	}
-	if s, ok := req.(*runtimev1pb.InvokeServiceRequest); ok {
-		return s.Message.GetMethod()
-	}
-	if s, ok := req.(*runtimev1pb.InvokeBindingRequest); ok {
-		return s.GetName()
-	}
-	if s, ok := req.(*runtimev1pb.GetStateRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.GetSecretRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.SaveStateRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.DeleteStateRequest); ok {
-		return s.GetStoreName()
-	}
-	if s, ok := req.(*runtimev1pb.TopicEventRequest); ok {
-		return s.GetTopic()
-	}
-	if s, ok := req.(*runtimev1pb.BindingEventRequest); ok {
-		return s.GetName()
-	}
-	return ""
 }
 
 var tracingConfig atomic.Value // access atomically


### PR DESCRIPTION
# Description

Following Open telemetry reference of span attributes : https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions

, adding correct set of span attributes .

## Issue reference

#1607

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
