### PR TITLE
Helm chart version bumps for release 1.1.0-rc1

### DIFF
--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
     version: "1.1.0-rc.1"
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
-    version: "1.1.0-rc.1"
+    version: "0.7.0"
     repository: "file://dapr_dashboard"

--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
-appVersion: "1.0.0"
+appVersion: "1.1.0-rc.1"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: 1.0.0
+version: 1.1.0-rc.1
 dependencies:
   - name: dapr_rbac
-    version: "0.6.0"
+    version: "1.1.0-rc.1"
     repository: "file://dapr_rbac"
   - name: dapr_operator
-    version: "0.6.0"
+    version: "1.1.0-rc.1"
     repository: "file://dapr_operator"
   - name: dapr_placement
-    version: "0.6.0"
+    version: "1.1.0-rc.1"
     repository: "file://dapr_placement"
   - name: dapr_sidecar_injector
-    version: "0.6.0"
+    version: "1.1.0-rc.1"
     repository: "file://dapr_sidecar_injector"
   - name: dapr_sentry
-    version: "0.6.0"
+    version: "1.1.0-rc.1"
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
-    version: "0.7.0"
+    version: "1.1.0-rc.1"
     repository: "file://dapr_dashboard"

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -75,10 +75,10 @@ The Helm chart has the follow configuration options that can be supplied:
 ### Global options:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
-| `global.registry`                         | Docker image registry                                       | `docker.io/daprio`      |
-| `global.tag`                              | Docker image version tag                                    | `0.11.0`            |
+| `global.registry`                         | Docker image registry                                                   | `docker.io/daprio`      |
+| `global.tag`                              | Docker image version tag                                                | `1.1.0-rc1`             |
 | `global.logAsJson`                        | Json log format for control plane services                              | `false`                 |
-| `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`                |
+| `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
 | `global.imagePullSecret`                  | Control plane service image pull secret for docker registry             | `""`                    |
 | `global.ha.enabled`                       | Highly Availability mode enabled for control plane, except for placement service | `false`             |
 | `global.ha.replicaCount`                  | Number of replicas of control plane services in Highly Availability mode  | `3`                   |

--- a/charts/dapr/charts/dapr_config/Chart.yaml
+++ b/charts/dapr/charts/dapr_config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr configuration
 name: dapr_config
-version: 0.6.0
+version: 1.1.0-rc.1

--- a/charts/dapr/charts/dapr_dashboard/Chart.yaml
+++ b/charts/dapr/charts/dapr_dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Dashboard
 name: dapr_dashboard
-version: 1.1.0-rc.1
+version: 0.7.0

--- a/charts/dapr/charts/dapr_dashboard/Chart.yaml
+++ b/charts/dapr/charts/dapr_dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Dashboard
 name: dapr_dashboard
-version: 0.7.0
+version: 1.1.0-rc.1

--- a/charts/dapr/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: 0.6.0
+version: 1.1.0-rc.1

--- a/charts/dapr/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr/charts/dapr_placement/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: 0.6.0
+version: 1.1.0-rc.1

--- a/charts/dapr/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr/charts/dapr_rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC components
 name: dapr_rbac
-version: 0.6.0
+version: 1.1.0-rc.1

--- a/charts/dapr/charts/dapr_sentry/Chart.yaml
+++ b/charts/dapr/charts/dapr_sentry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Sentry
 name: dapr_sentry
-version: 0.6.0
+version: 1.1.0-rc.1

--- a/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: 0.5.0
+version: 1.1.0-rc.1

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "1.0.0"
+  tag: "1.1.0-rc1"
   dnsSuffix: ".cluster.local"
   logAsJson: false
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
# Description

* Bumping all dapr image tags (except for dashboard) to `1.1.0-rc1`
* Made chart versions uniform (except for dashboard) `1.1.0-rc1`