### PR TITLE
Read DAPR_GRPC_PORT env for grpc api call in test

### DIFF
--- a/tests/apps/stateapp/app.go
+++ b/tests/apps/stateapp/app.go
@@ -14,8 +14,8 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
-	"strconv"
 	"time"
 
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
@@ -363,8 +363,8 @@ func grpcHandler(w http.ResponseWriter, r *http.Request) {
 	res.StartTime = epoch()
 	var statusCode = http.StatusOK
 
-	daprPort := 50001
-	daprAddress := fmt.Sprintf("localhost:%s", strconv.Itoa(daprPort))
+	daprPort, _ := os.LookupEnv("DAPR_GRPC_PORT")
+	daprAddress := fmt.Sprintf("127.0.0.1:%s", daprPort)
 	log.Printf("dapr grpc address is %s\n", daprAddress)
 	conn, err := grpc.Dial(daprAddress, grpc.WithInsecure())
 


### PR DESCRIPTION
# Description

Read DAPR_GRPC_PORT env for grpc api call in test

## Issue reference

n/a

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
