### PR TITLE
Reduce CodeCov spam

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -10,11 +10,6 @@ coverage:
       # only failing because of overall project coverage threshold.
       # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
       default: false
-comment:
-  # Delete old comment and post new one for new coverage information.
-  # This is so that the code coverage info is closer to the newly push
-  # commits on GitHub PR UI.
-  behavior: new
 ignore:
   # Configure what to ignore.
   - "**/zz_generated*.go" # - Generated files.


### PR DESCRIPTION
# Description

The `comment.behavior = new`, while nice in the UI because it keeps CodeCov info in the last comment, is very spammy since it sends an email every time a new commit happens (pushes, merge back from master, etc).

Changing back to default to avoid.

## Issue reference

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
