### PR TITLE
Fail state test if result has empty state

### DIFF
--- a/tests/e2e/stateapp/stateapp_test.go
+++ b/tests/e2e/stateapp/stateapp_test.go
@@ -377,6 +377,7 @@ func TestStateTransactionApps(t *testing.T) {
 							require.True(t, reflect.DeepEqual(er.Key, ri.Key))
 
 							if er.Value != nil {
+								require.NotNil(ri.Value)
 								require.True(t, reflect.DeepEqual(er.Value.Data, ri.Value.Data))
 							}
 						}


### PR DESCRIPTION
This PR makes the state test fail if a non-empty result is expected but the result comes back empty.

Currently the test will panic, this PR makes the test fail gracefully.

Related to https://github.com/dapr/dapr/pull/1905#issuecomment-674106924.