### PR TITLE
Add a force delete step to clean up stale pods

### DIFF
--- a/tests/test-infra/clean_up.sh
+++ b/tests/test-infra/clean_up.sh
@@ -17,4 +17,8 @@ done
 echo "Trying to delete namespace..."
 kubectl delete namespace $1 --timeout=10m
 
+for pod in `kubectl get pods -n $1 -o name`; do
+	kubectl delete --force -n $1 $pod
+done
+
 exit 0

--- a/tests/test-infra/find_cluster.sh
+++ b/tests/test-infra/find_cluster.sh
@@ -26,7 +26,7 @@ echo "Selected Dapr Test Resource group: $DAPR_TEST_RESOURCE_GROUP"
 echo "Selected Kubernetes Namespace: $DAPR_TEST_NAMESPACE"
 
 # Find the available cluster
-for clustername in `cat $1 | sed 's/\r//g' | xargs`; do
+for clustername in `cat $1 | sed 's/\r//g' | sort -R | xargs`; do
     echo "Scanning $clustername ..."
 
     echo "Switching to $clustername context..."


### PR DESCRIPTION
# Description

Quick and dirty workaround for the failed container shutdown problem.

## Manual Test

```bash
% ./tests/test-infra/clean_up.sh dapr-tests                                                                                               

Trying to delete namespace...
namespace "dapr-tests" deleted
error: timed out waiting for the condition on namespaces/dapr-tests
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
pod "actorapp-648b74fb97-lsp8c" force deleted
```

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
