### PR TITLE
[for test] Run TestMembershipChangeWorker several times

### DIFF
--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -32,10 +32,10 @@ func cleanupStates() {
 
 func TestMembershipChangeWorker(t *testing.T) {
 	// This test, due to concurrency, is somewhat indeterministic
-	// about the code paths being hit. So we run several times to excerise
+	// about the code paths being hit. So we run several times to exercise
 	// more code paths. There is no guarantee we can hit all of them, but
 	// it is strictly better than running once.
-	runNTimes(t, 10, func(t *testing.T) {
+	runNTimes(t, 15, func(t *testing.T) {
 		serverAddress, testServer, cleanupServer := newTestPlacementServer(testRaftServer)
 		testServer.hasLeadership = true
 


### PR DESCRIPTION
# Description

Run TestMembershipChangeWorker several times. 

This test, due to concurrency, is somewhat indeterministic about the code paths being hit. Here we run several times to exercise more code paths. There is no guarantee we can hit all of them, but it is strictly better than running once.

## Issue reference

This alleviates https://github.com/dapr/dapr/issues/2564

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
