### PR TITLE
Add unit tests to pkg/runtime

### DIFF
--- a/pkg/runtime/config_test.go
+++ b/pkg/runtime/config_test.go
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfig(t *testing.T) {
+	c := NewRuntimeConfig("app1", "localhost:5050", "localhost:5051", "*", "config", "components", "http", "kubernetes",
+		3500, 50002, 50001, 8080, 7070, true, 1, true, "localhost:5052")
+
+	assert.Equal(t, "app1", c.ID)
+	assert.Equal(t, "localhost:5050", c.PlacementServiceAddress)
+	assert.Equal(t, "localhost:5051", c.Kubernetes.ControlPlaneAddress)
+	assert.Equal(t, "*", c.AllowedOrigins)
+	assert.Equal(t, "config", c.GlobalConfig)
+	assert.Equal(t, "components", c.Standalone.ComponentsPath)
+	assert.Equal(t, "http", string(c.ApplicationProtocol))
+	assert.Equal(t, "kubernetes", string(c.Mode))
+	assert.Equal(t, 3500, c.HTTPPort)
+	assert.Equal(t, 50002, c.InternalGRPCPort)
+	assert.Equal(t, 50001, c.APIGRPCPort)
+	assert.Equal(t, 8080, c.ApplicationPort)
+	assert.Equal(t, 7070, c.ProfilePort)
+	assert.Equal(t, true, c.EnableProfiling)
+	assert.Equal(t, 1, c.MaxConcurrency)
+	assert.Equal(t, true, c.mtlsEnabled)
+	assert.Equal(t, "localhost:5052", c.SentryServiceAddress)
+}

--- a/pkg/runtime/security/auth_test.go
+++ b/pkg/runtime/security/auth_test.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"crypto/x509"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,4 +27,20 @@ func TestGetCurrentSignedCert(t *testing.T) {
 	a.(*authenticator).currentSignedCert = &SignedCertificate{}
 	c := a.GetCurrentSignedCert()
 	assert.NotNil(t, c)
+}
+
+func TestGetSentryIdentifier(t *testing.T) {
+	t.Run("with identity in env", func(t *testing.T) {
+		envID := "cluster.local"
+		os.Setenv("SENTRY_LOCAL_IDENTITY", envID)
+		defer os.Clearenv()
+
+		id := getSentryIdentifier("app1")
+		assert.Equal(t, envID, id)
+	})
+
+	t.Run("without identity in env", func(t *testing.T) {
+		id := getSentryIdentifier("app1")
+		assert.Equal(t, "app1", id)
+	})
 }

--- a/pkg/runtime/security/security_test.go
+++ b/pkg/runtime/security/security_test.go
@@ -66,3 +66,14 @@ func TestGenerateSidecarCSR(t *testing.T) {
 		assert.True(t, len(pk) > 0)
 	})
 }
+
+func TestInitSidecarAuthenticator(t *testing.T) {
+	os.Setenv(certs.TrustAnchorsEnvVar, testRootCert)
+	os.Setenv(certs.CertChainEnvVar, "111")
+	os.Setenv(certs.CertKeyEnvVar, "111")
+	defer os.Clearenv()
+
+	certChain, _ := GetCertChain()
+	_, err := GetSidecarAuthenticator("localhost:5050", certChain)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This PR increases test coverage for the `daprd` runtime by adding additional unit tests for areas in code that are either missing tests or containing code that can be considered likely to change.