### PR TITLE
Auto-generates release notes based on PRs and Issues

### DIFF
--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -17,6 +17,7 @@ from github import Github
 milestoneProjectRegex = "^(.*) Milestone$"
 releaseNoteRegex = "^RELEASE NOTE:(.*)$"
 dashboardReleaseVersionRegex="v([0-9\.]+)-?.*"
+majorReleaseRegex="^([0-9]+\.[0-9]+)\.[0-9]+$"
 
 githubToken = os.getenv("GITHUB_TOKEN")
 
@@ -84,6 +85,10 @@ print("Found project: {}".format(project.name))
 
 releaseVersion = re.search(milestoneProjectRegex, project.name).group(1)
 print("Generating release notes for Dapr {}...".format(releaseVersion))
+# Set REL_VERSION.
+print ("##[set-env name=REL_VERSION;]{}".format(releaseVersion))
+print ("##[set-env name=REL_BRANCH;]release-{}".format(
+    re.search(majorReleaseRegex, releaseVersion).group(1)))
 
 releases = sorted([r for r in g.get_repo("dapr/dashboard").get_releases()], key=lambda r: r.created_at, reverse=True)
 dashboardReleaseVersion = re.search(dashboardReleaseVersionRegex, releases[0].tag_name).group(1)

--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -16,8 +16,8 @@ from github import Github
 
 milestoneProjectRegex = "^(.*) Milestone$"
 releaseNoteRegex = "^RELEASE NOTE:(.*)$"
-dashboardReleaseVersionRegex="v([0-9\.]+)-?.*"
-majorReleaseRegex="^([0-9]+\.[0-9]+)\.[0-9]+$"
+dashboardReleaseVersionRegex = "v([0-9\.]+)-?.*"
+majorReleaseRegex = "^([0-9]+\.[0-9]+)\.[0-9]+$"
 
 githubToken = os.getenv("GITHUB_TOKEN")
 
@@ -105,7 +105,9 @@ for c in cards:
     match = re.search(releaseNoteRegex, issueOrPR.body, re.M)
     if match:
         repo = issueOrPR.repository
-        changes.append((repo, issueOrPR, match.group(1).strip()))
+        note = match.group(1).strip()
+        if note:
+            changes.append((repo, issueOrPR, note))
 
 warnings=[]
 

--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -1,0 +1,152 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+# This script finds all release notes from issues in the milestone project.
+
+import os
+import re
+import sys
+
+from datetime import date
+from string import Template
+
+from github import Github
+
+milestoneProjectRegex = "^(.*) Milestone$"
+releaseNoteRegex = "^RELEASE NOTE:(.*)$"
+dashboardReleaseVersionRegex="v([0-9\.]+)-?.*"
+
+githubToken = os.getenv("GITHUB_TOKEN")
+
+top_repos=[
+    'dapr',
+    'cli',
+    'components-contrib',
+    'dashboard',
+    'dotnet-sdk',
+    'go-sdk',
+    'java-sdk',
+    'python-sdk',
+    'rust-sdk',
+    'cpp-sdk',
+    'js-sdk',
+    'workflows',
+    'docs',
+    'quickstarts',
+    'samples']
+
+subtitles={
+    "dapr": "Dapr Runtime",
+    "cli": "Dapr CLI",
+    "dashboard": "Dashboard",
+    "components-contrib": "Components",
+    "java-sdk": "Java SDK",
+    "dotnet-sdk": ".NET SDK",
+    "go-sdk": "Go SDK",
+    "python-sdk": "Python SDK",
+    "js-sdk": "JavaScript SDK",
+    "rust-sdk": "Rust SDK",
+    "cpp-sdk": "C++ SDK",
+    "docs": "Documentation",
+}
+
+changes=[]
+
+def get_repo_subtitle(name):
+    if name in subtitles:
+        return subtitles[name]
+    return name.capitalize()
+
+def get_repo_priority(name):
+    if name in top_repos:
+        return top_repos.index(name)
+    return len(top_repos)
+
+# or using an access token
+g = Github(githubToken)
+
+org = g.get_organization("dapr")
+
+projects = [p for p in org.get_projects(state='open') if re.search(milestoneProjectRegex, p.name)]
+projects = sorted(projects, key=lambda p: p.id)
+if len(projects) == 0:
+    print("FATAL: could not find project for milestone to be released.")
+    sys.exit(0)
+
+if len(projects) > 1:
+    print("WARNING: found more than one project for release, so first project created will be picked: {}".format(
+        [p.name for p in projects]))
+
+project = projects[0]
+print("Found project: {}".format(project.name))
+
+releaseVersion = re.search(milestoneProjectRegex, project.name).group(1)
+print("Generating release notes for Dapr {}...".format(releaseVersion))
+
+releases = sorted([r for r in g.get_repo("dapr/dashboard").get_releases()], key=lambda r: r.created_at, reverse=True)
+dashboardReleaseVersion = re.search(dashboardReleaseVersionRegex, releases[0].tag_name).group(1)
+print("Detected Dapr Dashboard version {}".format(dashboardReleaseVersion))
+
+
+columns = project.get_columns()
+cards = []
+for column in columns:
+    cards = cards + [c for c in column.get_cards()]
+
+for c in cards:
+    issueOrPR = c.get_content()
+    match = re.search(releaseNoteRegex, issueOrPR.body, re.M)
+    if match:
+        repo = issueOrPR.repository
+        changes.append((repo, issueOrPR, match.group(1).strip()))
+
+warnings=[]
+
+changeLines=[]
+lastSubtitle=""
+
+breakingChangeLines=[]
+lastBreakingChangeSubtitle=""
+
+for change in sorted(changes, key=lambda c: (get_repo_priority(c[0].name), c[0].stargazers_count * -1, c[0].id, c[1].id)):
+    breakingChange='breaking-change' in [l.name for l in change[1].labels]
+    subtitle=get_repo_subtitle(change[0].name)
+    if lastSubtitle != subtitle:
+        lastSubtitle = subtitle
+        changeLines.append("### " + subtitle)
+    changeLines.append("- " + change[2])
+
+    if breakingChange:
+        if lastBreakingChangeSubtitle != subtitle:
+            lastBreakingChangeSubtitle = subtitle
+            breakingChangeLines.append("### " + subtitle)
+        breakingChangeLines.append("- " + change[2])
+
+if len(breakingChangeLines) > 0:
+    warnings.append("> **Note: This release contains a few [breaking changes](#breaking-changes).**")
+
+template=''
+releaseNoteTemplatePath="docs/release_notes/template.md"
+with open(releaseNoteTemplatePath, 'r') as file:
+    template = file.read()
+
+changesText='\n\n'.join(changeLines)
+breakingChangesText='None.'
+if len(breakingChangeLines) > 0:
+    breakingChangesText='\n\n'.join(breakingChangeLines)
+warningsText=''
+if len(warnings) > 0:
+    warningsText='\n\n'.join(warnings)
+
+releaseNotePath="docs/release_notes/v{}.md".format(releaseVersion)
+with open(releaseNotePath, 'w') as file:
+    file.write(Template(template).safe_substitute(
+        dapr_version=releaseVersion,
+        dapr_dashboard_version=dashboardReleaseVersion,
+        dapr_changes=changesText,
+        dapr_breaking_changes=breakingChangesText,
+        warnings=warningsText,
+        today=date.today().strftime("%Y-%m-%d")))
+print("Done.")

--- a/.github/workflows/dapr-release-notes.yml
+++ b/.github/workflows/dapr-release-notes.yml
@@ -5,9 +5,8 @@
 
 name: dapr-release-notes
 
-on:
-  repository_dispatch:
-    types: release_notes
+on: 
+  workflow_dispatch:
 jobs:
   build:
     name: Generate release notes
@@ -21,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
         run: python ./.github/scripts/generate_release_notes.py
-      - name: Commit and push to repository
+      - name: Commit and push to branch
         env:
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           COMMIT_MSG: |
@@ -32,8 +31,14 @@ jobs:
           git config user.name "daprweb@microsoft.com"
           # Update origin with token
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          # Checkout the branch so we can push back to it
-          git checkout master
+          git checkout ${REL_BRANCH} || git checkout master
+          echo "##[set-env name=BASE_BRANCH;]$(git branch --show-current)"
+          git checkout -b release-notes-${REL_VERSION}
           git add .
           # Only commit and push if we have changes
-          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)
+          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push --force origin release-notes-${REL_VERSION})
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+        run: |
+          gh pr create --title "Creates release notes for ${{ env.REL_VERSION }}." --body "Release notes." --base ${{ env.BASE_BRANCH }}

--- a/.github/workflows/dapr-release-notes.yml
+++ b/.github/workflows/dapr-release-notes.yml
@@ -1,0 +1,39 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+name: dapr-release-notes
+
+on:
+  repository_dispatch:
+    types: release_notes
+jobs:
+  build:
+    name: Generate release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pip install PyGithub
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+        run: python ./.github/scripts/generate_release_notes.py
+      - name: Commit and push to repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          COMMIT_MSG: |
+            Generating Dapr release notes.
+            skip-checks: true
+        run: |
+          git config user.email "Dapr Bot"
+          git config user.name "daprweb@microsoft.com"
+          # Update origin with token
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          # Checkout the branch so we can push back to it
+          git checkout master
+          git add .
+          # Only commit and push if we have changes
+          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)

--- a/.github/workflows/dapr-release-notes.yml
+++ b/.github/workflows/dapr-release-notes.yml
@@ -41,4 +41,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
         run: |
-          gh pr create --title "Creates release notes for ${{ env.REL_VERSION }}." --body "Release notes." --base ${{ env.BASE_BRANCH }}
+          gh pr create --title "Create release notes for ${{ env.REL_VERSION }}." --body "Release notes." --base ${{ env.BASE_BRANCH }}

--- a/docs/release_notes/template.md
+++ b/docs/release_notes/template.md
@@ -52,7 +52,7 @@ Runtime version: $dapr_version
 
 #### Upgrading from previous version
 
-If you previously installed Dapr using Helm, starting with this releases you can now upgrade Dapr to a new version.
+If you previously installed Dapr using Helm, you can upgrade Dapr to a new version.
 If you installed Dapr using the CLI, go [here](#starting-fresh-install-on-a-cluster).
 
 ##### 1. Get the latest CLI

--- a/docs/release_notes/template.md
+++ b/docs/release_notes/template.md
@@ -1,0 +1,178 @@
+  
+# Dapr $dapr_version
+
+We're happy to announce the release of Dapr $dapr_version!
+
+We would like to extend our thanks to all the new and existing contributors who helped make this release happen.
+
+**Highlights**
+
+If you're new to Dapr, visit the [getting started](https://github.com/dapr/docs/tree/master/getting-started) page and familiarize yourself with Dapr.
+
+Docs have been updated with all the new features and changes of this release. To get started with new capabilities introduced in this release, go to the [Concepts](https://github.com/dapr/docs/tree/master/concepts) and the [How To section](https://github.com/dapr/docs/tree/master/howto#how-tos).
+
+$warnings
+
+See [this](#upgrading-to-dapr-$dapr_version) section on upgrading Dapr to version $dapr_version.
+
+## New in this release
+
+$dapr_changes
+
+## Upgrading to Dapr $dapr_version
+
+To upgrade to this release of Dapr, follow the steps here to ensure a smooth upgrade. You know, the one where you don't get red errors on the terminal.. we all hate that, right?
+
+### Local Machine / Self-hosted
+
+Uninstall Dapr using the CLI you currently have installed. Note that this will remove the default $HOME/.dapr directory, binaries and all containers dapr_redis, dapr_placement and dapr_zipkin. Linux users need to run sudo if they have installed binary in default path /usr/local/bin/ or have docker command needing sudo:
+
+```bash
+dapr uninstall --all
+```
+
+Next, follow [these](https://github.com/dapr/cli#installing-dapr-cli) instructions to install the latest CLI version, or alternatively download the latest and greatest release from [here](https://github.com/dapr/cli/releases) and put the `dapr` binary in your PATH.
+
+Once you have installed the CLI, run:
+
+```bash
+dapr init
+```
+
+Wait for the update to finish,  ensure you are using the latest version of Dapr($dapr_version) with:
+
+```bash
+$ dapr --version
+
+CLI version: $dapr_version
+Runtime version: $dapr_version
+```
+
+### Kubernetes
+
+#### Upgrading from previous version
+
+If you previously installed Dapr using Helm, starting with this releases you can now upgrade Dapr to a new version.
+If you installed Dapr using the CLI, go [here](#starting-fresh-install-on-a-cluster).
+
+##### 1. Get the latest CLI
+
+Get the latest version of the Dapr CLI as outlined above, and put it in your path.
+You can also use the helper scripts outlined [here](https://github.com/dapr/cli#installing-dapr-cli) to get the latest version.
+
+##### 2. Upgrade existing cluster
+
+First, add new Dapr helm repository(see [breaking changes](#breaking-changes)) and update your Helm repos:
+
+```bash
+helm repo add dapr https://dapr.github.io/helm-charts/ --force-update
+helm repo update
+```
+
+Run the following commands to upgrade the Dapr control plane system services and data plane services:
+
+* Export certificates
+
+  ```
+  dapr mtls export -o ./certs
+  ```
+
+* Updating Dapr control plane pods
+  * Using the certs exported above, run the following command:
+    ```
+    helm upgrade dapr dapr/dapr --version $dapr_version --namespace dapr-system --reset-values --set-file dapr_sentry.tls.root.certPEM=./certs/ca.crt --set-file dapr_sentry.tls.issuer.certPEM=./certs/issuer.crt --set-file dapr_sentry.tls.issuer.keyPEM=./certs/issuer.key
+    ```
+
+  * Wait until all the pods are in Running state:
+
+    ```
+    kubectl get pods -w -n dapr-system
+    ```
+
+  * Verify the control plane is updated and healthy:
+
+    ```
+    $ dapr status -k
+
+    NAME                   NAMESPACE    HEALTHY  STATUS   REPLICAS  VERSION  AGE  CREATED
+    dapr-dashboard         dapr-system  True     Running  1         $dapr_dashboard_version    15s  $today 13:07.39
+    dapr-sidecar-injector  dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+    dapr-sentry            dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+    dapr-operator          dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+    dapr-placement         dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+    ```
+
+* Updating the data plane (sidecars)
+  * Next, issue a rolling update to your Dapr enabled deployments. When the pods restart, the new Dapr sidecar version will be picked up.
+
+    ```
+    kubectl rollout restart deploy/<DEPLOYMENT-NAME>
+    ```
+
+All done!
+
+#### Starting fresh install on a cluster 
+
+If you previously installed Dapr on your Kubernetes cluster using the Dapr CLI, run:
+
+*Note: Make sure you're uninstalling with your existing CLI version*
+
+```bash
+dapr uninstall --kubernetes
+```
+
+It's fine to ignore any errors that might show up.
+
+If you previously installed Dapr using __Helm 2.X__:
+
+```bash
+helm del --purge dapr
+```
+
+If you previously installed Dapr using __Helm 3.X__:
+
+```bash
+helm uninstall dapr -n dapr-system
+```
+
+Update the Dapr repo:
+
+```bash
+helm repo update
+```
+
+If you installed Dapr with Helm to a namespace other than `dapr-system`, modify the uninstall command above to account for that.
+
+You can now follow [these](https://github.com/dapr/docs/blob/master/getting-started/environment-setup.md#using-helm-advanced) instructions on how to install Dapr using __Helm 3__.
+
+Alternatively, you can use the newer version of CLI:
+
+```
+dapr init --kubernetes
+```
+
+##### Post installation
+
+Verify the control plane pods are running and are healthy:
+
+```
+$ dapr status -k
+
+  NAME                   NAMESPACE    HEALTHY  STATUS   REPLICAS  VERSION  AGE  CREATED
+  dapr-dashboard         dapr-system  True     Running  1         $dapr_dashboard_version    15s  $today 13:07.39
+  dapr-sidecar-injector  dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+  dapr-sentry            dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+  dapr-operator          dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+  dapr-placement         dapr-system  True     Running  1         $dapr_version   15s  $today 13:07.39
+```
+
+After Dapr $dapr_version has been installed, perform a rolling restart for your deployments to pick up the new version of the sidecar.
+This can be done with:
+
+```
+kubectl rollout restart deploy/<deployment-name>
+```
+
+## Breaking Changes
+
+$dapr_breaking_changes

--- a/docs/release_notes/template.md
+++ b/docs/release_notes/template.md
@@ -25,7 +25,7 @@ To upgrade to this release of Dapr, follow the steps here to ensure a smooth upg
 
 ### Local Machine / Self-hosted
 
-Uninstall Dapr using the CLI you currently have installed. Note that this will remove the default $HOME/.dapr directory, binaries and all containers dapr_redis, dapr_placement and dapr_zipkin. Linux users need to run sudo if they have installed binary in default path /usr/local/bin/ or have docker command needing sudo:
+Uninstall Dapr using the CLI you currently have installed. Note that this will remove the default $HOME/.dapr directory, binaries and all containers dapr_redis, dapr_placement and dapr_zipkin. Linux users need to run sudo if docker command needs sudo:
 
 ```bash
 dapr uninstall --all


### PR DESCRIPTION
# Description

Auto-generates release notes based on PRs and Issues that have `RELEASE NOTE:` line in description AND are in the given project.
Defines a template based on 0.11 release.
Auto-detects the release version based on open projects.
Auto-detects the dashboard version based on tags.
Shows repos in priority order.
Handles 'breaking-change' label.
Triggered manually via GitHub workflow or locally by running the script.

See example of auto-generated release notes below.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2171 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
