### PR TITLE
Update e2e tests with redis to verify secret ref

### DIFF
--- a/tests/config/dapr_redis_pubsub.yaml
+++ b/tests/config/dapr_redis_pubsub.yaml
@@ -11,6 +11,8 @@ spec:
   type: pubsub.redis
   metadata:
   - name: redisHost
-    value: dapr-redis-master:6379
+    secretKeyRef:
+      name: redissecret
+      key: host
   - name: redisPassword
     value: ""

--- a/tests/config/dapr_redis_state.yaml
+++ b/tests/config/dapr_redis_state.yaml
@@ -11,7 +11,9 @@ spec:
   type: state.redis
   metadata:
   - name: redisHost
-    value: dapr-redis-master:6379
+    secretKeyRef:
+      name: redissecret
+      key: host
   - name: redisPassword
     value: ""
   - name: actorStateStore

--- a/tests/config/kubernetes_redis_secret.yaml
+++ b/tests/config/kubernetes_redis_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redissecret
+type: Opaque
+data:
+  host: ZGFwci1yZWRpcy1tYXN0ZXI6NjM3OQ==

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -139,8 +139,9 @@ setup-app-configurations:
 
 # Apply component yaml for state, secrets, pubsub, and bindings
 setup-test-components:
-	$(KUBECTL) apply -f ./tests/config/dapr_redis_state.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/kubernetes_secret.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/kubernetes_redis_secret.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/dapr_redis_state.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_tests_cluster_role_binding.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_redis_pubsub.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_kafka_bindings.yaml --namespace $(DAPR_TEST_NAMESPACE)


### PR DESCRIPTION
# Description

Update e2e tests with redis to verify secret ref

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1988 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
