### PR TITLE
Update setup-dapr-development-env.md

### DIFF
--- a/docs/development/setup-dapr-development-env.md
+++ b/docs/development/setup-dapr-development-env.md
@@ -27,7 +27,7 @@ This document helps you get started developing Dapr. If you find any problem whi
 1. The Go language environment [(instructions)](https://golang.org/doc/install#windows).
    Make sure that your GOPATH and PATH are configured correctly - You may set environment variables through the "Environment Variables" button on the "Advanced" tab of the "System" control panel. Some versions of Windows provide this control panel through the "Advanced System Settings" option inside the "System" control panel.
    ```
-   GOPATH=c:\go
+   GOPATH=%USERPROFILE%\go
    PATH=%GOPATH%\bin;...
    ```
 2. [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation) for Go debugging


### PR DESCRIPTION
If you set GOPATH to C:\go as displayed you can't install Delve. You will get the following error:
```
C:\go is a GOROOT, not a GOPATH. For more details see: 'go help gopath'
```
After installing go with the MSI from the go site, GOPATH is already set to %USERPROFILE%\go which is what the `go help gopath` says it should be.

# Description

I used a clean Windows 10 virtual machine to test the steps described. 