### PR TITLE
[WIP/TEST] Switch KinD workflow to a cluster suffix not .cluster.local

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -80,11 +80,17 @@ jobs:
       #     https://github.com/kubernetes-sigs/kind/issues/1165, using
       #     a local repository speeds up the image pushes into KinD
       #     significantly.
+      # (c) a random cluster suffix instead of the default .svc.cluster.local
       working-directory: ./
       run: |
         cat > kind.yaml <<EOF
         apiVersion: kind.x-k8s.io/v1alpha4
         kind: Cluster
+        kubeadmConfigPatches:
+          - |
+            kind: ClusterConfiguration
+            networking:
+              dnsDomain: "n${RANDOM}.local"
         nodes:
         - role: control-plane
           image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}


### PR DESCRIPTION
This will ensure we support on-prem clusters who set their own cluster DNS suffix.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
