### PR TITLE
Adapting to state response ETag fields becoming *string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,9 @@ require (
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
 	github.com/PuerkitoBio/purell v1.1.1
+	github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b
 	github.com/cenkalti/backoff/v4 v4.1.0
-	github.com/dapr/components-contrib v1.0.1-0.20210301230228-a8de09faf452
+	github.com/dapr/components-contrib v1.0.1-0.20210303224242-1b70adb9a098
 	github.com/fasthttp/router v1.3.5
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
@@ -37,8 +38,6 @@ require (
 	go.opencensus.io v0.22.5
 	go.opentelemetry.io/otel v0.13.0
 	go.uber.org/atomic v1.6.0
-	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb // indirect
-	golang.org/x/sys v0.0.0-20201202213521-69691e467435 // indirect
 	google.golang.org/genproto v0.0.0-20201204160425-06b3db808446
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,7 @@ github.com/aerospike/aerospike-client-go v2.7.0+incompatible h1:NbjGs0ZMHKge1+0m
 github.com/aerospike/aerospike-client-go v2.7.0+incompatible/go.mod h1:zj8LBEnWBDOVEIJt8LvaRvDG5ARAoa5dBeHaB472NRc=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b h1:WMhlIaJkDgEQSVJQM06YV+cYUl1r5OY5//ijMXJNqtA=
 github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b/go.mod h1:Tie46d3UWzXpj+Fh9+DQTyaUxEpFBPOLXrnx7nxlKRo=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
@@ -282,10 +283,12 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
 github.com/dapr/components-contrib v1.0.0-rc2/go.mod h1:5r95bQ7UqLfjJA6oomcc1L+mDTXSTPTGg3hmGhoJIxs=
-github.com/dapr/components-contrib v1.0.1-0.20210301230228-a8de09faf452 h1:EqTwYZ1+dfiPZCN7fO7MrsQQxVNhPZX6m3IqiHFeTEs=
 github.com/dapr/components-contrib v1.0.1-0.20210301230228-a8de09faf452/go.mod h1:z5NR1Zzscfu8DXNblEJShdUb1dd6DYZIt0FzB53DXzg=
+github.com/dapr/components-contrib v1.0.1-0.20210303224242-1b70adb9a098 h1:c97H/neZzUHt5YK9BiZx6Kx4zavvI6r/CechgLjAJPM=
+github.com/dapr/components-contrib v1.0.1-0.20210303224242-1b70adb9a098/go.mod h1:6swYaoNxlLUFSh9DHORR59rNgbsHJ0GoNkQFaSSGNok=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/dapr v1.0.0-rc.2/go.mod h1:raAV9hKG114OTTudY8tfajM1EELp8YasLbK6OLgKuG0=
+github.com/dapr/dapr v1.0.1-0.20210303190006-b2271c9a8a58/go.mod h1:XjKeD6e35Z6dxjProOaNhgpT5o24K7SdkuG+6paeYO0=
 github.com/dapr/go-sdk v0.0.0-20200121181907-48249cda2fad/go.mod h1:yeOIFBz6+BigHpk4ASJbgQDVjQ8+00oCWrFyOAFdob8=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -958,12 +958,8 @@ func (a *actorsRuntime) getRemindersForActorType(actorType string) ([]Reminder, 
 
 	var reminders []Reminder
 	json.Unmarshal(resp.Data, &reminders)
-	var etag *string
-	// This check is needed due to https://github.com/dapr/components-contrib/issues/731
-	if resp.ETag != "" {
-		etag = &resp.ETag
-	}
-	return reminders, etag, nil
+
+	return reminders, resp.ETag, nil
 }
 
 func (a *actorsRuntime) DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error {

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -403,7 +403,7 @@ func (a *api) GetBulkState(ctx context.Context, in *runtimev1pb.GetBulkStateRequ
 			item := &runtimev1pb.BulkStateItem{
 				Key:      state_loader.GetOriginalStateKey(responses[i].Key),
 				Data:     responses[i].Data,
-				Etag:     responses[i].ETag,
+				Etag:     stringValueOrEmpty(responses[i].ETag),
 				Metadata: responses[i].Metadata,
 				Error:    responses[i].Error,
 			}
@@ -425,7 +425,7 @@ func (a *api) GetBulkState(ctx context.Context, in *runtimev1pb.GetBulkStateRequ
 				item.Error = err.Error()
 			} else if r != nil {
 				item.Data = r.Data
-				item.Etag = r.ETag
+				item.Etag = stringValueOrEmpty(r.ETag)
 				item.Metadata = r.Metadata
 			}
 			bulkResp.Items = append(bulkResp.Items, item)
@@ -475,7 +475,7 @@ func (a *api) GetState(ctx context.Context, in *runtimev1pb.GetStateRequest) (*r
 
 	response := &runtimev1pb.GetStateResponse{}
 	if getResponse != nil {
-		response.Etag = getResponse.ETag
+		response.Etag = stringValueOrEmpty(getResponse.ETag)
 		response.Data = getResponse.Data
 		response.Metadata = getResponse.Metadata
 	}
@@ -1084,4 +1084,12 @@ func (a *api) GetMetadata(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.
 func (a *api) SetMetadata(ctx context.Context, in *runtimev1pb.SetMetadataRequest) (*emptypb.Empty, error) {
 	a.extendedMetadata.Store(in.Key, in.Value)
 	return &emptypb.Empty{}, nil
+}
+
+func stringValueOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
 }

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -14,6 +14,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agrea/ptr"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.opencensus.io/trace"
+	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
+
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/secretstores"
@@ -32,19 +47,6 @@ import (
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	daprt "github.com/dapr/dapr/pkg/testing"
 	testtrace "github.com/dapr/dapr/pkg/testing/trace"
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/phayes/freeport"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"go.opencensus.io/trace"
-	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const maxGRPCServerUptime = 100 * time.Millisecond
@@ -943,7 +945,7 @@ func TestGetState(t *testing.T) {
 	})).Return(
 		&state.GetResponse{
 			Data: []byte("test-data"),
-			ETag: "test-etag",
+			ETag: ptr.String("test-etag"),
 		}, nil)
 	fakeStore.On("Get", mock.MatchedBy(func(req *state.GetRequest) bool {
 		return req.Key == "fakeAPI||error-key"
@@ -1028,7 +1030,7 @@ func TestGetBulkState(t *testing.T) {
 	})).Return(
 		&state.GetResponse{
 			Data: []byte("test-data"),
-			ETag: "test-etag",
+			ETag: ptr.String("test-etag"),
 		}, nil)
 	fakeStore.On("Get", mock.MatchedBy(func(req *state.GetRequest) bool {
 		return req.Key == "fakeAPI||error-key"

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -18,6 +18,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agrea/ptr"
+	routing "github.com/fasthttp/router"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/components-contrib/middleware"
 	"github.com/dapr/components-contrib/pubsub"
@@ -35,19 +50,6 @@ import (
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	daprt "github.com/dapr/dapr/pkg/testing"
 	testtrace "github.com/dapr/dapr/pkg/testing/trace"
-	routing "github.com/fasthttp/router"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/valyala/fasthttp"
-	"github.com/valyala/fasthttp/fasthttputil"
-	epb "google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var invalidJSON = []byte{0x7b, 0x7b}
@@ -2315,13 +2317,13 @@ func TestV1StateEndpoints(t *testing.T) {
 			{
 				Key:   "good-key",
 				Data:  jsoniter.RawMessage("life is good"),
-				ETag:  "`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'",
+				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
 			{
 				Key:   "foo",
 				Data:  nil,
-				ETag:  "",
+				ETag:  nil,
 				Error: "",
 			},
 		}
@@ -2348,13 +2350,13 @@ func TestV1StateEndpoints(t *testing.T) {
 			{
 				Key:   "good-key",
 				Data:  jsoniter.RawMessage("life is good"),
-				ETag:  "`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'",
+				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
 			{
 				Key:   "error-key",
 				Data:  nil,
-				ETag:  "",
+				ETag:  nil,
 				Error: "UPSTREAM STATE ERROR",
 			},
 		}
@@ -2405,7 +2407,7 @@ func (c fakeStateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if req.Key == "good-key" {
 		return &state.GetResponse{
 			Data: []byte("\"bGlmZSBpcyBnb29k\""),
-			ETag: "`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'",
+			ETag: ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 		}, nil
 	}
 	if req.Key == "error-key" {

--- a/pkg/http/responses.go
+++ b/pkg/http/responses.go
@@ -21,7 +21,7 @@ const (
 type BulkGetResponse struct {
 	Key   string              `json:"key"`
 	Data  jsoniter.RawMessage `json:"data,omitempty"`
-	ETag  string              `json:"etag,omitempty"`
+	ETag  *string             `json:"etag,omitempty"`
 	Error string              `json:"error,omitempty"`
 }
 
@@ -42,10 +42,12 @@ func respond(ctx *fasthttp.RequestCtx, code int, obj []byte) {
 }
 
 // respondWithETaggedJSON overrides the content-type with application/json and etag header
-func respondWithETaggedJSON(ctx *fasthttp.RequestCtx, code int, obj []byte, etag string) {
+func respondWithETaggedJSON(ctx *fasthttp.RequestCtx, code int, obj []byte, etag *string) {
 	respond(ctx, code, obj)
 	ctx.Response.Header.SetContentType(jsonContentTypeHeader)
-	ctx.Response.Header.Set(etagHeader, etag)
+	if etag != nil {
+		ctx.Response.Header.Set(etagHeader, *etag)
+	}
 }
 
 func respondWithError(ctx *fasthttp.RequestCtx, code int, resp ErrorResponse) {

--- a/pkg/http/responses_test.go
+++ b/pkg/http/responses_test.go
@@ -8,6 +8,7 @@ package http
 import (
 	"testing"
 
+	"github.com/agrea/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
 )
@@ -31,7 +32,7 @@ func TestHeaders(t *testing.T) {
 	t.Run("Respond with ETag JSON", func(t *testing.T) {
 		ctx := &fasthttp.RequestCtx{Request: fasthttp.Request{}}
 		etagValue := "etagValue"
-		respondWithETaggedJSON(ctx, 200, nil, etagValue)
+		respondWithETaggedJSON(ctx, 200, nil, ptr.String(etagValue))
 
 		assert.Equal(t, etagValue, string(ctx.Response.Header.Peek(etagHeader)))
 	})


### PR DESCRIPTION
# Description

This PR makes small changes to adapt to the ETag field from state responses changing from `string` to `*string`.

Also worth noting I put a work around for some proto messages that did not update from `string etag` to `common.v1.Etag etag`. The function `stringValueOrEmpty` simply returns the string value for non-nil and "" for nil. This is the best we can do without a breaking change the gRPC API.

## Issue reference

Resolves dapr/components-contrib#731

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
