### PR TITLE
Add permission of “watch subscription"

### DIFF
--- a/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
@@ -36,7 +36,7 @@ rules:
   resources: ["deployments", "services", "components", "configurations", "subscriptions"]
   verbs: ["list"]
 - apiGroups: ["*"]
-  resources: ["deployments", "services", "components", "configurations"]
+  resources: ["deployments", "services", "components", "configurations", "subscriptions"]
   verbs: ["watch"]
 - apiGroups: ["*"]
   resources: ["services", "secrets", "configmaps"]


### PR DESCRIPTION
# Description

ClusterRole of "dapr-operator-admin" need the permission of “watch subscription" , otherwise pod  dapr-operator will continuously output the error of "Failed to watch *v1alpha1.Subscription: unknown (get subscriptions.dapr.io)"

## Issue reference

closes https://github.com/dapr/dapr/issues/2208

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
