### PR TITLE
Use Aborted error code for ETag mismatch

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -496,7 +496,7 @@ func (a *api) stateErrorResponse(err error, format string, args ...interface{}) 
 	}
 	switch e.Kind() {
 	case state.ETagMismatch:
-		return status.Errorf(codes.AlreadyExists, format, args...)
+		return status.Errorf(codes.Aborted, format, args...)
 	case state.ETagInvalid:
 		return status.Errorf(codes.InvalidArgument, format, args...)
 	}

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -1498,7 +1498,7 @@ func TestStateStoreErrors(t *testing.T) {
 		err := state.NewETagError(state.ETagMismatch, errors.New("error"))
 		err2 := a.stateErrorResponse(err, messages.ErrStateSave, "a", err.Error())
 
-		assert.Equal(t, "rpc error: code = AlreadyExists desc = failed saving state in state store a: possible etag mismatch. error from state store: error", err2.Error())
+		assert.Equal(t, "rpc error: code = Aborted desc = failed saving state in state store a: possible etag mismatch. error from state store: error", err2.Error())
 	})
 
 	t.Run("save etag invalid", func(t *testing.T) {
@@ -1522,7 +1522,7 @@ func TestStateStoreErrors(t *testing.T) {
 		err := state.NewETagError(state.ETagMismatch, errors.New("error"))
 		err2 := a.stateErrorResponse(err, messages.ErrStateDelete, "a", err.Error())
 
-		assert.Equal(t, "rpc error: code = AlreadyExists desc = failed deleting state with key a: possible etag mismatch. error from state store: error", err2.Error())
+		assert.Equal(t, "rpc error: code = Aborted desc = failed deleting state with key a: possible etag mismatch. error from state store: error", err2.Error())
 	})
 
 	t.Run("delete etag invalid", func(t *testing.T) {


### PR DESCRIPTION
# Description

I started a discussion after https://github.com/dapr/dapr/pull/2647 was
merged because I think there's a better fit for an ETag mismatch than
AlreadyExists.

The gRPC docs have specific guidance that Aborted is the best status for
'when a client-specified test-and-set fails', which is this case. [link](https://github.com/grpc-ecosystem/grpc-gateway/blob/852b196e6ea50f6c64a776b1c4a67cb2feae27a1/third_party/googleapis/google/rpc/code.proto#L119)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Related to #2619

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
