### PR TITLE
Add POST endpoint for shutdown API

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -316,7 +316,7 @@ func (a *api) constructMetadataEndpoints() []Endpoint {
 func (a *api) constructShutdownEndpoints() []Endpoint {
 	return []Endpoint{
 		{
-			Methods: []string{fasthttp.MethodGet},
+			Methods: []string{fasthttp.MethodGet, fasthttp.MethodPost},
 			Route:   "shutdown",
 			Version: apiVersionV1,
 			Handler: a.onShutdown,
@@ -1186,6 +1186,10 @@ func (a *api) onPutMetadata(reqCtx *fasthttp.RequestCtx) {
 }
 
 func (a *api) onShutdown(reqCtx *fasthttp.RequestCtx) {
+	if !reqCtx.IsPost() {
+		log.Warn("Please use POST method when invoking shutdown API")
+	}
+
 	respondEmpty(reqCtx)
 	go func() {
 		a.shutdown()

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -241,6 +241,16 @@ func TestShutdownEndpoints(t *testing.T) {
 		m.AssertCalled(t, "shutdown")
 	})
 
+	t.Run("Shutdown supports POST - 204", func(t *testing.T) {
+		apiPath := fmt.Sprintf("%s/shutdown", apiVersionV1)
+		resp := fakeServer.DoRequest("POST", apiPath, nil, nil)
+		assert.Equal(t, 204, resp.StatusCode, "success shutdown")
+		for i := 0; i < 5 && len(m.Calls) == 0; i++ {
+			<-time.After(200 * time.Millisecond)
+		}
+		m.AssertCalled(t, "shutdown")
+	})
+
 	fakeServer.Shutdown()
 }
 

--- a/tests/apps/job-publisher/app.go
+++ b/tests/apps/job-publisher/app.go
@@ -25,7 +25,7 @@ const (
 
 func stopSidecar() {
 	log.Printf("Shutting down the sidecar at %s", fmt.Sprintf("http://localhost:%d/v1.0/shutdown", daprPort))
-	r, err := http.Get(fmt.Sprintf("http://localhost:%d/v1.0/shutdown", daprPort))
+	r, err := http.Post(fmt.Sprintf("http://localhost:%d/v1.0/shutdown", daprPort), "", bytes.NewBuffer([]byte{}))
 	if r != nil {
 		r.Body.Close()
 	}


### PR DESCRIPTION
# Description

The shutdown API definitely changes state of the Dapr sidecar, thus it makes much more sense to have this as a POST API. 


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#1366
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
