### PR TITLE
Add reentrancy to actor locking

### DIFF
--- a/pkg/actors/actor.go
+++ b/pkg/actors/actor.go
@@ -27,8 +27,8 @@ type actor struct {
 	// actorID is the ID of actorType.
 	actorID string
 
-	// concurrencyLock is the lock to maintain actor's turn-based concurrency.
-	concurrencyLock *sync.Mutex
+	// actorLock is the lock to maintain actor's turn-based concurrency with allowance for reentrancy if configured.
+	actorLock ActorLock
 	// pendingActorCalls is the number of the current pending actor calls by turn-based concurrency.
 	pendingActorCalls atomic.Int32
 
@@ -47,14 +47,14 @@ type actor struct {
 	once sync.Once
 }
 
-func newActor(actorType, actorID string) *actor {
+func newActor(actorType, actorID string, maxReentrancyDepth *int) *actor {
 	return &actor{
-		actorType:       actorType,
-		actorID:         actorID,
-		concurrencyLock: &sync.Mutex{},
-		disposeCh:       nil,
-		disposed:        false,
-		lastUsedTime:    time.Now().UTC(),
+		actorType:    actorType,
+		actorID:      actorID,
+		actorLock:    NewActorLock(int32(*maxReentrancyDepth)),
+		disposeCh:    nil,
+		disposed:     false,
+		lastUsedTime: time.Now().UTC(),
 	}
 }
 
@@ -72,10 +72,16 @@ func (a *actor) channel() chan struct{} {
 }
 
 // lock holds the lock for turn-based concurrency.
-func (a *actor) lock() error {
+func (a *actor) lock(reentrancyID *string) error {
+	log.Infof("Locking Actor - Req: %v", reentrancyID)
 	pending := a.pendingActorCalls.Inc()
 	diag.DefaultMonitoring.ReportActorPendingCalls(a.actorType, pending)
-	a.concurrencyLock.Lock()
+
+	err := a.actorLock.Lock(reentrancyID)
+	if err != nil {
+		return err
+	}
+
 	if a.disposed {
 		a.unlock()
 		return ErrActorDisposed
@@ -87,6 +93,7 @@ func (a *actor) lock() error {
 // unlock releases the lock for turn-based concurrency. If disposeCh is available,
 // it will close the channel to notify runtime to dispose actor.
 func (a *actor) unlock() {
+	log.Info("Unlocking actor")
 	pending := a.pendingActorCalls.Dec()
 	if pending == 0 {
 		if !a.disposed && a.disposeCh != nil {
@@ -98,6 +105,6 @@ func (a *actor) unlock() {
 		return
 	}
 
-	a.concurrencyLock.Unlock()
+	a.actorLock.Unlock()
 	diag.DefaultMonitoring.ReportActorPendingCalls(a.actorType, pending)
 }

--- a/pkg/actors/actor.go
+++ b/pkg/actors/actor.go
@@ -73,7 +73,6 @@ func (a *actor) channel() chan struct{} {
 
 // lock holds the lock for turn-based concurrency.
 func (a *actor) lock(reentrancyID *string) error {
-	log.Infof("Locking Actor - Req: %v", reentrancyID)
 	pending := a.pendingActorCalls.Inc()
 	diag.DefaultMonitoring.ReportActorPendingCalls(a.actorType, pending)
 
@@ -93,7 +92,6 @@ func (a *actor) lock(reentrancyID *string) error {
 // unlock releases the lock for turn-based concurrency. If disposeCh is available,
 // it will close the channel to notify runtime to dispose actor.
 func (a *actor) unlock() {
-	log.Info("Unlocking actor")
 	pending := a.pendingActorCalls.Dec()
 	if pending == 0 {
 		if !a.disposed && a.disposeCh != nil {

--- a/pkg/actors/actor_lock.go
+++ b/pkg/actors/actor_lock.go
@@ -36,9 +36,7 @@ func NewActorLock(maxStackDepth int32) ActorLock {
 
 func (a *ActorLock) Lock(requestID *string) error {
 	currentRequest := a.getCurrentID()
-	log.Infof("Attempting to lock Req %s Cur %s", a.idToString(requestID), a.idToString(currentRequest))
 
-	log.Infof("Stack depth: %s -> %s", a.stackDepth.Load(), a.maxStackDepth)
 	if a.stackDepth.Load() == a.maxStackDepth {
 		return ErrMaxStackDepthExceeded
 	}
@@ -57,7 +55,6 @@ func (a *ActorLock) Lock(requestID *string) error {
 func (a *ActorLock) Unlock() {
 	a.stackDepth.Dec()
 	if a.stackDepth.Load() == 0 {
-		log.Infof("Unlocking Req %s", a.idToString(a.getCurrentID()))
 		a.clearCurrentID()
 		a.methodLock.Unlock()
 	}
@@ -82,11 +79,4 @@ func (a *ActorLock) clearCurrentID() {
 	defer a.requestLock.Unlock()
 
 	a.activeRequest = nil
-}
-
-func (a *ActorLock) idToString(id *string) string {
-	if id == nil {
-		return "nil"
-	}
-	return *id
 }

--- a/pkg/actors/actor_lock.go
+++ b/pkg/actors/actor_lock.go
@@ -1,0 +1,92 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package actors
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+)
+
+var (
+	ErrMaxStackDepthExceeded error = errors.New("Maximum stack depth exceeded")
+)
+
+type ActorLock struct {
+	methodLock    *sync.Mutex
+	requestLock   *sync.Mutex
+	activeRequest *string
+	stackDepth    *atomic.Int32
+	maxStackDepth int32
+}
+
+func NewActorLock(maxStackDepth int32) ActorLock {
+	return ActorLock{
+		methodLock:    &sync.Mutex{},
+		requestLock:   &sync.Mutex{},
+		activeRequest: nil,
+		stackDepth:    atomic.NewInt32(int32(0)),
+		maxStackDepth: maxStackDepth,
+	}
+}
+
+func (a *ActorLock) Lock(requestID *string) error {
+	currentRequest := a.getCurrentID()
+	log.Infof("Attempting to lock Req %s Cur %s", a.idToString(requestID), a.idToString(currentRequest))
+
+	log.Infof("Stack depth: %s -> %s", a.stackDepth.Load(), a.maxStackDepth)
+	if a.stackDepth.Load() == a.maxStackDepth {
+		return ErrMaxStackDepthExceeded
+	}
+
+	if currentRequest == nil || *currentRequest != *requestID {
+		a.methodLock.Lock()
+		a.setCurrentID(requestID)
+		a.stackDepth.Inc()
+	} else {
+		a.stackDepth.Inc()
+	}
+
+	return nil
+}
+
+func (a *ActorLock) Unlock() {
+	a.stackDepth.Dec()
+	if a.stackDepth.Load() == 0 {
+		log.Infof("Unlocking Req %s", a.idToString(a.getCurrentID()))
+		a.clearCurrentID()
+		a.methodLock.Unlock()
+	}
+}
+
+func (a *ActorLock) getCurrentID() *string {
+	a.requestLock.Lock()
+	defer a.requestLock.Unlock()
+
+	return a.activeRequest
+}
+
+func (a *ActorLock) setCurrentID(id *string) {
+	a.requestLock.Lock()
+	defer a.requestLock.Unlock()
+
+	a.activeRequest = id
+}
+
+func (a *ActorLock) clearCurrentID() {
+	a.requestLock.Lock()
+	defer a.requestLock.Unlock()
+
+	a.activeRequest = nil
+}
+
+func (a *ActorLock) idToString(id *string) string {
+	if id == nil {
+		return "nil"
+	}
+	return *id
+}

--- a/pkg/actors/actor_lock_test.go
+++ b/pkg/actors/actor_lock_test.go
@@ -1,0 +1,147 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package actors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	baseID = "test"
+)
+
+func TestLockBaseCase(t *testing.T) {
+	for _, requestID := range []*string{&baseID, nil} {
+		lock := NewActorLock(32)
+
+		assert.Nil(t, lock.activeRequest)
+		assert.Equal(t, int32(0), lock.stackDepth.Load())
+
+		err := lock.Lock(requestID)
+
+		assert.Nil(t, err)
+		if requestID == nil {
+			assert.Nil(t, lock.activeRequest)
+		} else {
+			assert.Equal(t, *requestID, *lock.activeRequest)
+		}
+		assert.Equal(t, int32(1), lock.stackDepth.Load())
+
+		lock.Unlock()
+
+		assert.Nil(t, lock.activeRequest)
+		assert.Equal(t, int32(0), lock.stackDepth.Load())
+	}
+}
+
+func TestLockBypassWithMatchingID(t *testing.T) {
+	lock := NewActorLock(32)
+	requestID := &baseID
+
+	for i := 1; i < 5; i++ {
+		err := lock.Lock(requestID)
+
+		assert.Nil(t, err)
+		assert.Equal(t, *requestID, *lock.activeRequest)
+		assert.Equal(t, int32(i), lock.stackDepth.Load())
+	}
+}
+
+func TestLockHoldsUntilStackIsZero(t *testing.T) {
+	lock := NewActorLock(32)
+	requestID := &baseID
+
+	// Lock it twice.
+	lock.Lock(requestID)
+	lock.Lock(requestID)
+
+	assert.Equal(t, *requestID, *lock.activeRequest)
+	assert.Equal(t, int32(2), lock.stackDepth.Load())
+
+	// Unlock until request is nil
+	lock.Unlock()
+	assert.Equal(t, *requestID, *lock.activeRequest)
+	assert.Equal(t, int32(1), lock.stackDepth.Load())
+
+	lock.Unlock()
+	assert.Nil(t, lock.activeRequest)
+	assert.Equal(t, int32(0), lock.stackDepth.Load())
+}
+
+func TestStackDepthLimit(t *testing.T) {
+	lock := NewActorLock(1)
+	requestID := &baseID
+
+	err := lock.Lock(requestID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, *requestID, *lock.activeRequest)
+	assert.Equal(t, int32(1), lock.stackDepth.Load())
+
+	err = lock.Lock(requestID)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "Maximum stack depth exceeded", err.Error())
+}
+
+func TestLockBlocksForNonMatchingID(t *testing.T) {
+	lock := NewActorLock(32)
+	firstRequestID := "first"
+	secondRequestID := "second"
+
+	firstInChan := make(chan int)
+	firstOutChan := make(chan int)
+	secondInChan := make(chan int)
+	secondOutChan := make(chan int)
+
+	go func() {
+		<-firstInChan
+		lock.Lock(&firstRequestID)
+		firstOutChan <- 1
+		<-firstInChan
+		lock.Unlock()
+		firstOutChan <- 1
+	}()
+
+	go func() {
+		<-secondInChan
+		lock.Lock(&secondRequestID)
+		secondOutChan <- 2
+		<-secondInChan
+		lock.Unlock()
+		secondOutChan <- 2
+	}()
+
+	assert.Nil(t, lock.activeRequest)
+	assert.Equal(t, int32(0), lock.stackDepth.Load())
+
+	firstInChan <- 1
+	<-firstOutChan
+
+	assert.Equal(t, firstRequestID, *lock.activeRequest)
+	assert.Equal(t, int32(1), lock.stackDepth.Load())
+
+	secondInChan <- 2
+
+	assert.Equal(t, firstRequestID, *lock.activeRequest)
+	assert.Equal(t, int32(1), lock.stackDepth.Load())
+
+	firstInChan <- 1
+	<-firstOutChan
+	<-secondOutChan
+
+	assert.Equal(t, secondRequestID, *lock.activeRequest)
+	assert.Equal(t, int32(1), lock.stackDepth.Load())
+
+	secondInChan <- 2
+	<-secondOutChan
+
+	assert.Nil(t, lock.activeRequest)
+	assert.Nil(t, lock.activeRequest)
+	assert.Equal(t, int32(0), lock.stackDepth.Load())
+}

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -15,8 +15,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"github.com/valyala/fasthttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -262,6 +264,7 @@ func (a *actorsRuntime) startDeactivationTicker(interval, actorIdleTimeout time.
 }
 
 func (a *actorsRuntime) Call(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
+	log.Info("Calling actor\n")
 	a.placement.WaitUntilPlacementTableIsReady()
 
 	actor := req.Actor()
@@ -320,17 +323,34 @@ func (a *actorsRuntime) getOrCreateActor(actorType, actorID string) *actor {
 	// call newActor, but this is trivial.
 	val, ok := a.actorsTable.Load(key)
 	if !ok {
-		val, _ = a.actorsTable.LoadOrStore(key, newActor(actorType, actorID))
+		val, _ = a.actorsTable.LoadOrStore(key, newActor(actorType, actorID, a.config.Reentrancy.MaxStackDepth))
 	}
 
 	return val.(*actor)
 }
 
 func (a *actorsRuntime) callLocalActor(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
+	log.Infof("Entering callLocalActor: %s - %s", req.Actor().GetActorType(), req.Actor().GetActorId())
+	log.Infof("callLocalActor Request Headers: %v", req.Metadata())
 	actorTypeID := req.Actor()
 
 	act := a.getOrCreateActor(actorTypeID.GetActorType(), actorTypeID.GetActorId())
-	err := act.lock()
+
+	// Reentrancy to determine how we lock.
+	var reentrancyID *string
+	if headerValue, ok := req.Metadata()["Dapr-Reentrancy-Id"]; a.reentrancyEnabled && ok {
+		log.Infof("Reentrancy header found: %s", headerValue.GetValues()[0])
+		reentrancyID = &headerValue.GetValues()[0]
+	} else {
+		log.Info("No reentrancy header found, generatinga new one")
+		reentrancyHeader := fasthttp.RequestHeader{}
+		uuid := uuid.New().String()
+		reentrancyHeader.Add("Dapr-Reentrancy-Id", uuid)
+		req.AddHeaders(&reentrancyHeader)
+		reentrancyID = &uuid
+	}
+
+	err := act.lock(reentrancyID)
 	if err != nil {
 		return nil, status.Error(codes.ResourceExhausted, err.Error())
 	}
@@ -362,6 +382,8 @@ func (a *actorsRuntime) callRemoteActor(
 	ctx context.Context,
 	targetAddress, targetID string,
 	req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
+	log.Infof("Entering callRemoteActor: %s - %s", req.Actor().GetActorType(), req.Actor().GetActorId())
+	log.Infof("callRemoteActor Request Headers: %v", req.Metadata())
 	conn, err := a.grpcConnectionFn(targetAddress, targetID, a.config.Namespace, false, false, false)
 	if err != nil {
 		return nil, err

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -264,7 +264,6 @@ func (a *actorsRuntime) startDeactivationTicker(interval, actorIdleTimeout time.
 }
 
 func (a *actorsRuntime) Call(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
-	log.Info("Calling actor\n")
 	a.placement.WaitUntilPlacementTableIsReady()
 
 	actor := req.Actor()
@@ -330,8 +329,6 @@ func (a *actorsRuntime) getOrCreateActor(actorType, actorID string) *actor {
 }
 
 func (a *actorsRuntime) callLocalActor(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
-	log.Infof("Entering callLocalActor: %s - %s", req.Actor().GetActorType(), req.Actor().GetActorId())
-	log.Infof("callLocalActor Request Headers: %v", req.Metadata())
 	actorTypeID := req.Actor()
 
 	act := a.getOrCreateActor(actorTypeID.GetActorType(), actorTypeID.GetActorId())
@@ -339,10 +336,8 @@ func (a *actorsRuntime) callLocalActor(ctx context.Context, req *invokev1.Invoke
 	// Reentrancy to determine how we lock.
 	var reentrancyID *string
 	if headerValue, ok := req.Metadata()["Dapr-Reentrancy-Id"]; a.reentrancyEnabled && ok {
-		log.Infof("Reentrancy header found: %s", headerValue.GetValues()[0])
 		reentrancyID = &headerValue.GetValues()[0]
 	} else {
-		log.Info("No reentrancy header found, generatinga new one")
 		reentrancyHeader := fasthttp.RequestHeader{}
 		uuid := uuid.New().String()
 		reentrancyHeader.Add("Dapr-Reentrancy-Id", uuid)

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -129,7 +129,7 @@ func NewActors(
 		appHealthy:          true,
 		certChain:           certChain,
 		tracingSpec:         tracingSpec,
-		reentrancyEnabled:   configuration.IsFeatureEnabled(features, configuration.ActorRentrancy),
+		reentrancyEnabled:   configuration.IsFeatureEnabled(features, configuration.ActorRentrancy) && config.Reentrancy.Enabled,
 	}
 }
 

--- a/pkg/actors/config.go
+++ b/pkg/actors/config.go
@@ -5,7 +5,11 @@
 
 package actors
 
-import "time"
+import (
+	"time"
+
+	app_config "github.com/dapr/dapr/pkg/config"
+)
 
 // Config is the actor runtime configuration
 type Config struct {
@@ -20,18 +24,21 @@ type Config struct {
 	DrainOngoingCallTimeout       time.Duration
 	DrainRebalancedActors         bool
 	Namespace                     string
+	Reentrancy                    app_config.ReentrancyConfig
 }
 
 const (
-	defaultActorIdleTimeout   = time.Minute * 60
-	defaultHeartbeatInterval  = time.Second * 1
-	defaultActorScanInterval  = time.Second * 30
-	defaultOngoingCallTimeout = time.Second * 60
+	defaultActorIdleTimeout     = time.Minute * 60
+	defaultHeartbeatInterval    = time.Second * 1
+	defaultActorScanInterval    = time.Second * 30
+	defaultOngoingCallTimeout   = time.Second * 60
+	defaultReentrancyStackLimit = 32
 )
 
 // NewConfig returns the actor runtime configuration
 func NewConfig(hostAddress, appID string, placementAddresses []string, hostedActors []string, port int,
-	actorScanInterval, actorIdleTimeout, ongoingCallTimeout string, drainRebalancedActors bool, namespace string) Config {
+	actorScanInterval, actorIdleTimeout, ongoingCallTimeout string, drainRebalancedActors bool, namespace string,
+	reentrancy app_config.ReentrancyConfig) Config {
 	c := Config{
 		HostAddress:                   hostAddress,
 		AppID:                         appID,
@@ -44,6 +51,7 @@ func NewConfig(hostAddress, appID string, placementAddresses []string, hostedAct
 		DrainOngoingCallTimeout:       defaultOngoingCallTimeout,
 		DrainRebalancedActors:         drainRebalancedActors,
 		Namespace:                     namespace,
+		Reentrancy:                    reentrancy,
 	}
 
 	scanDuration, err := time.ParseDuration(actorScanInterval)
@@ -59,6 +67,11 @@ func NewConfig(hostAddress, appID string, placementAddresses []string, hostedAct
 	drainCallDuration, err := time.ParseDuration(ongoingCallTimeout)
 	if err == nil {
 		c.DrainOngoingCallTimeout = drainCallDuration
+	}
+
+	if reentrancy.MaxStackDepth == nil {
+		reentrancyLimit := defaultReentrancyStackLimit
+		c.Reentrancy.MaxStackDepth = &reentrancyLimit
 	}
 
 	return c

--- a/pkg/config/app_configuration.go
+++ b/pkg/config/app_configuration.go
@@ -13,6 +13,12 @@ type ApplicationConfig struct {
 	// Duration. example: "30s"
 	ActorScanInterval string `json:"actorScanInterval"`
 	// Duration. example: "30s"
-	DrainOngoingCallTimeout string `json:"drainOngoingCallTimeout"`
-	DrainRebalancedActors   bool   `json:"drainRebalancedActors"`
+	DrainOngoingCallTimeout string           `json:"drainOngoingCallTimeout"`
+	DrainRebalancedActors   bool             `json:"drainRebalancedActors"`
+	Reentrancy              ReentrancyConfig `json:"reentrancy,omitempty"`
+}
+
+type ReentrancyConfig struct {
+	Enabled       bool `json:"enabled"`
+	MaxStackDepth *int `json:"maxStackDepth,omitempty"`
 }

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -158,3 +158,24 @@ func (imr *InvokeMethodRequest) RawData() (string, []byte) {
 
 	return contentType, dataValue
 }
+
+// Adds a new header to the existing set.
+func (imr *InvokeMethodRequest) AddHeaders(header *fasthttp.RequestHeader) {
+	md := map[string][]string{}
+	header.VisitAll(func(key []byte, value []byte) {
+		md[string(key)] = []string{string(value)}
+	})
+
+	internalMd := MetadataToInternalMetadata(md)
+
+	if imr.r.Metadata == nil {
+		imr.r.Metadata = internalMd
+	} else {
+		for key, val := range internalMd {
+			// We're only adding new values, not overwriting existing
+			if _, ok := imr.r.Metadata[key]; !ok {
+				imr.r.Metadata[key] = val
+			}
+		}
+	}
+}

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -150,3 +150,27 @@ func TestProto(t *testing.T) {
 	assert.Equal(t, "application/json", req2.GetMessage().ContentType)
 	assert.Equal(t, []byte("test"), req2.GetMessage().Data.Value)
 }
+
+func TestAddHeaders(t *testing.T) {
+	req := NewInvokeMethodRequest("test_method")
+	header := fasthttp.RequestHeader{}
+	header.Add("Dapr-Reentrant-Id", "test")
+	req.AddHeaders(&header)
+
+	assert.NotNil(t, req.r.Metadata)
+	assert.NotNil(t, req.r.Metadata["Dapr-Reentrant-Id"])
+	assert.Equal(t, "test", req.r.Metadata["Dapr-Reentrant-Id"].Values[0])
+}
+
+func TestAddHeadersDoesNotOverwrite(t *testing.T) {
+	header := fasthttp.RequestHeader{}
+	header.Add("Dapr-Reentrant-Id", "test")
+	req := NewInvokeMethodRequest("test_method").WithFastHTTPHeaders(&header)
+
+	header.Set("Dapr-Reentrant-Id", "test2")
+	req.AddHeaders(&header)
+
+	assert.NotNil(t, req.r.Metadata)
+	assert.NotNil(t, req.r.Metadata["Dapr-Reentrant-Id"])
+	assert.Equal(t, "test", req.r.Metadata["Dapr-Reentrant-Id"].Values[0])
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1300,7 +1300,7 @@ func (a *DaprRuntime) initActors() error {
 		return err
 	}
 	actorConfig := actors.NewConfig(a.hostAddress, a.runtimeConfig.ID, a.runtimeConfig.PlacementAddresses, a.appConfig.Entities,
-		a.runtimeConfig.InternalGRPCPort, a.appConfig.ActorScanInterval, a.appConfig.ActorIdleTimeout, a.appConfig.DrainOngoingCallTimeout, a.appConfig.DrainRebalancedActors, a.namespace)
+		a.runtimeConfig.InternalGRPCPort, a.appConfig.ActorScanInterval, a.appConfig.ActorIdleTimeout, a.appConfig.DrainOngoingCallTimeout, a.appConfig.DrainRebalancedActors, a.namespace, a.appConfig.Reentrancy)
 	act := actors.NewActors(a.stateStores[a.actorStateStoreName], a.appChannel, a.grpc.GetGRPCConnection, actorConfig, a.runtimeConfig.CertChain, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.Features)
 	err = act.Init()
 	a.actor = act

--- a/tests/apps/actorreentrancy/app.go
+++ b/tests/apps/actorreentrancy/app.go
@@ -1,0 +1,264 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/dapr/dapr/pkg/config"
+	"github.com/gorilla/mux"
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	appPort                 = 22222
+	daprV1URL               = "http://localhost:3500/v1.0"
+	actorMethodURLFormat    = daprV1URL + "/actors/%s/%s/method/%s"
+	defaultActorType        = "reentrantActor"
+	actorIdleTimeout        = "1h"
+	actorScanInterval       = "30s"
+	drainOngoingCallTimeout = "30s"
+	drainRebalancedActors   = true
+	reentrantMethod         = "reentrantMethod"
+	standardMethod          = "standardMethod"
+)
+
+// represents a response for the APIs in this app.
+type actorLogEntry struct {
+	Action    string `json:"action,omitempty"`
+	ActorType string `json:"actorType,omitempty"`
+	ActorID   string `json:"actorId,omitempty"`
+}
+
+type daprConfig struct {
+	Entities                []string                `json:"entities,omitempty"`
+	ActorIdleTimeout        string                  `json:"actorIdleTimeout,omitempty"`
+	ActorScanInterval       string                  `json:"actorScanInterval,omitempty"`
+	DrainOngoingCallTimeout string                  `json:"drainOngoingCallTimeout,omitempty"`
+	DrainRebalancedActors   bool                    `json:"drainRebalancedActors,omitempty"`
+	Reentrancy              config.ReentrancyConfig `json:"reentrancy,omitempty"`
+}
+
+type reentrantRequest struct {
+	Calls []actorCall `json:"calls,omitempty"`
+}
+
+type actorCall struct {
+	ActorID   string `json:"id"`
+	ActorType string `json:"type"`
+	Method    string `json:"method"`
+}
+
+var actorLogs = []actorLogEntry{}
+var actorLogsMutex = &sync.Mutex{}
+var maxStackDepth = 5
+
+var daprConfigResponse = daprConfig{
+	[]string{defaultActorType},
+	actorIdleTimeout,
+	actorScanInterval,
+	drainOngoingCallTimeout,
+	drainRebalancedActors,
+	config.ReentrancyConfig{Enabled: true, MaxStackDepth: &maxStackDepth},
+}
+
+func resetLogs() {
+	actorLogsMutex.Lock()
+	defer actorLogsMutex.Unlock()
+
+	actorLogs = []actorLogEntry{}
+}
+
+func appendLog(actorType string, actorID string, action string) {
+	logEntry := actorLogEntry{
+		Action:    action,
+		ActorType: actorType,
+		ActorID:   actorID,
+	}
+
+	actorLogsMutex.Lock()
+	defer actorLogsMutex.Unlock()
+	actorLogs = append(actorLogs, logEntry)
+}
+
+func getLogs() []actorLogEntry {
+	return actorLogs
+}
+
+// indexHandler is the handler for root path
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println("indexHandler is called")
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func logsHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Processing dapr %s request for %s", r.Method, r.URL.RequestURI())
+	if r.Method == "DELETE" {
+		resetLogs()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(getLogs())
+}
+
+func configHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Processing dapr request for %s, responding with %v", r.URL.RequestURI(), daprConfigResponse)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(daprConfigResponse)
+}
+
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(""))
+}
+
+func actorTestCallHandler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Handling actor test call")
+
+	body, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+
+	if err != nil {
+		w.WriteHeader(fasthttp.StatusInternalServerError)
+		return
+	}
+
+	var reentrantReq reentrantRequest
+	json.Unmarshal(body, &reentrantReq)
+
+	if len(reentrantReq.Calls) == 0 {
+		log.Print("No calls in test chain")
+		return
+	}
+
+	nextCall, nextBody := advanceCallStackForNextRequest(reentrantReq)
+	req, _ := http.NewRequest("PUT", fmt.Sprintf(actorMethodURLFormat, nextCall.ActorType, nextCall.ActorID, nextCall.Method), bytes.NewReader(nextBody))
+
+	client := http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(fasthttp.StatusInternalServerError)
+		return
+	}
+
+	respBody, err := ioutil.ReadAll(res.Body)
+	defer res.Body.Close()
+
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(fasthttp.StatusInternalServerError)
+		return
+	}
+
+	w.Write(respBody)
+}
+
+func actorMethodHandler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Handling actor method call.")
+	method := mux.Vars(r)["method"]
+
+	switch method {
+	case reentrantMethod:
+		reentrantCallHandler(w, r)
+	case standardMethod:
+		fallthrough
+	default:
+		standardHandler(w, r)
+	}
+}
+
+func reentrantCallHandler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Handling reentrant call")
+	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Enter %s", mux.Vars(r)["method"]))
+	body, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+
+	if err != nil {
+		w.WriteHeader(fasthttp.StatusInternalServerError)
+		return
+	}
+
+	var reentrantReq reentrantRequest
+	json.Unmarshal(body, &reentrantReq)
+
+	if len(reentrantReq.Calls) == 0 {
+		log.Print("End of call chain")
+		return
+	}
+
+	nextCall, nextBody := advanceCallStackForNextRequest(reentrantReq)
+
+	log.Printf("Next call: %s on %s.%s", nextCall.Method, nextCall.ActorType, nextCall.ActorID)
+
+	url := fmt.Sprintf(actorMethodURLFormat, nextCall.ActorType, nextCall.ActorID, nextCall.Method)
+	req, _ := http.NewRequest("PUT", url, bytes.NewReader(nextBody))
+
+	reentrancyID := r.Header.Get("Dapr-Reentrancy-Id")
+	req.Header.Add("Dapr-Reentrancy-Id", reentrancyID)
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+
+	log.Printf("Call status: %d\n", resp.StatusCode)
+	if err != nil || resp.StatusCode == fasthttp.StatusInternalServerError {
+		w.WriteHeader(fasthttp.StatusInternalServerError)
+		appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Error %s", mux.Vars(r)["method"]))
+	} else {
+		appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Exit %s", mux.Vars(r)["method"]))
+	}
+	defer resp.Body.Close()
+}
+
+func standardHandler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Handling standard call")
+	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Enter %s", mux.Vars(r)["method"]))
+	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Exit %s", mux.Vars(r)["method"]))
+}
+
+func advanceCallStackForNextRequest(req reentrantRequest) (actorCall, []byte) {
+	nextCall := req.Calls[0]
+	log.Printf("Current call: %v\n", nextCall)
+	nextReq := req
+	nextReq.Calls = nextReq.Calls[1:]
+	log.Printf("Next req: %v\n", nextReq)
+	nextBody, _ := json.Marshal(nextReq)
+	return nextCall, nextBody
+}
+
+// appRouter initializes restful api router
+func appRouter() *mux.Router {
+	router := mux.NewRouter().StrictSlash(true)
+
+	router.HandleFunc("/", indexHandler).Methods("GET")
+	router.HandleFunc("/dapr/config", configHandler).Methods("GET")
+
+	router.HandleFunc("/actors/{actorType}/{id}/method/{method}", actorMethodHandler).Methods("PUT")
+	router.HandleFunc("/test/actors/{actorType}/{id}/method/{method}", actorTestCallHandler).Methods("POST")
+
+	router.HandleFunc("/test/logs", logsHandler).Methods("GET", "DELETE")
+	router.HandleFunc("/healthz", healthzHandler).Methods("GET")
+
+	router.Use(mux.CORSMethodMiddleware(router))
+
+	return router
+}
+
+func main() {
+	log.Printf("Actor App - listening on http://localhost:%d", appPort)
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", appPort), appRouter()))
+}

--- a/tests/apps/actorreentrancy/service.yaml
+++ b/tests/apps/actorreentrancy/service.yaml
@@ -1,0 +1,47 @@
+# In e2e test, this will not be used to deploy the app to test cluster.
+# This is created for testing purpose in order to deploy this app using kubectl
+# before writing e2e test.
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: reentrantactor
+  labels:
+    testapp: reentrantactor
+spec:
+  selector:
+    testapp: reentrantactor
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 3000
+  type: LoadBalancer
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reentrantactor
+  labels:
+    testapp: reentrantactor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      testapp: reentrantactor
+  template:
+    metadata:
+      labels:
+        testapp: reentrantactor
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "reentrantactor"
+        dapr.io/app-port: "3000"
+        dapr.io/config: "reentrantconfig"
+    spec:
+      containers:
+      - name: actorreentrancy
+        image: halspang/e2e-actorreentrancy:dev
+        ports:
+        - containerPort: 3000
+        imagePullPolicy: Always

--- a/tests/config/app_reentrant_actor.yaml
+++ b/tests/config/app_reentrant_actor.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: reentrantconfig
+spec:
+  features:
+    - name: Actor.Reentrancy
+      enabled: true

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -24,6 +24,7 @@ actorapp \
 actorclientapp \
 actorfeatures \
 actorinvocationapp \
+actorreentrancy \
 runtime \
 runtime_init \
 middleware \
@@ -239,9 +240,13 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/dapr_redis_state_badpass.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/uppercase.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/pipeline.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/app_reentrant_actor.yaml --namespace $(DAPR_TEST_NAMESPACE)
 
 	# Show the installed components
 	$(KUBECTL) get components --namespace $(DAPR_TEST_NAMESPACE)
+
+	# Show the installed configurations
+	$(KUBECTL) get configurations --namespace $(DAPR_TEST_NAMESPACE)
 
 # Clean up test environment
 clean-test-env:

--- a/tests/e2e/actor_reentrancy/actor_reentrancy_test.go
+++ b/tests/e2e/actor_reentrancy/actor_reentrancy_test.go
@@ -1,0 +1,224 @@
+// +build e2e
+
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package actor_features_e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dapr/dapr/tests/e2e/utils"
+	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
+	"github.com/dapr/dapr/tests/runner"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	appName              = "reentrantactor"                         // App name in Dapr.
+	numHealthChecks      = 60                                       // Number of get calls before starting tests.
+	actorInvokeURLFormat = "%s/test/actors/reentrantActor/%s/%s/%s" // URL to invoke a Dapr's actor method in test app.
+	actorlogsURLFormat   = "%s/test/logs"                           // URL to fetch logs from test app.
+)
+
+// represents a response for the APIs in this app.
+type actorLogEntry struct {
+	Action         string `json:"action,omitempty"`
+	ActorType      string `json:"actorType,omitempty"`
+	ActorID        string `json:"actorId,omitempty"`
+	StartTimestamp int    `json:"startTimestamp,omitempty"`
+	EndTimestamp   int    `json:"endTimestamp,omitempty"`
+}
+
+type activeActorsCount struct {
+	Type  string `json:"type"`
+	Count int    `json:"count"`
+}
+
+type metadata struct {
+	ID     string              `json:"id"`
+	Actors []activeActorsCount `json:"actors"`
+}
+
+type actorReminderOrTimer struct {
+	Data     string `json:"data,omitempty"`
+	DueTime  string `json:"dueTime,omitempty"`
+	Period   string `json:"period,omitempty"`
+	Callback string `json:"callback,omitempty"`
+}
+
+type reentrantRequest struct {
+	Calls []actorCall `json:"calls,omitempty"`
+}
+
+type actorCall struct {
+	ActorID   string `json:"id"`
+	ActorType string `json:"type"`
+	Method    string `json:"method"`
+}
+
+func parseLogEntries(resp []byte) []actorLogEntry {
+	logEntries := []actorLogEntry{}
+	err := json.Unmarshal(resp, &logEntries)
+	if err != nil {
+		return nil
+	}
+
+	return logEntries
+}
+
+var tr *runner.TestRunner
+
+func TestMain(m *testing.M) {
+	// These apps will be deployed before starting actual test
+	// and will be cleaned up after all tests are finished automatically
+	testApps := []kube.AppDescription{
+		{
+			AppName:        appName,
+			DaprEnabled:    true,
+			ImageName:      "e2e-actorreentrancy",
+			Replicas:       1,
+			IngressEnabled: true,
+			MetricsEnabled: true,
+			DaprCPULimit:   "2.0",
+			DaprCPURequest: "0.1",
+			AppCPULimit:    "2.0",
+			AppCPURequest:  "0.1",
+			Config:         "reentrantconfig",
+			AppPort:        22222,
+		},
+	}
+
+	tr = runner.NewTestRunner(appName, testApps, nil, nil)
+	os.Exit(tr.Start(m))
+}
+
+func TestActorReentrancy(t *testing.T) {
+	reentrantURL := tr.Platform.AcquireAppExternalURL(appName)
+	require.NotEmpty(t, reentrantURL, "external URL must not be empty!")
+
+	// This initial probe makes the test wait a little bit longer when needed,
+	// making this test less flaky due to delays in the deployment.
+	_, err := utils.HTTPGetNTimes(reentrantURL, numHealthChecks)
+	require.NoError(t, err)
+
+	firstActorId := "1"
+	secondActorId := "2"
+	actorType := "reentrantActor"
+
+	logsURL := fmt.Sprintf(actorlogsURLFormat, reentrantURL)
+
+	t.Run("Same Actor Reentrancy", func(t *testing.T) {
+		utils.HTTPDelete(logsURL)
+		req := reentrantRequest{
+			Calls: []actorCall{
+				{ActorID: firstActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: firstActorId, ActorType: actorType, Method: "standardMethod"},
+			},
+		}
+
+		reqBody, _ := json.Marshal(req)
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, reentrantURL, firstActorId, "method", "reentrantMethod"), reqBody)
+		require.NoError(t, err)
+
+		resp, err := utils.HTTPGet(logsURL)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		logs := parseLogEntries(resp)
+
+		require.Len(t, logs, len(req.Calls)*2)
+		index := 0
+		for i := 0; i < len(req.Calls); i++ {
+			require.Equal(t, fmt.Sprintf("Enter %s", req.Calls[i].Method), logs[index].Action)
+			require.Equal(t, req.Calls[i].ActorID, logs[index].ActorID)
+			require.Equal(t, req.Calls[i].ActorType, logs[index].ActorType)
+			index++
+		}
+
+		for i := len(req.Calls) - 1; i > -1; i-- {
+			require.Equal(t, fmt.Sprintf("Exit %s", req.Calls[i].Method), logs[index].Action)
+			require.Equal(t, req.Calls[i].ActorID, logs[index].ActorID)
+			require.Equal(t, req.Calls[i].ActorType, logs[index].ActorType)
+			index++
+		}
+	})
+
+	t.Run("Multi-actor Reentrancy", func(t *testing.T) {
+		utils.HTTPDelete(logsURL)
+		req := reentrantRequest{
+			Calls: []actorCall{
+				{ActorID: firstActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: secondActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: firstActorId, ActorType: actorType, Method: "standardMethod"},
+			},
+		}
+
+		reqBody, _ := json.Marshal(req)
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, reentrantURL, firstActorId, "method", "reentrantMethod"), reqBody)
+		require.NoError(t, err)
+
+		resp, err := utils.HTTPGet(logsURL)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		logs := parseLogEntries(resp)
+
+		require.Len(t, logs, len(req.Calls)*2)
+
+		index := 0
+		for i := 0; i < len(req.Calls); i++ {
+			require.Equal(t, fmt.Sprintf("Enter %s", req.Calls[i].Method), logs[index].Action)
+			require.Equal(t, req.Calls[i].ActorID, logs[index].ActorID)
+			require.Equal(t, req.Calls[i].ActorType, logs[index].ActorType)
+			index++
+		}
+
+		for i := len(req.Calls) - 1; i > -1; i-- {
+			require.Equal(t, fmt.Sprintf("Exit %s", req.Calls[i].Method), logs[index].Action)
+			require.Equal(t, req.Calls[i].ActorID, logs[index].ActorID)
+			require.Equal(t, req.Calls[i].ActorType, logs[index].ActorType)
+			index++
+		}
+	})
+
+	t.Run("Reentrancy Stack Depth Limit", func(t *testing.T) {
+		utils.HTTPDelete(logsURL)
+		// Limit is set to 5
+		req := reentrantRequest{
+			Calls: []actorCall{
+				{ActorID: firstActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: firstActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: firstActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: firstActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: firstActorId, ActorType: actorType, Method: "reentrantMethod"},
+				{ActorID: firstActorId, ActorType: actorType, Method: "standardMethod"},
+			},
+		}
+
+		reqBody, _ := json.Marshal(req)
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, reentrantURL, firstActorId, "method", "reentrantMethod"), reqBody)
+		require.NoError(t, err)
+
+		resp, err := utils.HTTPGet(logsURL)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		logs := parseLogEntries(resp)
+
+		// Should be 2 calls per stack item (limit 5)
+		require.Len(t, logs, 10)
+		for index := range logs {
+			if index < 5 {
+				require.Equal(t, "Enter reentrantMethod", logs[index].Action)
+			} else {
+				require.Equal(t, "Error reentrantMethod", logs[index].Action)
+			}
+		}
+	})
+}


### PR DESCRIPTION
# Description

Actors that are specified as reentrant are now capable of bypassing
their lock when a call that is servicing the same request is found.
The request ID (or reentrancy ID) used here is generated on the
first call to the reentrant actor and is passed through all
remaining calls.

**Note:** This PR is currently building off of https://github.com/dapr/dapr/pull/3077

## Issue reference

Please reference the issue this PR will close: #3078 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
