### PR TITLE
Bump helm chart version to 0.11.2

### DIFF
--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.11.1"
+appVersion: "0.11.2"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: 0.11.1
+version: 0.11.2
 dependencies:
   - name: dapr_rbac
     version: "0.5.0"

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "0.11.1"
+  tag: "0.11.2"
   logAsJson: false
   imagePullPolicy: Always
   imagePullSecrets: ""


### PR DESCRIPTION
DO NOT MERGE before `0.11.2` is released.