### PR TITLE
Change namespace FQDN order

### DIFF
--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -90,7 +90,7 @@ func (d *directMessaging) requestNamespace(targetAppID string) (string, error) {
 	if len(items) == 1 {
 		return d.namespace, nil
 	} else if len(items) == 2 {
-		return items[0], nil
+		return items[1], nil
 	} else {
 		return "", fmt.Errorf("invalid app id %s", targetAppID)
 	}

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -65,7 +65,7 @@ func TestKubernetesNamespace(t *testing.T) {
 	})
 
 	t.Run("with namespace", func(t *testing.T) {
-		appID := "ns1.app1"
+		appID := "app1.ns1"
 
 		dm := newDirectMessaging()
 		ns, err := dm.requestNamespace(appID)
@@ -75,7 +75,7 @@ func TestKubernetesNamespace(t *testing.T) {
 	})
 
 	t.Run("invalid namespace", func(t *testing.T) {
-		appID := "ns1.ns2.app1"
+		appID := "app1.ns1.ns2"
 
 		dm := newDirectMessaging()
 		_, err := dm.requestNamespace(appID)


### PR DESCRIPTION
The formatting for namespacing should be app.namesapce and not namespace.app.

This PR fixes this.