### PR TITLE
Add HA global config to helm charts [#1818]

### DIFF
--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     app: dapr-dashboard
 spec:
+{{- if eq .Values.global.ha.enabled true }}
+  replicas: {{ .Values.global.ha.replicaCount }}
+{{- else }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   selector:
     matchLabels:
       app: dapr-dashboard
@@ -14,6 +18,18 @@ spec:
       labels:
         app: dapr-dashboard
     spec:
+{{- if eq .Values.global.ha.enabled true }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - dapr-dashboard
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - name: dapr-dashboard
 {{- if contains "/" .Values.image.name }}

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     app: dapr-operator
 spec:
+{{- if eq .Values.global.ha.enabled true }}
+  replicas: {{ .Values.global.ha.replicaCount }}
+{{- else }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   selector:
     matchLabels:
       app: dapr-operator
@@ -20,6 +24,18 @@ spec:
         prometheus.io/path: "/"
 {{- end }}
     spec:
+{{- if eq .Values.global.ha.enabled true }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - dapr-operator
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - name: dapr-operator
         livenessProbe:

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -6,11 +6,7 @@ metadata:
   labels:
     app: dapr-placement
 spec:
-{{- if eq .Values.global.ha.enabled true }}
-  replicas: {{ .Values.global.ha.replicaCount }}
-{{- else }}
   replicas: {{ .Values.replicaCount }}
-{{- end }}
   selector:
     matchLabels:
       app: dapr-placement

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     app: dapr-placement
 spec:
+{{- if eq .Values.global.ha.enabled true }}
+  replicas: {{ .Values.global.ha.replicaCount }}
+{{- else }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   selector:
     matchLabels:
       app: dapr-placement
@@ -21,6 +25,18 @@ spec:
         prometheus.io/path: "/"
 {{- end }}
     spec:
+{{- if eq .Values.global.ha.enabled true }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - dapr-placement
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - name: dapr-placement
         livenessProbe:

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -16,7 +16,11 @@ metadata:
   labels:
     app: dapr-sentry
 spec:
+{{- if eq .Values.global.ha.enabled true }}
+  replicas: {{ .Values.global.ha.replicaCount }}
+{{- else }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   selector:
     matchLabels:
       app: dapr-sentry
@@ -31,6 +35,18 @@ spec:
         prometheus.io/path: "/"
 {{- end }}
     spec:
+{{- if eq .Values.global.ha.enabled true }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - dapr-sentry
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - name: dapr-sentry
         livenessProbe:

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     app: dapr-sidecar-injector
 spec:
-  replicas: {{ .Values.replicaCount }}
+{{- if eq .Values.global.ha.enabled true }}
+  replicas: {{ .Values.global.ha.replicaCount }}
+{{- end }}
   selector:
     matchLabels:
       app: dapr-sidecar-injector
@@ -21,6 +23,18 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: dapr-operator
+{{- if eq .Values.global.ha.enabled true }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - dapr-sidecar-injector
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - name: dapr-sidecar-injector
         livenessProbe:

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -4,6 +4,9 @@ global:
   logAsJson: false
   imagePullPolicy: Always
   imagePullSecrets: ""
+  ha:
+    enabled: true
+    replicaCount: 3
   prometheus:
     enabled: true
     port: 9090


### PR DESCRIPTION
# Description

Added HA global config to helm charts that controls replicaCount and pod anti-affinity

#1818 

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1818 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
