### PR TITLE
Remove use of downward API for pod IP

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -18,7 +18,6 @@ import (
 	auth "github.com/dapr/dapr/pkg/runtime/security"
 	"github.com/dapr/dapr/pkg/sentry/certs"
 	"github.com/dapr/dapr/pkg/validation"
-	"github.com/dapr/dapr/utils"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -511,14 +510,6 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 		},
 		Command: []string{"/daprd"},
 		Env: []corev1.EnvVar{
-			{
-				Name: utils.HostIPEnvVar,
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "status.podIP",
-					},
-				},
-			},
 			{
 				Name:  "NAMESPACE",
 				Value: namespace,

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -116,14 +116,12 @@ func TestGetSideCarContainer(t *testing.T) {
 		"--log-as-json",
 	}
 
-	// DAPR_HOST_IP
-	assert.Equal(t, "", container.Env[0].Value)
 	// NAMESPACE
-	assert.Equal(t, "dapr-system", container.Env[1].Value)
+	assert.Equal(t, "dapr-system", container.Env[0].Value)
 	// DAPR_API_TOKEN
-	assert.Equal(t, "secret", container.Env[2].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "secret", container.Env[1].ValueFrom.SecretKeyRef.Name)
 	// DAPR_APP_TOKEN
-	assert.Equal(t, "appsecret", container.Env[3].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "appsecret", container.Env[2].ValueFrom.SecretKeyRef.Name)
 	assert.EqualValues(t, expectedArgs, container.Args)
 	assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy)
 }


### PR DESCRIPTION
This PR removes the use of the Downward API to inject the Pod IP into a Dapr sidecar, which now re-uses the same rules for self-hosted mode.

This enables Dapr to run in Kubernetes distributions that do not enable the Downward API and allows Dapr sidecars to run as Virtual Kubelet pods and with AKS Virtual Nodes.

Closes https://github.com/dapr/dapr/issues/2348.