### PR TITLE
fix the grpc client method and status tags always empty

### DIFF
--- a/pkg/diagnostics/grpc_monitoring.go
+++ b/pkg/diagnostics/grpc_monitoring.go
@@ -168,7 +168,7 @@ func (g *grpcMetrics) ClientRequestSent(ctx context.Context, method string, cont
 	if g.enabled {
 		stats.RecordWithTags(
 			ctx,
-			diag_utils.WithTags(appIDKey, g.appID, KeyServerMethod, method),
+			diag_utils.WithTags(appIDKey, g.appID, KeyClientMethod, method),
 			g.clientSentBytes.M(contentSize))
 	}
 
@@ -180,7 +180,7 @@ func (g *grpcMetrics) ClientRequestRecieved(ctx context.Context, method, status 
 		elapsed := float64(time.Since(start) / time.Millisecond)
 		stats.RecordWithTags(
 			ctx,
-			diag_utils.WithTags(appIDKey, g.appID, KeyServerMethod, method, KeyServerStatus, status),
+			diag_utils.WithTags(appIDKey, g.appID, KeyClientMethod, method, KeyClientStatus, status),
 			g.clientRoundtripLatency.M(elapsed))
 		stats.RecordWithTags(
 			ctx, diag_utils.WithTags(appIDKey, g.appID),


### PR DESCRIPTION
# Description

The `grpc_client_method` and `grpc_client_status` tags of `dapr_grpc_io_client_xx` metrics are always empty

## Issue reference

fix #1900 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
