### PR TITLE
Enable HA mode for Sentry

### DIFF
--- a/pkg/sentry/ca/certificate_authority.go
+++ b/pkg/sentry/ca/certificate_authority.go
@@ -136,7 +136,7 @@ func shouldCreateCerts(conf config.SentryConfig) bool {
 		return false
 	}
 
-	if _, err := os.Stat(conf.RootCertPath); os.IsNotExist(err) {
+	if _, err = os.Stat(conf.RootCertPath); os.IsNotExist(err) {
 		return true
 	}
 	b, err := ioutil.ReadFile(conf.IssuerCertPath)

--- a/pkg/sentry/ca/certificate_authority.go
+++ b/pkg/sentry/ca/certificate_authority.go
@@ -23,6 +23,7 @@ const (
 	caCommonName               = "cluster.local"
 	selfSignedRootCertLifetime = time.Hour * 8760
 	certLoadTimeout            = time.Second * 30
+	certDetectInterval         = time.Second * 1
 )
 
 var log = logger.NewLogger("dapr.sentry.ca")
@@ -147,7 +148,7 @@ func shouldCreateCerts(conf config.SentryConfig) bool {
 }
 
 func detectCertificates(path string) error {
-	t := time.NewTicker(time.Second * 1)
+	t := time.NewTicker(certDetectInterval)
 	timeout := time.After(certLoadTimeout)
 
 	for {

--- a/pkg/sentry/ca/certificate_authority_test.go
+++ b/pkg/sentry/ca/certificate_authority_test.go
@@ -277,6 +277,6 @@ func TestDetectCertificates(t *testing.T) {
 
 		<-done
 		assert.NoError(t, err)
-		assert.True(t, time.Now().Sub(start).Seconds() >= 2)
+		assert.True(t, time.Since(start).Seconds() >= 2)
 	})
 }

--- a/pkg/sentry/ca/certificate_authority_test.go
+++ b/pkg/sentry/ca/certificate_authority_test.go
@@ -223,3 +223,60 @@ func TestCACertsGeneration(t *testing.T) {
 	assert.True(t, len(ca.GetCACertBundle().GetRootCertPem()) > 0)
 	assert.True(t, len(ca.GetCACertBundle().GetIssuerCertPem()) > 0)
 }
+
+func TestShouldCreateCerts(t *testing.T) {
+	t.Run("certs exist, should not create", func(t *testing.T) {
+		writeTestCredentialsToDisk()
+		defer cleanupCredentials()
+
+		a := getTestCertAuth()
+		r := shouldCreateCerts(a.(*defaultCA).config)
+		assert.False(t, r)
+	})
+
+	t.Run("certs do not exist, should create", func(t *testing.T) {
+		a := getTestCertAuth()
+		r := shouldCreateCerts(a.(*defaultCA).config)
+		assert.True(t, r)
+	})
+}
+
+func TestDetectCertificates(t *testing.T) {
+	t.Run("detected before timeout", func(t *testing.T) {
+		writeTestCredentialsToDisk()
+		defer cleanupCredentials()
+
+		a := getTestCertAuth()
+		rootCertPath := a.(*defaultCA).config.RootCertPath
+		err := detectCertificates(rootCertPath)
+		assert.NoError(t, err)
+	})
+
+	// this is a negative test scenario for the one above that doesn't require waiting the full 30s timeout.
+	// it's meant to check that detectCertificates doesn't detect the certs before they are loaded.
+	t.Run("cert arrives on disk after 2s", func(t *testing.T) {
+		defer cleanupCredentials()
+
+		a := getTestCertAuth()
+		rootCertPath := a.(*defaultCA).config.RootCertPath
+
+		go func() {
+			time.Sleep(time.Second * 2)
+			writeTestCredentialsToDisk()
+		}()
+
+		var start time.Time
+		var err error
+		done := make(chan bool, 1)
+
+		go func() {
+			start = time.Now()
+			err = detectCertificates(rootCertPath)
+			done <- true
+		}()
+
+		<-done
+		assert.NoError(t, err)
+		assert.True(t, time.Now().Sub(start).Seconds() >= 2)
+	})
+}

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -23,8 +23,8 @@ type CertificateAuthority interface {
 }
 
 type sentry struct {
-	server server.CAServer
-	doneCh chan struct{}
+	server    server.CAServer
+	reloading bool
 }
 
 // NewSentryCA returns a new Sentry Certificate Authority instance.
@@ -57,7 +57,6 @@ func (s *sentry) Run(ctx context.Context, conf config.SentryConfig, readyCh chan
 	log.Info("validator created")
 
 	// Run the CA server
-	s.doneCh = make(chan struct{})
 	s.server = server.NewCAServer(certAuth, v)
 
 	go func() {
@@ -65,12 +64,12 @@ func (s *sentry) Run(ctx context.Context, conf config.SentryConfig, readyCh chan
 		case <-ctx.Done():
 			log.Info("sentry certificate authority is shutting down")
 			s.server.Shutdown() // nolint: errcheck
-		case <-s.doneCh:
 		}
 	}()
 
 	if readyCh != nil {
 		readyCh <- true
+		s.reloading = false
 	}
 
 	log.Infof("sentry certificate authority is running, protecting ya'll")
@@ -93,7 +92,11 @@ func createValidator() (identity.Validator, error) {
 }
 
 func (s *sentry) Restart(ctx context.Context, conf config.SentryConfig) {
+	if s.reloading {
+		return
+	}
+	s.reloading = true
+
 	s.server.Shutdown()
-	close(s.doneCh)
 	go s.Run(ctx, conf, nil)
 }

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -60,11 +60,9 @@ func (s *sentry) Run(ctx context.Context, conf config.SentryConfig, readyCh chan
 	s.server = server.NewCAServer(certAuth, v)
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			log.Info("sentry certificate authority is shutting down")
-			s.server.Shutdown() // nolint: errcheck
-		}
+		<-ctx.Done()
+		log.Info("sentry certificate authority is shutting down")
+		s.server.Shutdown() // nolint: errcheck
 	}()
 
 	if readyCh != nil {

--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -20,8 +20,8 @@ E2E tests are designed for verifying the functional correctness by replicating e
     # If you want to run tests against Windows or arm kubernetes clusters, uncomment and set these
     # export TARGET_OS=linux
     # export TARGET_ARCH=amd64
- 
-    # If you are cross compiling (building on MacOS/Windows and running against a Linux Kubernetes cluster 
+
+    # If you are cross compiling (building on MacOS/Windows and running against a Linux Kubernetes cluster
     # or vice versa) uncomment and set these
     # export GOOS=linux
     # export GOARCH=amd64
@@ -128,8 +128,15 @@ make delete-test-namespace
 
 ## Run E2E tests through GitHub Actions
 
-To keep the build infrastructure simple, Dapr uses [dapr-test GitHub Actions Workflow](https://github.com/dapr/dapr/actions?query=workflow%3Adapr-test) to run e2e tests using one of [AKS clusters](https://github.com/dapr/dapr/blob/4cd61680a3129f729deae24a51da241d0701376c/tests/test-infra/find_cluster.sh#L12-L17).
+To keep the build infrastructure simple, Dapr uses [dapr-test GitHub
+Actions
+Workflow](https://github.com/dapr/dapr/actions?query=workflow%3Adapr-test)
+to run e2e tests using one of [AKS
+clusters](https://github.com/dapr/dapr/blob/4cd61680a3129f729deae24a51da241d0701376c/tests/test-infra/find_cluster.sh#L12-L17). A
+separate workflow also runs E2E in [KinD](https://kind.sigs.k8s.io/)
+clusters.
 
-Once a contributor creates pull request, maintainer can start E2E tests by adding `/ok-to-test` comment to Pull Request.
-
-
+Once a contributor creates a pull request, E2E tests on KinD clusters
+are automatically executed for faster feedback. In order to run the
+E2E tests on AKS, ask a maintainer or approver to add `/ok-to-test` comment to
+the Pull Request.


### PR DESCRIPTION
Closes #2187 

This PR adds an additional check for Sentry to see if credentials are already created, and if so wait for them to be detected on the filesystem before loading them.

In addition, this PR removes a redundant channel.

This fixes a (*possible) regression in 0.11.0 where multiple sentry pods would create the certs at the same time and until the pods were restarted, the cluster would exist with 3 different root CAs loaded in memory.

* possible because, although weird, this wasn't reproduced in 0.10.0