### PR TITLE
Create container log output directory before E2E apps are created

### DIFF
--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -99,6 +99,11 @@ func (m *AppManager) Init() error {
 		m.logPrefix = ContainerLogDefaultPath
 	}
 
+	if err := os.MkdirAll(m.logPrefix, os.ModePerm); err != nil {
+		log.Printf("Failed to create output log directory '%s' Error was: '%s'. Container logs will be discarded", m.logPrefix, err)
+		m.logPrefix = ""
+	}
+
 	log.Printf("Deploying app %v ...", m.app.AppName)
 	if m.app.IsJob {
 		// Deploy app and wait until deployment is done
@@ -164,11 +169,6 @@ func (m *AppManager) Init() error {
 		log.Printf("Creating pod port forwarder for app %v ....", m.app.AppName)
 		m.forwarder = NewPodPortForwarder(m.client, m.namespace)
 		log.Printf("Pod port forwarder for app %v has been created.", m.app.AppName)
-	}
-
-	if err := os.MkdirAll(m.logPrefix, os.ModePerm); err != nil {
-		log.Printf("Failed to create output log directory '%s' Error was: '%s'. Container logs will be discarded", m.logPrefix, err)
-		m.logPrefix = ""
 	}
 
 	return nil


### PR DESCRIPTION
# Description

When we added log streaming to E2E tests, we accidentally allowed test output files to be created before the output directory. The result was that we lost logs for the first 2 apps that run. The fix is, of course, to create the directory before creating any test apps.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #3333

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
