### PR TITLE
Pin latest Go 1.16.6 due to caching

### DIFF
--- a/.github/workflows/dapr-e2e-apps.yml
+++ b/.github/workflows/dapr-e2e-apps.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build on ${{ matrix.target_os }}_${{ matrix.target_arch }}
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.16
+      GOVER: 1.16.6
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org

--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -16,7 +16,7 @@ jobs:
     name: perf tests
     runs-on: ubuntu-latest
     env:
-      GOVER: 1.16
+      GOVER: 1.16.6
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: end-to-end ${{ matrix.target_os }} tests
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.16
+      GOVER: 1.16.6
       KUBECTLVER: v1.19.3
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: 1.16
+      GOVER: 1.16.6
       GOLANGCILINT_VER: v1.31
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -38,7 +38,7 @@ jobs:
       DAPR_REGISTRY: localhost:5000/dapr
       DAPR_TAG: dev
       DAPR_NAMESPACE: dapr-tests
-      GOVER: 1.16
+      GOVER: 1.16.6
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:


### PR DESCRIPTION
# Description

Pinning latest Go 1.16.6 in Build Workflow due to caching.