### PR TITLE
Handle the case when the app id could be duplicate but namespace is different

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -492,7 +492,7 @@ func IsOperationAllowedByAccessControlPolicy(spiffeID *SpiffeID, srcAppID string
 		return isActionAllowed(action), actionPolicy
 	}
 
-	// Look up the src app id in the in-memory table. The key is appID_namespace
+	// Look up the src app id in the in-memory table. The key is appID||namespace
 	key := getKeyForAppID(srcAppID, spiffeID.Namespace)
 	appPolicy, found := accessControlList.PolicySpec[key]
 
@@ -567,7 +567,7 @@ func isActionAllowed(action string) bool {
 }
 
 func getKeyForAppID(appID, namespace string) string {
-	key := appID + "_" + namespace
+	key := appID + "||" + namespace
 	return key
 }
 

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -369,7 +369,10 @@ func ParseAccessControlSpec(accessControlSpec AccessControlSpec) (*AccessControl
 			Namespace:           appPolicySpec.Namespace,
 			AppOperationActions: operationPolicy,
 		}
-		accessControlList.PolicySpec[aclPolicySpec.AppName] = aclPolicySpec
+
+		// The policy spec can have the same appID which belongs to different namespaces
+		key := aclPolicySpec.AppName + "_" + aclPolicySpec.Namespace
+		accessControlList.PolicySpec[key] = aclPolicySpec
 	}
 
 	if len(invalidTrustDomain) > 0 || len(invalidNamespace) > 0 || invalidAppName {
@@ -484,16 +487,17 @@ func IsOperationAllowedByAccessControlPolicy(spiffeID *SpiffeID, srcAppID string
 		return isActionAllowed(action), actionPolicy
 	}
 
-	// Look up the src app id in the in-memory table
-	appPolicy, found := accessControlList.PolicySpec[srcAppID]
-
-	if !found {
-		// no policies found for this src app id. Apply global default action
+	if spiffeID == nil {
+		// Could not retrieve spiffe id or it is invalid. Apply global default action
 		return isActionAllowed(action), actionPolicy
 	}
 
-	if spiffeID == nil {
-		// Could not retrieve spiffe id or it is invalid. Apply global default action
+	// Look up the src app id in the in-memory table. The key is appID_namespace
+	key := srcAppID + "_" + spiffeID.Namespace
+	appPolicy, found := accessControlList.PolicySpec[key]
+
+	if !found {
+		// no policies found for this src app id. Apply global default action
 		return isActionAllowed(action), actionPolicy
 	}
 

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -371,7 +371,7 @@ func ParseAccessControlSpec(accessControlSpec AccessControlSpec) (*AccessControl
 		}
 
 		// The policy spec can have the same appID which belongs to different namespaces
-		key := aclPolicySpec.AppName + "_" + aclPolicySpec.Namespace
+		key := getKeyForAppID(aclPolicySpec.AppName, aclPolicySpec.Namespace)
 		accessControlList.PolicySpec[key] = aclPolicySpec
 	}
 
@@ -493,7 +493,7 @@ func IsOperationAllowedByAccessControlPolicy(spiffeID *SpiffeID, srcAppID string
 	}
 
 	// Look up the src app id in the in-memory table. The key is appID_namespace
-	key := srcAppID + "_" + spiffeID.Namespace
+	key := getKeyForAppID(srcAppID, spiffeID.Namespace)
 	appPolicy, found := accessControlList.PolicySpec[key]
 
 	if !found {
@@ -564,6 +564,11 @@ func IsOperationAllowedByAccessControlPolicy(spiffeID *SpiffeID, srcAppID string
 
 func isActionAllowed(action string) bool {
 	return strings.EqualFold(action, AllowAccess)
+}
+
+func getKeyForAppID(appID, namespace string) string {
+	key := appID + "_" + namespace
+	return key
 }
 
 // getOperationPrefixAndPostfix returns an app operation prefix and postfix

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -17,6 +17,9 @@ const (
 	app1 = "app1"
 	app2 = "app2"
 	app3 = "app3"
+	key1 = "app1_ns1"
+	key2 = "app2_ns2"
+	key3 = "app3_ns1"
 )
 
 func TestLoadStandaloneConfiguration(t *testing.T) {
@@ -323,10 +326,10 @@ func TestParseAccessControlSpec(t *testing.T) {
 		assert.Equal(t, "public", accessControlList.TrustDomain)
 
 		// App1
-		assert.Equal(t, app1, accessControlList.PolicySpec[app1].AppName)
-		assert.Equal(t, AllowAccess, accessControlList.PolicySpec[app1].DefaultAction)
-		assert.Equal(t, "public", accessControlList.PolicySpec[app1].TrustDomain)
-		assert.Equal(t, "ns1", accessControlList.PolicySpec[app1].Namespace)
+		assert.Equal(t, app1, accessControlList.PolicySpec[key1].AppName)
+		assert.Equal(t, AllowAccess, accessControlList.PolicySpec[key1].DefaultAction)
+		assert.Equal(t, "public", accessControlList.PolicySpec[key1].TrustDomain)
+		assert.Equal(t, "ns1", accessControlList.PolicySpec[key1].Namespace)
 
 		op1Actions := AccessControlListOperationAction{
 			OperationPostFix: "/",
@@ -343,16 +346,16 @@ func TestParseAccessControlSpec(t *testing.T) {
 		op2Actions.VerbAction["*"] = DenyAccess
 		op2Actions.OperationAction = DenyAccess
 
-		assert.Equal(t, 2, len(accessControlList.PolicySpec[app1].AppOperationActions["/op1"].VerbAction))
-		assert.Equal(t, op1Actions, accessControlList.PolicySpec[app1].AppOperationActions["/op1"])
-		assert.Equal(t, 1, len(accessControlList.PolicySpec[app1].AppOperationActions["/op2"].VerbAction))
-		assert.Equal(t, op2Actions, accessControlList.PolicySpec[app1].AppOperationActions["/op2"])
+		assert.Equal(t, 2, len(accessControlList.PolicySpec[key1].AppOperationActions["/op1"].VerbAction))
+		assert.Equal(t, op1Actions, accessControlList.PolicySpec[key1].AppOperationActions["/op1"])
+		assert.Equal(t, 1, len(accessControlList.PolicySpec[key1].AppOperationActions["/op2"].VerbAction))
+		assert.Equal(t, op2Actions, accessControlList.PolicySpec[key1].AppOperationActions["/op2"])
 
 		// App2
-		assert.Equal(t, app2, accessControlList.PolicySpec[app2].AppName)
-		assert.Equal(t, DenyAccess, accessControlList.PolicySpec[app2].DefaultAction)
-		assert.Equal(t, "domain1", accessControlList.PolicySpec[app2].TrustDomain)
-		assert.Equal(t, "ns2", accessControlList.PolicySpec[app2].Namespace)
+		assert.Equal(t, app2, accessControlList.PolicySpec[key2].AppName)
+		assert.Equal(t, DenyAccess, accessControlList.PolicySpec[key2].DefaultAction)
+		assert.Equal(t, "domain1", accessControlList.PolicySpec[key2].TrustDomain)
+		assert.Equal(t, "ns2", accessControlList.PolicySpec[key2].Namespace)
 
 		op3Actions := AccessControlListOperationAction{
 			OperationPostFix: "/a/*",
@@ -369,16 +372,16 @@ func TestParseAccessControlSpec(t *testing.T) {
 		op4Actions.VerbAction["POST"] = AllowAccess
 		op4Actions.OperationAction = AllowAccess
 
-		assert.Equal(t, 2, len(accessControlList.PolicySpec[app2].AppOperationActions["/op3"].VerbAction))
-		assert.Equal(t, op3Actions, accessControlList.PolicySpec[app2].AppOperationActions["/op3"])
-		assert.Equal(t, 1, len(accessControlList.PolicySpec[app2].AppOperationActions["/op4"].VerbAction))
-		assert.Equal(t, op4Actions, accessControlList.PolicySpec[app2].AppOperationActions["/op4"])
+		assert.Equal(t, 2, len(accessControlList.PolicySpec[key2].AppOperationActions["/op3"].VerbAction))
+		assert.Equal(t, op3Actions, accessControlList.PolicySpec[key2].AppOperationActions["/op3"])
+		assert.Equal(t, 1, len(accessControlList.PolicySpec[key2].AppOperationActions["/op4"].VerbAction))
+		assert.Equal(t, op4Actions, accessControlList.PolicySpec[key2].AppOperationActions["/op4"])
 
 		// App3
-		assert.Equal(t, app3, accessControlList.PolicySpec[app3].AppName)
-		assert.Equal(t, "", accessControlList.PolicySpec[app3].DefaultAction)
-		assert.Equal(t, "domain1", accessControlList.PolicySpec[app3].TrustDomain)
-		assert.Equal(t, "ns1", accessControlList.PolicySpec[app3].Namespace)
+		assert.Equal(t, app3, accessControlList.PolicySpec[key3].AppName)
+		assert.Equal(t, "", accessControlList.PolicySpec[key3].DefaultAction)
+		assert.Equal(t, "domain1", accessControlList.PolicySpec[key3].TrustDomain)
+		assert.Equal(t, "ns1", accessControlList.PolicySpec[key3].Namespace)
 
 		op5Actions := AccessControlListOperationAction{
 			OperationPostFix: "/",
@@ -387,8 +390,8 @@ func TestParseAccessControlSpec(t *testing.T) {
 		op5Actions.VerbAction["POST"] = AllowAccess
 		op5Actions.OperationAction = AllowAccess
 
-		assert.Equal(t, 1, len(accessControlList.PolicySpec[app3].AppOperationActions["/op5"].VerbAction))
-		assert.Equal(t, op5Actions, accessControlList.PolicySpec[app3].AppOperationActions["/op5"])
+		assert.Equal(t, 1, len(accessControlList.PolicySpec[key3].AppOperationActions["/op5"].VerbAction))
+		assert.Equal(t, op5Actions, accessControlList.PolicySpec[key3].AppOperationActions["/op5"])
 	})
 
 	t.Run("test when no trust domain and namespace specified in app policy", func(t *testing.T) {

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -17,10 +17,10 @@ const (
 	app1    = "app1"
 	app2    = "app2"
 	app3    = "app3"
-	app1Ns1 = "app1_ns1"
-	app2Ns2 = "app2_ns2"
-	app3Ns1 = "app3_ns1"
-	app1Ns4 = "app1_ns4"
+	app1Ns1 = "app1||ns1"
+	app2Ns2 = "app2||ns2"
+	app3Ns1 = "app3||ns1"
+	app1Ns4 = "app1||ns4"
 )
 
 func TestLoadStandaloneConfiguration(t *testing.T) {

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 const (
-	app1 = "app1"
-	app2 = "app2"
-	app3 = "app3"
-	key1 = "app1_ns1"
-	key2 = "app2_ns2"
-	key3 = "app3_ns1"
-	key4 = "app1_ns4"
+	app1    = "app1"
+	app2    = "app2"
+	app3    = "app3"
+	app1Ns1 = "app1_ns1"
+	app2Ns2 = "app2_ns2"
+	app3Ns1 = "app3_ns1"
+	app1Ns4 = "app1_ns4"
 )
 
 func TestLoadStandaloneConfiguration(t *testing.T) {
@@ -340,10 +340,10 @@ func TestParseAccessControlSpec(t *testing.T) {
 		assert.Equal(t, "public", accessControlList.TrustDomain)
 
 		// App1
-		assert.Equal(t, app1, accessControlList.PolicySpec[key1].AppName)
-		assert.Equal(t, AllowAccess, accessControlList.PolicySpec[key1].DefaultAction)
-		assert.Equal(t, "public", accessControlList.PolicySpec[key1].TrustDomain)
-		assert.Equal(t, "ns1", accessControlList.PolicySpec[key1].Namespace)
+		assert.Equal(t, app1, accessControlList.PolicySpec[app1Ns1].AppName)
+		assert.Equal(t, AllowAccess, accessControlList.PolicySpec[app1Ns1].DefaultAction)
+		assert.Equal(t, "public", accessControlList.PolicySpec[app1Ns1].TrustDomain)
+		assert.Equal(t, "ns1", accessControlList.PolicySpec[app1Ns1].Namespace)
 
 		op1Actions := AccessControlListOperationAction{
 			OperationPostFix: "/",
@@ -360,16 +360,16 @@ func TestParseAccessControlSpec(t *testing.T) {
 		op2Actions.VerbAction["*"] = DenyAccess
 		op2Actions.OperationAction = DenyAccess
 
-		assert.Equal(t, 2, len(accessControlList.PolicySpec[key1].AppOperationActions["/op1"].VerbAction))
-		assert.Equal(t, op1Actions, accessControlList.PolicySpec[key1].AppOperationActions["/op1"])
-		assert.Equal(t, 1, len(accessControlList.PolicySpec[key1].AppOperationActions["/op2"].VerbAction))
-		assert.Equal(t, op2Actions, accessControlList.PolicySpec[key1].AppOperationActions["/op2"])
+		assert.Equal(t, 2, len(accessControlList.PolicySpec[app1Ns1].AppOperationActions["/op1"].VerbAction))
+		assert.Equal(t, op1Actions, accessControlList.PolicySpec[app1Ns1].AppOperationActions["/op1"])
+		assert.Equal(t, 1, len(accessControlList.PolicySpec[app1Ns1].AppOperationActions["/op2"].VerbAction))
+		assert.Equal(t, op2Actions, accessControlList.PolicySpec[app1Ns1].AppOperationActions["/op2"])
 
 		// App2
-		assert.Equal(t, app2, accessControlList.PolicySpec[key2].AppName)
-		assert.Equal(t, DenyAccess, accessControlList.PolicySpec[key2].DefaultAction)
-		assert.Equal(t, "domain1", accessControlList.PolicySpec[key2].TrustDomain)
-		assert.Equal(t, "ns2", accessControlList.PolicySpec[key2].Namespace)
+		assert.Equal(t, app2, accessControlList.PolicySpec[app2Ns2].AppName)
+		assert.Equal(t, DenyAccess, accessControlList.PolicySpec[app2Ns2].DefaultAction)
+		assert.Equal(t, "domain1", accessControlList.PolicySpec[app2Ns2].TrustDomain)
+		assert.Equal(t, "ns2", accessControlList.PolicySpec[app2Ns2].Namespace)
 
 		op3Actions := AccessControlListOperationAction{
 			OperationPostFix: "/a/*",
@@ -386,16 +386,16 @@ func TestParseAccessControlSpec(t *testing.T) {
 		op4Actions.VerbAction["POST"] = AllowAccess
 		op4Actions.OperationAction = AllowAccess
 
-		assert.Equal(t, 2, len(accessControlList.PolicySpec[key2].AppOperationActions["/op3"].VerbAction))
-		assert.Equal(t, op3Actions, accessControlList.PolicySpec[key2].AppOperationActions["/op3"])
-		assert.Equal(t, 1, len(accessControlList.PolicySpec[key2].AppOperationActions["/op4"].VerbAction))
-		assert.Equal(t, op4Actions, accessControlList.PolicySpec[key2].AppOperationActions["/op4"])
+		assert.Equal(t, 2, len(accessControlList.PolicySpec[app2Ns2].AppOperationActions["/op3"].VerbAction))
+		assert.Equal(t, op3Actions, accessControlList.PolicySpec[app2Ns2].AppOperationActions["/op3"])
+		assert.Equal(t, 1, len(accessControlList.PolicySpec[app2Ns2].AppOperationActions["/op4"].VerbAction))
+		assert.Equal(t, op4Actions, accessControlList.PolicySpec[app2Ns2].AppOperationActions["/op4"])
 
 		// App3
-		assert.Equal(t, app3, accessControlList.PolicySpec[key3].AppName)
-		assert.Equal(t, "", accessControlList.PolicySpec[key3].DefaultAction)
-		assert.Equal(t, "domain1", accessControlList.PolicySpec[key3].TrustDomain)
-		assert.Equal(t, "ns1", accessControlList.PolicySpec[key3].Namespace)
+		assert.Equal(t, app3, accessControlList.PolicySpec[app3Ns1].AppName)
+		assert.Equal(t, "", accessControlList.PolicySpec[app3Ns1].DefaultAction)
+		assert.Equal(t, "domain1", accessControlList.PolicySpec[app3Ns1].TrustDomain)
+		assert.Equal(t, "ns1", accessControlList.PolicySpec[app3Ns1].Namespace)
 
 		op5Actions := AccessControlListOperationAction{
 			OperationPostFix: "/",
@@ -404,14 +404,14 @@ func TestParseAccessControlSpec(t *testing.T) {
 		op5Actions.VerbAction["POST"] = AllowAccess
 		op5Actions.OperationAction = AllowAccess
 
-		assert.Equal(t, 1, len(accessControlList.PolicySpec[key3].AppOperationActions["/op5"].VerbAction))
-		assert.Equal(t, op5Actions, accessControlList.PolicySpec[key3].AppOperationActions["/op5"])
+		assert.Equal(t, 1, len(accessControlList.PolicySpec[app3Ns1].AppOperationActions["/op5"].VerbAction))
+		assert.Equal(t, op5Actions, accessControlList.PolicySpec[app3Ns1].AppOperationActions["/op5"])
 
 		// App1 with a different namespace
-		assert.Equal(t, app1, accessControlList.PolicySpec[key4].AppName)
-		assert.Equal(t, AllowAccess, accessControlList.PolicySpec[key4].DefaultAction)
-		assert.Equal(t, "public", accessControlList.PolicySpec[key4].TrustDomain)
-		assert.Equal(t, "ns4", accessControlList.PolicySpec[key4].Namespace)
+		assert.Equal(t, app1, accessControlList.PolicySpec[app1Ns4].AppName)
+		assert.Equal(t, AllowAccess, accessControlList.PolicySpec[app1Ns4].DefaultAction)
+		assert.Equal(t, "public", accessControlList.PolicySpec[app1Ns4].TrustDomain)
+		assert.Equal(t, "ns4", accessControlList.PolicySpec[app1Ns4].Namespace)
 
 		op6Actions := AccessControlListOperationAction{
 			OperationPostFix: "/",
@@ -420,8 +420,8 @@ func TestParseAccessControlSpec(t *testing.T) {
 		op6Actions.VerbAction["*"] = AllowAccess
 		op6Actions.OperationAction = AllowAccess
 
-		assert.Equal(t, 1, len(accessControlList.PolicySpec[key4].AppOperationActions["/op6"].VerbAction))
-		assert.Equal(t, op6Actions, accessControlList.PolicySpec[key4].AppOperationActions["/op6"])
+		assert.Equal(t, 1, len(accessControlList.PolicySpec[app1Ns4].AppOperationActions["/op6"].VerbAction))
+		assert.Equal(t, op6Actions, accessControlList.PolicySpec[app1Ns4].AppOperationActions["/op6"])
 	})
 
 	t.Run("test when no trust domain and namespace specified in app policy", func(t *testing.T) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -659,6 +659,8 @@ func (a *DaprRuntime) startGRPCAPIServer(api grpc.API, port int) error {
 }
 
 func (a *DaprRuntime) getNewServerConfig(port int) grpc.ServerConfig {
+	// Use the trust domain value from the access control policy spec to generate the cert
+	// If no access control policy has been specified, use a default value
 	trustDomain := config.DefaultTrustDomain
 	if a.accessControlList != nil {
 		trustDomain = a.accessControlList.TrustDomain

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -659,7 +659,7 @@ func (a *DaprRuntime) startGRPCAPIServer(api grpc.API, port int) error {
 }
 
 func (a *DaprRuntime) getNewServerConfig(port int) grpc.ServerConfig {
-	var trustDomain string
+	trustDomain := config.DefaultTrustDomain
 	if a.accessControlList != nil {
 		trustDomain = a.accessControlList.TrustDomain
 	}


### PR DESCRIPTION
# Description

The ACL policy code needs to handle the case when the policy spec has the same app id with a different namespace specified

#2124 

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2124 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
