### PR TITLE
fix(actors): delete invalid reminders codes

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -635,12 +635,6 @@ func (a *actorsRuntime) getUpcomingReminderInvokeTime(reminder *Reminder) (time.
 		} else {
 			nextInvokeTime = registeredTime.Add(dueTime)
 		}
-	} else {
-		if !lastFiredTime.IsZero() {
-			nextInvokeTime = lastFiredTime.Add(dueTime)
-		} else {
-			nextInvokeTime = registeredTime.Add(dueTime)
-		}
 	}
 
 	return nextInvokeTime, nil


### PR DESCRIPTION
the first time, daprd runtime actor received the reminder grpc/http request of placement,  than the reminder task will be executed after dueTime+time.Now;

next time, the reminder task will be executed in a scheduled daprd runtime actor,  execution time is nextInvokeTime+period

so the followed codes never be running.

```golang
    } else {
        if !lastFiredTime.IsZero() {
            nextInvokeTime = lastFiredTime.Add(dueTime)
        } else {
            nextInvokeTime = registeredTime.Add(dueTime)
        }
    }
```

if the period time of reminder is nil,  the reminder must be deleted in state and memory after the first execution 