### PR TITLE
Remove default components dir

### DIFF
--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -9,8 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strconv"
 
 	global_config "github.com/dapr/dapr/pkg/config"
@@ -33,7 +31,7 @@ func FromFlags() (*DaprRuntime, error) {
 	appPort := flag.String("app-port", "", "The port the application is listening on")
 	profilePort := flag.String("profile-port", fmt.Sprintf("%v", DefaultProfilePort), "The port for the profile server")
 	appProtocol := flag.String("protocol", string(HTTPProtocol), "Protocol for the application: grpc or http")
-	componentsPath := flag.String("components-path", getDefaultComponentsPath(), "Path for components directory. Standalone mode only")
+	componentsPath := flag.String("components-path", "", "Path for components directory. Standalone mode only")
 	config := flag.String("config", "", "Path to config file, or name of a configuration object")
 	appID := flag.String("app-id", "", "A unique ID for Dapr. Used for Service Discovery and state")
 	controlPlaneAddress := flag.String("control-plane-address", "", "Address for a Dapr control plane")
@@ -149,17 +147,4 @@ func FromFlags() (*DaprRuntime, error) {
 		globalConfig = global_config.LoadDefaultConfiguration()
 	}
 	return NewDaprRuntime(runtimeConfig, globalConfig), nil
-}
-
-// getDefaultComponentsPath returns the hidden .components folder created at init time
-func getDefaultComponentsPath() string {
-	const daprDirName = ".dapr"
-	const daprWindowsOS = "windows"
-	const componentsDirName = "components"
-	daprDirPath := os.Getenv("HOME")
-	if runtime.GOOS == daprWindowsOS {
-		daprDirPath = os.Getenv("USERPROFILE")
-	}
-
-	return filepath.Join(daprDirPath, daprDirName, componentsDirName)
 }

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -31,7 +31,7 @@ func FromFlags() (*DaprRuntime, error) {
 	appPort := flag.String("app-port", "", "The port the application is listening on")
 	profilePort := flag.String("profile-port", fmt.Sprintf("%v", DefaultProfilePort), "The port for the profile server")
 	appProtocol := flag.String("protocol", string(HTTPProtocol), "Protocol for the application: grpc or http")
-	componentsPath := flag.String("components-path", "", "Path for components directory. Standalone mode only")
+	componentsPath := flag.String("components-path", "", "Path for components directory. If empty, components will not be loaded. Self-hosted mode only")
 	config := flag.String("config", "", "Path to config file, or name of a configuration object")
 	appID := flag.String("app-id", "", "A unique ID for Dapr. Used for Service Discovery and state")
 	controlPlaneAddress := flag.String("control-plane-address", "", "Address for a Dapr control plane")

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -776,7 +776,7 @@ func NewTestDaprRuntime(mode modes.DaprMode) *DaprRuntime {
 		"10.10.10.11",
 		DefaultAllowedOrigins,
 		"globalConfig",
-		getDefaultComponentsPath(),
+		"",
 		string(HTTPProtocol),
 		string(mode),
 		DefaultDaprHTTPPort,


### PR DESCRIPTION
As discussed, `daprd` currently assumes a default components directory.

This is wrong because the runtime assumes the location is the default dir that is set up by the Dapr CLI, which creates a coupling between the two.

This PR removes the default components directory and streamlines the default behavior consistency - parameters that are optional, such as components dir, do not mandate a default directory. This makes it more explicit for the users and puts the burden on tooling, and there's no need to read docs (or code) when trying to run `daprd` and wonder where it looks for the components dir by default.

/cc @amanbha @vinayada1 