### PR TITLE
Remove sidecar validation for k8s job in E2E.

### DIFF
--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -100,12 +100,6 @@ func (m *AppManager) Init() error {
 			return err
 		}
 
-		log.Printf("Validating sidecar for app %v ....", m.app.AppName)
-		if err := m.WaitUntilSidecarPresent(); err != nil {
-			return err
-		}
-		log.Printf("Sidecar for app %v has been validated.", m.app.AppName)
-
 		// Wait until app is deployed completely
 		if _, err := m.WaitUntilJobState(m.IsJobCompleted); err != nil {
 			return err


### PR DESCRIPTION
# Description

This validation is flaky and optional. As long as the subscriber gets the message and the job completed successfully, trying to find the instant of time where the sidecar is found before being shutdown does not buy us much.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: endgame

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
