### PR TITLE
Subtract clock shew from the Certificate NotBefore time

### DIFF
--- a/pkg/sentry/ca/certificate_authority.go
+++ b/pkg/sentry/ca/certificate_authority.go
@@ -100,7 +100,7 @@ func (c *defaultCA) SignCSR(csrPem []byte, subject string, identity *identity.Bu
 		return nil, errors.Wrap(err, "error parsing csr pem")
 	}
 
-	crtb, err := csr.GenerateCSRCertificate(cert, subject, identity, signingCert, cert.PublicKey, signingKey.Key, certLifetime, isCA)
+	crtb, err := csr.GenerateCSRCertificate(cert, subject, identity, signingCert, cert.PublicKey, signingKey.Key, certLifetime, c.config.AllowedClockSkew, isCA)
 	if err != nil {
 		return nil, errors.Wrap(err, "error signing csr")
 	}
@@ -223,7 +223,7 @@ func (c *defaultCA) generateRootAndIssuerCerts() (*certs.Credentials, []byte, []
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	rootCsr, err := csr.GenerateRootCertCSR(caOrg, caCommonName, &rootKey.PublicKey, selfSignedRootCertLifetime)
+	rootCsr, err := csr.GenerateRootCertCSR(caOrg, caCommonName, &rootKey.PublicKey, selfSignedRootCertLifetime, c.config.AllowedClockSkew)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -245,7 +245,7 @@ func (c *defaultCA) generateRootAndIssuerCerts() (*certs.Credentials, []byte, []
 		return nil, nil, nil, err
 	}
 
-	issuerCsr, err := csr.GenerateIssuerCertCSR(caCommonName, &issuerKey.PublicKey, selfSignedRootCertLifetime)
+	issuerCsr, err := csr.GenerateIssuerCertCSR(caCommonName, &issuerKey.PublicKey, selfSignedRootCertLifetime, c.config.AllowedClockSkew)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/sentry/csr/csr.go
+++ b/pkg/sentry/csr/csr.go
@@ -22,6 +22,8 @@ const (
 	blockTypePrivateKey   = "PRIVATE KEY"    // PKCS#8 plain private key
 	encodeMsgCSR          = "CERTIFICATE REQUEST"
 	encodeMsgCert         = "CERTIFICATE"
+
+	notBeforeClockSkew = 15 * time.Minute
 )
 
 var (
@@ -60,25 +62,27 @@ func genCSRTemplate(org string) (*x509.CertificateRequest, error) {
 
 // generateBaseCert returns a base non-CA cert that can be made a workload or CA cert
 // By adding subjects, key usage and additional proerties.
-func generateBaseCert(ttl time.Duration, publicKey interface{}) (*x509.Certificate, error) {
+func generateBaseCert(ttl, skew time.Duration, publicKey interface{}) (*x509.Certificate, error) {
 	serNum, err := newSerialNumber()
 	if err != nil {
 		return nil, err
 	}
 
 	now := time.Now().UTC()
+	// Allow for clock skew with the NotBefore validity bound.
+	notBefore := now.Add(-1 * skew)
 	notAfter := now.Add(ttl)
 
 	return &x509.Certificate{
 		SerialNumber: serNum,
-		NotBefore:    now,
+		NotBefore:    notBefore,
 		NotAfter:     notAfter,
 		PublicKey:    publicKey,
 	}, nil
 }
 
-func GenerateIssuerCertCSR(cn string, publicKey interface{}, ttl time.Duration) (*x509.Certificate, error) {
-	cert, err := generateBaseCert(ttl, publicKey)
+func GenerateIssuerCertCSR(cn string, publicKey interface{}, ttl, skew time.Duration) (*x509.Certificate, error) {
+	cert, err := generateBaseCert(ttl, skew, publicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +99,8 @@ func GenerateIssuerCertCSR(cn string, publicKey interface{}, ttl time.Duration) 
 }
 
 // GenerateRootCertCSR returns a CA root cert x509 Certificate
-func GenerateRootCertCSR(org, cn string, publicKey interface{}, ttl time.Duration) (*x509.Certificate, error) {
-	cert, err := generateBaseCert(ttl, publicKey)
+func GenerateRootCertCSR(org, cn string, publicKey interface{}, ttl, skew time.Duration) (*x509.Certificate, error) {
+	cert, err := generateBaseCert(ttl, skew, publicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +120,8 @@ func GenerateRootCertCSR(org, cn string, publicKey interface{}, ttl time.Duratio
 
 // GenerateCSRCertificate returns an x509 Certificate from a CSR, signing cert, public key, signing private key and duration.
 func GenerateCSRCertificate(csr *x509.CertificateRequest, subject string, identityBundle *identity.Bundle, signingCert *x509.Certificate, publicKey interface{}, signingKey crypto.PrivateKey,
-	ttl time.Duration, isCA bool) ([]byte, error) {
-	cert, err := generateBaseCert(ttl, publicKey)
+	ttl, skew time.Duration, isCA bool) ([]byte, error) {
+	cert, err := generateBaseCert(ttl, skew, publicKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating csr certificate")
 	}

--- a/pkg/sentry/csr/csr_test.go
+++ b/pkg/sentry/csr/csr_test.go
@@ -20,7 +20,7 @@ func TestGenerateCSRTemplate(t *testing.T) {
 
 func TestGenerateBaseCertificate(t *testing.T) {
 	pk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	cert, err := generateBaseCert(time.Second*5, pk)
+	cert, err := generateBaseCert(time.Second*5, time.Minute*15, pk)
 
 	assert.NoError(t, err)
 	assert.Equal(t, cert.PublicKey, pk)
@@ -28,7 +28,7 @@ func TestGenerateBaseCertificate(t *testing.T) {
 
 func TestGenerateIssuerCertCSR(t *testing.T) {
 	pk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	cert, err := GenerateIssuerCertCSR("name", pk, time.Second*5)
+	cert, err := GenerateIssuerCertCSR("name", pk, time.Second*5, time.Minute*15)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "name", cert.DNSNames[0])
@@ -37,7 +37,7 @@ func TestGenerateIssuerCertCSR(t *testing.T) {
 
 func TestGenerateRootCertCSR(t *testing.T) {
 	pk, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	cert, err := GenerateRootCertCSR("org", "name", pk, time.Second*5)
+	cert, err := GenerateRootCertCSR("org", "name", pk, time.Second*5, time.Minute*15)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "name", cert.Subject.CommonName)


### PR DESCRIPTION
# Description

This PR subtracts the configurable `AllowableClockSkew` MTS setting from `time.Now()` for the NotBefore field of the x509 Certificate generated by Sentry.

## Issue reference

Resolves: #3063

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
