### PR TITLE
Remove windows line endings from cluster list

### DIFF
--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -26,7 +26,7 @@ echo "Selected Dapr Test Resource group: $DAPR_TEST_RESOURCE_GROUP"
 echo "Selected Kubernetes Namespace: $DAPR_TEST_NAMESPACE"
 
 # Find the available cluster
-for clustername in `cat $1 | xargs`; do
+for clustername in `cat $1 | sed 's/\r//g' | xargs`; do
     echo "Scanning $clustername ..."
 
     echo "Switching to $clustername context..."


### PR DESCRIPTION
# Description

Apparently the xargs command doesn't strip \r from input. This was making our find_cluster.sh script break on windows.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
