### PR TITLE
change slice declarations to array where length already obvious

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1070,7 +1070,7 @@ func (a *actorsRuntime) GetActiveActorsCount(ctx context.Context) []ActiveActors
 		return true
 	})
 
-	activeActorsCount := []ActiveActorsCount{}
+	activeActorsCount := make([]ActiveActorsCount, 0, len(actorCountMap))
 	for actorType, count := range actorCountMap {
 		activeActorsCount = append(activeActorsCount, ActiveActorsCount{Type: actorType, Count: count})
 	}

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1072,7 +1072,7 @@ func (a *api) GetMetadata(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.
 		temp[key.(string)] = value.(string)
 		return true
 	})
-	registeredComponents := []*runtimev1pb.RegisteredComponents{}
+	registeredComponents := make([]*runtimev1pb.RegisteredComponents, 0, len(a.components))
 
 	for _, comp := range a.components {
 		registeredComp := &runtimev1pb.RegisteredComponents{

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -1134,9 +1134,9 @@ func (a *api) onGetMetadata(reqCtx *fasthttp.RequestCtx) {
 		activeActorsCount = a.actor.GetActiveActorsCount(reqCtx)
 	}
 
-	registeredComponents := make([]registeredComponent, 0, len(a.getComponentsFn()))
-
 	components := a.getComponentsFn()
+	registeredComponents := make([]registeredComponent, 0, len(components))
+
 	for _, comp := range components {
 		registeredComp := registeredComponent{
 			Name:    comp.Name,

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -1134,7 +1134,7 @@ func (a *api) onGetMetadata(reqCtx *fasthttp.RequestCtx) {
 		activeActorsCount = a.actor.GetActiveActorsCount(reqCtx)
 	}
 
-	registeredComponents := []registeredComponent{}
+	registeredComponents := make([]registeredComponent, 0, len(a.getComponentsFn()))
 
 	components := a.getComponentsFn()
 	for _, comp := range components {

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -180,7 +180,7 @@ func addDaprEnvVarsToContainers(containers []corev1.Container) []PatchOperation 
 			Value: strconv.Itoa(sidecarAPIGRPCPort),
 		},
 	}
-	envPatchOps := make([]PatchOperation,0, len(containers))
+	envPatchOps := make([]PatchOperation, 0, len(containers))
 	for i, container := range containers {
 		path := fmt.Sprintf("%s/%d/env", containersPath, i)
 		patchOps := getEnvPatchOperations(container.Env, portEnv, path)

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -180,7 +180,7 @@ func addDaprEnvVarsToContainers(containers []corev1.Container) []PatchOperation 
 			Value: strconv.Itoa(sidecarAPIGRPCPort),
 		},
 	}
-	envPatchOps := []PatchOperation{}
+	envPatchOps := make([]PatchOperation,0, len(containers))
 	for i, container := range containers {
 		path := fmt.Sprintf("%s/%d/env", containersPath, i)
 		patchOps := getEnvPatchOperations(container.Env, portEnv, path)

--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -455,7 +455,7 @@ func (m *AppManager) GetHostDetails() ([]PodInfo, error) {
 		return nil, fmt.Errorf("expected number of pods for %s: %d, received: %d", m.app.AppName, m.app.Replicas, len(podList.Items))
 	}
 
-	result := []PodInfo{}
+	result := make([]PodInfo, 0, len(podList.Items))
 	for _, item := range podList.Items {
 		result = append(result, PodInfo{
 			Name: item.GetName(),


### PR DESCRIPTION
# Description

I change some slice declarations to array when the length is already known while initialization.
It might be a tiny performance improvement by preventing dynamic sizing.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

#2955 https://github.com/dapr/dapr/issues/2955

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
