### PR TITLE
Use a windows compatible path for container_logs

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Set up container log path
         run: |
-          echo "DAPR_CONTAINER_LOG_PATH=`pwd`/container_logs/perf_tests" >> $GITHUB_ENV
+          echo "DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/perf_tests" >> $GITHUB_ENV
         shell: bash
       - name: Set up for scheduled test
         if: github.event_name != 'repository_dispatch'

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Set up container log path
         run: |
-          echo "DAPR_CONTAINER_LOG_PATH=`pwd`/container_logs/${{ matrix.target_os }}_${{ matrix.target_arch }}" >> $GITHUB_ENV
+          echo "DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/${{ matrix.target_os }}_${{ matrix.target_arch }}" >> $GITHUB_ENV
         shell: bash
       - name: Set up for scheduled test
         if: github.event_name != 'repository_dispatch'

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -106,7 +106,7 @@ jobs:
         cat kind.yaml
 
         # Set log target directory
-        echo "DAPR_CONTAINER_LOG_PATH=`pwd`/container_logs/${{ matrix.k8s-version }}_${{ matrix.mode }}" >> $GITHUB_ENV
+        echo "DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/${{ matrix.k8s-version }}_${{ matrix.mode }}" >> $GITHUB_ENV
 
     - name: Create KinD Cluster
       uses: helm/kind-action@v1.0.0


### PR DESCRIPTION
# Description

Use an operating system agnostic path for DAPR_CONTAINER_LOG_PATH

## Manual test

Rigged my fork to run this, and it uploads correctly. https://github.com/wcs1only/dapr/runs/1267107374

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
