### PR TITLE
Add webhookFailurePolicy helm chart configuration

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -83,6 +83,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sidecar_injector.replicaCount`      | Number of replicas for Sidecar Injector                                 | `1`                     |
 | `dapr_sidecar_injector.logLevel`          | Sidecar Injector Log level                                              | `info`                  |
 | `dapr_sidecar_injector.image.name`        | Dapr runtime sidecar image name injecting to application (`global.registry/dapr_sidecar_injector.image.name`) | `daprd`                 |
+| `dapr_sidecar_injector.webhookFailurePolicy` | Failure policy for the sidecar injector                              | `Ignore`                |
 | `dapr_sentry.replicaCount`                | Number of replicas for Sentry CA                                        | `1`                     |
 | `dapr_sentry.logLevel`                    | Sentry CA Log level                                                     | `info`                  |
 | `dapr_sentry.image.name`                  | Sentry CA docker image name (`global.registry/dapr_sentry.image.name`)  | `dapr`                  |

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
@@ -38,6 +38,6 @@ webhooks:
     - pods
     operations:
     - CREATE
-  failurePolicy: Ignore
+  failurePolicy: {{ .Values.webhookFailurePolicy}}
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -8,3 +8,4 @@ image:
 
 nameOverride: ""
 fullnameOverride: ""
+webhookFailurePolicy: Ignore


### PR DESCRIPTION
# Description

Add a configuration option in the sidecar injector helm chart for the webhook failure policy

## Issue reference

Please reference the issue this PR will close: #2549 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] ~~Created/updated tests~~
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] ~~Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
* [ ] ~~Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
* [ ] ~~Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
