### PR TITLE
Tweak shutdown sequence

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1571,9 +1571,9 @@ func (a *DaprRuntime) shutdownComponents() error {
 
 // ShutdownWithWait will gracefully stop runtime and wait outstanding operations
 func (a *DaprRuntime) ShutdownWithWait() {
-	gracefulShutdownDuration := 5 * time.Second
 	a.stopActor()
-	log.Info("dapr shutting down. Waiting 5 seconds to finish outstanding operations")
+	gracefulShutdownDuration := 5 * time.Second
+	log.Infof("dapr shutting down. Waiting %s to finish outstanding operations", gracefulShutdownDuration)
 	<-time.After(gracefulShutdownDuration)
 	a.shutdownComponents()
 	os.Exit(0)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1502,14 +1502,16 @@ func (a *DaprRuntime) preprocessOneComponent(comp *components_v1alpha1.Component
 	return componentPreprocessRes{}
 }
 
-// Stop allows for a graceful shutdown of all runtime internal operations or components
-func (a *DaprRuntime) Stop() error {
-	log.Info("Stop command issued. Shutting down all operations")
-
+func (a *DaprRuntime) stopActor() {
 	if a.actor != nil {
+		log.Info("Shutting down actor")
 		a.actor.Stop()
 	}
+}
 
+// shutdownComponents allows for a graceful shutdown of all runtime internal operations or components
+func (a *DaprRuntime) shutdownComponents() error {
+	log.Info("Shutting down all components")
 	var merr error
 
 	// Close components if they implement `io.Closer`
@@ -1570,9 +1572,10 @@ func (a *DaprRuntime) Stop() error {
 // ShutdownWithWait will gracefully stop runtime and wait outstanding operations
 func (a *DaprRuntime) ShutdownWithWait() {
 	gracefulShutdownDuration := 5 * time.Second
+	a.stopActor()
 	log.Info("dapr shutting down. Waiting 5 seconds to finish outstanding operations")
-	a.Stop()
 	<-time.After(gracefulShutdownDuration)
+	a.shutdownComponents()
 	os.Exit(0)
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2766,7 +2766,7 @@ func TestStopWithErrors(t *testing.T) {
 	require.NoError(t, rt.initSecretStore(mockSecretsComponent))
 	rt.nameResolver = &mockNameResolver{closeErr: testErr}
 
-	err := rt.Stop()
+	err := rt.shutdownComponents()
 	assert.Error(t, err)
 	var merr *multierror.Error
 	merr, ok := err.(*multierror.Error)
@@ -2775,5 +2775,6 @@ func TestStopWithErrors(t *testing.T) {
 }
 
 func stopRuntime(t *testing.T, rt *DaprRuntime) {
-	assert.NoError(t, rt.Stop())
+	rt.stopActor()
+	assert.NoError(t, rt.shutdownComponents())
 }


### PR DESCRIPTION
# Description

Continuation of #3088. This PR changes the shutdown sequence to:

* stop actor
* delay
* close components
* exit

## Issue reference

Resolves #dapr/components-contrib#779

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
