### PR TITLE
Split windows e2e tests into a separate github workflow and only run them at release time.

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -106,6 +106,33 @@ jobs:
                   
                   console.log(`Trigger E2E test for ${JSON.stringify(testPayload)}`);
                 }
+              } else if (commentBody.indexOf("/ok-to-wintest") == 0) {
+                // Get pull request
+                const pull = await github.pulls.get({
+                  owner: issue.owner,
+                  repo: issue.repo,
+                  pull_number: issue.number
+                });
+
+                if (pull && pull.data) {
+                  // Get commit id and repo from pull head
+                  const testPayload = {
+                    pull_head_ref: pull.data.head.sha,
+                    pull_head_repo: pull.data.head.repo.full_name,
+                    command: "ok-to-wintest",
+                    issue: issue,
+                  };
+
+                  // Fire repository_dispatch event to trigger e2e test
+                  await github.repos.createDispatchEvent({
+                    owner: issue.owner,
+                    repo: issue.repo,
+                    event_type: "e2e-test-windows",
+                    client_payload: testPayload,
+                  });
+
+                  console.log(`Trigger E2E test for windows ${JSON.stringify(testPayload)}`);
+                }
               } else if (commentBody.indexOf("/ok-to-perf") == 0) {
                 // Get pull request
                 const pull = await github.pulls.get({

--- a/.github/workflows/dapr-test-windows.yml
+++ b/.github/workflows/dapr-test-windows.yml
@@ -3,21 +3,20 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-name: dapr-perf
+name: dapr-test-windows
 
 on:
-  schedule:
-    - cron: '0 */2 * * *'
   repository_dispatch:
-    type: perf-test
+    type: e2e-test-windows
+
 
 jobs:
-  test-perf:
-    name: perf tests
-    runs-on: ubuntu-latest
+  test-e2e-windows:
+    name: end-to-end windows tests
+    runs-on: windows-latest
     env:
       GOVER: 1.14.3
-      GOOS: linux
+      GOOS: windows
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       DAPR_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
@@ -25,16 +24,9 @@ jobs:
       HELMVER: v3.2.1
       DAPR_NAMESPACE: dapr-tests
       MAX_TEST_TIMEOUT: 5400
-      DAPR_PERF_QPS: 1000
-      DAPR_PERF_CONNECTIONS: 16
-      DAPR_TEST_DURATION: 1m
-      DAPR_PAYLOAD_SIZE_KB: 1
+      TARGET_OS: windows
+      TARGET_ARCH: amd64
     steps:
-      - name: Set up for scheduled test
-        if: github.event_name != 'repository_dispatch'
-        run: |
-          echo ::set-env name=CHECKOUT_REPO::${{ github.repository }}
-          echo ::set-env name=CHECKOUT_REF::refs/heads/master
       - name: Parse test payload
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@0.3.0
@@ -42,7 +34,7 @@ jobs:
           github-token: ${{secrets.DAPR_BOT_TOKEN}}
           script: |
             const testPayload = context.payload.client_payload;
-            if (testPayload && testPayload.command == "ok-to-perf") {
+            if (testPayload && testPayload.command == "ok-to-wintest") {
               // Set environment variables
               console.log(`::set-env name=CHECKOUT_REPO::${testPayload.pull_head_repo}`);
               console.log(`::set-env name=CHECKOUT_REF::${testPayload.pull_head_ref}`);
@@ -69,6 +61,7 @@ jobs:
       - name: Find the test cluster
         if: env.CHECKOUT_REPO != ''
         run: ./tests/test-infra/find_cluster.sh
+        shell: bash
       - name: Add the test status comment to PR
         if: github.event_name == 'repository_dispatch' && env.CHECKOUT_REPO != ''
         env:
@@ -100,27 +93,34 @@ jobs:
       - name: Build dapr and its docker image
         if: env.TEST_CLUSTER != ''
         run: |
-          make build-linux
+          make build
           make docker-build
-      - name: Build perf test apps
+      - name: Build e2e test apps
         if: env.TEST_CLUSTER != ''
-        run: make build-perf-app-all
+        run: make build-e2e-app-all
       - name: Push docker images to test dockerhub
         if: env.TEST_CLUSTER != ''
         run: |
           make docker-push
-          make push-perf-app-all
+          make push-e2e-app-all
       - name: Preparing ${{ env.TEST_CLUSTER }} cluster for test
         if: env.TEST_CLUSTER != ''
         run: |
           make setup-helm-init
+          make setup-test-env
           kubectl get pods -n ${{ env.DAPR_NAMESPACE }}
       - name: Deploy dapr to ${{ env.TEST_CLUSTER }} cluster
         if: env.TEST_CLUSTER != ''
         run: make docker-deploy-k8s
-      - name: Run Perf tests
+      - name: Deploy test components
         if: env.TEST_CLUSTER != ''
-        run: make test-perf-all
+        run: make setup-test-components
+      - name: Show dapr configurations
+        if: env.TEST_CLUSTER != ''
+        run: kubectl get configurations daprsystem -n ${{ env.DAPR_NAMESPACE }} -o yaml
+      - name: Run E2E tests
+        if: env.TEST_CLUSTER != ''
+        run: make test-e2e-all
       - name: Add test result comment to PR
         if: always() && github.event_name == 'repository_dispatch' && env.TEST_CLUSTER != ''
         env:
@@ -138,11 +138,11 @@ jobs:
             var message = "";
             
             if (jobStatus == "cancelled") {
-              message = "Dapr Perf tests cancelled.";
+              message = "End-to-end tests cancelled.";
             } else if (jobStatus == "success") {
-              message = "All Dapr perf tests completed.";
+              message = "Congrats! All end-to-end tests have passed. Thanks for your contribution!";
             } else if (jobStatus == "failure") {
-              message = "Dapr Perf tests failed.";
+              message = "End-to-end tests failed.";
             }
             
             if (message) {

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -9,32 +9,22 @@ on:
   schedule:
     - cron: '0 */2 * * *'
   repository_dispatch:
+    types: e2e-test
 
 jobs:
   test-e2e:
-    name: end-to-end  ${{ matrix.target_os }}_${{ matrix.target_arch }} tests
-    runs-on: ${{ matrix.os }}
+    name: end-to-end linux tests
+    runs-on: ubuntu-latest
     env:
       GOVER: 1.14.3
-      GOOS: ${{ matrix.target_os }}
-      GOARCH: ${{ matrix.target_arch }}
+      GOOS: linux
+      GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       DAPR_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       DAPR_TEST_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       HELMVER: v3.2.1
       DAPR_NAMESPACE: dapr-tests
       MAX_TEST_TIMEOUT: 5400
-      TARGET_OS: ${{ matrix.target_os }}
-      TARGET_ARCH: ${{ matrix.target_arch }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        target_arch: [amd64]
-        include:
-          - os: ubuntu-latest
-            target_os: linux
-          - os: windows-latest
-            target_os: windows
     steps:
       - name: Set up for scheduled test
         if: github.event_name != 'repository_dispatch'

--- a/tests/apps/runtime/Dockerfile-windows
+++ b/tests/apps/runtime/Dockerfile-windows
@@ -3,11 +3,14 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM golang:1.14-windowsservercore-1809
+FROM golang:1.14-windowsservercore-1809 as servercore
 
 WORKDIR /app
 COPY app.go .
 RUN go get -d -v
 RUN go build -o app.exe .
 
+FROM golang:1.14-nanoserver-1809
+WORKDIR /app
+COPY --from=servercore /app/app.exe /
 CMD ["app.exe"]

--- a/tests/apps/runtime_init/Dockerfile-windows
+++ b/tests/apps/runtime_init/Dockerfile-windows
@@ -3,11 +3,14 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM golang:1.14-windowsservercore-1809
+FROM golang:1.14-windowsservercore-1809 as servercore
 
 WORKDIR /app
 COPY app.go .
 RUN go get -d -v
 RUN go build -o app.exe .
 
+FROM golang:1.14-nanoserver-1809
+WORKDIR /app
+COPY --from=servercore /app/app.exe /
 CMD ["app.exe"]

--- a/tests/config/modify_kafka_template.py
+++ b/tests/config/modify_kafka_template.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+from __future__ import print_function
 import sys
 
 # This is a quick and dirty hack (with no additional dependacies) to work around that fact that the kafka

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -124,7 +124,7 @@ setup-test-env-redis:
 
 # install kafka to the cluster
 setup-test-env-kafka:
-	$(HELM) template dapr-kafka incubator/kafka --wait --timeout 10m0s -f ./tests/config/kafka_override.yaml | python3 ./tests/config/modify_kafka_template.py | kubectl apply -f - --namespace $(DAPR_TEST_NAMESPACE)
+	$(HELM) template dapr-kafka incubator/kafka --wait --timeout 10m0s -f ./tests/config/kafka_override.yaml | python ./tests/config/modify_kafka_template.py | kubectl apply -f - --namespace $(DAPR_TEST_NAMESPACE)
 
 # Install redis and kafka to test cluster
 setup-test-env: setup-test-env-kafka setup-test-env-redis


### PR DESCRIPTION


# Description

Fixes e2e tests on windows. Windows does not have a python3 to python symlink, so the kafka install was failing.

## Issue reference


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
