### PR TITLE
Return forbidden for pubsub and direct invoke acl failure (#2323)

### DIFF
--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dapr/dapr/pkg/logger"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
+	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	daprt "github.com/dapr/dapr/pkg/testing"
 	routing "github.com/fasthttp/router"
 	jsoniter "github.com/json-iterator/go"
@@ -54,6 +55,15 @@ func TestPubSubEndpoints(t *testing.T) {
 			if req.PubsubName == "errorpubsub" {
 				return fmt.Errorf("Error from pubsub %s", req.PubsubName)
 			}
+
+			if req.PubsubName == "errnotfound" {
+				return runtime_pubsub.NotFoundError{PubsubName: "errnotfound"}
+			}
+
+			if req.PubsubName == "errnotallowed" {
+				return runtime_pubsub.NotAllowedError{Topic: req.Topic, ID: "test"}
+			}
+
 			return nil
 		},
 		json: jsoniter.ConfigFastest,
@@ -164,6 +174,32 @@ func TestPubSubEndpoints(t *testing.T) {
 			assert.Equal(t, "ERR_PUBSUB_NOT_FOUND", resp.ErrorBody["errorCode"])
 		}
 		testAPI.publishFn = savePublishFn
+	})
+
+	t.Run("Pubsub not configured - 400", func(t *testing.T) {
+		apiPath := fmt.Sprintf("%s/publish/errnotfound/topic", apiVersionV1)
+		testMethods := []string{"POST", "PUT"}
+		for _, method := range testMethods {
+			// act
+			resp := fakeServer.DoRequest(method, apiPath, []byte("{\"key\": \"value\"}"), nil)
+			// assert
+			assert.Equal(t, 400, resp.StatusCode, "unexpected success publishing with %s", method)
+			assert.Equal(t, "ERR_PUBSUB_NOT_FOUND", resp.ErrorBody["errorCode"])
+			assert.Equal(t, "pubsub 'errnotfound' not found", resp.ErrorBody["message"])
+		}
+	})
+
+	t.Run("Pubsub not configured - 403", func(t *testing.T) {
+		apiPath := fmt.Sprintf("%s/publish/errnotallowed/topic", apiVersionV1)
+		testMethods := []string{"POST", "PUT"}
+		for _, method := range testMethods {
+			// act
+			resp := fakeServer.DoRequest(method, apiPath, []byte("{\"key\": \"value\"}"), nil)
+			// assert
+			assert.Equal(t, 403, resp.StatusCode, "unexpected success publishing with %s", method)
+			assert.Equal(t, "ERR_PUBSUB_FORBIDDEN", resp.ErrorBody["errorCode"])
+			assert.Equal(t, "topic topic is not allowed for app id test", resp.ErrorBody["message"])
+		}
 	})
 
 	fakeServer.Shutdown()

--- a/pkg/messages/api_errors.go
+++ b/pkg/messages/api_errors.go
@@ -26,6 +26,7 @@ const (
 	ErrTopicEmpty           = "topic is empty in pubsub %s"
 	ErrPubsubCloudEventsSer = "error when marshal cloud event envelop for topic %s pubsub %s: %s"
 	ErrPubsubPublishMessage = "error when publish to topic %s in pubsub %s: %s"
+	ErrPubsubForbidden      = "topic %s is not allowed for app id %s"
 
 	// AppChannel
 	ErrChannelNotFound       = "app channel is not initialized"

--- a/pkg/runtime/pubsub/errors.go
+++ b/pkg/runtime/pubsub/errors.go
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package pubsub
+
+import (
+	"fmt"
+
+	"github.com/dapr/dapr/pkg/messages"
+)
+
+// pubsub.NotFoundError is returned by the runtime when the pubsub does not exist
+type NotFoundError struct {
+	PubsubName string
+}
+
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("pubsub '%s' not found", e.PubsubName)
+}
+
+// pubsub.NotAllowedError is returned by the runtime when publishing is forbidden
+type NotAllowedError struct {
+	Topic string
+	ID    string
+}
+
+func (e NotAllowedError) Error() string {
+	return fmt.Sprintf(messages.ErrPubsubForbidden, e.Topic, e.ID)
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -986,11 +986,11 @@ func (a *DaprRuntime) initPubSub(c components_v1alpha1.Component) error {
 // This method is used by the HTTP and gRPC APIs.
 func (a *DaprRuntime) Publish(req *pubsub.PublishRequest) error {
 	if _, ok := a.pubSubs[req.PubsubName]; !ok {
-		return errors.New("pubsub not found")
+		return runtime_pubsub.NotFoundError{PubsubName: req.PubsubName}
 	}
 
 	if allowed := a.isPubSubOperationAllowed(req.PubsubName, req.Topic, a.scopedPublishings[req.PubsubName]); !allowed {
-		return errors.Errorf("topic %s is not allowed for app id %s", req.Topic, a.runtimeConfig.ID)
+		return runtime_pubsub.NotAllowedError{Topic: req.Topic, ID: a.runtimeConfig.ID}
 	}
 
 	return a.pubSubs[req.PubsubName].Publish(req)


### PR DESCRIPTION
# Description

Pubsub will now return a 403 on topic forbidden.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2323
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#963
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
