### PR TITLE
Update Helm instructions

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -35,7 +35,7 @@ For more details on initializing Helm, [read the Helm docs](https://helm.sh/docs
 
 2. Install the Dapr chart on your cluster in the dapr-system namespace:
     ```
-    helm install dapr dapr/dapr --namespace dapr-system
+    helm install dapr dapr/dapr --namespace dapr-system --wait
     ``` 
 
 ## Verify installation
@@ -102,7 +102,7 @@ The Helm chart has the follow configuration options that can be supplied:
 This command creates three replicas of each control plane pod for an HA deployment (with the exception of the Placement pod) in the dapr-system namespace:
 
 ```
-helm install dapr dapr/dapr --namespace dapr-system --set global.ha.enabled=true
+helm install dapr dapr/dapr --namespace dapr-system --set global.ha.enabled=true --wait
 ```
 
 ## Example of installing edge version of Dapr
@@ -110,5 +110,5 @@ helm install dapr dapr/dapr --namespace dapr-system --set global.ha.enabled=true
 This command deploys the latest `edge` version of Dapr to `dapr-system` namespace. This is useful if you want to deploy the latest version of Dapr to test a feature or some capability in your Kubernetes cluster. 
 
 ```
-helm install dapr dapr/dapr --namespace dapr-system --set-string global.tag=edge
+helm install dapr dapr/dapr --namespace dapr-system --set-string global.tag=edge --wait
 ```


### PR DESCRIPTION
This PR adds the --wait flag to the helm install commands, similar to the way we install the chart with our makefiles.

This makes sure that users do not rollout restart pods before the control plane pods are in Running status.

A follow up PR will be made to the docs repo.