### PR TITLE
Fix env in running e2e locally doc

### DIFF
--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -18,13 +18,13 @@ E2E tests are designed for verifying the functional correctness by replicating e
     ```
 * Set the environment variables
     ```bash
-    export DAPR_TEST_REGISTRY=docker.io/your_dockerhub_id
-    export DAPR_TEST_TAG=dev
+    export DAPR_REGISTRY=docker.io/your_dockerhub_id
+    export DAPR_TAG=dev
     export DAPR_NAMESPACE=dapr-tests
 
     # Do not set DAPR_TEST_ENV if you do not use minikube
     export DAPR_TEST_ENV=minikube
-    
+
     # Set the below environment variables if you want to use the different registry and tag for test apps
     # export DAPR_TEST_REGISTRY=docker.io/your_dockerhub_id
     # export DARP_TEST_TAG=dev
@@ -33,8 +33,8 @@ E2E tests are designed for verifying the functional correctness by replicating e
     ```bash
     make setup-helm-init
     make setup-test-env-redis
-    
-    # This may take a few minutes.  You can skip kafka install if you do not use bindings for your tests.  
+
+    # This may take a few minutes.  You can skip kafka install if you do not use bindings for your tests.
     make setup-test-env-kafka
     ```
 


### PR DESCRIPTION
# Description

The environment variables `DAPR_REGISTRY`/`DAPR_TAG` are required,
and `DAPR_TEST_REGISTRY`/`DARP_TEST_TAG` are optional and derived from
`DAPR_REGISTRY`/`DAPR_TAG` if absent.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1844 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
