### PR TITLE
Update golang extension in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 	},
 	"extensions": [
 		"davidanson.vscode-markdownlint",
-		"ms-vscode.go",
+		"golang.go",
 		"ms-azuretools.vscode-dapr",
 		"ms-azuretools.vscode-docker",
 		"ms-kubernetes-tools.vscode-kubernetes-tools"


### PR DESCRIPTION
# Description

Replace the deprecated `ms-vscode.go` extension with the currently supported `golang.go` extension in the Dapr devcontainer definition.

## Issue reference

Applies the fix for https://github.com/dapr/components-contrib/issues/1022 into the dapr/dapr repo as well.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
