### PR TITLE
Fix to check traceparent header in gRPC metadata for grpc-dotnet client

### DIFF
--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -71,31 +71,12 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 		if info.FullMethod != "/dapr.proto.runtime.v1.Dapr/InvokeService" {
 			traceContextBinary := propagation.Binary(span.SpanContext())
 			grpc.SetHeader(ctx, metadata.Pairs(grpcTraceContextKey, string(traceContextBinary)))
-
-			// add workaround to have traceparent header in gRPC response
-			// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
-			// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
-			spanContextToGRPCTraceparentMetadata(ctx, span.SpanContext())
 		}
 
 		UpdateSpanStatusFromGRPCError(span, err)
 		span.End()
 
 		return resp, err
-	}
-}
-
-// spanContextToGRPCTraceparentMetadata adds the spancontext in traceparent and tracestate headers in gRPC metadata.
-func spanContextToGRPCTraceparentMetadata(ctx context.Context, sc trace.SpanContext) {
-	// if sc is empty context, no ops.
-	if (trace.SpanContext{}) == sc {
-		return
-	}
-	h := SpanContextToW3CString(sc)
-	grpc.SetHeader(ctx, metadata.Pairs(traceparentHeader, h))
-	t := TraceStateToW3CString(sc)
-	if t != "" && len(t) <= maxTracestateLen {
-		grpc.SetHeader(ctx, metadata.Pairs(tracestateHeader, t))
 	}
 }
 
@@ -142,6 +123,9 @@ func SpanContextFromIncomingGRPCMetadata(ctx context.Context) (trace.SpanContext
 		traceContextBinary := []byte(traceContext[0])
 		sc, ok = propagation.FromBinary(traceContextBinary)
 	} else {
+		// add workaround to fallback on checking traceparent header
+		// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
+		// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
 		traceContext = md[traceparentHeader]
 		if len(traceContext) > 0 {
 			sc, ok = SpanContextFromW3CString(traceContext[0])

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -72,7 +72,7 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 			traceContextBinary := propagation.Binary(span.SpanContext())
 			grpc.SetHeader(ctx, metadata.Pairs(grpcTraceContextKey, string(traceContextBinary)))
 
-			// add short term fix to have traceparent header in gRPC response
+			// add workaround to have traceparent header in gRPC response
 			// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
 			// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
 			spanContextToGRPCTraceparentMetadata(ctx, span.SpanContext())

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -126,6 +126,7 @@ func SpanContextFromIncomingGRPCMetadata(ctx context.Context) (trace.SpanContext
 		// add workaround to fallback on checking traceparent header
 		// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
 		// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
+		// TODO : Remove this workaround fix once grpc-dotnet supports grpc-trace-bin header. Tracking issue https://github.com/dapr/dapr/issues/1827
 		traceContext = md[traceparentHeader]
 		if len(traceContext) > 0 {
 			sc, ok = SpanContextFromW3CString(traceContext[0])

--- a/pkg/diagnostics/http_tracing.go
+++ b/pkg/diagnostics/http_tracing.go
@@ -179,16 +179,9 @@ func SpanContextToHTTPHeaders(sc trace.SpanContext, setHeader func(string, strin
 }
 
 func tracestateToHeader(sc trace.SpanContext, setHeader func(string, string)) {
-	var pairs = make([]string, 0, len(sc.Tracestate.Entries()))
-	if sc.Tracestate != nil {
-		for _, entry := range sc.Tracestate.Entries() {
-			pairs = append(pairs, strings.Join([]string{entry.Key, entry.Value}, "="))
-		}
-		h := strings.Join(pairs, ",")
-
-		if h != "" && len(h) <= maxTracestateLen {
-			setHeader(tracestateHeader, h)
-		}
+	h := TraceStateToW3CString(sc)
+	if h != "" && len(h) <= maxTracestateLen {
+		setHeader(tracestateHeader, h)
 	}
 }
 

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -70,6 +70,19 @@ func SpanContextToW3CString(sc trace.SpanContext) string {
 		[]byte{byte(sc.TraceOptions)})
 }
 
+// TraceStateToW3CString extracts the TraceState from given SpanContext and returns its string representation
+func TraceStateToW3CString(sc trace.SpanContext) string {
+	var pairs = make([]string, 0, len(sc.Tracestate.Entries()))
+	var h string
+	if sc.Tracestate != nil {
+		for _, entry := range sc.Tracestate.Entries() {
+			pairs = append(pairs, strings.Join([]string{entry.Key, entry.Value}, "="))
+		}
+		h = strings.Join(pairs, ",")
+	}
+	return h
+}
+
 // SpanContextFromW3CString extracts a span context from given string which got earlier from SpanContextToW3CString format
 func SpanContextFromW3CString(h string) (sc trace.SpanContext, ok bool) {
 	if h == "" {

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/tracestate"
+)
+
+func TestSpanContextToW3CString(t *testing.T) {
+	t.Run("empty SpanContext", func(t *testing.T) {
+		expected := "00-00000000000000000000000000000000-0000000000000000-00"
+		sc := trace.SpanContext{}
+		got := SpanContextToW3CString(sc)
+		assert.Equal(t, expected, got)
+	})
+	t.Run("valid SpanContext", func(t *testing.T) {
+		expected := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+		sc := trace.SpanContext{
+			TraceID:      trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
+			SpanID:       trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
+			TraceOptions: trace.TraceOptions(1)}
+		got := SpanContextToW3CString(sc)
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestTraceStateToW3CString(t *testing.T) {
+	t.Run("empty Tracestate", func(t *testing.T) {
+		sc := trace.SpanContext{}
+		got := TraceStateToW3CString(sc)
+		assert.Empty(t, got)
+	})
+	t.Run("valid Tracestate", func(t *testing.T) {
+		entry := tracestate.Entry{Key: "key", Value: "value"}
+		ts, _ := tracestate.New(nil, entry)
+		sc := trace.SpanContext{}
+		sc.Tracestate = ts
+		got := TraceStateToW3CString(sc)
+		assert.Equal(t, "key=value", got)
+	})
+}

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -383,7 +383,7 @@ func processGRPCToGRPCTraceHeader(ctx context.Context, md metadata.MD, grpctrace
 		span := diag_utils.SpanFromContext(ctx)
 		sc := span.SpanContext()
 		md.Set(tracebinMetadata, string(propagation.Binary(sc)))
-		// add short term fix to have traceparent header in gRPC response
+		// add workaround to have traceparent header in gRPC response
 		// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
 		// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
 		addTraceParentHeadersInMetadata(sc, md)
@@ -391,7 +391,7 @@ func processGRPCToGRPCTraceHeader(ctx context.Context, md metadata.MD, grpctrace
 		decoded, err := base64.StdEncoding.DecodeString(grpctracebinValue)
 		if err == nil {
 			md.Set(tracebinMetadata, string(decoded))
-			// adding short term fix to have traceparent header in gRPC response as mentioned in above comment
+			// adding workaround to have traceparent header in gRPC response as mentioned in above comment
 			sc, _ := propagation.FromBinary(decoded)
 			addTraceParentHeadersInMetadata(sc, md)
 		}

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -383,26 +383,10 @@ func processGRPCToGRPCTraceHeader(ctx context.Context, md metadata.MD, grpctrace
 		span := diag_utils.SpanFromContext(ctx)
 		sc := span.SpanContext()
 		md.Set(tracebinMetadata, string(propagation.Binary(sc)))
-		// add workaround to have traceparent header in gRPC response
-		// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
-		// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
-		addTraceParentHeadersInMetadata(sc, md)
 	} else {
 		decoded, err := base64.StdEncoding.DecodeString(grpctracebinValue)
 		if err == nil {
 			md.Set(tracebinMetadata, string(decoded))
-			// adding workaround to have traceparent header in gRPC response as mentioned in above comment
-			sc, _ := propagation.FromBinary(decoded)
-			addTraceParentHeadersInMetadata(sc, md)
 		}
-	}
-}
-
-func addTraceParentHeadersInMetadata(sc trace.SpanContext, md metadata.MD) {
-	h := diag.SpanContextToW3CString(sc)
-	md.Set(traceparentHeader, h)
-	t := diag.TraceStateToW3CString(sc)
-	if t != "" {
-		md.Set(tracestateHeader, t)
 	}
 }

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -154,12 +154,7 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 
 	t.Run("with grpc header conversion for grpc headers", func(t *testing.T) {
 		convertedMD := InternalMetadataToGrpcMetadata(ctx, grpcMetadata, true)
-		// TODO remove this workaround fix
-		// We need to add workaround to have traceparent header in gRPC response
-		// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
-		// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
-		// so expected header will be 1 extra traceparent header in this test case - so expected length 9
-		assert.Equal(t, 9, convertedMD.Len())
+		assert.Equal(t, 8, convertedMD.Len())
 		assert.Equal(t, "localhost", convertedMD[":authority"][0])
 		assert.Equal(t, "1S", convertedMD["grpc-timeout"][0])
 		assert.Equal(t, "gzip, deflate", convertedMD["grpc-encoding"][0])

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -154,7 +154,12 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 
 	t.Run("with grpc header conversion for grpc headers", func(t *testing.T) {
 		convertedMD := InternalMetadataToGrpcMetadata(ctx, grpcMetadata, true)
-		assert.Equal(t, 8, convertedMD.Len())
+		// TODO remove short term fix
+		// We need to add short term fix to have traceparent header in gRPC response
+		// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
+		// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
+		// so expected header will be 1 extra traceparent header in this test case - so expected length 9
+		assert.Equal(t, 9, convertedMD.Len())
 		assert.Equal(t, "localhost", convertedMD[":authority"][0])
 		assert.Equal(t, "1S", convertedMD["grpc-timeout"][0])
 		assert.Equal(t, "gzip, deflate", convertedMD["grpc-encoding"][0])

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -154,8 +154,8 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 
 	t.Run("with grpc header conversion for grpc headers", func(t *testing.T) {
 		convertedMD := InternalMetadataToGrpcMetadata(ctx, grpcMetadata, true)
-		// TODO remove short term fix
-		// We need to add short term fix to have traceparent header in gRPC response
+		// TODO remove this workaround fix
+		// We need to add workaround to have traceparent header in gRPC response
 		// as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus , tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
 		// and grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
 		// so expected header will be 1 extra traceparent header in this test case - so expected length 9


### PR DESCRIPTION
# Description

Adding workaround fix to have `traceparent` header in gRPC response as grpc-trace-bin is not yet there in OpenTelemetry unlike OpenCensus .  

grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC calls.

This will enable Dapr dotnet-SDK to use W3C Trace Context feature built in ASP.NET Core and .NET Core 3.0 + .

## Issue reference
Closes #1824 
https://github.com/dapr/dapr/issues/1711
https://github.com/dapr/dotnet-sdk/issues/300

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
