### PR TITLE
Return GRPC OK for 2xx http status code

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/dapr/components-contrib/bindings"
@@ -41,6 +42,8 @@ const (
 	maxSeconds    = int64(10000 * 365.25 * 24 * 60 * 60)
 	minSeconds    = -maxSeconds
 	daprSeparator = "||"
+
+	daprHTTPStatusHeader = "dapr-http-status"
 )
 
 // API is the gRPC interface for the Dapr gRPC API. It implements both the internal and external proto definitions.
@@ -171,7 +174,7 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 		return nil, err
 	}
 
-	grpc.SetHeader(ctx, invokev1.InternalMetadataToGrpcMetadata(ctx, resp.Headers(), true))
+	var headerMD = invokev1.InternalMetadataToGrpcMetadata(ctx, resp.Headers(), true)
 
 	var respError error
 	if resp.IsHTTPResponse() {
@@ -180,11 +183,15 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 			_, errorMessage = resp.RawData()
 		}
 		respError = invokev1.ErrorFromHTTPResponseCode(int(resp.Status().Code), string(errorMessage))
+		// Populate http status code to header
+		headerMD.Set(daprHTTPStatusHeader, strconv.Itoa(int(resp.Status().Code)))
 	} else {
 		respError = invokev1.ErrorFromInternalStatus(resp.Status())
 		// ignore trailer if appchannel uses HTTP
 		grpc.SetTrailer(ctx, invokev1.InternalMetadataToGrpcMetadata(ctx, resp.Trailers(), false))
 	}
+
+	grpc.SetHeader(ctx, headerMD)
 
 	return resp.Message(), respError
 }

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -466,7 +466,7 @@ func TestInvokeServiceFromHTTPResponse(t *testing.T) {
 	}{
 		{
 			status:         200,
-			statusMessage:  "Accepted",
+			statusMessage:  "OK",
 			grpcStatusCode: codes.OK,
 			grpcMessage:    "",
 			errHTTPCode:    "",

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.opencensus.io/trace"
 	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
 	grpc_go "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -445,7 +447,7 @@ func TestAPIToken(t *testing.T) {
 	})
 }
 
-func TestInvokeService(t *testing.T) {
+func TestInvokeServiceFromHTTPResponse(t *testing.T) {
 	mockDirectMessaging := new(daprt.MockDirectMessaging)
 
 	// Setup Dapr API server
@@ -454,49 +456,108 @@ func TestInvokeService(t *testing.T) {
 		directMessaging: mockDirectMessaging,
 	}
 
-	t.Run("handle http response code", func(t *testing.T) {
-		fakeResp := invokev1.NewInvokeMethodResponse(404, "NotFound", nil)
-		fakeResp.WithRawData([]byte("fakeDirectMessageResponse"), "application/json")
+	var httpResponseTests = []struct {
+		status         int
+		statusMessage  string
+		grpcStatusCode codes.Code
+		grpcMessage    string
+		errHTTPCode    string
+		errHTTPMessage string
+	}{
+		{
+			status:         200,
+			statusMessage:  "Accepted",
+			grpcStatusCode: codes.OK,
+			grpcMessage:    "",
+			errHTTPCode:    "",
+			errHTTPMessage: "",
+		},
+		{
+			status:         201,
+			statusMessage:  "Accepted",
+			grpcStatusCode: codes.OK,
+			grpcMessage:    "",
+			errHTTPCode:    "",
+			errHTTPMessage: "",
+		},
+		{
+			status:         204,
+			statusMessage:  "Accepted",
+			grpcStatusCode: codes.OK,
+			grpcMessage:    "",
+			errHTTPCode:    "",
+			errHTTPMessage: "",
+		},
+		{
+			status:         404,
+			statusMessage:  "NotFound",
+			grpcStatusCode: codes.NotFound,
+			grpcMessage:    "Not Found",
+			errHTTPCode:    "404",
+			errHTTPMessage: "fakeDirectMessageResponse",
+		},
+	}
 
-		// Set up direct messaging mock
-		mockDirectMessaging.Calls = nil // reset call count
-		mockDirectMessaging.On("Invoke",
-			mock.AnythingOfType("*context.valueCtx"),
-			"fakeAppID",
-			mock.AnythingOfType("*v1.InvokeMethodRequest")).Return(fakeResp, nil).Once()
+	for _, tt := range httpResponseTests {
+		t.Run(fmt.Sprintf("handle http %d response code", tt.status), func(t *testing.T) {
+			fakeResp := invokev1.NewInvokeMethodResponse(int32(tt.status), tt.statusMessage, nil)
+			fakeResp.WithRawData([]byte(tt.errHTTPMessage), "application/json")
 
-		// Run test server
-		port, _ := freeport.GetFreePort()
-		server := startDaprAPIServer(port, fakeAPI, "")
-		defer server.Stop()
+			// Set up direct messaging mock
+			mockDirectMessaging.Calls = nil // reset call count
+			mockDirectMessaging.On("Invoke",
+				mock.AnythingOfType("*context.valueCtx"),
+				"fakeAppID",
+				mock.AnythingOfType("*v1.InvokeMethodRequest")).Return(fakeResp, nil).Once()
 
-		// Create gRPC test client
-		clientConn := createTestClient(port)
-		defer clientConn.Close()
+			// Run test server
+			port, _ := freeport.GetFreePort()
+			server := startDaprAPIServer(port, fakeAPI, "")
+			defer server.Stop()
 
-		// act
-		client := runtimev1pb.NewDaprClient(clientConn)
-		req := &runtimev1pb.InvokeServiceRequest{
-			Id: "fakeAppID",
-			Message: &commonv1pb.InvokeRequest{
-				Method: "fakeMethod",
-				Data:   &any.Any{Value: []byte("testData")},
-			},
-		}
-		_, err := client.InvokeService(context.Background(), req)
+			// Create gRPC test client
+			clientConn := createTestClient(port)
+			defer clientConn.Close()
 
-		// assert
-		mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 1)
-		s, ok := status.FromError(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.NotFound, s.Code())
-		assert.Equal(t, "Not Found", s.Message())
+			// act
+			client := runtimev1pb.NewDaprClient(clientConn)
+			req := &runtimev1pb.InvokeServiceRequest{
+				Id: "fakeAppID",
+				Message: &commonv1pb.InvokeRequest{
+					Method: "fakeMethod",
+					Data:   &any.Any{Value: []byte("testData")},
+				},
+			}
+			var header metadata.MD
+			_, err := client.InvokeService(context.Background(), req, grpc.Header(&header))
 
-		errInfo := s.Details()[0].(*epb.ErrorInfo)
-		assert.Equal(t, 1, len(s.Details()))
-		assert.Equal(t, "404", errInfo.Metadata["http.code"])
-		assert.Equal(t, "fakeDirectMessageResponse", errInfo.Metadata["http.error_message"])
-	})
+			// assert
+			mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 1)
+			s, ok := status.FromError(err)
+			assert.True(t, ok)
+			statusHeader := header.Get(daprHTTPStatusHeader)
+			assert.Equal(t, strconv.Itoa(tt.status), statusHeader[0])
+			assert.Equal(t, tt.grpcStatusCode, s.Code())
+			assert.Equal(t, tt.grpcMessage, s.Message())
+
+			if tt.errHTTPCode != "" {
+				errInfo := s.Details()[0].(*epb.ErrorInfo)
+				assert.Equal(t, 1, len(s.Details()))
+				assert.Equal(t, tt.errHTTPCode, errInfo.Metadata["http.code"])
+				assert.Equal(t, tt.errHTTPMessage, errInfo.Metadata["http.error_message"])
+			}
+		})
+	}
+}
+
+func TestInvokeServiceFromGRPCResponse(t *testing.T) {
+	mockDirectMessaging := new(daprt.MockDirectMessaging)
+
+	// Setup Dapr API server
+	fakeAPI := &api{
+		id:              "fakeAPI",
+		directMessaging: mockDirectMessaging,
+	}
 
 	t.Run("handle grpc response code", func(t *testing.T) {
 		fakeResp := invokev1.NewInvokeMethodResponse(

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -482,7 +482,7 @@ func TestInvokeServiceFromHTTPResponse(t *testing.T) {
 		},
 		{
 			status:         204,
-			statusMessage:  "Accepted",
+			statusMessage:  "No Content",
 			grpcStatusCode: codes.OK,
 			grpcMessage:    "",
 			errHTTPCode:    "",

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -270,8 +270,6 @@ func HTTPStatusFromCode(code codes.Code) int {
 // See: https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
 func CodeFromHTTPStatus(httpStatusCode int) codes.Code {
 	switch httpStatusCode {
-	case http.StatusOK:
-		return codes.OK
 	case http.StatusRequestTimeout:
 		return codes.Canceled
 	case http.StatusInternalServerError:
@@ -294,6 +292,10 @@ func CodeFromHTTPStatus(httpStatusCode int) codes.Code {
 		return codes.Unimplemented
 	case http.StatusServiceUnavailable:
 		return codes.Unavailable
+	}
+
+	if httpStatusCode >= 200 && httpStatusCode < 300 {
+		return codes.OK
 	}
 
 	return codes.Unknown

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -179,6 +179,14 @@ func TestErrorFromHTTPResponseCode(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("Created", func(t *testing.T) {
+		// act
+		err := ErrorFromHTTPResponseCode(201, "Created")
+
+		// assert
+		assert.NoError(t, err)
+	})
+
 	t.Run("NotFound", func(t *testing.T) {
 		// act
 		err := ErrorFromHTTPResponseCode(404, "Not Found")
@@ -191,20 +199,6 @@ func TestErrorFromHTTPResponseCode(t *testing.T) {
 		errInfo := (s.Details()[0]).(*epb.ErrorInfo)
 		assert.Equal(t, "404", errInfo.GetMetadata()[errorInfoHTTPCodeMetadata])
 		assert.Equal(t, "Not Found", errInfo.GetMetadata()[errorInfoHTTPErrorMetadata])
-	})
-
-	t.Run("Unknown", func(t *testing.T) {
-		// act
-		err := ErrorFromHTTPResponseCode(201, "Created")
-
-		// assert
-		s, ok := status.FromError(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.Unknown, s.Code())
-		assert.Equal(t, "Created", s.Message())
-		errInfo := (s.Details()[0]).(*epb.ErrorInfo)
-		assert.Equal(t, "201", errInfo.GetMetadata()[errorInfoHTTPCodeMetadata])
-		assert.Equal(t, "Created", errInfo.GetMetadata()[errorInfoHTTPErrorMetadata])
 	})
 
 	t.Run("Internal Server Error", func(t *testing.T) {


### PR DESCRIPTION
# Description

Return GRPC OK for 2xx http status code and populate `dapr-http-status` metadata header.

## Issue reference

#1700 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
