### PR TITLE
pkg/operator: replaced fmt.Errorf with error.wrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/phayes/freeport v0.0.0-20171002181615-b8543db493a5
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -17,7 +17,7 @@ import (
 	"github.com/dapr/dapr/pkg/logger"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/golang/protobuf/ptypes/empty"
-	pkgerror "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,11 +75,11 @@ func (a *apiServer) GetConfiguration(ctx context.Context, in *operatorv1pb.GetCo
 	key := types.NamespacedName{Namespace: in.Namespace, Name: in.Name}
 	var config configurationapi.Configuration
 	if err := a.Client.Get(ctx, key, &config); err != nil {
-		return nil, pkgerror.Wrap(err, "error getting configuration")
+		return nil, errors.Wrap(err, "error getting configuration")
 	}
 	b, err := json.Marshal(&config)
 	if err != nil {
-		return nil, pkgerror.Wrap(err, "error marshalling configuration")
+		return nil, errors.Wrap(err, "error marshalling configuration")
 	}
 	return &operatorv1pb.GetConfigurationResponse{
 		Configuration: b,
@@ -90,7 +90,7 @@ func (a *apiServer) GetConfiguration(ctx context.Context, in *operatorv1pb.GetCo
 func (a *apiServer) ListComponents(ctx context.Context, in *empty.Empty) (*operatorv1pb.ListComponentResponse, error) {
 	var components componentsapi.ComponentList
 	if err := a.Client.List(ctx, &components); err != nil {
-		return nil, pkgerror.Wrap(err, "error getting components")
+		return nil, errors.Wrap(err, "error getting components")
 	}
 	resp := &operatorv1pb.ListComponentResponse{
 		Components: [][]byte{},

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dapr/dapr/pkg/logger"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/golang/protobuf/ptypes/empty"
+	pkgerror "github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,11 +75,11 @@ func (a *apiServer) GetConfiguration(ctx context.Context, in *operatorv1pb.GetCo
 	key := types.NamespacedName{Namespace: in.Namespace, Name: in.Name}
 	var config configurationapi.Configuration
 	if err := a.Client.Get(ctx, key, &config); err != nil {
-		return nil, fmt.Errorf("error getting configuration: %s", err)
+		return nil, pkgerror.Wrap(err, "error getting configuration")
 	}
 	b, err := json.Marshal(&config)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling configuration: %s", err)
+		return nil, pkgerror.Wrap(err, "error marshalling configuration")
 	}
 	return &operatorv1pb.GetConfigurationResponse{
 		Configuration: b,
@@ -89,7 +90,7 @@ func (a *apiServer) GetConfiguration(ctx context.Context, in *operatorv1pb.GetCo
 func (a *apiServer) ListComponents(ctx context.Context, in *empty.Empty) (*operatorv1pb.ListComponentResponse, error) {
 	var components componentsapi.ComponentList
 	if err := a.Client.List(ctx, &components); err != nil {
-		return nil, fmt.Errorf("error getting components: %s", err)
+		return nil, pkgerror.Wrap(err, "error getting components")
 	}
 	resp := &operatorv1pb.ListComponentResponse{
 		Components: [][]byte{},

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -2,14 +2,13 @@ package client
 
 import (
 	"crypto/x509"
-	"errors"
 
 	dapr_credentials "github.com/dapr/dapr/pkg/credentials"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
-	pkgerror "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -32,12 +31,12 @@ func GetOperatorClient(address, serverName string, certChain *dapr_credentials.C
 		cp := x509.NewCertPool()
 		ok := cp.AppendCertsFromPEM(certChain.RootCA)
 		if !ok {
-			return nil, nil, pkgerror.Wrap(errors.New("failed to append PEM root cert to x509 CertPool"), "err")
+			return nil, nil, errors.New("failed to append PEM root cert to x509 CertPool")
 		}
 
 		config, err := dapr_credentials.TLSConfigFromCertAndKey(certChain.Cert, certChain.Key, serverName, cp)
 		if err != nil {
-			return nil, nil, pkgerror.Wrap(err, "failed to create tls config from cert and key")
+			return nil, nil, errors.Wrap(err, "failed to create tls config from cert and key")
 		}
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(config)))
 	} else {

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -3,13 +3,13 @@ package client
 import (
 	"crypto/x509"
 	"errors"
-	"fmt"
 
 	dapr_credentials "github.com/dapr/dapr/pkg/credentials"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	pkgerror "github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -32,12 +32,12 @@ func GetOperatorClient(address, serverName string, certChain *dapr_credentials.C
 		cp := x509.NewCertPool()
 		ok := cp.AppendCertsFromPEM(certChain.RootCA)
 		if !ok {
-			return nil, nil, errors.New("failed to append PEM root cert to x509 CertPool")
+			return nil, nil, pkgerror.Wrap(errors.New("failed to append PEM root cert to x509 CertPool"), "err")
 		}
 
 		config, err := dapr_credentials.TLSConfigFromCertAndKey(certChain.Cert, certChain.Key, serverName, cp)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create tls config from cert and key: %s", err)
+			return nil, nil, pkgerror.Wrap(err, "failed to create tls config from cert and key")
 		}
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(config)))
 	} else {


### PR DESCRIPTION
# Description

we have used fmt.errorf to formatted error in the entire code bases, but this loses many information.Instead of using fmt.errorf, we can use errors.Wrap and errors.Errorf in https://github.com/pkg/errors. This wrap errors in contextual information and still preserve the underlying error and originating stack trace.
## Issue reference

Please reference the issue this PR will close: #1954

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
