### PR TITLE
Add a windows-python-base nanoserver image 

### DIFF
--- a/docker/Dockerfile-windows-python-base
+++ b/docker/Dockerfile-windows-python-base
@@ -1,0 +1,17 @@
+ARG WINDOWS_VERSION=1809
+FROM python:3.7-windowsservercore-$WINDOWS_VERSION as python-servercore
+
+FROM mcr.microsoft.com/windows/nanoserver:$WINDOWS_VERSION
+COPY --from=python-servercore C:\\Python C:\\Python
+
+USER ContainerAdministrator
+
+ENV PYTHONPATH C:\\Python;C:\\Python\\Scripts;C:\\Python\\DLLs;C:\\Python\\Lib;C:\\Python\\Lib\\plat-win;C:\\Python\\Lib\\site-packages
+RUN setx.exe /m PATH %PATH%;%PYTHONPATH%
+RUN setx.exe /m PYTHONPATH %PYTHONPATH%
+RUN setx.exe /m PIP_CACHE_DIR C:\Users\ContainerUser\AppData\Local\pip\Cache
+RUN reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
+
+RUN pip install --upgrade pip
+
+CMD ["C:\\python\\python.exe"]

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -147,11 +147,13 @@ docker-windows-base-build: check-windows-version
 	$(DOCKER) build --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) -f $(DOCKERFILE_DIR)/$(DOCKERFILE)-base . -t $(DAPR_REGISTRY)/windows-base:$(WINDOWS_VERSION)
 	$(DOCKER) build --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) -f $(DOCKERFILE_DIR)/$(DOCKERFILE)-java-base . -t $(DAPR_REGISTRY)/windows-java-base:$(WINDOWS_VERSION)
 	$(DOCKER) build --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) -f $(DOCKERFILE_DIR)/$(DOCKERFILE)-php-base . -t $(DAPR_REGISTRY)/windows-php-base:$(WINDOWS_VERSION)
+	$(DOCKER) build --build-arg WINDOWS_VERSION=$(WINDOWS_VERSION) -f $(DOCKERFILE_DIR)/$(DOCKERFILE)-python-base . -t $(DAPR_REGISTRY)/windows-python-base:$(WINDOWS_VERSION)
 
 docker-windows-base-push: check-windows-version
 	$(DOCKER) push $(DAPR_REGISTRY)/windows-base:$(WINDOWS_VERSION)
 	$(DOCKER) push $(DAPR_REGISTRY)/windows-java-base:$(WINDOWS_VERSION)
 	$(DOCKER) push $(DAPR_REGISTRY)/windows-php-base:$(WINDOWS_VERSION)
+	$(DOCKER) push $(DAPR_REGISTRY)/windows-python-base:$(WINDOWS_VERSION)
 
 ################################################################################
 # Target: build-dev-container, push-dev-container                              #


### PR DESCRIPTION


# Description

Python e2e windows build is taking 10+ minutes. Most of that is downloading the python windows:servercore image. Creating a prebuilt nanoserver version should save us loads of e2e build time.


# Manual Test

```
C:\Users\Charlie\dapr>make docker-windows-base-build WINDOWS_VERSION=1809
...
docker build --build-arg WINDOWS_VERSION=1809 -f ./docker/Dockerfile-windows-python-base . -t wcs1only/windows-python-base:1809
Sending build context to Docker daemon  1.192GB
Step 1/12 : ARG WINDOWS_VERSION=1809
Step 2/12 : FROM python:3.7-windowsservercore-$WINDOWS_VERSION as python-servercore
3.7-windowsservercore-1809: Pulling from library/python
Digest: sha256:44d837727e0651a079f6375447520e19b680dd6bc35ea9a7d2857a63a1949621
Status: Downloaded newer image for python:3.7-windowsservercore-1809
 ---> d5cccad4ac52
Step 3/12 : FROM mcr.microsoft.com/windows/nanoserver:$WINDOWS_VERSION
 ---> 47284f980c64
Step 4/12 : COPY --from=python-servercore C:\\Python C:\\Python
 ---> Using cache
 ---> 3493d13e6ef7
Step 5/12 : USER ContainerAdministrator
 ---> Using cache
 ---> 70fd204bc125
Step 6/12 : ENV PYTHONPATH C:\\Python;C:\\Python\\Scripts;C:\\Python\\DLLs;C:\\Python\\Lib;C:\\Python\\Lib\\plat-win;C:\\Python\\Lib\\site-packages
 ---> Using cache
 ---> e40966d19076
Step 7/12 : RUN setx.exe /m PATH %PATH%;%PYTHONPATH%
 ---> Using cache
 ---> 62168ce2d4f1
Step 8/12 : RUN setx.exe /m PYTHONPATH %PYTHONPATH%
 ---> Using cache
 ---> 8985067b7f0b
Step 9/12 : RUN setx.exe /m PIP_CACHE_DIR C:\Users\ContainerUser\AppData\Local\pip\Cache
 ---> Using cache
 ---> 5c0ad2a116c8
Step 10/12 : RUN reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
 ---> Using cache
 ---> c40ee380578e
Step 11/12 : RUN pip install --upgrade pip
 ---> Using cache
 ---> 2cd69f1c9098
Step 12/12 : CMD ["C:\\python\\python.exe"]
 ---> Using cache
 ---> 0778e6088b65
Successfully built 0778e6088b65
Successfully tagged wcs1only/windows-python-base:1809

C:\Users\Charlie\dapr>docker run -it wcs1only/windows-python-base:1809
Python 3.7.9 (tags/v3.7.9:13c94747c7, Aug 17 2020, 18:58:18) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
