### PR TITLE
Enable custom cloudevent fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
-	github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803
+	github.com/dapr/components-contrib v1.0.0-rc2.0.20210105012307-80e5f2ca522e
 	github.com/dnaeon/go-vcr v1.1.0 // indirect
 	github.com/fasthttp/router v1.3.2
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
-	github.com/dapr/components-contrib v1.0.0-rc2.0.20201229222852-e6dadfab6c66
+	github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803
 	github.com/dnaeon/go-vcr v1.1.0 // indirect
 	github.com/fasthttp/router v1.3.2
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -297,12 +297,6 @@ github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20201229222852-e6dadfab6c66 h1:cAaBomTJwy57q0uwCG8h0u9hHdb5N+DKRYQLaTjdShs=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20201229222852-e6dadfab6c66/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20201231010632-a7ff1b0aadd2 h1:dCeH5ciYRgUqjKTqYFJYfv66oViQLF3x5bQBY+udoPs=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20201231010632-a7ff1b0aadd2/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20201231031047-b7584f670b35 h1:050oRzgYQhSTJm27N3wr62po2e0xhXkxjRdN111B1Ec=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20201231031047-b7584f670b35/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
 github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803 h1:9izXhecd70MGk1aPIUGs3WEieWRn8zHJc43xJuqa6UI=
 github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,12 @@ github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
 github.com/dapr/components-contrib v1.0.0-rc2.0.20201229222852-e6dadfab6c66 h1:cAaBomTJwy57q0uwCG8h0u9hHdb5N+DKRYQLaTjdShs=
 github.com/dapr/components-contrib v1.0.0-rc2.0.20201229222852-e6dadfab6c66/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20201231010632-a7ff1b0aadd2 h1:dCeH5ciYRgUqjKTqYFJYfv66oViQLF3x5bQBY+udoPs=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20201231010632-a7ff1b0aadd2/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20201231031047-b7584f670b35 h1:050oRzgYQhSTJm27N3wr62po2e0xhXkxjRdN111B1Ec=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20201231031047-b7584f670b35/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803 h1:9izXhecd70MGk1aPIUGs3WEieWRn8zHJc43xJuqa6UI=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad h1:RKWoYovBc+B9ltvjtZLMnbu49stSucH8rZze3MeqyvQ=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad/go.mod h1:yeOIFBz6+BigHpk4ASJbgQDVjQ8+00oCWrFyOAFdob8=

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803 h1:9izXhecd70MGk1aPIUGs3WEieWRn8zHJc43xJuqa6UI=
-github.com/dapr/components-contrib v1.0.0-rc2.0.20210104201239-a99b605db803/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20210105012307-80e5f2ca522e h1:xRez3y7U63GeUiYeMwfq6hVsEzxoEWsa4vZ40bGt864=
+github.com/dapr/components-contrib v1.0.0-rc2.0.20210105012307-80e5f2ca522e/go.mod h1:wmTSIgXHIqYeFCoCJDZTbDDw86ZqP/SeGbyp4ZKS+Y0=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad h1:RKWoYovBc+B9ltvjtZLMnbu49stSucH8rZze3MeqyvQ=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad/go.mod h1:yeOIFBz6+BigHpk4ASJbgQDVjQ8+00oCWrFyOAFdob8=

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -238,7 +238,7 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 		Pubsub:          in.PubsubName,
 	})
 	if err != nil {
-		err := status.Errorf(codes.InvalidArgument, messages.ErrPubsubCloudEventCreation, err.Error())
+		err = status.Errorf(codes.InvalidArgument, messages.ErrPubsubCloudEventCreation, err.Error())
 		apiServerLogger.Debug(err)
 		return &empty.Empty{}, err
 	}

--- a/pkg/messages/api_errors.go
+++ b/pkg/messages/api_errors.go
@@ -21,13 +21,14 @@ const (
 	ErrInvokeOutputBinding = "error when invoke output binding %s: %s"
 
 	// PubSub
-	ErrPubsubNotConfigured  = "no pubsub is configured"
-	ErrPubsubEmpty          = "pubsub name is empty"
-	ErrPubsubNotFound       = "pubsub %s not found"
-	ErrTopicEmpty           = "topic is empty in pubsub %s"
-	ErrPubsubCloudEventsSer = "error when marshal cloud event envelop for topic %s pubsub %s: %s"
-	ErrPubsubPublishMessage = "error when publish to topic %s in pubsub %s: %s"
-	ErrPubsubForbidden      = "topic %s is not allowed for app id %s"
+	ErrPubsubNotConfigured      = "no pubsub is configured"
+	ErrPubsubEmpty              = "pubsub name is empty"
+	ErrPubsubNotFound           = "pubsub %s not found"
+	ErrTopicEmpty               = "topic is empty in pubsub %s"
+	ErrPubsubCloudEventsSer     = "error when marshalling cloud event envelope for topic %s pubsub %s: %s"
+	ErrPubsubPublishMessage     = "error when publish to topic %s in pubsub %s: %s"
+	ErrPubsubForbidden          = "topic %s is not allowed for app id %s"
+	ErrPubsubCloudEventCreation = "cannot create cloudevent: %s"
 
 	// AppChannel
 	ErrChannelNotFound       = "app channel is not initialized"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -177,5 +177,4 @@ func (o *operator) Run(ctx context.Context) {
 	}()
 
 	o.apiServer.Run(certChain)
-	cancel()
 }

--- a/pkg/runtime/pubsub/cloudevents.go
+++ b/pkg/runtime/pubsub/cloudevents.go
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package pubsub
+
+import (
+	"github.com/dapr/components-contrib/pubsub"
+	contrib_pubsub "github.com/dapr/components-contrib/pubsub"
+	"github.com/google/uuid"
+)
+
+// CloudEvent is a reqeust object to create a Dapr compliant cloudevent
+type CloudEvent struct {
+	ID              string
+	Data            []byte
+	Topic           string
+	Pubsub          string
+	DataContentType string
+	TraceID         string
+}
+
+// NewCloudEvent encapusalates the creation of a Dapr cloudevent from an existing cloudevent or a raw payload
+func NewCloudEvent(req *CloudEvent) (map[string]interface{}, error) {
+	if req.DataContentType == contrib_pubsub.ContentType {
+		return contrib_pubsub.FromCloudEvent(req.Data, req.Topic, req.Pubsub, req.TraceID)
+	}
+	return pubsub.NewCloudEventsEnvelope(uuid.New().String(), req.ID, contrib_pubsub.DefaultCloudEventType, "", req.Topic, req.Pubsub,
+		req.DataContentType, req.Data, req.TraceID), nil
+}

--- a/pkg/runtime/pubsub/cloudevents.go
+++ b/pkg/runtime/pubsub/cloudevents.go
@@ -6,7 +6,6 @@
 package pubsub
 
 import (
-	"github.com/dapr/components-contrib/pubsub"
 	contrib_pubsub "github.com/dapr/components-contrib/pubsub"
 	"github.com/google/uuid"
 )
@@ -26,6 +25,6 @@ func NewCloudEvent(req *CloudEvent) (map[string]interface{}, error) {
 	if req.DataContentType == contrib_pubsub.ContentType {
 		return contrib_pubsub.FromCloudEvent(req.Data, req.Topic, req.Pubsub, req.TraceID)
 	}
-	return pubsub.NewCloudEventsEnvelope(uuid.New().String(), req.ID, contrib_pubsub.DefaultCloudEventType, "", req.Topic, req.Pubsub,
+	return contrib_pubsub.NewCloudEventsEnvelope(uuid.New().String(), req.ID, contrib_pubsub.DefaultCloudEventType, "", req.Topic, req.Pubsub,
 		req.DataContentType, req.Data, req.TraceID), nil
 }

--- a/pkg/runtime/pubsub/cloudevents_test.go
+++ b/pkg/runtime/pubsub/cloudevents_test.go
@@ -1,0 +1,63 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package pubsub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCloudEvent(t *testing.T) {
+	t.Run("raw payload", func(t *testing.T) {
+		ce, err := NewCloudEvent(&CloudEvent{
+			ID:              "a",
+			Topic:           "b",
+			Data:            []byte("hello"),
+			Pubsub:          "c",
+			DataContentType: "",
+			TraceID:         "d",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "a", ce["source"].(string))
+		assert.Equal(t, "b", ce["topic"].(string))
+		assert.Equal(t, "hello", ce["data"].(string))
+		assert.Equal(t, "text/plain", ce["datacontenttype"].(string))
+		assert.Equal(t, "d", ce["traceid"].(string))
+	})
+
+	t.Run("raw payload no data", func(t *testing.T) {
+		ce, err := NewCloudEvent(&CloudEvent{
+			ID:              "a",
+			Topic:           "b",
+			Pubsub:          "c",
+			DataContentType: "",
+			TraceID:         "d",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "a", ce["source"].(string))
+		assert.Equal(t, "b", ce["topic"].(string))
+		assert.Empty(t, ce["data"])
+		assert.Equal(t, "text/plain", ce["datacontenttype"].(string))
+		assert.Equal(t, "d", ce["traceid"].(string))
+	})
+
+	t.Run("custom cloudevent", func(t *testing.T) {
+		ce, err := NewCloudEvent(&CloudEvent{
+			Data:            []byte("world"),
+			DataContentType: "text/plain",
+			Topic:           "topic1",
+			TraceID:         "trace1",
+			Pubsub:          "pubsub",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "world", ce["data"].(string))
+		assert.Equal(t, "text/plain", ce["datacontenttype"].(string))
+		assert.Equal(t, "topic1", ce["topic"].(string))
+		assert.Equal(t, "trace1", ce["traceid"].(string))
+		assert.Equal(t, "pubsub", ce["pubsubname"].(string))
+	})
+}

--- a/pkg/runtime/pubsub/cloudevents_test.go
+++ b/pkg/runtime/pubsub/cloudevents_test.go
@@ -6,6 +6,7 @@
 package pubsub
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,9 +47,17 @@ func TestNewCloudEvent(t *testing.T) {
 	})
 
 	t.Run("custom cloudevent", func(t *testing.T) {
+		m := map[string]interface{}{
+			"specversion":     "1.0",
+			"id":              "event",
+			"datacontenttype": "text/plain",
+			"data":            "world",
+		}
+		b, _ := json.Marshal(m)
+
 		ce, err := NewCloudEvent(&CloudEvent{
-			Data:            []byte("world"),
-			DataContentType: "text/plain",
+			Data:            b,
+			DataContentType: "application/cloudevents+json",
 			Topic:           "topic1",
 			TraceID:         "trace1",
 			Pubsub:          "pubsub",

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1072,16 +1072,17 @@ func (a *DaprRuntime) initNameResolution() error {
 }
 
 func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
-	subject := ""
-	var cloudEvent pubsub.CloudEventsEnvelope
+	var cloudEvent map[string]interface{}
 	err := a.json.Unmarshal(msg.Data, &cloudEvent)
-	if err == nil {
-		subject = cloudEvent.Subject
+	if err != nil {
+		log.Debug(errors.Errorf("failed to deserialize cloudevent: %s", err))
+		return err
+	}
+	traceID := cloudEvent[pubsub.TraceIDField].(string)
 
-		if cloudEvent.HasExpired() {
-			log.Warnf("dropping expired pub/sub event %v as of %v", cloudEvent.ID, cloudEvent.Expiration)
-			return nil
-		}
+	if pubsub.HasExpired(cloudEvent) {
+		log.Warnf("dropping expired pub/sub event %v as of %v", cloudEvent[pubsub.IDField].(string), cloudEvent[pubsub.ExpirationField].(string))
+		return nil
 	}
 
 	route := a.topicRoutes[msg.Metadata[pubsubName]].routes[msg.Topic]
@@ -1089,8 +1090,7 @@ func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
 	req.WithHTTPExtension(nethttp.MethodPost, "")
 	req.WithRawData(msg.Data, pubsub.ContentType)
 
-	// subject contains the correlationID which is passed span context
-	sc, _ := diag.SpanContextFromW3CString(subject)
+	sc, _ := diag.SpanContextFromW3CString(traceID)
 	spanName := fmt.Sprintf("pubsub/%s", msg.Topic)
 	ctx, span := diag.StartInternalCallbackSpan(spanName, sc, a.globalConfig.Spec.TracingSpec)
 
@@ -1115,7 +1115,7 @@ func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
 		var appResponse pubsub.AppResponse
 		err := a.json.Unmarshal(body, &appResponse)
 		if err != nil {
-			log.Debugf("skipping status check due to error parsing result from pub/sub event %v", cloudEvent.ID)
+			log.Debugf("skipping status check due to error parsing result from pub/sub event %v", cloudEvent[pubsub.IDField].(string))
 			// Return no error so message does not get reprocessed.
 			return nil
 		}
@@ -1127,63 +1127,57 @@ func (a *DaprRuntime) publishMessageHTTP(msg *pubsub.NewMessage) error {
 		case pubsub.Success:
 			return nil
 		case pubsub.Retry:
-			return errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent.ID)
+			return errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField].(string))
 		case pubsub.Drop:
-			log.Warnf("DROP status returned from app while processing pub/sub event %v", cloudEvent.ID)
+			log.Warnf("DROP status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField].(string))
 			return nil
 		}
 		// Consider unknown status field as error and retry
-		return errors.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent.ID, appResponse.Status)
+		return errors.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent[pubsub.IDField].(string), appResponse.Status)
 	}
 
 	if statusCode == nethttp.StatusNotFound {
 		// These are errors that are not retriable, for now it is just 404 but more status codes can be added.
 		// When adding/removing an error here, check if that is also applicable to GRPC since there is a mapping between HTTP and GRPC errors:
 		// https://cloud.google.com/apis/design/errors#handling_errors
-		log.Errorf("non-retriable error returned from app while processing pub/sub event %v: %s. status code returned: %v", cloudEvent.ID, body, statusCode)
+		log.Errorf("non-retriable error returned from app while processing pub/sub event %v: %s. status code returned: %v", cloudEvent[pubsub.IDField].(string), body, statusCode)
 		return nil
 	}
 
 	// Every error from now on is a retriable error.
-	log.Warnf("retriable error returned from app while processing pub/sub event %v: %s. status code returned: %v", cloudEvent.ID, body, statusCode)
-	return errors.Errorf("retriable error returned from app while processing pub/sub event %v: %s. status code returned: %v", cloudEvent.ID, body, statusCode)
+	log.Warnf("retriable error returned from app while processing pub/sub event %v: %s. status code returned: %v", cloudEvent[pubsub.IDField].(string), body, statusCode)
+	return errors.Errorf("retriable error returned from app while processing pub/sub event %v: %s. status code returned: %v", cloudEvent[pubsub.IDField].(string), body, statusCode)
 }
 
 func (a *DaprRuntime) publishMessageGRPC(msg *pubsub.NewMessage) error {
-	var cloudEvent pubsub.CloudEventsEnvelope
+	var cloudEvent map[string]interface{}
 	err := a.json.Unmarshal(msg.Data, &cloudEvent)
 	if err != nil {
 		log.Debugf("error deserializing cloud events proto: %s", err)
 		return err
 	}
 
-	if cloudEvent.HasExpired() {
-		log.Warnf("dropping expired pub/sub event %v as of %v", cloudEvent.ID, cloudEvent.Expiration)
+	if pubsub.HasExpired(cloudEvent) {
+		log.Warnf("dropping expired pub/sub event %v as of %v", cloudEvent[pubsub.IDField].(string), cloudEvent[pubsub.ExpirationField].(string))
 		return nil
 	}
 
 	envelope := &runtimev1pb.TopicEventRequest{
-		Id:              cloudEvent.ID,
-		Source:          cloudEvent.Source,
-		DataContentType: cloudEvent.DataContentType,
-		Type:            cloudEvent.Type,
-		SpecVersion:     cloudEvent.SpecVersion,
+		Id:              cloudEvent[pubsub.IDField].(string),
+		Source:          cloudEvent[pubsub.SourceField].(string),
+		DataContentType: cloudEvent[pubsub.DataContentTypeField].(string),
+		Type:            cloudEvent[pubsub.TypeField].(string),
+		SpecVersion:     cloudEvent[pubsub.SpecVersionField].(string),
 		Topic:           msg.Topic,
 		PubsubName:      msg.Metadata[pubsubName],
 	}
 
-	if cloudEvent.Data != nil {
-		envelope.Data = nil
-		if cloudEvent.DataContentType == "text/plain" {
-			envelope.Data = []byte(cloudEvent.Data.(string))
-		} else if cloudEvent.DataContentType == "application/json" {
-			envelope.Data, _ = a.json.Marshal(cloudEvent.Data)
-		}
+	if data, ok := cloudEvent[pubsub.DataField]; ok && data != nil {
+		envelope.Data = []byte(cloudEvent[pubsub.DataField].(string))
 	}
 
-	// subject contains the correlationID which is passed span context
-	subject := cloudEvent.Subject
-	sc, _ := diag.SpanContextFromW3CString(subject)
+	traceID := cloudEvent[pubsub.TraceIDField].(string)
+	sc, _ := diag.SpanContextFromW3CString(traceID)
 	spanName := fmt.Sprintf("pubsub/%s", msg.Topic)
 
 	// no ops if trace is off
@@ -1205,11 +1199,11 @@ func (a *DaprRuntime) publishMessageGRPC(msg *pubsub.NewMessage) error {
 		errStatus, hasErrStatus := status.FromError(err)
 		if hasErrStatus && (errStatus.Code() == codes.Unimplemented) {
 			// DROP
-			log.Warnf("non-retriable error returned from app while processing pub/sub event %v: %s", cloudEvent.ID, err)
+			log.Warnf("non-retriable error returned from app while processing pub/sub event %v: %s", cloudEvent[pubsub.IDField].(string), err)
 			return nil
 		}
 
-		err = errors.Errorf("error returned from app while processing pub/sub event %v: %s", cloudEvent.ID, err)
+		err = errors.Errorf("error returned from app while processing pub/sub event %v: %s", cloudEvent[pubsub.IDField].(string), err)
 		log.Debug(err)
 		// on error from application, return error for redelivery of event
 		return err
@@ -1221,13 +1215,13 @@ func (a *DaprRuntime) publishMessageGRPC(msg *pubsub.NewMessage) error {
 		// success from protobuf definition
 		return nil
 	case runtimev1pb.TopicEventResponse_RETRY:
-		return errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent.ID)
+		return errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField].(string))
 	case runtimev1pb.TopicEventResponse_DROP:
-		log.Warnf("DROP status returned from app while processing pub/sub event %v", cloudEvent.ID)
+		log.Warnf("DROP status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField].(string))
 		return nil
 	}
 	// Consider unknown status field as error and retry
-	return errors.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent.ID, res.GetStatus())
+	return errors.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent[pubsub.IDField].(string), res.GetStatus())
 }
 
 func (a *DaprRuntime) initActors() error {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1354,7 +1354,7 @@ func TestInitSecretStoresInKubernetesMode(t *testing.T) {
 func TestOnNewPublishedMessage(t *testing.T) {
 	topic := "topic1"
 
-	envelope := pubsub.NewCloudEventsEnvelope("", "", pubsub.DefaultCloudEventType, "", topic, TestSecondPubsubName, "", []byte("Test Message"))
+	envelope := pubsub.NewCloudEventsEnvelope("", "", pubsub.DefaultCloudEventType, "", topic, TestSecondPubsubName, "", []byte("Test Message"), "")
 	b, err := json.Marshal(envelope)
 	assert.Nil(t, err)
 
@@ -1440,10 +1440,10 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		err := rt.publishMessageHTTP(testPubSubMessage)
 
 		// assert
-		var cloudEvent pubsub.CloudEventsEnvelope
+		var cloudEvent map[string]interface{}
 		json := jsoniter.ConfigFastest
 		json.Unmarshal(testPubSubMessage.Data, &cloudEvent)
-		expectedClientError := errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent.ID)
+		expectedClientError := errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent["id"].(string))
 		assert.Equal(t, expectedClientError.Error(), err.Error())
 		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 	})
@@ -1568,10 +1568,10 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		err := rt.publishMessageHTTP(testPubSubMessage)
 
 		// assert
-		var cloudEvent pubsub.CloudEventsEnvelope
+		var cloudEvent map[string]interface{}
 		json := jsoniter.ConfigFastest
 		json.Unmarshal(testPubSubMessage.Data, &cloudEvent)
-		expectedClientError := errors.Errorf("retriable error returned from app while processing pub/sub event %v: Internal Error. status code returned: 500", cloudEvent.ID)
+		expectedClientError := errors.Errorf("retriable error returned from app while processing pub/sub event %v: Internal Error. status code returned: 500", cloudEvent["id"].(string))
 		assert.Equal(t, expectedClientError.Error(), err.Error())
 		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 	})
@@ -1580,7 +1580,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 func TestOnNewPublishedMessageGRPC(t *testing.T) {
 	topic := "topic1"
 
-	envelope := pubsub.NewCloudEventsEnvelope("", "", pubsub.DefaultCloudEventType, "", topic, TestSecondPubsubName, "", []byte("Test Message"))
+	envelope := pubsub.NewCloudEventsEnvelope("", "", pubsub.DefaultCloudEventType, "", topic, TestSecondPubsubName, "", []byte("Test Message"), "")
 	b, err := json.Marshal(envelope)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
This PR fixes #506 and does the following:

1. Custom fields on a user created Cloud Event will no longer be stripped by Dapr
2. The `subject` field is no longer used for setting the traceid and has long been a source of confusion. instead, a dedicated `traceid` field has been added and users are free to use `subject` as they see fit.