### PR TITLE
Fixes JSON for bulk get response.

### DIFF
--- a/pkg/http/responses.go
+++ b/pkg/http/responses.go
@@ -20,9 +20,9 @@ const (
 // BulkGetResponse is the response object for a state bulk get operation
 type BulkGetResponse struct {
 	Key   string              `json:"key"`
-	Data  jsoniter.RawMessage `json:"data"`
-	ETag  string              `json:"etag"`
-	Error string              `json:"error"`
+	Data  jsoniter.RawMessage `json:"data,omitempty"`
+	ETag  string              `json:"etag,omitempty"`
+	Error string              `json:"error,omitempty"`
 }
 
 // respondWithJSON overrides the content-type with application/json


### PR DESCRIPTION
# Description

JSON returned for non-existent data is invalid and cannot be deserialized in Java's Jackson library

Before:
```
[
    {
        "key": "100",
        "data":,
        "etag": "",
        "error": ""
    }
]
```

After:
```
[
    {
        "key": "100"
    }
]
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1338 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
