### PR TITLE
Add sentry unit tests

### DIFF
--- a/pkg/sentry/ca/certificate_authority_test.go
+++ b/pkg/sentry/ca/certificate_authority_test.go
@@ -212,3 +212,14 @@ func TestSignCSR(t *testing.T) {
 		}
 	})
 }
+
+func TestCACertsGeneration(t *testing.T) {
+	defer cleanupCredentials()
+
+	ca := getTestCertAuth()
+	err := ca.LoadOrStoreTrustBundle()
+
+	assert.NoError(t, err)
+	assert.True(t, len(ca.GetCACertBundle().GetRootCertPem()) > 0)
+	assert.True(t, len(ca.GetCACertBundle().GetIssuerCertPem()) > 0)
+}

--- a/pkg/sentry/ca/trust_bundle_test.go
+++ b/pkg/sentry/ca/trust_bundle_test.go
@@ -50,3 +50,35 @@ func TestBundleIssuerCertMatch(t *testing.T) {
 
 	assert.Equal(t, issuerCert.Raw, bundle.GetIssuerCertPem())
 }
+
+func TestRootCertPEM(t *testing.T) {
+	bundle := trustRootBundle{}
+	cert := getTestCert()
+	bundle.rootCertPem = cert.Raw
+
+	assert.Equal(t, cert.Raw, bundle.GetRootCertPem())
+}
+
+func TestIssuerCertPEM(t *testing.T) {
+	bundle := trustRootBundle{}
+	cert := getTestCert()
+	bundle.issuerCertPem = cert.Raw
+
+	assert.Equal(t, cert.Raw, bundle.GetIssuerCertPem())
+}
+
+func TestTrustDomain(t *testing.T) {
+	td := "td1"
+	bundle := trustRootBundle{}
+	bundle.trustDomain = td
+
+	assert.Equal(t, td, bundle.GetTrustDomain())
+}
+
+func TestTrustAnchors(t *testing.T) {
+	bundle := trustRootBundle{}
+	pool := &x509.CertPool{}
+	bundle.trustAnchors = pool
+
+	assert.Equal(t, pool, bundle.GetTrustAnchors())
+}

--- a/pkg/sentry/csr/csr_test.go
+++ b/pkg/sentry/csr/csr_test.go
@@ -1,7 +1,11 @@
 package csr
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -12,4 +16,43 @@ func TestGenerateCSRTemplate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "test-org", tmpl.Subject.Organization[0])
 	})
+}
+
+func TestGenerateBaseCertificate(t *testing.T) {
+	pk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	cert, err := generateBaseCert(time.Second*5, pk)
+
+	assert.NoError(t, err)
+	assert.Equal(t, cert.PublicKey, pk)
+}
+
+func TestGenerateIssuerCertCSR(t *testing.T) {
+	pk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	cert, err := GenerateIssuerCertCSR("name", pk, time.Second*5)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "name", cert.DNSNames[0])
+	assert.Equal(t, "name", cert.Subject.CommonName)
+}
+
+func TestGenerateRootCertCSR(t *testing.T) {
+	pk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	cert, err := GenerateRootCertCSR("org", "name", pk, time.Second*5)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "name", cert.Subject.CommonName)
+	assert.Equal(t, "org", cert.Subject.Organization[0])
+}
+
+func TestCertSerialNumber(t *testing.T) {
+	n, err := newSerialNumber()
+	assert.NoError(t, err)
+	assert.NotNil(t, n)
+}
+
+func TestGenerateCSR(t *testing.T) {
+	c, b, err := GenerateCSR("org", false)
+	assert.NoError(t, err)
+	assert.True(t, len(b) > 0)
+	assert.True(t, len(c) > 0)
 }


### PR DESCRIPTION
This PR increases test coverage for Sentry by adding additional unit tests for areas in code that are either missing tests or containing code that can be considered likely to change.