### PR TITLE
Linter script was defaulting to latest

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GOVER: 1.15.3
-      GOLANGCILINT_VER: 1.31
+      GOLANGCILINT_VER: v1.31
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
@@ -70,7 +70,7 @@ jobs:
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
         uses: golangci/golangci-lint-action@v2.2.1
         with:
-          version: ${{ env.GOLANGLINT_VER }}
+          version: ${{ env.GOLANGCILINT_VER }}
       - name: Run make test
         env:
           COVERAGE_OPTS: "-coverprofile=coverage.txt -covermode=atomic"


### PR DESCRIPTION
# Description

We had a variable name mismatch which was causing the github action script to install the latest linter version (which broke when a new upstream version was released).

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
