### PR TITLE
Revert pinning of Go 1.16.6

### DIFF
--- a/docs/release_notes/v1.3.0.md
+++ b/docs/release_notes/v1.3.0.md
@@ -1,0 +1,306 @@
+
+# Dapr 1.3.0
+
+We're happy to announce the release of Dapr 1.3.0!
+
+We would like to extend our thanks to all the new and existing contributors who helped make this release happen.
+
+**Highlights**
+
+If you’re new to Dapr, familiarize yourself by visiting the [getting started](https://docs.dapr.io/getting-started/) page.
+
+- **Service Invocation**
+    - Added **gRPC proxying to enable bring-your-own-proto [(preview feature)](https://docs.dapr.io/operations/support/support-preview-features.md)** [#323](https://github.com/dapr/dapr/issues/3231). Use your existing proto based gRPC services and have the traffic go through the Dapr sidecar. This enables Dapr applications to use the benefits of Service Invocation, including security, retries and ACLs to these gRPC services. See our [How-To: Invoke services using gRPC](https://docs.dapr.io/developing-applications/building-blocks/service-invocation/howto-invoke-services-grpc/) documentation for further details. 
+- **Actors**
+    - **Actor reminders and triggers now support ISO 8601 intervals** [#2513](https://github.com/dapr/dapr/issues/2513). Read more [here](https://docs.dapr.io/developing-applications/building-blocks/actors/howto-actors.md)
+    - Added **actor reentrancy support in .NET, PHP and Python SDKs [(preview feature)](https://docs.dapr.io/operations/support/support-preview-features.md)** . Actor reentrancy remains a [preview feature](https://docs.dapr.io/operations/support/support-preview-features.md) in this release. Note that Java and PHP SDKs will support actor reentrancy in the next release.
+    - Added **configuration for actor reentrancy [(preview feature)](https://docs.dapr.io/operations/support/support-preview-features.md)** [#3049](https://github.com/dapr/dapr/issues/3049). Actor reentrancy has several configuration values that must be understood by the runtime/actors. The configuration is provided to the runtime during the call to dapr/config
+    - Support for **actor reminder storage partitioning [(preview feature)](https://docs.dapr.io/operations/support/support-preview-features.md)** [#2889](https://github.com/dapr/dapr/issues/2889). Applications can now enable partitioning of actor reminders in the state store across multiple keys for improved scale and performance. For more information on actor reminder storage partitioning, visit [Dapr's Actors Documentation]()
+- **State Management**
+    - Added **support for TTL (time to live) to a subset of state store components** [#306](https://github.com/dapr/components-contrib/issues/306). Applications can set time-to-live per state stored, and these states cannot be retrieved after expiration (the state is deleted) [Supported state store components that support TTL](https://docs.dapr.io/reference/components-reference/supported-state-stores/) are: Cassandra, Memcache, Redis, CosmosDB. Read more about [state TTL](https://docs.dapr.io/developing-applications/building-blocks/state-management/state-store-ttl/)
+- **New components**
+    - [**GraphQL binding**](https://docs.dapr.io/reference/components-reference/supported-bindings/graghql/) 
+    - [**AWS SSM Parameter Store**](https://docs.dapr.io/reference/components-reference/supported-secret-stores/aws-parameter-store/) 
+- **Setup VS Code development in a containerized environment and use this in GitHub Codespaces for contributing to dapr project** [#3229](https://github.com/dapr/dapr/issues/3229). Read more [here](https://github.com/dapr/dapr/blob/master/docs/development/setup-dapr-development-using-vscode.md)
+
+> **Note: This release contains [breaking changes](#breaking-changes).**
+
+See [this](#upgrading-to-dapr-1.3.0) section on upgrading Dapr to version 1.3.0.
+
+## Acknowledgements
+
+Thanks to everyone who made this release possible!
+
+@1046102779, @AaronCrawfis, @Banchio, @CodeMonkeyLeet, @CodingSinger, @DanAbara, @DarqueWarrior, @Junnplus, @Taction, @akkie, @alvinhenrick, @amirmm11, @anhldbk, @artursouza, @beiwei30, @berndverst, @bjorkstromm, @daixiang0, @delvh, @dmitsh, @eNeRGy164, @emattiza, @fabistb, @gogi2811, @greenie-msft, @halspang, @iamazy, @jasonviviano, @jcdickinson, @jigargandhi, @luckyxiaoqiang, @marviniter, @msfussell, @mukundansundar, @orizohar, @pinxiong, @pkedy, @puzpuzpuz, @rovangju, @seeflood, @skyao, @stulzq, @tanvigour, @tianjipeng, @tomkerkhove, @wcs1only, @withinboredom, @yaron2
+
+## New in this release
+
+### Dapr Runtime
+- **RESOLVED** Devcontainer: Shared docker or docker-in-docker? [2483](https://github.com/dapr/dapr/issues/2483)
+- **RESOLVED** Have Actor reminder and triggers support ISO 8601 intervals standard format [2513](https://github.com/dapr/dapr/issues/2513)
+- **RESOLVED** Make development documentation complete for newcomers [2529](https://github.com/dapr/dapr/issues/2529)
+- **ADDED** Custom component definition of Kubernetes secret store [2821](https://github.com/dapr/dapr/issues/2821)
+- **RESOLVED** Storage of actor reminders in one single db-field [2889](https://github.com/dapr/dapr/issues/2889)
+- **RESOLVED** Fix utils test and make it run from Makefile too [2924](https://github.com/dapr/dapr/pull/2924)
+- **RESOLVED** Get PHP app to work on E2E test for actors on Windows [2953](https://github.com/dapr/dapr/issues/2953)
+- **FIXED** Data race and concurrency problems of actor placement. [2961](https://github.com/dapr/dapr/issues/2961)
+- Log missing app port when pub/sub component is loaded. [2979](https://github.com/dapr/dapr/issues/2979)
+- **FIXED** Race condition between placement service table dissemination and actor removal [3023](https://github.com/dapr/dapr/issues/3023)
+- **ADDED** Configuration for actor reentrancy [3049](https://github.com/dapr/dapr/issues/3049)
+- **RESOLVED** Dapr-Dev-Container build is broken. [3056](https://github.com/dapr/dapr/issues/3056)
+- **RESOLVED** Crash in daprd sidecar when multiple invocation requests are made without the server running [3128](https://github.com/dapr/dapr/issues/3128)
+- **ADD:** Spread Dapr instances across zones in Kubernetes cluster for high-availability [3147](https://github.com/dapr/dapr/issues/3147)
+- **ADDED** Use Pod Disruption Budget to ensure Dapr remains up [3148](https://github.com/dapr/dapr/issues/3148)
+- **RESOLVED** Injector customize cluster domain of k8s when access some system service [3163](https://github.com/dapr/dapr/issues/3163)
+- **RESOLVED** GetState API does not return metadata in HTTP [3172](https://github.com/dapr/dapr/issues/3172)
+- **RESOLVED** operator and sidecar boot sequencing error is being ignored causing messaging pipeline to break on k8s node reboot [3175](https://github.com/dapr/dapr/issues/3175)
+- **FIXED** Helm install of custom sidecar container image without injector fails [3192](https://github.com/dapr/dapr/issues/3192)
+- **RESOLVED** Use separate custom image for injector service in dapr_sidecar_injector chart [3193](https://github.com/dapr/dapr/pull/3193)
+- **RESOLVED** clean up mixed tab and spaces [3196](https://github.com/dapr/dapr/pull/3196)
+- **RESOLVED** ci: sort import path [3197](https://github.com/dapr/dapr/pull/3197)
+- **RESOLVED** Fix build on Darwin Arm64 [3218](https://github.com/dapr/dapr/pull/3218)
+- **RESOLVED** Add support for metadata in pub/sub subscription CRD [3225](https://github.com/dapr/dapr/issues/3225)
+- **RESOLVED** components-contrib#749 The URL is wrong [3226](https://github.com/dapr/dapr/issues/3226)
+- **RESOLVED** Support GitHub Codespaces for contributing to dapr project [3229](https://github.com/dapr/dapr/issues/3229)
+- **RESOLVED** Call existing gRPC methods and bring your own gRPC protos - renewed gRPC experience.  [3231](https://github.com/dapr/dapr/issues/3231)
+- **ADDED** PKCS8 support [3240](https://github.com/dapr/dapr/issues/3240)
+- **RESOLVED** before make e2e-build-deploy-run should delete mutatingwebhookconfigurations file [3249](https://github.com/dapr/dapr/issues/3249)
+- **RESOLVED** Go Panic on Actors usage (Redis) with PubSub (Redis) on Start [3258](https://github.com/dapr/dapr/issues/3258)
+- **FIXED** Dapr instructions for security reporting in issue templates. [3263](https://github.com/dapr/dapr/issues/3263)
+- **RESOLVED** Apply max request body to gRPC channel [3265](https://github.com/dapr/dapr/issues/3265)
+- **RESOLVED** fix: sendToOutputBinding incorrect make slice [3270](https://github.com/dapr/dapr/pull/3270)
+- **RESOLVED** use dapr.io/enable-debug: "true" to debug dapr failed [3287](https://github.com/dapr/dapr/issues/3287)
+- **RESOLVED** Race condition in grpc/api.go [3323](https://github.com/dapr/dapr/issues/3323)
+- **RESOLVED** InvokeBinding API now returns metadata in HTTP [3326](https://github.com/dapr/dapr/issues/3326)
+- **RESOLVED** `make lint` command does not lint e2e [3328](https://github.com/dapr/dapr/issues/3328)
+- **RESOLVED** Git commit hash to version output in STDOUT [3341](https://github.com/dapr/dapr/issues/3341)
+- **RESOLVED** unblockPlacements concurrent calls will raise panic bug [3364](https://github.com/dapr/dapr/issues/3364)
+- **RESOLVED** dapr: add aws parameter store support [3369](https://github.com/dapr/dapr/pull/3369)
+- **RESOLVED** hotfix: operator component crd resouces update all dapr runtime [3375](https://github.com/dapr/dapr/pull/3375)
+- **RESOLVED** Add GraphQL Binding (components-contrib#844) [3394](https://github.com/dapr/dapr/pull/3394)
+- **RESOLVED** Fix typo in error message [3400](https://github.com/dapr/dapr/pull/3400)
+- **RESOLVED** Add security policy file [3419](https://github.com/dapr/dapr/issues/3419)
+- **RESOLVED** Fix typos [3427](https://github.com/dapr/dapr/pull/3427)
+### Dapr CLI
+- **RESOLVED** Make install script work with non-privilege's environments like Azure Cloud Shell  [580](https://github.com/dapr/cli/issues/580)
+- **ADDED** git commit hash of cli and runtime to --version output [599](https://github.com/dapr/cli/issues/599)
+- **RESOLVED** `dapr uninstall -k` does not remove CRDs [656](https://github.com/dapr/cli/issues/656)
+- **FIXED** Add secondary CDN backed source of truth for latest Dapr version [677](https://github.com/dapr/cli/issues/677)
+- **RESOLVED** `dapr run` doesn't allow you to configure placement-port [705](https://github.com/dapr/cli/issues/705)
+- **RESOLVED** Fixing typos [718](https://github.com/dapr/cli/pull/718)
+- **RESOLVED** Fix build on Darwin Arm64 [725](https://github.com/dapr/cli/pull/725)
+- **RESOLVED** JSON/YAML format for `dapr list` [728](https://github.com/dapr/cli/issues/728)
+- **RESOLVED** Add CI/CD Test for Windows Powershell Installer [732](https://github.com/dapr/cli/pull/732)
+- **RESOLVED** Dapr List Displays Dapr Dashboards As Empty Services [736](https://github.com/dapr/cli/issues/736)
+- **RESOLVED** CLI assumes a version prefix of "v" trims `1.2.2` to `.2.2` [761](https://github.com/dapr/cli/issues/761)
+- **RESOLVED** Run command: fix bool args passed to daprd [768](https://github.com/dapr/cli/pull/768)
+### Components
+- **RESOLVED** Event-Hub input binding should propagate event meta-data [227](https://github.com/dapr/components-contrib/issues/227)
+- **RESOLVED** Add optional support for TTL (Time to Live) for state stores [306](https://github.com/dapr/components-contrib/issues/306)
+    - *Currently supported components: Cassandra, Memcache, Redis, CosmosDB. See [this table](https://v1-3.docs.dapr.io/reference/components-reference/supported-state-stores/).*
+- **RESOLVED** Add vscode devcontainer [316](https://github.com/dapr/components-contrib/issues/316)
+- **RESOLVED** AWS Managed Cassandra State : not working [691](https://github.com/dapr/components-contrib/issues/691)
+- **RESOLVED** Azure Storage - getBlobRetryCount [758](https://github.com/dapr/components-contrib/issues/758)
+- **RESOLVED** Move The common Redis code to internal [857](https://github.com/dapr/components-contrib/issues/857)
+- **RESOLVED** Add backoff for rabbitmq PubSub component [861](https://github.com/dapr/components-contrib/issues/861)
+- **RESOLVED** Rabbitmq component goroutine not exit after close [863](https://github.com/dapr/components-contrib/issues/863)
+- **RESOLVED** Update Zeebe to version 1.0 [875](https://github.com/dapr/components-contrib/issues/875)
+- **RESOLVED** ci: enable gofumt linter [887](https://github.com/dapr/components-contrib/pull/887)
+- **RESOLVED** Move retry and config packages to dapr/kit for reuse [893](https://github.com/dapr/components-contrib/issues/893)
+- **RESOLVED** Binding to GraphQL [902](https://github.com/dapr/components-contrib/issues/902)
+- **RESOLVED** Dapr Mongo State Store component does not support srv record format [904](https://github.com/dapr/components-contrib/issues/904)
+- **RESOLVED** ci: add test skip case [922](https://github.com/dapr/components-contrib/pull/922)
+- **RESOLVED** Mysql should support more data types. [923](https://github.com/dapr/components-contrib/issues/923)
+- **RESOLVED** Delete unused code and update test [924](https://github.com/dapr/components-contrib/pull/924)
+- **RESOLVED** Hashicorp Vault - using BulkGetSecret (through asp.net core) always return 404 Not Found [925](https://github.com/dapr/components-contrib/issues/925)
+- **RESOLVED** Fix typo [927](https://github.com/dapr/components-contrib/pull/927)
+- **RESOLVED** Why is the value of ConsumerID assigned to consumerGroup? [928](https://github.com/dapr/components-contrib/issues/928)
+- **RESOLVED** Support Codespaces and VSCode devcontainers in Components-Contrib repo [935](https://github.com/dapr/components-contrib/issues/935)
+- **RESOLVED** fix: Dapr runtime panic when handle Pub/Sub (dapr#3281) [967](https://github.com/dapr/components-contrib/pull/967)
+- **RESOLVED** Implement E2E tests for the Zeebe binding [973](https://github.com/dapr/components-contrib/pull/973)
+- **RESOLVED** Allow Azure Key Vault conformance test use environment variable for vaultName [974](https://github.com/dapr/components-contrib/issues/974)
+- **RESOLVED** Fix reported vulnerabilities [979](https://github.com/dapr/components-contrib/issues/979)
+- **RESOLVED** Upgrade to github.com/golang-jwt/jwt [989](https://github.com/dapr/components-contrib/issues/989)
+### .NET SDK
+- **ADDED** Support for actor reentrancy [661](https://github.com/dapr/dotnet-sdk/issues/661)
+- **RESOLVED** Add support to provide Pubsub (and Topic) during runtime at startup for controller methods. [678](https://github.com/dapr/dotnet-sdk/issues/678)
+- **RESOLVED** Adds support for providing pubsub and topic names during runtime. [681](https://github.com/dapr/dotnet-sdk/pull/681)
+- **RESOLVED** Improve Actor descriptions [684](https://github.com/dapr/dotnet-sdk/pull/684)
+- **RESOLVED** Fix typo in .NET Actor client docs [690](https://github.com/dapr/dotnet-sdk/pull/690)
+- **RESOLVED** Fix typo in .NET SDK docs [697](https://github.com/dapr/dotnet-sdk/pull/697)
+- **RESOLVED** Update dotnet-development-tye.md [700](https://github.com/dapr/dotnet-sdk/pull/700)
+- **RESOLVED** Fix CODEOWNERS [703](https://github.com/dapr/dotnet-sdk/pull/703)
+- **RESOLVED** Add support for Actor Reentrancy [708](https://github.com/dapr/dotnet-sdk/pull/708)
+- **RESOLVED** docs fix: only UseHttpsRedirection for non-dev env [710](https://github.com/dapr/dotnet-sdk/pull/710)
+- **RESOLVED** fix: InvalidProgramException under ASP.Net 6.0 [711](https://github.com/dapr/dotnet-sdk/pull/711)
+- **RESOLVED** Configurable actor reminder storage partitions [712](https://github.com/dapr/dotnet-sdk/pull/712)
+- **RESOLVED** GrpcServiceSample: No message returned from method [719](https://github.com/dapr/dotnet-sdk/issues/719)
+### Go SDK
+- **RESOLVED** Add metadata support for PublishEvent API [164](https://github.com/dapr/go-sdk/issues/164)
+- **RESOLVED** Rationalize PublishEvent* APIs [174](https://github.com/dapr/go-sdk/issues/174)
+### Java SDK
+- **RESOLVED** Update Spring Boot DaprBeanPostProcessor to evaluate expressions Topic attribute values [554](https://github.com/dapr/java-sdk/issues/554)
+- **RESOLVED** fix: Fatal error compiling: invalid flag: --release [560](https://github.com/dapr/java-sdk/pull/560)
+- **FIXED** Actor gRPC client to be non-blocking [562](https://github.com/dapr/java-sdk/issues/562)
+- **RESOLVED** Update GRPC libraries for security updates [573](https://github.com/dapr/java-sdk/pull/573)
+- **RESOLVED** Add support for configuring actor reminder storage partitions [574](https://github.com/dapr/java-sdk/pull/574)
+### Python SDK
+- **ADDED** Support for actor reentrancy [214](https://github.com/dapr/python-sdk/issues/214)
+- **RESOLVED** Chore: remove invalid args comment [215](https://github.com/dapr/python-sdk/pull/215)
+- **RESOLVED** [Docs-CONTENT] Wrong link reference in docs  [220](https://github.com/dapr/python-sdk/issues/220)
+- **RESOLVED** Enable dependabot [228](https://github.com/dapr/python-sdk/pull/228)
+- **RESOLVED** Configurable actor reminder storage patitions [236](https://github.com/dapr/python-sdk/pull/236)
+- **RESOLVED** Implement State Isolation for Reentrant Actor Calls [237](https://github.com/dapr/python-sdk/issues/237)
+### PHP SDK
+- **ADDED** Dapr API token support [81](https://github.com/dapr/php-sdk/issues/81)
+- **RESOLVED** Add Laravel example [84](https://github.com/dapr/php-sdk/pull/84)
+- **ADDED** Support for actor reentrancy [85](https://github.com/dapr/php-sdk/issues/85)
+- **RESOLVED** Enable reentrancy for actors [89](https://github.com/dapr/php-sdk/pull/89)
+- **RESOLVED** A whole new client [93](https://github.com/dapr/php-sdk/pull/93)
+- **ADDED** native DateInterval support [95](https://github.com/dapr/php-sdk/issues/95)
+- **RESOLVED** Support Reminder Storage Partitions Actor Runtime Config [97](https://github.com/dapr/php-sdk/issues/97)
+### Documentation
+- **RESOLVED** Add deployment and upgrade guidelines for self-hosted mode [760](https://github.com/dapr/docs/issues/760)
+- **RESOLVED** [CONTENT] Incorrect curl syntax in Actors API examples [1365](https://github.com/dapr/docs/issues/1365)
+- **RESOLVED** Enabling HA for existing Dapr installations on Kubernetes [1476](https://github.com/dapr/docs/issues/1476)
+- **RESOLVED** [CONTENT] Actor sections should mention that only a single state store can be used for actor state [1525](https://github.com/dapr/docs/issues/1525)
+- **RESOLVED** VS Code Dapr Extension Documentation Update [1533](https://github.com/dapr/docs/issues/1533)
+- **RESOLVED** GCP Pub/Sub Binding required fields [1534](https://github.com/dapr/docs/issues/1534)
+- **RESOLVED** gRPC service extension examples won't run [1542](https://github.com/dapr/docs/issues/1542)
+- **RESOLVED** Secrets getting started guide should clarify path to file [1544](https://github.com/dapr/docs/issues/1544)
+- **RESOLVED** Add gRPC proxy section [1548](https://github.com/dapr/docs/issues/1548)
+- **RESOLVED** Building blocks articles do not link to the SDK topic for that building block [1549](https://github.com/dapr/docs/issues/1549)
+- **RESOLVED** Add automation to create PR for submodule updates [1562](https://github.com/dapr/docs/issues/1562)
+- **RESOLVED** metadata missing consumerGroup [1575](https://github.com/dapr/docs/issues/1575)
+- **RESOLVED** Need topic that list all the **preview features** and when they were introduced [1592](https://github.com/dapr/docs/issues/1592)
+- **RESOLVED** Actors reminder and triggers support ISO 8601 intervals standard format [1600](https://github.com/dapr/docs/issues/1600)
+- **RESOLVED** Update info about supported Kubernetes versions [1603](https://github.com/dapr/docs/pull/1603)
+- **RESOLVED** Document kubernetes secret store [1622](https://github.com/dapr/docs/pull/1622)
+- **RESOLVED** Document how to use partitioning for actor reminders storage [1648](https://github.com/dapr/docs/issues/1648)
+- **RESOLVED** updated Actor How To docs for reminder intervals [1651](https://github.com/dapr/docs/pull/1651)
+- **RESOLVED** Document actor reminder partitioning [1658](https://github.com/dapr/docs/pull/1658)
+- **RESOLVED** Add gRPC proxying content [1671](https://github.com/dapr/docs/issues/1671)
+- **RESOLVED** Added a How-To section for VSCode debugging [1673](https://github.com/dapr/docs/pull/1673)
+- **RESOLVED** Fix profiling flag example [1675](https://github.com/dapr/docs/pull/1675)
+- **RESOLVED** Add a list of all current preview features [1678](https://github.com/dapr/docs/pull/1678)
+- **RESOLVED** Update the list of supported Dapr versions for v1.3  [1684](https://github.com/dapr/docs/issues/1684)
+
+## Upgrading to Dapr 1.3.0
+
+To upgrade to this release of Dapr, follow the steps here to ensure a smooth upgrade. You know, the one where you don't get red errors on the terminal.. we all hate that, right?
+
+### Local Machine / Self-hosted
+
+Uninstall Dapr using the CLI you currently have installed. Note that this will remove the default $HOME/.dapr directory, binaries and all containers dapr_redis, dapr_placement and dapr_zipkin. Linux users need to run sudo if docker command needs sudo:
+
+```bash
+dapr uninstall --all
+```
+
+For RC releases like this, download the latest and greatest release from [here](https://github.com/dapr/cli/releases) and put the `dapr` binary in your PATH.
+
+Once you have installed the CLI, run:
+
+```bash
+dapr init --runtime-version=1.3.0
+```
+
+Wait for the update to finish,  ensure you are using the latest version of Dapr(1.3.0) with:
+
+```bash
+$ dapr --version
+
+CLI version: 1.3.0
+Runtime version: 1.3.0
+```
+
+### Kubernetes
+
+#### Upgrading from previous version
+
+You can perform zero-downtime upgrades using both Helm 3 and the Dapr CLI.
+
+##### Upgrade using the CLI
+
+Download the latest RC release from [here](https://github.com/dapr/cli/releases) and put the `dapr` binary in your PATH.
+
+To upgrade Dapr, run:
+
+```
+dapr upgrade --runtime-version 1.3.0 -k
+```
+
+To upgrade with high availability mode:
+
+```
+dapr upgrade --runtime-version 1.3.0 --enable-ha=true -k
+```
+
+Wait until the operation is finished and check your status with `dapr status -k`.
+
+All done!
+
+*Note: Make sure your deployments are restarted to pick the latest version of the Dapr sidecar*
+
+##### Upgrade using Helm
+
+To upgrade Dapr using Helm, run:
+
+```
+helm repo add dapr https://dapr.github.io/helm-charts/
+helm repo update
+
+helm upgrade dapr dapr/dapr --version 1.3.0 --namespace=dapr-system --wait
+```
+
+Wait until the operation is finished and check your status with `dapr status -k`.
+
+All done!
+
+*Note: Make sure your deployments are restarted to pick the latest version of the Dapr sidecar*
+
+#### Starting a fresh install on a cluster
+
+Please see [how to deploy Dapr on a Kubernetes cluster](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/) for a complete guide to installing Dapr on Kubernetes
+
+You can use Helm 3 to install Dapr:
+```
+helm repo add dapr https://dapr.github.io/helm-charts/
+helm repo update
+
+kubectl create namespace dapr-system
+
+helm install dapr dapr/dapr --version 1.3.0 --namespace dapr-system --wait
+```
+
+Alternatively, you can use the latest version of CLI:
+
+```
+dapr init --runtime-version=1.3.0 -k
+```
+
+##### Post installation
+
+Verify the control plane pods are running and are healthy:
+
+```
+$ dapr status -k
+  NAME                   NAMESPACE    HEALTHY  STATUS   REPLICAS  VERSION  AGE  CREATED
+  dapr-dashboard         dapr-system  True     Running  1         0.7.0    15s  2021-07-26 13:07.39
+  dapr-sidecar-injector  dapr-system  True     Running  1         1.3.0   15s  2021-07-26 13:07.39
+  dapr-sentry            dapr-system  True     Running  1         1.3.0   15s  2021-07-26 13:07.39
+  dapr-operator          dapr-system  True     Running  1         1.3.0   15s  2021-07-26 13:07.39
+  dapr-placement         dapr-system  True     Running  1         1.3.0   15s  2021-07-26 13:07.39
+```
+
+After Dapr 1.3.0 has been installed, perform a rolling restart for your deployments to pick up the new version of the sidecar.
+This can be done with:
+
+```
+kubectl rollout restart deploy/<deployment-name>
+```
+
+## Breaking Changes
+
+### Components
+- **RESOLVED** Update Zeebe to version 1.0 [875](https://github.com/dapr/components-contrib/issues/875)


### PR DESCRIPTION
# Description

Reverts pinning of Go 1.16.6 which is no longer necessary as of today because GitHub Actions environments now default to 1.16.6.