### PR TITLE
Dashboard deployment fix

### DIFF
--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
@@ -41,11 +41,7 @@ spec:
 {{- end }}
       containers:
       - name: dapr-dashboard
-{{- if contains "/" .Values.image.name }}
-        image: "{{ .Values.image.name }}"
-{{- else }}
-        image: "{{ .Values.global.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-{{- end }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         env:
         - name: NAMESPACE

--- a/charts/dapr/charts/dapr_dashboard/values.yaml
+++ b/charts/dapr/charts/dapr_dashboard/values.yaml
@@ -2,6 +2,7 @@ replicaCount: 1
 logLevel: info
 
 image:
+  registry: docker.io/daprio
   name: dashboard
   tag: "0.1.0"
 


### PR DESCRIPTION
# Description

* Dashboard pod will now always use the global docker.io/daprio/dashboard:<tag> image

## Issue reference

Closes #1878 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
