### PR TITLE
Fix sidecar check for e2e test apps with IngressEnabled=false

### DIFF
--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -122,12 +122,12 @@ func (m *AppManager) Init() error {
 		log.Printf("Validating sidecar for app %v ....", m.app.AppName)
 		for i := 0; i <= maxSideCarDetectionRetries; i++ {
 			// Validate daprd side car is injected
-			if ok, err := m.ValidateSidecar(); err != nil || ok != m.app.IngressEnabled {
+			if err := m.ValidateSidecar(); err != nil {
 				if i == maxSideCarDetectionRetries {
 					return err
 				}
 
-				log.Printf("Did not find sidecar for app %v, retrying ....", m.app.AppName)
+				log.Printf("Did not find sidecar for app %v error %s, retrying ....", m.app.AppName, err)
 				time.Sleep(10 * time.Second)
 				continue
 			}
@@ -321,9 +321,9 @@ func (m *AppManager) IsDeploymentDeleted(deployment *appsv1.Deployment, err erro
 }
 
 // ValidateSidecar validates that dapr side car is running in dapr enabled pods
-func (m *AppManager) ValidateSidecar() (bool, error) {
+func (m *AppManager) ValidateSidecar() error {
 	if !m.app.DaprEnabled {
-		return false, fmt.Errorf("dapr is not enabled for this app")
+		return fmt.Errorf("dapr is not enabled for this app")
 	}
 
 	podClient := m.client.Pods(m.namespace)
@@ -332,11 +332,11 @@ func (m *AppManager) ValidateSidecar() (bool, error) {
 		LabelSelector: fmt.Sprintf("%s=%s", TestAppLabelKey, m.app.AppName),
 	})
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if len(podList.Items) != int(m.app.Replicas) {
-		return false, fmt.Errorf("expected number of pods for %s: %d, received: %d", m.app.AppName, m.app.Replicas, len(podList.Items))
+		return fmt.Errorf("expected number of pods for %s: %d, received: %d", m.app.AppName, m.app.Replicas, len(podList.Items))
 	}
 
 	// Each pod must have daprd sidecar
@@ -348,11 +348,11 @@ func (m *AppManager) ValidateSidecar() (bool, error) {
 			}
 		}
 		if !daprdFound {
-			return false, fmt.Errorf("cannot find dapr sidecar in pod %s", pod.Name)
+			return fmt.Errorf("cannot find dapr sidecar in pod %s", pod.Name)
 		}
 	}
 
-	return true, nil
+	return nil
 }
 
 // getSidecarInfo returns if sidecar is present and how many containers there are.

--- a/tests/platforms/kubernetes/appmanager_test.go
+++ b/tests/platforms/kubernetes/appmanager_test.go
@@ -285,10 +285,9 @@ func TestValidateSidecar(t *testing.T) {
 			})
 
 		appManager := NewAppManager(client, testNamespace, testApp)
-		found, err := appManager.ValidateSidecar()
+		err := appManager.ValidateSidecar()
 
 		assert.NoError(t, err)
-		assert.True(t, found)
 	})
 
 	t.Run("Sidecar is not injected", func(t *testing.T) {
@@ -321,8 +320,7 @@ func TestValidateSidecar(t *testing.T) {
 			})
 
 		appManager := NewAppManager(client, testNamespace, testApp)
-		found, err := appManager.ValidateSidecar()
-		assert.False(t, found)
+		err := appManager.ValidateSidecar()
 		assert.Error(t, err)
 	})
 
@@ -344,8 +342,7 @@ func TestValidateSidecar(t *testing.T) {
 			})
 
 		appManager := NewAppManager(client, testNamespace, testApp)
-		found, err := appManager.ValidateSidecar()
-		assert.False(t, found)
+		err := appManager.ValidateSidecar()
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
# Description

This is a minor fix that was costing us some test time. Basically, if IngressEnabled=false the sidecar check would fail continuously until the check loop ended at which point it wold succeed because err=nil. Basically this was costing us 30s per app of our 10min total test timeout and was causing the invoke tests to hit their timeout sometimes. 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
