### PR TITLE
Add Dapr Core team to test runner ACLs

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -31,7 +31,13 @@ jobs:
               "orizohar",
               "pruthvidhodda",
               "mchmarny",
-              "tcnghia"
+              "tcnghia",
+              "berndverst",
+              "halspang",
+              "tanvigour",
+              "dmitsh",
+              "pkedy",
+              "CodeMonkeyLeet"
             ];
 
             const payload = context.payload;


### PR DESCRIPTION
Allows the Dapr Core team to run tests via `/ok-to-test` and `/ok-to-perf`