### PR TITLE
#2729, when use http for service invocation, append http req's headers into internal grpc metadata

### DIFF
--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -460,7 +460,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 
 		mockDirectMessaging.On(
 			"Invoke",
-			mock.AnythingOfType("*fasthttp.RequestCtx"),
+			mock.AnythingOfType("*context.valueCtx"),
 			"fakeAppID",
 			mock.AnythingOfType("*v1.InvokeMethodRequest")).Return(fakeInternalErrorResponse, nil).Once()
 
@@ -494,7 +494,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 
 		mockDirectMessaging.On(
 			"Invoke",
-			mock.AnythingOfType("*fasthttp.RequestCtx"),
+			mock.AnythingOfType("*context.valueCtx"),
 			"fakeAppID",
 			mock.AnythingOfType("*v1.InvokeMethodRequest")).Return(fakeInternalErrorResponse, nil).Once()
 


### PR DESCRIPTION
when use http for service invocation, append http req's headers into internal grpc metadata

# Description

i find when app use grpc service invocation, internal grpc call can inherit app grpc req's metadata, while when app call http service invocation, internal grp c call can't get app req's headers. 

## Issue reference

[#2729]https://github.com/dapr/dapr/issues/2729

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
