### PR TITLE
Remove token header after validation

### DIFF
--- a/pkg/grpc/auth.go
+++ b/pkg/grpc/auth.go
@@ -27,6 +27,8 @@ func setAPIAuthenticationMiddlewareUnary(apiToken, authHeader string) grpc.Unary
 			err := v1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "authentication error: api token mismatch")
 			return nil, err
 		}
+
+		md.Set(authHeader, "")
 		return handler(ctx, req)
 	}
 }

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -127,6 +127,7 @@ func useAPIAuthentication(next fasthttp.RequestHandler) fasthttp.RequestHandler 
 	return func(ctx *fasthttp.RequestCtx) {
 		v := ctx.Request.Header.Peek(auth.APITokenHeader)
 		if auth.ExcludedRoute(string(ctx.Request.URI().FullURI())) || string(v) == token {
+			ctx.Request.Header.Del(auth.APITokenHeader)
 			next(ctx)
 		} else {
 			ctx.Error("invalid api token", http.StatusUnauthorized)


### PR DESCRIPTION
This PR removes API tokens from HTTP/gRPC header and metadata values respectively after the validation has occured.

This remedies the fact that today these secure values get sent over the write to tracing backends as part of the request.