### PR TITLE
improve code to use defer for unlock operation in case of return or panic

### DIFF
--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -54,7 +54,7 @@ func NewPlacementService() *Service {
 func (p *Service) ReportDaprStatus(srv placementv1pb.Placement_ReportDaprStatusServer) error {
 	ctx := srv.Context()
 
-	id, err := p.getIdFromContextAndSaveHost(ctx, srv)
+	id, err := p.addHost(ctx, srv)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (p *Service) ReportDaprStatus(srv placementv1pb.Placement_ReportDaprStatusS
 	}
 }
 
-func (p *Service) getIdFromContextAndSaveHost(ctx context.Context, srv placementv1pb.Placement_ReportDaprStatusServer) (string, error) {
+func (p *Service) addHost(ctx context.Context, srv placementv1pb.Placement_ReportDaprStatusServer) (string, error) {
 	p.hostsLock.Lock()
 	defer p.hostsLock.Unlock()
 

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -54,7 +54,7 @@ func NewPlacementService() *Service {
 func (p *Service) ReportDaprStatus(srv placementv1pb.Placement_ReportDaprStatusServer) error {
 	ctx := srv.Context()
 
-	id, err := p.getIdFromContext(ctx, srv)
+	id, err := p.getIdFromContextAndSaveHost(ctx, srv)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (p *Service) ReportDaprStatus(srv placementv1pb.Placement_ReportDaprStatusS
 	}
 }
 
-func (p *Service) getIdFromContext(ctx context.Context, srv placementv1pb.Placement_ReportDaprStatusServer) (string, error) {
+func (p *Service) getIdFromContextAndSaveHost(ctx context.Context, srv placementv1pb.Placement_ReportDaprStatusServer) (string, error) {
 	p.hostsLock.Lock()
 	defer p.hostsLock.Unlock()
 


### PR DESCRIPTION


# Description

Use defer for unlock operation in case of return or panic between lock and unlock:

```go
	ctx := srv.Context()
	p.hostsLock.Lock()
	md, _ := metadata.FromIncomingContext(srv.Context())
	v := md.Get("id")
	if len(v) == 0 {
                 // if we really return
		return errors.New("id header not found in metadata")
	}

	id := v[0]
	p.hosts = append(p.hosts, srv)
	log.Infof("host added: %s", id)
         // then we don't have the chance to unlock it
         // it will be very dangurous
	p.hostsLock.Unlock()
```

## Issue reference



## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
