### PR TITLE
Changing to SetHeader instead of SendHeader

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -171,7 +171,7 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 		return nil, err
 	}
 
-	grpc.SendHeader(ctx, invokev1.InternalMetadataToGrpcMetadata(ctx, resp.Headers(), true))
+	grpc.SetHeader(ctx, invokev1.InternalMetadataToGrpcMetadata(ctx, resp.Headers(), true))
 
 	var respError error
 	if resp.IsHTTPResponse() {


### PR DESCRIPTION
Using SetHeader instead of SendHeader.
SendHeader sends header metadata but in the rpc call lifecycle it may be called at most once.

Reference : godoc.org/google.golang.org/grpc#SendHeader
godoc.org/google.golang.org/grpc#SetHeader

When using SetHeader, when called multiple times, all the provided metadata will be merged.
All the metadata will be sent out when one of the following happens:

grpc.SendHeader() is called;
The first response is sent out;
An RPC status is sent out (error or success).

## Issue reference

Closes #1684 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
