### PR TITLE
remove bou.ke/monkey depencences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ release: build archive
 ################################################################################
 .PHONY: test
 test: test-deps
-	gotestsum --jsonfile $(TEST_OUTPUT_FILE_PREFIX)_unit.json --format standard-quiet -- -gcflags=-l ./pkg/... ./utils/... ./cmd/... $(COVERAGE_OPTS)
+	gotestsum --jsonfile $(TEST_OUTPUT_FILE_PREFIX)_unit.json --format standard-quiet -- ./pkg/... ./utils/... ./cmd/... $(COVERAGE_OPTS)
 	go test ./tests/...
 
 ################################################################################

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/dapr/dapr
 go 1.17
 
 require (
-	bou.ke/monkey v1.0.2
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
 	contrib.go.opencensus.io/exporter/zipkin v0.1.1
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/components/standalone_loader_test.go
+++ b/pkg/components/standalone_loader_test.go
@@ -1,71 +1,12 @@
 package components
 
 import (
-	"fmt"
-	"io/ioutil"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 
 	config "github.com/dapr/dapr/pkg/config/modes"
 )
-
-func TestLoadComponentsFromFile(t *testing.T) {
-	request := &StandaloneComponents{
-		config: config.StandaloneConfig{
-			ComponentsPath: "test_component_path",
-		},
-	}
-	t.Run("valid yaml content", func(t *testing.T) {
-		filename := "test-component.yaml"
-		yaml := `
-apiVersion: dapr.io/v1alpha1
-kind: Component
-metadata:
-   name: statestore
-spec:
-   type: state.couchbase
-   metadata:
-   - name: prop1
-     value: value1
-   - name: prop2
-     value: value2
-`
-		monkey.Patch(ioutil.ReadFile, func(_ string) ([]byte, error) {
-			return []byte(yaml), nil
-		})
-		defer monkey.UnpatchAll()
-		components := request.loadComponentsFromFile(filename)
-		assert.Len(t, components, 1)
-	})
-
-	t.Run("invalid yaml head", func(t *testing.T) {
-		filename := "test-component.yaml"
-		yaml := `
-INVALID_YAML_HERE
-apiVersion: dapr.io/v1alpha1
-kind: Component
-metadata:
-name: statestore`
-		monkey.Patch(ioutil.ReadFile, func(_ string) ([]byte, error) {
-			return []byte(yaml), nil
-		})
-		defer monkey.UnpatchAll()
-		components := request.loadComponentsFromFile(filename)
-		assert.Len(t, components, 0)
-	})
-
-	t.Run("load components file not exist", func(t *testing.T) {
-		filename := "test-component.yaml"
-		monkey.Patch(ioutil.ReadFile, func(_ string) ([]byte, error) {
-			return nil, fmt.Errorf("no such file or directory")
-		})
-		defer monkey.UnpatchAll()
-		components := request.loadComponentsFromFile(filename)
-		assert.Len(t, components, 0)
-	})
-}
 
 func TestIsYaml(t *testing.T) {
 	request := &StandaloneComponents{


### PR DESCRIPTION
Signed-off-by: Long <long0dai@foxmail.com>

# Description

`loadComponentsFromFile` is equal to `io.ReadFile` + `decodeYaml`, no need to test ` io.ReadFile` as it is standard.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3563

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
