### PR TITLE
Authenticate requests from api-server in sidecar injector

### DIFF
--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -49,7 +49,12 @@ func main() {
 		}
 	}()
 
-	injector.NewInjector(cfg, daprClient, kubeClient).Run(ctx)
+	uid, err := injector.ReplicasetAccountUID(kubeClient)
+	if err != nil {
+		log.Fatalf("failed to get authentication uid from service account: %s", err)
+	}
+
+	injector.NewInjector(uid, cfg, daprClient, kubeClient).Run(ctx)
 
 	shutdownDuration := 5 * time.Second
 	log.Infof("allowing %s for graceful shutdown to complete", shutdownDuration)

--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -43,9 +43,9 @@ func main() {
 		healthzServer := health.NewServer(log)
 		healthzServer.Ready()
 
-		err := healthzServer.Run(ctx, healthzPort)
-		if err != nil {
-			log.Fatalf("failed to start healthz server: %s", err)
+		healthzErr := healthzServer.Run(ctx, healthzPort)
+		if healthzErr != nil {
+			log.Fatalf("failed to start healthz server: %s", healthzErr)
 		}
 	}()
 

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -21,7 +21,7 @@ const (
 )
 
 func TestConfigCorrectValues(t *testing.T) {
-	i := NewInjector(Config{
+	i := NewInjector("", Config{
 		TLSCertFile:            "a",
 		TLSKeyFile:             "b",
 		SidecarImage:           "c",


### PR DESCRIPTION
Adds the ability to authenticate requests coming from the Kubernetes API server for the webhook admission server.

Closes #1780 