### PR TITLE
Add linux node affinity to dapr_dashboard helm chart (#1846)

### DIFF
--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
@@ -18,8 +18,17 @@ spec:
       labels:
         app: dapr-dashboard
     spec:
-{{- if eq .Values.global.ha.enabled true }}
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                  - {{ .Values.global.daprControlPlaneOs }}
+{{- if eq .Values.global.ha.enabled true }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:


### PR DESCRIPTION
# Description

Updated dapr-dashboard helm chart
## Issue reference

Please reference the issue this PR will close: #1846

## Manual Test
```bash
willardstanley@MININT-2KH1IKT cli % kubectl get pods
NAME                                     READY   STATUS    RESTARTS   AGE
dapr-dashboard-7b48557b9f-gskjg          1/1     Running   0          15s
dapr-operator-7b57d884cd-4vhj9           0/1     Running   0          15s
dapr-placement-86b76f6545-blb84          1/1     Running   0          15s
dapr-sentry-7c7bf75d8b-c2g9t             1/1     Running   0          15s
dapr-sidecar-injector-7b847db96f-vjcsr   1/1     Running   0          15s
```

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
