### PR TITLE
Use prebuilt python windows nanoserver image for e2e test

### DIFF
--- a/tests/apps/actorpython/Dockerfile-windows
+++ b/tests/apps/actorpython/Dockerfile-windows
@@ -1,4 +1,5 @@
-FROM python:3.7-windowsservercore
+ARG WINDOWS_VERSION=1809
+FROM daprio/windows-python-base:$WINDOWS_VERSION
 WORKDIR /app
 ADD . /app
 RUN pip install -r requirements.txt
@@ -6,3 +7,4 @@ RUN pip install -r requirements.txt
 EXPOSE 3000
 ENTRYPOINT ["python"]
 CMD ["flask_service.py"]
+


### PR DESCRIPTION
# Description

Now that we have a python nanoserver image, actually use it.


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
