### PR TITLE
Propagate app response back to input binding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1
 	github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b
 	github.com/cenkalti/backoff/v4 v4.1.0
-	github.com/dapr/components-contrib v1.0.1-0.20210305225523-931048aa6009
+	github.com/dapr/components-contrib v1.0.1-0.20210318212214-192461889c55
 	github.com/fasthttp/router v1.3.5
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz
 github.com/dapr/components-contrib v0.0.0-20200219164914-5b75f4d0fbc6/go.mod h1:AZi8IGs8LFdywJg/YGwDs7MAxJkvGa8RgHN4NoJSKt0=
 github.com/dapr/components-contrib v1.0.0-rc2/go.mod h1:5r95bQ7UqLfjJA6oomcc1L+mDTXSTPTGg3hmGhoJIxs=
 github.com/dapr/components-contrib v1.0.1-0.20210301230228-a8de09faf452/go.mod h1:z5NR1Zzscfu8DXNblEJShdUb1dd6DYZIt0FzB53DXzg=
-github.com/dapr/components-contrib v1.0.1-0.20210305225523-931048aa6009 h1:JWwYTw7eG0/1wqi3+YOzkGSJCYTr0saiPGr1QVIr+9Q=
-github.com/dapr/components-contrib v1.0.1-0.20210305225523-931048aa6009/go.mod h1:6swYaoNxlLUFSh9DHORR59rNgbsHJ0GoNkQFaSSGNok=
+github.com/dapr/components-contrib v1.0.1-0.20210318212214-192461889c55 h1:ga4PThrD2OExyFYjAldlzTzf0B48suED5pizJE8PZm4=
+github.com/dapr/components-contrib v1.0.1-0.20210318212214-192461889c55/go.mod h1:6swYaoNxlLUFSh9DHORR59rNgbsHJ0GoNkQFaSSGNok=
 github.com/dapr/dapr v0.4.1-0.20200228055659-71892bc0111e/go.mod h1:c60DJ9TdSdpbLjgqP55A5u4ZCYChFwa9UGYIXd9pmm4=
 github.com/dapr/dapr v1.0.0-rc.2/go.mod h1:raAV9hKG114OTTudY8tfajM1EELp8YasLbK6OLgKuG0=
 github.com/dapr/dapr v1.0.1-0.20210303190006-b2271c9a8a58/go.mod h1:XjKeD6e35Z6dxjProOaNhgpT5o24K7SdkuG+6paeYO0=

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -583,10 +583,12 @@ func (a *DaprRuntime) onAppResponse(response *bindings.AppResponse) error {
 	return nil
 }
 
-func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, metadata map[string]string) error {
+func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, metadata map[string]string) ([]byte, error) {
 	var response bindings.AppResponse
 	spanName := fmt.Sprintf("bindings/%s", bindingName)
 	ctx, span := diag.StartInternalCallbackSpan(spanName, trace.SpanContext{}, a.globalConfig.Spec.TracingSpec)
+
+	var appResponseBody []byte
 
 	if a.runtimeConfig.ApplicationProtocol == GRPCProtocol {
 		ctx = diag.SpanContextToGRPCMetadata(ctx, span.SpanContext())
@@ -607,7 +609,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 		}
 
 		if err != nil {
-			return errors.Wrap(err, "error invoking app")
+			return nil, errors.Wrap(err, "error invoking app")
 		}
 		if resp != nil {
 			if resp.Concurrency == runtimev1pb.BindingEventResponse_PARALLEL {
@@ -619,6 +621,8 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 			response.To = resp.To
 
 			if resp.Data != nil {
+				appResponseBody = resp.Data
+
 				var d interface{}
 				err := a.json.Unmarshal(resp.Data, &d)
 				if err == nil {
@@ -626,6 +630,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 				}
 			}
 
+			// TODO: THIS SHOULD BE DEPRECATED FOR v1.3
 			for _, s := range resp.States {
 				var i interface{}
 				a.json.Unmarshal(s.Value, &i)
@@ -649,7 +654,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 
 		resp, err := a.appChannel.InvokeMethod(ctx, req)
 		if err != nil {
-			return errors.Wrap(err, "error invoking app")
+			return nil, errors.Wrap(err, "error invoking app")
 		}
 
 		if span != nil {
@@ -662,10 +667,14 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 		}
 
 		if resp.Status().Code != nethttp.StatusOK {
-			return errors.Errorf("fails to send binding event to http app channel, status code: %d", resp.Status().Code)
+			return nil, errors.Errorf("fails to send binding event to http app channel, status code: %d", resp.Status().Code)
 		}
 
-		// TODO: Do we need to check content-type?
+		if resp.Message().Data != nil && len(resp.Message().Data.Value) > 0 {
+			appResponseBody = resp.Message().Data.Value
+		}
+
+		// TODO: THIS SHOULD BE DEPRECATED FOR v1.3
 		if err := a.json.Unmarshal(resp.Message().Data.Value, &response); err != nil {
 			log.Debugf("error deserializing app response: %s", err)
 		}
@@ -676,19 +685,21 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 			log.Errorf("error executing app response: %s", err)
 		}
 	}
-	return nil
+
+	return appResponseBody, nil
 }
 
 func (a *DaprRuntime) readFromBinding(name string, binding bindings.InputBinding) error {
-	err := binding.Read(func(resp *bindings.ReadResponse) error {
+	err := binding.Read(func(resp *bindings.ReadResponse) ([]byte, error) {
 		if resp != nil {
-			err := a.sendBindingEventToApp(name, resp.Data, resp.Metadata)
+			b, err := a.sendBindingEventToApp(name, resp.Data, resp.Metadata)
 			if err != nil {
 				log.Debugf("error from app consumer for binding [%s]: %s", name, err)
-				return err
+				return nil, err
 			}
+			return b, err
 		}
-		return nil
+		return nil, nil
 	})
 	return err
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2050,14 +2050,14 @@ func (b *mockBinding) Init(metadata bindings.Metadata) error {
 	return nil
 }
 
-func (b *mockBinding) Read(handler func(*bindings.ReadResponse) error) error {
+func (b *mockBinding) Read(handler func(*bindings.ReadResponse) ([]byte, error)) error {
 	b.data = string(testInputBindingData)
 	metadata := map[string]string{}
 	if b.metadata != nil {
 		metadata = b.metadata
 	}
 
-	err := handler(&bindings.ReadResponse{
+	_, err := handler(&bindings.ReadResponse{
 		Metadata: metadata,
 		Data:     []byte(b.data),
 	})

--- a/pkg/testing/bindings_mock.go
+++ b/pkg/testing/bindings_mock.go
@@ -16,7 +16,7 @@ func (m *MockBinding) Init(metadata bindings.Metadata) error {
 }
 
 // Read is a mock read method
-func (m *MockBinding) Read(handler func(*bindings.ReadResponse) error) error {
+func (m *MockBinding) Read(handler func(*bindings.ReadResponse) ([]byte, error)) error {
 	args := m.Called(handler)
 	return args.Error(0)
 }


### PR DESCRIPTION
This PR enables an app to response to an input binding event and enable the component to take further action based on the response.

Closes #2628 

/cc @akkie