### PR TITLE
Default to linux/amd64 docker containers for E2E tests (#1884)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ else
 endif
 export GOOS ?= $(TARGET_OS_LOCAL)
 
+# Default docker container and e2e test targst.
+TARGET_OS ?= linux
+TARGET_ARCH ?= amd64
+
 ifeq ($(GOOS),windows)
 BINARY_EXT_LOCAL:=.exe
 GOLANGCI_LINT:=golangci-lint.exe

--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -21,8 +21,9 @@ E2E tests are designed for verifying the functional correctness by replicating e
     export DAPR_REGISTRY=docker.io/your_dockerhub_id
     export DAPR_TAG=dev
     export DAPR_NAMESPACE=dapr-tests
-    export TARGET_OS=linux
-    export TARGET_ARCH=amd64
+    # If you want to run tests against windows or arm, uncomment and set these
+    # export TARGET_OS=linux
+    # export TARGET_ARCH=amd64
 
     # Do not set DAPR_TEST_ENV if you do not use minikube
     export DAPR_TEST_ENV=minikube


### PR DESCRIPTION
# Description

We now default to linux/amd64 for TARGET_OS/TARGET_ARCH rather than making them required fields.

## Issue reference

Please reference the issue this PR will close: #1884

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
