### PR TITLE
Close previous connection when overwriting grpc context (#2533)

### DIFF
--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -124,6 +124,10 @@ func (g *Manager) GetGRPCConnection(address, id string, namespace string, skipTL
 		return nil, err
 	}
 
+	if c, ok := g.connectionPool[address]; ok {
+		c.Close()
+	}
+
 	g.connectionPool[address] = conn
 	g.lock.Unlock()
 

--- a/pkg/grpc/grpc_test.go
+++ b/pkg/grpc/grpc_test.go
@@ -7,11 +7,13 @@ package grpc
 
 import (
 	"crypto/x509"
+	"fmt"
 	"testing"
 
 	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/runtime/security"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/connectivity"
 )
 
 type authenticatorMock struct {
@@ -38,6 +40,21 @@ func TestNewGRPCManager(t *testing.T) {
 		m := NewGRPCManager(modes.KubernetesMode)
 		assert.NotNil(t, m)
 		assert.Equal(t, modes.KubernetesMode, m.mode)
+	})
+}
+
+func TestGetGRPCConnection(t *testing.T) {
+	t.Run("Connection is closed", func(t *testing.T) {
+		m := NewGRPCManager(modes.StandaloneMode)
+		assert.NotNil(t, m)
+		port := 55555
+		sslEnabled := false
+		conn, err := m.GetGRPCConnection(fmt.Sprintf("127.0.0.1:%v", port), "", "", true, true, sslEnabled)
+		assert.NoError(t, err)
+		conn2, err2 := m.GetGRPCConnection(fmt.Sprintf("127.0.0.1:%v", port), "", "", true, true, sslEnabled)
+		assert.NoError(t, err2)
+		assert.Equal(t, connectivity.Shutdown, conn.GetState())
+		conn2.Close()
 	})
 }
 


### PR DESCRIPTION
# Description

A previously failed grpc connection does not get cleaned up by an expired dialContext (see https://pkg.go.dev/google.golang.org/grpc#DialContext). Repeated failed connection attempts end up leaking grpc contexts, which also leaks several goroutines that are responsible for retrying the connection.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2533
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
