### PR TITLE
Remove destination id header from app channel

### DIFF
--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -26,11 +26,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	v1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
-)
-
-var (
-	destinationAppIDHeader = fmt.Sprintf("%s-destination-app-id", invokev1.DaprHeaderPrefix)
 )
 
 // messageClientConnection is the function type to connect to the other
@@ -162,7 +159,7 @@ func (d *directMessaging) invokeRemote(ctx context.Context, targetID string, req
 }
 
 func (d *directMessaging) addDestinationAppIDHeaderToMetadata(appID string, req *invokev1.InvokeMethodRequest) {
-	req.Metadata()[destinationAppIDHeader] = &internalv1pb.ListStringValue{
+	req.Metadata()[v1.DestinationIDHeader] = &internalv1pb.ListStringValue{
 		Values: []string{appID},
 	}
 }

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	v1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
 )
@@ -25,7 +26,7 @@ func TestDestinationHeaders(t *testing.T) {
 
 		dm := newDirectMessaging()
 		dm.addDestinationAppIDHeaderToMetadata(appID, req)
-		md := req.Metadata()[destinationAppIDHeader]
+		md := req.Metadata()[v1.DestinationIDHeader]
 		assert.Equal(t, appID, md.Values[0])
 	})
 }

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -204,6 +204,8 @@ func InternalMetadataToHTTPHeader(ctx context.Context, internalMD DaprInternalMe
 		case tracebinMetadata:
 			grpctracebinValue = listVal.Values[0]
 			continue
+		case DestinationIDHeader:
+			continue
 		}
 
 		if len(listVal.Values) == 0 || strings.HasSuffix(keyName, gRPCBinaryMetadataSuffix) || keyName == ContentTypeHeader {

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -44,6 +44,9 @@ const (
 	tracestateHeader  = "tracestate"
 	tracebinMetadata  = "grpc-trace-bin"
 
+	// DestinationIDHeader is the header carrying the value of the invoked app id
+	DestinationIDHeader = "destination-app-id"
+
 	// ErrorInfo metadata value is limited to 64 chars
 	// https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L126
 	maxMetadataValueLen = 63
@@ -133,6 +136,8 @@ func InternalMetadataToGrpcMetadata(ctx context.Context, internalMD DaprInternal
 			continue
 		case tracebinMetadata:
 			grpctracebinValue = listVal.Values[0]
+			continue
+		case DestinationIDHeader:
 			continue
 		}
 


### PR DESCRIPTION
Removes destination ID header from the app channel.