### PR TITLE
Allow e2e tests to specify which architecture they run on (#2159)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ docker-deploy-k8s: check-docker-env check-arch
 	$(info Deploying ${DAPR_REGISTRY}/${RELEASE_NAME}:${DAPR_TAG} to the current K8S context...)
 	$(HELM) install \
 		$(RELEASE_NAME) --namespace=$(DAPR_NAMESPACE) --wait --timeout 5m0s\
-		--set global.ha.enabled=$(HA_MODE) --set-string global.tag=$(DAPR_TAG)-$(TARGET_OS)-$(TARGET_ARCH) --set-string global.registry=$(DAPR_REGISTRY) --set global.logAsJson=true --set global.daprControlPlaneOs=$(TARGET_OS) $(HELM_CHART_DIR)
+		--set global.ha.enabled=$(HA_MODE) --set-string global.tag=$(DAPR_TAG)-$(TARGET_OS)-$(TARGET_ARCH) --set-string global.registry=$(DAPR_REGISTRY) --set global.logAsJson=true --set global.daprControlPlaneOs=$(TARGET_OS) --set global.daprControlPlaneArch=$(TARGET_ARCH) $(HELM_CHART_DIR)
 
 ################################################################################
 # Target: archive                                                              #

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -75,6 +75,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `global.mtls.workloadCertTTL`             | TTL for workload cert                                                   | `24h`                   |
 | `global.mtls.allowedClockSkew`            | Allowed clock skew for workload cert rotation                           | `15m`                   |
 | `global.daprControlPlaneOs`               | Operating System for Dapr control plane                                 | `linux`                 |
+| `global.daprControlPlaneArch`             | CPU Architecture for Dapr control plane                                 | `amd64`                 |
 | `dapr_operator.replicaCount`              | Number of replicas for Operator                                         | `1`                     |
 | `dapr_operator.logLevel`                  | Operator Log level                                                      | `info`                  |
 | `dapr_operator.image.name`                | Operator docker image name (`global.registry/dapr_operator.image.name`) | `dapr`                  |

--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
@@ -33,7 +33,14 @@ spec:
                 - key: kubernetes.io/os
                   operator: In
                   values:
-                  - linux
+                  - {{ .Values.global.daprControlPlaneOs }}
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - {{ .Values.global.daprControlPlaneArch }}
 {{- if eq .Values.global.ha.enabled true }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -109,6 +109,13 @@ spec:
                   operator: In
                   values:
                   - {{ .Values.global.daprControlPlaneOs }}
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - {{ .Values.global.daprControlPlaneArch }}
 {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecrets }}

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -92,6 +92,13 @@ spec:
                   operator: In
                   values:
                   - {{ .Values.global.daprControlPlaneOs }}
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - {{ .Values.global.daprControlPlaneArch }}
 {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecrets }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -122,6 +122,13 @@ spec:
                   operator: In
                   values:
                   - {{ .Values.global.daprControlPlaneOs }}
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - {{ .Values.global.daprControlPlaneArch }}
 {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecrets }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -118,6 +118,13 @@ spec:
                   operator: In
                   values:
                   - {{ .Values.global.daprControlPlaneOs }}
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - {{ .Values.global.daprControlPlaneArch }}
 {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecrets }}

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -15,3 +15,4 @@ global:
     workloadCertTTL: 24h
     allowedClockSkew: 15m
   daprControlPlaneOs: linux
+  daprControlPlaneArch: amd64

--- a/tests/config/kafka_override.yaml
+++ b/tests/config/kafka_override.yaml
@@ -24,6 +24,10 @@ affinity:
             operator: In
             values:
             - linux
+          - key: kubernetes.io/arch
+            operator: In
+            values:
+            - amd64
 zookeeper:
   replicaCount: 1
   affinity:
@@ -35,3 +39,7 @@ zookeeper:
               operator: In
               values:
               - linux
+            - key: kubernetes.io/arch
+              operator: In
+              values:
+              - amd64

--- a/tests/config/modify_kafka_template.py
+++ b/tests/config/modify_kafka_template.py
@@ -22,5 +22,9 @@ for template in stdin_contents.split("---")[1:]:
                   operator: In
                   values:
                   - linux
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - amd64
 """)
 

--- a/tests/config/redis_override.yaml
+++ b/tests/config/redis_override.yaml
@@ -20,3 +20,7 @@ master:
               operator: In
               values:
               - linux
+            - key: kubernetes.io/arch
+              operator: In
+              values:
+              - amd64


### PR DESCRIPTION
# Description

Helm chart now allows us to specify an architecture.

### Current behavior

default os -> linux
default arch -> none (let the kubernetes scheduler decide)

### With this change
default os -> linux
default arch -> amd64
> *Note:* if the user does not specify an arch, and tries to deploy to a cluster with no amd64 nodes available, we will still fall back to whatever is available. This keeps us from breaking helm deployments to arm64 only k8s clusters.

Also in this change: when running the e2e tests, force kafka and redis to be deployed to amd64 nodes. The helm charts we use for the e2e tests point to amd64 only containers. For now, to run our E2E tests on arm, they will need to be deployed to a hybrid cluster that has both amd64 and arm64. The dapr control plane and E2E tests apps will be run on TARGET_OS and TARGET_ARCH. If we want to run the E2E tests fully on an arm64 only cluster, we'll need additional work to set up arm64 compatible kafka and redis containers.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2159

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
