### PR TITLE
Fix dashboard helm chart to point to 0.6 instead of edge.

### DIFF
--- a/charts/dapr/charts/dapr_dashboard/values.yaml
+++ b/charts/dapr/charts/dapr_dashboard/values.yaml
@@ -4,7 +4,7 @@ logLevel: info
 image:
   registry: docker.io/daprio
   name: dashboard
-  tag: "edge"
+  tag: "0.6.0"
   imagePullSecrets: ""
 
 nameOverride: ""


### PR DESCRIPTION
# Description

Update dashboard 0.6

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: endgame
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
