### PR TITLE
log and return error on incorrect component type

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1295,6 +1295,12 @@ func (a *DaprRuntime) processComponentAndDependents(comp components_v1alpha1.Com
 	}
 
 	compCategory := a.extractComponentCategory(comp)
+	if compCategory == "" {
+		// the category entered is incorrect, return error
+		err := errors.Errorf("incorrect type %s", comp.Spec.Type)
+		log.Errorf("process component %s error, %s", comp.Name, err)
+		return err
+	}
 	if err := a.doProcessOneComponent(compCategory, comp); err != nil {
 		log.Errorf("process component %s error, %s", comp.Name, err)
 		return err

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1275,7 +1275,10 @@ func (a *DaprRuntime) processComponents() {
 		if comp.Name == "" {
 			continue
 		}
-		a.processComponentAndDependents(comp)
+		err := a.processComponentAndDependents(comp)
+		if err != nil {
+			log.Errorf("process component %s error, %s", comp.Name, err)
+		}
 	}
 }
 
@@ -1297,12 +1300,9 @@ func (a *DaprRuntime) processComponentAndDependents(comp components_v1alpha1.Com
 	compCategory := a.extractComponentCategory(comp)
 	if compCategory == "" {
 		// the category entered is incorrect, return error
-		err := errors.Errorf("incorrect type %s", comp.Spec.Type)
-		log.Errorf("process component %s error, %s", comp.Name, err)
-		return err
+		return errors.Errorf("incorrect type %s", comp.Spec.Type)
 	}
 	if err := a.doProcessOneComponent(compCategory, comp); err != nil {
-		log.Errorf("process component %s error, %s", comp.Name, err)
 		return err
 	}
 

--- a/pkg/testing/state_mock.go
+++ b/pkg/testing/state_mock.go
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package testing
+
+import (
+	"github.com/dapr/components-contrib/state"
+	mock "github.com/stretchr/testify/mock"
+)
+
+type MockStateStore struct {
+	mock.Mock
+}
+
+// Init is a mock initialization method
+func (m *MockStateStore) Init(metadata state.Metadata) error {
+	args := m.Called(metadata)
+	return args.Error(0)
+}
+func (m *MockStateStore) Delete(req *state.DeleteRequest) error {
+	args := m.Called(req)
+	return args.Error(0)
+}
+func (m *MockStateStore) BulkDelete(req []state.DeleteRequest) error {
+	args := m.Called(req)
+	return args.Error(0)
+}
+func (m *MockStateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+	args := m.Called(req)
+	return nil, args.Error(0)
+}
+func (m *MockStateStore) Set(req *state.SetRequest) error {
+	args := m.Called(req)
+	return args.Error(0)
+}
+func (m *MockStateStore) BulkSet(req []state.SetRequest) error {
+	args := m.Called(req)
+	return args.Error(0)
+}


### PR DESCRIPTION
# Description

log and return error on incorrect component type

additionally added some more unit tests for `doProcessComponent` and `initState`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2146 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
