### PR TITLE
Allow to disable tracing for perf tests

### DIFF
--- a/tests/config/dapr_observability_off_config.yaml
+++ b/tests/config/dapr_observability_off_config.yaml
@@ -1,0 +1,7 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: disable-observability
+spec:
+  tracing:
+    samplingRate: "0"

--- a/tests/config/dapr_telemetry_off_config.yaml
+++ b/tests/config/dapr_telemetry_off_config.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: disable-observability
+  name: disable-telemetry
 spec:
   tracing:
     samplingRate: "0"

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -130,8 +130,12 @@ setup-test-env-kafka:
 setup-test-env: setup-test-env-kafka setup-test-env-redis
 
 # Apply default config yaml to turn mTLS off for testing (mTLS is enabled by default)
-setup-test-config:
+setup-disable-mtls:
 	$(KUBECTL) apply -f ./tests/config/dapr_mtls_off_config.yaml --namespace $(DAPR_TEST_NAMESPACE)
+
+# Apply default config yaml to turn tracing off for testing (tracing is enabled by default)
+setup-app-configurations:
+	$(KUBECTL) apply -f ./tests/config/dapr_observability_off_config.yaml --namespace $(DAPR_TEST_NAMESPACE)
 
 # Apply component yaml for state, secrets, pubsub, and bindings
 setup-test-components:

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -135,7 +135,7 @@ setup-disable-mtls:
 
 # Apply default config yaml to turn tracing off for testing (tracing is enabled by default)
 setup-app-configurations:
-	$(KUBECTL) apply -f ./tests/config/dapr_observability_off_config.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/dapr_telemetry_off_config.yaml --namespace $(DAPR_TEST_NAMESPACE)
 
 # Apply component yaml for state, secrets, pubsub, and bindings
 setup-test-components:

--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -59,7 +59,7 @@ make docker-deploy-k8s
 ### Optional: Apply this configuration to disable mTLS
 
 ```bash
-make setup-test-config
+make setup-disable-mtls
 ```
 
 ### Register the default component configurations for testing

--- a/tests/docs/running-perf-tests.md
+++ b/tests/docs/running-perf-tests.md
@@ -67,7 +67,7 @@ make setup-app-configurations
 ### Optional: Disable tracing
 
 ```bash
-export DAPR_DISABLE_OBSERVABILITY=true
+export DAPR_DISABLE_TELEMETRY=true
 ```
 
 ### Optional: Apply this configuration to disable mTLS

--- a/tests/docs/running-perf-tests.md
+++ b/tests/docs/running-perf-tests.md
@@ -58,10 +58,22 @@ make docker-push
 make docker-deploy-k8s
 ```
 
+### Register app configurations
+
+```bash
+make setup-app-configurations
+```
+
+### Optional: Disable tracing
+
+```bash
+export DAPR_DISABLE_OBSERVABILITY=true
+```
+
 ### Optional: Apply this configuration to disable mTLS
 
 ```bash
-make setup-test-config
+make setup-disable-mtls
 ```
 
 ### Build and push test apps to docker hub

--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -16,4 +16,5 @@ type AppDescription struct {
 	Replicas       int32
 	IngressEnabled bool
 	MetricsPort    string
+	Config         string
 }

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -58,6 +58,9 @@ func buildDeploymentObject(namespace string, appDesc AppDescription) *appsv1.Dep
 	if appDesc.MetricsPort != "" {
 		annotationObject["dapr.io/metrics-port"] = appDesc.MetricsPort
 	}
+	if appDesc.Config != "" {
+		annotationObject["dapr.io/config"] = appDesc.Config
+	}
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	defaultImageRegistry       = "docker.io/dapriotest"
-	defaultImageTag            = "latest"
-	disableObservabilityConfig = "disable-observability"
+	defaultImageRegistry   = "docker.io/dapriotest"
+	defaultImageTag        = "latest"
+	disableTelemetryConfig = "disable-telemetry"
 )
 
 // KubeTestPlatform includes K8s client for testing cluster and kubernetes testing apps.
@@ -81,7 +81,7 @@ func (c *KubeTestPlatform) addApps(apps []kube.AppDescription) error {
 		return fmt.Errorf("kubernetes cluster needs to be setup before calling BuildAppResources")
 	}
 
-	do := c.disableObservability()
+	dt := c.disableTelemetry()
 
 	for _, app := range apps {
 		if app.RegistryName == "" {
@@ -92,8 +92,8 @@ func (c *KubeTestPlatform) addApps(apps []kube.AppDescription) error {
 		}
 		app.ImageName = fmt.Sprintf("%s:%s", app.ImageName, c.imageTag())
 
-		if do {
-			app.Config = disableObservabilityConfig
+		if dt {
+			app.Config = disableTelemetryConfig
 		}
 
 		log.Printf("Adding app %v", app)
@@ -124,8 +124,8 @@ func (c *KubeTestPlatform) imageTag() string {
 	return tag
 }
 
-func (c *KubeTestPlatform) disableObservability() bool {
-	disableVal := os.Getenv("DAPR_DISABLE_OBSERVABILITY")
+func (c *KubeTestPlatform) disableTelemetry() bool {
+	disableVal := os.Getenv("DAPR_DISABLE_TELEMETRY")
 	disable, err := strconv.ParseBool(disableVal)
 	if err != nil {
 		return false

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	defaultImageRegistry = "docker.io/dapriotest"
-	defaultImageTag      = "latest"
+	defaultImageRegistry       = "docker.io/dapriotest"
+	defaultImageTag            = "latest"
 	disableObservabilityConfig = "disable-observability"
 )
 


### PR DESCRIPTION
This PR does the following:

Partially resolves #1429 

1. Adds ability to turn off observability (currently tracing only until Dapr supports turning off metrics) for perf tests
2. Changes name of `setup-test-config` to a more clear name: `setup-disable-mtls`.