### PR TITLE
Added version to all component registries

### DIFF
--- a/pkg/components/bindings/registry.go
+++ b/pkg/components/bindings/registry.go
@@ -8,8 +8,10 @@ package bindings
 import (
 	"strings"
 
-	"github.com/dapr/components-contrib/bindings"
 	"github.com/pkg/errors"
+
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/components"
 )
 
 type (
@@ -128,8 +130,7 @@ func (b *bindingsRegistry) getOutputBinding(name, version string) (func() bindin
 	if ok {
 		return bindingFn, true
 	}
-	switch versionLower {
-	case "", "v0", "v1":
+	if components.IsInitialVersion(versionLower) {
 		bindingFn, ok = b.outputBindings[nameLower]
 	}
 	return bindingFn, ok

--- a/pkg/components/bindings/registry.go
+++ b/pkg/components/bindings/registry.go
@@ -6,7 +6,7 @@
 package bindings
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/pkg/errors"
@@ -108,27 +108,33 @@ func (b *bindingsRegistry) HasOutputBinding(name, version string) bool {
 }
 
 func (b *bindingsRegistry) getInputBinding(name, version string) (func() bindings.InputBinding, bool) {
-	binding, ok := b.inputBindings[name+"/"+version]
-	if ok {
-		return binding, true
-	}
-	if version == "" || version == "v0" || version == "v1" {
-		binding, ok = b.inputBindings[name]
-	}
-	return binding, ok
-}
-
-func (b *bindingsRegistry) getOutputBinding(name, version string) (func() bindings.OutputBinding, bool) {
-	bindingFn, ok := b.outputBindings[name+"/"+version]
+	nameLower := strings.ToLower(name)
+	versionLower := strings.ToLower(version)
+	bindingFn, ok := b.inputBindings[nameLower+"/"+versionLower]
 	if ok {
 		return bindingFn, true
 	}
-	if version == "" || version == "v0" || version == "v1" {
-		bindingFn, ok = b.outputBindings[name]
+	switch versionLower {
+	case "", "v0", "v1":
+		bindingFn, ok = b.inputBindings[nameLower]
+	}
+	return bindingFn, ok
+}
+
+func (b *bindingsRegistry) getOutputBinding(name, version string) (func() bindings.OutputBinding, bool) {
+	nameLower := strings.ToLower(name)
+	versionLower := strings.ToLower(version)
+	bindingFn, ok := b.outputBindings[nameLower+"/"+versionLower]
+	if ok {
+		return bindingFn, true
+	}
+	switch versionLower {
+	case "", "v0", "v1":
+		bindingFn, ok = b.outputBindings[nameLower]
 	}
 	return bindingFn, ok
 }
 
 func createFullName(name string) string {
-	return fmt.Sprintf("bindings.%s", name)
+	return strings.ToLower("bindings." + name)
 }

--- a/pkg/components/bindings/registry_test.go
+++ b/pkg/components/bindings/registry_test.go
@@ -6,6 +6,7 @@
 package bindings_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -59,6 +60,11 @@ func TestRegistry(t *testing.T) {
 		// assert v2
 		assert.True(t, testRegistry.HasInputBinding(componentName, "v2"))
 		pV2, e := testRegistry.CreateInputBinding(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockInputV2, pV2)
+
+		// check case-insensitivity
+		pV2, e = testRegistry.CreateInputBinding(strings.ToUpper(componentName), "V2")
 		assert.NoError(t, e)
 		assert.Same(t, mockInputV2, pV2)
 	})

--- a/pkg/components/bindings/registry_test.go
+++ b/pkg/components/bindings/registry_test.go
@@ -1,0 +1,137 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package bindings_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	b "github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/dapr/pkg/components/bindings"
+)
+
+type (
+	mockInputBinding struct {
+		b.InputBinding
+	}
+
+	mockOutputBinding struct {
+		b.OutputBinding
+	}
+)
+
+func TestRegistry(t *testing.T) {
+	testRegistry := bindings.NewRegistry()
+
+	t.Run("input binding is registered", func(t *testing.T) {
+		const (
+			inputBindingName   = "mockInputBinding"
+			inputBindingNameV2 = "mockInputBinding/v2"
+			componentName      = "bindings." + inputBindingName
+		)
+
+		// Initiate mock object
+		mockInput := &mockInputBinding{}
+		mockInputV2 := &mockInputBinding{}
+
+		// act
+		testRegistry.RegisterInputBindings(bindings.NewInput(inputBindingName, func() b.InputBinding {
+			return mockInput
+		}))
+		testRegistry.RegisterInputBindings(bindings.NewInput(inputBindingNameV2, func() b.InputBinding {
+			return mockInputV2
+		}))
+
+		// assert v0 and v1
+		assert.True(t, testRegistry.HasInputBinding(componentName, "v0"))
+		p, e := testRegistry.CreateInputBinding(componentName, "v0")
+		assert.NoError(t, e)
+		assert.Same(t, mockInput, p)
+		p, e = testRegistry.CreateInputBinding(componentName, "v1")
+		assert.NoError(t, e)
+		assert.Same(t, mockInput, p)
+
+		// assert v2
+		assert.True(t, testRegistry.HasInputBinding(componentName, "v2"))
+		pV2, e := testRegistry.CreateInputBinding(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockInputV2, pV2)
+	})
+
+	t.Run("input binding is not registered", func(t *testing.T) {
+		const (
+			inputBindingName = "fakeInputBinding"
+			componentName    = "bindings." + inputBindingName
+		)
+
+		// act
+		assert.False(t, testRegistry.HasInputBinding(componentName, "v0"))
+		assert.False(t, testRegistry.HasInputBinding(componentName, "v1"))
+		assert.False(t, testRegistry.HasInputBinding(componentName, "v2"))
+		p, actualError := testRegistry.CreateInputBinding(componentName, "v1")
+		expectedError := errors.Errorf("couldn't find input binding %s/v1", componentName)
+
+		// assert
+		assert.Nil(t, p)
+		assert.Equal(t, expectedError.Error(), actualError.Error())
+	})
+
+	t.Run("output binding is registered", func(t *testing.T) {
+		const (
+			outputBindingName   = "mockInputBinding"
+			outputBindingNameV2 = "mockInputBinding/v2"
+			componentName       = "bindings." + outputBindingName
+		)
+
+		// Initiate mock object
+		mockOutput := &mockOutputBinding{}
+		mockOutputV2 := &mockOutputBinding{}
+
+		// act
+		testRegistry.RegisterOutputBindings(bindings.NewOutput(outputBindingName, func() b.OutputBinding {
+			return mockOutput
+		}))
+		testRegistry.RegisterOutputBindings(bindings.NewOutput(outputBindingNameV2, func() b.OutputBinding {
+			return mockOutputV2
+		}))
+
+		// assert v0 and v1
+		assert.True(t, testRegistry.HasOutputBinding(componentName, "v0"))
+		p, e := testRegistry.CreateOutputBinding(componentName, "v0")
+		assert.NoError(t, e)
+		assert.Same(t, mockOutput, p)
+		assert.True(t, testRegistry.HasOutputBinding(componentName, "v1"))
+		p, e = testRegistry.CreateOutputBinding(componentName, "v1")
+		assert.NoError(t, e)
+		assert.Same(t, mockOutput, p)
+
+		// assert v2
+		assert.True(t, testRegistry.HasOutputBinding(componentName, "v2"))
+		pV2, e := testRegistry.CreateOutputBinding(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockOutputV2, pV2)
+	})
+
+	t.Run("output binding is not registered", func(t *testing.T) {
+		const (
+			outputBindingName = "fakeOutputBinding"
+			componentName     = "bindings." + outputBindingName
+		)
+
+		// act
+		assert.False(t, testRegistry.HasOutputBinding(componentName, "v0"))
+		assert.False(t, testRegistry.HasOutputBinding(componentName, "v1"))
+		assert.False(t, testRegistry.HasOutputBinding(componentName, "v2"))
+		p, actualError := testRegistry.CreateOutputBinding(componentName, "v1")
+		expectedError := errors.Errorf("couldn't find output binding %s/v1", componentName)
+
+		// assert
+		assert.Nil(t, p)
+		assert.Equal(t, expectedError.Error(), actualError.Error())
+	})
+}

--- a/pkg/components/middleware/http/registry.go
+++ b/pkg/components/middleware/http/registry.go
@@ -8,9 +8,11 @@ package http
 import (
 	"strings"
 
-	middleware "github.com/dapr/components-contrib/middleware"
-	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 	"github.com/pkg/errors"
+
+	middleware "github.com/dapr/components-contrib/middleware"
+	"github.com/dapr/dapr/pkg/components"
+	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 )
 
 type (
@@ -68,8 +70,7 @@ func (p *httpMiddlewareRegistry) getMiddleware(name, version string) (func(middl
 	if ok {
 		return middlewareFn, true
 	}
-	switch versionLower {
-	case "", "v0", "v1":
+	if components.IsInitialVersion(versionLower) {
 		middlewareFn, ok = p.middleware[nameLower]
 	}
 	return middlewareFn, ok

--- a/pkg/components/middleware/http/registry.go
+++ b/pkg/components/middleware/http/registry.go
@@ -6,7 +6,7 @@
 package http
 
 import (
-	"fmt"
+	"strings"
 
 	middleware "github.com/dapr/components-contrib/middleware"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
@@ -62,16 +62,19 @@ func (p *httpMiddlewareRegistry) Create(name, version string, metadata middlewar
 }
 
 func (p *httpMiddlewareRegistry) getMiddleware(name, version string) (func(middleware.Metadata) http_middleware.Middleware, bool) {
-	middlewareFn, ok := p.middleware[name+"/"+version]
+	nameLower := strings.ToLower(name)
+	versionLower := strings.ToLower(version)
+	middlewareFn, ok := p.middleware[nameLower+"/"+versionLower]
 	if ok {
 		return middlewareFn, true
 	}
-	if version == "" || version == "v0" || version == "v1" {
-		middlewareFn, ok = p.middleware[name]
+	switch versionLower {
+	case "", "v0", "v1":
+		middlewareFn, ok = p.middleware[nameLower]
 	}
 	return middlewareFn, ok
 }
 
 func createFullName(name string) string {
-	return fmt.Sprintf("middleware.http.%s", name)
+	return strings.ToLower("middleware.http." + name)
 }

--- a/pkg/components/middleware/http/registry.go
+++ b/pkg/components/middleware/http/registry.go
@@ -23,7 +23,7 @@ type (
 	// Registry is the interface for callers to get registered HTTP middleware
 	Registry interface {
 		Register(components ...Middleware)
-		Create(name string, metadata middleware.Metadata) (http_middleware.Middleware, error)
+		Create(name, version string, metadata middleware.Metadata) (http_middleware.Middleware, error)
 	}
 
 	httpMiddlewareRegistry struct {
@@ -54,11 +54,22 @@ func (p *httpMiddlewareRegistry) Register(components ...Middleware) {
 }
 
 // Create instantiates a HTTP middleware based on `name`.
-func (p *httpMiddlewareRegistry) Create(name string, metadata middleware.Metadata) (http_middleware.Middleware, error) {
-	if method, ok := p.middleware[name]; ok {
+func (p *httpMiddlewareRegistry) Create(name, version string, metadata middleware.Metadata) (http_middleware.Middleware, error) {
+	if method, ok := p.getMiddleware(name, version); ok {
 		return method(metadata), nil
 	}
-	return nil, errors.Errorf("HTTP middleware %s has not been registered", name)
+	return nil, errors.Errorf("HTTP middleware %s/%s has not been registered", name, version)
+}
+
+func (p *httpMiddlewareRegistry) getMiddleware(name, version string) (func(middleware.Metadata) http_middleware.Middleware, bool) {
+	middlewareFn, ok := p.middleware[name+"/"+version]
+	if ok {
+		return middlewareFn, true
+	}
+	if version == "" || version == "v0" || version == "v1" {
+		middlewareFn, ok = p.middleware[name]
+	}
+	return middlewareFn, ok
 }
 
 func createFullName(name string) string {

--- a/pkg/components/middleware/http/registry_test.go
+++ b/pkg/components/middleware/http/registry_test.go
@@ -7,6 +7,7 @@ package http_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -60,6 +61,11 @@ func TestRegistry(t *testing.T) {
 
 		// assert v2
 		pV2, e := testRegistry.Create(componentName, "v2", metadata)
+		assert.NoError(t, e)
+		assert.Equal(t, fmt.Sprintf("%v", mockV2), fmt.Sprintf("%v", pV2))
+
+		// check case-insensitivity
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2", metadata)
 		assert.NoError(t, e)
 		assert.Equal(t, fmt.Sprintf("%v", mockV2), fmt.Sprintf("%v", pV2))
 	})

--- a/pkg/components/middleware/http/registry_test.go
+++ b/pkg/components/middleware/http/registry_test.go
@@ -1,0 +1,83 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package http_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+
+	h "github.com/dapr/components-contrib/middleware"
+	"github.com/dapr/dapr/pkg/components/middleware/http"
+	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
+)
+
+func TestRegistry(t *testing.T) {
+	testRegistry := http.NewRegistry()
+
+	t.Run("middleware is registered", func(t *testing.T) {
+		const (
+			middlewareName   = "mockMiddleware"
+			middlewareNameV2 = "mockMiddleware/v2"
+			componentName    = "middleware.http." + middlewareName
+		)
+
+		// Initiate mock object
+		mock := http_middleware.Middleware(func(h fasthttp.RequestHandler) fasthttp.RequestHandler {
+			return nil
+		})
+		mockV2 := http_middleware.Middleware(func(h fasthttp.RequestHandler) fasthttp.RequestHandler {
+			return nil
+		})
+		metadata := h.Metadata{}
+
+		// act
+		testRegistry.Register(http.New(middlewareName, func(h.Metadata) http_middleware.Middleware {
+			return mock
+		}))
+		testRegistry.Register(http.New(middlewareNameV2, func(h.Metadata) http_middleware.Middleware {
+			return mockV2
+		}))
+
+		// Function values are not comparable.
+		// You can't take the address of a function, but if you print it with
+		// the fmt package, it prints its address. So you can use fmt.Sprintf()
+		// to get the address of a function value.
+
+		// assert v0 and v1
+		p, e := testRegistry.Create(componentName, "v0", metadata)
+		assert.NoError(t, e)
+		assert.Equal(t, fmt.Sprintf("%v", mock), fmt.Sprintf("%v", p))
+		p, e = testRegistry.Create(componentName, "v1", metadata)
+		assert.NoError(t, e)
+		assert.Equal(t, fmt.Sprintf("%v", mock), fmt.Sprintf("%v", p))
+
+		// assert v2
+		pV2, e := testRegistry.Create(componentName, "v2", metadata)
+		assert.NoError(t, e)
+		assert.Equal(t, fmt.Sprintf("%v", mockV2), fmt.Sprintf("%v", pV2))
+	})
+
+	t.Run("middleware is not registered", func(t *testing.T) {
+		const (
+			middlewareName = "fakeMiddleware"
+			componentName  = "middleware.http." + middlewareName
+		)
+
+		metadata := h.Metadata{}
+
+		// act
+		p, actualError := testRegistry.Create(componentName, "v1", metadata)
+		expectedError := errors.Errorf("HTTP middleware %s/v1 has not been registered", componentName)
+
+		// assert
+		assert.Nil(t, p)
+		assert.Equal(t, expectedError.Error(), actualError.Error())
+	})
+}

--- a/pkg/components/nameresolution/registry.go
+++ b/pkg/components/nameresolution/registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	nr "github.com/dapr/components-contrib/nameresolution"
+	"github.com/dapr/dapr/pkg/components"
 )
 
 type (
@@ -68,8 +69,7 @@ func (s *nameResolutionRegistry) getResolver(name, version string) (func() nr.Re
 	if ok {
 		return resolverFn, true
 	}
-	switch versionLower {
-	case "", "v0", "v1":
+	if components.IsInitialVersion(versionLower) {
 		resolverFn, ok = s.resolvers[nameLower]
 	}
 	return resolverFn, ok

--- a/pkg/components/nameresolution/registry.go
+++ b/pkg/components/nameresolution/registry.go
@@ -6,7 +6,7 @@
 package nameresolution
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -62,16 +62,19 @@ func (s *nameResolutionRegistry) Create(name, version string) (nr.Resolver, erro
 }
 
 func (s *nameResolutionRegistry) getResolver(name, version string) (func() nr.Resolver, bool) {
-	resolverFn, ok := s.resolvers[name+"/"+version]
+	nameLower := strings.ToLower(name)
+	versionLower := strings.ToLower(version)
+	resolverFn, ok := s.resolvers[nameLower+"/"+versionLower]
 	if ok {
 		return resolverFn, true
 	}
-	if version == "" || version == "v0" || version == "v1" {
-		resolverFn, ok = s.resolvers[name]
+	switch versionLower {
+	case "", "v0", "v1":
+		resolverFn, ok = s.resolvers[nameLower]
 	}
 	return resolverFn, ok
 }
 
 func createFullName(name string) string {
-	return fmt.Sprintf("nameresolution.%s", name)
+	return strings.ToLower("nameresolution." + name)
 }

--- a/pkg/components/nameresolution/registry_test.go
+++ b/pkg/components/nameresolution/registry_test.go
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package nameresolution_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	nr "github.com/dapr/components-contrib/nameresolution"
+	"github.com/dapr/dapr/pkg/components/nameresolution"
+)
+
+type mockResolver struct {
+	nr.Resolver
+}
+
+func TestRegistry(t *testing.T) {
+	testRegistry := nameresolution.NewRegistry()
+
+	t.Run("name resolver is registered", func(t *testing.T) {
+		const (
+			resolverName   = "mockResolver"
+			resolverNameV2 = "mockResolver/v2"
+			componentName  = "nameresolution." + resolverName
+		)
+
+		// Initiate mock object
+		mock := &mockResolver{}
+		mockV2 := &mockResolver{}
+
+		// act
+		testRegistry.Register(nameresolution.New(resolverName, func() nr.Resolver {
+			return mock
+		}))
+		testRegistry.Register(nameresolution.New(resolverNameV2, func() nr.Resolver {
+			return mockV2
+		}))
+
+		// assert v0 and v1
+		p, e := testRegistry.Create(resolverName, "v0")
+		assert.NoError(t, e)
+		assert.Same(t, mock, p)
+		p, e = testRegistry.Create(resolverName, "v1")
+		assert.NoError(t, e)
+		assert.Same(t, mock, p)
+
+		// assert v2
+		pV2, e := testRegistry.Create(resolverName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockV2, pV2)
+	})
+
+	t.Run("name resolver is not registered", func(t *testing.T) {
+		const (
+			resolverName  = "fakeResolver"
+			componentName = "nameresolution." + resolverName
+		)
+
+		// act
+		p, actualError := testRegistry.Create(resolverName, "v1")
+		expectedError := errors.Errorf("couldn't find name resolver %s/v1", resolverName)
+
+		// assert
+		assert.Nil(t, p)
+		assert.Equal(t, expectedError.Error(), actualError.Error())
+	})
+}

--- a/pkg/components/nameresolution/registry_test.go
+++ b/pkg/components/nameresolution/registry_test.go
@@ -6,6 +6,7 @@
 package nameresolution_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -51,6 +52,11 @@ func TestRegistry(t *testing.T) {
 
 		// assert v2
 		pV2, e := testRegistry.Create(resolverName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockV2, pV2)
+
+		// check case-insensitivity
+		pV2, e = testRegistry.Create(strings.ToUpper(resolverName), "V2")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 	})

--- a/pkg/components/pubsub/registry.go
+++ b/pkg/components/pubsub/registry.go
@@ -7,6 +7,7 @@ package pubsub
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -62,16 +63,22 @@ func (p *pubSubRegistry) Create(name, version string) (pubsub.PubSub, error) {
 }
 
 func (p *pubSubRegistry) getPubSub(name, version string) (func() pubsub.PubSub, bool) {
-	pubSubFn, ok := p.messageBuses[name+"/"+version]
+	nameLower := strings.ToLower(name)
+	versionLower := strings.ToLower(version)
+	for key := range p.messageBuses {
+		fmt.Println(key, nameLower+"/"+versionLower, name+"/"+version)
+	}
+	pubSubFn, ok := p.messageBuses[nameLower+"/"+versionLower]
 	if ok {
 		return pubSubFn, true
 	}
-	if version == "" || version == "v0" || version == "v1" {
-		pubSubFn, ok = p.messageBuses[name]
+	switch versionLower {
+	case "", "v0", "v1":
+		pubSubFn, ok = p.messageBuses[nameLower]
 	}
 	return pubSubFn, ok
 }
 
 func createFullName(name string) string {
-	return fmt.Sprintf("pubsub.%s", name)
+	return strings.ToLower("pubsub." + name)
 }

--- a/pkg/components/pubsub/registry.go
+++ b/pkg/components/pubsub/registry.go
@@ -6,7 +6,6 @@
 package pubsub
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -65,9 +64,6 @@ func (p *pubSubRegistry) Create(name, version string) (pubsub.PubSub, error) {
 func (p *pubSubRegistry) getPubSub(name, version string) (func() pubsub.PubSub, bool) {
 	nameLower := strings.ToLower(name)
 	versionLower := strings.ToLower(version)
-	for key := range p.messageBuses {
-		fmt.Println(key, nameLower+"/"+versionLower, name+"/"+version)
-	}
 	pubSubFn, ok := p.messageBuses[nameLower+"/"+versionLower]
 	if ok {
 		return pubSubFn, true

--- a/pkg/components/pubsub/registry.go
+++ b/pkg/components/pubsub/registry.go
@@ -8,8 +8,9 @@ package pubsub
 import (
 	"fmt"
 
-	"github.com/dapr/components-contrib/pubsub"
 	"github.com/pkg/errors"
+
+	"github.com/dapr/components-contrib/pubsub"
 )
 
 type (
@@ -22,7 +23,7 @@ type (
 	// Registry is the interface for callers to get registered pub-sub components
 	Registry interface {
 		Register(components ...PubSub)
-		Create(name string) (pubsub.PubSub, error)
+		Create(name, version string) (pubsub.PubSub, error)
 	}
 
 	pubSubRegistry struct {
@@ -53,11 +54,22 @@ func (p *pubSubRegistry) Register(components ...PubSub) {
 }
 
 // Create instantiates a pub/sub based on `name`.
-func (p *pubSubRegistry) Create(name string) (pubsub.PubSub, error) {
-	if method, ok := p.messageBuses[name]; ok {
+func (p *pubSubRegistry) Create(name, version string) (pubsub.PubSub, error) {
+	if method, ok := p.getPubSub(name, version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find message bus %s", name)
+	return nil, errors.Errorf("couldn't find message bus %s/%s", name, version)
+}
+
+func (p *pubSubRegistry) getPubSub(name, version string) (func() pubsub.PubSub, bool) {
+	pubSubFn, ok := p.messageBuses[name+"/"+version]
+	if ok {
+		return pubSubFn, true
+	}
+	if version == "" || version == "v0" || version == "v1" {
+		pubSubFn, ok = p.messageBuses[name]
+	}
+	return pubSubFn, ok
 }
 
 func createFullName(name string) string {

--- a/pkg/components/pubsub/registry.go
+++ b/pkg/components/pubsub/registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/components"
 )
 
 type (
@@ -68,8 +69,7 @@ func (p *pubSubRegistry) getPubSub(name, version string) (func() pubsub.PubSub, 
 	if ok {
 		return pubSubFn, true
 	}
-	switch versionLower {
-	case "", "v0", "v1":
+	if components.IsInitialVersion(versionLower) {
 		pubSubFn, ok = p.messageBuses[nameLower]
 	}
 	return pubSubFn, ok

--- a/pkg/components/pubsub/registry_test.go
+++ b/pkg/components/pubsub/registry_test.go
@@ -6,6 +6,7 @@
 package pubsub
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dapr/components-contrib/pubsub"
@@ -36,32 +37,40 @@ func TestCreatePubSub(t *testing.T) {
 	testRegistry := NewRegistry()
 
 	t.Run("pubsub messagebus is registered", func(t *testing.T) {
-		const PubSubName = "mockPubSub"
-		const PubSubNameV2 = "mockPubSub/v2"
+		const (
+			pubSubName    = "mockPubSub"
+			pubSubNameV2  = "mockPubSub/v2"
+			componentName = "pubsub." + pubSubName
+		)
 
 		// Initiate mock object
 		mockPubSub := new(daprt.MockPubSub)
 		mockPubSubV2 := new(daprt.MockPubSub)
 
 		// act
-		testRegistry.Register(New(PubSubName, func() pubsub.PubSub {
+		testRegistry.Register(New(pubSubName, func() pubsub.PubSub {
 			return mockPubSub
 		}))
-		testRegistry.Register(New(PubSubNameV2, func() pubsub.PubSub {
+		testRegistry.Register(New(pubSubNameV2, func() pubsub.PubSub {
 			return mockPubSubV2
 		}))
 
 		// assert v0 and v1
-		p, e := testRegistry.Create(createFullName(PubSubName), "v0")
+		p, e := testRegistry.Create(componentName, "v0")
 		assert.NoError(t, e)
 		assert.Same(t, mockPubSub, p)
 
-		p, e = testRegistry.Create(createFullName(PubSubName), "v1")
+		p, e = testRegistry.Create(componentName, "v1")
 		assert.NoError(t, e)
 		assert.Same(t, mockPubSub, p)
 
 		// assert v2
-		pV2, e := testRegistry.Create(createFullName(PubSubName), "v2")
+		pV2, e := testRegistry.Create(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockPubSubV2, pV2)
+
+		// check case-insensitivity
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2")
 		assert.NoError(t, e)
 		assert.Same(t, mockPubSubV2, pV2)
 	})

--- a/pkg/components/secretstores/registry.go
+++ b/pkg/components/secretstores/registry.go
@@ -6,7 +6,7 @@
 package secretstores
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/pkg/errors"
@@ -62,16 +62,19 @@ func (s *secretStoreRegistry) Create(name, version string) (secretstores.SecretS
 }
 
 func (s *secretStoreRegistry) getSecretStore(name, version string) (func() secretstores.SecretStore, bool) {
-	secretStoreFn, ok := s.secretStores[name+"/"+version]
+	nameLower := strings.ToLower(name)
+	versionLower := strings.ToLower(version)
+	secretStoreFn, ok := s.secretStores[nameLower+"/"+versionLower]
 	if ok {
 		return secretStoreFn, true
 	}
-	if version == "" || version == "v0" || version == "v1" {
-		secretStoreFn, ok = s.secretStores[name]
+	switch versionLower {
+	case "", "v0", "v1":
+		secretStoreFn, ok = s.secretStores[nameLower]
 	}
 	return secretStoreFn, ok
 }
 
 func createFullName(name string) string {
-	return fmt.Sprintf("secretstores.%s", name)
+	return strings.ToLower("secretstores." + name)
 }

--- a/pkg/components/secretstores/registry.go
+++ b/pkg/components/secretstores/registry.go
@@ -8,8 +8,10 @@ package secretstores
 import (
 	"strings"
 
-	"github.com/dapr/components-contrib/secretstores"
 	"github.com/pkg/errors"
+
+	"github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/dapr/pkg/components"
 )
 
 type (
@@ -68,8 +70,7 @@ func (s *secretStoreRegistry) getSecretStore(name, version string) (func() secre
 	if ok {
 		return secretStoreFn, true
 	}
-	switch versionLower {
-	case "", "v0", "v1":
+	if components.IsInitialVersion(versionLower) {
 		secretStoreFn, ok = s.secretStores[nameLower]
 	}
 	return secretStoreFn, ok

--- a/pkg/components/secretstores/registry_test.go
+++ b/pkg/components/secretstores/registry_test.go
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package secretstores_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	ss "github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/dapr/pkg/components/secretstores"
+)
+
+type mockSecretStore struct {
+	ss.SecretStore
+}
+
+func TestRegistry(t *testing.T) {
+	testRegistry := secretstores.NewRegistry()
+
+	t.Run("secret store is registered", func(t *testing.T) {
+		const (
+			secretStoreName   = "mockSecretStore"
+			secretStoreNameV2 = "mockSecretStore/v2"
+			componentName     = "secretstores." + secretStoreName
+		)
+
+		// Initiate mock object
+		mock := &mockSecretStore{}
+		mockV2 := &mockSecretStore{}
+
+		// act
+		testRegistry.Register(secretstores.New(secretStoreName, func() ss.SecretStore {
+			return mock
+		}))
+		testRegistry.Register(secretstores.New(secretStoreNameV2, func() ss.SecretStore {
+			return mockV2
+		}))
+
+		// assert v0 and v1
+		p, e := testRegistry.Create(componentName, "v0")
+		assert.NoError(t, e)
+		assert.Same(t, mock, p)
+		p, e = testRegistry.Create(componentName, "v1")
+		assert.NoError(t, e)
+		assert.Same(t, mock, p)
+
+		// assert v2
+		pV2, e := testRegistry.Create(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockV2, pV2)
+	})
+
+	t.Run("secret store is not registered", func(t *testing.T) {
+		const (
+			resolverName  = "fakeSecretStore"
+			componentName = "secretstores." + resolverName
+		)
+
+		// act
+		p, actualError := testRegistry.Create(componentName, "v1")
+		expectedError := errors.Errorf("couldn't find secret store %s/v1", componentName)
+
+		// assert
+		assert.Nil(t, p)
+		assert.Equal(t, expectedError.Error(), actualError.Error())
+	})
+}

--- a/pkg/components/secretstores/registry_test.go
+++ b/pkg/components/secretstores/registry_test.go
@@ -6,6 +6,7 @@
 package secretstores_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -51,6 +52,11 @@ func TestRegistry(t *testing.T) {
 
 		// assert v2
 		pV2, e := testRegistry.Create(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockV2, pV2)
+
+		// check case-insensitivity
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 	})

--- a/pkg/components/state/registry.go
+++ b/pkg/components/state/registry.go
@@ -6,7 +6,7 @@
 package state
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/dapr/components-contrib/state"
 	"github.com/pkg/errors"
@@ -57,16 +57,19 @@ func (s *stateStoreRegistry) Create(name, version string) (state.Store, error) {
 }
 
 func (s *stateStoreRegistry) getSecretStore(name, version string) (func() state.Store, bool) {
-	stateStoreFn, ok := s.stateStores[name+"/"+version]
+	nameLower := strings.ToLower(name)
+	versionLower := strings.ToLower(version)
+	stateStoreFn, ok := s.stateStores[nameLower+"/"+versionLower]
 	if ok {
 		return stateStoreFn, true
 	}
-	if version == "" || version == "v0" || version == "v1" {
-		stateStoreFn, ok = s.stateStores[name]
+	switch versionLower {
+	case "", "v0", "v1":
+		stateStoreFn, ok = s.stateStores[nameLower]
 	}
 	return stateStoreFn, ok
 }
 
 func createFullName(name string) string {
-	return fmt.Sprintf("state.%s", name)
+	return strings.ToLower("state." + name)
 }

--- a/pkg/components/state/registry_test.go
+++ b/pkg/components/state/registry_test.go
@@ -6,6 +6,7 @@
 package state_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -51,6 +52,11 @@ func TestRegistry(t *testing.T) {
 
 		// assert v2
 		pV2, e := testRegistry.Create(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockV2, pV2)
+
+		// check case-insensitivity
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 	})

--- a/pkg/components/state/registry_test.go
+++ b/pkg/components/state/registry_test.go
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package state_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	s "github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/components/state"
+)
+
+type mockState struct {
+	s.Store
+}
+
+func TestRegistry(t *testing.T) {
+	testRegistry := state.NewRegistry()
+
+	t.Run("state is registered", func(t *testing.T) {
+		const (
+			stateName     = "mockState"
+			stateNameV2   = "mockState/v2"
+			componentName = "state." + stateName
+		)
+
+		// Initiate mock object
+		mock := &mockState{}
+		mockV2 := &mockState{}
+
+		// act
+		testRegistry.Register(state.New(stateName, func() s.Store {
+			return mock
+		}))
+		testRegistry.Register(state.New(stateNameV2, func() s.Store {
+			return mockV2
+		}))
+
+		// assert v0 and v1
+		p, e := testRegistry.Create(componentName, "v0")
+		assert.NoError(t, e)
+		assert.Same(t, mock, p)
+		p, e = testRegistry.Create(componentName, "v1")
+		assert.NoError(t, e)
+		assert.Same(t, mock, p)
+
+		// assert v2
+		pV2, e := testRegistry.Create(componentName, "v2")
+		assert.NoError(t, e)
+		assert.Same(t, mockV2, pV2)
+	})
+
+	t.Run("state is not registered", func(t *testing.T) {
+		const (
+			stateName     = "fakeState"
+			componentName = "state." + stateName
+		)
+
+		// act
+		p, actualError := testRegistry.Create(componentName, "v1")
+		expectedError := errors.Errorf("couldn't find state store %s/v1", componentName)
+
+		// assert
+		assert.Nil(t, p)
+		assert.Equal(t, expectedError.Error(), actualError.Error())
+	})
+}

--- a/pkg/components/versioning.go
+++ b/pkg/components/versioning.go
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package components
+
+import "strings"
+
+// IsInitialVersion returns true when a version is considered an unstable version (v0)
+// or first stable version (v1). For backward compatibility, empty strings are also included.
+func IsInitialVersion(version string) bool {
+	v := strings.ToLower(version)
+	return v == "" || v == "v0" || v == "v1"
+}

--- a/pkg/components/versioning_test.go
+++ b/pkg/components/versioning_test.go
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package components_test
+
+import (
+	"testing"
+
+	"github.com/dapr/dapr/pkg/components"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInitialVersion(t *testing.T) {
+	tests := map[string]struct {
+		version string
+		initial bool
+	}{
+		"unknown":             {version: "", initial: true},
+		"unstable":            {version: "v0", initial: true},
+		"first stable":        {version: "v1", initial: true},
+		"second stable":       {version: "v2", initial: false},
+		"unstable upper":      {version: "V0", initial: true},
+		"first stable upper":  {version: "V1", initial: true},
+		"second stable upper": {version: "V2", initial: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := components.IsInitialVersion(tc.version)
+			assert.Equal(t, tc.initial, actual)
+		})
+	}
+}

--- a/pkg/components/versioning_test.go
+++ b/pkg/components/versioning_test.go
@@ -17,7 +17,7 @@ func TestIsInitialVersion(t *testing.T) {
 		version string
 		initial bool
 	}{
-		"unknown":             {version: "", initial: true},
+		"empty version":       {version: "", initial: true},
 		"unstable":            {version: "v0", initial: true},
 		"first stable":        {version: "v1", initial: true},
 		"second stable":       {version: "v2", initial: false},

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -104,6 +104,7 @@ type PipelineSpec struct {
 type HandlerSpec struct {
 	Name         string       `json:"name" yaml:"name"`
 	Type         string       `json:"type" yaml:"type"`
+	Version      string       `json:"version" yaml:"version"`
 	SelectorSpec SelectorSpec `json:"selector,omitempty" yaml:"selector,omitempty"`
 }
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -1781,7 +1781,7 @@ func buildHTTPPineline(spec config.PipelineSpec) http_middleware.Pipeline {
 	}))
 	var handlers []http_middleware.Middleware
 	for i := 0; i < len(spec.Handlers); i++ {
-		handler, err := registry.Create(spec.Handlers[i].Type, middleware.Metadata{})
+		handler, err := registry.Create(spec.Handlers[i].Type, spec.Handlers[i].Version, middleware.Metadata{})
 		if err != nil {
 			return http_middleware.Pipeline{}
 		}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -373,16 +373,17 @@ func (a *DaprRuntime) buildHTTPPipeline() (http_middleware.Pipeline, error) {
 			middlewareSpec := a.globalConfig.Spec.HTTPPipelineSpec.Handlers[i]
 			component := a.getComponent(middlewareSpec.Type, middlewareSpec.Name)
 			if component == nil {
-				return http_middleware.Pipeline{}, errors.Errorf("couldn't find middleware component with name %s and type %s",
+				return http_middleware.Pipeline{}, errors.Errorf("couldn't find middleware component with name %s and type %s/%s",
 					middlewareSpec.Name,
-					middlewareSpec.Type)
+					middlewareSpec.Type,
+					middlewareSpec.Version)
 			}
-			handler, err := a.httpMiddlewareRegistry.Create(middlewareSpec.Type,
+			handler, err := a.httpMiddlewareRegistry.Create(middlewareSpec.Type, middlewareSpec.Version,
 				middleware.Metadata{Properties: a.convertMetadataItemsToProperties(component.Spec.Metadata)})
 			if err != nil {
 				return http_middleware.Pipeline{}, err
 			}
-			log.Infof("enabled %s http middleware", middlewareSpec.Type)
+			log.Infof("enabled %s/%s http middleware", middlewareSpec.Type, middlewareSpec.Version)
 			handlers = append(handlers, handler)
 		}
 	}
@@ -390,14 +391,14 @@ func (a *DaprRuntime) buildHTTPPipeline() (http_middleware.Pipeline, error) {
 }
 
 func (a *DaprRuntime) initBinding(c components_v1alpha1.Component) error {
-	if a.bindingsRegistry.HasOutputBinding(c.Spec.Type) {
+	if a.bindingsRegistry.HasOutputBinding(c.Spec.Type, c.Spec.Version) {
 		if err := a.initOutputBinding(c); err != nil {
 			log.Errorf("failed to init output bindings: %s", err)
 			return err
 		}
 	}
 
-	if a.bindingsRegistry.HasInputBinding(c.Spec.Type) {
+	if a.bindingsRegistry.HasInputBinding(c.Spec.Type, c.Spec.Version) {
 		if err := a.initInputBinding(c); err != nil {
 			log.Errorf("failed to init input bindings: %s", err)
 			return err
@@ -771,9 +772,9 @@ func (a *DaprRuntime) isAppSubscribedToBinding(binding string) bool {
 }
 
 func (a *DaprRuntime) initInputBinding(c components_v1alpha1.Component) error {
-	binding, err := a.bindingsRegistry.CreateInputBinding(c.Spec.Type)
+	binding, err := a.bindingsRegistry.CreateInputBinding(c.Spec.Type, c.Spec.Version)
 	if err != nil {
-		log.Warnf("failed to create input binding %s (%s): %s", c.ObjectMeta.Name, c.Spec.Type, err)
+		log.Warnf("failed to create input binding %s (%s/%s): %s", c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation")
 		return err
 	}
@@ -782,21 +783,21 @@ func (a *DaprRuntime) initInputBinding(c components_v1alpha1.Component) error {
 		Name:       c.ObjectMeta.Name,
 	})
 	if err != nil {
-		log.Errorf("failed to init input binding %s (%s): %s", c.ObjectMeta.Name, c.Spec.Type, err)
+		log.Errorf("failed to init input binding %s (%s/%s): %s", c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init")
 		return err
 	}
 
-	log.Infof("successful init for input binding %s (%s)", c.ObjectMeta.Name, c.Spec.Type)
+	log.Infof("successful init for input binding %s (%s/%s)", c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 	a.inputBindings[c.Name] = binding
 	diag.DefaultMonitoring.ComponentInitialized(c.Spec.Type)
 	return nil
 }
 
 func (a *DaprRuntime) initOutputBinding(c components_v1alpha1.Component) error {
-	binding, err := a.bindingsRegistry.CreateOutputBinding(c.Spec.Type)
+	binding, err := a.bindingsRegistry.CreateOutputBinding(c.Spec.Type, c.Spec.Version)
 	if err != nil {
-		log.Warnf("failed to create output binding %s (%s): %s", c.ObjectMeta.Name, c.Spec.Type, err)
+		log.Warnf("failed to create output binding %s (%s/%s): %s", c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation")
 		return err
 	}
@@ -807,11 +808,11 @@ func (a *DaprRuntime) initOutputBinding(c components_v1alpha1.Component) error {
 			Name:       c.ObjectMeta.Name,
 		})
 		if err != nil {
-			log.Errorf("failed to init output binding %s (%s): %s", c.ObjectMeta.Name, c.Spec.Type, err)
+			log.Errorf("failed to init output binding %s (%s/%s): %s", c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version, err)
 			diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init")
 			return err
 		}
-		log.Infof("successful init for output binding %s (%s)", c.ObjectMeta.Name, c.Spec.Type)
+		log.Infof("successful init for output binding %s (%s/%s)", c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		a.outputBindings[c.ObjectMeta.Name] = binding
 		diag.DefaultMonitoring.ComponentInitialized(c.Spec.Type)
 	}
@@ -820,9 +821,9 @@ func (a *DaprRuntime) initOutputBinding(c components_v1alpha1.Component) error {
 
 // Refer for state store api decision  https://github.com/dapr/dapr/blob/master/docs/decision_records/api/API-008-multi-state-store-api-design.md
 func (a *DaprRuntime) initState(s components_v1alpha1.Component) error {
-	store, err := a.stateStoreRegistry.CreateStateStore(s.Spec.Type)
+	store, err := a.stateStoreRegistry.Create(s.Spec.Type, s.Spec.Version)
 	if err != nil {
-		log.Warnf("error creating state store %s: %s", s.Spec.Type, err)
+		log.Warnf("error creating state store %s (%s/%s): %s", s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "creation")
 		return err
 	}
@@ -833,7 +834,7 @@ func (a *DaprRuntime) initState(s components_v1alpha1.Component) error {
 		})
 		if err != nil {
 			diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init")
-			log.Warnf("error initializing state store %s: %s", s.Spec.Type, err)
+			log.Warnf("error initializing state store %s (%s/%s): %s", s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version, err)
 			return err
 		}
 
@@ -951,9 +952,9 @@ func (a *DaprRuntime) getTopicRoutes() (map[string]TopicRoute, error) {
 }
 
 func (a *DaprRuntime) initPubSub(c components_v1alpha1.Component) error {
-	pubSub, err := a.pubSubRegistry.Create(c.Spec.Type)
+	pubSub, err := a.pubSubRegistry.Create(c.Spec.Type, c.Spec.Version)
 	if err != nil {
-		log.Warnf("error creating pub sub %s: %s", c.Spec.Type, err)
+		log.Warnf("error creating pub sub %s (%s/%s): %s", &c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation")
 		return err
 	}
@@ -969,7 +970,7 @@ func (a *DaprRuntime) initPubSub(c components_v1alpha1.Component) error {
 		Properties: properties,
 	})
 	if err != nil {
-		log.Warnf("error initializing pub sub %s: %s", c.Spec.Type, err)
+		log.Warnf("error initializing pub sub %s/%s: %s", c.Spec.Type, c.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init")
 		return err
 	}
@@ -1043,9 +1044,9 @@ func (a *DaprRuntime) initNameResolution() error {
 
 	switch a.runtimeConfig.Mode {
 	case modes.KubernetesMode:
-		resolver, err = a.nameResolutionRegistry.Create("kubernetes")
+		resolver, err = a.nameResolutionRegistry.Create("kubernetes", "v1")
 	case modes.StandaloneMode:
-		resolver, err = a.nameResolutionRegistry.Create("mdns")
+		resolver, err = a.nameResolutionRegistry.Create("mdns", "v1")
 		// properties to register mDNS instances.
 		resolverMetadata.Properties = map[string]string{
 			nr.MDNSInstanceName:    a.runtimeConfig.ID,
@@ -1345,7 +1346,7 @@ func (a *DaprRuntime) flushOutstandingComponents() {
 }
 
 func (a *DaprRuntime) processComponentAndDependents(comp components_v1alpha1.Component) error {
-	log.Debugf("loading component. name: %s, type: %s", comp.ObjectMeta.Name, comp.Spec.Type)
+	log.Debugf("loading component. name: %s, type: %s/%s", comp.ObjectMeta.Name, comp.Spec.Type, comp.Spec.Version)
 	res := a.preprocessOneComponent(&comp)
 	if res.unreadyDependency != "" {
 		a.pendingComponentDependents[res.unreadyDependency] = append(a.pendingComponentDependents[res.unreadyDependency], comp)
@@ -1378,7 +1379,7 @@ func (a *DaprRuntime) processComponentAndDependents(comp components_v1alpha1.Com
 		return fmt.Errorf("init timeout for component %s exceeded after %s", comp.Name, timeout.String())
 	}
 
-	log.Infof("component loaded. name: %s, type: %s", comp.ObjectMeta.Name, comp.Spec.Type)
+	log.Infof("component loaded. name: %s, type: %s/%s", comp.ObjectMeta.Name, comp.Spec.Type, comp.Spec.Version)
 	a.appendOrReplaceComponents(comp)
 	diag.DefaultMonitoring.ComponentLoaded()
 
@@ -1619,7 +1620,8 @@ func (a *DaprRuntime) builtinSecretStore() []components_v1alpha1.Component {
 				Name: "kubernetes",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetes",
+				Type:    "secretstores.kubernetes",
+				Version: "v1",
 			},
 		}}
 	}
@@ -1627,9 +1629,9 @@ func (a *DaprRuntime) builtinSecretStore() []components_v1alpha1.Component {
 }
 
 func (a *DaprRuntime) initSecretStore(c components_v1alpha1.Component) error {
-	secretStore, err := a.secretStoresRegistry.Create(c.Spec.Type)
+	secretStore, err := a.secretStoresRegistry.Create(c.Spec.Type, c.Spec.Version)
 	if err != nil {
-		log.Warnf("failed creating secret store %s: %s", c.Spec.Type, err)
+		log.Warnf("failed creating secret store %s/%s: %s", c.Spec.Type, c.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation")
 		return err
 	}
@@ -1638,7 +1640,7 @@ func (a *DaprRuntime) initSecretStore(c components_v1alpha1.Component) error {
 		Properties: a.convertMetadataItemsToProperties(c.Spec.Metadata),
 	})
 	if err != nil {
-		log.Warnf("failed to init state store %s named %s: %s", c.Spec.Type, c.ObjectMeta.Name, err)
+		log.Warnf("failed to init state store %s/%s named %s: %s", c.Spec.Type, c.Spec.Version, c.ObjectMeta.Name, err)
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init")
 		return err
 	}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -195,6 +195,7 @@ func TestProcessComponentsAndDependents(t *testing.T) {
 		},
 		Spec: components_v1alpha1.ComponentSpec{
 			Type:     "pubsubs.mockPubSub",
+			Version:  "v1",
 			Metadata: getFakeMetadataItems(),
 		},
 	}
@@ -216,6 +217,7 @@ func TestDoProcessComponent(t *testing.T) {
 		},
 		Spec: components_v1alpha1.ComponentSpec{
 			Type:     "pubsub.mockPubSub",
+			Version:  "v1",
 			Metadata: getFakeMetadataItems(),
 		},
 	}
@@ -260,7 +262,8 @@ func TestInitState(t *testing.T) {
 			Name: TestPubsubName,
 		},
 		Spec: components_v1alpha1.ComponentSpec{
-			Type: "state.mockState",
+			Type:    "state.mockState",
+			Version: "v1",
 			Metadata: []components_v1alpha1.MetadataItem{
 				{
 					Name: "actorStateStore",
@@ -395,6 +398,7 @@ func TestMetadataUUID(t *testing.T) {
 		},
 		Spec: components_v1alpha1.ComponentSpec{
 			Type:     "pubsub.mockPubSub",
+			Version:  "v1",
 			Metadata: getFakeMetadataItems(),
 		},
 	}
@@ -473,6 +477,7 @@ func TestConsumerID(t *testing.T) {
 		},
 		Spec: components_v1alpha1.ComponentSpec{
 			Type:     "pubsub.mockPubSub",
+			Version:  "v1",
 			Metadata: metadata,
 		},
 	}
@@ -506,6 +511,7 @@ func TestInitPubSub(t *testing.T) {
 			},
 			Spec: components_v1alpha1.ComponentSpec{
 				Type:     "pubsub.mockPubSub",
+				Version:  "v1",
 				Metadata: getFakeMetadataItems(),
 			},
 		}, {
@@ -514,6 +520,7 @@ func TestInitPubSub(t *testing.T) {
 			},
 			Spec: components_v1alpha1.ComponentSpec{
 				Type:     "pubsub.mockPubSub2",
+				Version:  "v1",
 				Metadata: getFakeMetadataItems(),
 			},
 		},
@@ -996,10 +1003,11 @@ func TestInitSecretStores(t *testing.T) {
 				Name: "kubernetesMock",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMock",
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
 			},
 		})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("secret store is registered", func(t *testing.T) {
@@ -1010,14 +1018,16 @@ func TestInitSecretStores(t *testing.T) {
 				return m
 			}))
 
-		rt.processComponentAndDependents(components_v1alpha1.Component{
+		err := rt.processComponentAndDependents(components_v1alpha1.Component{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: "kubernetesMock",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMock",
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
 			},
 		})
+		assert.NoError(t, err)
 		assert.NotNil(t, rt.secretStores["kubernetesMock"])
 	})
 
@@ -1035,7 +1045,8 @@ func TestInitSecretStores(t *testing.T) {
 				Name: "kubernetesMock",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMock",
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
 			},
 		})
 
@@ -1149,7 +1160,8 @@ func TestProcessComponentSecrets(t *testing.T) {
 			Name: "mockBinding",
 		},
 		Spec: components_v1alpha1.ComponentSpec{
-			Type: "bindings.mock",
+			Type:    "bindings.mock",
+			Version: "v1",
 			Metadata: []components_v1alpha1.MetadataItem{
 				{
 					Name: "a",
@@ -1194,7 +1206,8 @@ func TestProcessComponentSecrets(t *testing.T) {
 				Name: "kubernetes",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetes",
+				Type:    "secretstores.kubernetes",
+				Version: "v1",
 			},
 		})
 
@@ -1281,7 +1294,8 @@ func TestExtractComponentCategory(t *testing.T) {
 		t.Run(tt.specType, func(t *testing.T) {
 			fakeComp := components_v1alpha1.Component{
 				Spec: components_v1alpha1.ComponentSpec{
-					Type: tt.specType,
+					Type:    tt.specType,
+					Version: "v1",
 				},
 			}
 			assert.Equal(t, string(rt.extractComponentCategory(fakeComp)), tt.category)
@@ -1309,7 +1323,8 @@ func TestFlushOutstandingComponent(t *testing.T) {
 				Name: "kubernetesMock",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMock",
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
 			},
 		}
 		rt.flushOutstandingComponents()
@@ -1327,7 +1342,8 @@ func TestFlushOutstandingComponent(t *testing.T) {
 				Name: "kubernetesMock2",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMock",
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
 			},
 		}
 		rt.flushOutstandingComponents()
@@ -1369,7 +1385,8 @@ func TestFlushOutstandingComponent(t *testing.T) {
 				Name: "kubernetesMockGrandChild",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMockGrandChild",
+				Type:    "secretstores.kubernetesMockGrandChild",
+				Version: "v1",
 				Metadata: []components_v1alpha1.MetadataItem{
 					{
 						Name: "a",
@@ -1389,7 +1406,8 @@ func TestFlushOutstandingComponent(t *testing.T) {
 				Name: "kubernetesMockChild",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMockChild",
+				Type:    "secretstores.kubernetesMockChild",
+				Version: "v1",
 				Metadata: []components_v1alpha1.MetadataItem{
 					{
 						Name: "a",
@@ -1409,7 +1427,8 @@ func TestFlushOutstandingComponent(t *testing.T) {
 				Name: "kubernetesMock",
 			},
 			Spec: components_v1alpha1.ComponentSpec{
-				Type: "secretstores.kubernetesMock",
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
 			},
 		}
 		rt.flushOutstandingComponents()
@@ -1426,7 +1445,8 @@ func TestInitSecretStoresInKubernetesMode(t *testing.T) {
 			Name: "fakeSecretStore",
 		},
 		Spec: components_v1alpha1.ComponentSpec{
-			Type: "secretstores.fake.secretstore",
+			Type:    "secretstores.fake.secretstore",
+			Version: "v1",
 			Metadata: []components_v1alpha1.MetadataItem{
 				{
 					Name: "a",


### PR DESCRIPTION
This PR adds the ability for all the component registries to support Version 2 of components and beyond.

This was needed before any documentation on when and how to version components (dapr/components-contrib#526) could be written.