### PR TITLE
Skip default metric test

### DIFF
--- a/tests/e2e/metrics/metrics_test.go
+++ b/tests/e2e/metrics/metrics_test.go
@@ -51,8 +51,10 @@ func TestMain(m *testing.M) {
 			IngressEnabled: true,
 		},
 		{
-			AppName:        "grpcmetrics",
-			Config:         "obs-defaultmetric",
+			AppName: "grpcmetrics",
+			// TODO: Some AKS clusters created before do not support CRD defaulting even
+			// if Kubernetes version is 1.16/1.17 later.
+			// Config:         "obs-defaultmetric",
 			DaprEnabled:    true,
 			ImageName:      "e2e-stateapp",
 			Replicas:       1,


### PR DESCRIPTION
# Description

CRD default value feature is not working in some existing AKS cluster. CRD default feature is the GA feature in 1.17.
Even if the existing AKS cluster is 1.17 later, it doesn't support for some reason. but if we created new one, it works.

This is the temporary fix to skip metric e2e test for default value testing.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
