### PR TITLE
Fix windows to the patched cluster

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -90,7 +90,7 @@ jobs:
           az login --service-principal -u ${{ secrets.AZURE_LOGIN_USER }} -p ${{ secrets.AZURE_LOGIN_PASS }} --tenant ${{ secrets.AZURE_TENANT }} --output none
       - name: Find the test cluster
         if: env.CHECKOUT_REPO != ''
-        run: ./tests/test-infra/find_cluster.sh ./tests/test-infra/e2e-list.txt
+        run: ./tests/test-infra/find_cluster.sh ./tests/test-infra/e2e-list.${{ matrix.target_os }}.txt
         shell: bash
       - name: Add the test status comment to PR
         if: github.event_name == 'repository_dispatch' && env.CHECKOUT_REPO != ''

--- a/tests/test-infra/e2e-list.linux.txt
+++ b/tests/test-infra/e2e-list.linux.txt
@@ -1,5 +1,3 @@
-dapr-aks-e2e-05
-dapr-aks-e2e-06
 dapr-aks-e2e-07
 dapr-aks-e2e-08
 

--- a/tests/test-infra/e2e-list.windows.txt
+++ b/tests/test-infra/e2e-list.windows.txt
@@ -1,0 +1,2 @@
+dapr-aks-e2e-05
+dapr-aks-e2e-06


### PR DESCRIPTION
# Description

After weeks of testing, we've confirmed that our Windows AKS clusters have been experiencing the upstream k8s bug: 
https://github.com/kubernetes/kubernetes/issues/100384

The kube-proxy version 1.19.12-rc.0 binary is confirmed to address the above. AKS team reports that this fix won't be downstreamed for several more weeks, so in the mean time, I will manually patch our AKS clusters. To simplify this effort, I'm going to separate our 4 existing AKS clusters into 2 linux and 2 Windows. When we used to share these clusters with the perf tests, it made sense to have one big pool. Now that they are separate, we have have 2 & 2. We can probably leave it this way going forward to save us some $$$ (we don't need Windows nodes running in our linux clusters anymore).


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
