### PR TITLE
Clarify release notes breaking change

### DIFF
--- a/docs/release_notes/v1.0.0-rc.1.md
+++ b/docs/release_notes/v1.0.0-rc.1.md
@@ -402,7 +402,7 @@ kubectl rollout restart deploy/<deployment-name>
 
 ### Dapr CLI
 
-- **REMOVED** deprecated commands [503](https://github.com/dapr/cli/issues/503)
+- **REMOVED** deprecated cli command flags [503](https://github.com/dapr/cli/issues/503)
 
 
 ## Acknowledgements


### PR DESCRIPTION
# Description

Release note for deprecated cli command flags was referencing
just commands instead of the flags. This commit clarifies the
message.