### PR TITLE
Make test names consistent across runs for actor_sdks e2e test

### DIFF
--- a/tests/e2e/actor_sdks/actor_sdks_test.go
+++ b/tests/e2e/actor_sdks/actor_sdks_test.go
@@ -189,7 +189,7 @@ func TestActorInvocationCrossSDKs(t *testing.T) {
 		for _, actorType := range actorTypes {
 			for _, tt := range scenarios {
 				method := fmt.Sprintf(tt.method, actorType, uuid.New().String())
-				name := fmt.Sprintf("Test %s calling %s", app, method)
+				name := fmt.Sprintf("Test %s calling %s", app, fmt.Sprintf(tt.method, actorType, ""))
 				t.Run(name, func(t *testing.T) {
 
 					resp, err := utils.HTTPPost(fmt.Sprintf("%s/%s", externalURL, method), []byte(tt.payload))

--- a/tests/e2e/actor_sdks/actor_sdks_test.go
+++ b/tests/e2e/actor_sdks/actor_sdks_test.go
@@ -189,7 +189,7 @@ func TestActorInvocationCrossSDKs(t *testing.T) {
 		for _, actorType := range actorTypes {
 			for _, tt := range scenarios {
 				method := fmt.Sprintf(tt.method, actorType, uuid.New().String())
-				name := fmt.Sprintf("Test %s calling %s", app, fmt.Sprintf(tt.method, actorType, ""))
+				name := fmt.Sprintf("Test %s calling %s", app, fmt.Sprintf(tt.method, actorType, "ActorId"))
 				t.Run(name, func(t *testing.T) {
 
 					resp, err := utils.HTTPPost(fmt.Sprintf("%s/%s", externalURL, method), []byte(tt.payload))


### PR DESCRIPTION
# Description

Remove UUID from test name in actor_sdks e2e tests. This is so that we can easily track test results across runs.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
