### PR TITLE
Run golangci/golangci-lint-action@v2 to have result annotated

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GOVER: 1.15
-      GOLANGCILINT_VER: 1.26.0
+      GOLANGCILINT_VER: 1.28
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
@@ -62,17 +62,16 @@ jobs:
           sudo apt update
           sudo apt install docker-ce
           docker -v
-      - name: Install golangci-lint
-        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
-        run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${{ env.GOROOT }}/bin" v${{ env.GOLANGCILINT_VER }}
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Parse release version and set REL_VERSION
         run: python ./.github/scripts/get_release_version.py
-      - name: Run make lint
+      - name: golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
-        run: make lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: ${{ env.GOLANGLINT_VER }}
+          only-new-issues: true
       - name: Run make test
         env:
           COVERAGE_OPTS: "-coverprofile=coverage.txt -covermode=atomic"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -237,3 +237,4 @@ linters:
     - testpackage
     - goerr113
     - nestif
+    - gofumpt


### PR DESCRIPTION
# Description

I notice that our golanglint runs only shows errors in the stderr. This change would make the linter annotate the PR directly with comments for easy fixing.

The GitHub action only supports version 1.28 or above. I've bumped the version minimally so we can easily merge with the changes in https://github.com/dapr/dapr/pull/2175 .

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
