### PR TITLE
Fix Regex for Repeatable Reminders in accordance with ISO 8601

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -49,7 +49,7 @@ const (
 
 var log = logger.NewLogger("dapr.runtime.actor")
 
-var pattern = regexp.MustCompile(`^(R(?P<repetiton>\d+))?P((?P<year>\d+)Y)?((?P<month>\d+)M)?((?P<week>\d+)W)?((?P<day>\d+)D)?(T((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d+)S)?)?$`)
+var pattern = regexp.MustCompile(`^(R(?P<repetiton>\d+)/)?P((?P<year>\d+)Y)?((?P<month>\d+)M)?((?P<week>\d+)W)?((?P<day>\d+)D)?(T((?P<hour>\d+)H)?((?P<minute>\d+)M)?((?P<second>\d+)S)?)?$`)
 
 // Actors allow calling into virtual actors as well as actor state management.
 type Actors interface {

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -1142,7 +1142,7 @@ func TestParseDuration(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	t.Run("parse ISO 8601 duration", func(t *testing.T) {
-		duration, repetition, err := parseDuration("R5PT30M")
+		duration, repetition, err := parseDuration("R5/PT30M")
 		assert.Equal(t, time.Minute*30, duration)
 		assert.Equal(t, 5, repetition)
 		assert.Nil(t, err)

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -213,7 +213,7 @@ func TestActorReminderPeriod(t *testing.T) {
 	reminder := actorReminder{
 		Data:    "reminderdata",
 		DueTime: "1s",
-		Period:  "R5PT1S",
+		Period:  "R5/PT1S",
 	}
 	reminderBody, err := json.Marshal(reminder)
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

Fix up for the new functionality contributed in #3095 (#2513).

Note:
Neither #3095 nor this PR support all ISO8601 recurrence time formats -- only the simplest format (without start and/or end datetime) is supported. This PR only aims to fix up the functionality already contributed.

## Issue reference
#3095 (#2513).

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
