### PR TITLE
Update developing-dapr and setup docs for Windows

### DIFF
--- a/docs/development/developing-dapr.md
+++ b/docs/development/developing-dapr.md
@@ -18,27 +18,32 @@ git clone https://github.com/dapr/dapr.git github.com/dapr/dapr
 
 ## Build the Dapr binaries
 
-You can build dapr binaries with the `make` tool.
-When running `make`, you need to be at the root of the `dapr/dapr` repo directory, for example: `$GOPATH/src/github.com/dapr/dapr`.
+You can build Dapr binaries with the `make` tool.
 
-Once built, the release binaries will be found in `./dist/{os}_{arch}/release/`, where `{os}_{arch}` is your current OS and architecture.
+> On Windows, the `make` commands must be run under [git-bash](https://www.atlassian.com/git/tutorials/git-bash).
+>
+> These instructions also require that a `make` alias has been created for `mingw32-make.exe` according to the [setup instructions](./setup-dapr-development-env.md#installing-make).
 
-For example, running `make build` on MacOS will generate the directory `./dist/darwin_amd64/release.
+- When running `make`, you need to be at the root of the `dapr/dapr` repo directory, for example: `$GOPATH/src/github.com/dapr/dapr`.
 
-> Note : for a Windows environment with MinGW, use `mingw32-make.exe` instead of `make`.
+- Once built, the release binaries will be found in `./dist/{os}_{arch}/release/`, where `{os}_{arch}` is your current OS and architecture.
 
-- Build for your current local environment
+  For example, running `make build` on an Intel-based MacOS will generate the directory `./dist/darwin_amd64/release`.
 
-```bash
-cd $GOPATH/src/github.com/dapr/dapr/
-make build
-```
+- To build for your current local environment:
 
-- Cross compile for multi platforms
+   ```bash
+   cd $GOPATH/src/github.com/dapr/dapr/
+   make build
+   ```
 
-```bash
-make build GOOS=linux GOARCH=amd64
-```
+- To cross-compile for a different platform:
+
+   ```bash
+   make build GOOS=windows GOARCH=amd64
+   ```
+
+  For example, developers on Windows who prefer to develop in [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10) can use the Linux development environment to cross-compile binaries like `daprd.exe` that run on Windows natively.
 
 ## Run unit tests
 
@@ -48,11 +53,11 @@ make test
 
 ## Debug Dapr
 
-We highly recommend to use [VSCode with Go plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) for your productivity. If you want to use the different editors, you can find the [list of editor plugins](https://github.com/go-delve/delve/blob/master/Documentation/EditorIntegration.md) for Delve.
+We highly recommend using VSCode with the [Go plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) for your productivity. If you want to use other code editors, please refer to the list of [editor plugins for Delve](https://github.com/go-delve/delve/blob/master/Documentation/EditorIntegration.md).
 
-This section introduces how to start debugging with Delve CLI. Please see [Delve documentation](https://github.com/go-delve/delve/tree/master/Documentation) for the detail usage.
+This section introduces how to start debugging with the Delve CLI. Please refer to the [Delve documentation](https://github.com/go-delve/delve/tree/master/Documentation) for more details.
 
-### Start the dapr runtime with a debugger
+### Start the Dapr runtime with a debugger
 
 ```bash
 $ cd $GOPATH/src/github.com/dapr/dapr/cmd/daprd
@@ -64,34 +69,35 @@ Type 'help' for list of commands.
 
 ### Attach a Debugger to running process
 
-This is useful to debug dapr when the process is running.
+This is useful to debug Dapr when the process is running.
 
-1. Build dapr binaries for debugging
-   With `DEBUG=1` option, dapr binaries will be generated without code optimization in `./dist/{os}_{arch}/debug/`
+1. Build Dapr binaries for debugging.
+
+   Use the `DEBUG=1` option to generate Dapr binaries without code optimization in `./dist/{os}_{arch}/debug/`
 
    ```bash
    make DEBUG=1 build
    ```
 
-2. Create component yaml file under `./dist/{os}_{arch}/debug/components` e.g. statestore component yaml
+2. Create a component yaml file under `./dist/{os}_{arch}/debug/components` e.g. statestore component yaml
 
-3. Run dapr runtime
+3. Start the Dapr runtime
 
    ```bash
    /dist/{os}_{arch}/debug/daprd
    ```
 
-4. Find the process id and attach the debugger
+4. Find the process ID (e.g. `PID` displayed by the `ps` command for `daprd`) and attach the debugger
 
    ```bash
-   dlv attach [pid]
+   dlv attach {PID}
    ```
 
 ### Debug unit-tests
 
+Specify the package that you want to test when running the `dlv test`. For example, to debug the `./pkg/actors` tests:
+
 ```bash
-# Specify the package that you want to test
-# e.g. debugging ./pkg/actors
 dlv test ./pkg/actors
 ```
 
@@ -111,16 +117,12 @@ export DAPR_TAG=dev
 
 #### Windows
 
-```powershell
+```cmd
 set DAPR_REGISTRY=docker.io/<your_docker_hub_account>
 set DAPR_TAG=dev
 ```
 
 ### Building the Container Image
-
-Run the appropriate command below to build the container image.
-
-#### Linux/macOS
 
 ```bash
 # Build Linux binaries
@@ -130,37 +132,19 @@ make build-linux
 make docker-build
 ```
 
-#### Windows
-
-```powershell
-# Build Linux binaries
-mingw32-make build-linux
-
-# Build Docker image with Linux binaries
-mingw32-make.exe docker-build
-```
-
 ## Push the Container Image
 
 To push the image to DockerHub, complete your `docker login` and run:
 
-### Linux/macOS
-
 ```bash
 make docker-push
-```
-
-### Windows
-
-```powershell
-mingw32-make.exe docker-push
 ```
 
 ## Deploy Dapr With Your Changes
 
 Now we'll deploy Dapr with your changes.
 
-Create the dapr-system namespace
+To create the dapr-system namespace:
 
 ```bash
 kubectl create namespace dapr-system
@@ -172,18 +156,10 @@ If you deployed Dapr to your cluster before, delete it now using:
 helm uninstall dapr -n dapr-system
 ```
 
-and run the following to deploy your change to your Kubernetes cluster:
-
-### Linux/macOS
+To deploy your changes to your Kubernetes cluster:
 
 ```bash
 make docker-deploy-k8s
-```
-
-### Windows
-
-```powershell
-mingw32-make.exe docker-deploy-k8s
 ```
 
 ## Verifying your changes
@@ -191,7 +167,7 @@ mingw32-make.exe docker-deploy-k8s
 Once Dapr is deployed, print the Dapr pods:
 
 ```bash
-kubectl get pod -n dapr-system
+$ kubectl get pod -n dapr-system
 
 NAME                                    READY   STATUS    RESTARTS   AGE
 dapr-operator-86cddcfcb7-v2zjp          1/1     Running   0          4d3h

--- a/docs/development/setup-dapr-development-env.md
+++ b/docs/development/setup-dapr-development-env.md
@@ -2,6 +2,18 @@
 
 This document helps you get started developing Dapr. If you find any problems while following this guide, please create a Pull Request to update this document.
 
+## Git
+
+1. Install [Git](https://git-scm.com/downloads)
+
+   > On Windows, the Dapr build environment depends on Git BASH that comes as a part of [Git for Windows](https://gitforwindows.org).
+   >
+   > Ensure that the Git and Unix tools are part of the `PATH` environment variable, and that the editor experience is integrated with Windows terminal. For example, if [installing Git with chocolatey](https://chocolatey.org/packages/git), you may want to specify:
+   >
+   > ```cmd
+   > choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTerminal"
+   > ```
+
 ## Docker environment
 
 1. Install [Docker](https://docs.docker.com/install/)
@@ -11,83 +23,70 @@ This document helps you get started developing Dapr. If you find any problems wh
 
 ## Golang dev environment
 
-### Linux and MacOS
-
 1. Download and install [Go 1.16 or later](https://golang.org/doc/install#tarball).
+
    - Make sure that your `GOPATH` and `PATH` environment variables are configured so that go modules can be run. For example:
 
-   ```bash
-   export GOPATH=~/go
-   export PATH=$PATH:$GOPATH/bin
-   ```
+     **Linux and MacOS**
+
+     ```bash
+     export GOPATH=~/go
+     export PATH=$PATH:$GOPATH/bin
+     ```
+
+     **Windows**
+
+     ```cmd
+     set GOPATH=%USERPROFILE%\go
+     set PATH=%PATH%;%GOPATH%\bin
+     ```
 
 2. Install [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation) for Go debugging, if desired.
 
 3. Install [golangci-lint](https://golangci-lint.run/usage/install).
 
-### Windows
-
-1. Download and install [Go 1.16 or later](https://golang.org/doc/install#windows).
-   - Make sure that your `GOPATH` and `PATH` environment variables are configured so that go modules can be run. For example:
-
-   ```cmd
-   set GOPATH=%USERPROFILE%\go
-   set PATH=%PATH%;%GOPATH%\bin
-   ```
-
-   - You may also set environment variables through the "Environment Variables" button on the "Advanced" tab of the "System" control panel. Some versions of Windows provide this control panel through the "Advanced System Settings" option inside the "System" control panel.
-
-2. Install [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation) for Go debugging, if desired.
-   Delve for Go (NOTE: this is NOT Delve from the Office365) is a debugger utility is a debugger for the Go programming language. Please refer to [Delve Home Page](https://github.com/go-delve/delve) for a detailed explanation.
-
-3. [Git for Windows](https://gitforwindows.org)
-   - Install [Git with chocolatey](https://chocolatey.org/packages/git) and ensure that Git bin directory is in PATH environment variable
-
-    ```cmd
-    choco install git -y --package-parameters="/GitAndUnixToolsOnPath /WindowsTerminal /NoShellIntegration"
-    ```
-
-4. [MinGW](https://sourceforge.net/projects/mingw/files/MinGW)
-   Install [MinGW v8.1.0 with chocolatey](https://chocolatey.org/packages/mingw/8.1.0) and ensure that MinGW bin directory is in PATH environment variable. Version 8.1.0 is the last version that installs mingw32-make.exe.
-
-    ```cmd
-    choco install mingw --version 8.1.0
-    ```
-
-5. Rename mingw32-make.exe to make.exe from an administrative PowerShell.
-
-    ```cmd
-    copy C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\mingw32-make.exe C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\make.exe
-    ```
-
 ## Setup a Kubernetes development environment
 
-Follow the guide on [how to set up a Kubernetes cluster for Dapr](https://docs.dapr.io/operations/hosting/kubernetes/cluster/).
+1. Follow the guide on [how to set up a Kubernetes cluster for Dapr](https://docs.dapr.io/operations/hosting/kubernetes/cluster/).
 
-For development purposes, you will also want to follow the optional steps to install [Helm 3.x](https://helm.sh/docs/intro/install/).
+2. For development purposes, you will also want to follow the optional steps to install [Helm 3.x](https://helm.sh/docs/intro/install/).
 
 ## Installing Make
 
-Dapr uses `make` to build and test its binaries.
-
-### Windows
-
-Download [MingGW](https://sourceforge.net/projects/mingw/files/MinGW/Extension/make/mingw32-make-3.80-3/) and use `ming32-make.exe` instead of `make`.
-
-Make sure `ming32-make.exe` is in your path.
+Dapr uses `make` for a variety of build and test actions, and needs to be installed as appropriate for your platform:
 
 ### Linux
 
-```bash
-sudo apt-get install build-essential
-```
+1. Install the `build-essential` package:
 
-### Mac
+   ```bash
+   sudo apt-get install build-essential
+   ```
 
-In Xcode preferences go to the "Downloads" tab and under "Components" push the "Install" button next to "Command Line Tools". After you have successfully downloaded and installed the command line tools you should also type the following command in the Terminal to make sure all your Xcode command line tools are switched to use the new versions:
+### MacOS
 
-```bash
-sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
-```
+1. In Xcode Preferences, go to the _Downloads_ tab.
+2. Under _Components_ push the _Install_ button next to _Command Line Tools_.
+3. After the tools are installed, ensure that the tools are switched to the new versions:
 
-Once everything is successfully installed you should see `make` and other command line developer tools in `/usr/bin`.
+   ```bash
+   sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
+   ```
+
+4. When completed, you should see `make` and other command line developer tools in `/usr/bin`.
+
+### Windows
+
+1. Install [MinGW v8.1.0](https://chocolatey.org/packages/mingw/8.1.0) with [Chocolatey](https://chocolatey.org/install):
+
+   ```cmd
+   choco install mingw --version 8.1.0
+   ```
+
+   > Versions of MinGW newer than 8.1.0 will not contain `mingw32-make.exe`, so the `--version` must be specified.
+
+2. Create a link to `mingw32-make.exe` so that it can be invoked as `make`:
+
+   ```cmd
+   mklink C:\ProgramData\chocolatey\bin\make.exe C:\ProgramData\chocolatey\bin\mingw32-make.exe
+   ```


### PR DESCRIPTION
# Description

- Update the developer docs to clarify issues around Windows dev environment setup pointed out in #2529. 
- Simplify the developer docs so that the `make` commands are convergent with Linux/MacOS commands.
- Align the manual instructions with what the dapr.yml workflow uses in the GitHub runner [Windows 2019](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md) configuration. 
   - In particular, running under git-bash resolves `make build` and `make lint` issues encountered with previous instructions.
  
## Issue reference

Resolves: #2529 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
