### PR TITLE
Fix secret store key to `key:*`,because it may contain `/`.

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -203,7 +203,7 @@ func (a *api) constructSecretEndpoints() []Endpoint {
 		},
 		{
 			Methods: []string{fasthttp.MethodGet},
-			Route:   "secrets/{secretStoreName}/{key}",
+			Route:   "secrets/{secretStoreName}/{key:*}",
 			Version: apiVersionV1,
 			Handler: a.onGetSecret,
 		},


### PR DESCRIPTION
# Description

Change get secret route from key to key:* , because in vault component the key of a secret may contain `/`.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3090

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
