### PR TITLE
Webhook cert fix

### DIFF
--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
@@ -1,4 +1,5 @@
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "dapr-sidecar-injector-cert"}}
+{{- $existingWebHookConfig := lookup "admissionregistration.k8s.io/v1" "MutatingWebhookConfiguration" .Release.Namespace "dapr-sidecar-injector"}}
 {{- $ca := genCA "dapr-sidecar-injector-ca" 3650 }}
 {{- $cn := printf "dapr-sidecar-injector" }}
 {{- $altName1 := printf "dapr-sidecar-injector.%s" .Release.Namespace }}
@@ -20,7 +21,6 @@ data:
   {{ if $existingSecret }}tls.key: {{ index $existingSecret.data "tls.key" }}
   {{ else }}tls.key: {{ b64enc $cert.Key }}
   {{ end }}
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -35,7 +35,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       name: dapr-sidecar-injector
       path: "/mutate"
-    caBundle: {{ if $existingSecret }}{{ index $existingSecret.data "tls.crt" }}{{ else }}{{ b64enc $ca.Cert }}{{ end }}
+    caBundle: {{ if $existingWebHookConfig }}{{ (index $existingWebHookConfig.webhooks 0).clientConfig.caBundle }}{{ else }}{{ b64enc $ca.Cert }}{{ end }}
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
# Description
Fixes a bug where caBundle lookups didnt' work as expected when running Helm upgrade

Previously we stored the generated ca cert in the sidecar-injector cert secret, and looked it up from there. The problem with this was that for upgrades from pre-rc3, the ca key didn't exist, and the upgrade failed. With this PR we look up the required string directly from the existing versino of the webhook config. This is much more precise, and allows us to not store secret data we don't really need.

Tested like this:
```
helm upgrade --install dapr dapr/dapr --namespace dapr-system --create-namespace --version 1.0.0-rc.2 --wait
firstcert=$(kubectl get MutatingWebhookConfiguration dapr-sidecar-injector -o jsonpath='{.webhooks[0].clientConfig.caBundle}')

# run helm upgrade using local dapr chart dir
helm upgrade --install dapr . --namespace dapr-system --create-namespace --wait --values ~/Desktop/values.yml
secondcert=$(kubectl get MutatingWebhookConfiguration dapr-sidecar-injector -o jsonpath='{.webhooks[0].clientConfig.caBundle}')


if [[ "$firstcert" == "$secondcert" ]] then
   echo "IDENTICAL"
else
   echo "NOT IDENTICAL"
fi
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2743

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [x] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [x] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
