### PR TITLE
add appid in ValidateKubernetesAppID error msg

### DIFF
--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -28,7 +28,7 @@ func ValidateKubernetesAppID(appID string) error {
 	if len(r) == 0 {
 		return nil
 	}
-	s := fmt.Sprintf("invalid app id: %s", strings.Join(r, ","))
+	s := fmt.Sprintf("invalid app id(input: %s): %s", appID, strings.Join(r, ","))
 	return errors.New(s)
 }
 

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -24,6 +24,9 @@ var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
 
 // ValidateKubernetesAppID returns a bool that indicates whether a dapr app id is valid for the Kubernetes platform.
 func ValidateKubernetesAppID(appID string) error {
+	if appID == "" {
+		return errors.New("value for the dapr.io/app-id annotation is empty")
+	}
 	r := isDNS1123Label(appID)
 	if len(r) == 0 {
 		return nil

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -42,6 +42,6 @@ func TestValidationForKubernetes(t *testing.T) {
 	t.Run("invalid empty", func(t *testing.T) {
 		id := ""
 		err := ValidateKubernetesAppID(id)
-		assert.Error(t, err)
+		assert.Regexp(t, "value for the dapr.io/app-id annotation is empty", err.Error())
 	})
 }


### PR DESCRIPTION
# Description

add print app-id annotation input for debug. There is already empty string error test. 
https://github.com/dapr/dapr/blob/445972d1c3ca69ad34b7039fd6ca7b5d7c1dd6aa/pkg/validation/validation_test.go#L42

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/2603

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
