### PR TITLE
pkg/injector:replace fmt.Errorf by error.wrap

### DIFF
--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -16,6 +16,7 @@ import (
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	"github.com/dapr/dapr/pkg/injector/monitoring"
 	"github.com/dapr/dapr/pkg/logger"
+	"github.com/pkg/errors"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -154,7 +155,7 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Can't decode body: %v", err)
 	} else {
 		if ar.Request.Kind.Kind != "Pod" {
-			err = fmt.Errorf("invalid kind for review: %s", ar.Kind)
+			err = errors.Wrapf(err, "invalid kind for review: %s", ar.Kind)
 			log.Error(err)
 		} else {
 			patchOps, err = i.getPodPatchOperations(&ar, i.config.Namespace, i.config.SidecarImage, i.kubeClient, i.daprClient)

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -17,6 +17,7 @@ import (
 	auth "github.com/dapr/dapr/pkg/runtime/security"
 	"github.com/dapr/dapr/pkg/sentry/certs"
 	"github.com/dapr/dapr/utils"
+	"github.com/pkg/errors"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -90,7 +91,7 @@ func (i *injector) getPodPatchOperations(ar *v1beta1.AdmissionReview,
 	req := ar.Request
 	var pod corev1.Pod
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
-		log.Errorf("could not unmarshal raw object: %v", err)
+		errors.Wrap(err, "could not unmarshal raw object")
 		return nil, err
 	}
 
@@ -364,7 +365,7 @@ func getInt32Annotation(annotations map[string]string, key string) (int32, error
 	}
 	value, err := strconv.ParseInt(s, 10, 32)
 	if err != nil {
-		return -1, fmt.Errorf("error parsing %s int value %s: %s", key, s, err)
+		return -1, errors.Wrapf(err, "error parsing %s int value %s ", key, s)
 	}
 	return int32(value), nil
 }
@@ -404,7 +405,7 @@ func getResourceRequirements(annotations map[string]string) (*corev1.ResourceReq
 	if ok {
 		list, err := appendQuantityToResourceList(cpuLimit, corev1.ResourceCPU, r.Limits)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing sidecar cpu limit: %s", err)
+			return nil, errors.Wrap(err, "error parsing sidecar cpu limit")
 		}
 		r.Limits = *list
 	}
@@ -412,7 +413,7 @@ func getResourceRequirements(annotations map[string]string) (*corev1.ResourceReq
 	if ok {
 		list, err := appendQuantityToResourceList(memLimit, corev1.ResourceMemory, r.Limits)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing sidecar memory limit: %s", err)
+			return nil, errors.Wrap(err, "error parsing sidecar memory limit")
 		}
 		r.Limits = *list
 	}
@@ -420,7 +421,7 @@ func getResourceRequirements(annotations map[string]string) (*corev1.ResourceReq
 	if ok {
 		list, err := appendQuantityToResourceList(cpuRequest, corev1.ResourceCPU, r.Requests)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing sidecar cpu request: %s", err)
+			return nil, errors.Wrap(err, "error parsing sidecar cpu request")
 		}
 		r.Requests = *list
 	}
@@ -428,7 +429,7 @@ func getResourceRequirements(annotations map[string]string) (*corev1.ResourceReq
 	if ok {
 		list, err := appendQuantityToResourceList(memRequest, corev1.ResourceMemory, r.Requests)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing sidecar memory request: %s", err)
+			return nil, errors.Wrap(err, "error parsing sidecar memory request")
 		}
 		r.Requests = *list
 	}


### PR DESCRIPTION
# Description

replacing fmt.Errorf by error.wrap from library
https://github.com/pkg/errors. This wrap errors in
contextual information and still preserve the underlying
error and originating stack trace.

## Issue reference

Please reference the issue this PR will close: #1954 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
