### PR TITLE
Drop defaultSidecarCPURequest to 0.1 for e2e test framework

### DIFF
--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -21,7 +21,7 @@ const (
 	disableTelemetryConfig      = "disable-telemetry"
 	defaultSidecarCPULimit      = "4.0"
 	defaultSidecarMemoryLimit   = "512Mi"
-	defaultSidecarCPURequest    = "0.5"
+	defaultSidecarCPURequest    = "0.1"
 	defaultSidecarMemoryRequest = "250Mi"
 )
 


### PR DESCRIPTION
# Description

With the recent changes to Dapr control plane CPU requests, our e2e tests were starving the test AKS clusters. We weren't actually using any more CPU, just requesting more than the scheduler could place. I've dropped the defaultSidecarCPURequest to compensate.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
