### PR TITLE
Fix help message and creds for stale bot.

### DIFF
--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-name: dapr-schedule
+name: dapr-bot-schedule
 
 on:
   schedule:
@@ -31,18 +31,18 @@ jobs:
     - name: Prune Stale
       uses: actions/stale@v3.0.14
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.DAPR_BOT_TOKEN }}
         # Different amounts of days for issues/PRs are not currently supported but there is a PR
         # open for it: https://github.com/actions/stale/issues/214
         days-before-stale: 30
         days-before-close: 7
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had activity in the
-          last 30 days. It will be closed in the next 7 days unless it is tagged "help wanted" or "no stalebot" or other activity
+          last 30 days. It will be closed in the next 7 days unless it is tagged (pinned, good first issue, help wanted or triaged/resolved) or other activity
           occurs. Thank you for your contributions.
         close-issue-message: >
           This issue has been automatically closed because it has not had activity in the
-          last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted" or "no stalebot".
+          last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as pinned, good first issue, help wanted or triaged/resolved.
           Thank you for your contributions.
         stale-pr-message: >
           This pull request has been automatically marked as stale because it has not had
@@ -54,7 +54,7 @@ jobs:
           activity in the last 37 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
           Thank you for your contributions!
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'pinned,help wanted,triaged/resolved'
+        exempt-issue-labels: 'pinned,good first issue,help wanted,triaged/resolved'
         stale-pr-label: 'stale'
         exempt-pr-labels: 'pinned'
         operations-per-run: 500


### PR DESCRIPTION
# Description

Use Dapr bot in stale bot and update help message. Also, added "good first issue" as a valid sticky label.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

PR is part of: #3245 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
