### PR TITLE
Optimize: Support dashboard service annotation

### DIFF
--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_service.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_service.yaml
@@ -2,6 +2,10 @@ kind: Service
 apiVersion: v1
 metadata:
   name: dapr-dashboard
+  annotations:
+    {{- range $key, $val := .Values.serviceAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
 spec:
   selector:
     app: dapr-dashboard

--- a/charts/dapr/charts/dapr_dashboard/values.yaml
+++ b/charts/dapr/charts/dapr_dashboard/values.yaml
@@ -18,3 +18,4 @@ ports:
 runAsNonRoot: true
 serviceType: ClusterIP
 resources: {}
+serviceAnnotations: {}


### PR DESCRIPTION
# Description

In cloud providers, we need add some annotation in service for LoadBalancer.
```
    serviceType: LoadBalancer
    serviceAnnotations:
      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
      service.beta.kubernetes.io/aws-load-balancer-internal: 'true'
      service.beta.kubernetes.io/aws-load-balancer-type: nlb
```
