### PR TITLE
Change default components folder used by runtime

### DIFF
--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -33,7 +33,7 @@ func FromFlags() (*DaprRuntime, error) {
 	appPort := flag.String("app-port", "", "The port the application is listening on")
 	profilePort := flag.String("profile-port", fmt.Sprintf("%v", DefaultProfilePort), "The port for the profile server")
 	appProtocol := flag.String("protocol", string(HTTPProtocol), "Protocol for the application: grpc or http")
-	componentsPath := flag.String("components-path", getDefaultComponentsFolder(), "Path for components directory. Standalone mode only")
+	componentsPath := flag.String("components-path", getDefaultComponentsPath(), "Path for components directory. Standalone mode only")
 	config := flag.String("config", "", "Path to config file, or name of a configuration object")
 	appID := flag.String("app-id", "", "A unique ID for Dapr. Used for Service Discovery and state")
 	controlPlaneAddress := flag.String("control-plane-address", "", "Address for a Dapr control plane")
@@ -151,8 +151,8 @@ func FromFlags() (*DaprRuntime, error) {
 	return NewDaprRuntime(runtimeConfig, globalConfig), nil
 }
 
-// getDefaultComponentsFolder returns the hidden .components folder created at init time
-func getDefaultComponentsFolder() string {
+// getDefaultComponentsPath returns the hidden .components folder created at init time
+func getDefaultComponentsPath() string {
 	const daprDirName = ".dapr"
 	const daprWindowsOS = "windows"
 	const componentsDirName = "components"
@@ -161,6 +161,5 @@ func getDefaultComponentsFolder() string {
 		daprDirPath = os.Getenv("USERPROFILE")
 	}
 
-	defaultComponentsPath := filepath.Join(daprDirPath, daprDirName, componentsDirName)
-	return defaultComponentsPath
+	return filepath.Join(daprDirPath, daprDirName, componentsDirName)
 }

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -9,6 +9,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strconv"
 
 	global_config "github.com/dapr/dapr/pkg/config"
@@ -31,7 +33,7 @@ func FromFlags() (*DaprRuntime, error) {
 	appPort := flag.String("app-port", "", "The port the application is listening on")
 	profilePort := flag.String("profile-port", fmt.Sprintf("%v", DefaultProfilePort), "The port for the profile server")
 	appProtocol := flag.String("protocol", string(HTTPProtocol), "Protocol for the application: grpc or http")
-	componentsPath := flag.String("components-path", DefaultComponentsPath, "Path for components directory. Standalone mode only")
+	componentsPath := flag.String("components-path", getDefaultComponentsFolder(), "Path for components directory. Standalone mode only")
 	config := flag.String("config", "", "Path to config file, or name of a configuration object")
 	appID := flag.String("app-id", "", "A unique ID for Dapr. Used for Service Discovery and state")
 	controlPlaneAddress := flag.String("control-plane-address", "", "Address for a Dapr control plane")
@@ -147,4 +149,18 @@ func FromFlags() (*DaprRuntime, error) {
 		globalConfig = global_config.LoadDefaultConfiguration()
 	}
 	return NewDaprRuntime(runtimeConfig, globalConfig), nil
+}
+
+// getDefaultComponentsFolder returns the hidden .components folder created at init time
+func getDefaultComponentsFolder() string {
+	const daprDirName = ".dapr"
+	const daprWindowsOS = "windows"
+	const componentsDirName = "components"
+	daprDirPath := os.Getenv("HOME")
+	if runtime.GOOS == daprWindowsOS {
+		daprDirPath = os.Getenv("USERPROFILE")
+	}
+
+	defaultComponentsPath := filepath.Join(daprDirPath, daprDirName, componentsDirName)
+	return defaultComponentsPath
 }

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -27,8 +27,6 @@ const (
 	DefaultProfilePort = 7777
 	// DefaultMetricsPort is the default port for metrics endpoints
 	DefaultMetricsPort = 9090
-	// DefaultComponentsPath is the default dir for Dapr components (standalone mode)
-	DefaultComponentsPath = "./components"
 	// DefaultAllowedOrigins is the default origins allowed for the Dapr HTTP servers
 	DefaultAllowedOrigins = "*"
 )

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -776,7 +776,7 @@ func NewTestDaprRuntime(mode modes.DaprMode) *DaprRuntime {
 		"10.10.10.11",
 		DefaultAllowedOrigins,
 		"globalConfig",
-		getDefaultComponentsFolder(),
+		getDefaultComponentsPath(),
 		string(HTTPProtocol),
 		string(mode),
 		DefaultDaprHTTPPort,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -776,7 +776,7 @@ func NewTestDaprRuntime(mode modes.DaprMode) *DaprRuntime {
 		"10.10.10.11",
 		DefaultAllowedOrigins,
 		"globalConfig",
-		DefaultComponentsPath,
+		getDefaultComponentsFolder(),
 		string(HTTPProtocol),
 		string(mode),
 		DefaultDaprHTTPPort,


### PR DESCRIPTION
# Description

Change default components folder used by dapr runtime

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1655

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
