### PR TITLE
Rename role-tokenreview-binding to prevent naming collisions with other products

### DIFF
--- a/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
@@ -14,7 +14,7 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: role-tokenreview-binding
+  name: dapr-role-tokenreview-binding
 subjects:
 - kind: ServiceAccount
   name: dapr-operator


### PR DESCRIPTION
# Description

Renamed `role-tokenreview-binding` to `dapr-role-tokenreview-binding` to prevent clashing with a [Vault installation](https://docs.armory.io/docs/armory-admin/secrets/vault-k8s-configuration/) or other products.

I definitely want @yaron2 to chime in here but I felt like renaming `role-tokenreview-binding` to something with a `dapr-` prefix was the simplest solution compared to merging or patching (if that is even possible). I tested installing Dapr to K8s then upgrading after the rename and everything worked as expected. So in theory this should not effect customers with existing Dapr installations. It would still leave the old binding in place but the operator could choose to delete it because `dapr-role-tokenreview-binding` would apply.

Can you see any undesirable side affect from this, @yaron2?

## Issue reference

Resolves #2651

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
