### PR TITLE
fix runtime flaky test

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1570,12 +1570,19 @@ func TestOnNewPublishedMessageGRPC(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// setup
+			// getting new port for every run to avoid conflict and timing issues between tests if sharing same port
 			port, _ := freeport.GetFreePort()
 			rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, string(GRPCProtocol), port)
 			rt.topicRoutes = map[string]TopicRoute{}
-			rt.topicRoutes[TestPubsubName] = TopicRoute{routes: make(map[string]string)}
-			rt.topicRoutes[TestPubsubName].routes["topic1"] = "topic1"
+			rt.topicRoutes[TestPubsubName] = TopicRoute{
+				routes: map[string]string{
+					topic: topic,
+				},
+			}
+			// create a new AppChannel and gRPC client for every test
 			rt.createAppChannel()
+			// properly close the app channel created
 			defer rt.grpc.AppClient.Close()
 			var grpcServer *grpc.Server
 
@@ -1590,6 +1597,7 @@ func TestOnNewPublishedMessageGRPC(t *testing.T) {
 				})
 			}
 			if grpcServer != nil {
+				// properly stop the gRPC server
 				defer grpcServer.Stop()
 			}
 


### PR DESCRIPTION
# Description

fix runtime flaky test. 
properly close runtime app channel client.

Flaky test: https://github.com/dapr/dapr/runs/1280621052?check_suite_focus=true#step:7:218

The ports between tests were shared also the app channel opened in the runtime was not closed properly before. 
Fixing those in this PR.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2235 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
