### PR TITLE
Lock placement table updates at operation level

### DIFF
--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -224,6 +224,10 @@ func (p *Service) processRaftStateCommand(stopCh chan struct{}) {
 				// until the state is consistent.
 				logApplyConcurrency <- struct{}{}
 				go func() {
+					// We lock dissemination to ensure the updates can complete before the table is disseminated.
+					p.disseminateLock.Lock()
+					defer p.disseminateLock.Unlock()
+
 					updated, raftErr := p.raftNode.ApplyCommand(op.cmdType, op.host)
 					if raftErr != nil {
 						log.Errorf("fail to apply command: %v", raftErr)
@@ -247,29 +251,36 @@ func (p *Service) processRaftStateCommand(stopCh chan struct{}) {
 			case raft.TableDisseminate:
 				// TableDisseminate will be triggered by disseminateTimer.
 				// This disseminates the latest consistent hashing tables to Dapr runtime.
-				nStreamConnPool := len(p.streamConnPool)
-				nTargetConns := len(p.raftNode.FSM().State().Members)
-
-				monitoring.RecordRuntimesCount(nStreamConnPool)
-				monitoring.RecordActorRuntimesCount(nTargetConns)
-
-				// ignore dissemination if there is no member update.
-				if cnt := p.memberUpdateCount.Load(); cnt > 0 {
-					state := p.raftNode.FSM().PlacementState()
-					log.Infof(
-						"Start disseminating tables. memberUpdateCount: %d, streams: %d, targets: %d, table generation: %s",
-						cnt, nStreamConnPool, nTargetConns, state.Version)
-					p.performTablesUpdate(p.streamConnPool, state)
-					log.Infof(
-						"Completed dissemination. memberUpdateCount: %d, streams: %d, targets: %d, table generation: %s",
-						cnt, nStreamConnPool, nTargetConns, state.Version)
-					p.memberUpdateCount.Store(0)
-
-					// set faultyHostDetectDuration to the default duration.
-					p.faultyHostDetectDuration = faultyHostDetectDefaultDuration
-				}
+				p.performTableDissemination()
 			}
 		}
+	}
+}
+
+func (p *Service) performTableDissemination() {
+	nStreamConnPool := len(p.streamConnPool)
+	nTargetConns := len(p.raftNode.FSM().State().Members)
+
+	monitoring.RecordRuntimesCount(nStreamConnPool)
+	monitoring.RecordActorRuntimesCount(nTargetConns)
+
+	// ignore dissemination if there is no member update.
+	if cnt := p.memberUpdateCount.Load(); cnt > 0 {
+		p.disseminateLock.Lock()
+		defer p.disseminateLock.Unlock()
+
+		state := p.raftNode.FSM().PlacementState()
+		log.Infof(
+			"Start disseminating tables. memberUpdateCount: %d, streams: %d, targets: %d, table generation: %s",
+			cnt, nStreamConnPool, nTargetConns, state.Version)
+		p.performTablesUpdate(p.streamConnPool, state)
+		log.Infof(
+			"Completed dissemination. memberUpdateCount: %d, streams: %d, targets: %d, table generation: %s",
+			cnt, nStreamConnPool, nTargetConns, state.Version)
+		p.memberUpdateCount.Store(0)
+
+		// set faultyHostDetectDuration to the default duration.
+		p.faultyHostDetectDuration = faultyHostDetectDefaultDuration
 	}
 }
 
@@ -278,9 +289,6 @@ func (p *Service) processRaftStateCommand(stopCh chan struct{}) {
 // in runtime, it proceeds to update new table to Dapr runtimes and then unlock
 // once all runtimes have been updated.
 func (p *Service) performTablesUpdate(hosts []placementGRPCStream, newTable *v1pb.PlacementTables) {
-	p.disseminateLock.Lock()
-	defer p.disseminateLock.Unlock()
-
 	// TODO: error from disseminationOperation needs to be handle properly.
 	// Otherwise, each Dapr runtime will have inconsistent hashing table.
 	p.disseminateOperation(hosts, "lock", nil)


### PR DESCRIPTION
# Description
Under specific circumstances, the actor placement table can get out
of sync and not have new disseminations queued. This can happen
when a dissemination begins followed by an update which finishes
before the dissemination. This puts the placement table into a state
where it does not know there are more updates when one has not been
sent.

## Issue reference
PR will close: #3023 


<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
