### PR TITLE
Single quote DAPR_CONTAINER_LOG_PATH for windows compatibility

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -155,7 +155,8 @@ delete-test-env-kafka:
 setup-test-env: setup-test-env-kafka setup-test-env-redis
 
 save-dapr-control-plane-k8s-logs:
-	kubectl logs -l 'app.kubernetes.io/name=dapr' -n $(DAPR_TEST_NAMESPACE) > $(DAPR_CONTAINER_LOG_PATH)/control_plane_containers.log
+	mkdir -p '$(DAPR_CONTAINER_LOG_PATH)'
+	kubectl logs -l 'app.kubernetes.io/name=dapr' -n $(DAPR_TEST_NAMESPACE) > '$(DAPR_CONTAINER_LOG_PATH)/control_plane_containers.log'
 
 # Apply default config yaml to turn mTLS off for testing (mTLS is enabled by default)
 setup-disable-mtls:


### PR DESCRIPTION
# Description

Add control plane container logs broke the windows test run. Just need to single quote some commands to make sure paths resolve correctly on windows.


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
