### PR TITLE
Fix a concurrent bug and a typo about state api

### DIFF
--- a/pkg/components/state/registry.go
+++ b/pkg/components/state/registry.go
@@ -52,13 +52,13 @@ func (s *stateStoreRegistry) Register(components ...State) {
 }
 
 func (s *stateStoreRegistry) Create(name, version string) (state.Store, error) {
-	if method, ok := s.getSecretStore(name, version); ok {
+	if method, ok := s.getStateStore(name, version); ok {
 		return method(), nil
 	}
 	return nil, errors.Errorf("couldn't find state store %s/%s", name, version)
 }
 
-func (s *stateStoreRegistry) getSecretStore(name, version string) (func() state.Store, bool) {
+func (s *stateStoreRegistry) getStateStore(name, version string) (func() state.Store, bool) {
 	nameLower := strings.ToLower(name)
 	versionLower := strings.ToLower(version)
 	stateStoreFn, ok := s.stateStores[nameLower+"/"+versionLower]


### PR DESCRIPTION
# Description

1. fix a race condition in grpc/api.go, see https://github.com/dapr/dapr/issues/3323

2. fix a typo.Change 'getSecretStore' to 'getStateStore' in pkg/components/state/registry.go

## Issue reference
#3323


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
