### PR TITLE
Change codecov patch diff to be informational only.

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -6,6 +6,9 @@ coverage:
       default:
         target: auto
         threshold: 0%
+    patch:
+      default:
+        informational: true
 
 ignore:
   # Configure what to ignore.


### PR DESCRIPTION
# Description

Change codecov patch diff to be informational only. This will enable more auto-merge scenarios since we are not enforcing the patch diff anyway.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
