### PR TITLE
Fix exporters component typo

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -77,7 +77,7 @@ type ComponentCategory string
 
 const (
 	bindingsComponent    ComponentCategory = "bindings"
-	exporterComponent    ComponentCategory = "exporter"
+	exporterComponent    ComponentCategory = "exporters"
 	pubsubComponent      ComponentCategory = "pubsub"
 	secretStoreComponent ComponentCategory = "secretstores"
 	stateComponent       ComponentCategory = "state"
@@ -1261,7 +1261,7 @@ func (a *DaprRuntime) appendOrReplaceComponents(component components_v1alpha1.Co
 	}
 }
 
-func (a *DaprRuntime) figureOutComponentCategory(component components_v1alpha1.Component) ComponentCategory {
+func (a *DaprRuntime) extractComponentCategory(component components_v1alpha1.Component) ComponentCategory {
 	for _, category := range componentCategoriesNeedProcess {
 		if strings.HasPrefix(component.Spec.Type, fmt.Sprintf("%s.", category)) {
 			return category
@@ -1294,7 +1294,7 @@ func (a *DaprRuntime) processComponentAndDependents(comp components_v1alpha1.Com
 		return nil
 	}
 
-	compCategory := a.figureOutComponentCategory(comp)
+	compCategory := a.extractComponentCategory(comp)
 	if err := a.doProcessOneComponent(compCategory, comp); err != nil {
 		log.Errorf("process component %s error, %s", comp.Name, err)
 		return err

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -825,6 +825,39 @@ func TestProcessComponentSecrets(t *testing.T) {
 	})
 }
 
+func TestExtractComponentCategory(t *testing.T) {
+	compCategoryTests := []struct {
+		specType string
+		category string
+	}{
+		{"pubsub.redis", "pubsub"},
+		{"pubsubs.redis", ""},
+		{"secretstores.azure.keyvault", "secretstores"},
+		{"secretstore.azure.keyvault", ""},
+		{"exporters.zipkin", "exporters"},
+		{"exporter.zipkin", ""},
+		{"state.redis", "state"},
+		{"states.redis", ""},
+		{"bindings.kafka", "bindings"},
+		{"binding.kafka", ""},
+		{"this.is.invalid.category", ""},
+	}
+
+	rt := NewTestDaprRuntime(modes.StandaloneMode)
+
+	for _, tt := range compCategoryTests {
+		t.Run(tt.specType, func(t *testing.T) {
+			fakeComp := components_v1alpha1.Component{
+				Spec: components_v1alpha1.ComponentSpec{
+					Type: tt.specType,
+				},
+			}
+
+			assert.Equal(t, string(rt.extractComponentCategory(fakeComp)), tt.category)
+		})
+	}
+}
+
 // Test that flushOutstandingComponents waits for components
 func TestFlushOutstandingComponent(t *testing.T) {
 	t.Run("We can call flushOustandingComponents more than once", func(t *testing.T) {


### PR DESCRIPTION
# Description

Problem: component loading refactoring caused the regression because of typo of `exporters` component.

* rename `figureOutComponentCategory` to `extractComponentCategory` 
* fix exporter typo
* add unit-test to validate available component types

## Issue reference

#2153 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
