### PR TITLE
Fix ：the wrap error will transfer to sdk, and will cause the real error lost

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -210,7 +210,6 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 	envelope := pubsub.NewCloudEventsEnvelope(uuid.New().String(), a.id, pubsub.DefaultCloudEventType, corID, topic, pubsubName, body)
 	b, err := jsoniter.ConfigFastest.Marshal(envelope)
 	if err != nil {
-		err = errors.Wrap(err, "ERR_PUBSUB_CLOUD_EVENTS_SER")
 		apiServerLogger.Debug(err)
 		return &empty.Empty{}, err
 	}
@@ -223,7 +222,6 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 
 	err = a.publishFn(&req)
 	if err != nil {
-		err = errors.Wrap(err, "ERR_PUBSUB_PUBLISH_MESSAGE")
 		apiServerLogger.Debug(err)
 		return &empty.Empty{}, err
 	}
@@ -276,7 +274,6 @@ func (a *api) InvokeBinding(ctx context.Context, in *runtimev1pb.InvokeBindingRe
 	r := &runtimev1pb.InvokeBindingResponse{}
 	resp, err := a.sendToOutputBindingFn(in.Name, req)
 	if err != nil {
-		err = errors.Wrap(err, "ERR_INVOKE_OUTPUT_BINDING")
 		apiServerLogger.Debug(err)
 		return r, err
 	}
@@ -353,7 +350,6 @@ func (a *api) GetState(ctx context.Context, in *runtimev1pb.GetStateRequest) (*r
 
 	getResponse, err := store.Get(&req)
 	if err != nil {
-		err = errors.Wrap(err, "ERR_STATE_GET")
 		apiServerLogger.Debug(err)
 		return &runtimev1pb.GetStateResponse{}, err
 	}
@@ -392,7 +388,6 @@ func (a *api) SaveState(ctx context.Context, in *runtimev1pb.SaveStateRequest) (
 
 	err = store.BulkSet(reqs)
 	if err != nil {
-		err = errors.Wrap(err, "ERR_STATE_SAVE")
 		apiServerLogger.Debug(err)
 		return &empty.Empty{}, err
 	}
@@ -420,7 +415,6 @@ func (a *api) DeleteState(ctx context.Context, in *runtimev1pb.DeleteStateReques
 
 	err = store.Delete(&req)
 	if err != nil {
-		err = errors.Wrapf(err, "ERR_STATE_DELETE: failed deleting state with key %s", in.Key)
 		apiServerLogger.Debug(err)
 		return &empty.Empty{}, err
 	}
@@ -463,7 +457,6 @@ func (a *api) GetSecret(ctx context.Context, in *runtimev1pb.GetSecretRequest) (
 	getResponse, err := a.secretStores[secretStoreName].GetSecret(req)
 
 	if err != nil {
-		err = errors.Wrap(err, "ERR_SECRET_GET")
 		apiServerLogger.Debug(err)
 		return &runtimev1pb.GetSecretResponse{}, err
 	}
@@ -559,7 +552,6 @@ func (a *api) ExecuteStateTransaction(ctx context.Context, in *runtimev1pb.Execu
 	})
 
 	if err != nil {
-		err = errors.Wrap(err, "ERR_STATE_TRANSACTION")
 		apiServerLogger.Debug(err)
 		return &empty.Empty{}, err
 	}


### PR DESCRIPTION
# Description
```
errors.Wrap(err, "ERR_PUBSUB_CLOUD_EVENTS_SER")
```
The wrap error will transfer to sdk, thenl cause the real error cannot be recognized.
So we should remove the wrap function, and transfer real cause to the sdk .

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
