### PR TITLE
Fix: have invoke span name include target app id

### DIFF
--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -147,10 +147,10 @@ func spanAttributesMapFromGRPC(appID string, req interface{}, rpcMethod string) 
 
 		// Rename spanname
 		if s.GetActor() == nil {
-			m[daprAPISpanNameInternal] = fmt.Sprintf("%s/CallLocal/%s", appID, s.Message.GetMethod())
+			m[daprAPISpanNameInternal] = fmt.Sprintf("CallLocal/%s/%s", appID, s.Message.GetMethod())
 			m[daprAPIInvokeMethod] = s.Message.GetMethod()
 		} else {
-			m[daprAPISpanNameInternal] = fmt.Sprintf("%s/CallActor/%s", s.GetActor().GetActorType(), s.Message.GetMethod())
+			m[daprAPISpanNameInternal] = fmt.Sprintf("CallActor/%s/%s", s.GetActor().GetActorType(), s.Message.GetMethod())
 			m[daprAPIActorTypeID] = fmt.Sprintf("%s.%s", s.GetActor().GetActorType(), s.GetActor().GetActorId())
 		}
 
@@ -158,7 +158,7 @@ func spanAttributesMapFromGRPC(appID string, req interface{}, rpcMethod string) 
 	case *runtimev1pb.InvokeServiceRequest:
 		m[gRPCServiceSpanAttributeKey] = daprGRPCServiceInvocationService
 		m[netPeerNameSpanAttributeKey] = s.GetId()
-		m[daprAPISpanNameInternal] = fmt.Sprintf("%s/CallLocal/%s", s.GetId(), s.Message.GetMethod())
+		m[daprAPISpanNameInternal] = fmt.Sprintf("CallLocal/%s/%s", s.GetId(), s.Message.GetMethod())
 
 	case *runtimev1pb.PublishEventRequest:
 		m[gRPCServiceSpanAttributeKey] = daprGRPCDaprService

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -171,7 +171,7 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 		interceptor(ctx, fakeReq, fakeInfo, assertHandler)
 
 		sc := span.SpanContext()
-		assert.True(t, strings.Contains(span.String(), "targetID/CallLocal/method1"))
+		assert.True(t, strings.Contains(span.String(), "CallLocal/targetID/method1"))
 		assert.NotEmpty(t, fmt.Sprintf("%x", sc.TraceID[:]))
 		assert.NotEmpty(t, fmt.Sprintf("%x", sc.SpanID[:]))
 	})

--- a/pkg/diagnostics/http_tracing.go
+++ b/pkg/diagnostics/http_tracing.go
@@ -266,7 +266,7 @@ func spanAttributesMapFromHTTPContext(ctx *fasthttp.RequestCtx) map[string]strin
 		m[gRPCServiceSpanAttributeKey] = daprGRPCServiceInvocationService
 		targetID := getContextValue(ctx, "id")
 		m[netPeerNameSpanAttributeKey] = targetID
-		m[daprAPISpanNameInternal] = fmt.Sprintf("%s/CallLocal/%s", targetID, getContextValue(ctx, "method"))
+		m[daprAPISpanNameInternal] = fmt.Sprintf("CallLocal/%s/%s", targetID, getContextValue(ctx, "method"))
 
 	case "publish":
 		m[messagingSystemSpanAttributeKey] = pubsubBuildingBlockType
@@ -314,7 +314,7 @@ func populateActorParams(ctx *fasthttp.RequestCtx, m map[string]string) string {
 	case "method":
 		m[gRPCServiceSpanAttributeKey] = daprGRPCServiceInvocationService
 		m[netPeerNameSpanAttributeKey] = m[daprAPIActorTypeID]
-		m[daprAPISpanNameInternal] = fmt.Sprintf("%s/CallActor/%s", actorType, getContextValue(ctx, "method"))
+		m[daprAPISpanNameInternal] = fmt.Sprintf("CallActor/%s/%s", actorType, getContextValue(ctx, "method"))
 
 	case "state":
 		dbType = stateBuildingBlockType

--- a/pkg/diagnostics/http_tracing_test.go
+++ b/pkg/diagnostics/http_tracing_test.go
@@ -150,16 +150,79 @@ func TestGetAPIComponent(t *testing.T) {
 
 func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
 	var tests = []struct {
-		path          string
-		expectedType  string
-		expectedValue string
+		path string
+		out  map[string]string
 	}{
-		{"/v1.0/state/statestore/key", "state", "statestore"},
-		{"/v1.0/state/statestore", "state", "statestore"},
-		{"/v1.0/secrets/keyvault/name", "secrets", "keyvault"},
-		{"/v1.0/invoke/fakeApp/method/add", "invoke", "fakeApp"},
-		{"/v1/publish/topicA", "pubsub", "topicA"},
-		{"/v1/bindings/kafka", "bindings", "kafka"},
+		{
+			"/v1.0/state/statestore/key",
+			map[string]string{
+				dbTypeSpanAttributeKey:      "state",
+				dbInstanceSpanAttributeKey:  "statestore",
+				dbStatementSpanAttributeKey: "GET /v1.0/state/statestore/key",
+				dbURLSpanAttributeKey:       "state",
+			},
+		},
+		{
+			"/v1.0/state/statestore",
+			map[string]string{
+				dbTypeSpanAttributeKey:      "state",
+				dbInstanceSpanAttributeKey:  "statestore",
+				dbStatementSpanAttributeKey: "GET /v1.0/state/statestore",
+				dbURLSpanAttributeKey:       "state",
+			},
+		},
+		{
+			"/v1.0/secrets/keyvault/name",
+			map[string]string{
+				dbTypeSpanAttributeKey:      secretBuildingBlockType,
+				dbInstanceSpanAttributeKey:  "keyvault",
+				dbStatementSpanAttributeKey: "GET /v1.0/secrets/keyvault/name",
+				dbURLSpanAttributeKey:       secretBuildingBlockType,
+			},
+		},
+		{
+			"/v1.0/invoke/fakeApp/method/add",
+			map[string]string{
+				gRPCServiceSpanAttributeKey: daprGRPCServiceInvocationService,
+				netPeerNameSpanAttributeKey: "fakeApp",
+				daprAPISpanNameInternal:     "fakeApp/CallLocal/add",
+			},
+		},
+		{
+			"/v1/publish/topicA",
+			map[string]string{
+				messagingSystemSpanAttributeKey:          pubsubBuildingBlockType,
+				messagingDestinationSpanAttributeKey:     "topicA",
+				messagingDestinationKindSpanAttributeKey: messagingDestinationTopicKind,
+			},
+		},
+		{
+			"/v1/bindings/kafka",
+			map[string]string{
+				dbTypeSpanAttributeKey:      bindingBuildingBlockType,
+				dbInstanceSpanAttributeKey:  "kafka",
+				dbStatementSpanAttributeKey: "GET /v1/bindings/kafka",
+				dbURLSpanAttributeKey:       bindingBuildingBlockType,
+			},
+		},
+		{
+			"/v1.0/actors/demo_actor/1/state/my_data",
+			map[string]string{
+				dbTypeSpanAttributeKey:      stateBuildingBlockType,
+				dbInstanceSpanAttributeKey:  "actor",
+				dbStatementSpanAttributeKey: "GET /v1.0/actors/demo_actor/1/state/my_data",
+				dbURLSpanAttributeKey:       stateBuildingBlockType,
+				daprAPIActorTypeID:          "demo_actor.1",
+			},
+		},
+		{
+			"/v1.0/actors/demo_actor/1/method/method1",
+			map[string]string{
+				gRPCServiceSpanAttributeKey: daprGRPCServiceInvocationService,
+				netPeerNameSpanAttributeKey: "demo_actor.1",
+				daprAPIActorTypeID:          "demo_actor.1",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -170,38 +233,19 @@ func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
 			req.SetRequestURI(tt.path)
 			reqCtx := &fasthttp.RequestCtx{}
 			req.CopyTo(&reqCtx.Request)
-			method := string(req.Header.Method())
 
 			reqCtx.SetUserValue("storeName", "statestore")
 			reqCtx.SetUserValue("secretStoreName", "keyvault")
 			reqCtx.SetUserValue("topic", "topicA")
 			reqCtx.SetUserValue("name", "kafka")
+			reqCtx.SetUserValue("id", "fakeApp")
+			reqCtx.SetUserValue("method", "add")
+			reqCtx.SetUserValue("actorType", "demo_actor")
+			reqCtx.SetUserValue("actorId", "1")
 
 			got := spanAttributesMapFromHTTPContext(reqCtx)
-			_, componentType := getAPIComponent(tt.path)
-			switch componentType {
-			case "state":
-				assert.Equal(t, got[dbTypeSpanAttributeKey], tt.expectedType)
-				assert.Equal(t, got[dbInstanceSpanAttributeKey], tt.expectedValue)
-				assert.Equal(t, got[dbStatementSpanAttributeKey], fmt.Sprintf("%s %s", method, tt.path))
-				assert.Equal(t, got[dbURLSpanAttributeKey], tt.expectedType)
-
-			case "secrets":
-				assert.Equal(t, got[dbTypeSpanAttributeKey], tt.expectedType)
-				assert.Equal(t, got[dbInstanceSpanAttributeKey], tt.expectedValue)
-				assert.Equal(t, got[dbStatementSpanAttributeKey], fmt.Sprintf("%s %s", method, tt.path))
-				assert.Equal(t, got[dbURLSpanAttributeKey], tt.expectedType)
-
-			case "bindings":
-				assert.Equal(t, got[dbTypeSpanAttributeKey], tt.expectedType)
-				assert.Equal(t, got[dbInstanceSpanAttributeKey], tt.expectedValue)
-				assert.Equal(t, got[dbStatementSpanAttributeKey], fmt.Sprintf("%s %s", method, tt.path))
-				assert.Equal(t, got[dbURLSpanAttributeKey], tt.expectedType)
-
-			case "publish":
-				assert.Equal(t, got[messagingSystemSpanAttributeKey], tt.expectedType)
-				assert.Equal(t, got[messagingDestinationSpanAttributeKey], tt.expectedValue)
-				assert.Equal(t, got[messagingDestinationKindSpanAttributeKey], messagingDestinationTopicKind)
+			for k, v := range tt.out {
+				assert.Equal(t, v, got[k])
 			}
 		})
 	}
@@ -275,10 +319,16 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 			requestBody, "/v1.0/invoke/callee/method/method1",
 			map[string]string{},
 		)
+		testRequestCtx.SetUserValue("id", "callee")
+		testRequestCtx.SetUserValue("method", "method1")
+
+		// act
 		handler(testRequestCtx)
+
+		// assert
 		span := diag_utils.SpanFromContext(testRequestCtx)
 		sc := span.SpanContext()
-		assert.True(t, strings.Contains(span.String(), daprServiceInvocationFullMethod))
+		assert.True(t, strings.Contains(span.String(), "callee/CallLocal/method1"))
 		assert.NotEmpty(t, fmt.Sprintf("%x", sc.TraceID[:]))
 		assert.NotEmpty(t, fmt.Sprintf("%x", sc.SpanID[:]))
 	})

--- a/pkg/diagnostics/http_tracing_test.go
+++ b/pkg/diagnostics/http_tracing_test.go
@@ -185,7 +185,7 @@ func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
 			map[string]string{
 				gRPCServiceSpanAttributeKey: daprGRPCServiceInvocationService,
 				netPeerNameSpanAttributeKey: "fakeApp",
-				daprAPISpanNameInternal:     "fakeApp/CallLocal/add",
+				daprAPISpanNameInternal:     "CallLocal/fakeApp/add",
 			},
 		},
 		{
@@ -221,6 +221,7 @@ func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
 				gRPCServiceSpanAttributeKey: daprGRPCServiceInvocationService,
 				netPeerNameSpanAttributeKey: "demo_actor.1",
 				daprAPIActorTypeID:          "demo_actor.1",
+				daprAPISpanNameInternal:     "CallActor/demo_actor/add",
 			},
 		},
 	}
@@ -328,7 +329,7 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 		// assert
 		span := diag_utils.SpanFromContext(testRequestCtx)
 		sc := span.SpanContext()
-		assert.True(t, strings.Contains(span.String(), "callee/CallLocal/method1"))
+		assert.True(t, strings.Contains(span.String(), "CallLocal/callee/method1"))
 		assert.NotEmpty(t, fmt.Sprintf("%x", sc.TraceID[:]))
 		assert.NotEmpty(t, fmt.Sprintf("%x", sc.SpanID[:]))
 	})

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -20,6 +20,13 @@ const (
 	daprHeaderPrefix    = "dapr-"
 	daprHeaderBinSuffix = "-bin"
 
+	// daprInternalSpanAttrPrefix is the internal span attribution prefix.
+	// Middleware will not populate it if the span key starts with this prefix.
+	daprInternalSpanAttrPrefix = "__dapr."
+	// daprAPISpanNameInternal is the internal attributation, but not populated
+	// to span attribution.
+	daprAPISpanNameInternal = daprInternalSpanAttrPrefix + "spanname"
+
 	// span attribute keys
 	// Reference trace semantics https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
 	dbTypeSpanAttributeKey      = "db.type"
@@ -39,6 +46,7 @@ const (
 	daprAPIStatusCodeSpanAttributeKey = "dapr.status_code"
 	daprAPIProtocolSpanAttributeKey   = "dapr.protocol"
 	daprAPIInvokeMethod               = "dapr.invoke_method"
+	daprAPIActorTypeID                = "dapr.actor"
 
 	daprAPIHTTPSpanAttrValue = "http"
 	daprAPIGRPCSpanAttrValue = "grpc"
@@ -128,7 +136,8 @@ func AddAttributesToSpan(span *trace.Span, attributes map[string]string) {
 	}
 
 	for k, v := range attributes {
-		if v != "" {
+		// Skip if key is for internal use.
+		if !strings.HasPrefix(k, daprInternalSpanAttrPrefix) && v != "" {
 			span.AddAttributes(trace.StringAttribute(k, v))
 		}
 	}

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -58,8 +58,6 @@ const (
 
 	daprGRPCServiceInvocationService = "ServiceInvocation"
 	daprGRPCDaprService              = "Dapr"
-
-	daprServiceInvocationFullMethod = "/dapr.proto.internals.v1.ServiceInvocation/CallLocal"
 )
 
 // SpanContextToW3CString returns the SpanContext string representation


### PR DESCRIPTION
# Description

This is the local-forwarder specific issue (OT Collector or zipkin have no issue) To resolve the problem, we need to specify the different span name per gRPC internal call.

* Rename Service Invocation Spanname: /dapr.proto.internals.v1.ServiceInvocation/CallLocal -> CallLocal/[targetID]/[method]
* Enable missing Actor invocation trace
* Add more unit-tests

## Issue reference

https://github.com/dapr/dapr/issues/1659

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
