### PR TITLE
actor get state should return 204 instead of 200 if key not found

### DIFF
--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -330,7 +330,7 @@ func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
 		assert.Equal(t, "2s", reminders[0].DueTime)
 		assert.Equal(t, "b", reminders[0].Data)
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(3 * time.Second)
 
 		// Test only the last reminder update fires
 		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -859,6 +859,10 @@ func (a *api) onGetActorState(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, 500, msg)
 		log.Debug(msg)
 	} else {
+		if resp == nil || resp.Data == nil {
+			respondEmpty(reqCtx, 204)
+			return
+		}
 		respondWithJSON(reqCtx, 200, resp.Data)
 	}
 }


### PR DESCRIPTION
# Description

An actor state get should return 204 if the key is not present.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1983

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
