### PR TITLE
Actor state tests

### DIFF
--- a/tests/apps/actorfeatures/app.go
+++ b/tests/apps/actorfeatures/app.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -20,10 +21,11 @@ import (
 )
 
 const (
-	appPort              = 3000
-	daprV1URL            = "http://localhost:3500/v1.0"
-	actorMethodURLFormat = daprV1URL + "/actors/%s/%s/%s/%s"
-
+	appPort                 = 3000
+	daprV1URL               = "http://localhost:3500/v1.0"
+	actorMethodURLFormat    = daprV1URL + "/actors/%s/%s/%s/%s"
+	actorSaveStateURLFormat = daprV1URL + "/actors/%s/%s/state/"
+	actorGetStateURLFormat  = daprV1URL + "/actors/%s/%s/state/%s/"
 	registedActorType       = "testactorfeatures" // Actor type must be unique per test app.
 	actorIdleTimeout        = "1h"
 	actorScanInterval       = "30s"
@@ -84,6 +86,21 @@ type response struct {
 	StartTime int    `json:"start_time,omitempty"`
 	EndTime   int    `json:"end_time,omitempty"`
 	Message   string `json:"message,omitempty"`
+}
+
+// copied from actors.go for test purposes
+type TempTransactionalOperation struct {
+	Operation string      `json:"operation"`
+	Request   interface{} `json:"request"`
+}
+
+type TempTransactionalUpsert struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+type TempTransactionalDelete struct {
+	Key string `json:"key"`
 }
 
 var actorLogs = []actorLogEntry{}
@@ -164,6 +181,15 @@ func actorMethodHandler(w http.ResponseWriter, r *http.Request) {
 		id:        actorID,
 		value:     epoch(),
 	})
+
+	// if it's a state test, call state apis
+	if method == "savestatetest" || method == "getstatetest" ||
+		method == "savestatetest2" || method == "getstatetest2" {
+		e := actorStateTest(method, w, actorType, id)
+		if e != nil {
+			return
+		}
+	}
 
 	hostname, err := os.Hostname()
 	var data []byte
@@ -258,7 +284,7 @@ func testCallActorHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	body, err := httpCall(r.Method, url, req)
+	body, err := httpCall(r.Method, url, req, 200)
 	if err != nil {
 		log.Printf("Could not read actor's test response: %s", err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
@@ -273,7 +299,7 @@ func testCallActorHandler(w http.ResponseWriter, r *http.Request) {
 	var response daprActorResponse
 	err = json.Unmarshal(body, &response)
 	if err != nil {
-		log.Printf("Could parse actor's test response: %s", err.Error())
+		log.Printf("Could not parse actor's test response: %s", err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -285,7 +311,7 @@ func testCallMetadataHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Processing %s test request for %s", r.Method, r.URL.RequestURI())
 
 	metadataURL := fmt.Sprintf("%s/metadata", daprV1URL)
-	body, err := httpCall(r.Method, metadataURL, nil)
+	body, err := httpCall(r.Method, metadataURL, nil, 200)
 	if err != nil {
 		log.Printf("Could not read metadata response: %s", err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
@@ -295,7 +321,140 @@ func testCallMetadataHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func httpCall(method string, url string, requestBody interface{}) ([]byte, error) {
+// the test side calls the 4 cases below in order
+func actorStateTest(testName string, w http.ResponseWriter, actorType string, id string) error {
+
+	// save multiple key values
+	if testName == "savestatetest" {
+		url := fmt.Sprintf(actorSaveStateURLFormat, actorType, id)
+
+		operations := []TempTransactionalOperation{
+			{
+				Operation: "upsert",
+				Request: TempTransactionalUpsert{
+					Key:   "key1",
+					Value: "data1",
+				},
+			},
+			{
+				Operation: "upsert",
+				Request: TempTransactionalUpsert{
+					Key:   "key2",
+					Value: "data2",
+				},
+			},
+			{
+				Operation: "upsert",
+				Request: TempTransactionalUpsert{
+					Key:   "key3",
+					Value: "data3",
+				},
+			},
+			{
+				Operation: "upsert",
+				Request: TempTransactionalUpsert{
+					Key:   "key4",
+					Value: "data4",
+				},
+			},
+		}
+
+		_, err := httpCall("POST", url, operations, 201)
+		if err != nil {
+			log.Printf("actor state call failed: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
+		}
+	} else if testName == "getstatetest" {
+
+		// perform a get on a key saved above
+		url := fmt.Sprintf(actorGetStateURLFormat, actorType, id, "key1")
+
+		body, err := httpCall("GET", url, nil, 200)
+		if err != nil {
+			log.Printf("actor state call failed: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
+		}
+
+		// query a non-existing key.  This should return 204 with 0 length response.
+		url = fmt.Sprintf(actorGetStateURLFormat, actorType, "999", "keynotpresent")
+		body, err = httpCall("GET", url, nil, 204)
+		if err != nil {
+			log.Printf("actor state call failed: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
+		}
+
+		if len(body) != 0 {
+			log.Println("expected 0 length reponse")
+			w.WriteHeader(http.StatusInternalServerError)
+			return errors.New("expected 0 length reponse")
+		}
+
+	} else if testName == "savestatetest2" {
+		// perform another transaction including a delete
+		url := fmt.Sprintf(actorSaveStateURLFormat, actorType, id)
+
+		// modify 1 key and delete another
+		operations := []TempTransactionalOperation{
+			{
+				Operation: "upsert",
+				Request: TempTransactionalUpsert{
+					Key:   "key1",
+					Value: "data1v2",
+				},
+			},
+
+			{
+				Operation: "delete",
+				Request: TempTransactionalDelete{
+					Key: "key4",
+				},
+			},
+		}
+
+		_, err := httpCall("POST", url, operations, 201)
+		if err != nil {
+			log.Printf("actor state call failed: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
+		}
+	} else if testName == "getstatetest2" {
+
+		// perform a get on an existing key
+		url := fmt.Sprintf(actorGetStateURLFormat, actorType, id, "key1")
+
+		body, err := httpCall("GET", url, nil, 200)
+		if err != nil {
+			log.Printf("actor state call failed: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
+		}
+
+		// query a non-existing key - this was present but deleted.  This should return 204 with 0 length response.
+		url = fmt.Sprintf(actorGetStateURLFormat, actorType, id, "key4")
+
+		body, err = httpCall("GET", url, nil, 204)
+		if err != nil {
+			log.Printf("actor state call failed: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
+		}
+
+		if len(body) != 0 {
+			log.Println("expected 0 length reponse")
+			w.WriteHeader(http.StatusInternalServerError)
+			return errors.New("expected 0 length reponse")
+		}
+	} else {
+		return errors.New("actorStateTest() - unexpected option")
+	}
+
+	return nil
+}
+
+func httpCall(method string, url string, requestBody interface{}, expectedHTTPStatusCode int) ([]byte, error) {
 	var body []byte
 	var err error
 
@@ -318,6 +477,11 @@ func httpCall(method string, url string, requestBody interface{}) ([]byte, error
 	}
 
 	defer res.Body.Close()
+
+	if res.StatusCode != expectedHTTPStatusCode {
+		t := fmt.Errorf("Expected http status %d, received %d", expectedHTTPStatusCode, res.StatusCode)
+		return nil, t
+	}
 
 	resBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
@@ -343,10 +507,14 @@ func appRouter() *mux.Router {
 
 	router.HandleFunc("/", indexHandler).Methods("GET")
 	router.HandleFunc("/dapr/config", configHandler).Methods("GET")
+
+	router.HandleFunc("/test/{actorType}/{id}/{callType}/{method}", testCallActorHandler).Methods("POST", "DELETE")
+
 	router.HandleFunc("/actors/{actorType}/{id}/method/{method}", actorMethodHandler).Methods("PUT")
 	router.HandleFunc("/actors/{actorType}/{id}/method/{reminderOrTimer}/{method}", actorMethodHandler).Methods("PUT")
+
 	router.HandleFunc("/actors/{actorType}/{id}", deactivateActorHandler).Methods("POST", "DELETE")
-	router.HandleFunc("/test/{actorType}/{id}/{callType}/{method}", testCallActorHandler).Methods("POST", "DELETE")
+
 	router.HandleFunc("/test/logs", logsHandler).Methods("GET")
 	router.HandleFunc("/test/metadata", testCallMetadataHandler).Methods("GET")
 	router.HandleFunc("/test/logs", logsHandler).Methods("DELETE")

--- a/tests/e2e/actor_features/actor_features_test.go
+++ b/tests/e2e/actor_features/actor_features_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dapr/dapr/tests/e2e/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	guuid "github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -130,6 +131,23 @@ func TestActorFeatures(t *testing.T) {
 	// making this test less flaky due to delays in the deployment.
 	_, err := utils.HTTPGetNTimes(externalURL, numHealthChecks)
 	require.NoError(t, err)
+
+	t.Run("Actor state.", func(t *testing.T) {
+		// Each test needs to have a different actorID
+		actorID := guuid.New().String()
+
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "method", "savestatetest"), []byte{})
+		require.NoError(t, err)
+
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "method", "getstatetest"), []byte{})
+		require.NoError(t, err)
+
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "method", "savestatetest2"), []byte{})
+		require.NoError(t, err)
+
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "method", "getstatetest2"), []byte{})
+		require.NoError(t, err)
+	})
 
 	t.Run("Actor reminder.", func(t *testing.T) {
 		// Each test needs to have a different actorID


### PR DESCRIPTION
# Description

This adds actor state e2e tests.  It also validates a recent change that if an actor queries a non-existent key it returns 204 instead of 200.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1758

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
