### PR TITLE
Fix helm chart non-root issue

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -125,7 +125,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_placement.cluster.logStoreWinPath`  | Mount path for persistent volume for log store in windows when `global.ha.enabled` is true | `C:\\raft-log`   |
 | `dapr_placement.volumeclaims.storageSize` | Attached volume size | `1Gi`   |
 | `dapr_placement.volumeclaims.storageClassName` | storage class name |    |
-| `dapr_placement.runAsNonRoot`             | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
+| `dapr_placement.runAsNonRoot`             | Boolean value for `securityContext.runAsNonRoot`. Does not apply unless `forceInMemoryLog` is set to `true`. You may have to set this to `false` when running in Minikube | `false` |
 | `dapr_placement.resources`                | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 
 ### Dapr Sentry options:

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -115,7 +115,11 @@ spec:
 {{- end }}
 {{- if eq .Values.global.daprControlPlaneOs "linux" }}
         securityContext:
+{{- if eq .Values.cluster.forceInMemoryLog true }}
           runAsNonRoot: {{ .Values.runAsNonRoot }}
+{{- else }}
+          runAsUser: 0
+{{- end }}
 {{- end }}
         env:
           - name: PLACEMENT_ID


### PR DESCRIPTION
In HA mode, the placement service's Raft server tries to create log file directories on disk. As Dapr uses a nonroot Docker image, this is not possible and the pods crash with a `permissions denied` error.

This PR disables `runAsNonRoot: true` for the placement service unless `dapr_placement.cluster.forceInMemoryLog` is set to `true`, in which case logs are kept in memory and do not need to be stored to disk, allowing the container to run as non-root.