### PR TITLE
Populate traceparent and grpc-trace-bin in response header (#1638)

### DIFF
--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
-	diag "github.com/dapr/dapr/pkg/diagnostics"
-	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -72,14 +70,10 @@ func (g *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 		g.ch <- 1
 	}
 
-	span := diag_utils.SpanFromContext(ctx)
-
 	clientV1 := runtimev1pb.NewAppCallbackClient(g.client)
-	grpcMetadata := invokev1.InternalMetadataToGrpcMetadata(req.Metadata(), true)
+	grpcMetadata := invokev1.InternalMetadataToGrpcMetadata(ctx, req.Metadata(), true)
 	// Prepare gRPC Metadata
 	ctx = metadata.NewOutgoingContext(context.Background(), grpcMetadata)
-	// Populate span context. no ops if span context is empty
-	ctx = diag.SpanContextToGRPCMetadata(ctx, span.SpanContext())
 
 	ctx, cancel := context.WithTimeout(ctx, channel.DefaultChannelRequestTimeout)
 	defer cancel()

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -15,7 +15,6 @@ import (
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
-	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
@@ -129,11 +128,7 @@ func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMeth
 	channelReq.Header.SetMethod(req.Message().HttpExtension.Verb.String())
 
 	// Recover headers
-	invokev1.InternalMetadataToHTTPHeader(req.Metadata(), channelReq.Header.Set)
-
-	span := diag_utils.SpanFromContext(ctx)
-	// no ops if sc is nil
-	diag.SpanContextToRequest(span.SpanContext(), channelReq)
+	invokev1.InternalMetadataToHTTPHeader(ctx, req.Metadata(), channelReq.Header.Set)
 
 	// Set Content body and types
 	contentType, body := req.RawData()

--- a/pkg/diagnostics/http_tracing_test.go
+++ b/pkg/diagnostics/http_tracing_test.go
@@ -8,6 +8,7 @@ package diagnostics
 import (
 	"fmt"
 	"net"
+	"net/textproto"
 	"strings"
 	"testing"
 	"time"
@@ -90,7 +91,7 @@ func TestUserDefinedHTTPHeaders(t *testing.T) {
 	assert.Equal(t, "value2", m["dapr-userdefined-2"])
 }
 
-func TestSpanContextToRequest(t *testing.T) {
+func TestSpanContextToHTTPHeaders(t *testing.T) {
 	tests := []struct {
 		sc trace.SpanContext
 	}{
@@ -103,20 +104,20 @@ func TestSpanContextToRequest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run("SpanContextToRequest", func(t *testing.T) {
+		t.Run("SpanContextToHTTPHeaders", func(t *testing.T) {
 			req := &fasthttp.Request{}
-			SpanContextToRequest(tt.sc, req)
+			SpanContextToHTTPHeaders(tt.sc, req.Header.Set)
 
 			got, _ := SpanContextFromRequest(req)
 
-			assert.Equalf(t, got, tt.sc, "SpanContextToRequest() got = %v, want %v", got, tt.sc)
+			assert.Equalf(t, got, tt.sc, "SpanContextToHTTPHeaders() got = %v, want %v", got, tt.sc)
 		})
 	}
 
 	t.Run("empty span context", func(t *testing.T) {
 		req := &fasthttp.Request{}
 		sc := trace.SpanContext{}
-		SpanContextToRequest(sc, req)
+		SpanContextToHTTPHeaders(sc, req.Header.Set)
 
 		assert.Nil(t, req.Header.Peek(traceparentHeader))
 	})
@@ -252,6 +253,31 @@ func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
 	}
 }
 
+func TestSpanContextToResponse(t *testing.T) {
+	tests := []struct {
+		sc trace.SpanContext
+	}{
+		{
+			sc: trace.SpanContext{
+				TraceID:      trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
+				SpanID:       trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
+				TraceOptions: trace.TraceOptions(1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run("SpanContextToResponse", func(t *testing.T) {
+			resp := &fasthttp.Response{}
+			SpanContextToHTTPHeaders(tt.sc, resp.Header.Set)
+
+			h := string(resp.Header.Peek(textproto.CanonicalMIMEHeaderKey("traceparent")))
+			got, _ := SpanContextFromW3CString(h)
+
+			assert.Equalf(t, got, tt.sc, "SpanContextToResponse() got = %v, want %v", got, tt.sc)
+		})
+	}
+}
+
 func getTestHTTPRequest() *fasthttp.Request {
 	req := &fasthttp.Request{}
 	req.SetRequestURI("/v1.0/state/statestore/key")
@@ -271,7 +297,7 @@ func getTestHTTPRequest() *fasthttp.Request {
 		TraceOptions: 0x0,
 	}
 
-	SpanContextToRequest(sc, req)
+	SpanContextToHTTPHeaders(sc, req.Header.Set)
 	return req
 }
 

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -171,7 +171,7 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 		return nil, err
 	}
 
-	grpc.SendHeader(ctx, invokev1.InternalMetadataToGrpcMetadata(resp.Headers(), true))
+	grpc.SendHeader(ctx, invokev1.InternalMetadataToGrpcMetadata(ctx, resp.Headers(), true))
 
 	var respError error
 	if resp.IsHTTPResponse() {
@@ -183,7 +183,7 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 	} else {
 		respError = invokev1.ErrorFromInternalStatus(resp.Status())
 		// ignore trailer if appchannel uses HTTP
-		grpc.SetTrailer(ctx, invokev1.InternalMetadataToGrpcMetadata(resp.Trailers(), false))
+		grpc.SetTrailer(ctx, invokev1.InternalMetadataToGrpcMetadata(ctx, resp.Trailers(), false))
 	}
 
 	return resp.Message(), respError

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -519,8 +519,7 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// TODO: add trace parent and state
-	invokev1.InternalMetadataToHTTPHeader(resp.Headers(), reqCtx.Response.Header.Set)
+	invokev1.InternalMetadataToHTTPHeader(reqCtx, resp.Headers(), reqCtx.Response.Header.Set)
 	contentType, body := resp.RawData()
 	reqCtx.Response.Header.SetContentType(contentType)
 
@@ -529,6 +528,7 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 	if !resp.IsHTTPResponse() {
 		statusCode = invokev1.HTTPStatusFromCode(codes.Code(statusCode))
 	}
+
 	respond(reqCtx, statusCode, body)
 }
 
@@ -753,8 +753,7 @@ func (a *api) onDirectActorMessage(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// TODO: add trace parent and state
-	invokev1.InternalMetadataToHTTPHeader(resp.Headers(), reqCtx.Response.Header.Set)
+	invokev1.InternalMetadataToHTTPHeader(reqCtx, resp.Headers(), reqCtx.Response.Header.Set)
 	contentType, body := resp.RawData()
 	reqCtx.Response.Header.SetContentType(contentType)
 

--- a/tests/apps/service_invocation/app.go
+++ b/tests/apps/service_invocation/app.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,8 +42,9 @@ const (
 )
 
 type testCommandRequest struct {
-	RemoteApp string `json:"remoteApp,omitempty"`
-	Method    string `json:"method,omitempty"`
+	RemoteApp        string `json:"remoteApp,omitempty"`
+	Method           string `json:"method,omitempty"`
+	RemoteAppTracing string `json:"remoteAppTracing"`
 }
 
 type appResponse struct {
@@ -255,6 +257,11 @@ func retrieveRequestObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; utf-8")
 	w.Header().Set("DaprTest-Response-1", "DaprTest-Response-Value-1")
 	w.Header().Set("DaprTest-Response-2", "DaprTest-Response-Value-2")
+
+	if val, ok := headers["Daprtest-Traceid"]; ok {
+		// val[0] is client app given trace id
+		w.Header().Set("traceparent", val[0])
+	}
 	w.WriteHeader(http.StatusOK)
 	w.Write(serializedHeaders)
 }
@@ -283,14 +290,21 @@ func testV1RequestHTTPToHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fmt.Printf("httpTohttpTest calling with message %s\n", string(b))
+	headers := map[string]string{
+		"DaprTest-Request-1": "DaprValue1",
+		"DaprTest-Request-2": "DaprValue2",
+	}
+
+	tracing, _ := strconv.ParseBool(commandBody.RemoteAppTracing)
+	if tracing {
+		headers["Daprtest-Traceid"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	}
+
 	resp, err := invokeServiceWithBodyHeader(
 		commandBody.RemoteApp,
 		"retrieve_request_object",
 		b,
-		map[string]string{
-			"DaprTest-Request-1": "DaprValue1",
-			"DaprTest-Request-2": "DaprValue2",
-		},
+		headers,
 	)
 
 	if err != nil {
@@ -351,15 +365,21 @@ func testV1RequestHTTPToGRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("httpTohttpTest calling with message %s\n", string(b))
+	fmt.Printf("httpTogrpcTest calling with message %s\n", string(b))
+	headers := map[string]string{
+		"DaprTest-Request-1": "DaprValue1",
+		"DaprTest-Request-2": "DaprValue2",
+	}
+
+	tracing, _ := strconv.ParseBool(commandBody.RemoteAppTracing)
+	if tracing {
+		headers["Daprtest-Traceid"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	}
 	resp, err := invokeServiceWithBodyHeader(
 		commandBody.RemoteApp,
 		"retrieve_request_object",
 		b,
-		map[string]string{
-			"DaprTest-Request-1": "DaprValue1",
-			"DaprTest-Request-2": "DaprValue2",
-		},
+		headers,
 	)
 
 	if err != nil {
@@ -399,7 +419,7 @@ func testV1RequestHTTPToGRPC(w http.ResponseWriter, r *http.Request) {
 
 // testV1RequestGRPCToGRPC calls from http caller to grpc callee
 func testV1RequestGRPCToGRPC(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("Enter service invocation v1 - http -> grpc")
+	fmt.Println("Enter service invocation v1 - grpc -> grpc")
 	var commandBody testCommandRequest
 	err := json.NewDecoder(r.Body).Decode(&commandBody)
 	if err != nil {
@@ -407,7 +427,7 @@ func testV1RequestGRPCToGRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("httpTogRPCTest - target app: %s\n", commandBody.RemoteApp)
+	fmt.Printf("gRPCTogRPCTest - target app: %s\n", commandBody.RemoteApp)
 
 	daprAddress := fmt.Sprintf("localhost:%s", "50001")
 
@@ -420,10 +440,22 @@ func testV1RequestGRPCToGRPC(w http.ResponseWriter, r *http.Request) {
 
 	// Create the client
 	client := runtimev1pb.NewDaprClient(conn)
-	ctx := metadata.AppendToOutgoingContext(
-		context.Background(),
-		"DaprTest-Request-1", "DaprValue1",
-		"DaprTest-Request-2", "DaprValue2")
+	tracing, _ := strconv.ParseBool(commandBody.RemoteAppTracing)
+	var ctx context.Context
+	if tracing {
+		ctx = metadata.AppendToOutgoingContext(
+			context.Background(),
+			"DaprTest-Request-1", "DaprValue1",
+			"DaprTest-Request-2", "DaprValue2",
+			"Daprtest-Traceid", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		)
+	} else {
+		ctx = metadata.AppendToOutgoingContext(
+			context.Background(),
+			"DaprTest-Request-1", "DaprValue1",
+			"DaprTest-Request-2", "DaprValue2",
+		)
+	}
 	req := &runtimev1pb.InvokeServiceRequest{
 		Id: commandBody.RemoteApp,
 		Message: &commonv1pb.InvokeRequest{
@@ -447,13 +479,24 @@ func testV1RequestGRPCToGRPC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reqHeadersString := resp.GetData().Value
+
 	respHeaders := map[string][]string{}
 	for k, vals := range header {
-		respHeaders[k] = vals
+		var listValue []string
+		if strings.HasSuffix(k, "-bin") {
+			for _, val := range vals {
+				listValue = append(listValue, base64.StdEncoding.EncodeToString([]byte(val)))
+			}
+		} else {
+			listValue = append(listValue, vals...)
+		}
+		respHeaders[k] = listValue
 	}
+
 	respHeaderString, _ := json.Marshal(respHeaders)
 
 	respTrailers := map[string][]string{}
+
 	for k, vals := range trailer {
 		respTrailers[k] = vals
 	}
@@ -499,10 +542,24 @@ func testV1RequestGRPCToHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Create the client
 	client := runtimev1pb.NewDaprClient(conn)
-	ctx := metadata.AppendToOutgoingContext(
-		context.Background(),
-		"DaprTest-Request-1", "DaprValue1",
-		"DaprTest-Request-2", "DaprValue2")
+
+	tracing, _ := strconv.ParseBool(commandBody.RemoteAppTracing)
+	var ctx context.Context
+	if tracing {
+		ctx = metadata.AppendToOutgoingContext(
+			context.Background(),
+			"DaprTest-Request-1", "DaprValue1",
+			"DaprTest-Request-2", "DaprValue2",
+			"Daprtest-Traceid", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		)
+	} else {
+		ctx = metadata.AppendToOutgoingContext(
+			context.Background(),
+			"DaprTest-Request-1", "DaprValue1",
+			"DaprTest-Request-2", "DaprValue2",
+		)
+	}
+
 	req := &runtimev1pb.InvokeServiceRequest{
 		Id: commandBody.RemoteApp,
 		Message: &commonv1pb.InvokeRequest{
@@ -528,10 +585,20 @@ func testV1RequestGRPCToHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reqHeadersString := resp.GetData().Value
+
 	respHeaders := map[string][]string{}
 	for k, vals := range header {
-		respHeaders[k] = vals
+		var listValue []string
+		if strings.HasSuffix(k, "-bin") {
+			for _, val := range vals {
+				listValue = append(listValue, base64.StdEncoding.EncodeToString([]byte(val)))
+			}
+		} else {
+			listValue = append(listValue, vals...)
+		}
+		respHeaders[k] = listValue
 	}
+
 	respHeaderString, _ := json.Marshal(respHeaders)
 
 	respMessage := map[string]string{

--- a/tests/apps/service_invocation_grpc/app.go
+++ b/tests/apps/service_invocation_grpc/app.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
 
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -80,6 +82,15 @@ func (s *server) retrieveRequestObject(ctx context.Context) ([]byte, error) {
 	header := metadata.Pairs(
 		"DaprTest-Response-1", "DaprTest-Response-Value-1",
 		"DaprTest-Response-2", "DaprTest-Response-Value-2")
+
+	// following traceid byte is of expectedTraceID "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	sc := trace.SpanContext{
+		TraceID:      trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
+		SpanID:       trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
+		TraceOptions: trace.TraceOptions(1),
+	}
+	header.Set("grpc-trace-bin", string(propagation.Binary(sc)))
+
 	grpc.SendHeader(ctx, header)
 	trailer := metadata.Pairs(
 		"DaprTest-Trailer-1", "DaprTest-Trailer-Value-1",

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -8,22 +8,26 @@
 package service_invocation_e2e
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/tests/e2e/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opencensus.io/trace/propagation"
 )
 
 type testCommandRequest struct {
-	RemoteApp string `json:"remoteApp,omitempty"`
-	Method    string `json:"method,omitempty"`
+	RemoteApp        string `json:"remoteApp,omitempty"`
+	Method           string `json:"method,omitempty"`
+	RemoteAppTracing string `json:"remoteAppTracing"`
 }
 
 type appResponse struct {
@@ -246,6 +250,7 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, "application/json; utf-8", responseHeaders["Content-Type"][0])
 		assert.Equal(t, "DaprTest-Response-Value-1", responseHeaders["Daprtest-Response-1"][0])
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["Daprtest-Response-2"][0])
+		assert.NotNil(t, responseHeaders["Traceparent"][0])
 	})
 
 	t.Run("grpc-to-grpc", func(t *testing.T) {
@@ -288,6 +293,8 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, "application/grpc", responseHeaders["content-type"][0])
 		assert.Equal(t, "DaprTest-Response-Value-1", responseHeaders["daprtest-response-1"][0])
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["daprtest-response-2"][0])
+		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
+		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
 
 		assert.Equal(t, "DaprTest-Trailer-Value-1", trailerHeaders["daprtest-trailer-1"][0])
 		assert.Equal(t, "DaprTest-Trailer-Value-2", trailerHeaders["daprtest-trailer-2"][0])
@@ -296,7 +303,7 @@ func TestHeaders(t *testing.T) {
 	t.Run("grpc-to-http", func(t *testing.T) {
 		body, err := json.Marshal(testCommandRequest{
 			RemoteApp: "serviceinvocation-callee-0",
-			Method:    "grpc-to-grpc",
+			Method:    "grpc-to-http",
 		})
 		require.NoError(t, err)
 
@@ -334,6 +341,8 @@ func TestHeaders(t *testing.T) {
 		assert.NotNil(t, responseHeaders["dapr-date"][0])
 		assert.Equal(t, "DaprTest-Response-Value-1", responseHeaders["daprtest-response-1"][0])
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["daprtest-response-2"][0])
+		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
+		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
 	})
 
 	t.Run("http-to-grpc", func(t *testing.T) {
@@ -378,6 +387,179 @@ func TestHeaders(t *testing.T) {
 		assert.NotNil(t, responseHeaders["Date"][0])
 		assert.Equal(t, "DaprTest-Response-Value-1", responseHeaders["Daprtest-Response-1"][0])
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["Daprtest-Response-2"][0])
+		assert.NotNil(t, responseHeaders["Traceparent"][0])
 	})
 
+	/* Tracing specific tests */
+	/*
+		// following is the span context of expectedTraceID
+		trace.SpanContext{
+		TraceID:      trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
+		SpanID:       trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
+		TraceOptions: trace.TraceOptions(1),
+		}
+
+		string representation of span context : "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+		all the -bin headers are stored in Dapr as base64 encoded string.
+		for the above span context when passed in grpc-trace-bin header, Dapr retrieved binary header and stored as encoded string.
+		the encoded string for the above span context is :
+		"AABL+S81d7NNpqPOkp0ODkc2AQDwZ6oLqQK3AgE="
+	*/
+	expectedTraceID := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	expectedEncodedTraceID := "AABL+S81d7NNpqPOkp0ODkc2AQDwZ6oLqQK3AgE="
+
+	t.Run("http-to-http-tracing", func(t *testing.T) {
+		body, err := json.Marshal(testCommandRequest{
+			RemoteApp:        "serviceinvocation-callee-0",
+			Method:           "http-to-http-tracing",
+			RemoteAppTracing: "true",
+		})
+		require.NoError(t, err)
+
+		resp, err := utils.HTTPPost(
+			fmt.Sprintf("http://%s/tests/v1_httptohttptest", externalURL), body)
+		t.Log("checking err...")
+		require.NoError(t, err)
+
+		var appResp appResponse
+		t.Logf("unmarshalling..%s\n", string(resp))
+		err = json.Unmarshal(resp, &appResp)
+
+		var actualHeaders = map[string]string{}
+		json.Unmarshal([]byte(appResp.Message), &actualHeaders)
+		var requestHeaders = map[string][]string{}
+		var responseHeaders = map[string][]string{}
+		json.Unmarshal([]byte(actualHeaders["request"]), &requestHeaders)
+		json.Unmarshal([]byte(actualHeaders["response"]), &responseHeaders)
+
+		require.NoError(t, err)
+
+		assert.NotNil(t, requestHeaders["Traceparent"][0])
+		assert.Equal(t, expectedTraceID, requestHeaders["Daprtest-Traceid"][0])
+
+		assert.NotNil(t, responseHeaders["Traceparent"][0])
+		assert.Equal(t, expectedTraceID, responseHeaders["Traceparent"][0])
+	})
+
+	t.Run("grpc-to-grpc-tracing", func(t *testing.T) {
+		body, err := json.Marshal(testCommandRequest{
+			RemoteApp:        "grpcapp",
+			Method:           "grpc-to-grpc-tracing",
+			RemoteAppTracing: "true",
+		})
+		require.NoError(t, err)
+
+		resp, err := utils.HTTPPost(
+			fmt.Sprintf("http://%s/tests/v1_grpctogrpctest", externalURL), body)
+		t.Log("checking err...")
+		require.NoError(t, err)
+
+		var appResp appResponse
+		t.Logf("unmarshalling..%s\n", string(resp))
+		err = json.Unmarshal(resp, &appResp)
+
+		var actualHeaders = map[string]string{}
+		json.Unmarshal([]byte(appResp.Message), &actualHeaders)
+		var requestHeaders = map[string][]string{}
+		var responseHeaders = map[string][]string{}
+		var trailerHeaders = map[string][]string{}
+		json.Unmarshal([]byte(actualHeaders["request"]), &requestHeaders)
+		json.Unmarshal([]byte(actualHeaders["response"]), &responseHeaders)
+		json.Unmarshal([]byte(actualHeaders["trailers"]), &trailerHeaders)
+
+		require.NoError(t, err)
+
+		assert.NotNil(t, requestHeaders["grpc-trace-bin"][0])
+		assert.Equal(t, 1, len(requestHeaders["grpc-trace-bin"]))
+
+		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
+		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
+		traceContext := responseHeaders["grpc-trace-bin"][0]
+
+		t.Logf("received response grpc header..%s\n", traceContext)
+		assert.Equal(t, expectedEncodedTraceID, traceContext)
+		decoded, _ := base64.StdEncoding.DecodeString(traceContext)
+		gotSc, ok := propagation.FromBinary([]byte(decoded))
+
+		assert.True(t, ok)
+		assert.NotNil(t, gotSc)
+		assert.Equal(t, expectedTraceID, diag.SpanContextToW3CString(gotSc))
+	})
+
+	t.Run("http-to-grpc-tracing", func(t *testing.T) {
+		body, err := json.Marshal(testCommandRequest{
+			RemoteApp:        "grpcapp",
+			Method:           "http-to-grpc-tracing",
+			RemoteAppTracing: "true",
+		})
+		require.NoError(t, err)
+
+		resp, err := utils.HTTPPost(
+			fmt.Sprintf("http://%s/tests/v1_httptogrpctest", externalURL), body)
+		t.Log("checking err...")
+		require.NoError(t, err)
+
+		var appResp appResponse
+		t.Logf("unmarshalling..%s\n", string(resp))
+		err = json.Unmarshal(resp, &appResp)
+
+		var actualHeaders = map[string]string{}
+		json.Unmarshal([]byte(appResp.Message), &actualHeaders)
+		var requestHeaders = map[string][]string{}
+		var responseHeaders = map[string][]string{}
+		json.Unmarshal([]byte(actualHeaders["request"]), &requestHeaders)
+		json.Unmarshal([]byte(actualHeaders["response"]), &responseHeaders)
+
+		require.NoError(t, err)
+
+		assert.NotNil(t, requestHeaders["grpc-trace-bin"][0])
+		assert.Equal(t, 1, len(requestHeaders["grpc-trace-bin"]))
+
+		assert.NotNil(t, responseHeaders["Traceparent"][0])
+		assert.Equal(t, expectedTraceID, responseHeaders["Traceparent"][0])
+	})
+
+	t.Run("grpc-to-http-tracing", func(t *testing.T) {
+		body, err := json.Marshal(testCommandRequest{
+			RemoteApp:        "serviceinvocation-callee-0",
+			Method:           "grpc-to-http-tracing",
+			RemoteAppTracing: "true",
+		})
+		require.NoError(t, err)
+
+		resp, err := utils.HTTPPost(
+			fmt.Sprintf("http://%s/tests/v1_grpctohttptest", externalURL), body)
+		t.Log("checking err...")
+		require.NoError(t, err)
+
+		var appResp appResponse
+		t.Logf("unmarshalling..%s\n", string(resp))
+		err = json.Unmarshal(resp, &appResp)
+
+		var actualHeaders = map[string]string{}
+		json.Unmarshal([]byte(appResp.Message), &actualHeaders)
+		var requestHeaders = map[string][]string{}
+		var responseHeaders = map[string][]string{}
+		json.Unmarshal([]byte(actualHeaders["request"]), &requestHeaders)
+		json.Unmarshal([]byte(actualHeaders["response"]), &responseHeaders)
+
+		require.NoError(t, err)
+
+		assert.NotNil(t, requestHeaders["Traceparent"][0])
+		assert.Equal(t, expectedTraceID, requestHeaders["Daprtest-Traceid"][0])
+
+		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
+		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
+		traceContext := responseHeaders["grpc-trace-bin"][0]
+
+		t.Logf("received response grpc header..%s\n", traceContext)
+		assert.Equal(t, expectedEncodedTraceID, traceContext)
+		decoded, _ := base64.StdEncoding.DecodeString(traceContext)
+		gotSc, ok := propagation.FromBinary([]byte(decoded))
+
+		assert.True(t, ok)
+		assert.NotNil(t, gotSc)
+		assert.Equal(t, expectedTraceID, diag.SpanContextToW3CString(gotSc))
+	})
 }


### PR DESCRIPTION
Populate traceparent and grpc-trace-bin in response header

(cherry picked from master , commit c69fd275891d086f05b259ed0865b8e9d9f207ee)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
