### PR TITLE
Stop using component-contribs/exporters/string_exporter for tests

### DIFF
--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 
 	"github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/components-contrib/exporters"
-	"github.com/dapr/components-contrib/exporters/stringexporter"
 	"github.com/dapr/components-contrib/middleware"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/secretstores"
@@ -36,6 +34,7 @@ import (
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	daprt "github.com/dapr/dapr/pkg/testing"
+	testtrace "github.com/dapr/dapr/pkg/testing/trace"
 	routing "github.com/fasthttp/router"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -330,13 +329,7 @@ func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 	buffer := ""
 	spec := config.TracingSpec{SamplingRate: "1"}
 
-	meta := exporters.Metadata{
-		Buffer: &buffer,
-		Properties: map[string]string{
-			"Enabled": "true",
-		},
-	}
-	createExporters(meta)
+	createExporters(&buffer)
 
 	testAPI := &api{
 		sendToOutputBindingFn: func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) { return nil, nil },
@@ -564,13 +557,7 @@ func TestV1DirectMessagingEndpointsWithTracer(t *testing.T) {
 	buffer := ""
 	spec := config.TracingSpec{SamplingRate: "1"}
 
-	meta := exporters.Metadata{
-		Buffer: &buffer,
-		Properties: map[string]string{
-			"Enabled": "true",
-		},
-	}
-	createExporters(meta)
+	createExporters(&buffer)
 
 	testAPI := &api{
 		directMessaging: mockDirectMessaging,
@@ -1352,9 +1339,9 @@ func TestV1MetadataEndpoint(t *testing.T) {
 	fakeServer.Shutdown()
 }
 
-func createExporters(meta exporters.Metadata) {
-	exporter := stringexporter.NewStringExporter(logger.NewLogger("fakeLogger"))
-	exporter.Init("fakeID", "fakeAddress", meta)
+func createExporters(buffer *string) {
+	exporter := testtrace.NewStringExporter(buffer, logger.NewLogger("fakeLogger"))
+	exporter.Register("fakeID")
 }
 
 func TestV1ActorEndpointsWithTracer(t *testing.T) {
@@ -1363,13 +1350,7 @@ func TestV1ActorEndpointsWithTracer(t *testing.T) {
 	buffer := ""
 	spec := config.TracingSpec{SamplingRate: "1"}
 
-	meta := exporters.Metadata{
-		Buffer: &buffer,
-		Properties: map[string]string{
-			"Enabled": "true",
-		},
-	}
-	createExporters(meta)
+	createExporters(&buffer)
 
 	testAPI := &api{
 		actor:       nil,
@@ -1636,13 +1617,7 @@ func TestEmptyPipelineWithTracer(t *testing.T) {
 	spec := config.TracingSpec{SamplingRate: "1.0"}
 	pipe := http_middleware.Pipeline{}
 
-	meta := exporters.Metadata{
-		Buffer: &buffer,
-		Properties: map[string]string{
-			"Enabled": "true",
-		},
-	}
-	createExporters(meta)
+	createExporters(&buffer)
 
 	testAPI := &api{
 		directMessaging: mockDirectMessaging,
@@ -1731,13 +1706,7 @@ func TestSinglePipelineWithTracer(t *testing.T) {
 		},
 	})
 
-	meta := exporters.Metadata{
-		Buffer: &buffer,
-		Properties: map[string]string{
-			"Enabled": "true",
-		},
-	}
-	createExporters(meta)
+	createExporters(&buffer)
 
 	testAPI := &api{
 		directMessaging: mockDirectMessaging,
@@ -1803,13 +1772,7 @@ func TestSinglePipelineWithNoTracing(t *testing.T) {
 		},
 	})
 
-	meta := exporters.Metadata{
-		Buffer: &buffer,
-		Properties: map[string]string{
-			"Enabled": "true",
-		},
-	}
-	createExporters(meta)
+	createExporters(&buffer)
 
 	testAPI := &api{
 		directMessaging: mockDirectMessaging,

--- a/pkg/testing/trace/trace.go
+++ b/pkg/testing/trace/trace.go
@@ -1,0 +1,35 @@
+package trace
+
+import (
+	"strconv"
+
+	"github.com/dapr/dapr/pkg/logger"
+	"go.opencensus.io/trace"
+)
+
+// NewStringExporter returns a new string exporter instance.
+//
+// It is very useful in testing scenario where we want to validate trace propagation.
+func NewStringExporter(buffer *string, logger logger.Logger) *Exporter {
+	return &Exporter{
+		Buffer: buffer,
+		logger: logger,
+	}
+}
+
+// Exporter is an OpenCensus string exporter
+type Exporter struct {
+	Buffer *string
+	logger logger.Logger
+}
+
+// ExportSpan exports span content to the buffer
+func (se *Exporter) ExportSpan(sd *trace.SpanData) {
+	*se.Buffer = strconv.Itoa(int(sd.Status.Code))
+}
+
+// Register creates a new string exporter endpoint and reporter
+func (se *Exporter) Register(daprID string) {
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(se)
+}


### PR DESCRIPTION
# Description

Stop using component-contribs/exporters/string_exporter for tests. Instead we add a test utility in `pkg/testing` to validate traces.

This prepares for deletion of code in dapr/component-contribs/exporters.

## Issue reference
This is a clean up/follow up of #2522 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation (in previous parts of #2337)
* [x] Specification has been updated (in previous parts of #2337)
* [x] Provided sample for the feature (in previous parts of #2337)
