### PR TITLE
Adjust windows TCP timeout settings when running e2e test on windows …

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -135,6 +135,12 @@ jobs:
       - name: Show dapr configurations
         if: env.TEST_CLUSTER != ''
         run: kubectl get configurations daprsystem -n ${{ env.DAPR_NAMESPACE }} -o yaml
+      - name: Set windows TCP timeouts
+        if: matrix.target_os == 'windows'
+        run: |
+          netsh interface tcp set global initialRto=3000
+          netsh interface tcp set global maxSynRetransmissions=8
+          netsh interface tcp show global
       - name: Run E2E tests
         if: env.TEST_CLUSTER != ''
         run: make test-e2e-all


### PR DESCRIPTION
…(#1945)

# Description

Windows actor rebalance tests are occasionally taking longer than the windows default TCP connect timeout. This change extends the timeout to ensure the tests pass while I continue to investigate what is causing the windows tests to take longer than their linux counterparts.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1945

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
