### PR TITLE
Fix typos in comments

### DIFF
--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -80,7 +80,7 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 	}
 }
 
-// userDefinedMetadata returns dapr- prefixed header from incoming metdata.
+// userDefinedMetadata returns dapr- prefixed header from incoming metadata.
 // Users can add dapr- prefixed headers that they want to see in span attributes.
 func userDefinedMetadata(ctx context.Context) map[string]string {
 	var daprMetadata = map[string]string{}

--- a/pkg/diagnostics/http_tracing.go
+++ b/pkg/diagnostics/http_tracing.go
@@ -69,7 +69,7 @@ func HTTPTraceMiddleware(next fasthttp.RequestHandler, appID string, spec config
 	}
 }
 
-// userDefinedHTTPHeaders returns dapr- prefixed header from incoming metdata.
+// userDefinedHTTPHeaders returns dapr- prefixed header from incoming metadata.
 // Users can add dapr- prefixed headers that they want to see in span attributes.
 func userDefinedHTTPHeaders(reqCtx *fasthttp.RequestCtx) map[string]string {
 	var m = map[string]string{}

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -29,7 +29,7 @@ const (
 	// daprInternalSpanAttrPrefix is the internal span attribution prefix.
 	// Middleware will not populate it if the span key starts with this prefix.
 	daprInternalSpanAttrPrefix = "__dapr."
-	// daprAPISpanNameInternal is the internal attributation, but not populated
+	// daprAPISpanNameInternal is the internal attribution, but not populated
 	// to span attribution.
 	daprAPISpanNameInternal = daprInternalSpanAttrPrefix + "spanname"
 


### PR DESCRIPTION
# Description

Fix typos in comments of `diagnostics` package.

