### PR TITLE
Return E2E parallel test count to 2

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -119,7 +119,7 @@ test-e2e-all: check-e2e-env
 	# tests. In the future, if we add any tests that modify global state (such as dapr config), we'll 
 	# have to be sure and run them after the main test suite, so as not to alter the state of a running
 	# test
-	GOOS=$(TARGET_OS_LOCAL) DAPR_TEST_NAMESPACE=$(DAPR_TEST_NAMESPACE) DAPR_TEST_TAG=$(DAPR_TEST_TAG) DAPR_TEST_REGISTRY=$(DAPR_TEST_REGISTRY) DAPR_TEST_MINIKUBE_IP=$(MINIKUBE_NODE_IP) go test -p 1 -count=1 -v -tags=e2e ./tests/e2e/...
+	GOOS=$(TARGET_OS_LOCAL) DAPR_TEST_NAMESPACE=$(DAPR_TEST_NAMESPACE) DAPR_TEST_TAG=$(DAPR_TEST_TAG) DAPR_TEST_REGISTRY=$(DAPR_TEST_REGISTRY) DAPR_TEST_MINIKUBE_IP=$(MINIKUBE_NODE_IP) go test -p 2 -count=1 -v -tags=e2e ./tests/e2e/...
 
 # start all perf tests
 test-perf-all: check-e2e-env

--- a/tests/docs/writing-e2e-test.md
+++ b/tests/docs/writing-e2e-test.md
@@ -51,6 +51,8 @@ kubectl delete -f service.yaml
 
 A test driver is a typical Go test with `e2e` build tag under [/tests/e2e/](../e2e/). It can deploy test apps to a test cluster, run the tests, and clean up all test apps and any resources. We provides test runner framework to manage the test app's lifecycle during the test so that you do not need to manage the test apps by yourself. We plan to add more functionalities to test runner later, such as the log collection of test app POD.
 
+> *Note:* Any test app you deploy should have a name unique to your test driver. Multiple test drivers may be run at the same time by the automated E2E test runner, so if you have an app name which is not unique, you may collide with another test app. Also, make sure that any stateful resources (pubsub topics, statestores, secrets, etc.) have names unique to your test driver.
+
 ### Writing test app
 
 1. Create new test directory under [/tests/e2e/](../e2e).


### PR DESCRIPTION
# Description

We root caused the connection timeouts we were receiving to a connection leak in the pubsub tests (#2047). We were hitting the shared gateway SNAT limit on the build host. We had recently increased the number of pubsub messages we were sending by 50%, which is what ultimately caused us to go over the limit. At this time -p2 is not believed to be a contributing factor. 

Running two test suites at a time saves us ~8-12 minutes per E2E test run
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
