### PR TITLE
Add PHP SDK to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ See the [Development Guide](https://docs.dapr.io/contributing/) to get started w
 | [Dotnet-sdk](https://github.com/dapr/dotnet-sdk) | Dapr SDK for .NET Core
 | [Rust-sdk](https://github.com/dapr/rust-sdk) | Dapr SDK for Rust
 | [Cpp-sdk](https://github.com/dapr/cpp-sdk) | Dapr SDK for C++
+| [PHP-sdk](https://github.com/dapr/php-sdk) | Dapr SDK for PHP
 
 
 ## Code of Conduct


### PR DESCRIPTION
# Description

This adds a link to the PHP SDK to the readme.

## Issue reference

Considering the PHP SDK published :)

Please reference the issue this PR will close: closes dapr/php-sdk#1

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation
