### PR TITLE
Update ClusterRoleBinding.yaml

### DIFF
--- a/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
@@ -12,24 +12,23 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: secret-reader
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
+  verbs: ["get"]
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-secret-reader
+  namespace: default
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: default
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: secret-reader
   apiGroup: rbac.authorization.k8s.io
-


### PR DESCRIPTION
This PR turns ClusterRole and ClusterRoleBinding into Role and RoleBinding.

Without this change, malicious code inside the pod/namespace can get all the secrets in *all* namespaces.

This PR also reduces secret permissions to "get" instead of "list" and "watch".

Fixes https://github.com/dapr/dapr/issues/1691