### PR TITLE
Dapr dashboard does not have a windows image. Force it to linux for now

### DIFF
--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
@@ -33,7 +33,7 @@ spec:
                 - key: kubernetes.io/os
                   operator: In
                   values:
-                  - {{ .Values.global.daprControlPlaneOs }}
+                  - linux
 {{- if eq .Values.global.ha.enabled true }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
# Description

Dapr dashboard should only be installed on linux for now. This was breaking the --wait flag for the windows helm install.



## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
