### PR TITLE
Use a different AKS cluster for perf tests (#2590)

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -72,7 +72,7 @@ jobs:
           az login --service-principal -u ${{ secrets.AZURE_LOGIN_USER }} -p ${{ secrets.AZURE_LOGIN_PASS }} --tenant ${{ secrets.AZURE_TENANT }} --output none
       - name: Find the test cluster
         if: env.CHECKOUT_REPO != ''
-        run: ./tests/test-infra/find_cluster.sh
+        run: ./tests/test-infra/find_cluster.sh ./tests/test-infra/perf-list.txt
       - name: Add the test status comment to PR
         if: github.event_name == 'repository_dispatch' && env.CHECKOUT_REPO != ''
         env:

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -83,7 +83,7 @@ jobs:
           az login --service-principal -u ${{ secrets.AZURE_LOGIN_USER }} -p ${{ secrets.AZURE_LOGIN_PASS }} --tenant ${{ secrets.AZURE_TENANT }} --output none
       - name: Find the test cluster
         if: env.CHECKOUT_REPO != ''
-        run: ./tests/test-infra/find_cluster.sh
+        run: ./tests/test-infra/find_cluster.sh ./tests/test-infra/e2e-list.txt
         shell: bash
       - name: Add the test status comment to PR
         if: github.event_name == 'repository_dispatch' && env.CHECKOUT_REPO != ''

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -99,6 +99,8 @@ setup-3rd-party: setup-helm-init setup-test-env-redis setup-test-env-kafka
 
 e2e-build-deploy-run: create-test-namespace setup-3rd-party build docker-push docker-deploy-k8s setup-test-components build-e2e-app-all push-e2e-app-all test-e2e-all
 
+perf-build-deploy-run: create-test-namespace setup-3rd-party build docker-push docker-deploy-k8s setup-test-components build-perf-app-all push-perf-app-all test-perf-all
+
 # Generate perf app image push targets
 $(foreach ITEM,$(PERF_TEST_APPS),$(eval $(call genPerfAppImagePush,$(ITEM))))
 

--- a/tests/test-infra/e2e-list.txt
+++ b/tests/test-infra/e2e-list.txt
@@ -1,0 +1,5 @@
+dapr-aks-e2e-05
+dapr-aks-e2e-06
+dapr-aks-e2e-07
+dapr-aks-e2e-08
+

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -7,14 +7,7 @@
 
 # This script scans all AKS clusters in test cluster pools to find the available test cluster
 
-# The test cluster pool for e2e test
-# TODO: Add more aks test clusters
-testclusterpool=(
-    "dapr-aks-e2e-05"
-    "dapr-aks-e2e-06"
-    "dapr-aks-e2e-07"
-    "dapr-aks-e2e-08"
-)
+# Usage: find_cluster.sh <cluster_list_file>
 
 # Define max e2e test timeout, 1.5 hours
 [ -z "$MAX_TEST_TIMEOUT" ] && MAX_TEST_TIMEOUT=5400
@@ -33,7 +26,7 @@ echo "Selected Dapr Test Resource group: $DAPR_TEST_RESOURCE_GROUP"
 echo "Selected Kubernetes Namespace: $DAPR_TEST_NAMESPACE"
 
 # Find the available cluster
-for clustername in ${testclusterpool[@]}; do
+for clustername in `cat $1 | xargs`; do
     echo "Scanning $clustername ..."
 
     echo "Switching to $clustername context..."

--- a/tests/test-infra/perf-list.txt
+++ b/tests/test-infra/perf-list.txt
@@ -1,0 +1,1 @@
+dapr-aks-perf-01


### PR DESCRIPTION
# Description

Add a separate per cluster with more powerful instance types for the perf tests.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2590
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
