### PR TITLE
Avoid unnecessary heap allocs in actor invocation

### DIFF
--- a/pkg/actors/actor.go
+++ b/pkg/actors/actor.go
@@ -50,14 +50,14 @@ func (a *actor) lock() {
 	a.concurrencyLock.Lock()
 
 	a.busy = true
-	a.busyCh = make(chan bool, 1)
 	a.lastUsedTime = time.Now().UTC()
 }
 
 func (a *actor) unLock() {
 	if a.busy {
 		a.busy = false
-		close(a.busyCh)
+		// this signals to drain actors earlier than DrainOngoingCallTimeout.
+		a.busyCh <- false
 	}
 
 	a.concurrencyLock.Unlock()

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -296,12 +296,24 @@ func (a *actorsRuntime) callRemoteActorWithRetry(
 	return nil, errors.Errorf("failed to invoke target %s after %v retries", targetAddress, numRetries)
 }
 
+func (a *actorsRuntime) getOrCreateActor(actorType, actorID string) *actor {
+	key := a.constructCompositeKey(actorType, actorID)
+
+	// This avoids allocating multiple actor allocations by calling newActor
+	// whenever actor is invoked. When storing actor key first, there is a chance to
+	// call newActor, but this is trivial.
+	val, ok := a.actorsTable.Load(key)
+	if !ok {
+		val, _ = a.actorsTable.LoadOrStore(key, newActor(actorType, actorID))
+	}
+
+	return val.(*actor)
+}
+
 func (a *actorsRuntime) callLocalActor(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
 	actorTypeID := req.Actor()
-	key := a.constructCompositeKey(actorTypeID.GetActorType(), actorTypeID.GetActorId())
 
-	val, _ := a.actorsTable.LoadOrStore(key, newActor(actorTypeID.GetActorType(), actorTypeID.GetActorId()))
-	act := val.(*actor)
+	act := a.getOrCreateActor(actorTypeID.GetActorType(), actorTypeID.GetActorId())
 	act.lock()
 	defer act.unLock()
 

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -792,6 +792,23 @@ func TestTransactionalState(t *testing.T) {
 	})
 }
 
+func TestGetOrCreateActor(t *testing.T) {
+	const testActorType = "fakeActor"
+	testActorRuntime := newTestActorsRuntime()
+
+	t.Run("create new key", func(t *testing.T) {
+		act := testActorRuntime.getOrCreateActor(testActorType, "id-1")
+		assert.NotNil(t, act)
+	})
+
+	t.Run("try to create the same key", func(t *testing.T) {
+		oldActor := testActorRuntime.getOrCreateActor(testActorType, "id-2")
+		assert.NotNil(t, oldActor)
+		newActor := testActorRuntime.getOrCreateActor(testActorType, "id-2")
+		assert.Same(t, oldActor, newActor, "should not create new actor")
+	})
+}
+
 func TestActiveActorsCount(t *testing.T) {
 	ctx := context.Background()
 	t.Run("Actors Count", func(t *testing.T) {


### PR DESCRIPTION
# Description

After profiling dapr runtime under high load invocation, we found two unnecessary memory allocations:

1. Do not create busy channel per invocation: actor busy channel is used to signal for draining actor. we create channel during lock() and close channel to signal to draining logic. Creating channel per invocation will create unnecessary channel allocations. Instead, we can use one channel to signal for draining actor. Original test, actor_test.go, can cover this scenario. 

2. Do not alloc actor object per invocation: `newActor` will alloc unnecessary actor whenever actor is called.  
```
        val, _ := a.actorsTable.LoadOrStore(key, newActor(actorTypeID.GetActorType(), actorTypeID.GetActorId()))
	act := val.(*actor)
```
New way will try to load first and allocate actors. But there is a chance to allocate multiple actor instance when actor does not exist. This allocated memory when activating actor will be trivial so we do not need lock for it.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2093 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
