### PR TITLE
fix typo in comments

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -168,7 +168,7 @@ func (a *actorsRuntime) Init() error {
 
 	// Be careful to configure healthz endpoint option. If app healthz returns unhealthy status, Dapr will
 	// disconnect from placement to remove the node from consistent hashing ring.
-	// i.e if app is busy state, the heathz status would be flaky, which leads to frequent
+	// i.e if app is busy state, the healthz status would be flaky, which leads to frequent
 	// actor rebalancing. It will impact the entire service.
 	go a.startAppHealthCheck(
 		health.WithFailureThreshold(4),


### PR DESCRIPTION
# Description

fix typo.
`heathz` -> `healthz`

## Issue reference

- no issues referenced