### PR TITLE
Revert "Sign Dapr artifacts in GitHub (#3279)"

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -249,14 +249,6 @@ jobs:
           done
       - name: generate checksum files
         run: cd ${ARTIFACT_DIR} && for i in *; do sha256sum -b $i > "$i.sha256"; done && cd -
-      - name: import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
-        with:
-          gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
-          passphrase: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
-      - name: generate signed files
-        run: cd ${ARTIFACT_DIR} && for i in $(ls -I "*.sha256"); do gpg --armor --detach-sign $i; done && cd -
       - name: lists artifacts
         run: ls -l ${{ env.ARTIFACT_DIR }}
       - name: publish binaries to github


### PR DESCRIPTION
This reverts commit 38197b4957246f194123a7813711525b8fa53c59.

# Description

Disables signing until we know which entity can sign binaries and how it would work on each OS.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3272 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
