### PR TITLE
Limit Reentrancy Id strictly to reentrant calls

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -387,14 +387,16 @@ func (a *actorsRuntime) callLocalActor(ctx context.Context, req *invokev1.Invoke
 
 	// Reentrancy to determine how we lock.
 	var reentrancyID *string
-	if headerValue, ok := req.Metadata()["Dapr-Reentrancy-Id"]; a.reentrancyEnabled && ok {
-		reentrancyID = &headerValue.GetValues()[0]
-	} else {
-		reentrancyHeader := fasthttp.RequestHeader{}
-		uuid := uuid.New().String()
-		reentrancyHeader.Add("Dapr-Reentrancy-Id", uuid)
-		req.AddHeaders(&reentrancyHeader)
-		reentrancyID = &uuid
+	if a.reentrancyEnabled {
+		if headerValue, ok := req.Metadata()["Dapr-Reentrancy-Id"]; ok {
+			reentrancyID = &headerValue.GetValues()[0]
+		} else {
+			reentrancyHeader := fasthttp.RequestHeader{}
+			uuid := uuid.New().String()
+			reentrancyHeader.Add("Dapr-Reentrancy-Id", uuid)
+			req.AddHeaders(&reentrancyHeader)
+			reentrancyID = &uuid
+		}
 	}
 
 	err := act.lock(reentrancyID)


### PR DESCRIPTION
# Description
As written, reentrancy assigned a context to all actor calls. Only
reentrant calls would have the same Id passed through, which is what
enabled reentrancy.

This change limits that as we have found cases where being able to
distinguish between reentrant and non-reentrant calls to be valuable.

## Issue reference

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
