### PR TITLE
Register APNs Output Binding

### DIFF
--- a/cmd/daprd/main.go
+++ b/cmd/daprd/main.go
@@ -80,6 +80,7 @@ import (
 
 	// Bindings
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/bindings/apns"
 	"github.com/dapr/components-contrib/bindings/aws/dynamodb"
 	"github.com/dapr/components-contrib/bindings/aws/kinesis"
 	"github.com/dapr/components-contrib/bindings/aws/s3"
@@ -311,6 +312,9 @@ func main() {
 			}),
 		),
 		runtime.WithOutputBindings(
+			bindings_loader.NewOutput("apns", func() bindings.OutputBinding {
+				return apns.NewAPNS(logContrib)
+			}),
 			bindings_loader.NewOutput("aws.sqs", func() bindings.OutputBinding {
 				return sqs.NewAWSSQS(logContrib)
 			}),

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
 	github.com/coreos/etcd v3.3.18+incompatible // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/dapr/components-contrib v0.4.1
+	github.com/dapr/components-contrib v0.4.1-0.20201009172644-b08e920cdd71
 	github.com/fasthttp/router v1.3.1
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,11 @@ github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
+github.com/dapr/components-contrib v0.4.1-0.20201009172644-b08e920cdd71 h1:WsOdr6KaKphhe7DvJLnaMvzUlunCjKtYnIOCYTMxzCk=
+github.com/dapr/components-contrib v0.4.1-0.20201009172644-b08e920cdd71/go.mod h1:PB89pXKGk+FVWa/6WSzgx5T5w5aubHlXzCc77+RUOb8=
 github.com/dapr/components-contrib v0.4.1 h1:0qyzUuIy5mLuU7/XrDDX1Y9soRRrNcMKoIhiVmpQPjk=
 github.com/dapr/components-contrib v0.4.1/go.mod h1:PB89pXKGk+FVWa/6WSzgx5T5w5aubHlXzCc77+RUOb8=
+github.com/dapr/components-contrib v0.9.113 h1:IMD5/8MNGzDklfm9u6x2+eN5GTZiEuMi+pAEOC9LCTM=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad/go.mod h1:yeOIFBz6+BigHpk4ASJbgQDVjQ8+00oCWrFyOAFdob8=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -232,9 +232,6 @@ github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
 github.com/dapr/components-contrib v0.4.1-0.20201009172644-b08e920cdd71 h1:WsOdr6KaKphhe7DvJLnaMvzUlunCjKtYnIOCYTMxzCk=
 github.com/dapr/components-contrib v0.4.1-0.20201009172644-b08e920cdd71/go.mod h1:PB89pXKGk+FVWa/6WSzgx5T5w5aubHlXzCc77+RUOb8=
-github.com/dapr/components-contrib v0.4.1 h1:0qyzUuIy5mLuU7/XrDDX1Y9soRRrNcMKoIhiVmpQPjk=
-github.com/dapr/components-contrib v0.4.1/go.mod h1:PB89pXKGk+FVWa/6WSzgx5T5w5aubHlXzCc77+RUOb8=
-github.com/dapr/components-contrib v0.9.113 h1:IMD5/8MNGzDklfm9u6x2+eN5GTZiEuMi+pAEOC9LCTM=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad/go.mod h1:yeOIFBz6+BigHpk4ASJbgQDVjQ8+00oCWrFyOAFdob8=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/testing/exporter_mock.go
+++ b/pkg/testing/exporter_mock.go
@@ -15,3 +15,8 @@ func (m *MockExporter) Init(appID string, hostAddress string, metadata exporters
 	args := m.Called(appID, hostAddress, metadata)
 	return args.Error(0)
 }
+
+// Unregister is a mock method.
+func (m *MockExporter) Unregister() {
+	m.Called()
+}


### PR DESCRIPTION
# Description

I updated `main.go` to register the APNs output binding that was added to `components-contrib`.

## Issue reference

See dapr/components-contrib#480 and dapr/components-contrib#481.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#830
* [x] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#830
* [x] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#830
