### PR TITLE
Clean up heartbeat and stop loop earlier while revoking leadership

### DIFF
--- a/pkg/actors/internal/placement.go
+++ b/pkg/actors/internal/placement.go
@@ -30,7 +30,7 @@ const (
 	unlockOperation = "unlock"
 	updateOperation = "update"
 
-	placementReconnectInterval    = 100 * time.Millisecond
+	placementReconnectInterval    = 500 * time.Millisecond
 	statusReportHeartbeatInterval = 1 * time.Second
 
 	grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
@@ -253,7 +253,7 @@ func (p *ActorPlacement) establishStreamConn() (v1pb.Placement_ReportDaprStatusC
 			continue
 		}
 
-		log.Infof("try to connect to placement service: %s", serverAddr)
+		log.Debugf("try to connect to placement service: %s", serverAddr)
 
 		opts, err := dapr_credentials.GetClientOptions(p.clientCert, security.TLSServerName)
 		if err != nil {
@@ -291,7 +291,7 @@ func (p *ActorPlacement) establishStreamConn() (v1pb.Placement_ReportDaprStatusC
 			goto NEXT_SERVER
 		}
 
-		log.Infof("established connection to placement service at %s", conn.Target())
+		log.Debugf("established connection to placement service at %s", conn.Target())
 		return stream, conn
 	}
 

--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -180,11 +180,7 @@ func (p *Service) membershipChangeWorker(stopCh chan struct{}) {
 					// of placement servers.
 					// Before all runtimes connect to the leader of placements, it will record the current
 					// time as heartbeat timestamp.
-					heartbeat, ok := p.lastHeartBeat.Load(v.Name)
-					if !ok {
-						p.lastHeartBeat.Store(v.Name, time.Now().UnixNano())
-						continue
-					}
+					heartbeat, _ := p.lastHeartBeat.LoadOrStore(v.Name, time.Now().UnixNano())
 
 					elapsed := t.UnixNano() - heartbeat.(int64)
 					if elapsed < int64(p.faultyHostDetectDuration) {

--- a/tests/apps/actorload/cmd/stateactor/service/server.go
+++ b/tests/apps/actorload/cmd/stateactor/service/server.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 
@@ -48,7 +47,7 @@ func NewActorService(port int, config *actor_rt.DaprConfig) *ActorService {
 	if config == nil {
 		daprConfig = actor_rt.DaprConfig{
 			Entities:                []string{},
-			ActorIdleTimeout:        "5m",
+			ActorIdleTimeout:        "60m",
 			ActorScanInterval:       "10s",
 			DrainOngoingCallTimeout: "10s",
 			DrainRebalancedActors:   true,
@@ -193,12 +192,10 @@ func actorMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actorType := chi.URLParam(r, "actorType")
 		actorID := chi.URLParam(r, "actorID")
-		hostname, _ := os.Hostname()
 
 		ctx := context.WithValue(r.Context(), "actorType", actorType)
 		ctx = context.WithValue(ctx, "actorID", actorID)
 
-		log.Printf("%s.%s, %s, %s", actorType, actorID, hostname, r.URL.EscapedPath())
 		w.Header().Add("Content-Type", "application/json")
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/tests/apps/actorload/pkg/actor/client/http/client.go
+++ b/tests/apps/actorload/pkg/actor/client/http/client.go
@@ -139,7 +139,7 @@ func (c *httpClient) GetState(actorType, actorID, name string) ([]byte, error) {
 func (c *httpClient) WaitUntilDaprIsReady() error {
 	for i := 0; i < 10; i++ {
 		resp, err := c.client.Get(fmt.Sprintf("%s/%s", c.address, "v1.0/healthz"))
-		if err == nil && resp.StatusCode == 200 {
+		if err == nil && resp.StatusCode == 204 {
 			return nil
 		}
 		time.Sleep(time.Millisecond * 500)


### PR DESCRIPTION
# Description

Clean up heartbeat and stop loop earlier during revoking leadership.

- Delete all heartbeat timestamps during revoking leadership
- Change the reconnection interval (100ms seems to harsh)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2420 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
