### PR TITLE
Make healthz port configurable for placement service

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -68,7 +68,7 @@ jobs:
         run: python ./.github/scripts/get_release_version.py
       - name: golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v2.2.1
         with:
           version: ${{ env.GOLANGLINT_VER }}
       - name: Run make test

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -34,7 +34,7 @@ const (
 
 func main() {
 	placementPort := flag.Int("port", defaultPlacementPort, "sets the gRPC port for the placement service")
-	healthzPort := flag.Int("port", defaultHealthzPort, "sets the HTTP port for the healthz server")
+	healthzPort := flag.Int("healthz-port", defaultHealthzPort, "sets the HTTP port for the healthz server")
 
 	loggerOptions := logger.DefaultOptions()
 	loggerOptions.AttachCmdFlags(flag.StringVar, flag.BoolVar)
@@ -99,7 +99,7 @@ func main() {
 	p := placement.NewPlacementService()
 	go p.Run(fmt.Sprint(*placementPort), certChain)
 
-	log.Infof("placement Service started on port %s", *placementPort)
+	log.Infof("placement Service started on port %v", *placementPort)
 
 	go func() {
 		healthzServer := health.NewServer(log)

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -33,7 +33,7 @@ const (
 )
 
 func main() {
-	port := flag.Int("port", defaultPlacementPort, "sets the gRPC port for the placement service")
+	placementPort := flag.Int("port", defaultPlacementPort, "sets the gRPC port for the placement service")
 	healthzPort := flag.Int("port", defaultHealthzPort, "sets the HTTP port for the healthz server")
 
 	loggerOptions := logger.DefaultOptions()
@@ -97,9 +97,9 @@ func main() {
 	}
 
 	p := placement.NewPlacementService()
-	go p.Run(fmt.Sprint(*port), certChain)
+	go p.Run(fmt.Sprint(*placementPort), certChain)
 
-	log.Infof("placement Service started on port %s", *port)
+	log.Infof("placement Service started on port %s", *placementPort)
 
 	go func() {
 		healthzServer := health.NewServer(log)

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -8,9 +8,9 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 
 	"github.com/dapr/dapr/pkg/credentials"
 	"github.com/dapr/dapr/pkg/fswatcher"
@@ -97,9 +97,9 @@ func main() {
 	}
 
 	p := placement.NewPlacementService()
-	go p.Run(fmt.Sprint(*placementPort), certChain)
+	go p.Run(strconv.Itoa(*placementPort), certChain)
 
-	log.Infof("placement Service started on port %v", *placementPort)
+	log.Infof("placement service started on port %v", *placementPort)
 
 	go func() {
 		healthzServer := health.NewServer(log)


### PR DESCRIPTION
Fixes #2242 

This PR makes the healthz server port configurable for the placement service, allowing it to run in environments that have port `8080` already taken.

In addition, this PR refactors the flag operations for ports, makes them consistent and adds usages.