### PR TITLE
Raise error when component category is invalid

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1330,7 +1330,7 @@ func (a *DaprRuntime) doProcessOneComponent(category ComponentCategory, comp com
 	case stateComponent:
 		return a.initState(comp)
 	}
-	return nil
+	return errors.Errorf("invalid component type: %s", comp.Spec.Type)
 }
 
 func (a *DaprRuntime) preprocessOneComponent(comp *components_v1alpha1.Component) componentPreprocessRes {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1264,7 +1264,7 @@ func (a *DaprRuntime) appendOrReplaceComponents(component components_v1alpha1.Co
 func (a *DaprRuntime) extractComponentCategory(component components_v1alpha1.Component) (ComponentCategory, error) {
 	compCategory := strings.Split(component.Spec.Type, ".")[0]
 	for _, category := range componentCategoriesNeedProcess {
-		if compCategory == fmt.Sprintf("%s", category) {
+		if compCategory == string(category) {
 			return category, nil
 		}
 	}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -858,6 +858,26 @@ func TestExtractComponentCategory(t *testing.T) {
 	}
 }
 
+// Test that doProcessOneComponent raises an error when the component category is empty
+func TestDoProcessOneComponentRaisesErrorWhenCategoryIsEmpty(t *testing.T) {
+	t.Run("An error is raised when the component category is empty", func(t *testing.T) {
+		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		category := (ComponentCategory)("")
+		comp := components_v1alpha1.Component{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name: "invalidComponent",
+			},
+			Spec: components_v1alpha1.ComponentSpec{
+				Type: "thisCategoryDoesNotExist.foo",
+			},
+		}
+		err := rt.doProcessOneComponent(category, comp)
+		expectedError := errors.Errorf("invalid component type: %s", comp.Spec.Type)
+		assert.NotNil(t, err)
+		assert.Equal(t, expectedError.Error(), err.Error())
+	})
+}
+
 // Test that flushOutstandingComponents waits for components
 func TestFlushOutstandingComponent(t *testing.T) {
 	t.Run("We can call flushOustandingComponents more than once", func(t *testing.T) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -826,7 +826,6 @@ func TestProcessComponentSecrets(t *testing.T) {
 }
 
 func TestExtractComponentCategory(t *testing.T) {
-
 	t.Run("category result", func(t *testing.T) {
 		compCategoryTests := []struct {
 			specType string
@@ -844,9 +843,7 @@ func TestExtractComponentCategory(t *testing.T) {
 			{"binding.kafka", ""},
 			{"this.is.invalid.category", ""},
 		}
-	
 		rt := NewTestDaprRuntime(modes.StandaloneMode)
-	
 		for _, tt := range compCategoryTests {
 			t.Run(tt.specType, func(t *testing.T) {
 				fakeComp := components_v1alpha1.Component{
@@ -870,9 +867,7 @@ func TestExtractComponentCategory(t *testing.T) {
 			{"exporter", "invalid component category: exporter"},
 			{"this.is.invalid.category", "invalid component category: this"},
 		}
-	
 		rt := NewTestDaprRuntime(modes.StandaloneMode)
-	
 		for _, tt := range compCategoryTests {
 			t.Run(tt.specType, func(t *testing.T) {
 				fakeComp := components_v1alpha1.Component{


### PR DESCRIPTION
# Description

Raise an error when the component category is invalid, e.g. (note the double **cc** in **seccretstores.local.env**):
```
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: envvar-secret-store
  namespace: default
spec:
  type: seccretstores.local.env
  metadata:
```

This PR ensures that an error is written to the log:
```
== DAPR == time="2020-10-02T14:01:02.98259+02:00" level=error msg="component envvar-secret-store error, invalid component category: seccretstores" app_id=trafficcontrolservice instance=Luna scope=dapr.runtime type=log ver=0.11.0
```

## Issue reference

This PR will close: #2178

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
