### PR TITLE
Add configurable replication factor for actor placement

### DIFF
--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -76,6 +76,8 @@ spec:
 {{- end }}
 {{- if eq .Values.global.prometheus.enabled true }}
         - "--enable-metrics"
+        - "--replicationFactor"
+        - "{{ .Values.replicationFactor }}"
         - "--metrics-port"
         - "{{ .Values.global.prometheus.port }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_placement/values.yaml
+++ b/charts/dapr/charts/dapr_placement/values.yaml
@@ -11,3 +11,4 @@ ports:
   protocol: TCP
   port: 80
   targetPort: 50005
+replicationFactor: 1000

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -27,14 +27,16 @@ var certChainPath string
 var tlsEnabled bool
 
 const (
-	defaultCredentialsPath = "/var/run/dapr/credentials"
-	defaultHealthzPort     = 8080
-	defaultPlacementPort   = 50005
+	defaultCredentialsPath   = "/var/run/dapr/credentials"
+	defaultHealthzPort       = 8080
+	defaultPlacementPort     = 50005
+	defaultReplicationFactor = 1000
 )
 
 func main() {
 	placementPort := flag.Int("port", defaultPlacementPort, "sets the gRPC port for the placement service")
 	healthzPort := flag.Int("healthz-port", defaultHealthzPort, "sets the HTTP port for the healthz server")
+	replicationFactor := flag.Int("replicationFactor", defaultReplicationFactor, "sets the replication factor for actor distribution on vnodes")
 
 	loggerOptions := logger.DefaultOptions()
 	loggerOptions.AttachCmdFlags(flag.StringVar, flag.BoolVar)
@@ -95,6 +97,8 @@ func main() {
 		certChain = chain
 		log.Info("tls certificates loaded successfully")
 	}
+
+	placement.SetReplicationFactor(*replicationFactor)
 
 	p := placement.NewPlacementService()
 	go p.Run(strconv.Itoa(*placementPort), certChain)

--- a/pkg/placement/consisent_hash_test.go
+++ b/pkg/placement/consisent_hash_test.go
@@ -1,0 +1,65 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package placement
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var nodes = []string{"node1", "node2", "node3", "node4", "node5"}
+
+func TestReplicationFactor(t *testing.T) {
+	keys := []string{}
+	for i := 0; i < 100; i++ {
+		keys = append(keys, fmt.Sprint(i))
+	}
+
+	t.Run("varying replication factors, no movement", func(t *testing.T) {
+		factors := []int{1, 100, 1000, 10000}
+
+		for _, f := range factors {
+			SetReplicationFactor(f)
+
+			h := NewConsistentHash()
+			for _, n := range nodes {
+				s := h.Add(n, n, 1)
+				assert.False(t, s)
+			}
+
+			k1 := map[string]string{}
+
+			for _, k := range keys {
+				h, err := h.Get(k)
+				assert.NoError(t, err)
+
+				k1[k] = h
+			}
+
+			nodeToRemove := "node3"
+			h.Remove(nodeToRemove)
+
+			for _, k := range keys {
+				h, err := h.Get(k)
+				assert.NoError(t, err)
+
+				orgS := k1[k]
+				if orgS != nodeToRemove {
+					assert.Equal(t, h, orgS)
+				}
+			}
+		}
+	})
+}
+
+func TestSetReplicationFactor(t *testing.T) {
+	f := 10
+	SetReplicationFactor(f)
+
+	assert.Equal(t, f, replicationFactor)
+}

--- a/pkg/placement/consistent_hash.go
+++ b/pkg/placement/consistent_hash.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const replicationFactor = 10
+var replicationFactor int
 
 // ErrNoHosts is an error for no hosts
 var ErrNoHosts = errors.New("no hosts added")
@@ -329,4 +329,9 @@ func (c *Consistent) delSlice(val uint64) {
 func (c *Consistent) hash(key string) uint64 {
 	out := blake2b.Sum512([]byte(key))
 	return binary.LittleEndian.Uint64(out[:])
+}
+
+// SetReplicationFactor sets the replication factor for actor placement on vnodes
+func SetReplicationFactor(factor int) {
+	replicationFactor = factor
 }


### PR DESCRIPTION
Closes https://github.com/dapr/dapr/issues/2094

This PR adds the ability to set a replication factor (vnodes) for the placement service.
The default value is 1000, assuming a ration of 100 vnodes per host (pod) that will exist in a cluster.