### PR TITLE
Use filepath pkg to do file path joining operations

### DIFF
--- a/pkg/components/standalone_loader.go
+++ b/pkg/components/standalone_loader.go
@@ -8,7 +8,6 @@ package components
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"path/filepath"
@@ -48,14 +47,15 @@ func (s *StandaloneComponents) LoadComponents() ([]components_v1alpha1.Component
 
 	for _, file := range files {
 		if !file.IsDir() && s.isYaml(file.Name()) {
-			b, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", dir, file.Name()))
+			path := filepath.Join(dir, file.Name())
 
+			b, err := ioutil.ReadFile(path)
 			if err != nil {
-				log.Warnf("error reading file %s/%s : %s", dir, file.Name(), err)
+				log.Warnf("error reading file %s : %s", path, err)
 				continue
 			}
 
-			components, _ := s.decodeYaml(fmt.Sprintf("%s/%s", dir, file.Name()), b)
+			components, _ := s.decodeYaml(path, b)
 			list = append(list, components...)
 		}
 	}

--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -3,10 +3,10 @@ package pubsub
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	subscriptionsapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	"github.com/dapr/dapr/pkg/channel"
@@ -106,7 +106,7 @@ func DeclarativeSelfHosted(componentsPath string, log logger.Logger) []Subscript
 
 	for _, f := range files {
 		if !f.IsDir() {
-			filePath := fmt.Sprintf("%s/%s", componentsPath, f.Name())
+			filePath := filepath.Join(componentsPath, f.Name())
 			b, err := ioutil.ReadFile(filePath)
 			if err != nil {
 				log.Errorf("failed to read file %s: %s", filePath, err)

--- a/pkg/runtime/pubsub/subscriptions_test.go
+++ b/pkg/runtime/pubsub/subscriptions_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	subscriptionsapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
@@ -56,7 +57,7 @@ func writeSubscriptionToDisk(subscription subscriptionsapi.Subscription, filePat
 }
 
 func TestDeclarativeSubscriptions(t *testing.T) {
-	dir := "./components"
+	dir := filepath.Join(".", "components")
 	os.Mkdir(dir, 0777)
 	defer os.RemoveAll(dir)
 
@@ -64,7 +65,7 @@ func TestDeclarativeSubscriptions(t *testing.T) {
 		s := testDeclarativeSubscription()
 		s.Scopes = []string{"scope1"}
 
-		filePath := "./components/sub.yaml"
+		filePath := filepath.Join(".", "components", "sub.yaml")
 		writeSubscriptionToDisk(s, filePath)
 
 		subs := DeclarativeSelfHosted(dir, log)


### PR DESCRIPTION
# Description

Use filepath pkg to do file path joining operations. `filepath.Join` can joins path elements with the OS specific separator.

## Issue reference

Close #2936 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
