### PR TITLE
sidecar injector readiness/liveness probe path adjustement

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -276,7 +276,7 @@ func getInt32Annotation(annotations map[string]string, key string) (int32, error
 	return int32(value), nil
 }
 
-func getProbeHttpHandler(port int32, pathElements ...string) corev1.Handler {
+func getProbeHTTPHandler(port int32, pathElements ...string) corev1.Handler {
 	return corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Path: formatProbePath(pathElements...),
@@ -370,7 +370,7 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 		log.Warn(err)
 	}
 
-	httpHandler := getProbeHttpHandler(sidecarHTTPPort, apiVersionV1, sidecarHealthzPath)
+	httpHandler := getProbeHTTPHandler(sidecarHTTPPort, apiVersionV1, sidecarHealthzPath)
 
 	c := &corev1.Container{
 		Name:            sidecarContainerName,

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -8,6 +8,7 @@ package injector
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 
@@ -408,7 +409,7 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: fmt.Sprintf("%s/%s", apiVersionV1, sidecarHealthzPath),
+					Path: path.Clean(fmt.Sprintf("/%s/%s", apiVersionV1, sidecarHealthzPath)),
 					Port: intstr.IntOrString{IntVal: sidecarHTTPPort},
 				},
 			},
@@ -420,7 +421,7 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 		LivenessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: fmt.Sprintf("%s/%s", apiVersionV1, sidecarHealthzPath),
+					Path: path.Clean(fmt.Sprintf("/%s/%s", apiVersionV1, sidecarHealthzPath)),
 					Port: intstr.IntOrString{IntVal: sidecarHTTPPort},
 				},
 			},

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -276,6 +276,23 @@ func getInt32Annotation(annotations map[string]string, key string) (int32, error
 	return int32(value), nil
 }
 
+func getProbeHttpHandler(port int32, pathElements... string) corev1.Handler {
+	return corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: formatProbePath(pathElements...),
+				Port: intstr.IntOrString{IntVal: port},
+			},
+		}
+}
+
+func formatProbePath(elements... string) string {
+	pathStr := path.Join(elements...)
+	if !strings.HasPrefix(pathStr, "/") {
+		pathStr =  fmt.Sprintf("/%s",pathStr)
+	}
+	return pathStr
+}
+
 func appendQuantityToResourceList(quantity string, resourceName corev1.ResourceName, resourceList corev1.ResourceList) (*corev1.ResourceList, error) {
 	q, err := resource.ParseQuantity(quantity)
 	if err != nil {
@@ -353,6 +370,8 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 		log.Warn(err)
 	}
 
+	httpHandler := getProbeHttpHandler(sidecarHTTPPort, apiVersionV1, sidecarHealthzPath)
+
 	c := &corev1.Container{
 		Name:            sidecarContainerName,
 		Image:           daprSidecarImage,
@@ -407,24 +426,14 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 			"--metrics-port", fmt.Sprintf("%v", metricsPort),
 		},
 		ReadinessProbe: &corev1.Probe{
-			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: path.Clean(fmt.Sprintf("/%s/%s", apiVersionV1, sidecarHealthzPath)),
-					Port: intstr.IntOrString{IntVal: sidecarHTTPPort},
-				},
-			},
+			Handler: httpHandler,
 			InitialDelaySeconds: getInt32AnnotationOrDefault(annotations, daprReadinessProbeDelayKey, defaultHealthzProbeDelaySeconds),
 			TimeoutSeconds:      getInt32AnnotationOrDefault(annotations, daprReadinessProbeTimeoutKey, defaultHealthzProbeTimeoutSeconds),
 			PeriodSeconds:       getInt32AnnotationOrDefault(annotations, daprReadinessProbePeriodKey, defaultHealthzProbePeriodSeconds),
 			FailureThreshold:    getInt32AnnotationOrDefault(annotations, daprReadinessProbeThresholdKey, defaultHealthzProbeThreshold),
 		},
 		LivenessProbe: &corev1.Probe{
-			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: path.Clean(fmt.Sprintf("/%s/%s", apiVersionV1, sidecarHealthzPath)),
-					Port: intstr.IntOrString{IntVal: sidecarHTTPPort},
-				},
-			},
+			Handler: httpHandler,
 			InitialDelaySeconds: getInt32AnnotationOrDefault(annotations, daprLivenessProbeDelayKey, defaultHealthzProbeDelaySeconds),
 			TimeoutSeconds:      getInt32AnnotationOrDefault(annotations, daprLivenessProbeTimeoutKey, defaultHealthzProbeTimeoutSeconds),
 			PeriodSeconds:       getInt32AnnotationOrDefault(annotations, daprLivenessProbePeriodKey, defaultHealthzProbePeriodSeconds),

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -276,19 +276,19 @@ func getInt32Annotation(annotations map[string]string, key string) (int32, error
 	return int32(value), nil
 }
 
-func getProbeHttpHandler(port int32, pathElements... string) corev1.Handler {
+func getProbeHttpHandler(port int32, pathElements ...string) corev1.Handler {
 	return corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: formatProbePath(pathElements...),
-				Port: intstr.IntOrString{IntVal: port},
-			},
-		}
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: formatProbePath(pathElements...),
+			Port: intstr.IntOrString{IntVal: port},
+		},
+	}
 }
 
-func formatProbePath(elements... string) string {
+func formatProbePath(elements ...string) string {
 	pathStr := path.Join(elements...)
 	if !strings.HasPrefix(pathStr, "/") {
-		pathStr =  fmt.Sprintf("/%s",pathStr)
+		pathStr = fmt.Sprintf("/%s", pathStr)
 	}
 	return pathStr
 }
@@ -426,14 +426,14 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 			"--metrics-port", fmt.Sprintf("%v", metricsPort),
 		},
 		ReadinessProbe: &corev1.Probe{
-			Handler: httpHandler,
+			Handler:             httpHandler,
 			InitialDelaySeconds: getInt32AnnotationOrDefault(annotations, daprReadinessProbeDelayKey, defaultHealthzProbeDelaySeconds),
 			TimeoutSeconds:      getInt32AnnotationOrDefault(annotations, daprReadinessProbeTimeoutKey, defaultHealthzProbeTimeoutSeconds),
 			PeriodSeconds:       getInt32AnnotationOrDefault(annotations, daprReadinessProbePeriodKey, defaultHealthzProbePeriodSeconds),
 			FailureThreshold:    getInt32AnnotationOrDefault(annotations, daprReadinessProbeThresholdKey, defaultHealthzProbeThreshold),
 		},
 		LivenessProbe: &corev1.Probe{
-			Handler: httpHandler,
+			Handler:             httpHandler,
 			InitialDelaySeconds: getInt32AnnotationOrDefault(annotations, daprLivenessProbeDelayKey, defaultHealthzProbeDelaySeconds),
 			TimeoutSeconds:      getInt32AnnotationOrDefault(annotations, daprLivenessProbeTimeoutKey, defaultHealthzProbeTimeoutSeconds),
 			PeriodSeconds:       getInt32AnnotationOrDefault(annotations, daprLivenessProbePeriodKey, defaultHealthzProbePeriodSeconds),

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -6,9 +6,10 @@
 package injector
 
 import (
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -79,7 +80,7 @@ func TestGetProbeHttpHandler(t *testing.T) {
 		},
 	}
 
-	assert.EqualValues(t, expectedHandler, getProbeHttpHandler(sidecarHTTPPort, pathElements...))
+	assert.EqualValues(t, expectedHandler, getProbeHTTPHandler(sidecarHTTPPort, pathElements...))
 }
 
 func TestGetSideCarContainer(t *testing.T) {


### PR DESCRIPTION
# Description

This PR adds leading `/` in liveness and readiness probe path.
Initial discussion started with @yaron2 on the community channel.
## Issue reference

Please reference the issue this PR will close: #1650 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

