### PR TITLE
tests: add metrics-server setup for kind

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -270,6 +270,8 @@ setup-kind:
 	docker run -d --restart=always -p 5000:5000 --name kind-registry registry:2
 	# Connect the registry to the KinD network.
 	docker network connect "kind" kind-registry
+	# Setup metrics-server
+	helm install ms stable/metrics-server -n kube-system --set=args={--kubelet-insecure-tls}
 
 describe-kind-env:
 	@echo "\


### PR DESCRIPTION
Signed-off-by: Long <long0dai@foxmail.com>

# Description

Add metrics-server setup for kind.

Metrics-server is necessary for pert test, if not exist, would return below error:
```
    service_invocation_http_test.go:110: running dapr test...
    service_invocation_http_test.go:112: checking err...
    service_invocation_http_test.go:117:
                Error Trace:    service_invocation_http_test.go:117
                Error:          Received unexpected error:
                                the server could not find the requested resource (get pods.metrics.k8s.io testapp-7bb57c757d-jnt9w)
                Test:           TestServiceInvocationHTTPPerformance
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
