### PR TITLE
fix: InvokeBinding API does not return metadata in HTTP (#3326)

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -397,7 +397,7 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 	if resp == nil {
 		respond(reqCtx, withEmpty())
 	} else {
-		respond(reqCtx, withJSON(fasthttp.StatusOK, resp.Data))
+		respond(reqCtx, withMetadata(resp.Metadata), withJSON(fasthttp.StatusOK, resp.Data))
 	}
 }
 


### PR DESCRIPTION
# Description

fix: InvokeBinding API does not return metadata in HTTP (#3326)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3326

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
