### PR TITLE
Add protocol field to api rule

### DIFF
--- a/charts/dapr/crds/configuration.yaml
+++ b/charts/dapr/crds/configuration.yaml
@@ -78,6 +78,8 @@ spec:
                       properties:
                         name:
                           type: string
+                        protocol:
+                          type: string
                         version:
                           type: string
                       required:

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -54,8 +54,9 @@ type APISpec struct {
 
 // APIAccessRule describes an access rule for allowing a Dapr API to be enabled and accessible by an app
 type APIAccessRule struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Protocol string `json:"protocol"`
 }
 
 // NameResolutionSpec is the spec for name resolution configuration

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -115,8 +115,9 @@ type APISpec struct {
 
 // APIAccessRule describes an access rule for allowing a Dapr API to be enabled and accessible by an app
 type APIAccessRule struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Protocol string `json:"protocol"`
 }
 
 type HandlerSpec struct {

--- a/pkg/grpc/endpoints.go
+++ b/pkg/grpc/endpoints.go
@@ -54,13 +54,23 @@ var endpoints = map[string][]string{
 	},
 }
 
+const protocol = "grpc"
+
 func setAPIEndpointsMiddlewareUnary(rules []config.APIAccessRule) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if len(rules) == 0 {
+		var grpcRules []config.APIAccessRule
+
+		for _, rule := range rules {
+			if rule.Protocol == protocol {
+				grpcRules = append(grpcRules, rule)
+			}
+		}
+
+		if len(grpcRules) == 0 {
 			return handler(ctx, req)
 		}
 
-		for _, rule := range rules {
+		for _, rule := range grpcRules {
 			if list, ok := endpoints[rule.Name+"."+rule.Version]; ok {
 				for _, method := range list {
 					if method == info.FullMethod {

--- a/pkg/grpc/endpoints_test.go
+++ b/pkg/grpc/endpoints_test.go
@@ -22,8 +22,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("state endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "state",
-				Version: "v1",
+				Name:     "state",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -51,8 +52,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("publish endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "publish",
-				Version: "v1",
+				Name:     "publish",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -80,8 +82,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("actors endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "actors",
-				Version: "v1",
+				Name:     "actors",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -109,8 +112,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("bindings endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "bindings",
-				Version: "v1",
+				Name:     "bindings",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -138,8 +142,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("secrets endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "secrets",
-				Version: "v1",
+				Name:     "secrets",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -167,8 +172,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("metadata endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "metadata",
-				Version: "v1",
+				Name:     "metadata",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -196,8 +202,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("shutdown endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "shutdown",
-				Version: "v1",
+				Name:     "shutdown",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -225,8 +232,9 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 	t.Run("invoke endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
-				Name:    "invoke",
-				Version: "v1",
+				Name:     "invoke",
+				Version:  "v1",
+				Protocol: "grpc",
 			},
 		}
 
@@ -260,6 +268,27 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			}, h)
 			assert.NoError(t, err)
 		}
+
+		for _, v := range endpoints {
+			for _, e := range v {
+				_, err := f(nil, nil, &grpc.UnaryServerInfo{
+					FullMethod: e,
+				}, h)
+				assert.NoError(t, err)
+			}
+		}
+	})
+
+	t.Run("protocol mismatch, rule not applied", func(t *testing.T) {
+		a := []config.APIAccessRule{
+			{
+				Name:     "state",
+				Version:  "v1",
+				Protocol: "http",
+			},
+		}
+
+		f := setAPIEndpointsMiddlewareUnary(a)
 
 		for _, v := range endpoints {
 			for _, e := range v {

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -28,6 +28,8 @@ import (
 
 var log = logger.NewLogger("dapr.runtime.http")
 
+const protocol = "http"
+
 // Server is an interface for the Dapr HTTP server
 type Server interface {
 	StartNonBlocking()
@@ -195,7 +197,14 @@ func (s *server) getRouter(endpoints []Endpoint) *routing.Router {
 }
 
 func (s *server) endpointAllowed(endpoint Endpoint) bool {
-	if len(s.apiSpec.Allowed) == 0 {
+	var httpRules []config.APIAccessRule
+
+	for _, rule := range s.apiSpec.Allowed {
+		if rule.Protocol == protocol {
+			httpRules = append(httpRules, rule)
+		}
+	}
+	if len(httpRules) == 0 {
 		return true
 	}
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -208,7 +208,7 @@ func (s *server) endpointAllowed(endpoint Endpoint) bool {
 		return true
 	}
 
-	for _, rule := range s.apiSpec.Allowed {
+	for _, rule := range httpRules {
 		if (strings.Index(endpoint.Route, rule.Name) == 0 && endpoint.Version == rule.Version) || endpoint.Route == "healthz" {
 			return true
 		}

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -42,8 +42,9 @@ func TestAllowedAPISpec(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "state",
-						Version: "v1.0",
+						Name:     "state",
+						Version:  "v1.0",
+						Protocol: "http",
 					},
 				},
 			},
@@ -82,8 +83,9 @@ func TestAllowedAPISpec(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "publish",
-						Version: "v1.0",
+						Name:     "publish",
+						Version:  "v1.0",
+						Protocol: "http",
 					},
 				},
 			},
@@ -122,8 +124,9 @@ func TestAllowedAPISpec(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "invoke",
-						Version: "v1.0",
+						Name:     "invoke",
+						Version:  "v1.0",
+						Protocol: "http",
 					},
 				},
 			},
@@ -162,8 +165,9 @@ func TestAllowedAPISpec(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "bindings",
-						Version: "v1.0",
+						Name:     "bindings",
+						Version:  "v1.0",
+						Protocol: "http",
 					},
 				},
 			},
@@ -202,8 +206,9 @@ func TestAllowedAPISpec(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "metadata",
-						Version: "v1.0",
+						Name:     "metadata",
+						Version:  "v1.0",
+						Protocol: "http",
 					},
 				},
 			},
@@ -242,8 +247,9 @@ func TestAllowedAPISpec(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "secrets",
-						Version: "v1.0",
+						Name:     "secrets",
+						Version:  "v1.0",
+						Protocol: "http",
 					},
 				},
 			},
@@ -282,8 +288,9 @@ func TestAllowedAPISpec(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "shutdown",
-						Version: "v1.0",
+						Name:     "shutdown",
+						Version:  "v1.0",
+						Protocol: "http",
 					},
 				},
 			},
@@ -350,13 +357,45 @@ func TestAllowedAPISpec(t *testing.T) {
 		}
 	})
 
+	t.Run("router handler mismatch protocol, all handlers exist", func(t *testing.T) {
+		s := server{
+			apiSpec: config.APISpec{
+				Allowed: []config.APIAccessRule{
+					{
+						Name:     "state",
+						Version:  "v1.0",
+						Protocol: "grpc",
+					},
+				},
+			},
+		}
+
+		a := &api{}
+		eps := a.APIEndpoints()
+
+		router := s.getRouter(eps)
+		r := &fasthttp.RequestCtx{
+			Request: fasthttp.Request{},
+		}
+
+		for _, e := range eps {
+			path := fmt.Sprintf("/%s/%s", e.Version, e.Route)
+			for _, m := range e.Methods {
+				handler, ok := router.Lookup(m, path, r)
+				assert.NotNil(t, handler)
+				assert.True(t, ok)
+			}
+		}
+	})
+
 	t.Run("router handler rules applied, only handlers exist", func(t *testing.T) {
 		s := server{
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Version: "v1.0",
-						Name:    "state",
+						Version:  "v1.0",
+						Name:     "state",
+						Protocol: "http",
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds a `protocol` field to the API Access Rule to make the choice between an HTTP and gRPC rule clearer than just by using the version.