### PR TITLE
Add dapr sidecar as first container in pod

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -144,7 +144,7 @@ func (i *injector) getPodPatchOperations(ar *v1beta1.AdmissionReview,
 		value = []corev1.Container{*sidecarContainer}
 	} else {
 		envPatchOps = addDaprEnvVarsToContainers(pod.Spec.Containers)
-		path = "/spec/containers/-"
+		path = "/spec/containers/0"
 		value = sidecarContainer
 	}
 


### PR DESCRIPTION
Helping with issue https://github.com/dapr/dapr/issues/2007

Now that the sidecar KEP in Kubernetes has been postponed indefinitely, we need to help increase the chances for the Dapr sidecar to start initializing before the app.

As it turn out, Kubernetes does start containers sequentially when operating on the list of containers in the pod spec.
This PR makes sure the Dapr container is placed first so Kubernetes will attempt to schedule the Dapr container lifecycle first.

This doesn't guarantee that Dapr will always start first, as the container lifecycle happens in parallel and the pulling and starting of the containers happen together, but it reduces the chance for the application to try reaching an unavailable sidecar.