### PR TITLE
Remove double-quotation for kubectl annotate cmd

### DIFF
--- a/docs/release_notes/v1.0.0-rc.1.md
+++ b/docs/release_notes/v1.0.0-rc.1.md
@@ -268,8 +268,8 @@ Follow instructions below to migrate from 0.11.x placement service to 1.0.0-rc.1
 First run these two commands to disable `helm upgrade` from uninstall 0.11.x placement service.
 
 ```sh
-kubectl annotate deployment dapr-placement "helm.sh/resource-policy"=keep -n dapr-system
-kubectl annotate svc dapr-placement "helm.sh/resource-policy"=keep -n dapr-system
+kubectl annotate deployment dapr-placement helm.sh/resource-policy=keep -n dapr-system
+kubectl annotate svc dapr-placement helm.sh/resource-policy=keep -n dapr-system
 ```
 
 Then, export certs:


### PR DESCRIPTION
# Description

Using double-quote for annotation in powershell caused the error.

```
kubectl annotate deployment dapr-placement "helm.sh/resource-policy"=keep -n dapr-system
```

error: at least one annotation update is required


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
