### PR TITLE
Manually remove CRDs after each test run

### DIFF
--- a/tests/test-infra/clean_up.sh
+++ b/tests/test-infra/clean_up.sh
@@ -14,6 +14,8 @@ for app in $installed_apps; do
     helm uninstall $app -n $1
 done
 
+kubectl delete crds components.dapr.io configurations.dapr.io subscriptions.dapr.io
+
 echo "Trying to delete namespace..."
 kubectl delete namespace $1 --timeout=10m
 


### PR DESCRIPTION
# Description

There is currently no sanctioned way to remove CRDs between kubernetes runs other than to just delete them manually.


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
