### PR TITLE
Make cors middleware optional + tests

### DIFF
--- a/pkg/cors/cors.go
+++ b/pkg/cors/cors.go
@@ -1,0 +1,9 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cors
+
+// DefaultAllowedOrigins is the default origins allowed for the Dapr HTTP servers
+const DefaultAllowedOrigins = "*"

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -12,6 +12,7 @@ import (
 
 	cors "github.com/AdhityaRamadhanus/fasthttpcors"
 	"github.com/dapr/dapr/pkg/config"
+	cors_dapr "github.com/dapr/dapr/pkg/cors"
 	"github.com/dapr/dapr/pkg/logger"
 
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -99,6 +100,10 @@ func (s *server) useComponents(next fasthttp.RequestHandler) fasthttp.RequestHan
 }
 
 func (s *server) useCors(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	if s.config.AllowedOrigins == cors_dapr.DefaultAllowedOrigins {
+		return next
+	}
+
 	log.Infof("enabled cors http middleware")
 	origins := strings.Split(s.config.AllowedOrigins, ",")
 	corsHandler := s.getCorsHandler(origins)

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -1,0 +1,62 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package http
+
+import (
+	"testing"
+
+	"github.com/dapr/dapr/pkg/cors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+type mockHost struct {
+	hasCORS bool
+}
+
+func (m *mockHost) mockHandler() fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		b := ctx.Response.Header.Peek("Access-Control-Allow-Origin")
+		m.hasCORS = len(b) > 0
+	}
+}
+
+func newServer() server {
+	return server{
+		config: ServerConfig{},
+	}
+}
+
+func TestCorsHandler(t *testing.T) {
+	t.Run("with default cors, middleware not enabled", func(t *testing.T) {
+		srv := newServer()
+		srv.config.AllowedOrigins = cors.DefaultAllowedOrigins
+
+		mh := mockHost{}
+		h := srv.useCors(mh.mockHandler())
+		r := &fasthttp.RequestCtx{
+			Request: fasthttp.Request{},
+		}
+		r.Request.Header.Set("Origin", "*")
+		h(r)
+
+		assert.False(t, mh.hasCORS)
+	})
+
+	t.Run("with custom cors, middleware enabled", func(t *testing.T) {
+		srv := newServer()
+		srv.config.AllowedOrigins = "http://test.com"
+
+		mh := mockHost{}
+		h := srv.useCors(mh.mockHandler())
+		r := &fasthttp.RequestCtx{
+			Request: fasthttp.Request{},
+		}
+		r.Request.Header.Set("Origin", "http://test.com")
+		h(r)
+		assert.True(t, mh.hasCORS)
+	})
+}

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	global_config "github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/cors"
 	"github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/grpc"
 	"github.com/dapr/dapr/pkg/logger"
@@ -38,7 +39,7 @@ func FromFlags() (*DaprRuntime, error) {
 	controlPlaneAddress := flag.String("control-plane-address", "", "Address for a Dapr control plane")
 	sentryAddress := flag.String("sentry-address", "", "Address for the Sentry CA service")
 	placementServiceHostAddress := flag.String("placement-host-address", "", "Address for the Dapr placement service")
-	allowedOrigins := flag.String("allowed-origins", DefaultAllowedOrigins, "Allowed HTTP origins")
+	allowedOrigins := flag.String("allowed-origins", cors.DefaultAllowedOrigins, "Allowed HTTP origins")
 	enableProfiling := flag.Bool("enable-profiling", false, "Enable profiling")
 	runtimeVersion := flag.Bool("version", false, "Prints the runtime version")
 	appMaxConcurrency := flag.Int("app-max-concurrency", -1, "Controls the concurrency level when forwarding requests to user code")

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -27,8 +27,6 @@ const (
 	DefaultProfilePort = 7777
 	// DefaultMetricsPort is the default port for metrics endpoints
 	DefaultMetricsPort = 9090
-	// DefaultAllowedOrigins is the default origins allowed for the Dapr HTTP servers
-	DefaultAllowedOrigins = "*"
 )
 
 // Config holds the Dapr Runtime configuration

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -29,6 +29,7 @@ import (
 	secretstores_loader "github.com/dapr/dapr/pkg/components/secretstores"
 	state_loader "github.com/dapr/dapr/pkg/components/state"
 	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/cors"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
@@ -1481,7 +1482,7 @@ func NewTestDaprRuntime(mode modes.DaprMode) *DaprRuntime {
 		TestRuntimeConfigID,
 		"10.10.10.12",
 		"10.10.10.11",
-		DefaultAllowedOrigins,
+		cors.DefaultAllowedOrigins,
 		"globalConfig",
 		"",
 		string(HTTPProtocol),


### PR DESCRIPTION
This PR does the following:

1. Adds unit tests for the CORS middleware
2. Does not add the fasthttp handler middleware unless needed. Profiling has shown this code consumes a significant amount of memory under load (~1MB).