### PR TITLE
Remove lifecycle hook (#3308)

### DIFF
--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
-appVersion: "1.2.1"
+appVersion: "1.2.2"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: 1.2.1
+version: 1.2.2
 dependencies:
   - name: dapr_rbac
-    version: "1.2.1"
+    version: "1.2.2"
     repository: "file://dapr_rbac"
   - name: dapr_operator
-    version: "1.2.1"
+    version: "1.2.2"
     repository: "file://dapr_operator"
   - name: dapr_placement
-    version: "1.2.1"
+    version: "1.2.2"
     repository: "file://dapr_placement"
   - name: dapr_sidecar_injector
-    version: "1.2.1"
+    version: "1.2.2"
     repository: "file://dapr_sidecar_injector"
   - name: dapr_sentry
-    version: "1.2.1"
+    version: "1.2.2"
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
     version: "0.7.0"

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -76,7 +76,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
 | `global.registry`                         | Docker image registry                                                   | `docker.io/daprio`      |
-| `global.tag`                              | Docker image version tag                                                | `1.2.1`                 |
+| `global.tag`                              | Docker image version tag                                                | `1.2.2`                 |
 | `global.logAsJson`                        | Json log format for control plane services                              | `false`                 |
 | `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
 | `global.imagePullSecret`                  | Control plane service image pull secret for docker registry             | `""`                    |

--- a/charts/dapr/charts/dapr_config/Chart.yaml
+++ b/charts/dapr/charts/dapr_config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr configuration
 name: dapr_config
-version: 1.2.1
+version: 1.2.2

--- a/charts/dapr/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: 1.2.1
+version: 1.2.2

--- a/charts/dapr/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr/charts/dapr_placement/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: 1.2.1
+version: 1.2.2

--- a/charts/dapr/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr/charts/dapr_rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC components
 name: dapr_rbac
-version: 1.2.1
+version: 1.2.2

--- a/charts/dapr/charts/dapr_sentry/Chart.yaml
+++ b/charts/dapr/charts/dapr_sentry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Sentry
 name: dapr_sentry
-version: 1.2.1
+version: 1.2.2

--- a/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: 1.2.1
+version: 1.2.2

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "1.2.1"
+  tag: "1.2.2"
   dnsSuffix: ".cluster.local"
   logAsJson: false
   imagePullPolicy: IfNotPresent

--- a/docs/release_notes/v1.2.1 copy.md
+++ b/docs/release_notes/v1.2.1 copy.md
@@ -1,0 +1,17 @@
+  
+# Dapr 1.2.2
+
+## Fixes
+
+* Container order change clashes with readiness probes (https://github.com/dapr/dapr/issues/3304)
+
+### Overview
+
+This release contains a fix that complements the 1.2.1 regression fix, removing a lifecycle hook that causes additional deployment configurations on Kubernetes
+To delay startup times.
+
+You should upgrade to this version if all the following conditions are met:
+
+1. You are using Dapr on Kubernetes
+2. Your app has readiness probes
+3. Your app configured a `dapr.io/app-port` setting

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -597,13 +597,6 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 			PeriodSeconds:       getInt32AnnotationOrDefault(annotations, daprLivenessProbePeriodKey, defaultHealthzProbePeriodSeconds),
 			FailureThreshold:    getInt32AnnotationOrDefault(annotations, daprLivenessProbeThresholdKey, defaultHealthzProbeThreshold),
 		},
-		Lifecycle: &corev1.Lifecycle{
-			PostStart: &corev1.Handler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/daprd", "--wait"},
-				},
-			},
-		},
 	}
 
 	c.Env = append(c.Env, utils.ParseEnvString(annotations[daprEnvKey])...)


### PR DESCRIPTION
Remove lifecycle hook to eliminate  intermittent startup delay for Kubernetes deployments caused by a Lifecycle hook that is never executed.