### PR TITLE
Add app-ssl annotation to sidecar injector

### DIFF
--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -357,4 +357,41 @@ func TestAppSSL(t *testing.T) {
 		s := appSSLEnabled(annotations)
 		assert.False(t, s)
 	})
+
+	t.Run("get sidecar container enabled", func(t *testing.T) {
+		annotations := map[string]string{
+			daprAppSSLKey: "true",
+		}
+		c, _ := getSidecarContainer(annotations, "app", "image", "ns", "a", "b", nil, "", "", "", "", false, "")
+		found := false
+		for _, a := range c.Args {
+			if a == "--app-ssl" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found)
+	})
+
+	t.Run("get sidecar container disabled", func(t *testing.T) {
+		annotations := map[string]string{
+			daprAppSSLKey: "false",
+		}
+		c, _ := getSidecarContainer(annotations, "app", "image", "ns", "a", "b", nil, "", "", "", "", false, "")
+		for _, a := range c.Args {
+			if a == "--app-ssl" {
+				t.FailNow()
+			}
+		}
+	})
+
+	t.Run("get sidecar container not specified", func(t *testing.T) {
+		annotations := map[string]string{}
+		c, _ := getSidecarContainer(annotations, "app", "image", "ns", "a", "b", nil, "", "", "", "", false, "")
+		for _, a := range c.Args {
+			if a == "--app-ssl" {
+				t.FailNow()
+			}
+		}
+	})
 }

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -334,3 +334,27 @@ func TestAPITokenSecret(t *testing.T) {
 		assert.Equal(t, "", s)
 	})
 }
+
+func TestAppSSL(t *testing.T) {
+	t.Run("ssl enabled", func(t *testing.T) {
+		annotations := map[string]string{
+			daprAppSSLKey: "true",
+		}
+		s := appSSLEnabled(annotations)
+		assert.True(t, s)
+	})
+
+	t.Run("ssl disabled", func(t *testing.T) {
+		annotations := map[string]string{
+			daprAppSSLKey: "false",
+		}
+		s := appSSLEnabled(annotations)
+		assert.False(t, s)
+	})
+
+	t.Run("ssl not specified", func(t *testing.T) {
+		annotations := map[string]string{}
+		s := appSSLEnabled(annotations)
+		assert.False(t, s)
+	})
+}

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -52,6 +52,7 @@ const (
 	daprReadinessProbeTimeoutKey      = "dapr.io/sidecar-readiness-probe-timeout-seconds"
 	daprReadinessProbePeriodKey       = "dapr.io/sidecar-readiness-probe-period-seconds"
 	daprReadinessProbeThresholdKey    = "dapr.io/sidecar-readiness-probe-threshold"
+	daprAppSSLKey                     = "dapr.io/app-ssl"
 	containersPath                    = "/spec/containers"
 	sidecarHTTPPort                   = 3500
 	sidecarAPIGRPCPort                = 50001
@@ -67,6 +68,7 @@ const (
 	sidecarMetricsPortName            = "dapr-metrics"
 	defaultLogLevel                   = "info"
 	defaultLogAsJSON                  = false
+	defaultAppSSL                     = false
 	kubernetesMountPath               = "/var/run/secrets/kubernetes.io/serviceaccount"
 	defaultConfig                     = "daprsystem"
 	defaultMetricsPort                = 9090
@@ -329,6 +331,10 @@ func profilingEnabled(annotations map[string]string) bool {
 	return isEnabled
 }
 
+func appSSLEnabled(annotations map[string]string) bool {
+	return getBoolAnnotationOrDefault(annotations, daprAppSSLKey, defaultAppSSL)
+}
+
 func getAPITokenSecret(annotations map[string]string) string {
 	return getStringAnnotationOrDefault(annotations, daprAPITokenSecret, "")
 }
@@ -472,6 +478,7 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 		log.Warn(err)
 	}
 
+	sslEnabled := appSSLEnabled(annotations)
 	httpHandler := getProbeHTTPHandler(sidecarHTTPPort, apiVersionV1, sidecarHealthzPath)
 
 	c := &corev1.Container{
@@ -575,6 +582,10 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, na
 				Name:  "SENTRY_LOCAL_IDENTITY",
 				Value: identity,
 			})
+	}
+
+	if sslEnabled {
+		c.Args = append(c.Args, "--app-ssl")
 	}
 
 	secret := getAPITokenSecret(annotations)


### PR DESCRIPTION
This PR adds the missing app-ssl annotation to the sidecar injector.