### PR TITLE
Update Component YAML and cleanup error handling on init

### DIFF
--- a/charts/dapr/crds/components.yaml
+++ b/charts/dapr/crds/components.yaml
@@ -39,6 +39,8 @@ spec:
             properties:
               initTimeout:
                 type: string
+              ignoreErrors:
+                type: boolean
               metadata:
                 items:
                   description: MetadataItem is a name/value pair for a metadata

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1301,7 +1301,6 @@ func (a *DaprRuntime) processComponents() {
 			e := fmt.Sprintf("process component %s error: %s", comp.Name, err.Error())
 			if !comp.Spec.IgnoreErrors {
 				log.Fatalf(e)
-
 			}
 			log.Errorf(e)
 		}

--- a/tests/config/dapr_redis_state_badhost.yaml
+++ b/tests/config/dapr_redis_state_badhost.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   type: state.redis
   initTimeout: 1m
+  ignoreErrors: true
   metadata:
   - name: redisHost
     value: badhost:6379

--- a/tests/config/dapr_redis_state_badpass.yaml
+++ b/tests/config/dapr_redis_state_badpass.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   type: state.redis
   initTimeout: 1m
+  ignoreErrors: true
   metadata:
   - name: redisHost
     value: localhost:6379

--- a/tests/config/uppercase.yaml
+++ b/tests/config/uppercase.yaml
@@ -3,6 +3,7 @@ kind: Component
 metadata:
   name: uppercase
 spec:
+  ignoreErrors: true
   type: middleware.http.uppercase
   metadata:
     - name: scopes


### PR DESCRIPTION
This PR updated the Component schema with the `ignoreErrors` field and makes a slight cleanup in the runtime.