### PR TITLE
Service Invocation: Adding OpenTelemetry headers to gRPC invocations

### DIFF
--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -406,9 +406,7 @@ func processGRPCToGRPCTraceHeader(ctx context.Context, md metadata.MD, grpctrace
 		diag.SpanContextToHTTPHeaders(sc, func(header, value string) {
 			md.Set(header, value)
 		})
-		traceBinary := propagation.Binary(sc)
-		traceValue := string(traceBinary)
-		md.Set(tracebinMetadata, traceValue)
+		md.Set(tracebinMetadata, string(propagation.Binary(sc)))
 	} else {
 		decoded, err := base64.StdEncoding.DecodeString(grpctracebinValue)
 		if err == nil {

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -386,6 +386,12 @@ func processHTTPToGRPCTraceHeader(ctx context.Context, md metadata.MD, tracepare
 		span := diag_utils.SpanFromContext(ctx)
 		sc = span.SpanContext()
 	}
+	// Workaround for lack of grpc-trace-bin support in OpenTelemetry (unlike OpenCensus), tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
+	// grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
+	// TODO : Remove this workaround fix once grpc-dotnet supports grpc-trace-bin header. Tracking issue https://github.com/dapr/dapr/issues/1827
+	diag.SpanContextToHTTPHeaders(sc, func(header, value string) {
+		md.Set(header, value)
+	})
 	md.Set(tracebinMetadata, string(propagation.Binary(sc)))
 }
 
@@ -393,10 +399,27 @@ func processGRPCToGRPCTraceHeader(ctx context.Context, md metadata.MD, grpctrace
 	if grpctracebinValue == "" {
 		span := diag_utils.SpanFromContext(ctx)
 		sc := span.SpanContext()
-		md.Set(tracebinMetadata, string(propagation.Binary(sc)))
+
+		// Workaround for lack of grpc-trace-bin support in OpenTelemetry (unlike OpenCensus), tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
+		// grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
+		// TODO : Remove this workaround fix once grpc-dotnet supports grpc-trace-bin header. Tracking issue https://github.com/dapr/dapr/issues/1827
+		diag.SpanContextToHTTPHeaders(sc, func(header, value string) {
+			md.Set(header, value)
+		})
+		traceBinary := propagation.Binary(sc)
+		traceValue := string(traceBinary)
+		md.Set(tracebinMetadata, traceValue)
 	} else {
 		decoded, err := base64.StdEncoding.DecodeString(grpctracebinValue)
 		if err == nil {
+			// Workaround for lack of grpc-trace-bin support in OpenTelemetry (unlike OpenCensus), tracking issue https://github.com/open-telemetry/opentelemetry-specification/issues/639
+			// grpc-dotnet client adheres to OpenTelemetry Spec which only supports http based traceparent header in gRPC path
+			// TODO : Remove this workaround fix once grpc-dotnet supports grpc-trace-bin header. Tracking issue https://github.com/dapr/dapr/issues/1827
+			if sc, ok := propagation.FromBinary(decoded); ok {
+				diag.SpanContextToHTTPHeaders(sc, func(header, value string) {
+					md.Set(header, value)
+				})
+			}
 			md.Set(tracebinMetadata, string(decoded))
 		}
 	}

--- a/tests/apps/service_invocation_grpc/app.go
+++ b/tests/apps/service_invocation_grpc/app.go
@@ -6,12 +6,10 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
-
-	"context"
-
 	"net"
 
 	"go.opencensus.io/trace"

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -351,8 +351,18 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, "DaprValue1", requestHeaders["daprtest-request-1"][0])
 		assert.Equal(t, "DaprValue2", requestHeaders["daprtest-request-2"][0])
 		assert.NotNil(t, requestHeaders["user-agent"][0])
-		assert.NotNil(t, requestHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(requestHeaders["grpc-trace-bin"]))
+		grpcTraceBinRq := requestHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRq, "grpc-trace-bin is missing from the request") {
+			if assert.Equal(t, 1, len(grpcTraceBinRq), "grpc-trace-bin is missing from the request") {
+				assert.NotEqual(t, "", grpcTraceBinRq[0], "grpc-trace-bin is missing from the request")
+			}
+		}
+		traceParentRq := requestHeaders["traceparent"]
+		if assert.NotNil(t, traceParentRq, "traceparent is missing from the request") {
+			if assert.Equal(t, 1, len(traceParentRq), "traceparent is missing from the request") {
+				assert.NotEqual(t, "", traceParentRq[0], "traceparent is missing from the request")
+			}
+		}
 		assert.Equal(t, hostIP, requestHeaders["x-forwarded-for"][0])
 		assert.Equal(t, hostname, requestHeaders["x-forwarded-host"][0])
 		assert.Equal(t, expectedForwarded, requestHeaders["forwarded"][0])
@@ -360,8 +370,18 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, "application/grpc", responseHeaders["content-type"][0])
 		assert.Equal(t, "DaprTest-Response-Value-1", responseHeaders["daprtest-response-1"][0])
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["daprtest-response-2"][0])
-		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
+		grpcTraceBinRs := responseHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRs, "grpc-trace-bin is missing from the response") {
+			if assert.Equal(t, 1, len(grpcTraceBinRs), "grpc-trace-bin is missing from the response") {
+				assert.NotEqual(t, "", grpcTraceBinRs[0], "grpc-trace-bin is missing from the response")
+			}
+		}
+		traceParentRs := responseHeaders["traceparent"]
+		if assert.NotNil(t, traceParentRs, "traceparent is missing from the response") {
+			if assert.Equal(t, 1, len(traceParentRs), "traceparent is missing from the response") {
+				assert.NotEqual(t, "", traceParentRs[0], "traceparent is missing from the response")
+			}
+		}
 
 		assert.Equal(t, "DaprTest-Trailer-Value-1", trailerHeaders["daprtest-trailer-1"][0])
 		assert.Equal(t, "DaprTest-Trailer-Value-2", trailerHeaders["daprtest-trailer-2"][0])
@@ -408,8 +428,13 @@ func TestHeaders(t *testing.T) {
 		assert.NotNil(t, responseHeaders["dapr-date"][0])
 		assert.Equal(t, "DaprTest-Response-Value-1", responseHeaders["daprtest-response-1"][0])
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["daprtest-response-2"][0])
-		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
+
+		grpcTraceBinRs := responseHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRs, "grpc-trace-bin is missing from the response") {
+			if assert.Equal(t, 1, len(grpcTraceBinRs), "grpc-trace-bin is missing from the response") {
+				assert.NotEqual(t, "", grpcTraceBinRs[0], "grpc-trace-bin is missing from the response")
+			}
+		}
 	})
 
 	t.Run("http-to-grpc", func(t *testing.T) {
@@ -445,8 +470,18 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, "DaprValue1", requestHeaders["daprtest-request-1"][0])
 		assert.Equal(t, "DaprValue2", requestHeaders["daprtest-request-2"][0])
 		assert.NotNil(t, requestHeaders["user-agent"][0])
-		assert.NotNil(t, requestHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(requestHeaders["grpc-trace-bin"]))
+		grpcTraceBinRq := requestHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRq, "grpc-trace-bin is missing from the request") {
+			if assert.Equal(t, 1, len(grpcTraceBinRq), "grpc-trace-bin is missing from the request") {
+				assert.NotEqual(t, "", grpcTraceBinRq[0], "grpc-trace-bin is missing from the request")
+			}
+		}
+		traceParentRq := requestHeaders["traceparent"]
+		if assert.NotNil(t, traceParentRq, "traceparent is missing from the request") {
+			if assert.Equal(t, 1, len(traceParentRq), "traceparent is missing from the request") {
+				assert.NotEqual(t, "", traceParentRq[0], "traceparent is missing from the request")
+			}
+		}
 		assert.Equal(t, hostIP, requestHeaders["x-forwarded-for"][0])
 		assert.Equal(t, hostname, requestHeaders["x-forwarded-host"][0])
 		assert.Equal(t, expectedForwarded, requestHeaders["forwarded"][0])
@@ -507,8 +542,12 @@ func TestHeaders(t *testing.T) {
 		assert.NotNil(t, requestHeaders["Traceparent"][0])
 		assert.Equal(t, expectedTraceID, requestHeaders["Daprtest-Traceid"][0])
 
-		assert.NotNil(t, responseHeaders["Traceparent"][0])
-		assert.Equal(t, expectedTraceID, responseHeaders["Traceparent"][0])
+		traceParentRs := responseHeaders["Traceparent"]
+		if assert.NotNil(t, traceParentRs, "Traceparent is missing from the response") {
+			if assert.Equal(t, 1, len(traceParentRs), "Traceparent is missing from the response") {
+				assert.Equal(t, expectedTraceID, traceParentRs[0], "Traceparent value was not expected")
+			}
+		}
 	})
 
 	t.Run("grpc-to-grpc-tracing", func(t *testing.T) {
@@ -539,21 +578,39 @@ func TestHeaders(t *testing.T) {
 
 		require.NoError(t, err)
 
-		assert.NotNil(t, requestHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(requestHeaders["grpc-trace-bin"]))
+		grpcTraceBinRq := requestHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRq, "grpc-trace-bin is missing from the request") {
+			if assert.Equal(t, 1, len(grpcTraceBinRq), "grpc-trace-bin is missing from the request") {
+				assert.NotEqual(t, "", grpcTraceBinRq[0], "grpc-trace-bin is missing from the request")
+			}
+		}
+		traceParentRq := requestHeaders["traceparent"]
+		if assert.NotNil(t, traceParentRq, "traceparent is missing from the request") {
+			if assert.Equal(t, 1, len(traceParentRq), "traceparent is missing from the request") {
+				assert.NotEqual(t, "", traceParentRq[0], "traceparent is missing from the request")
+			}
+		}
 
-		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
-		traceContext := responseHeaders["grpc-trace-bin"][0]
+		grpcTraceBinRs := responseHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRs) {
+			if assert.Equal(t, 1, len(grpcTraceBinRs)) {
+				traceContext := grpcTraceBinRs[0]
+				t.Logf("received response grpc header..%s\n", traceContext)
+				assert.Equal(t, expectedEncodedTraceID, traceContext)
+				decoded, _ := base64.StdEncoding.DecodeString(traceContext)
+				gotSc, ok := propagation.FromBinary(decoded)
 
-		t.Logf("received response grpc header..%s\n", traceContext)
-		assert.Equal(t, expectedEncodedTraceID, traceContext)
-		decoded, _ := base64.StdEncoding.DecodeString(traceContext)
-		gotSc, ok := propagation.FromBinary([]byte(decoded))
-
-		assert.True(t, ok)
-		assert.NotNil(t, gotSc)
-		assert.Equal(t, expectedTraceID, diag.SpanContextToW3CString(gotSc))
+				assert.True(t, ok)
+				assert.NotNil(t, gotSc)
+				assert.Equal(t, expectedTraceID, diag.SpanContextToW3CString(gotSc))
+			}
+		}
+		traceParentRs := responseHeaders["traceparent"]
+		if assert.NotNil(t, traceParentRs, "traceparent is missing from the response") {
+			if assert.Equal(t, 1, len(traceParentRs), "traceparent is missing from the response") {
+				assert.Equal(t, expectedTraceID, traceParentRs[0], "traceparent value was not expected")
+			}
+		}
 	})
 
 	t.Run("http-to-grpc-tracing", func(t *testing.T) {
@@ -582,11 +639,19 @@ func TestHeaders(t *testing.T) {
 
 		require.NoError(t, err)
 
-		assert.NotNil(t, requestHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(requestHeaders["grpc-trace-bin"]))
+		grpcTraceBinRq := requestHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRq, "grpc-trace-bin is missing from the request") {
+			if assert.Equal(t, 1, len(grpcTraceBinRq), "grpc-trace-bin is missing from the request") {
+				assert.NotEqual(t, "", grpcTraceBinRq[0], "grpc-trace-bin is missing from the request")
+			}
+		}
 
-		assert.NotNil(t, responseHeaders["Traceparent"][0])
-		assert.Equal(t, expectedTraceID, responseHeaders["Traceparent"][0])
+		// traceParentRs := responseHeaders["traceparent"]
+		// if assert.NotNil(t, traceParentRs, "traceparent is missing from the response") {
+		// 	if assert.Equal(t, 1, len(traceParentRs), "traceparent is missing from the response") {
+		// 		assert.Equal(t, expectedTraceID, traceParentRs[0], "traceparent value was not expected")
+		// 	}
+		// }
 	})
 
 	t.Run("grpc-to-http-tracing", func(t *testing.T) {
@@ -618,18 +683,28 @@ func TestHeaders(t *testing.T) {
 		assert.NotNil(t, requestHeaders["Traceparent"][0])
 		assert.Equal(t, expectedTraceID, requestHeaders["Daprtest-Traceid"][0])
 
-		assert.NotNil(t, responseHeaders["grpc-trace-bin"][0])
-		assert.Equal(t, 1, len(responseHeaders["grpc-trace-bin"]))
-		traceContext := responseHeaders["grpc-trace-bin"][0]
+		grpcTraceBinRs := responseHeaders["grpc-trace-bin"]
+		if assert.NotNil(t, grpcTraceBinRs, "grpc-trace-bin is missing from the response") {
+			if assert.Equal(t, 1, len(grpcTraceBinRs), "grpc-trace-bin is missing from the response") {
+				traceContext := grpcTraceBinRs[0]
+				assert.NotEqual(t, "", traceContext)
 
-		t.Logf("received response grpc header..%s\n", traceContext)
-		assert.Equal(t, expectedEncodedTraceID, traceContext)
-		decoded, _ := base64.StdEncoding.DecodeString(traceContext)
-		gotSc, ok := propagation.FromBinary([]byte(decoded))
+				t.Logf("received response grpc header..%s\n", traceContext)
+				assert.Equal(t, expectedEncodedTraceID, traceContext)
+				decoded, _ := base64.StdEncoding.DecodeString(traceContext)
+				gotSc, ok := propagation.FromBinary([]byte(decoded))
 
-		assert.True(t, ok)
-		assert.NotNil(t, gotSc)
-		assert.Equal(t, expectedTraceID, diag.SpanContextToW3CString(gotSc))
+				assert.True(t, ok)
+				assert.NotNil(t, gotSc)
+				assert.Equal(t, expectedTraceID, diag.SpanContextToW3CString(gotSc))
+			}
+		}
+		// traceParentRs := responseHeaders["Traceparent"]
+		// if assert.NotNil(t, traceParentRs, "Traceparent is missing from the response") {
+		// 	if assert.Equal(t, 1, len(traceParentRs), "Traceparent is missing from the response") {
+		// 		assert.Equal(t, expectedTraceID, traceParentRs[0], "Traceparent value was not expected")
+		// 	}
+		// }
 	})
 }
 

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -645,13 +645,6 @@ func TestHeaders(t *testing.T) {
 				assert.NotEqual(t, "", grpcTraceBinRq[0], "grpc-trace-bin is missing from the request")
 			}
 		}
-
-		// traceParentRs := responseHeaders["traceparent"]
-		// if assert.NotNil(t, traceParentRs, "traceparent is missing from the response") {
-		// 	if assert.Equal(t, 1, len(traceParentRs), "traceparent is missing from the response") {
-		// 		assert.Equal(t, expectedTraceID, traceParentRs[0], "traceparent value was not expected")
-		// 	}
-		// }
 	})
 
 	t.Run("grpc-to-http-tracing", func(t *testing.T) {
@@ -699,12 +692,6 @@ func TestHeaders(t *testing.T) {
 				assert.Equal(t, expectedTraceID, diag.SpanContextToW3CString(gotSc))
 			}
 		}
-		// traceParentRs := responseHeaders["Traceparent"]
-		// if assert.NotNil(t, traceParentRs, "Traceparent is missing from the response") {
-		// 	if assert.Equal(t, 1, len(traceParentRs), "Traceparent is missing from the response") {
-		// 		assert.Equal(t, expectedTraceID, traceParentRs[0], "Traceparent value was not expected")
-		// 	}
-		// }
 	})
 }
 


### PR DESCRIPTION
# Description

I added headers that OpenTelemetry can use when invoking gRPC services. This is to support `grpc-dotnet` which adheres to the OpenTelemetry spec which only supports the HTTP-based `traceparent` header for gRPC invocation.

## Testing the change

Reproducing the issue: The gateway does creates a trace ID and the .NET gRPC add does not see it and creates a new one

<img width="780" alt="TraceID_not_working_01" src="https://user-images.githubusercontent.com/714039/110182553-fc0d3a80-7dda-11eb-8ee7-b2347b7923e9.png">

<img width="944" alt="TraceID_not_working_02" src="https://user-images.githubusercontent.com/714039/110182612-1d6e2680-7ddb-11eb-9c82-3cd338e84287.png">

After the fix: The trace ID carries over to the .NET gRPC side because a `traceparent` header is sent

<img width="769" alt="TraceID_working_01" src="https://user-images.githubusercontent.com/714039/110182689-47274d80-7ddb-11eb-9c60-cbc9b532441a.png">

<img width="939" alt="TraceID_working_02" src="https://user-images.githubusercontent.com/714039/110182702-4bec0180-7ddb-11eb-823d-120da9c9e67e.png">

Thanks @rynowak for resurrecting your test code to quickly verify this!

## Issue reference

Fixes #2749

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
