### PR TITLE
tests: load registry env first

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -271,8 +271,8 @@ describe-kind-env:
 	export MINIKUBE_NODE_IP=`kubectl get nodes \
 	    -lkubernetes.io/hostname!=kind-control-plane \
         -ojsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`\n\
-	export DAPR_REGISTRY=localhost:5000/dapr\n\
-	export DAPR_TEST_REGISTRY=localhost:5000/dapr\n\
+	export DAPR_REGISTRY=$${DAPR_REGISTRY:-localhost:5000/dapr}\n\
+	export DAPR_TEST_REGISTRY=$${DAPR_TEST_REGISTRY:-localhost:5000/dapr}\n\
 	export DAPR_TAG=dev\n\
 	export DAPR_NAMESPACE=dapr-tests"
 	


### PR DESCRIPTION
Signed-off-by: Long <long0dai@foxmail.com>

# Description

Make tests config easily, if we set with env, users can use `eval `make describe-kind-env``, no need to copy and paste.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

RELEASE NOTES: N/A