### PR TITLE
set timeout for kubectl commands to skip long namespace deletion request

### DIFF
--- a/tests/test-infra/clean_up.sh
+++ b/tests/test-infra/clean_up.sh
@@ -15,6 +15,6 @@ for app in $installed_apps; do
 done
 
 echo "Trying to delete namespace..."
-kubectl delete namespace $1
+kubectl delete namespace $1 --timeout=5m
 
 exit 0

--- a/tests/test-infra/clean_up.sh
+++ b/tests/test-infra/clean_up.sh
@@ -15,6 +15,6 @@ for app in $installed_apps; do
 done
 
 echo "Trying to delete namespace..."
-kubectl delete namespace $1 --timeout=5m
+kubectl delete namespace $1 --timeout=10m
 
 exit 0

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -49,7 +49,7 @@ for clustername in ${testclusterpool[@]}; do
     # this script tries to create the namespace. If it is failed, we can assume 
     # that this cluster is being used by the other tests.
     echo "Trying to create ${DAPR_TEST_NAMESPACE} namespace..."
-    kubectl create namespace ${DAPR_TEST_NAMESPACE}
+    kubectl create namespace ${DAPR_TEST_NAMESPACE} --timeout=5m
     if [ $? -eq 0 ]; then
         echo "Created ${DAPR_TEST_NAMESPACE} successfully and use $clustername cluster"
         echo "::set-env name=TEST_CLUSTER::$clustername"

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -49,7 +49,7 @@ for clustername in ${testclusterpool[@]}; do
     # this script tries to create the namespace. If it is failed, we can assume 
     # that this cluster is being used by the other tests.
     echo "Trying to create ${DAPR_TEST_NAMESPACE} namespace..."
-    kubectl create namespace ${DAPR_TEST_NAMESPACE} --timeout=5m
+    kubectl create namespace ${DAPR_TEST_NAMESPACE} --timeout=10m
     if [ $? -eq 0 ]; then
         echo "Created ${DAPR_TEST_NAMESPACE} successfully and use $clustername cluster"
         echo "::set-env name=TEST_CLUSTER::$clustername"


### PR DESCRIPTION
# Description

e2e test stuck for 6 hours (Max VM occupation time limit) while deleting kubernetes namespace deletion. This timeout for kubectl commands will unblock unexpected long namespace deletion.

## Issue reference

n/a

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
