### PR TITLE
Disable e2e test and apps for sdks on Windows

### DIFF
--- a/.github/workflows/dapr-e2e-apps.yml
+++ b/.github/workflows/dapr-e2e-apps.yml
@@ -1,0 +1,50 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+name: Validate build for E2E test apps
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - release-*
+jobs:
+  build:
+    name: Build on ${{ matrix.target_os }}_${{ matrix.target_arch }}
+    runs-on: ${{ matrix.os }}
+    env:
+      GOVER: 1.15.3
+      GOOS: ${{ matrix.target_os }}
+      GOARCH: ${{ matrix.target_arch }}
+      GOPROXY: https://proxy.golang.org
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        target_arch: [arm, arm64, amd64]
+        include:
+          - os: ubuntu-latest
+            target_os: linux
+          - os: windows-latest
+            target_os: windows
+        exclude:
+          - os: windows-latest
+            target_arch: arm
+          - os: windows-latest
+            target_arch: arm64
+    steps:
+      - name: Set up Go ${{ env.GOVER }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Build all E2E test apps
+        env:
+          TARGET_OS: ${{ matrix.target_os }}
+          TARGET_ARCH: ${{ matrix.target_arch }}
+          DAPR_TEST_REGISTRY: localhost:5000
+          DAPR_TEST_TAG: dev
+        run: make build-e2e-app-all

--- a/tests/apps/actordotnet/Dockerfile-windows
+++ b/tests/apps/actordotnet/Dockerfile-windows
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
+WORKDIR /app
+
+# Copy csproj and restore as distinct layers
+COPY *.csproj ./
+RUN dotnet restore
+
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish -c Release -o out
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+WORKDIR /app
+EXPOSE 3000
+COPY --from=build-env /app/out .
+ENTRYPOINT ["dotnet", "CarActor.dll"]

--- a/tests/apps/actorjava/Dockerfile-windows
+++ b/tests/apps/actorjava/Dockerfile-windows
@@ -1,0 +1,31 @@
+# escape=`
+ARG JAVA_VERSION=11.0.6
+
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019 as build
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV chocolateyUseWindowsCompression=false
+RUN iex (wget 'https://chocolatey.org/install.ps1' -UseBasicParsing)
+
+RUN choco feature enable -n=allowGlobalConfirmation
+RUN choco feature disable -n=showDownloadProgress
+RUN choco config set cachelocation C:\chococache
+
+RUN choco install ojdkbuild11 maven --limit-output --timeout 3600; Remove-Item C:\chococache  -Recurse -Force
+
+RUN mkdir "c:\build"
+WORKDIR "c:\build"
+
+RUN refreshenv
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+ADD src/ "c:\build\src\"
+RUN mvn package
+
+FROM openjdk:${JAVA_VERSION}-windowsservercore-1809
+COPY --from=build "c:\build\target\app.jar" app.jar
+
+EXPOSE 3000
+ENTRYPOINT java -jar app.jar --server.port=3000

--- a/tests/apps/actorjava/Dockerfile-windows
+++ b/tests/apps/actorjava/Dockerfile-windows
@@ -1,7 +1,7 @@
 # escape=`
 ARG JAVA_VERSION=11.0.6
 
-FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019 as build
+FROM openjdk:${JAVA_VERSION}-windowsservercore-1809 as build
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -12,7 +12,7 @@ RUN choco feature enable -n=allowGlobalConfirmation
 RUN choco feature disable -n=showDownloadProgress
 RUN choco config set cachelocation C:\chococache
 
-RUN choco install ojdkbuild11 maven --limit-output --timeout 3600; Remove-Item C:\chococache  -Recurse -Force
+RUN choco install maven --limit-output --timeout 3600; Remove-Item C:\chococache  -Recurse -Force
 
 RUN mkdir "c:\build"
 WORKDIR "c:\build"

--- a/tests/apps/actorjava/Dockerfile-windows
+++ b/tests/apps/actorjava/Dockerfile-windows
@@ -1,7 +1,7 @@
 # escape=`
 ARG JAVA_VERSION=11.0.6
 
-FROM mcr.microsoft.com/windows/nanoserver:1809 as build
+FROM openjdk:${JAVA_VERSION}-windowsservercore-1809 as build
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -12,7 +12,7 @@ RUN choco feature enable -n=allowGlobalConfirmation
 RUN choco feature disable -n=showDownloadProgress
 RUN choco config set cachelocation C:\chococache
 
-RUN choco install ojdkbuild11 maven --limit-output --timeout 3600; Remove-Item C:\chococache  -Recurse -Force
+RUN choco install maven --limit-output --timeout 3600; Remove-Item C:\chococache  -Recurse -Force
 
 RUN mkdir "c:\build"
 WORKDIR "c:\build"

--- a/tests/apps/actorjava/Dockerfile-windows
+++ b/tests/apps/actorjava/Dockerfile-windows
@@ -1,7 +1,7 @@
 # escape=`
 ARG JAVA_VERSION=11.0.6
 
-FROM openjdk:${JAVA_VERSION}-windowsservercore-1809 as build
+FROM mcr.microsoft.com/windows/nanoserver:1809 as build
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -12,7 +12,7 @@ RUN choco feature enable -n=allowGlobalConfirmation
 RUN choco feature disable -n=showDownloadProgress
 RUN choco config set cachelocation C:\chococache
 
-RUN choco install maven --limit-output --timeout 3600; Remove-Item C:\chococache  -Recurse -Force
+RUN choco install ojdkbuild11 maven --limit-output --timeout 3600; Remove-Item C:\chococache  -Recurse -Force
 
 RUN mkdir "c:\build"
 WORKDIR "c:\build"

--- a/tests/apps/actorpython/Dockerfile-windows
+++ b/tests/apps/actorpython/Dockerfile-windows
@@ -1,0 +1,8 @@
+FROM python:3.7-windowsservercore
+WORKDIR /app
+ADD . /app
+RUN pip install -r requirements.txt
+
+EXPOSE 3000
+ENTRYPOINT ["python"]
+CMD ["flask_service.py"]

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -79,7 +79,11 @@ ifeq (,$(wildcard $(E2E_TESTAPP_DIR)/$(1)/$(DOCKERFILE)))
 	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o $(E2E_TESTAPP_DIR)/$(1)/app$(BINARY_EXT_LOCAL) $(E2E_TESTAPP_DIR)/$(1)/app.go
 	$(DOCKER) build -f $(E2E_TESTAPP_DIR)/$(DOCKERFILE) $(E2E_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG)
 else
+# Builds of E2E apps within Docker works for Windows but are too slow. Disabling them for now.
+# See https://github.com/dapr/dapr/issues/2695
+ifeq ($(TARGET_OS),linux)
 	$(DOCKER) build -f $(E2E_TESTAPP_DIR)/$(1)/$(DOCKERFILE) $(E2E_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG)
+endif
 endif
 endef
 

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -93,7 +93,15 @@ $(foreach ITEM,$(E2E_TEST_APPS),$(eval $(call genTestAppImageBuild,$(ITEM))))
 define genTestAppImagePush
 .PHONY: push-e2e-app-$(1)
 push-e2e-app-$(1): check-e2e-env
+ifeq ($(TARGET_OS),windows)
+ifeq (,$(wildcard $(E2E_TESTAPP_DIR)/$(1)/$(DOCKERFILE)))
+# Builds of E2E apps within Docker works for Windows but are too slow. Disabling them for now.
+# See https://github.com/dapr/dapr/issues/2695
 	$(DOCKER) push $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG)
+endif
+else
+	$(DOCKER) push $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG)
+endif
 endef
 
 # Generate test app image push targets

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -75,12 +75,12 @@ endif
 define genTestAppImageBuild
 .PHONY: build-e2e-app-$(1)
 build-e2e-app-$(1): check-e2e-env
-	if [ -f "$(E2E_TESTAPP_DIR)/$(1)/$(DOCKERFILE)" ]; then \
-		$(DOCKER) build -f $(E2E_TESTAPP_DIR)/$(1)/$(DOCKERFILE) $(E2E_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG); \
-	else \
-		CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o $(E2E_TESTAPP_DIR)/$(1)/app$(BINARY_EXT_LOCAL) $(E2E_TESTAPP_DIR)/$(1)/app.go && \
-		$(DOCKER) build -f $(E2E_TESTAPP_DIR)/$(DOCKERFILE) $(E2E_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG); \
-	fi
+ifeq (,$(wildcard $(E2E_TESTAPP_DIR)/$(1)/$(DOCKERFILE)))
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o $(E2E_TESTAPP_DIR)/$(1)/app$(BINARY_EXT_LOCAL) $(E2E_TESTAPP_DIR)/$(1)/app.go
+	$(DOCKER) build -f $(E2E_TESTAPP_DIR)/$(DOCKERFILE) $(E2E_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG)
+else
+	$(DOCKER) build -f $(E2E_TESTAPP_DIR)/$(1)/$(DOCKERFILE) $(E2E_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/e2e-$(1):$(DAPR_TEST_TAG)
+endif
 endef
 
 # Generate test app image build targets

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -5,7 +5,10 @@
 
 # E2E test app list
 # e.g. E2E_TEST_APPS=hellodapr state service_invocation
-E2E_TEST_APPS=hellodapr \
+E2E_TEST_APPS=actorjava \
+actordotnet \
+actorpython \
+hellodapr \
 stateapp \
 secretapp \
 service_invocation \
@@ -21,10 +24,7 @@ actorfeatures \
 actorinvocationapp \
 runtime \
 runtime_init \
-middleware \
-actorjava \
-actordotnet \
-actorpython
+middleware
 
 # PERFORMACE test app list
 PERF_TEST_APPS=actorjava tester service_invocation_http

--- a/tests/e2e/actor_sdks/actor_sdks_test.go
+++ b/tests/e2e/actor_sdks/actor_sdks_test.go
@@ -10,6 +10,7 @@ package actor_sdks_e2e
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -52,6 +53,13 @@ func healthCheckApp(t *testing.T, externalURL string, numHealthChecks int) {
 }
 
 func TestMain(m *testing.M) {
+	// Disables this test for Windows temporarily due to issues with Windows containers.
+	// Technically, this test can still work on Windows against K8s on Linux.
+	// See https://github.com/dapr/dapr/issues/2695
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	// These apps will be deployed before starting actual test
 	// and will be cleaned up after all tests are finished automatically
 	apps = []kube.AppDescription{


### PR DESCRIPTION
# Description

Disable e2e sdk win.
Adds a workflow to test build of E2E apps early in the PR.
Adds Windows dockerfiles.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1165 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
