### PR TITLE
Add destination appID target and header tests

### DIFF
--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -1,0 +1,53 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package messaging
+
+import (
+	"testing"
+
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func newDirectMessaging() *directMessaging {
+	return &directMessaging{}
+}
+
+func TestDestinationHeaders(t *testing.T) {
+	t.Run("destination header present", func(t *testing.T) {
+		appID := "test1"
+		req := invokev1.NewInvokeMethodRequest("GET")
+		req.WithMetadata(map[string][]string{})
+
+		dm := newDirectMessaging()
+		dm.addDestinationAppIDHeaderToMetadata(appID, req)
+		md := req.Metadata()[destinationAppIDHeader]
+		assert.Equal(t, appID, md.Values[0])
+	})
+}
+
+func TestForwardedHeaders(t *testing.T) {
+	t.Run("forwarded headers present", func(t *testing.T) {
+		req := invokev1.NewInvokeMethodRequest("GET")
+		req.WithMetadata(map[string][]string{})
+
+		dm := newDirectMessaging()
+		dm.hostAddress = "1"
+		dm.hostName = "2"
+
+		dm.addForwardedHeadersToMetadata(req)
+
+		md := req.Metadata()[fasthttp.HeaderXForwardedFor]
+		assert.Equal(t, "1", md.Values[0])
+
+		md = req.Metadata()[fasthttp.HeaderXForwardedHost]
+		assert.Equal(t, "2", md.Values[0])
+
+		md = req.Metadata()[fasthttp.HeaderForwarded]
+		assert.Equal(t, "for=1;by=1;host=2", md.Values[0])
+	})
+}


### PR DESCRIPTION
This PR adds the following:

1. Direct messaging test for forward headers
2. Add a header metadata for the target app ID
3. Direct messaging test for target app ID header