### PR TITLE
Clone appchannel response body to prevent GC

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
 github.com/dapr/components-contrib v0.2.4 h1:tglSWgiZolaLyZ7yxzC9x+UsR2njEPb9fn7vrjNVvyU=
+github.com/dapr/components-contrib v0.2.4/go.mod h1:JSMSHTHQEcLgv7MZKIbKbHXgudogZfIjEkZMmn7nJwQ=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad h1:RKWoYovBc+B9ltvjtZLMnbu49stSucH8rZze3MeqyvQ=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad/go.mod h1:yeOIFBz6+BigHpk4ASJbgQDVjQ8+00oCWrFyOAFdob8=

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -86,10 +86,8 @@ func (imr *InvokeMethodRequest) WithRawData(data []byte, contentType string) *In
 	if contentType == "" {
 		contentType = JSONContentType
 	}
-
 	imr.r.Message.ContentType = contentType
 	imr.r.Message.Data = &any.Any{Value: data}
-
 	return imr
 }
 

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -86,8 +86,11 @@ func (imr *InvokeMethodRequest) WithRawData(data []byte, contentType string) *In
 	if contentType == "" {
 		contentType = JSONContentType
 	}
+
+	// Clone data to prevent GC from deallocating data
+	imr.r.Message.Data = &any.Any{Value: cloneBytes(data)}
 	imr.r.Message.ContentType = contentType
-	imr.r.Message.Data = &any.Any{Value: data}
+
 	return imr
 }
 

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -87,9 +87,8 @@ func (imr *InvokeMethodRequest) WithRawData(data []byte, contentType string) *In
 		contentType = JSONContentType
 	}
 
-	// Clone data to prevent GC from deallocating data
-	imr.r.Message.Data = &any.Any{Value: cloneBytes(data)}
 	imr.r.Message.ContentType = contentType
+	imr.r.Message.Data = &any.Any{Value: data}
 
 	return imr
 }

--- a/pkg/messaging/v1/invoke_method_response.go
+++ b/pkg/messaging/v1/invoke_method_response.go
@@ -54,7 +54,9 @@ func (imr *InvokeMethodResponse) WithRawData(data []byte, contentType string) *I
 	}
 
 	imr.r.Message.ContentType = contentType
-	imr.r.Message.Data = &any.Any{Value: data}
+
+	// Clone data to prevent GC from deallocating data
+	imr.r.Message.Data = &any.Any{Value: cloneBytes(data)}
 
 	return imr
 }

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -388,3 +388,12 @@ func processGRPCToGRPCTraceHeader(ctx context.Context, md metadata.MD, grpctrace
 		}
 	}
 }
+
+func cloneBytes(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+	cloneData := make([]byte, len(data))
+	copy(cloneData, data)
+	return cloneData
+}

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -253,3 +253,23 @@ func TestErrorFromInternalStatus(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, expected, actual)
 }
+
+func TestCloneBytes(t *testing.T) {
+	t.Run("data is nil", func(t *testing.T) {
+		assert.Nil(t, cloneBytes(nil))
+	})
+
+	t.Run("data is empty", func(t *testing.T) {
+		orig := []byte{}
+
+		assert.Equal(t, orig, cloneBytes(orig))
+		assert.NotSame(t, orig, cloneBytes(orig))
+	})
+
+	t.Run("data is not empty", func(t *testing.T) {
+		orig := []byte("fakedata")
+
+		assert.Equal(t, orig, cloneBytes(orig))
+		assert.NotSame(t, orig, cloneBytes(orig))
+	})
+}


### PR DESCRIPTION
# Description

Clone appchannel response body to prevent GC

## Root cause: 

I dump tcp packets of server and client side with wireshark
> You can open the captured packets on wireshark by downloading this [high_freq.pcapng.gz](https://github.com/dapr/python-sdk/files/4963842/high_freq.pcapng.gz)

Based on the investigation, actorservice returned correct json format response when proxy called actor and its method. but when dapr sidecar for actor client returned the corrupted response data to proxy client.

For example, two invocation requests, such as A and B, come to dapr sidecar for invocation in a row with almost several ns time gap, where A comes first and B next. actorservice returns the response for B and then response for A. but B's response body is same as A's response body, but no header change. B's headers are not changed and content-length is correct for B's original body. 

so when proxy tried to deserialize B's response body, it was failed because B's response body was A's and B's data was truncated or B's data included garbage data.

## Fix

To prevent GC from deallocating response body by `ReleaseResponse` before returning data over internal grpc channel, this fix clones the body payload and sends it to the internal grpc channel response.

https://github.com/dapr/dapr/blob/eaf2cad054fd918b382aab756f23870ab2966257/pkg/channel/http/http_channel.go#L106

## Issue reference

#1833

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
