### PR TITLE
Revert container order change

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -156,7 +156,7 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 		value = []corev1.Container{*sidecarContainer}
 	} else {
 		envPatchOps = addDaprEnvVarsToContainers(pod.Spec.Containers)
-		path = "/spec/containers/0"
+		path = "/spec/containers/-"
 		value = sidecarContainer
 	}
 
@@ -188,7 +188,7 @@ func addDaprEnvVarsToContainers(containers []corev1.Container) []PatchOperation 
 	}
 	envPatchOps := make([]PatchOperation, 0, len(containers))
 	for i, container := range containers {
-		path := fmt.Sprintf("%s/%d/env", containersPath, i+1)
+		path := fmt.Sprintf("%s/%d/env", containersPath, i)
 		patchOps := getEnvPatchOperations(container.Env, portEnv, path)
 		envPatchOps = append(envPatchOps, patchOps...)
 	}

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -231,7 +231,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 			expOps: []PatchOperation{
 				{
 					Op:   "add",
-					Path: "/spec/containers/1/env",
+					Path: "/spec/containers/0/env",
 					Value: []corev1.EnvVar{
 						{
 							Name:  userContainerDaprHTTPPortName,
@@ -260,7 +260,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 			expOps: []PatchOperation{
 				{
 					Op:   "add",
-					Path: "/spec/containers/1/env/-",
+					Path: "/spec/containers/0/env/-",
 					Value: corev1.EnvVar{
 						Name:  userContainerDaprHTTPPortName,
 						Value: strconv.Itoa(sidecarHTTPPort),
@@ -268,7 +268,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 				},
 				{
 					Op:   "add",
-					Path: "/spec/containers/1/env/-",
+					Path: "/spec/containers/0/env/-",
 					Value: corev1.EnvVar{
 						Name:  userContainerDaprGRPCPortName,
 						Value: strconv.Itoa(sidecarAPIGRPCPort),
@@ -295,7 +295,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 			expOps: []PatchOperation{
 				{
 					Op:   "add",
-					Path: "/spec/containers/1/env/-",
+					Path: "/spec/containers/0/env/-",
 					Value: corev1.EnvVar{
 						Name:  userContainerDaprHTTPPortName,
 						Value: strconv.Itoa(sidecarHTTPPort),


### PR DESCRIPTION
This PR reverts https://github.com/dapr/dapr/pull/3150 to fix a regression where the container startup time may grow to 1s - 60s+ in some scenarios.