### PR TITLE
Default devcontainer to daprio/dapr-dev:0.1.3 image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
 	"name": "Dapr Dev Environment",
 	// Update the container version when you publish dev-container
-	// "image": "docker.io/dapr/dapr-dev:0.1.3",
+	"image": "docker.io/daprio/dapr-dev:0.1.3",
 	// Replace with uncommented line below to build your own local copy of the image
-	"dockerFile": "../docker/Dockerfile-dev",
+	// "dockerFile": "../docker/Dockerfile-dev",
 	"containerEnv": {
 		// Uncomment to overwrite devcontainer .kube/config and .minikube certs with the localhost versions
 		// each time the devcontainer starts, if the respective .kube-localhost/config and .minikube-localhost


### PR DESCRIPTION
# Description

Changed the default devcontainer.json setting to use the newly published daprio/dapr-dev:0.1.3 image instead of building the docker image from scratch each time.

## Issue reference

Resolves: #3229

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
