### PR TITLE
Fail startup if config cannot be read (#2425)

### DIFF
--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -166,7 +166,7 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	if configErr != nil {
-		log.Warnf("error loading configuration: %s", configErr)
+		log.Fatalf("error loading configuration: %s", configErr)
 	}
 	if globalConfig == nil {
 		log.Info("loading default configuration")


### PR DESCRIPTION
# Description

Since we rely on configuration to enforce security controls, we must fail startup of daprd if we can't load configuration.
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2425 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
