### PR TITLE
Fix race condition causing reminders to get fired multiple times [#973]

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -7,10 +7,11 @@ package actors
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	nethttp "net/http"
 	"strings"
 	"sync"
@@ -955,7 +956,8 @@ func (a *actorsRuntime) CreateReminder(ctx context.Context, req *CreateReminderR
 	actorKey := a.constructCompositeKey(req.ActorType, req.ActorID)
 	reminderKey := a.constructCompositeKey(actorKey, req.Name)
 	stop := make(chan bool, 1)
-	reminderID := rand.Int()
+	id, _ := rand.Int(rand.Reader, big.NewInt(5000))
+	reminderID := int(id.Int64())
 	activeReminder := ActiveReminder{
 		ID:       reminderID,
 		StopChan: stop,

--- a/pkg/actors/reminder.go
+++ b/pkg/actors/reminder.go
@@ -7,6 +7,7 @@ package actors
 
 // Reminder represents a persisted reminder for a unique actor
 type Reminder struct {
+	ReminderID     int         `json:"reminderID"`
 	ActorID        string      `json:"actorID,omitempty"`
 	ActorType      string      `json:"actorType,omitempty"`
 	Name           string      `json:"name,omitempty"`
@@ -14,4 +15,10 @@ type Reminder struct {
 	Period         string      `json:"period"`
 	DueTime        string      `json:"dueTime"`
 	RegisteredTime string      `json:"registeredTime,omitempty"`
+}
+
+// ActiveReminder info cached in memory
+type ActiveReminder struct {
+	ID       int       `json:"reminderID"`
+	StopChan chan bool `json:"stopChannel"`
 }


### PR DESCRIPTION
# Description

When reminder is registered with different parameters multiple times in quick succession, there was a race condition causing the old values of reminder to be fired as well as the new. Fixed this code.

#973 

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #973 
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
