### PR TITLE
Add windows e2e tests to CI/CD (#1906)

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -12,18 +12,29 @@ on:
 
 jobs:
   test-e2e:
-    name: end-to-end tests
-    runs-on: ubuntu-latest
+    name: end-to-end  ${{ matrix.target_os }}_${{ matrix.target_arch }} tests
+    runs-on: ${{ matrix.os }}
     env:
       GOVER: 1.14.3
-      GOOS: linux
-      GOARCH: amd64
+      GOOS: ${{ matrix.target_os }}
+      GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
       DAPR_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       DAPR_TEST_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       HELMVER: v3.2.1
       DAPR_NAMESPACE: dapr-tests
       MAX_TEST_TIMEOUT: 5400
+      TARGET_OS: ${{ matrix.target_os }}
+      TARGET_ARCH: ${{ matrix.target_arch }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        target_arch: [amd64]
+        include:
+          - os: ubuntu-latest
+            target_os: linux
+          - os: windows-latest
+            target_os: windows
     steps:
       - name: Set up for scheduled test
         if: github.event_name != 'repository_dispatch'

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -10,10 +10,10 @@
 # The test cluster pool for e2e test
 # TODO: Add more aks test clusters
 testclusterpool=(
-    "dapr-aks-e2e-01"
-    "dapr-aks-e2e-02"
-    "dapr-aks-e2e-03"
-    "dapr-aks-e2e-04"
+    "dapr-aks-e2e-05"
+    "dapr-aks-e2e-06"
+    "dapr-aks-e2e-07"
+    "dapr-aks-e2e-08"
 )
 
 # Define max e2e test timeout, 1.5 hours


### PR DESCRIPTION
# Description

Since e2e tests now support windows, upgrading CI/CD pipelines to run a matrix build of the e2e tests.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1906
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
