### PR TITLE
Reduce the number of outstanding connections used by the e2e test suite (#2047)

### DIFF
--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -104,6 +104,7 @@ func sendToPublisher(t *testing.T, publisherExternalURL string, topic string) ([
 
 			return nil, err
 		}
+		postResp.Body.Close()
 	}
 
 	return sentMessages, nil


### PR DESCRIPTION

# Description

There was a concern that the number of open connections that our e2e test suite has may be causing us to hit the azure SNAT limits. This change contains two fixes:

1. Fix a resource leak that was causing us to hold http connections open for every published message in the pubsub test
1. Use a singleton http client in the test http utility.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2047

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
