### PR TITLE
Correct ADR links

### DIFF
--- a/docs/decision_records/decision_records.md
+++ b/docs/decision_records/decision_records.md
@@ -37,15 +37,15 @@ All decisions are categorized in the following folders:
   
 * **SDKs** - Decisions on Dapr SDKs.
 
-  - [SDK-001: SDK releases](./sdk/SDK-001-releases.MD)
-  - [SDK-002: Java JDK versions](./sdk/SDK-002-java-jdk-versions.MD)
+  - [SDK-001: SDK releases](./sdk/SDK-001-releases.md)
+  - [SDK-002: Java JDK versions](./sdk/SDK-002-java-jdk-versions.md)
 
 * **Engineering** - Decisions on Engineering practices, including CI/CD, testing and releases.
 
-  - [ENG-001: Image Tagging](./engineering/ENG-001-tagging.MD)
-  - [ENG-002: Dapr Release](./engineering/ENG-002-Dapr-Release.MD)
-  - [ENG-003: Test Infrastructure](./engineering/ENG-003-test-infrastructure.MD)
-  - [ENG-004: Signing](./engineering/ENG-004-signing.MD)
+  - [ENG-001: Image Tagging](./engineering/ENG-001-tagging.md)
+  - [ENG-002: Dapr Release](./engineering/ENG-002-Dapr-Release.md)
+  - [ENG-003: Test Infrastructure](./engineering/ENG-003-test-infrastructure.md)
+  - [ENG-004: Signing](./engineering/ENG-004-signing.md)
 
 ## Creating new decision records
 

--- a/docs/decision_records/engineering/ENG-001-tagging.md
+++ b/docs/decision_records/engineering/ENG-001-tagging.md
@@ -1,0 +1,27 @@
+# ENG-001: Image Tagging
+
+## Status
+Accepted
+
+## Context
+As we embraced using Docker repositories to store our images, and keeping in mind we support multiple repositories along with versioning of images and different architectures,
+We needed a way to construct an accepted and constant way of naming our Docker images.
+
+## Decisions
+
+* An image will conform to the following format: \<namespace>/\<repository>:\<tag>
+* A valid tag conforms to the following format: \<version>-\<architecture>, or just \<version>, then arch is assumed Linux
+  
+## Consequences
+
+This keeps us constant with widely accepted naming conventions and sets clear guidelines for naming of future images.
+
+## Examples
+
+Dapr Runtime, latest Linux:
+
+actionscore.azurecr.io/dapr:latest
+
+Dapr Runtime, v0.1.0-alpha for ARM:
+
+actionscore.azurecr.io/dapr:v0.1.0-alpha-arm

--- a/docs/decision_records/engineering/ENG-002-Dapr-Release.md
+++ b/docs/decision_records/engineering/ENG-002-Dapr-Release.md
@@ -1,0 +1,48 @@
+# ENG-002: Dapr Release
+
+## Status
+
+Proposal
+
+## Context
+
+This record descibes how to safely release new dapr binaries and the corresponding configurations without any blockers to users.
+
+## Decisions
+
+### Integration build release
+
+Integration build refers to the build from `master` branch once we merge PullRequest to master branch. This build will be used for development purposes and must not be released to users and impact their environments.
+
+### Official build release
+
+#### Pre-release build
+
+Pre-release build will be built from `release-<major>.<minor>` branch and versioned by git version tag suffix e.g. `-alpha.0`, `-alpha.1`, etc. This build is not released to users who use the latest stable version.
+
+**Pre-release process**
+1. Create branch `release-<major>.<minor>` from master and push the branch. e.g. `release-0.1`
+2. Add pre-release version tag(with suffix -alpha.0 e.g. v0.1.0-alpha.0) and push the tag
+```
+$ git tag "v0.1.0-alpha.0" -m "v0.1.0-alpha.0"
+$ git push --tags
+```
+3. CI creates new build and push the images with only version tag
+4. Test and validate the functionalities with the specific version
+5. If there are regressions and bugs, fix them in release-* branch and merge back to master
+6. Create new pre-release version tag(with suffix -alpha.1, -alpha.2, etc)
+7. Repeat from 4 to 6 until all bugs are fixed
+
+
+#### Release the stable version to users
+
+Once all bugs are fixed, we will create the release note under [./docs/release_notes](https://github.com/dapr/dapr/tree/master/docs/release_notes) and run CI release manually in order to deliver the stable version to users.
+
+### Release Patch version
+
+We will work on the existing `release-<major>.<minor>` branch to release patch version. Once all bugs are fixed, we will add new patch version tag, such as `v0.1.1-alpha.0`, and then release the build manually.
+
+## Consequences
+
+* Keep master branch in a working state
+* Deliver the stable version to user safely

--- a/docs/decision_records/engineering/ENG-004-signing.md
+++ b/docs/decision_records/engineering/ENG-004-signing.md
@@ -1,0 +1,15 @@
+# ENG-004: Binary Signing
+
+## Status
+Accepted
+
+## Context
+Authenticode signing of binaries.
+
+## Decisions
+
+* Binaries will not be signed with Microsoft keys. In future we can revisit to sign the binaries with dapr.io keys.
+  
+## Consequences
+
+This will allow the Dapr releases to be built outside of Microsoft build and release pipelines.

--- a/docs/decision_records/sdk/SDK-001-releases.md
+++ b/docs/decision_records/sdk/SDK-001-releases.md
@@ -1,0 +1,19 @@
+# SDK-001: SDK Releases
+
+## Status
+Accepted
+
+## Context
+Dapr exposes APIs for building blocks which can be invoked over http/gRPC by the user code. Making raw http/gRPC calls from user code works but it doesn't provide a good strongly typed experience for developers.
+
+## Decisions
+
+* Dapr provides language specific SDKs for developers for C#, Java, Javascript, Python, Go, Rust, C++. There may be others in the future
+  - For the current release, the SDKs are auto-generated from the Dapr proto specifications using gRPC tools.
+  - In future releases, we will work on creating and releasing strongly typed SDKs for the languages, which are wrappers on top of the auto-generated gRPC SDKs (e.g. C# SDK shipped for state management APIs with the 0.1.0 release.) This is the preferred approach. Creating purely handcrafted SDKs is discouraged.
+* For Actors, language specific SDKs are written as Actor specific handcrafted code is preferred since this greatly simplifies the user experience. e.g. The C# Actor SDK shipped with the 0.1.0 release.
+  
+## Consequences
+
+Auto-generation of gRPC client side code from Dapr proto files allows Dapr to provide SDKs for the major languages with the 0.1.0 release and set us on the correct path to generate more user friendly SDKs by wrapping the auto-generated gRPC ones. There will be no auto-generated code for actor SDKs, which are also handcrafted to focus on API usability.
+

--- a/docs/decision_records/sdk/SDK-002-java-jdk-versions.md
+++ b/docs/decision_records/sdk/SDK-002-java-jdk-versions.md
@@ -1,0 +1,23 @@
+# SDK-002: Java JDK Versions
+
+## Status
+Accepted
+
+## Context
+Dapr offers a Java SDK. Java 11 is the latest LTS version. Java 8 is the previous LTS version but still the mainly used version by the Java community in 2019. What should be the minimum Java version supported by Dapr's Java SDK?
+
+See https://github.com/dapr/java-sdk/issues/17
+
+## Decisions
+
+* Java 8 should be the minimum version supported for Dapr's Java SDK.
+* Java 11 should be used in samples and user documentation to encourage adoption.
+* Java 8's commercial support ends in 2022. Dapr's Java SDK shoud migrate to Java 11 prior to that. The timeline still not decided.
+  
+## Consequences
+
+* Customers running with Java 7 or below cannot use Dapr's Java SDK.
+* Customers running with Java 8 are still supported, even through Java 11 is the recommended version.
+* Modern language features will not be available in Dapr's Java SDK code.
+* Modern JVM features can still be used since the Java 11 JVM can run Java 8 bytecode.
+


### PR DESCRIPTION
# Description

Some of the hyperlinks link to .MD instead of .md. 

This doesn't work correctly on Github.com (Windows machine, Chrome browser).
Realligned the links so they work again.

## Issue reference

/

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

~~strikethrough~~ => not relevant for this PR

* ~~[ ] Code compiles correctly~~
* ~~[ ] Created/updated tests~~
* ~~[ ] Unit tests passing~~
* ~~[ ] End-to-end tests passing~~
* [ x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* ~~[ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
* ~~[ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
