### PR TITLE
Add sidecar image pull policy to helm chart

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -80,6 +80,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_operator.replicaCount`              | Number of replicas for Operator                                         | `1`                     |
 | `dapr_operator.logLevel`                  | Operator Log level                                                      | `info`                  |
 | `dapr_operator.image.name`                | Operator docker image name (`global.registry/dapr_operator.image.name`) | `dapr`                  |
+| `dapr_sidecar_injector.sidecarImagePullPolicy`      | Dapr sidecar image pull policy                               | `Always`                     |
 | `dapr_sidecar_injector.replicaCount`      | Number of replicas for Sidecar Injector                                 | `1`                     |
 | `dapr_sidecar_injector.logLevel`          | Sidecar Injector Log level                                              | `info`                  |
 | `dapr_sidecar_injector.image.name`        | Dapr runtime sidecar image name injecting to application (`global.registry/dapr_sidecar_injector.image.name`) | `daprd`                 |

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -87,6 +87,8 @@ spec:
 {{- else }}
           value: "{{ .Values.global.registry }}/daprd:{{ .Values.global.tag }}"
 {{- end }}
+        - name: SIDECAR_IMAGE_PULL_POLICY
+          value: "{{ .Values.sidecarImagePullPolicy }}"
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -9,3 +9,4 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 webhookFailurePolicy: Ignore
+sidecarImagePullPolicy: Always


### PR DESCRIPTION
This PR adds the ability to override the image pull policy of the Dapr sidecar.