### PR TITLE
Write reminders in multiple partitions

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -547,10 +547,11 @@ func (a *actorsRuntime) drainRebalancedActors() {
 			actorType, actorID := a.getActorTypeAndIDFromKey(actorKey)
 			address, _ := a.placement.LookupActor(actorType, actorID)
 			if address != "" && !a.isActorLocal(address, a.config.HostAddress, a.config.Port) {
-				// actor has been moved to a different host, deactivate when calls are done
-				// cancel any reminders
+				// actor has been moved to a different host, deactivate when calls are done cancel any reminders
+				// each item in reminders contain a struct with some metadata + the actual reminder struct
 				reminders := a.reminders[actorType]
 				for _, r := range reminders {
+					// r.reminder refers to the actual reminder struct that is saved in the db
 					if r.reminder.ActorType == actorType && r.reminder.ActorID == actorID {
 						reminderKey := constructCompositeKey(actorKey, r.reminder.Name)
 						stopChan, exists := a.activeReminders.Load(reminderKey)
@@ -1295,7 +1296,7 @@ func (a *actorsRuntime) migrateRemindersForActorType(actorType string, actorMeta
 		return nil, err
 	}
 
-	// Save new metadata so the new "metadataID" becomes the new de-factor referenced list for reminders.
+	// Save new metadata so the new "metadataID" becomes the new de factor referenced list for reminders.
 	err = a.saveActorTypeMetadata(actorType, actorMetadata)
 	if err != nil {
 		return nil, err

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dapr/components-contrib/state"
 	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -580,6 +580,23 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 }
 
 func TestDeleteReminder(t *testing.T) {
+	appChannel := new(mockAppChannel)
+	testActorsRuntime := newTestActorsRuntimeWithMockAndActorMetadataPartition(appChannel)
+	actorType, actorID := getTestActorTypeAndID()
+	ctx := context.Background()
+	reminder := createReminderData(actorID, actorType, "reminder1", "1s", "1s", "")
+	testActorsRuntime.CreateReminder(ctx, &reminder)
+	assert.Equal(t, 1, len(testActorsRuntime.reminders[actorType]))
+	err := testActorsRuntime.DeleteReminder(ctx, &DeleteReminderRequest{
+		Name:      "reminder1",
+		ActorID:   actorID,
+		ActorType: actorType,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(testActorsRuntime.reminders[actorType]))
+}
+
+func TestDeleteReminderWithPartitions(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()
 	ctx := context.Background()

--- a/pkg/actors/config.go
+++ b/pkg/actors/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	DrainRebalancedActors         bool
 	Namespace                     string
 	Reentrancy                    app_config.ReentrancyConfig
+	RemindersStoragePartitions    int
 }
 
 const (
@@ -38,7 +39,7 @@ const (
 // NewConfig returns the actor runtime configuration.
 func NewConfig(hostAddress, appID string, placementAddresses []string, hostedActors []string, port int,
 	actorScanInterval, actorIdleTimeout, ongoingCallTimeout string, drainRebalancedActors bool, namespace string,
-	reentrancy app_config.ReentrancyConfig) Config {
+	reentrancy app_config.ReentrancyConfig, remindersStoragePartitions int) Config {
 	c := Config{
 		HostAddress:                   hostAddress,
 		AppID:                         appID,
@@ -52,6 +53,7 @@ func NewConfig(hostAddress, appID string, placementAddresses []string, hostedAct
 		DrainRebalancedActors:         drainRebalancedActors,
 		Namespace:                     namespace,
 		Reentrancy:                    reentrancy,
+		RemindersStoragePartitions:    remindersStoragePartitions,
 	}
 
 	scanDuration, err := time.ParseDuration(actorScanInterval)

--- a/pkg/config/app_configuration.go
+++ b/pkg/config/app_configuration.go
@@ -13,9 +13,10 @@ type ApplicationConfig struct {
 	// Duration. example: "30s"
 	ActorScanInterval string `json:"actorScanInterval"`
 	// Duration. example: "30s"
-	DrainOngoingCallTimeout string           `json:"drainOngoingCallTimeout"`
-	DrainRebalancedActors   bool             `json:"drainRebalancedActors"`
-	Reentrancy              ReentrancyConfig `json:"reentrancy,omitempty"`
+	DrainOngoingCallTimeout    string           `json:"drainOngoingCallTimeout"`
+	DrainRebalancedActors      bool             `json:"drainRebalancedActors"`
+	Reentrancy                 ReentrancyConfig `json:"reentrancy,omitempty"`
+	RemindersStoragePartitions int              `json:"remindersStoragePartitions"`
 }
 
 type ReentrancyConfig struct {

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -36,6 +36,7 @@ const (
 	HTTPProtocol                = "http"
 	GRPCProtocol                = "grpc"
 	ActorRentrancy      Feature = "Actor.Reentrancy"
+	ActorTypeMetadata   Feature = "Actor.TypeMetadata"
 )
 
 type Feature string

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1390,7 +1390,8 @@ func (a *DaprRuntime) initActors() error {
 		return err
 	}
 	actorConfig := actors.NewConfig(a.hostAddress, a.runtimeConfig.ID, a.runtimeConfig.PlacementAddresses, a.appConfig.Entities,
-		a.runtimeConfig.InternalGRPCPort, a.appConfig.ActorScanInterval, a.appConfig.ActorIdleTimeout, a.appConfig.DrainOngoingCallTimeout, a.appConfig.DrainRebalancedActors, a.namespace, a.appConfig.Reentrancy)
+		a.runtimeConfig.InternalGRPCPort, a.appConfig.ActorScanInterval, a.appConfig.ActorIdleTimeout, a.appConfig.DrainOngoingCallTimeout,
+		a.appConfig.DrainRebalancedActors, a.namespace, a.appConfig.Reentrancy, a.appConfig.RemindersStoragePartitions)
 	act := actors.NewActors(a.stateStores[a.actorStateStoreName], a.appChannel, a.grpc.GetGRPCConnection, actorConfig, a.runtimeConfig.CertChain, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.Features)
 	err = act.Init()
 	a.actor = act

--- a/tests/config/app_actor_type_metadata.yaml
+++ b/tests/config/app_actor_type_metadata.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: actortypemetadata
+spec:
+  features:
+    - name: Actor.TypeMetadata
+      enabled: true

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -243,6 +243,7 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/uppercase.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/pipeline.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/app_reentrant_actor.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/app_actor_type_metadata.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/kubernetes_grpc_proxy_config.yaml --namespace $(DAPR_TEST_NAMESPACE)
 
 	# Show the installed components

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -143,6 +143,9 @@ func TestActorReminder(t *testing.T) {
 				time.Sleep(secondsToCheckReminderResult * time.Second)
 
 				for i := 0; i < numActorsPerThread; i++ {
+					_, err := utils.HTTPGetNTimes(externalURL, numHealthChecks)
+					require.NoError(t, err)
+
 					actorID := fmt.Sprintf(actorIDRestartTemplate, i+(1000*iteration))
 					// Unregistering reminder
 					_, err = utils.HTTPDelete(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName))

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -196,53 +196,6 @@ func TestActorReminder(t *testing.T) {
 
 		t.Log("Done.")
 	})
-
-	t.Run("Actor reminder changes number of partitions.", func(t *testing.T) {
-		for i := 0; i < numActorsPerThread; i++ {
-			if i == numActorsPerThread/2 {
-				// We change the number of partitions midway.
-				// This will test that the migration path also works.
-				// And validate that new reminders can work after increasing number of partitions.
-				tr.Platform.SetAppEnv(appName, "TEST_APP_ACTOR_REMINDERS_PARTITIONS", "5")
-			}
-
-			actorID := fmt.Sprintf(actorIDPartitionTemplate, i+1000)
-			// Deleting pre-existing reminder
-			_, err = utils.HTTPDelete(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName))
-			require.NoError(t, err)
-
-			// Registering reminder
-			_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName), reminderBody)
-			require.NoError(t, err)
-		}
-
-		t.Logf("Sleeping for %d seconds ...", secondsToCheckReminderResult)
-		time.Sleep(secondsToCheckReminderResult * time.Second)
-
-		for i := 0; i < numActorsPerThread; i++ {
-			actorID := fmt.Sprintf(actorIDRestartTemplate, i+1000)
-			// Unregistering reminder
-			_, err = utils.HTTPDelete(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName))
-			require.NoError(t, err)
-		}
-
-		t.Logf("Getting logs from %s to see if reminders did trigger ...", logsURL)
-		resp, err := utils.HTTPGet(logsURL)
-		require.NoError(t, err)
-
-		t.Log("Checking if all reminders did trigger ...")
-		// Errors below should NOT be considered flakyness and must be investigated.
-		// If there was no other error until now, there should be reminders triggered.
-		for i := 0; i < numActorsPerThread; i++ {
-			actorID := fmt.Sprintf(actorIDRestartTemplate, i+1000)
-			count := countActorAction(resp, actorID, reminderName)
-			// Due to possible load stress, we do not expect all reminders to be called at the same frequency.
-			// There are other E2E tests that validate the correct frequency of reminders in a happy path.
-			require.True(t, count >= 1, "Reminder %s for Actor %s was invoked %d times.", reminderName, actorID, count)
-		}
-
-		t.Log("Done.")
-	})
 }
 
 func TestActorReminderPeriod(t *testing.T) {

--- a/tests/e2e/actor_reminder_partition/actor_reminder_partition_test.go
+++ b/tests/e2e/actor_reminder_partition/actor_reminder_partition_test.go
@@ -1,0 +1,167 @@
+// +build e2e
+
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package actor_reminder_e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dapr/dapr/tests/e2e/utils"
+	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
+	"github.com/dapr/dapr/tests/runner"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	appName                      = "actorreminderpartition"                      // App name in Dapr.
+	actorIDPartitionTemplate     = "actor-reminder-partition-test-%d"            // Template for Actor ID.
+	reminderName                 = "PartitionTestReminder"                       // Reminder name.
+	numIterations                = 7                                             // Number of times each test should run.
+	numHealthChecks              = 60                                            // Number of get calls before starting tests.
+	numActorsPerThread           = 10                                            // Number of get calls before starting tests.
+	secondsToCheckReminderResult = 20 + 60                                       // How much time to wait to make sure the result is in logs.
+	actorInvokeURLFormat         = "%s/test/testactorreminderpartition/%s/%s/%s" // URL to invoke a Dapr's actor method in test app.
+	actorlogsURLFormat           = "%s/test/logs"                                // URL to fetch logs from test app.
+)
+
+// represents a response for the APIs in this app.
+type actorLogEntry struct {
+	Action         string `json:"action,omitempty"`
+	ActorType      string `json:"actorType,omitempty"`
+	ActorID        string `json:"actorId,omitempty"`
+	StartTimestamp int    `json:"startTimestamp,omitempty"`
+	EndTimestamp   int    `json:"endTimestamp,omitempty"`
+}
+
+type actorReminder struct {
+	Data     string `json:"data,omitempty"`
+	DueTime  string `json:"dueTime,omitempty"`
+	Period   string `json:"period,omitempty"`
+	Callback string `json:"callback,omitempty"`
+}
+
+func parseLogEntries(resp []byte) []actorLogEntry {
+	logEntries := []actorLogEntry{}
+	err := json.Unmarshal(resp, &logEntries)
+	if err != nil {
+		return nil
+	}
+
+	return logEntries
+}
+
+func countActorAction(resp []byte, actorID string, action string) int {
+	count := 0
+	logEntries := parseLogEntries(resp)
+	for _, logEntry := range logEntries {
+		if (logEntry.ActorID == actorID) && (logEntry.Action == action) {
+			count++
+		}
+	}
+
+	return count
+}
+
+var tr *runner.TestRunner
+
+func TestMain(m *testing.M) {
+	// These apps will be deployed before starting actual test
+	// and will be cleaned up after all tests are finished automatically
+	testApps := []kube.AppDescription{
+		{
+			AppName:        appName,
+			DaprEnabled:    true,
+			ImageName:      "e2e-actorfeatures",
+			Replicas:       1,
+			IngressEnabled: true,
+			MetricsEnabled: true,
+			DaprCPULimit:   "2.0",
+			DaprCPURequest: "0.1",
+			AppCPULimit:    "2.0",
+			AppCPURequest:  "0.1",
+			AppEnv: map[string]string{
+				"TEST_APP_ACTOR_TYPE": "testactorreminderpartition",
+			},
+		},
+	}
+
+	tr = runner.NewTestRunner(appName, testApps, nil, nil)
+	os.Exit(tr.Start(m))
+}
+
+func TestActorReminder(t *testing.T) {
+	externalURL := tr.Platform.AcquireAppExternalURL(appName)
+	require.NotEmpty(t, externalURL, "external URL must not be empty!")
+
+	logsURL := fmt.Sprintf(actorlogsURLFormat, externalURL)
+
+	// This initial probe makes the test wait a little bit longer when needed,
+	// making this test less flaky due to delays in the deployment.
+	t.Logf("Checking if app is healthy ...")
+	_, err := utils.HTTPGetNTimes(externalURL, numHealthChecks)
+	require.NoError(t, err)
+
+	// Set reminder
+	reminder := actorReminder{
+		Data:    "reminderdata",
+		DueTime: "1s",
+		Period:  "1s",
+	}
+	reminderBody, err := json.Marshal(reminder)
+	require.NoError(t, err)
+
+	t.Run("Actor reminder changes number of partitions.", func(t *testing.T) {
+		for i := 0; i < numActorsPerThread; i++ {
+			if i == numActorsPerThread/2 {
+				// We change the number of partitions midway.
+				// This will test that the migration path also works.
+				// And validate that new reminders can work after increasing number of partitions.
+				tr.Platform.SetAppEnv(appName, "TEST_APP_ACTOR_REMINDERS_PARTITIONS", "5")
+			}
+
+			actorID := fmt.Sprintf(actorIDPartitionTemplate, i+1000)
+			// Deleting pre-existing reminder
+			_, err = utils.HTTPDelete(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName))
+			require.NoError(t, err)
+
+			// Registering reminder
+			_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName), reminderBody)
+			require.NoError(t, err)
+		}
+
+		t.Logf("Sleeping for %d seconds ...", secondsToCheckReminderResult)
+		time.Sleep(secondsToCheckReminderResult * time.Second)
+
+		for i := 0; i < numActorsPerThread; i++ {
+			actorID := fmt.Sprintf(actorIDPartitionTemplate, i+1000)
+			// Unregistering reminder
+			_, err = utils.HTTPDelete(fmt.Sprintf(actorInvokeURLFormat, externalURL, actorID, "reminders", reminderName))
+			require.NoError(t, err)
+		}
+
+		t.Logf("Getting logs from %s to see if reminders did trigger ...", logsURL)
+		resp, err := utils.HTTPGet(logsURL)
+		require.NoError(t, err)
+
+		t.Log("Checking if all reminders did trigger ...")
+		// Errors below should NOT be considered flakyness and must be investigated.
+		// If there was no other error until now, there should be reminders triggered.
+		for i := 0; i < numActorsPerThread; i++ {
+			actorID := fmt.Sprintf(actorIDPartitionTemplate, i+1000)
+			count := countActorAction(resp, actorID, reminderName)
+			// Due to possible load stress, we do not expect all reminders to be called at the same frequency.
+			// There are other E2E tests that validate the correct frequency of reminders in a happy path.
+			require.True(t, count >= 1, "Reminder %s for Actor %s was invoked %d times.", reminderName, actorID, count)
+		}
+
+		t.Log("Done.")
+	})
+}

--- a/tests/e2e/actor_reminder_partition/actor_reminder_partition_test.go
+++ b/tests/e2e/actor_reminder_partition/actor_reminder_partition_test.go
@@ -27,7 +27,7 @@ const (
 	numIterations                = 7                                             // Number of times each test should run.
 	numHealthChecks              = 60                                            // Number of get calls before starting tests.
 	numActorsPerThread           = 10                                            // Number of get calls before starting tests.
-	secondsToCheckReminderResult = 20 + 60                                       // How much time to wait to make sure the result is in logs.
+	secondsToCheckReminderResult = 20                                            // How much time to wait to make sure the result is in logs.
 	actorInvokeURLFormat         = "%s/test/testactorreminderpartition/%s/%s/%s" // URL to invoke a Dapr's actor method in test app.
 	actorlogsURLFormat           = "%s/test/logs"                                // URL to fetch logs from test app.
 )
@@ -90,6 +90,7 @@ func TestMain(m *testing.M) {
 			AppEnv: map[string]string{
 				"TEST_APP_ACTOR_TYPE": "testactorreminderpartition",
 			},
+			Config: "actortypemetadata",
 		},
 	}
 

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -266,6 +266,20 @@ func (c *KubeTestPlatform) Scale(name string, replicas int32) error {
 	return err
 }
 
+// SetAppEnv sets the container environment variable.
+func (c *KubeTestPlatform) SetAppEnv(name, key, value string) error {
+	app := c.AppResources.FindActiveResource(name)
+	appManager := app.(*kube.AppManager)
+
+	if err := appManager.SetAppEnv(key, value); err != nil {
+		return err
+	}
+
+	_, err := appManager.WaitUntilDeploymentState(appManager.IsDeploymentDone)
+
+	return err
+}
+
 // Restart restarts all instances for the app.
 func (c *KubeTestPlatform) Restart(name string) error {
 	// To minic the restart behavior, scale to 0 and then scale to the original replicas.

--- a/tests/runner/testrunner.go
+++ b/tests/runner/testrunner.go
@@ -33,6 +33,7 @@ type PlatformInterface interface {
 	Restart(name string) error
 	Scale(name string, replicas int32) error
 	PortForwardToApp(appName string, targetPort ...int) ([]int, error)
+	SetAppEnv(appName, key, value string) error
 	GetAppUsage(appName string) (*AppUsage, error)
 	GetSidecarUsage(appName string) (*AppUsage, error)
 	GetTotalRestarts(appname string) (int, error)

--- a/tests/runner/testrunner_test.go
+++ b/tests/runner/testrunner_test.go
@@ -61,6 +61,11 @@ func (m *MockPlatform) Scale(name string, replicas int32) error {
 	return args.Error(0)
 }
 
+func (m *MockPlatform) SetAppEnv(name, key, value string) error {
+	args := m.Called(key)
+	return args.Error(0)
+}
+
 func (m *MockPlatform) Restart(name string) error {
 	args := m.Called(name)
 	return args.Error(0)


### PR DESCRIPTION
# Description

Split actor reminders storage into multiple keys.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #2889 
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
