### PR TITLE
hotfix(tests/actor_features): Greater to GreaterOrEqual

### DIFF
--- a/tests/e2e/actor_features/actor_features_test.go
+++ b/tests/e2e/actor_features/actor_features_test.go
@@ -353,7 +353,7 @@ func TestActorFeatures(t *testing.T) {
 
 		resp, err = utils.HTTPGet(logsURL)
 		require.NoError(t, err)
-		require.Greater(t, countActorAction(resp, actorID, reminderName), firstCount)
+		require.GreaterOrEqual(t, countActorAction(resp, actorID, reminderName), firstCount)
 		require.GreaterOrEqual(t, countActorAction(resp, actorID, reminderName), minimumCallsForTimerAndReminderResult)
 	})
 


### PR DESCRIPTION
in the  deactivateActorHandler  method, if request's method is delete and actor instance exists in actors , it will firstly delete actor and then add new actor. 

so len(actors) will not change.

