### PR TITLE
Fix bug where Name and Kind was not set for config in standalone mode.

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	yaml "gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -43,9 +44,12 @@ const (
 	GRPCProtocol        = "grpc"
 )
 
+// Configuration is an internal (and duplicate) representation of Dapr's Configuration CRD.
 type Configuration struct {
-	Name string            `json:"-" yaml:"-"`
-	Kind string            `json:"-" yaml:"-"`
+	metav1.TypeMeta `json:",inline" yaml:",inline"`
+	// See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	// See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	Spec ConfigurationSpec `json:"spec" yaml:"spec"`
 }
 

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -59,6 +59,16 @@ func TestLoadStandaloneConfiguration(t *testing.T) {
 	}
 }
 
+func TestLoadStandaloneConfigurationKindName(t *testing.T) {
+	t.Run("test Kind and Name", func(t *testing.T) {
+		config, _, err := LoadStandaloneConfiguration("./testdata/config.yaml")
+		assert.NoError(t, err, "Unexpected error")
+		assert.NotNil(t, config, "Config not loaded as expected")
+		assert.Equal(t, "secretappconfig", config.ObjectMeta.Name)
+		assert.Equal(t, "Configuration", config.TypeMeta.Kind)
+	})
+}
+
 func TestMetricSpecForStandAlone(t *testing.T) {
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
# Description

Fix bug where Name and Kind was not set for config in standalone mode.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dashboard/issues/103

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
