### PR TITLE
Fix copy path in windows runtime e2e test Dockerfiles

### DIFF
--- a/tests/apps/runtime/Dockerfile-windows
+++ b/tests/apps/runtime/Dockerfile-windows
@@ -12,5 +12,5 @@ RUN go build -o app.exe .
 
 FROM golang:1.14-nanoserver-1809
 WORKDIR /app
-COPY --from=servercore /app/app.exe /
+COPY --from=servercore /app/app.exe /app/app.exe
 CMD ["app.exe"]

--- a/tests/apps/runtime_init/Dockerfile-windows
+++ b/tests/apps/runtime_init/Dockerfile-windows
@@ -12,5 +12,5 @@ RUN go build -o app.exe .
 
 FROM golang:1.14-nanoserver-1809
 WORKDIR /app
-COPY --from=servercore /app/app.exe /
+COPY --from=servercore /app/app.exe /app/app.exe
 CMD ["app.exe"]


### PR DESCRIPTION
# Description

Fix copy path in windows runtime e2e test Dockerfiles. This should be the last broken windows test.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1906

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
