### PR TITLE
log token authentication + log consistency

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -137,19 +137,19 @@ func (s *server) generateWorkloadCert() error {
 
 func (s *server) getMiddlewareOptions() []grpc_go.ServerOption {
 	opts := []grpc_go.ServerOption{}
-
-	s.logger.Infof("enabled monitoring middleware")
-
 	intr := []grpc_go.UnaryServerInterceptor{}
 
 	if diag_utils.IsTracingEnabled(s.tracingSpec.SamplingRate) {
+		s.logger.Info("enabled gRPC tracing middleware")
 		intr = append(intr, diag.GRPCTraceUnaryServerInterceptor(s.config.AppID, s.tracingSpec))
 	}
 
 	if diag.DefaultGRPCMonitoring.IsEnabled() {
+		s.logger.Info("enabled gRPC metrics middleware")
 		intr = append(intr, diag.DefaultGRPCMonitoring.UnaryServerInterceptor())
 	}
 	if s.authToken != "" {
+		s.logger.Info("enabled token authentication on gRPC server")
 		intr = append(intr, setAPIAuthenticationMiddlewareUnary(s.authToken, auth.APITokenHeader))
 	}
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -108,6 +108,8 @@ func useAPIAuthentication(next fasthttp.RequestHandler) fasthttp.RequestHandler 
 	if token == "" {
 		return next
 	}
+	log.Info("enabled token authentication on http server")
+
 	return func(ctx *fasthttp.RequestCtx) {
 		v := ctx.Request.Header.Peek(auth.APITokenHeader)
 		if auth.ExcludedRoute(string(ctx.Request.URI().FullURI())) || string(v) == token {


### PR DESCRIPTION
Closes #1854

This PR does the following:

1. logs when token based auth is enabled (both http/gRPC)
2. cleans up server logs and makes tracing/metrics messages consistent