### PR TITLE
Add -dapr-listen-address option to daprd

### DIFF
--- a/pkg/grpc/config.go
+++ b/pkg/grpc/config.go
@@ -13,10 +13,11 @@ type ServerConfig struct {
 	NameSpace          string
 	TrustDomain        string
 	MaxRequestBodySize int
+	APIListenAddress   string
 }
 
 // NewServerConfig returns a new grpc server config.
-func NewServerConfig(appID string, hostAddress string, port int, namespace string, trustDomain string, maxRequestBodySize int) ServerConfig {
+func NewServerConfig(appID string, hostAddress string, port int, namespace string, trustDomain string, maxRequestBodySize int, apiListenAddress string) ServerConfig {
 	return ServerConfig{
 		AppID:              appID,
 		HostAddress:        hostAddress,
@@ -24,5 +25,6 @@ func NewServerConfig(appID string, hostAddress string, port int, namespace strin
 		NameSpace:          namespace,
 		TrustDomain:        trustDomain,
 		MaxRequestBodySize: maxRequestBodySize,
+		APIListenAddress:   apiListenAddress,
 	}
 }

--- a/pkg/grpc/config_test.go
+++ b/pkg/grpc/config_test.go
@@ -19,13 +19,15 @@ func TestServerConfig(t *testing.T) {
 		"default",
 		"td1",
 		4,
+		"1.2.3.4",
 	}
 
-	c := NewServerConfig(vals[0].(string), vals[1].(string), vals[2].(int), vals[3].(string), vals[4].(string), vals[5].(int))
+	c := NewServerConfig(vals[0].(string), vals[1].(string), vals[2].(int), vals[3].(string), vals[4].(string), vals[5].(int), vals[6].(string))
 	assert.Equal(t, vals[0], c.AppID)
 	assert.Equal(t, vals[1], c.HostAddress)
 	assert.Equal(t, vals[2], c.Port)
 	assert.Equal(t, vals[3], c.NameSpace)
 	assert.Equal(t, vals[4], c.TrustDomain)
 	assert.Equal(t, vals[5], c.MaxRequestBodySize)
+	assert.Equal(t, vals[6], c.APIListenAddress)
 }

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -105,7 +105,7 @@ func getDefaultMaxAgeDuration() *time.Duration {
 
 // StartNonBlocking starts a new server in a goroutine.
 func (s *server) StartNonBlocking() error {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", s.config.Port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.Port))
 	if err != nil {
 		return err
 	}

--- a/pkg/http/config.go
+++ b/pkg/http/config.go
@@ -14,10 +14,11 @@ type ServerConfig struct {
 	ProfilePort        int
 	EnableProfiling    bool
 	MaxRequestBodySize int
+	APIListenAddress   string
 }
 
 // NewServerConfig returns a new HTTP server config.
-func NewServerConfig(appID string, hostAddress string, port int, profilePort int, allowedOrigins string, enableProfiling bool, maxRequestBodySize int) ServerConfig {
+func NewServerConfig(appID string, hostAddress string, port int, profilePort int, allowedOrigins string, enableProfiling bool, maxRequestBodySize int, apiListenAddress string) ServerConfig {
 	return ServerConfig{
 		AllowedOrigins:     allowedOrigins,
 		AppID:              appID,
@@ -26,5 +27,6 @@ func NewServerConfig(appID string, hostAddress string, port int, profilePort int
 		ProfilePort:        profilePort,
 		EnableProfiling:    enableProfiling,
 		MaxRequestBodySize: maxRequestBodySize,
+		APIListenAddress:   apiListenAddress,
 	}
 }

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -73,13 +73,13 @@ func (s *server) StartNonBlocking() {
 	}
 
 	go func() {
-		log.Fatal(customServer.ListenAndServe(fmt.Sprintf(":%v", s.config.Port)))
+		log.Fatal(customServer.ListenAndServe(fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.Port)))
 	}()
 
 	if s.config.EnableProfiling {
 		go func() {
 			log.Infof("starting profiling server on port %v", s.config.ProfilePort)
-			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.ProfilePort), pprofhandler.PprofHandler))
+			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.ProfilePort), pprofhandler.PprofHandler))
 		}()
 	}
 }

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -101,6 +101,7 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--dapr-http-port", "3500",
 			"--dapr-grpc-port", "50001",
 			"--dapr-internal-grpc-port", "50002",
+			"--dapr-listen-address", "localhost",
 			"--app-port", "5000",
 			"--app-id", "app_id",
 			"--control-plane-address", "controlplane:9000",
@@ -150,6 +151,7 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--dapr-http-port", "3500",
 			"--dapr-grpc-port", "50001",
 			"--dapr-internal-grpc-port", "50002",
+			"--dapr-listen-address", "localhost",
 			"--app-port", "5000",
 			"--app-id", "app_id",
 			"--control-plane-address", "controlplane:9000",
@@ -174,6 +176,34 @@ func TestGetSideCarContainer(t *testing.T) {
 		assert.Equal(t, "appsecret", container.Env[2].ValueFrom.SecretKeyRef.Name)
 		assert.EqualValues(t, expectedArgs, container.Args)
 		assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy)
+	})
+	t.Run("get sidecar container override listen address", func(t *testing.T) {
+		annotations := map[string]string{}
+		annotations[daprConfigKey] = "config"
+		annotations[daprListenAddress] = "1.2.3.4"
+		container, _ := getSidecarContainer(annotations, "app_id", "darpio/dapr", "Always", "dapr-system", "controlplane:9000", "placement:50000", nil, "", "", "", "sentry:50000", true, "pod_identity")
+
+		expectedArgs := []string{
+			"--mode", "kubernetes",
+			"--dapr-http-port", "3500",
+			"--dapr-grpc-port", "50001",
+			"--dapr-internal-grpc-port", "50002",
+			"--dapr-listen-address", "1.2.3.4",
+			"--app-port", "",
+			"--app-id", "app_id",
+			"--control-plane-address", "controlplane:9000",
+			"--app-protocol", "http",
+			"--placement-host-address", "placement:50000",
+			"--config", "config",
+			"--log-level", "info",
+			"--app-max-concurrency", "-1",
+			"--sentry-address", "sentry:50000",
+			"--enable-metrics=true",
+			"--metrics-port", "9090",
+			"--dapr-http-max-request-size", "-1",
+		}
+
+		assert.EqualValues(t, expectedArgs, container.Args)
 	})
 }
 

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -33,6 +33,7 @@ import (
 func FromFlags() (*DaprRuntime, error) {
 	mode := flag.String("mode", string(modes.StandaloneMode), "Runtime mode for Dapr")
 	daprHTTPPort := flag.String("dapr-http-port", fmt.Sprintf("%v", DefaultDaprHTTPPort), "HTTP port for Dapr API to listen on")
+	daprAPIListenAddress := flag.String("dapr-listen-address", DefaultAPIListenAddress, "address for the Dapr API to listen on")
 	daprAPIGRPCPort := flag.String("dapr-grpc-port", fmt.Sprintf("%v", DefaultDaprAPIGRPCPort), "gRPC port for the Dapr API to listen on")
 	daprInternalGRPCPort := flag.String("dapr-internal-grpc-port", "", "gRPC port for the Dapr Internal API to listen on")
 	appPort := flag.String("app-port", "", "The port the application is listening on")
@@ -74,7 +75,10 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	if *waitCommand {
-		waitUntilDaprOutboundReady(*daprHTTPPort)
+		err := waitUntilDaprOutboundReady(*daprHTTPPort)
+		if err != nil {
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 
@@ -155,7 +159,7 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	runtimeConfig := NewRuntimeConfig(*appID, placementAddresses, *controlPlaneAddress, *allowedOrigins, *config, *componentsPath,
-		appPrtcl, *mode, daprHTTP, daprInternalGRPC, daprAPIGRPC, applicationPort, profPort, *enableProfiling, concurrency, *enableMTLS, *sentryAddress, *appSSL, maxRequestBodySize)
+		appPrtcl, *mode, daprHTTP, daprInternalGRPC, daprAPIGRPC, *daprAPIListenAddress, applicationPort, profPort, *enableProfiling, concurrency, *enableMTLS, *sentryAddress, *appSSL, maxRequestBodySize)
 
 	// set environment variables
 	// TODO - consider adding host address to runtime config and/or caching result in utils package

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -29,6 +29,8 @@ const (
 	DefaultMetricsPort = 9090
 	// DefaultMaxRequestBodySize is the default option for the maximum body size in MB for Dapr HTTP servers.
 	DefaultMaxRequestBodySize = 4
+	// DefaultAPIListenAddress is which address to listen for the Dapr HTTP and GRPC APIs. Empty string is all addresses.
+	DefaultAPIListenAddress = ""
 )
 
 // Config holds the Dapr Runtime configuration.
@@ -53,13 +55,14 @@ type Config struct {
 	CertChain            *credentials.CertChain
 	AppSSL               bool
 	MaxRequestBodySize   int
+	APIListenAddress     string
 }
 
 // NewRuntimeConfig returns a new runtime config.
 func NewRuntimeConfig(
 	id string, placementAddresses []string,
 	controlPlaneAddress, allowedOrigins, globalConfig, componentsPath, appProtocol, mode string,
-	httpPort, internalGRPCPort, apiGRPCPort, appPort, profilePort int,
+	httpPort, internalGRPCPort, apiGRPCPort int, apiListenAddress string, appPort, profilePort int,
 	enableProfiling bool, maxConcurrency int, mtlsEnabled bool, sentryAddress string, appSSL bool, maxRequestBodySize int) *Config {
 	return &Config{
 		ID:                  id,
@@ -85,5 +88,6 @@ func NewRuntimeConfig(
 		SentryServiceAddress: sentryAddress,
 		AppSSL:               appSSL,
 		MaxRequestBodySize:   maxRequestBodySize,
+		APIListenAddress:     apiListenAddress,
 	}
 }

--- a/pkg/runtime/config_test.go
+++ b/pkg/runtime/config_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	c := NewRuntimeConfig("app1", []string{"localhost:5050"}, "localhost:5051", "*", "config", "components", "http", "kubernetes",
-		3500, 50002, 50001, 8080, 7070, true, 1, true, "localhost:5052", true, 4)
+		3500, 50002, 50001, "1.2.3.4", 8080, 7070, true, 1, true, "localhost:5052", true, 4)
 
 	assert.Equal(t, "app1", c.ID)
 	assert.Equal(t, "localhost:5050", c.PlacementAddresses[0])
@@ -26,6 +26,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, 3500, c.HTTPPort)
 	assert.Equal(t, 50002, c.InternalGRPCPort)
 	assert.Equal(t, 50001, c.APIGRPCPort)
+	assert.Equal(t, "1.2.3.4", c.APIListenAddress)
 	assert.Equal(t, 8080, c.ApplicationPort)
 	assert.Equal(t, 7070, c.ProfilePort)
 	assert.Equal(t, true, c.EnableProfiling)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -780,34 +780,35 @@ func (a *DaprRuntime) readFromBinding(name string, binding bindings.InputBinding
 func (a *DaprRuntime) startHTTPServer(port, profilePort int, allowedOrigins string, pipeline http_middleware.Pipeline) {
 	a.daprHTTPAPI = http.NewAPI(a.runtimeConfig.ID, a.appChannel, a.directMessaging, a.getComponents, a.stateStores, a.secretStores,
 		a.secretsConfiguration, a.getPublishAdapter(), a.actor, a.sendToOutputBinding, a.globalConfig.Spec.TracingSpec, a.ShutdownWithWait)
-	serverConf := http.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, profilePort, allowedOrigins, a.runtimeConfig.EnableProfiling, a.runtimeConfig.MaxRequestBodySize)
+	serverConf := http.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, profilePort, allowedOrigins, a.runtimeConfig.EnableProfiling, a.runtimeConfig.MaxRequestBodySize, a.runtimeConfig.APIListenAddress)
 
 	server := http.NewServer(a.daprHTTPAPI, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, pipeline, a.globalConfig.Spec.APISpec)
 	server.StartNonBlocking()
 }
 
 func (a *DaprRuntime) startGRPCInternalServer(api grpc.API, port int) error {
-	serverConf := a.getNewServerConfig(port)
+	// Since GRPCInteralServer is encrypted & authenticated, it is safe to listen on *
+	serverConf := a.getNewServerConfig("", port)
 	server := grpc.NewInternalServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, a.authenticator, a.proxy)
 	err := server.StartNonBlocking()
 	return err
 }
 
 func (a *DaprRuntime) startGRPCAPIServer(api grpc.API, port int) error {
-	serverConf := a.getNewServerConfig(port)
+	serverConf := a.getNewServerConfig(a.runtimeConfig.APIListenAddress, port)
 	server := grpc.NewAPIServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, a.globalConfig.Spec.APISpec, a.proxy)
 	err := server.StartNonBlocking()
 	return err
 }
 
-func (a *DaprRuntime) getNewServerConfig(port int) grpc.ServerConfig {
+func (a *DaprRuntime) getNewServerConfig(listenAddress string, port int) grpc.ServerConfig {
 	// Use the trust domain value from the access control policy spec to generate the cert
 	// If no access control policy has been specified, use a default value
 	trustDomain := config.DefaultTrustDomain
 	if a.accessControlList != nil {
 		trustDomain = a.accessControlList.TrustDomain
 	}
-	return grpc.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, a.namespace, trustDomain, a.runtimeConfig.MaxRequestBodySize)
+	return grpc.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, a.namespace, trustDomain, a.runtimeConfig.MaxRequestBodySize, listenAddress)
 }
 
 func (a *DaprRuntime) getGRPCAPI() grpc.API {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2340,6 +2340,7 @@ func NewTestDaprRuntimeWithProtocol(mode modes.DaprMode, protocol string, appPor
 		DefaultDaprHTTPPort,
 		0,
 		DefaultDaprAPIGRPCPort,
+		DefaultAPIListenAddress,
 		appPort,
 		DefaultProfilePort,
 		false,

--- a/pkg/runtime/wait.go
+++ b/pkg/runtime/wait.go
@@ -19,7 +19,7 @@ var (
 	urlFormat            string = "http://localhost:%s/v1.0/healthz/outbound"
 )
 
-func waitUntilDaprOutboundReady(daprHTTPPort string) {
+func waitUntilDaprOutboundReady(daprHTTPPort string) error {
 	outboundReadyHealthURL := fmt.Sprintf(urlFormat, daprHTTPPort)
 	client := &http.Client{
 		Timeout: time.Duration(requestTimeoutMillis) * time.Millisecond,
@@ -33,7 +33,7 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) {
 		err = checkIfOutboundReady(client, outboundReadyHealthURL)
 		if err == nil {
 			println("Dapr is outbound ready!")
-			return
+			return nil
 		}
 
 		if time.Now().After(lastPrintErrorTime) {
@@ -46,6 +46,7 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) {
 	}
 
 	println(fmt.Sprintf("timeout waiting for Dapr to become outbound ready. Last error: %v", err))
+	return err
 }
 
 func checkIfOutboundReady(client *http.Client, outboundReadyHealthURL string) error {


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
There is now a --dapr-listen-address option added to daprd. This is to allow the Dapr API to bind to specific addresses, largely as an improved security posture for the Dapr API. For k8s, where we control a lot more of the experience, we'll default to listening only on 127.0.0.1. For standalone mode daprd invocations, we'll default to listening on all addresses, since we don't know what existing standalone daprd deployments look like.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #2914

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
