### PR TITLE
GRPC publish event callback will use data_base64 cloud event field if present

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1754,8 +1754,19 @@ func TestOnNewPublishedMessageGRPC(t *testing.T) {
 		Metadata: map[string]string{pubsubName: TestPubsubName},
 	}
 
+	envelope = pubsub.NewCloudEventsEnvelope("", "", pubsub.DefaultCloudEventType, "", topic, TestSecondPubsubName, "application/octet-stream", []byte{0x1}, "")
+	base64, err := json.Marshal(envelope)
+	assert.Nil(t, err)
+
+	testPubSubMessageBase64 := &pubsub.NewMessage{
+		Topic:    topic,
+		Data:     base64,
+		Metadata: map[string]string{pubsubName: TestPubsubName},
+	}
+
 	testCases := []struct {
 		name             string
+		message          *pubsub.NewMessage
 		responseStatus   runtimev1pb.TopicEventResponse_TopicEventResponseStatus
 		errorExpected    bool
 		noResponseStatus bool
@@ -1763,35 +1774,47 @@ func TestOnNewPublishedMessageGRPC(t *testing.T) {
 	}{
 		{
 			name:             "failed to publish message to user app with unimplemented error",
+			message:          testPubSubMessage,
 			noResponseStatus: true,
 			responseError:    status.Errorf(codes.Unimplemented, "unimplemented method"),
 			errorExpected:    false, // should be dropped with no error
 		},
 		{
 			name:             "failed to publish message to user app with response error",
+			message:          testPubSubMessage,
 			noResponseStatus: true,
 			responseError:    assert.AnError,
 			errorExpected:    true,
 		},
 		{
 			name:             "succeeded to publish message to user app with empty response",
+			message:          testPubSubMessage,
 			noResponseStatus: true,
 		},
 		{
 			name:           "succeeded to publish message to user app with success response",
+			message:        testPubSubMessage,
+			responseStatus: runtimev1pb.TopicEventResponse_SUCCESS,
+		},
+		{
+			name:           "succeeded to publish message to user app with base64 encoded cloud event",
+			message:        testPubSubMessageBase64,
 			responseStatus: runtimev1pb.TopicEventResponse_SUCCESS,
 		},
 		{
 			name:           "succeeded to publish message to user app with retry",
+			message:        testPubSubMessage,
 			responseStatus: runtimev1pb.TopicEventResponse_RETRY,
 			errorExpected:  true,
 		},
 		{
 			name:           "succeeded to publish message to user app with drop",
+			message:        testPubSubMessage,
 			responseStatus: runtimev1pb.TopicEventResponse_DROP,
 		},
 		{
 			name:           "succeeded to publish message to user app with invalid response",
+			message:        testPubSubMessage,
 			responseStatus: runtimev1pb.TopicEventResponse_TopicEventResponseStatus(99),
 			errorExpected:  true,
 		},
@@ -1833,7 +1856,7 @@ func TestOnNewPublishedMessageGRPC(t *testing.T) {
 			defer rt.grpc.AppClient.Close()
 
 			// act
-			err = rt.publishMessageGRPC(testPubSubMessage)
+			err = rt.publishMessageGRPC(tc.message)
 
 			// assert
 			if tc.errorExpected {


### PR DESCRIPTION


# Description

On a grpc publish callback, the runtime will check first if the data_base64 field is present. It will decode it and use it if so. Otherwise it will just use data.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2794
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
