### PR TITLE
Add grpc unit tests

### DIFF
--- a/pkg/grpc/config_test.go
+++ b/pkg/grpc/config_test.go
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerConfig(t *testing.T) {
+	vals := []interface{}{
+		"app1",
+		"localhost:5050",
+		50001,
+		"default",
+		"td1",
+	}
+
+	c := NewServerConfig(vals[0].(string), vals[1].(string), vals[2].(int), vals[3].(string), vals[4].(string))
+	assert.Equal(t, vals[0], c.AppID)
+	assert.Equal(t, vals[1], c.HostAddress)
+	assert.Equal(t, vals[2], c.Port)
+	assert.Equal(t, vals[3], c.NameSpace)
+	assert.Equal(t, vals[4], c.TrustDomain)
+}

--- a/pkg/grpc/grpc_test.go
+++ b/pkg/grpc/grpc_test.go
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package grpc
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/dapr/dapr/pkg/modes"
+	"github.com/dapr/dapr/pkg/runtime/security"
+	"github.com/stretchr/testify/assert"
+)
+
+type authenticatorMock struct {
+}
+
+func (a *authenticatorMock) GetTrustAnchors() *x509.CertPool {
+	return nil
+}
+func (a *authenticatorMock) GetCurrentSignedCert() *security.SignedCertificate {
+	return nil
+}
+func (a *authenticatorMock) CreateSignedWorkloadCert(id, namespace, trustDomain string) (*security.SignedCertificate, error) {
+	return nil, nil
+}
+
+func TestNewGRPCManager(t *testing.T) {
+	t.Run("with self hosted", func(t *testing.T) {
+		m := NewGRPCManager(modes.StandaloneMode)
+		assert.NotNil(t, m)
+		assert.Equal(t, modes.StandaloneMode, m.mode)
+	})
+
+	t.Run("with kubernetes", func(t *testing.T) {
+		m := NewGRPCManager(modes.KubernetesMode)
+		assert.NotNil(t, m)
+		assert.Equal(t, modes.KubernetesMode, m.mode)
+	})
+}
+
+func TestSetAuthenticator(t *testing.T) {
+	a := &authenticatorMock{}
+	m := NewGRPCManager(modes.StandaloneMode)
+	m.SetAuthenticator(a)
+
+	assert.Equal(t, a, m.auth)
+}

--- a/pkg/grpc/port_test.go
+++ b/pkg/grpc/port_test.go
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFreePort(t *testing.T) {
+	p, err := GetFreePort()
+	assert.NoError(t, err)
+	assert.NotZero(t, p)
+}

--- a/pkg/grpc/util_test.go
+++ b/pkg/grpc/util_test.go
@@ -1,0 +1,47 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package grpc
+
+import (
+	"testing"
+
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsistency(t *testing.T) {
+	t.Run("valid eventual", func(t *testing.T) {
+		c := stateConsistencyToString(commonv1pb.StateOptions_CONSISTENCY_EVENTUAL)
+		assert.Equal(t, "eventual", c)
+	})
+
+	t.Run("valid strong", func(t *testing.T) {
+		c := stateConsistencyToString(commonv1pb.StateOptions_CONSISTENCY_STRONG)
+		assert.Equal(t, "strong", c)
+	})
+
+	t.Run("empty when invalid", func(t *testing.T) {
+		c := stateConsistencyToString(commonv1pb.StateOptions_CONSISTENCY_UNSPECIFIED)
+		assert.Empty(t, c)
+	})
+}
+
+func TestConcurrency(t *testing.T) {
+	t.Run("valid first write", func(t *testing.T) {
+		c := stateConcurrencyToString(commonv1pb.StateOptions_CONCURRENCY_FIRST_WRITE)
+		assert.Equal(t, "first-write", c)
+	})
+
+	t.Run("valid last write", func(t *testing.T) {
+		c := stateConcurrencyToString(commonv1pb.StateOptions_CONCURRENCY_LAST_WRITE)
+		assert.Equal(t, "last-write", c)
+	})
+
+	t.Run("empty when invalid", func(t *testing.T) {
+		c := stateConcurrencyToString(commonv1pb.StateOptions_CONCURRENCY_UNSPECIFIED)
+		assert.Empty(t, c)
+	})
+}


### PR DESCRIPTION
This PR increases test coverage for gRPC by adding additional unit tests for areas in code that are either missing tests or containing code that can be considered likely to change.