### PR TITLE
 HTTP API make status codes consistent (#2338)

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -301,7 +301,7 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 	err := a.json.Unmarshal(body, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err))
-		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
+		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
 		log.Debug(msg)
 		return
 	}
@@ -338,7 +338,7 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 	if resp == nil {
-		respondEmpty(reqCtx, fasthttp.StatusOK)
+		respondEmpty(reqCtx)
 	} else {
 		respondWithJSON(reqCtx, fasthttp.StatusOK, resp.Data)
 	}
@@ -395,7 +395,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 func (a *api) getStateStoreWithRequestValidation(reqCtx *fasthttp.RequestCtx) (state.Store, error) {
 	if a.stateStores == nil || len(a.stateStores) == 0 {
 		msg := NewErrorResponse("ERR_STATE_STORES_NOT_CONFIGURED", messages.ErrStateStoresNotConfigured)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return nil, errors.New(msg.Message)
 	}
@@ -439,7 +439,7 @@ func (a *api) onGetState(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 	if resp == nil || resp.Data == nil {
-		respondEmpty(reqCtx, fasthttp.StatusNoContent)
+		respondEmpty(reqCtx)
 		return
 	}
 	respondWithETaggedJSON(reqCtx, fasthttp.StatusOK, resp.Data, resp.ETag)
@@ -477,13 +477,13 @@ func (a *api) onDeleteState(reqCtx *fasthttp.RequestCtx) {
 		log.Debug(msg)
 		return
 	}
-	respondEmpty(reqCtx, fasthttp.StatusOK)
+	respondEmpty(reqCtx)
 }
 
 func (a *api) onGetSecret(reqCtx *fasthttp.RequestCtx) {
 	if a.secretStores == nil || len(a.secretStores) == 0 {
-		msg := NewErrorResponse("ERR_SECRET_STORE_NOT_CONFIGURED", messages.ErrSecretStoreNotConfigured)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		msg := NewErrorResponse("ERR_SECRET_STORES_NOT_CONFIGURED", messages.ErrSecretStoreNotConfigured)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -522,7 +522,7 @@ func (a *api) onGetSecret(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	if resp.Data == nil {
-		respondEmpty(reqCtx, fasthttp.StatusNoContent)
+		respondEmpty(reqCtx)
 		return
 	}
 
@@ -559,7 +559,7 @@ func (a *api) onPostState(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	respondEmpty(reqCtx, fasthttp.StatusCreated)
+	respondEmpty(reqCtx)
 }
 
 func (a *api) getStateStoreName(reqCtx *fasthttp.RequestCtx) string {
@@ -622,7 +622,7 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 func (a *api) onCreateActorReminder(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		return
 	}
 
@@ -649,14 +649,14 @@ func (a *api) onCreateActorReminder(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusOK)
+		respondEmpty(reqCtx)
 	}
 }
 
 func (a *api) onCreateActorTimer(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -684,14 +684,14 @@ func (a *api) onCreateActorTimer(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusOK)
+		respondEmpty(reqCtx)
 	}
 }
 
 func (a *api) onDeleteActorReminder(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -712,14 +712,14 @@ func (a *api) onDeleteActorReminder(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusOK)
+		respondEmpty(reqCtx)
 	}
 }
 
 func (a *api) onActorStateTransaction(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -761,14 +761,14 @@ func (a *api) onActorStateTransaction(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusCreated)
+		respondEmpty(reqCtx)
 	}
 }
 
 func (a *api) onGetActorReminder(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -802,7 +802,7 @@ func (a *api) onGetActorReminder(reqCtx *fasthttp.RequestCtx) {
 func (a *api) onDeleteActorTimer(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -822,14 +822,14 @@ func (a *api) onDeleteActorTimer(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusOK)
+		respondEmpty(reqCtx)
 	}
 }
 
 func (a *api) onDirectActorMessage(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -875,7 +875,7 @@ func (a *api) onDirectActorMessage(reqCtx *fasthttp.RequestCtx) {
 func (a *api) onGetActorState(reqCtx *fasthttp.RequestCtx) {
 	if a.actor == nil {
 		msg := NewErrorResponse("ERR_ACTOR_RUNTIME_NOT_FOUND", messages.ErrActorRuntimeNotFound)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -909,7 +909,7 @@ func (a *api) onGetActorState(reqCtx *fasthttp.RequestCtx) {
 		log.Debug(msg)
 	} else {
 		if resp == nil || resp.Data == nil {
-			respondEmpty(reqCtx, fasthttp.StatusNoContent)
+			respondEmpty(reqCtx)
 			return
 		}
 		respondWithJSON(reqCtx, fasthttp.StatusOK, resp.Data)
@@ -945,7 +945,7 @@ func (a *api) onPutMetadata(reqCtx *fasthttp.RequestCtx) {
 	key := fmt.Sprintf("%v", reqCtx.UserValue("key"))
 	body := reqCtx.PostBody()
 	a.extendedMetadata.Store(key, string(body))
-	respondEmpty(reqCtx, fasthttp.StatusOK)
+	respondEmpty(reqCtx)
 }
 
 func (a *api) onPublish(reqCtx *fasthttp.RequestCtx) {
@@ -1003,7 +1003,7 @@ func (a *api) onPublish(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusOK)
+		respondEmpty(reqCtx)
 	}
 }
 
@@ -1025,7 +1025,7 @@ func (a *api) onGetHealthz(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusOK)
+		respondEmpty(reqCtx)
 	}
 }
 
@@ -1046,7 +1046,7 @@ func getMetadataFromRequest(reqCtx *fasthttp.RequestCtx) map[string]string {
 func (a *api) onPostStateTransaction(reqCtx *fasthttp.RequestCtx) {
 	if a.stateStores == nil || len(a.stateStores) == 0 {
 		msg := NewErrorResponse("ERR_STATE_STORES_NOT_CONFIGURED", messages.ErrStateStoresNotConfigured)
-		respondWithError(reqCtx, fasthttp.StatusBadRequest, msg)
+		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 		return
 	}
@@ -1128,7 +1128,7 @@ func (a *api) onPostStateTransaction(reqCtx *fasthttp.RequestCtx) {
 		respondWithError(reqCtx, fasthttp.StatusInternalServerError, msg)
 		log.Debug(msg)
 	} else {
-		respondEmpty(reqCtx, fasthttp.StatusCreated)
+		respondEmpty(reqCtx)
 	}
 }
 

--- a/pkg/http/responses.go
+++ b/pkg/http/responses.go
@@ -53,7 +53,7 @@ func respondWithError(ctx *fasthttp.RequestCtx, code int, resp ErrorResponse) {
 	respondWithJSON(ctx, code, b)
 }
 
-func respondEmpty(ctx *fasthttp.RequestCtx, code int) {
+func respondEmpty(ctx *fasthttp.RequestCtx) {
 	ctx.Response.SetBody(nil)
-	ctx.Response.SetStatusCode(code)
+	ctx.Response.SetStatusCode(fasthttp.StatusNoContent)
 }

--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -74,7 +74,7 @@ func sendToPublisher(t *testing.T, publisherExternalURL string, topic string) ([
 
 		statusCode, err := postSingleMessage(url, jsonValue)
 		// return on an unsuccessful publish
-		if statusCode != http.StatusOK {
+		if statusCode != http.StatusNoContent {
 			return nil, err
 		}
 

--- a/tests/e2e/stateapp/stateapp_test.go
+++ b/tests/e2e/stateapp/stateapp_test.go
@@ -172,13 +172,13 @@ func generateTestCases(isHTTP bool) []testCase {
 					"save",
 					emptyRequest,
 					emptyResponse,
-					201,
+					204,
 				},
 				{
 					"delete",
 					emptyRequest,
 					emptyResponse,
-					200,
+					204,
 				},
 			},
 			protocol,
@@ -197,7 +197,7 @@ func generateTestCases(isHTTP bool) []testCase {
 					"save",
 					newRequest(utils.SimpleKeyValue{testCase1Key, testCase1Value}),
 					emptyResponse,
-					201,
+					204,
 				},
 				{
 					"get",
@@ -209,7 +209,7 @@ func generateTestCases(isHTTP bool) []testCase {
 					"delete",
 					newRequest(utils.SimpleKeyValue{testCase1Key, nil}),
 					emptyResponse,
-					200,
+					204,
 				},
 				{
 					"get",
@@ -234,7 +234,7 @@ func generateTestCases(isHTTP bool) []testCase {
 					"save",
 					newRequest(testCaseManyKeyValues...),
 					emptyResponse,
-					201,
+					204,
 				},
 				{
 					"get",
@@ -252,7 +252,7 @@ func generateTestCases(isHTTP bool) []testCase {
 					"delete",
 					newRequest(testCaseManyKeys...),
 					emptyResponse,
-					200,
+					204,
 				},
 				{
 					"get",
@@ -271,13 +271,13 @@ func generateTestCases(isHTTP bool) []testCase {
 					"save",
 					generateSpecificLengthSample(1024 * 1024), // Less than limit
 					emptyResponse,
-					201,
+					204,
 				},
 				{
 					"save",
 					generateSpecificLengthSample(1024*1024*3 - 55), // Exact limit
 					emptyResponse,
-					201,
+					204,
 				},
 				{
 					"save",
@@ -387,12 +387,14 @@ func TestStateApp(t *testing.T) {
 
 				resp, statusCode, err := utils.HTTPPostWithStatus(url, body)
 				require.NoError(t, err)
-				require.Equal(t, step.expectedStatusCode, statusCode)
+				require.Equal(t, step.expectedStatusCode, statusCode, url)
 
 				var appResp requestResponse
-				err = json.Unmarshal(resp, &appResp)
+				if statusCode != 204 {
+					err = json.Unmarshal(resp, &appResp)
 
-				require.NoError(t, err)
+					require.NoError(t, err)
+				}
 
 				for _, er := range step.expectedResponse.States {
 					for _, ri := range appResp.States {
@@ -510,7 +512,7 @@ func TestMissingAndMisconfiguredStateStore(t *testing.T) {
 		{
 			statestore:   "missingstore",
 			protocol:     "http",
-			errorMessage: "expected status code 201, got 400",
+			errorMessage: "expected status code 204, got 400",
 			status:       500,
 		},
 		{
@@ -522,7 +524,7 @@ func TestMissingAndMisconfiguredStateStore(t *testing.T) {
 		{
 			statestore:   "badhost-store",
 			protocol:     "http",
-			errorMessage: "expected status code 201, got 400",
+			errorMessage: "expected status code 204, got 400",
 			status:       500,
 		},
 		{
@@ -534,7 +536,7 @@ func TestMissingAndMisconfiguredStateStore(t *testing.T) {
 		{
 			statestore:   "badpass-store",
 			protocol:     "http",
-			errorMessage: "expected status code 201, got 400",
+			errorMessage: "expected status code 204, got 400",
 			status:       500,
 		},
 		{


### PR DESCRIPTION
# Description

Updated our HTTP API status codes to be both consistent with our docs, and to be more consistent with what is a server side error and what is a client side error.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2338 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
