### PR TITLE
Allow concurrent reconciliation in controller

### DIFF
--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 const (
@@ -76,6 +77,9 @@ func (h *DaprHandler) Init() error {
 	return ctrl.NewControllerManagedBy(h.mgr).
 		For(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 100,
+		}).
 		Complete(h)
 }
 


### PR DESCRIPTION
Closes https://github.com/dapr/dapr/issues/2993.

This PR adds the MaxCocncurrentReconciles setting to controller options.
This change will allow 100 goroutines to reconcile concurrently.