### PR TITLE
Enable placement lock when updating tables

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -232,14 +232,14 @@ func (a *actorsRuntime) startDeactivationTicker(interval, actorIdleTimeout time.
 }
 
 func (a *actorsRuntime) Call(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
+	if a.placementBlock {
+		<-a.placementSignal
+	}
+
 	actor := req.Actor()
 	targetActorAddress, appID := a.lookupActorAddress(actor.GetActorType(), actor.GetActorId())
 	if targetActorAddress == "" {
 		return nil, fmt.Errorf("error finding address for actor type %s with id %s", actor.GetActorType(), actor.GetActorId())
-	}
-
-	if a.placementBlock {
-		<-a.placementSignal
 	}
 
 	var resp *invokev1.InvokeMethodResponse
@@ -596,6 +596,9 @@ func (a *actorsRuntime) unblockPlacements() {
 }
 
 func (a *actorsRuntime) updatePlacements(in *placementv1pb.PlacementTables) {
+	a.placementTableLock.Lock()
+	defer a.placementTableLock.Unlock()
+
 	if in.Version != a.placementTables.Version {
 		for k, v := range in.Entries {
 			loadMap := map[string]*placement.Host{}
@@ -611,7 +614,7 @@ func (a *actorsRuntime) updatePlacements(in *placementv1pb.PlacementTables) {
 
 		log.Info("actors: placement tables updated")
 
-		go a.evaluateReminders()
+		a.evaluateReminders()
 	}
 }
 
@@ -727,9 +730,9 @@ func (a *actorsRuntime) evaluateReminders() {
 }
 
 func (a *actorsRuntime) lookupActorAddress(actorType, actorID string) (string, string) {
-	// read lock for table map
-	a.placementTableLock.RLock()
-	defer a.placementTableLock.RUnlock()
+	if a.placementTables == nil {
+		return "", ""
+	}
 
 	t := a.placementTables.Entries[actorType]
 	if t == nil {


### PR DESCRIPTION
Might fix https://github.com/dapr/dapr/issues/1732

This PR does the following:

1. Places missing lock when updating the table entries
2. Removes redundant read lock from the method that looks up the actor address
3. When invoking an actor, moves the block-when-updating before the actor address is looked up
4. Adds a safety check for an empty placement table in case a call came to invoke an actor before an initial placement update occurred
5. makes the placement update operation finish only after reminders have been finalized