### PR TITLE
Suppress connection and content-length headers

### DIFF
--- a/docs/release_notes/v0.11.2.md
+++ b/docs/release_notes/v0.11.2.md
@@ -1,0 +1,6 @@
+  
+# Dapr 0.11.2
+
+## Fixes
+
+* Fixed remote actor invocation timeout error on Kubernetes with mTLS enabled (https://github.com/dapr/dapr/issues/2195)

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -96,7 +96,7 @@ func isPermanentHTTPHeader(hdr string) bool {
 		"Accept-Language",
 		"Accept-Ranges",
 		// Connection-specific header fields such as Connection and Keep-Alive are prohibited in HTTP/2.
-		// For grpc-dotnet users, Kestrel server throws the exception if connection header is given.
+		// For grpc-dotnet users, Kestrel server throws the exception if connection header is given. See https://github.com/aspnet/KestrelHttpServer/issues/175 
 		"Connection",
 		"Cache-Control",
 		"Content-Type",

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -96,12 +96,14 @@ func isPermanentHTTPHeader(hdr string) bool {
 		"Accept-Language",
 		"Accept-Ranges",
 		// Connection-specific header fields such as Connection and Keep-Alive are prohibited in HTTP/2.
-		// For grpc-dotnet users, Kestrel server throws the exception if connection header is given. See https://github.com/aspnet/KestrelHttpServer/issues/175 
+		// For grpc-dotnet users, Kestrel server throws the exception if connection header is given.
+		// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection.
 		"Connection",
 		"Cache-Control",
 		"Content-Type",
 		// Remove content-length header since it represents http1.1 payload size,
-		// not the sum of the h2 DATA frame payload lengths. See https://httpwg.org/specs/rfc7540.html#malformed
+		// not the sum of the h2 DATA frame payload lengths.
+		// See https://httpwg.org/specs/rfc7540.html#malformed.
 		"Content-Length",
 		"Cookie",
 		"Date",

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -96,9 +96,12 @@ func isPermanentHTTPHeader(hdr string) bool {
 		"Accept-Language",
 		"Accept-Ranges",
 		// Connection-specific header fields such as Connection and Keep-Alive are prohibited in HTTP/2.
-		// For grpc-dotnet users, Kestrel server throws the exception if connection header is given.
-		// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection.
+		// See https://tools.ietf.org/html/rfc7540#section-8.1.2.2.
 		"Connection",
+		"Keep-Alive",
+		"Proxy-Connection",
+		"Transfer-Encoding",
+		"Upgrade",
 		"Cache-Control",
 		"Content-Type",
 		// Remove content-length header since it represents http1.1 payload size,

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -95,9 +95,13 @@ func isPermanentHTTPHeader(hdr string) bool {
 		"Accept-Charset",
 		"Accept-Language",
 		"Accept-Ranges",
-		// "Authorization",
+		// Connection-specific header fields such as Connection and Keep-Alive are prohibited in HTTP/2.
+		// For grpc-dotnet users, Kestrel server throws the exception if connection header is given.
+		"Connection",
 		"Cache-Control",
 		"Content-Type",
+		// Content-Length is http 1.1 specific.
+		"Content-Length",
 		"Cookie",
 		"Date",
 		"Expect",
@@ -112,7 +116,6 @@ func isPermanentHTTPHeader(hdr string) bool {
 		"Origin",
 		"Pragma",
 		"Referer",
-		// "User-Agent",
 		"Via",
 		"Warning":
 		return true

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -100,7 +100,8 @@ func isPermanentHTTPHeader(hdr string) bool {
 		"Connection",
 		"Cache-Control",
 		"Content-Type",
-		// Content-Length is http 1.1 specific.
+		// Remove content-length header since it represents http1.1 payload size,
+		// not the sum of the h2 DATA frame payload lengths. See https://httpwg.org/specs/rfc7540.html#malformed
 		"Content-Length",
 		"Cookie",
 		"Date",

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -89,6 +89,12 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 		"Content-Type": {
 			Values: []string{"application/json"},
 		},
+		"Content-Length": {
+			Values: []string{"2000"},
+		},
+		"Connection": {
+			Values: []string{"keep-alive"},
+		},
 		"Accept-Encoding": {
 			Values: []string{"gzip, deflate"},
 		},
@@ -102,8 +108,10 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 	t.Run("without http header conversion for http headers", func(t *testing.T) {
 		convertedMD := InternalMetadataToGrpcMetadata(ctx, httpHeaders, false)
 		// always trace header is returned
-		assert.Equal(t, 5, convertedMD.Len())
+		assert.Equal(t, 7, convertedMD.Len())
 		assert.Equal(t, "localhost", convertedMD["host"][0])
+		assert.Equal(t, "keep-alive", convertedMD["connection"][0])
+		assert.Equal(t, "2000", convertedMD["content-length"][0])
 		assert.Equal(t, "application/json", convertedMD["content-type"][0])
 		assert.Equal(t, "gzip, deflate", convertedMD["accept-encoding"][0])
 		assert.Equal(t, "Go-http-client/1.1", convertedMD["user-agent"][0])
@@ -112,8 +120,10 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 	t.Run("with http header conversion for http headers", func(t *testing.T) {
 		convertedMD := InternalMetadataToGrpcMetadata(ctx, httpHeaders, true)
 		// always trace header is returned
-		assert.Equal(t, 5, convertedMD.Len())
+		assert.Equal(t, 7, convertedMD.Len())
 		assert.Equal(t, "localhost", convertedMD["dapr-host"][0])
+		assert.Equal(t, "keep-alive", convertedMD["dapr-connection"][0])
+		assert.Equal(t, "2000", convertedMD["dapr-content-length"][0])
 		assert.Equal(t, "application/json", convertedMD["dapr-content-type"][0])
 		assert.Equal(t, "gzip, deflate", convertedMD["accept-encoding"][0])
 		assert.Equal(t, "Go-http-client/1.1", convertedMD["user-agent"][0])

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -95,6 +95,18 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 		"Connection": {
 			Values: []string{"keep-alive"},
 		},
+		"Keep-Alive": {
+			Values: []string{"timeout=5", "max=1000"},
+		},
+		"Proxy-Connection": {
+			Values: []string{"keep-alive"},
+		},
+		"Transfer-Encoding": {
+			Values: []string{"gzip", "chunked"},
+		},
+		"Upgrade": {
+			Values: []string{"WebSocket"},
+		},
 		"Accept-Encoding": {
 			Values: []string{"gzip, deflate"},
 		},
@@ -108,25 +120,53 @@ func TestInternalMetadataToGrpcMetadata(t *testing.T) {
 	t.Run("without http header conversion for http headers", func(t *testing.T) {
 		convertedMD := InternalMetadataToGrpcMetadata(ctx, httpHeaders, false)
 		// always trace header is returned
-		assert.Equal(t, 7, convertedMD.Len())
-		assert.Equal(t, "localhost", convertedMD["host"][0])
-		assert.Equal(t, "keep-alive", convertedMD["connection"][0])
-		assert.Equal(t, "2000", convertedMD["content-length"][0])
-		assert.Equal(t, "application/json", convertedMD["content-type"][0])
-		assert.Equal(t, "gzip, deflate", convertedMD["accept-encoding"][0])
-		assert.Equal(t, "Go-http-client/1.1", convertedMD["user-agent"][0])
+		assert.Equal(t, 11, convertedMD.Len())
+
+		var testHeaders = []struct {
+			key      string
+			expected string
+		}{
+			{"host", "localhost"},
+			{"connection", "keep-alive"},
+			{"content-length", "2000"},
+			{"content-type", "application/json"},
+			{"keep-alive", "timeout=5"},
+			{"proxy-connection", "keep-alive"},
+			{"transfer-encoding", "gzip"},
+			{"upgrade", "WebSocket"},
+			{"accept-encoding", "gzip, deflate"},
+			{"user-agent", "Go-http-client/1.1"},
+		}
+
+		for _, ht := range testHeaders {
+			assert.Equal(t, ht.expected, convertedMD[ht.key][0])
+		}
 	})
 
 	t.Run("with http header conversion for http headers", func(t *testing.T) {
 		convertedMD := InternalMetadataToGrpcMetadata(ctx, httpHeaders, true)
 		// always trace header is returned
-		assert.Equal(t, 7, convertedMD.Len())
-		assert.Equal(t, "localhost", convertedMD["dapr-host"][0])
-		assert.Equal(t, "keep-alive", convertedMD["dapr-connection"][0])
-		assert.Equal(t, "2000", convertedMD["dapr-content-length"][0])
-		assert.Equal(t, "application/json", convertedMD["dapr-content-type"][0])
-		assert.Equal(t, "gzip, deflate", convertedMD["accept-encoding"][0])
-		assert.Equal(t, "Go-http-client/1.1", convertedMD["user-agent"][0])
+		assert.Equal(t, 11, convertedMD.Len())
+
+		var testHeaders = []struct {
+			key      string
+			expected string
+		}{
+			{"dapr-host", "localhost"},
+			{"dapr-connection", "keep-alive"},
+			{"dapr-content-length", "2000"},
+			{"dapr-content-type", "application/json"},
+			{"dapr-keep-alive", "timeout=5"},
+			{"dapr-proxy-connection", "keep-alive"},
+			{"dapr-transfer-encoding", "gzip"},
+			{"dapr-upgrade", "WebSocket"},
+			{"accept-encoding", "gzip, deflate"},
+			{"user-agent", "Go-http-client/1.1"},
+		}
+
+		for _, ht := range testHeaders {
+			assert.Equal(t, ht.expected, convertedMD[ht.key][0])
+		}
 	})
 
 	var keyBinValue = []byte{100, 50}

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -335,7 +335,7 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, hostname, requestHeaders["X-Forwarded-Host"][0])
 		assert.Equal(t, expectedForwarded, requestHeaders["Forwarded"][0])
 
-		assert.NotNil(t, responseHeaders["content-length"][0])
+		assert.NotNil(t, responseHeaders["dapr-content-length"][0])
 		assert.Equal(t, "application/grpc", responseHeaders["content-type"][0])
 		assert.Equal(t, "application/json; utf-8", responseHeaders["dapr-content-type"][0])
 		assert.NotNil(t, responseHeaders["dapr-date"][0])
@@ -370,6 +370,8 @@ func TestHeaders(t *testing.T) {
 
 		require.NoError(t, err)
 
+		assert.Nil(t, requestHeaders["connection"])
+		assert.Nil(t, requestHeaders["content-length"])
 		assert.True(t, strings.HasPrefix(requestHeaders["dapr-host"][0], "localhost:"))
 		assert.Equal(t, "application/grpc", requestHeaders["content-type"][0])
 		assert.True(t, strings.HasPrefix(requestHeaders[":authority"][0], "127.0.0.1:"))


### PR DESCRIPTION
# Description

Suppress `connection` and `content-length` headers. 

In http->gRPC invocation scenario, translating HTTP 1.1 request headers to gRPC request metadata, both headers are copied to GRPC metadata. However, both headers are applicable only for http 1.1. gRPC over Kestrel server validate these headers for http 2 connection unlike the other gRPC implementation. So we can see the problem only in .net gRPC service application.

This PR will added `dapr-` prefix to two headers to suppress them.

Reference: 
* https://github.com/aspnet/KestrelHttpServer/issues/175 
* https://github.com/improbable-eng/grpc-web/issues/568
* https://github.com/envoyproxy/envoy/pull/2946/files 

## Issue reference

#2221 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
