### PR TITLE
Remove gRPC connection block and extend timeout

### DIFF
--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -26,7 +26,7 @@ import (
 const (
 	// needed to load balance requests for target services with multiple endpoints, ie. multiple instances
 	grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
-	dialTimeout       = time.Second * 5
+	dialTimeout       = time.Second * 30
 )
 
 // Manager is a wrapper around gRPC connection pooling

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -77,7 +77,6 @@ func (g *Manager) GetGRPCConnection(address, id string, namespace string, skipTL
 	}
 
 	opts := []grpc.DialOption{
-		grpc.WithBlock(),
 		grpc.WithDefaultServiceConfig(grpcServiceConfig),
 	}
 


### PR DESCRIPTION
This PR removes the `WithBlock()` gRPC option and sets the timeout to `30s` instead of `5s`.
When gRPC is blocking and timeout passes, the Dial method will return a Context Exceeded error instead of the real underlying error.

By removing block, the connection happens in the background and any connection error is reported when invoking the target proto method.

Closes https://github.com/dapr/dapr/issues/2272.