### PR TITLE
Remove redundant log message

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1516,7 +1516,6 @@ func (a *DaprRuntime) getConfigurationHTTP() (*config.ApplicationConfig, error) 
 	}
 
 	contentType, body := resp.RawData()
-	log.Infof("body received is %s", string(body))
 	if contentType != invokev1.JSONContentType {
 		log.Debugf("dapr/config returns invalid content_type: %s", contentType)
 	}


### PR DESCRIPTION
The removed line in this PR prints a configuration data from the app, which might contain sensitive info.

Reported by @mukundansundar 