### PR TITLE
reduce test app docker image size

### DIFF
--- a/tests/apps/Dockerfile
+++ b/tests/apps/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM golang:1.15
+FROM debian:buster-slim
 
 WORKDIR /app
 COPY . .

--- a/tests/apps/Dockerfile-windows
+++ b/tests/apps/Dockerfile-windows
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM golang:1.15-nanoserver-1809
+FROM mcr.microsoft.com/windows/nanoserver:2004
 
 WORKDIR /app
 COPY . .

--- a/tests/apps/Dockerfile-windows
+++ b/tests/apps/Dockerfile-windows
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM mcr.microsoft.com/windows/nanoserver:2004
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 WORKDIR /app
 COPY . .

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -49,7 +49,7 @@ endif
 define genTestAppImageBuild
 .PHONY: build-e2e-app-$(1)
 build-e2e-app-$(1): check-e2e-env
-	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o $(E2E_TESTAPP_DIR)/$(1)/app$(BINARY_EXT_LOCAL) $(E2E_TESTAPP_DIR)/$(1)/app.go
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o $(E2E_TESTAPP_DIR)/$(1)/app$(BINARY_EXT_LOCAL) $(E2E_TESTAPP_DIR)/$(1)/app.go
 	$(DOCKER) build -f $(E2E_TESTAPP_DIR)/$(DOCKERFILE) $(E2E_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG)
 endef
 


### PR DESCRIPTION
# Description

reduce test app docker image size:
1. linux image : from `golang`(500M) to `debian:buster-slim` (80M)
2. windows image : `golang:1.15-nanoserver-1809` (235M) -> `mcr.microsoft.com/windows/nanoserver:1809` (~100M)

## Issue reference

n/a

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
