### PR TITLE
Remove log of admission response

### DIFF
--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -190,7 +190,6 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			admissionResponse = toAdmissionResponse(err)
 		} else {
-			log.Infof("AdmissionResponse: patch=%v\n", string(patchBytes))
 			admissionResponse = &v1beta1.AdmissionResponse{
 				Allowed: true,
 				Patch:   patchBytes,


### PR DESCRIPTION
Prevent leaking keys in the sidecar injector log.