### PR TITLE
Revert "Add -dapr-listen-address option to daprd (#3429)"

### DIFF
--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
-appVersion: "1.3.0-rc.1"
+appVersion: "1.3.0-rc.2"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: 1.3.0-rc.1
+version: 1.3.0-rc.2
 dependencies:
   - name: dapr_rbac
-    version: "1.3.0-rc.1"
+    version: "1.3.0-rc.2"
     repository: "file://dapr_rbac"
   - name: dapr_operator
-    version: "1.3.0-rc.1"
+    version: "1.3.0-rc.2"
     repository: "file://dapr_operator"
   - name: dapr_placement
-    version: "1.3.0-rc.1"
+    version: "1.3.0-rc.2"
     repository: "file://dapr_placement"
   - name: dapr_sidecar_injector
-    version: "1.3.0-rc.1"
+    version: "1.3.0-rc.2"
     repository: "file://dapr_sidecar_injector"
   - name: dapr_sentry
-    version: "1.3.0-rc.1"
+    version: "1.3.0-rc.2"
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
     version: "0.7.0"

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -76,7 +76,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
 | `global.registry`                         | Docker image registry                                                   | `docker.io/daprio`      |
-| `global.tag`                              | Docker image version tag                                                | `1.3.0-rc.1`                 |
+| `global.tag`                              | Docker image version tag                                                | `1.3.0-rc.2`                 |
 | `global.logAsJson`                        | Json log format for control plane services                              | `false`                 |
 | `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
 | `global.imagePullSecret`                  | Control plane service image pull secret for docker registry             | `""`                    |

--- a/charts/dapr/charts/dapr_config/Chart.yaml
+++ b/charts/dapr/charts/dapr_config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr configuration
 name: dapr_config
-version: 1.3.0-rc.1
+version: 1.3.0-rc.2

--- a/charts/dapr/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: 1.3.0-rc.1
+version: 1.3.0-rc.2

--- a/charts/dapr/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr/charts/dapr_placement/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: 1.3.0-rc.1
+version: 1.3.0-rc.2

--- a/charts/dapr/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr/charts/dapr_rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC components
 name: dapr_rbac
-version: 1.3.0-rc.1
+version: 1.3.0-rc.2

--- a/charts/dapr/charts/dapr_sentry/Chart.yaml
+++ b/charts/dapr/charts/dapr_sentry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Sentry
 name: dapr_sentry
-version: 1.3.0-rc.1
+version: 1.3.0-rc.2

--- a/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: 1.3.0-rc.1
+version: 1.3.0-rc.2

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "1.3.0-rc.1"
+  tag: "1.3.0-rc.2"
   dnsSuffix: ".cluster.local"
   logAsJson: false
   imagePullPolicy: IfNotPresent

--- a/pkg/grpc/config.go
+++ b/pkg/grpc/config.go
@@ -13,11 +13,10 @@ type ServerConfig struct {
 	NameSpace          string
 	TrustDomain        string
 	MaxRequestBodySize int
-	APIListenAddress   string
 }
 
 // NewServerConfig returns a new grpc server config.
-func NewServerConfig(appID string, hostAddress string, port int, namespace string, trustDomain string, maxRequestBodySize int, apiListenAddress string) ServerConfig {
+func NewServerConfig(appID string, hostAddress string, port int, namespace string, trustDomain string, maxRequestBodySize int) ServerConfig {
 	return ServerConfig{
 		AppID:              appID,
 		HostAddress:        hostAddress,
@@ -25,6 +24,5 @@ func NewServerConfig(appID string, hostAddress string, port int, namespace strin
 		NameSpace:          namespace,
 		TrustDomain:        trustDomain,
 		MaxRequestBodySize: maxRequestBodySize,
-		APIListenAddress:   apiListenAddress,
 	}
 }

--- a/pkg/grpc/config_test.go
+++ b/pkg/grpc/config_test.go
@@ -19,15 +19,13 @@ func TestServerConfig(t *testing.T) {
 		"default",
 		"td1",
 		4,
-		"1.2.3.4",
 	}
 
-	c := NewServerConfig(vals[0].(string), vals[1].(string), vals[2].(int), vals[3].(string), vals[4].(string), vals[5].(int), vals[6].(string))
+	c := NewServerConfig(vals[0].(string), vals[1].(string), vals[2].(int), vals[3].(string), vals[4].(string), vals[5].(int))
 	assert.Equal(t, vals[0], c.AppID)
 	assert.Equal(t, vals[1], c.HostAddress)
 	assert.Equal(t, vals[2], c.Port)
 	assert.Equal(t, vals[3], c.NameSpace)
 	assert.Equal(t, vals[4], c.TrustDomain)
 	assert.Equal(t, vals[5], c.MaxRequestBodySize)
-	assert.Equal(t, vals[6], c.APIListenAddress)
 }

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -105,7 +105,7 @@ func getDefaultMaxAgeDuration() *time.Duration {
 
 // StartNonBlocking starts a new server in a goroutine.
 func (s *server) StartNonBlocking() error {
-	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.Port))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", s.config.Port))
 	if err != nil {
 		return err
 	}

--- a/pkg/http/config.go
+++ b/pkg/http/config.go
@@ -14,11 +14,10 @@ type ServerConfig struct {
 	ProfilePort        int
 	EnableProfiling    bool
 	MaxRequestBodySize int
-	APIListenAddress   string
 }
 
 // NewServerConfig returns a new HTTP server config.
-func NewServerConfig(appID string, hostAddress string, port int, profilePort int, allowedOrigins string, enableProfiling bool, maxRequestBodySize int, apiListenAddress string) ServerConfig {
+func NewServerConfig(appID string, hostAddress string, port int, profilePort int, allowedOrigins string, enableProfiling bool, maxRequestBodySize int) ServerConfig {
 	return ServerConfig{
 		AllowedOrigins:     allowedOrigins,
 		AppID:              appID,
@@ -27,6 +26,5 @@ func NewServerConfig(appID string, hostAddress string, port int, profilePort int
 		ProfilePort:        profilePort,
 		EnableProfiling:    enableProfiling,
 		MaxRequestBodySize: maxRequestBodySize,
-		APIListenAddress:   apiListenAddress,
 	}
 }

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -73,13 +73,13 @@ func (s *server) StartNonBlocking() {
 	}
 
 	go func() {
-		log.Fatal(customServer.ListenAndServe(fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.Port)))
+		log.Fatal(customServer.ListenAndServe(fmt.Sprintf(":%v", s.config.Port)))
 	}()
 
 	if s.config.EnableProfiling {
 		go func() {
 			log.Infof("starting profiling server on port %v", s.config.ProfilePort)
-			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.ProfilePort), pprofhandler.PprofHandler))
+			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.ProfilePort), pprofhandler.PprofHandler))
 		}()
 	}
 }

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -51,7 +51,6 @@ const (
 	daprMemoryLimitKey                = "dapr.io/sidecar-memory-limit"
 	daprCPURequestKey                 = "dapr.io/sidecar-cpu-request"
 	daprMemoryRequestKey              = "dapr.io/sidecar-memory-request"
-	daprListenAddress                 = "dapr.io/sidecar-listen-address"
 	daprLivenessProbeDelayKey         = "dapr.io/sidecar-liveness-probe-delay-seconds"
 	daprLivenessProbeTimeoutKey       = "dapr.io/sidecar-liveness-probe-timeout-seconds"
 	daprLivenessProbePeriodKey        = "dapr.io/sidecar-liveness-probe-period-seconds"
@@ -88,7 +87,6 @@ const (
 	defaultMetricsPort                = 9090
 	defaultSidecarDebug               = false
 	defaultSidecarDebugPort           = 40000
-	defaultSidecarListenAddress       = "localhost"
 	sidecarHealthzPath                = "healthz"
 	defaultHealthzProbeDelaySeconds   = 3
 	defaultHealthzProbeTimeoutSeconds = 3
@@ -345,10 +343,6 @@ func getMaxRequestBodySize(annotations map[string]string) (int32, error) {
 	return getInt32Annotation(annotations, daprMaxRequestBodySize)
 }
 
-func getListenAddress(annotations map[string]string) string {
-	return getStringAnnotationOrDefault(annotations, daprListenAddress, defaultSidecarListenAddress)
-}
-
 func getBoolAnnotationOrDefault(annotations map[string]string, key string, defaultValue bool) bool {
 	enabled, ok := annotations[key]
 	if !ok {
@@ -399,19 +393,6 @@ func getProbeHTTPHandler(port int32, pathElements ...string) corev1.Handler {
 		HTTPGet: &corev1.HTTPGetAction{
 			Path: formatProbePath(pathElements...),
 			Port: intstr.IntOrString{IntVal: port},
-		},
-	}
-}
-
-func getProbeExecHandler(port int32) corev1.Handler {
-	return corev1.Handler{
-		Exec: &corev1.ExecAction{
-			Command: []string{
-				"/daprd",
-				"--wait",
-				"--dapr-http-port",
-				fmt.Sprintf("%v", port),
-			},
 		},
 	}
 }
@@ -511,7 +492,6 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 	metricsEnabled := getEnableMetrics(annotations)
 	metricsPort := getMetricsPort(annotations)
 	maxConcurrency, err := getMaxConcurrency(annotations)
-	sidecarListenAddress := getListenAddress(annotations)
 	if err != nil {
 		log.Warn(err)
 	}
@@ -520,14 +500,7 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 
 	pullPolicy := getPullPolicy(imagePullPolicy)
 
-	var probeHandler corev1.Handler
-
-	if sidecarListenAddress == "localhost" {
-		// kubelet healthcheck cannot talk to localhost for a pod, so we use daprd --wait to run the healthcheck instead
-		probeHandler = getProbeExecHandler(sidecarHTTPPort)
-	} else {
-		probeHandler = getProbeHTTPHandler(sidecarHTTPPort, apiVersionV1, sidecarHealthzPath)
-	}
+	httpHandler := getProbeHTTPHandler(sidecarHTTPPort, apiVersionV1, sidecarHealthzPath)
 
 	allowPrivilegeEscalation := false
 
@@ -562,7 +535,6 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 		"--dapr-http-port", fmt.Sprintf("%v", sidecarHTTPPort),
 		"--dapr-grpc-port", fmt.Sprintf("%v", sidecarAPIGRPCPort),
 		"--dapr-internal-grpc-port", fmt.Sprintf("%v", sidecarInternalGRPCPort),
-		"--dapr-listen-address", sidecarListenAddress,
 		"--app-port", appPortStr,
 		"--app-id", id,
 		"--control-plane-address", controlPlaneAddress,
@@ -616,14 +588,14 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 		},
 		Args: args,
 		ReadinessProbe: &corev1.Probe{
-			Handler:             probeHandler,
+			Handler:             httpHandler,
 			InitialDelaySeconds: getInt32AnnotationOrDefault(annotations, daprReadinessProbeDelayKey, defaultHealthzProbeDelaySeconds),
 			TimeoutSeconds:      getInt32AnnotationOrDefault(annotations, daprReadinessProbeTimeoutKey, defaultHealthzProbeTimeoutSeconds),
 			PeriodSeconds:       getInt32AnnotationOrDefault(annotations, daprReadinessProbePeriodKey, defaultHealthzProbePeriodSeconds),
 			FailureThreshold:    getInt32AnnotationOrDefault(annotations, daprReadinessProbeThresholdKey, defaultHealthzProbeThreshold),
 		},
 		LivenessProbe: &corev1.Probe{
-			Handler:             probeHandler,
+			Handler:             httpHandler,
 			InitialDelaySeconds: getInt32AnnotationOrDefault(annotations, daprLivenessProbeDelayKey, defaultHealthzProbeDelaySeconds),
 			TimeoutSeconds:      getInt32AnnotationOrDefault(annotations, daprLivenessProbeTimeoutKey, defaultHealthzProbeTimeoutSeconds),
 			PeriodSeconds:       getInt32AnnotationOrDefault(annotations, daprLivenessProbePeriodKey, defaultHealthzProbePeriodSeconds),

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -101,7 +101,6 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--dapr-http-port", "3500",
 			"--dapr-grpc-port", "50001",
 			"--dapr-internal-grpc-port", "50002",
-			"--dapr-listen-address", "localhost",
 			"--app-port", "5000",
 			"--app-id", "app_id",
 			"--control-plane-address", "controlplane:9000",
@@ -151,7 +150,6 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--dapr-http-port", "3500",
 			"--dapr-grpc-port", "50001",
 			"--dapr-internal-grpc-port", "50002",
-			"--dapr-listen-address", "localhost",
 			"--app-port", "5000",
 			"--app-id", "app_id",
 			"--control-plane-address", "controlplane:9000",
@@ -176,34 +174,6 @@ func TestGetSideCarContainer(t *testing.T) {
 		assert.Equal(t, "appsecret", container.Env[2].ValueFrom.SecretKeyRef.Name)
 		assert.EqualValues(t, expectedArgs, container.Args)
 		assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy)
-	})
-	t.Run("get sidecar container override listen address", func(t *testing.T) {
-		annotations := map[string]string{}
-		annotations[daprConfigKey] = "config"
-		annotations[daprListenAddress] = "1.2.3.4"
-		container, _ := getSidecarContainer(annotations, "app_id", "darpio/dapr", "Always", "dapr-system", "controlplane:9000", "placement:50000", nil, "", "", "", "sentry:50000", true, "pod_identity")
-
-		expectedArgs := []string{
-			"--mode", "kubernetes",
-			"--dapr-http-port", "3500",
-			"--dapr-grpc-port", "50001",
-			"--dapr-internal-grpc-port", "50002",
-			"--dapr-listen-address", "1.2.3.4",
-			"--app-port", "",
-			"--app-id", "app_id",
-			"--control-plane-address", "controlplane:9000",
-			"--app-protocol", "http",
-			"--placement-host-address", "placement:50000",
-			"--config", "config",
-			"--log-level", "info",
-			"--app-max-concurrency", "-1",
-			"--sentry-address", "sentry:50000",
-			"--enable-metrics=true",
-			"--metrics-port", "9090",
-			"--dapr-http-max-request-size", "-1",
-		}
-
-		assert.EqualValues(t, expectedArgs, container.Args)
 	})
 }
 

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -33,7 +33,6 @@ import (
 func FromFlags() (*DaprRuntime, error) {
 	mode := flag.String("mode", string(modes.StandaloneMode), "Runtime mode for Dapr")
 	daprHTTPPort := flag.String("dapr-http-port", fmt.Sprintf("%v", DefaultDaprHTTPPort), "HTTP port for Dapr API to listen on")
-	daprAPIListenAddress := flag.String("dapr-listen-address", DefaultAPIListenAddress, "address for the Dapr API to listen on")
 	daprAPIGRPCPort := flag.String("dapr-grpc-port", fmt.Sprintf("%v", DefaultDaprAPIGRPCPort), "gRPC port for the Dapr API to listen on")
 	daprInternalGRPCPort := flag.String("dapr-internal-grpc-port", "", "gRPC port for the Dapr Internal API to listen on")
 	appPort := flag.String("app-port", "", "The port the application is listening on")
@@ -75,10 +74,7 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	if *waitCommand {
-		err := waitUntilDaprOutboundReady(*daprHTTPPort)
-		if err != nil {
-			os.Exit(1)
-		}
+		waitUntilDaprOutboundReady(*daprHTTPPort)
 		os.Exit(0)
 	}
 
@@ -159,7 +155,7 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	runtimeConfig := NewRuntimeConfig(*appID, placementAddresses, *controlPlaneAddress, *allowedOrigins, *config, *componentsPath,
-		appPrtcl, *mode, daprHTTP, daprInternalGRPC, daprAPIGRPC, *daprAPIListenAddress, applicationPort, profPort, *enableProfiling, concurrency, *enableMTLS, *sentryAddress, *appSSL, maxRequestBodySize)
+		appPrtcl, *mode, daprHTTP, daprInternalGRPC, daprAPIGRPC, applicationPort, profPort, *enableProfiling, concurrency, *enableMTLS, *sentryAddress, *appSSL, maxRequestBodySize)
 
 	// set environment variables
 	// TODO - consider adding host address to runtime config and/or caching result in utils package

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -29,8 +29,6 @@ const (
 	DefaultMetricsPort = 9090
 	// DefaultMaxRequestBodySize is the default option for the maximum body size in MB for Dapr HTTP servers.
 	DefaultMaxRequestBodySize = 4
-	// DefaultAPIListenAddress is which address to listen for the Dapr HTTP and GRPC APIs. Empty string is all addresses.
-	DefaultAPIListenAddress = ""
 )
 
 // Config holds the Dapr Runtime configuration.
@@ -55,14 +53,13 @@ type Config struct {
 	CertChain            *credentials.CertChain
 	AppSSL               bool
 	MaxRequestBodySize   int
-	APIListenAddress     string
 }
 
 // NewRuntimeConfig returns a new runtime config.
 func NewRuntimeConfig(
 	id string, placementAddresses []string,
 	controlPlaneAddress, allowedOrigins, globalConfig, componentsPath, appProtocol, mode string,
-	httpPort, internalGRPCPort, apiGRPCPort int, apiListenAddress string, appPort, profilePort int,
+	httpPort, internalGRPCPort, apiGRPCPort, appPort, profilePort int,
 	enableProfiling bool, maxConcurrency int, mtlsEnabled bool, sentryAddress string, appSSL bool, maxRequestBodySize int) *Config {
 	return &Config{
 		ID:                  id,
@@ -88,6 +85,5 @@ func NewRuntimeConfig(
 		SentryServiceAddress: sentryAddress,
 		AppSSL:               appSSL,
 		MaxRequestBodySize:   maxRequestBodySize,
-		APIListenAddress:     apiListenAddress,
 	}
 }

--- a/pkg/runtime/config_test.go
+++ b/pkg/runtime/config_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	c := NewRuntimeConfig("app1", []string{"localhost:5050"}, "localhost:5051", "*", "config", "components", "http", "kubernetes",
-		3500, 50002, 50001, "1.2.3.4", 8080, 7070, true, 1, true, "localhost:5052", true, 4)
+		3500, 50002, 50001, 8080, 7070, true, 1, true, "localhost:5052", true, 4)
 
 	assert.Equal(t, "app1", c.ID)
 	assert.Equal(t, "localhost:5050", c.PlacementAddresses[0])
@@ -26,7 +26,6 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, 3500, c.HTTPPort)
 	assert.Equal(t, 50002, c.InternalGRPCPort)
 	assert.Equal(t, 50001, c.APIGRPCPort)
-	assert.Equal(t, "1.2.3.4", c.APIListenAddress)
 	assert.Equal(t, 8080, c.ApplicationPort)
 	assert.Equal(t, 7070, c.ProfilePort)
 	assert.Equal(t, true, c.EnableProfiling)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -780,35 +780,34 @@ func (a *DaprRuntime) readFromBinding(name string, binding bindings.InputBinding
 func (a *DaprRuntime) startHTTPServer(port, profilePort int, allowedOrigins string, pipeline http_middleware.Pipeline) {
 	a.daprHTTPAPI = http.NewAPI(a.runtimeConfig.ID, a.appChannel, a.directMessaging, a.getComponents, a.stateStores, a.secretStores,
 		a.secretsConfiguration, a.getPublishAdapter(), a.actor, a.sendToOutputBinding, a.globalConfig.Spec.TracingSpec, a.ShutdownWithWait)
-	serverConf := http.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, profilePort, allowedOrigins, a.runtimeConfig.EnableProfiling, a.runtimeConfig.MaxRequestBodySize, a.runtimeConfig.APIListenAddress)
+	serverConf := http.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, profilePort, allowedOrigins, a.runtimeConfig.EnableProfiling, a.runtimeConfig.MaxRequestBodySize)
 
 	server := http.NewServer(a.daprHTTPAPI, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, pipeline, a.globalConfig.Spec.APISpec)
 	server.StartNonBlocking()
 }
 
 func (a *DaprRuntime) startGRPCInternalServer(api grpc.API, port int) error {
-	// Since GRPCInteralServer is encrypted & authenticated, it is safe to listen on *
-	serverConf := a.getNewServerConfig("", port)
+	serverConf := a.getNewServerConfig(port)
 	server := grpc.NewInternalServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, a.authenticator, a.proxy)
 	err := server.StartNonBlocking()
 	return err
 }
 
 func (a *DaprRuntime) startGRPCAPIServer(api grpc.API, port int) error {
-	serverConf := a.getNewServerConfig(a.runtimeConfig.APIListenAddress, port)
+	serverConf := a.getNewServerConfig(port)
 	server := grpc.NewAPIServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, a.globalConfig.Spec.APISpec, a.proxy)
 	err := server.StartNonBlocking()
 	return err
 }
 
-func (a *DaprRuntime) getNewServerConfig(listenAddress string, port int) grpc.ServerConfig {
+func (a *DaprRuntime) getNewServerConfig(port int) grpc.ServerConfig {
 	// Use the trust domain value from the access control policy spec to generate the cert
 	// If no access control policy has been specified, use a default value
 	trustDomain := config.DefaultTrustDomain
 	if a.accessControlList != nil {
 		trustDomain = a.accessControlList.TrustDomain
 	}
-	return grpc.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, a.namespace, trustDomain, a.runtimeConfig.MaxRequestBodySize, listenAddress)
+	return grpc.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, a.namespace, trustDomain, a.runtimeConfig.MaxRequestBodySize)
 }
 
 func (a *DaprRuntime) getGRPCAPI() grpc.API {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2340,7 +2340,6 @@ func NewTestDaprRuntimeWithProtocol(mode modes.DaprMode, protocol string, appPor
 		DefaultDaprHTTPPort,
 		0,
 		DefaultDaprAPIGRPCPort,
-		DefaultAPIListenAddress,
 		appPort,
 		DefaultProfilePort,
 		false,

--- a/pkg/runtime/wait.go
+++ b/pkg/runtime/wait.go
@@ -19,7 +19,7 @@ var (
 	urlFormat            string = "http://localhost:%s/v1.0/healthz/outbound"
 )
 
-func waitUntilDaprOutboundReady(daprHTTPPort string) error {
+func waitUntilDaprOutboundReady(daprHTTPPort string) {
 	outboundReadyHealthURL := fmt.Sprintf(urlFormat, daprHTTPPort)
 	client := &http.Client{
 		Timeout: time.Duration(requestTimeoutMillis) * time.Millisecond,
@@ -33,7 +33,7 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) error {
 		err = checkIfOutboundReady(client, outboundReadyHealthURL)
 		if err == nil {
 			println("Dapr is outbound ready!")
-			return nil
+			return
 		}
 
 		if time.Now().After(lastPrintErrorTime) {
@@ -46,7 +46,6 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) error {
 	}
 
 	println(fmt.Sprintf("timeout waiting for Dapr to become outbound ready. Last error: %v", err))
-	return err
 }
 
 func checkIfOutboundReady(client *http.Client, outboundReadyHealthURL string) error {


### PR DESCRIPTION
This reverts commit 87d76e4dbc4d910644c04a13cc479379cea7c98a.

# Description

We've discovered that the healthcheck introduced in this change is too costly. We're reverting until we have a viable substitute.

Also cut a new rc.2.


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
