### PR TITLE
Fix race condition causing "zombie" reminders.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
 	github.com/PuerkitoBio/purell v1.1.1
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/dapr/components-contrib v1.0.0-rc6
 	github.com/fasthttp/router v1.3.5
 	github.com/fsnotify/fsnotify v1.4.9

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -960,7 +960,12 @@ func (a *actorsRuntime) getRemindersForActorType(actorType string) ([]Reminder, 
 
 	var reminders []Reminder
 	json.Unmarshal(resp.Data, &reminders)
-	return reminders, &resp.ETag, nil
+	var etag *string
+	// This check is needed due to https://github.com/dapr/components-contrib/issues/731
+	if resp.ETag != "" {
+		etag = &resp.ETag
+	}
+	return reminders, etag, nil
 }
 
 func (a *actorsRuntime) DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error {

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/state"
@@ -60,24 +61,25 @@ type Actors interface {
 }
 
 type actorsRuntime struct {
-	appChannel          channel.AppChannel
-	store               state.Store
-	placement           *internal.ActorPlacement
-	grpcConnectionFn    func(address, id string, namespace string, skipTLS, recreateIfExists, enableSSL bool) (*grpc.ClientConn, error)
-	config              Config
-	actorsTable         *sync.Map
-	activeTimers        *sync.Map
-	activeTimersLock    *sync.RWMutex
-	activeReminders     *sync.Map
-	remindersLock       *sync.RWMutex
-	activeRemindersLock *sync.RWMutex
-	reminders           map[string][]Reminder
-	evaluationLock      *sync.RWMutex
-	evaluationBusy      bool
-	evaluationChan      chan bool
-	appHealthy          bool
-	certChain           *dapr_credentials.CertChain
-	tracingSpec         config.TracingSpec
+	appChannel            channel.AppChannel
+	store                 state.Store
+	placement             *internal.ActorPlacement
+	grpcConnectionFn      func(address, id string, namespace string, skipTLS, recreateIfExists, enableSSL bool) (*grpc.ClientConn, error)
+	config                Config
+	actorsTable           *sync.Map
+	activeTimers          *sync.Map
+	activeTimersLock      *sync.RWMutex
+	activeReminders       *sync.Map
+	remindersLock         *sync.RWMutex
+	activeRemindersLock   *sync.RWMutex
+	reminders             map[string][]Reminder
+	remindersStateBackoff backoff.BackOff
+	evaluationLock        *sync.RWMutex
+	evaluationBusy        bool
+	evaluationChan        chan bool
+	appHealthy            bool
+	certChain             *dapr_credentials.CertChain
+	tracingSpec           config.TracingSpec
 }
 
 // ActiveActorsCount contain actorType and count of actors each type has
@@ -99,23 +101,24 @@ func NewActors(
 	certChain *dapr_credentials.CertChain,
 	tracingSpec config.TracingSpec) Actors {
 	return &actorsRuntime{
-		appChannel:          appChannel,
-		config:              config,
-		store:               stateStore,
-		grpcConnectionFn:    grpcConnectionFn,
-		actorsTable:         &sync.Map{},
-		activeTimers:        &sync.Map{},
-		activeTimersLock:    &sync.RWMutex{},
-		activeReminders:     &sync.Map{},
-		remindersLock:       &sync.RWMutex{},
-		activeRemindersLock: &sync.RWMutex{},
-		reminders:           map[string][]Reminder{},
-		evaluationLock:      &sync.RWMutex{},
-		evaluationBusy:      false,
-		evaluationChan:      make(chan bool),
-		appHealthy:          true,
-		certChain:           certChain,
-		tracingSpec:         tracingSpec,
+		appChannel:            appChannel,
+		config:                config,
+		store:                 stateStore,
+		grpcConnectionFn:      grpcConnectionFn,
+		actorsTable:           &sync.Map{},
+		activeTimers:          &sync.Map{},
+		activeTimersLock:      &sync.RWMutex{},
+		activeReminders:       &sync.Map{},
+		remindersLock:         &sync.RWMutex{},
+		activeRemindersLock:   &sync.RWMutex{},
+		reminders:             map[string][]Reminder{},
+		remindersStateBackoff: backoff.NewExponentialBackOff(), // TODO: Make the backoff configurable
+		evaluationLock:        &sync.RWMutex{},
+		evaluationBusy:        false,
+		evaluationChan:        make(chan bool),
+		appHealthy:            true,
+		certChain:             certChain,
+		tracingSpec:           tracingSpec,
 	}
 }
 
@@ -530,7 +533,7 @@ func (a *actorsRuntime) evaluateReminders() {
 
 	var wg sync.WaitGroup
 	for _, t := range a.config.HostedActorTypes {
-		vals, err := a.getRemindersForActorType(t)
+		vals, _, err := a.getRemindersForActorType(t)
 		if err != nil {
 			log.Debugf("error getting reminders for actor type %s: %s", t, err)
 		} else {
@@ -800,24 +803,31 @@ func (a *actorsRuntime) CreateReminder(ctx context.Context, req *CreateReminderR
 		RegisteredTime: time.Now().UTC().Format(time.RFC3339),
 	}
 
-	reminders, err := a.getRemindersForActorType(req.ActorType)
+	err := backoff.Retry(func() error {
+		reminders, remindersEtag, err := a.getRemindersForActorType(req.ActorType)
+		if err != nil {
+			return err
+		}
+
+		reminders = append(reminders, reminder)
+
+		err = a.store.Set(&state.SetRequest{
+			Key:   a.constructCompositeKey("actors", req.ActorType),
+			Value: reminders,
+			ETag:  remindersEtag,
+		})
+		if err != nil {
+			return err
+		}
+
+		a.remindersLock.Lock()
+		a.reminders[req.ActorType] = reminders
+		a.remindersLock.Unlock()
+		return nil
+	}, a.remindersStateBackoff)
 	if err != nil {
 		return err
 	}
-
-	reminders = append(reminders, reminder)
-
-	err = a.store.Set(&state.SetRequest{
-		Key:   a.constructCompositeKey("actors", req.ActorType),
-		Value: reminders,
-	})
-	if err != nil {
-		return err
-	}
-
-	a.remindersLock.Lock()
-	a.reminders[req.ActorType] = reminders
-	a.remindersLock.Unlock()
 
 	err = a.startReminder(&reminder, stop)
 	if err != nil {
@@ -939,18 +949,18 @@ func (a *actorsRuntime) executeTimer(actorType, actorID, name, dueTime, period, 
 	return err
 }
 
-func (a *actorsRuntime) getRemindersForActorType(actorType string) ([]Reminder, error) {
+func (a *actorsRuntime) getRemindersForActorType(actorType string) ([]Reminder, *string, error) {
 	key := a.constructCompositeKey("actors", actorType)
 	resp, err := a.store.Get(&state.GetRequest{
 		Key: key,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var reminders []Reminder
 	json.Unmarshal(resp.Data, &reminders)
-	return reminders, nil
+	return reminders, &resp.ETag, nil
 }
 
 func (a *actorsRuntime) DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error {
@@ -974,28 +984,35 @@ func (a *actorsRuntime) DeleteReminder(ctx context.Context, req *DeleteReminderR
 		a.activeReminders.Delete(reminderKey)
 	}
 
-	reminders, err := a.getRemindersForActorType(req.ActorType)
-	if err != nil {
-		return err
-	}
-
-	for i := len(reminders) - 1; i >= 0; i-- {
-		if reminders[i].ActorType == req.ActorType && reminders[i].ActorID == req.ActorID && reminders[i].Name == req.Name {
-			reminders = append(reminders[:i], reminders[i+1:]...)
+	err := backoff.Retry(func() error {
+		reminders, remindersEtag, err := a.getRemindersForActorType(req.ActorType)
+		if err != nil {
+			return err
 		}
-	}
 
-	err = a.store.Set(&state.SetRequest{
-		Key:   key,
-		Value: reminders,
-	})
+		for i := len(reminders) - 1; i >= 0; i-- {
+			if reminders[i].ActorType == req.ActorType && reminders[i].ActorID == req.ActorID && reminders[i].Name == req.Name {
+				reminders = append(reminders[:i], reminders[i+1:]...)
+			}
+		}
+
+		err = a.store.Set(&state.SetRequest{
+			Key:   key,
+			Value: reminders,
+			ETag:  remindersEtag,
+		})
+		if err != nil {
+			return err
+		}
+
+		a.remindersLock.Lock()
+		a.reminders[req.ActorType] = reminders
+		a.remindersLock.Unlock()
+		return nil
+	}, a.remindersStateBackoff)
 	if err != nil {
 		return err
 	}
-
-	a.remindersLock.Lock()
-	a.reminders[req.ActorType] = reminders
-	a.remindersLock.Unlock()
 
 	err = a.store.Delete(&state.DeleteRequest{
 		Key: reminderKey,
@@ -1008,7 +1025,7 @@ func (a *actorsRuntime) DeleteReminder(ctx context.Context, req *DeleteReminderR
 }
 
 func (a *actorsRuntime) GetReminder(ctx context.Context, req *GetReminderRequest) (*Reminder, error) {
-	reminders, err := a.getRemindersForActorType(req.ActorType)
+	reminders, _, err := a.getRemindersForActorType(req.ActorType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -273,7 +273,7 @@ func TestOverrideReminder(t *testing.T) {
 
 		reminder2 := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "b")
 		testActorsRuntime.CreateReminder(ctx, &reminder2)
-		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
+		reminders, _, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		assert.Equal(t, "b", reminders[0].Data)
 	})
@@ -287,7 +287,7 @@ func TestOverrideReminder(t *testing.T) {
 
 		reminder2 := createReminderData(actorID, actorType, "reminder1", "1s", "2s", "")
 		testActorsRuntime.CreateReminder(ctx, &reminder2)
-		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
+		reminders, _, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		assert.Equal(t, "2s", reminders[0].DueTime)
 	})
@@ -301,7 +301,7 @@ func TestOverrideReminder(t *testing.T) {
 
 		reminder2 := createReminderData(actorID, actorType, "reminder1", "2s", "1s", "")
 		testActorsRuntime.CreateReminder(ctx, &reminder2)
-		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
+		reminders, _, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		assert.Equal(t, "2s", reminders[0].Period)
 	})
@@ -321,7 +321,7 @@ func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
 
 		reminder2 := createReminderData(actorID, actorType, reminderName, "9s", "1s", "b")
 		testActorsRuntime.CreateReminder(ctx, &reminder2)
-		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
+		reminders, _, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		// Check reminder is updated
 		assert.Equal(t, "9s", reminders[0].Period)
@@ -330,7 +330,7 @@ func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
 
 		reminder3 := createReminderData(actorID, actorType, reminderName, "8s", "2s", "b")
 		testActorsRuntime.CreateReminder(ctx, &reminder3)
-		reminders, err = testActorsRuntime.getRemindersForActorType(actorType)
+		reminders, _, err = testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		// Check reminder is updated
 		assert.Equal(t, "8s", reminders[0].Period)
@@ -366,7 +366,7 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 		time.Sleep(2 * time.Second)
 
 		// Check reminder is updated
-		reminders, err := testActorsRuntime.getRemindersForActorType(actorType)
+		reminders, _, err := testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 		// The statestore could have either reminder2 or reminder3 based on the timing.
 		// Therefore, not verifying data field
@@ -377,7 +377,7 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 
 		reminder4 := createReminderData(actorID, actorType, reminderName, "7s", "2s", "d")
 		testActorsRuntime.CreateReminder(ctx, &reminder4)
-		reminders, err = testActorsRuntime.getRemindersForActorType(actorType)
+		reminders, _, err = testActorsRuntime.getRemindersForActorType(actorType)
 		assert.Nil(t, err)
 
 		time.Sleep(2*time.Second + 100*time.Millisecond)

--- a/tests/apps/actorfeatures/app.go
+++ b/tests/apps/actorfeatures/app.go
@@ -58,6 +58,8 @@ type daprConfig struct {
 	DrainRebalancedActors   bool     `json:"drainRebalancedActors,omitempty"`
 }
 
+
+// response object from an actor invocation request
 type daprActorResponse struct {
 	Data     []byte            `json:"data"`
 	Metadata map[string]string `json:"metadata"`

--- a/tests/apps/actorfeatures/app.go
+++ b/tests/apps/actorfeatures/app.go
@@ -26,7 +26,8 @@ const (
 	actorMethodURLFormat    = daprV1URL + "/actors/%s/%s/%s/%s"
 	actorSaveStateURLFormat = daprV1URL + "/actors/%s/%s/state/"
 	actorGetStateURLFormat  = daprV1URL + "/actors/%s/%s/state/%s/"
-	registedActorType       = "testactorfeatures" // Actor type must be unique per test app.
+	defaultActorType        = "testactorfeatures"   // Actor type must be unique per test app.
+	actorTypeEnvName        = "TEST_APP_ACTOR_TYPE" // Env variable tests can set to change actor type.
 	actorIdleTimeout        = "1h"
 	actorScanInterval       = "30s"
 	drainOngoingCallTimeout = "30s"
@@ -55,14 +56,6 @@ type daprConfig struct {
 	ActorScanInterval       string   `json:"actorScanInterval,omitempty"`
 	DrainOngoingCallTimeout string   `json:"drainOngoingCallTimeout,omitempty"`
 	DrainRebalancedActors   bool     `json:"drainRebalancedActors,omitempty"`
-}
-
-var daprConfigResponse = daprConfig{
-	[]string{registedActorType},
-	actorIdleTimeout,
-	actorScanInterval,
-	drainOngoingCallTimeout,
-	drainRebalancedActors,
 }
 
 type daprActorResponse struct {
@@ -105,14 +98,31 @@ type TempTransactionalDelete struct {
 
 var actorLogs = []actorLogEntry{}
 var actorLogsMutex = &sync.Mutex{}
-
+var registedActorType = getActorType()
 var actors sync.Map
+
+var daprConfigResponse = daprConfig{
+	[]string{getActorType()},
+	actorIdleTimeout,
+	actorScanInterval,
+	drainOngoingCallTimeout,
+	drainRebalancedActors,
+}
 
 func resetLogs() {
 	actorLogsMutex.Lock()
 	defer actorLogsMutex.Unlock()
 
 	actorLogs = []actorLogEntry{}
+}
+
+func getActorType() string {
+	actorType := os.Getenv(actorTypeEnvName)
+	if actorType == "" {
+		return defaultActorType
+	}
+
+	return actorType
 }
 
 func appendLog(actorType string, actorID string, action string, start int) {
@@ -156,7 +166,7 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func configHandler(w http.ResponseWriter, r *http.Request) {
-	log.Printf("Processing dapr request for %s", r.URL.RequestURI())
+	log.Printf("Processing dapr request for %s, responding with %v", r.URL.RequestURI(), daprConfigResponse)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -486,6 +496,12 @@ func httpCall(method string, url string, requestBody interface{}, expectedHTTPSt
 	defer res.Body.Close()
 
 	if res.StatusCode != expectedHTTPStatusCode {
+		errBody, err := ioutil.ReadAll(res.Body)
+		if err == nil {
+			t := fmt.Errorf("Expected http status %d, received %d, payload ='%s'", expectedHTTPStatusCode, res.StatusCode, string(errBody))
+			return nil, t
+		}
+
 		t := fmt.Errorf("Expected http status %d, received %d", expectedHTTPStatusCode, res.StatusCode)
 		return nil, t
 	}

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -155,7 +155,6 @@ func TestActorReminder(t *testing.T) {
 					count := countActorAction(resp, actorID, reminderName)
 					// Due to possible load stress, we do not expect all reminders to be called at the same frequency.
 					// There are other E2E tests that validate the correct frequency of reminders in a happy path.
-					t.Logf("Reminder %s for Actor %s was invoked %d times - expects >= than %d.", reminderName, actorID, count, 1)
 					require.True(t, count >= 1, "Reminder %s for Actor %s was invoked %d times.", reminderName, actorID, count)
 				}
 			}(i)

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -185,7 +185,6 @@ func TestActorReminder(t *testing.T) {
 			for i := 0; i < numActorsPerThread; i++ {
 				actorID := fmt.Sprintf(actorIDTemplate, i+(1000*iteration))
 				count := countActorAction(resp, actorID, reminderName)
-				t.Logf("After restarting app, reminder %s for Actor %s was invoked %d times - expects 0.", reminderName, actorID, count)
 				require.True(t, count == 0, "Reminder %s for Actor %s was invoked %d times.", reminderName, actorID, count)
 			}
 		}

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -1,0 +1,195 @@
+// +build e2e
+
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package actor_reminder_e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dapr/dapr/tests/e2e/utils"
+	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
+	"github.com/dapr/dapr/tests/runner"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	appName                      = "actorreminder"                      // App name in Dapr.
+	actorIDTemplate              = "actor-reminder-restart-test-%d"     // Template for Actor ID
+	reminderName                 = "RestartTestReminder"                // Reminder name
+	numIterations                = 7                                    // Number of times each test should run.
+	numHealthChecks              = 60                                   // Number of get calls before starting tests.
+	numActorsPerThread           = 10                                   // Number of get calls before starting tests.
+	secondsToCheckReminderResult = 20                                   // How much time to wait to make sure the result is in logs.
+	actorInvokeURLFormat         = "%s/test/testactorreminder/%s/%s/%s" // URL to invoke a Dapr's actor method in test app.
+	actorlogsURLFormat           = "%s/test/logs"                       // URL to fetch logs from test app.
+)
+
+// represents a response for the APIs in this app.
+type actorLogEntry struct {
+	Action         string `json:"action,omitempty"`
+	ActorType      string `json:"actorType,omitempty"`
+	ActorID        string `json:"actorId,omitempty"`
+	StartTimestamp int    `json:"startTimestamp,omitempty"`
+	EndTimestamp   int    `json:"endTimestamp,omitempty"`
+}
+
+type actorReminder struct {
+	Data     string `json:"data,omitempty"`
+	DueTime  string `json:"dueTime,omitempty"`
+	Period   string `json:"period,omitempty"`
+	Callback string `json:"callback,omitempty"`
+}
+
+func parseLogEntries(resp []byte) []actorLogEntry {
+	logEntries := []actorLogEntry{}
+	err := json.Unmarshal(resp, &logEntries)
+	if err != nil {
+		return nil
+	}
+
+	return logEntries
+}
+
+func countActorAction(resp []byte, actorID string, action string) int {
+	count := 0
+	logEntries := parseLogEntries(resp)
+	for _, logEntry := range logEntries {
+		if (logEntry.ActorID == actorID) && (logEntry.Action == action) {
+			count = count + 1
+		}
+	}
+
+	return count
+}
+
+var tr *runner.TestRunner
+
+func TestMain(m *testing.M) {
+	// These apps will be deployed before starting actual test
+	// and will be cleaned up after all tests are finished automatically
+	testApps := []kube.AppDescription{
+		{
+			AppName:        appName,
+			DaprEnabled:    true,
+			ImageName:      "e2e-actorfeatures",
+			Replicas:       1,
+			IngressEnabled: true,
+			AppEnv: map[string]string{
+				"TEST_APP_ACTOR_TYPE": "testactorreminder",
+			},
+		},
+	}
+
+	tr = runner.NewTestRunner(appName, testApps, nil, nil)
+	os.Exit(tr.Start(m))
+}
+
+func TestActorReminder(t *testing.T) {
+	externalURL := tr.Platform.AcquireAppExternalURL(appName)
+	require.NotEmpty(t, externalURL, "external URL must not be empty!")
+
+	logsURL := fmt.Sprintf(actorlogsURLFormat, externalURL)
+
+	// This initial probe makes the test wait a little bit longer when needed,
+	// making this test less flaky due to delays in the deployment.
+	t.Logf("Checking if app is healthy ...")
+	_, err := utils.HTTPGetNTimes(externalURL, numHealthChecks)
+	require.NoError(t, err)
+
+	// Set reminder
+	reminder := actorReminder{
+		Data:    "reminderdata",
+		DueTime: "1s",
+		Period:  "1s",
+	}
+	reminderBody, err := json.Marshal(reminder)
+	require.NoError(t, err)
+
+	t.Run("Actor reminder unregister then restart should not trigger anymore.", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for i := 1; i <= numIterations; i++ {
+			wg.Add(1)
+			go func(iteration int) {
+				defer wg.Done()
+				t.Logf("Running iteration %d out of %d ...", iteration, numIterations)
+
+				for i := 0; i < numActorsPerThread; i++ {
+					actorID := fmt.Sprintf(actorIDTemplate, i+(1000*iteration))
+					// Deleting pre-existing reminder
+					_, err = utils.HTTPDelete(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName))
+					require.NoError(t, err)
+
+					// Registering reminder
+					_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName), reminderBody)
+					require.NoError(t, err)
+				}
+
+				t.Logf("Sleeping for %d seconds ...", secondsToCheckReminderResult)
+				time.Sleep(secondsToCheckReminderResult * time.Second)
+
+				for i := 0; i < numActorsPerThread; i++ {
+					actorID := fmt.Sprintf(actorIDTemplate, i+(1000*iteration))
+					// Unregistering reminder
+					_, err = utils.HTTPDelete(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName))
+					require.NoError(t, err)
+				}
+
+				t.Logf("Getting logs from %s to see if reminders did trigger ...", logsURL)
+				resp, err := utils.HTTPGet(logsURL)
+				require.NoError(t, err)
+
+				t.Log("Checking if all reminders did trigger ...")
+				// Errors below should NOT be considered flakyness and must be investigated.
+				// If there was no other error until now, there should be reminders triggered.
+				for i := 0; i < numActorsPerThread; i++ {
+					actorID := fmt.Sprintf(actorIDTemplate, i+(1000*iteration))
+					count := countActorAction(resp, actorID, reminderName)
+					// Due to possible load stress, we do not expect all reminders to be called at the same frequency.
+					// There are other E2E tests that validate the correct frequency of reminders in a happy path.
+					t.Logf("Reminder %s for Actor %s was invoked %d times - expects >= than %d.", reminderName, actorID, count, 1)
+					require.True(t, count >= 1, "Reminder %s for Actor %s was invoked %d times.", reminderName, actorID, count)
+				}
+			}(i)
+		}
+		wg.Wait()
+
+		t.Logf("Restarting %s ...", appName)
+		tr.Platform.Restart(appName)
+
+		// This initial probe makes the test wait a little bit longer when needed,
+		// making this test less flaky due to delays in the deployment.
+		t.Logf("Checking if app is healthy ...")
+		_, err = utils.HTTPGetNTimes(externalURL, numHealthChecks)
+		require.NoError(t, err)
+
+		t.Logf("Sleeping for %d seconds to see if reminders will trigger ...", secondsToCheckReminderResult)
+		time.Sleep(secondsToCheckReminderResult * time.Second)
+
+		t.Logf("Getting logs from %s ...", logsURL)
+		resp, err := utils.HTTPGet(logsURL)
+		require.NoError(t, err)
+
+		t.Log("Checking if NO reminder triggered ...")
+		for iteration := 1; iteration <= numIterations; iteration++ {
+			// Errors below should NOT be considered flakyness and must be investigated.
+			// After the app unregisters a reminder and is restarted, there should be no more reminders triggered.
+			for i := 0; i < numActorsPerThread; i++ {
+				actorID := fmt.Sprintf(actorIDTemplate, i+(1000*iteration))
+				count := countActorAction(resp, actorID, reminderName)
+				t.Logf("After restarting app, reminder %s for Actor %s was invoked %d times - expects 0.", reminderName, actorID, count)
+				require.True(t, count == 0, "Reminder %s for Actor %s was invoked %d times.", reminderName, actorID, count)
+			}
+		}
+
+		t.Log("Done.")
+	})
+}

--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -10,6 +10,7 @@ type AppDescription struct {
 	AppName           string
 	AppPort           int
 	AppProtocol       string
+	AppEnv            map[string]string
 	DaprEnabled       bool
 	ImageName         string
 	RegistryName      string

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -82,6 +82,16 @@ func buildDeploymentObject(namespace string, appDesc AppDescription) *appsv1.Dep
 		annotationObject["dapr.io/config"] = appDesc.Config
 	}
 
+	appEnv := []apiv1.EnvVar{}
+	if appDesc.AppEnv != nil {
+		for key, value := range appDesc.AppEnv {
+			appEnv = append(appEnv, apiv1.EnvVar{
+				Name:  key,
+				Value: value,
+			})
+		}
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appDesc.AppName,
@@ -114,6 +124,7 @@ func buildDeploymentObject(namespace string, appDesc AppDescription) *appsv1.Dep
 									ContainerPort: DefaultContainerPort,
 								},
 							},
+							Env: appEnv,
 						},
 					},
 					Affinity: &apiv1.Affinity{


### PR DESCRIPTION
# Description

Add E2E test to validate "zombie" reminders.
Fix race condition causing zombie reminders.

Two instances of daprd will change the reminder's key in parallel, so this check must be done in the db and not in memory. In addition, it means that Actors now require databases to support eTag. I plan to add an extra method for state stores for components to declare that they have etag support. This will allow dapr to fail in case of a bad config. That can be interpreted as a breaking change, so we can have it to be a warning instead.

**This change means that databases will need to support etag for running Actors reliably in production.**

The following issues must be addressed prior to this PR being merged:
https://github.com/dapr/components-contrib/issues/725
https://github.com/dapr/components-contrib/issues/726
https://github.com/dapr/components-contrib/issues/727
https://github.com/dapr/components-contrib/issues/728

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2705 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Unit tests passing
* [X] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
