### PR TITLE
Reorder e2e tests to ensure that dapr control plane has enough time to startup (#2042)

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -107,19 +107,11 @@ jobs:
         if: env.TEST_CLUSTER != ''
         run: |
           docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
-      - name: Build dapr and its docker image
+      - name: Build dapr and its docker image and push them to test registry
         if: env.TEST_CLUSTER != ''
         run: |
           make build
-          make docker-build
-      - name: Build e2e test apps
-        if: env.TEST_CLUSTER != ''
-        run: make build-e2e-app-all
-      - name: Push docker images to test dockerhub
-        if: env.TEST_CLUSTER != ''
-        run: |
           make docker-push
-          make push-e2e-app-all
       - name: Preparing ${{ env.TEST_CLUSTER }} cluster for test
         if: env.TEST_CLUSTER != ''
         run: |
@@ -141,6 +133,13 @@ jobs:
           netsh interface tcp set global initialRto=3000
           netsh interface tcp set global maxSynRetransmissions=8
           netsh interface tcp show global
+      - name: Build e2e test apps
+        if: env.TEST_CLUSTER != ''
+        run: make build-e2e-app-all
+      - name: Push e2e app images to test dockerhub
+        if: env.TEST_CLUSTER != ''
+        run: |
+          make push-e2e-app-all
       - name: Run E2E tests
         if: env.TEST_CLUSTER != ''
         run: make test-e2e-all

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ upload-helmchart:
 docker-deploy-k8s: check-docker-env check-arch
 	$(info Deploying ${DAPR_REGISTRY}/${RELEASE_NAME}:${DAPR_TAG} to the current K8S context...)
 	$(HELM) install \
-		$(RELEASE_NAME) --namespace=$(DAPR_NAMESPACE) \
+		$(RELEASE_NAME) --namespace=$(DAPR_NAMESPACE) --wait --timeout 5m0s\
 		--set-string global.tag=$(DAPR_TAG)-$(TARGET_OS)-$(TARGET_ARCH) --set-string global.registry=$(DAPR_REGISTRY) --set global.logAsJson=true --set global.daprControlPlaneOs=$(TARGET_OS) $(HELM_CHART_DIR)
 
 ################################################################################


### PR DESCRIPTION

# Description

The first e2e tests were racing with the dapr install. We'll add an explicit --wait to the dapr helm install and move the dapr install prior to the e2e test app build and push to give the control plane plenty of time to come up before running the tests.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2042

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
