### PR TITLE
add missing metadata in getBulkState() response

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -347,13 +347,11 @@ func (a *api) GetBulkState(ctx context.Context, in *runtimev1pb.GetBulkStateRequ
 		}
 		for i := 0; i < len(responses); i++ {
 			item := &runtimev1pb.BulkStateItem{
-				Key: state_loader.GetOriginalStateKey(responses[i].Key),
-			}
-			if responses[i].Error != "" {
-				item.Error = responses[i].Error
-			} else {
-				item.Data = responses[i].Data
-				item.Etag = responses[i].ETag
+				Key:      state_loader.GetOriginalStateKey(responses[i].Key),
+				Data:     responses[i].Data,
+				Etag:     responses[i].ETag,
+				Metadata: responses[i].Metadata,
+				Error:    responses[i].Error,
 			}
 			bulkResp.Items = append(bulkResp.Items, item)
 		}


### PR DESCRIPTION
# Description

In getBulkState() response, the metadata field is missing. Add it back.

## Issue reference



## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
