### PR TITLE
fix wrong yaml format for boolean: use true/false, not "true"/"false"

### DIFF
--- a/tests/config/dapr_mtls_off_config.yaml
+++ b/tests/config/dapr_mtls_off_config.yaml
@@ -4,6 +4,6 @@ metadata:
   name: daprsystem
 spec:
   mtls:
-    enabled: "false"
+    enabled: false
     workloadCertTTL: "1h"
     allowedClockSkew: "20m"


### PR DESCRIPTION
# Description

Wrong yaml format for boolean: use true/false, not "true"/"false"

## Issue reference

#2108 

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
