### PR TITLE
Update dapr_dashboard_deployment.yaml

### DIFF
--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_deployment.yaml
@@ -5,11 +5,7 @@ metadata:
   labels:
     app: dapr-dashboard
 spec:
-{{- if eq .Values.global.ha.enabled true }}
-  replicas: {{ .Values.global.ha.replicaCount }}
-{{- else }}
   replicas: {{ .Values.replicaCount }}
-{{- end }}
   selector:
     matchLabels:
       app: dapr-dashboard


### PR DESCRIPTION
The dashboard does not need to run in HA mode.

This PR changes the replicaCount to match the `values.yaml` file.

## Release Note

RELEASE NOTE: **Change** Dashboard replicas to 1 and remove HA mode