### PR TITLE
Enable PR gating on unit test coverage regressions (#2262)

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -4,12 +4,9 @@ coverage:
   status:
     project:
       default:
-        informational: true
-    patch:
-      # Disable the coverage threshold of the patch, so that PRs are
-      # only failing because of overall project coverage threshold.
-      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
-      default: false
+        target: auto
+        threshold: 0%
+
 ignore:
   # Configure what to ignore.
   - "**/zz_generated*.go" # - Generated files.


### PR DESCRIPTION
# Description

Turn on PR gating based on codecov. For now, the rule is, no PR should reduce unit test coverage.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2262 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
