### PR TITLE
Fix init bindings

### DIFF
--- a/pkg/components/bindings/registry.go
+++ b/pkg/components/bindings/registry.go
@@ -29,6 +29,8 @@ type (
 	Registry interface {
 		RegisterInputBindings(components ...InputBinding)
 		RegisterOutputBindings(components ...OutputBinding)
+		HasInputBinding(name string) bool
+		HasOutputBinding(name string) bool
 		CreateInputBinding(name string) (bindings.InputBinding, error)
 		CreateOutputBinding(name string) (bindings.OutputBinding, error)
 	}
@@ -91,6 +93,18 @@ func (b *bindingsRegistry) CreateOutputBinding(name string) (bindings.OutputBind
 		return method(), nil
 	}
 	return nil, errors.Errorf("couldn't find output binding %s", name)
+}
+
+// HasInputBinding checks if an input binding based on `name` exists in the registry.
+func (b *bindingsRegistry) HasInputBinding(name string) bool {
+	_, ok := b.inputBindings[name]
+	return ok
+}
+
+// HasOutputBinding checks if an output binding based on `name` exists in the registry.
+func (b *bindingsRegistry) HasOutputBinding(name string) bool {
+	_, ok := b.outputBindings[name]
+	return ok
 }
 
 func createFullName(name string) string {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -344,14 +344,18 @@ func (a *DaprRuntime) buildHTTPPipeline() (http_middleware.Pipeline, error) {
 }
 
 func (a *DaprRuntime) initBinding(c components_v1alpha1.Component) error {
-	if err := a.initOutputBinding(c); err != nil {
-		log.Errorf("failed to init output bindings: %s", err)
-		return err
+	if a.bindingsRegistry.HasOutputBinding(c.Spec.Type) {
+		if err := a.initOutputBinding(c); err != nil {
+			log.Errorf("failed to init output bindings: %s", err)
+			return err
+		}
 	}
 
-	if err := a.initInputBinding(c); err != nil {
-		log.Errorf("failed to init input bindings: %s", err)
-		return err
+	if a.bindingsRegistry.HasInputBinding(c.Spec.Type) {
+		if err := a.initInputBinding(c); err != nil {
+			log.Errorf("failed to init input bindings: %s", err)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/testing/bindings_mock.go
+++ b/pkg/testing/bindings_mock.go
@@ -1,0 +1,33 @@
+package testing
+
+import (
+	"github.com/dapr/components-contrib/bindings"
+	mock "github.com/stretchr/testify/mock"
+)
+
+// MockBinding is a mock input/output component object
+type MockBinding struct {
+	mock.Mock
+}
+
+// Init is a mock initialization method
+func (m *MockBinding) Init(metadata bindings.Metadata) error {
+	return nil
+}
+
+// Read is a mock read method
+func (m *MockBinding) Read(handler func(*bindings.ReadResponse) error) error {
+	args := m.Called(handler)
+	return args.Error(0)
+}
+
+// Invoke is a mock invoke method
+func (m *MockBinding) Invoke(req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) {
+	args := m.Called(req)
+	return nil, args.Error(0)
+}
+
+// Operations is a mock operations method
+func (m *MockBinding) Operations() []bindings.OperationKind {
+	return []bindings.OperationKind{bindings.CreateOperation}
+}


### PR DESCRIPTION
Fixes https://github.com/dapr/dapr/issues/2222.

This PR fixes the logic of `inputBindings` to load a binding as input/output by its registration status.
Relevant unit tests were added.
