### PR TITLE
Adding optional API listen address and public port options

### DIFF
--- a/pkg/grpc/config.go
+++ b/pkg/grpc/config.go
@@ -10,6 +10,7 @@ type ServerConfig struct {
 	AppID              string
 	HostAddress        string
 	Port               int
+	APIListenAddress   string
 	NameSpace          string
 	TrustDomain        string
 	MaxRequestBodySize int
@@ -17,11 +18,12 @@ type ServerConfig struct {
 }
 
 // NewServerConfig returns a new grpc server config.
-func NewServerConfig(appID string, hostAddress string, port int, namespace string, trustDomain string, maxRequestBodySize int, enableDomainSocket bool) ServerConfig {
+func NewServerConfig(appID string, hostAddress string, port int, apiListenAddress string, namespace string, trustDomain string, maxRequestBodySize int, enableDomainSocket bool) ServerConfig {
 	return ServerConfig{
 		AppID:              appID,
 		HostAddress:        hostAddress,
 		Port:               port,
+		APIListenAddress:   apiListenAddress,
 		NameSpace:          namespace,
 		TrustDomain:        trustDomain,
 		MaxRequestBodySize: maxRequestBodySize,

--- a/pkg/grpc/config_test.go
+++ b/pkg/grpc/config_test.go
@@ -16,18 +16,19 @@ func TestServerConfig(t *testing.T) {
 		"app1",
 		"localhost:5050",
 		50001,
+		"1.2.3.4",
 		"default",
 		"td1",
 		4,
 		false,
 	}
 
-	c := NewServerConfig(vals[0].(string), vals[1].(string), vals[2].(int), vals[3].(string), vals[4].(string), vals[5].(int), vals[6].(bool))
+	c := NewServerConfig(vals[0].(string), vals[1].(string), vals[2].(int), vals[3].(string), vals[4].(string), vals[5].(string), vals[6].(int), vals[7].(bool))
 	assert.Equal(t, vals[0], c.AppID)
 	assert.Equal(t, vals[1], c.HostAddress)
 	assert.Equal(t, vals[2], c.Port)
-	assert.Equal(t, vals[3], c.NameSpace)
-	assert.Equal(t, vals[4], c.TrustDomain)
-	assert.Equal(t, vals[5], c.MaxRequestBodySize)
-	assert.Equal(t, vals[6], c.EnableDomainSocket)
+	assert.Equal(t, vals[3], c.APIListenAddress)
+	assert.Equal(t, vals[4], c.NameSpace)
+	assert.Equal(t, vals[5], c.TrustDomain)
+	assert.Equal(t, vals[6], c.MaxRequestBodySize)
 }

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -113,7 +113,7 @@ func (s *server) StartNonBlocking() error {
 		socket := fmt.Sprintf("/tmp/dapr-%s-grpc.socket", s.config.AppID)
 		lis, err = net.Listen("unix", socket)
 	} else {
-		lis, err = net.Listen("tcp", fmt.Sprintf(":%v", s.config.Port))
+		lis, err = net.Listen("tcp", fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.Port))
 	}
 	if err != nil {
 		return err

--- a/pkg/http/config.go
+++ b/pkg/http/config.go
@@ -11,6 +11,8 @@ type ServerConfig struct {
 	AppID              string
 	HostAddress        string
 	Port               int
+	APIListenAddress   string
+	PublicPort         *int
 	ProfilePort        int
 	EnableProfiling    bool
 	MaxRequestBodySize int
@@ -18,12 +20,14 @@ type ServerConfig struct {
 }
 
 // NewServerConfig returns a new HTTP server config.
-func NewServerConfig(appID string, hostAddress string, port int, profilePort int, allowedOrigins string, enableProfiling bool, maxRequestBodySize int, enableDomainSocket bool) ServerConfig {
+func NewServerConfig(appID string, hostAddress string, port int, apiListenAddress string, publicPort *int, profilePort int, allowedOrigins string, enableProfiling bool, maxRequestBodySize int, enableDomainSocket bool) ServerConfig {
 	return ServerConfig{
 		AllowedOrigins:     allowedOrigins,
 		AppID:              appID,
 		HostAddress:        hostAddress,
 		Port:               port,
+		APIListenAddress:   apiListenAddress,
+		PublicPort:         publicPort,
 		ProfilePort:        profilePort,
 		EnableProfiling:    enableProfiling,
 		MaxRequestBodySize: maxRequestBodySize,

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -78,14 +78,29 @@ func (s *server) StartNonBlocking() {
 			socket := fmt.Sprintf("/tmp/dapr-%s-http.socket", s.config.AppID)
 			log.Fatal(customServer.ListenAndServeUNIX(socket, os.FileMode(0600)))
 		} else {
-			log.Fatal(customServer.ListenAndServe(fmt.Sprintf(":%v", s.config.Port)))
+			log.Fatal(customServer.ListenAndServe(fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.Port)))
 		}
 	}()
+
+	if s.config.PublicPort != nil {
+		publicHandler := s.usePublicRouter()
+		publicHandler = s.useMetrics(publicHandler)
+		publicHandler = s.useTracing(publicHandler)
+
+		healthServer := &fasthttp.Server{
+			Handler:            publicHandler,
+			MaxRequestBodySize: s.config.MaxRequestBodySize * 1024 * 1024,
+		}
+
+		go func() {
+			log.Fatal(healthServer.ListenAndServe(fmt.Sprintf(":%d", *s.config.PublicPort)))
+		}()
+	}
 
 	if s.config.EnableProfiling {
 		go func() {
 			log.Infof("starting profiling server on port %v", s.config.ProfilePort)
-			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf(":%v", s.config.ProfilePort), pprofhandler.PprofHandler))
+			log.Fatal(fasthttp.ListenAndServe(fmt.Sprintf("%s:%v", s.config.APIListenAddress, s.config.ProfilePort), pprofhandler.PprofHandler))
 		}()
 	}
 }
@@ -101,14 +116,24 @@ func (s *server) useTracing(next fasthttp.RequestHandler) fasthttp.RequestHandle
 func (s *server) useMetrics(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	if s.metricSpec.Enabled {
 		log.Infof("enabled metrics http middleware")
+
 		return diag.DefaultHTTPMonitoring.FastHTTPMiddleware(next)
 	}
+
 	return next
 }
 
 func (s *server) useRouter() fasthttp.RequestHandler {
 	endpoints := s.api.APIEndpoints()
 	router := s.getRouter(endpoints)
+
+	return router.Handler
+}
+
+func (s *server) usePublicRouter() fasthttp.RequestHandler {
+	endpoints := s.api.PublicEndpoints()
+	router := s.getRouter(endpoints)
+
 	return router.Handler
 }
 

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -101,6 +101,8 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--dapr-http-port", "3500",
 			"--dapr-grpc-port", "50001",
 			"--dapr-internal-grpc-port", "50002",
+			"--dapr-listen-address", "localhost",
+			"--dapr-public-port", "3501",
 			"--app-port", "5000",
 			"--app-id", "app_id",
 			"--control-plane-address", "controlplane:9000",
@@ -151,6 +153,8 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--dapr-http-port", "3500",
 			"--dapr-grpc-port", "50001",
 			"--dapr-internal-grpc-port", "50002",
+			"--dapr-listen-address", "localhost",
+			"--dapr-public-port", "3501",
 			"--app-port", "5000",
 			"--app-id", "app_id",
 			"--control-plane-address", "controlplane:9000",
@@ -176,6 +180,36 @@ func TestGetSideCarContainer(t *testing.T) {
 		assert.Equal(t, "appsecret", container.Env[6].ValueFrom.SecretKeyRef.Name)
 		assert.EqualValues(t, expectedArgs, container.Args)
 		assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy)
+	})
+	t.Run("get sidecar container override listen address", func(t *testing.T) {
+		annotations := map[string]string{}
+		annotations[daprConfigKey] = "config"
+		annotations[daprListenAddress] = "1.2.3.4"
+		container, _ := getSidecarContainer(annotations, "app_id", "darpio/dapr", "Always", "dapr-system", "controlplane:9000", "placement:50000", nil, "", "", "", "sentry:50000", true, "pod_identity")
+
+		expectedArgs := []string{
+			"--mode", "kubernetes",
+			"--dapr-http-port", "3500",
+			"--dapr-grpc-port", "50001",
+			"--dapr-internal-grpc-port", "50002",
+			"--dapr-listen-address", "1.2.3.4",
+			"--dapr-public-port", "3501",
+			"--app-port", "",
+			"--app-id", "app_id",
+			"--control-plane-address", "controlplane:9000",
+			"--app-protocol", "http",
+			"--placement-host-address", "placement:50000",
+			"--config", "config",
+			"--log-level", "info",
+			"--app-max-concurrency", "-1",
+			"--sentry-address", "sentry:50000",
+			"--enable-metrics=true",
+			"--metrics-port", "9090",
+			"--dapr-http-max-request-size", "-1",
+			"--enable-mtls",
+		}
+
+		assert.EqualValues(t, expectedArgs, container.Args)
 	})
 }
 

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -132,9 +132,9 @@ func FromFlags() (*DaprRuntime, error) {
 
 	var publicPort *int
 	if *daprPublicPort != "" {
-		port, err := strconv.Atoi(*daprPublicPort)
-		if err != nil {
-			return nil, errors.Wrap(err, "error parsing app-port")
+		port, cerr := strconv.Atoi(*daprPublicPort)
+		if cerr != nil {
+			return nil, errors.Wrap(cerr, "error parsing dapr-public-port")
 		}
 		publicPort = &port
 	}

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -77,10 +77,7 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	if *waitCommand {
-		err := waitUntilDaprOutboundReady(*daprHTTPPort)
-		if err != nil {
-			os.Exit(1)
-		}
+		waitUntilDaprOutboundReady(*daprHTTPPort)
 		os.Exit(0)
 	}
 

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -33,7 +33,7 @@ import (
 func FromFlags() (*DaprRuntime, error) {
 	mode := flag.String("mode", string(modes.StandaloneMode), "Runtime mode for Dapr")
 	daprHTTPPort := flag.String("dapr-http-port", fmt.Sprintf("%v", DefaultDaprHTTPPort), "HTTP port for Dapr API to listen on")
-	daprAPIListenAddress := flag.String("dapr-listen-address", DefaultAPIListenAddress, "address for the Dapr API to listen on")
+	daprAPIListenAddress := flag.String("dapr-listen-address", DefaultAPIListenAddress, "Address for the Dapr API to listen on")
 	daprPublicPort := flag.String("dapr-public-port", "", "Public port for Dapr Health and Metadata to listen on")
 	daprAPIGRPCPort := flag.String("dapr-grpc-port", fmt.Sprintf("%v", DefaultDaprAPIGRPCPort), "gRPC port for the Dapr API to listen on")
 	daprInternalGRPCPort := flag.String("dapr-internal-grpc-port", "", "gRPC port for the Dapr Internal API to listen on")

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -33,6 +33,8 @@ import (
 func FromFlags() (*DaprRuntime, error) {
 	mode := flag.String("mode", string(modes.StandaloneMode), "Runtime mode for Dapr")
 	daprHTTPPort := flag.String("dapr-http-port", fmt.Sprintf("%v", DefaultDaprHTTPPort), "HTTP port for Dapr API to listen on")
+	daprAPIListenAddress := flag.String("dapr-listen-address", DefaultAPIListenAddress, "address for the Dapr API to listen on")
+	daprPublicPort := flag.String("dapr-public-port", "", "Public port for Dapr Health and Metadata to listen on")
 	daprAPIGRPCPort := flag.String("dapr-grpc-port", fmt.Sprintf("%v", DefaultDaprAPIGRPCPort), "gRPC port for the Dapr API to listen on")
 	daprInternalGRPCPort := flag.String("dapr-internal-grpc-port", "", "gRPC port for the Dapr Internal API to listen on")
 	appPort := flag.String("app-port", "", "The port the application is listening on")
@@ -75,7 +77,10 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	if *waitCommand {
-		waitUntilDaprOutboundReady(*daprHTTPPort)
+		err := waitUntilDaprOutboundReady(*daprHTTPPort)
+		if err != nil {
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 
@@ -125,6 +130,15 @@ func FromFlags() (*DaprRuntime, error) {
 		}
 	}
 
+	var publicPort *int
+	if *daprPublicPort != "" {
+		port, err := strconv.Atoi(*daprPublicPort)
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing app-port")
+		}
+		publicPort = &port
+	}
+
 	var applicationPort int
 	if *appPort != "" {
 		applicationPort, err = strconv.Atoi(*appPort)
@@ -156,7 +170,7 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	runtimeConfig := NewRuntimeConfig(*appID, placementAddresses, *controlPlaneAddress, *allowedOrigins, *config, *componentsPath,
-		appPrtcl, *mode, daprHTTP, daprInternalGRPC, daprAPIGRPC, applicationPort, profPort, *enableProfiling, concurrency, *enableMTLS, *sentryAddress, *appSSL, maxRequestBodySize, *enableDomainSocket)
+		appPrtcl, *mode, daprHTTP, daprInternalGRPC, daprAPIGRPC, *daprAPIListenAddress, publicPort, applicationPort, profPort, *enableProfiling, concurrency, *enableMTLS, *sentryAddress, *appSSL, maxRequestBodySize, *enableDomainSocket)
 
 	// set environment variables
 	// TODO - consider adding host address to runtime config and/or caching result in utils package

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -21,6 +21,8 @@ const (
 	HTTPProtocol Protocol = "http"
 	// DefaultDaprHTTPPort is the default http port for Dapr.
 	DefaultDaprHTTPPort = 3500
+	// DefaultDaprPublicPort is the default http port for Dapr.
+	DefaultDaprPublicPort = 3501
 	// DefaultDaprAPIGRPCPort is the default API gRPC port for Dapr.
 	DefaultDaprAPIGRPCPort = 50001
 	// DefaultProfilePort is the default port for profiling endpoints.
@@ -29,17 +31,21 @@ const (
 	DefaultMetricsPort = 9090
 	// DefaultMaxRequestBodySize is the default option for the maximum body size in MB for Dapr HTTP servers.
 	DefaultMaxRequestBodySize = 4
+	// DefaultAPIListenAddress is which address to listen for the Dapr HTTP and GRPC APIs. Empty string is all addresses.
+	DefaultAPIListenAddress = ""
 )
 
 // Config holds the Dapr Runtime configuration.
 type Config struct {
 	ID                   string
 	HTTPPort             int
+	PublicPort           *int
 	ProfilePort          int
 	EnableProfiling      bool
 	APIGRPCPort          int
 	InternalGRPCPort     int
 	ApplicationPort      int
+	APIListenAddress     string
 	ApplicationProtocol  Protocol
 	Mode                 modes.DaprMode
 	PlacementAddresses   []string
@@ -60,15 +66,17 @@ type Config struct {
 func NewRuntimeConfig(
 	id string, placementAddresses []string,
 	controlPlaneAddress, allowedOrigins, globalConfig, componentsPath, appProtocol, mode string,
-	httpPort, internalGRPCPort, apiGRPCPort, appPort, profilePort int,
+	httpPort, internalGRPCPort, apiGRPCPort int, apiListenAddress string, publicPort *int, appPort, profilePort int,
 	enableProfiling bool, maxConcurrency int, mtlsEnabled bool, sentryAddress string, appSSL bool, maxRequestBodySize int, enableDomainSocket bool) *Config {
 	return &Config{
 		ID:                  id,
 		HTTPPort:            httpPort,
+		PublicPort:          publicPort,
 		InternalGRPCPort:    internalGRPCPort,
 		APIGRPCPort:         apiGRPCPort,
 		ApplicationPort:     appPort,
 		ProfilePort:         profilePort,
+		APIListenAddress:    apiListenAddress,
 		ApplicationProtocol: Protocol(appProtocol),
 		Mode:                modes.DaprMode(mode),
 		PlacementAddresses:  placementAddresses,

--- a/pkg/runtime/config_test.go
+++ b/pkg/runtime/config_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 func TestNewConfig(t *testing.T) {
+	var publicPort = DefaultDaprPublicPort
 	c := NewRuntimeConfig("app1", []string{"localhost:5050"}, "localhost:5051", "*", "config", "components", "http", "kubernetes",
-		3500, 50002, 50001, 8080, 7070, true, 1, true, "localhost:5052", true, 4, false)
+		3500, 50002, 50001, "1.2.3.4", &publicPort, 8080, 7070, true, 1, true, "localhost:5052", true, 4, false)
 
 	assert.Equal(t, "app1", c.ID)
 	assert.Equal(t, "localhost:5050", c.PlacementAddresses[0])
@@ -26,6 +27,8 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, 3500, c.HTTPPort)
 	assert.Equal(t, 50002, c.InternalGRPCPort)
 	assert.Equal(t, 50001, c.APIGRPCPort)
+	assert.Equal(t, &publicPort, c.PublicPort)
+	assert.Equal(t, "1.2.3.4", c.APIListenAddress)
 	assert.Equal(t, 8080, c.ApplicationPort)
 	assert.Equal(t, 7070, c.ProfilePort)
 	assert.Equal(t, true, c.EnableProfiling)

--- a/pkg/runtime/config_test.go
+++ b/pkg/runtime/config_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewConfig(t *testing.T) {
-	var publicPort = DefaultDaprPublicPort
+	publicPort := DefaultDaprPublicPort
 	c := NewRuntimeConfig("app1", []string{"localhost:5050"}, "localhost:5051", "*", "config", "components", "http", "kubernetes",
 		3500, 50002, 50001, "1.2.3.4", &publicPort, 8080, 7070, true, 1, true, "localhost:5052", true, 4, false)
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -355,7 +355,7 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 	}
 
 	// Start HTTP Server
-	a.startHTTPServer(a.runtimeConfig.HTTPPort, a.runtimeConfig.ProfilePort, a.runtimeConfig.AllowedOrigins, pipeline)
+	a.startHTTPServer(a.runtimeConfig.HTTPPort, a.runtimeConfig.PublicPort, a.runtimeConfig.ProfilePort, a.runtimeConfig.AllowedOrigins, pipeline)
 	if a.runtimeConfig.EnableDomainSocket {
 		log.Info("http server is running on socket")
 	} else {
@@ -892,37 +892,38 @@ func (a *DaprRuntime) readFromBinding(name string, binding bindings.InputBinding
 	return err
 }
 
-func (a *DaprRuntime) startHTTPServer(port, profilePort int, allowedOrigins string, pipeline http_middleware.Pipeline) {
+func (a *DaprRuntime) startHTTPServer(port int, publicPort *int, profilePort int, allowedOrigins string, pipeline http_middleware.Pipeline) {
 	a.daprHTTPAPI = http.NewAPI(a.runtimeConfig.ID, a.appChannel, a.directMessaging, a.getComponents, a.stateStores, a.secretStores,
 		a.secretsConfiguration, a.getPublishAdapter(), a.actor, a.sendToOutputBinding, a.globalConfig.Spec.TracingSpec, a.ShutdownWithWait)
-	serverConf := http.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, profilePort, allowedOrigins, a.runtimeConfig.EnableProfiling, a.runtimeConfig.MaxRequestBodySize, a.runtimeConfig.EnableDomainSocket)
+	serverConf := http.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, a.runtimeConfig.APIListenAddress, publicPort, profilePort, allowedOrigins, a.runtimeConfig.EnableProfiling, a.runtimeConfig.MaxRequestBodySize, a.runtimeConfig.EnableDomainSocket)
 
 	server := http.NewServer(a.daprHTTPAPI, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, pipeline, a.globalConfig.Spec.APISpec)
 	server.StartNonBlocking()
 }
 
 func (a *DaprRuntime) startGRPCInternalServer(api grpc.API, port int) error {
-	serverConf := a.getNewServerConfig(port)
+	// Since GRPCInteralServer is encrypted & authenticated, it is safe to listen on *
+	serverConf := a.getNewServerConfig("", port)
 	server := grpc.NewInternalServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, a.authenticator, a.proxy)
 	err := server.StartNonBlocking()
 	return err
 }
 
 func (a *DaprRuntime) startGRPCAPIServer(api grpc.API, port int) error {
-	serverConf := a.getNewServerConfig(port)
+	serverConf := a.getNewServerConfig(a.runtimeConfig.APIListenAddress, port)
 	server := grpc.NewAPIServer(api, serverConf, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.MetricSpec, a.globalConfig.Spec.APISpec, a.proxy)
 	err := server.StartNonBlocking()
 	return err
 }
 
-func (a *DaprRuntime) getNewServerConfig(port int) grpc.ServerConfig {
+func (a *DaprRuntime) getNewServerConfig(listenAddress string, port int) grpc.ServerConfig {
 	// Use the trust domain value from the access control policy spec to generate the cert
 	// If no access control policy has been specified, use a default value
 	trustDomain := config.DefaultTrustDomain
 	if a.accessControlList != nil {
 		trustDomain = a.accessControlList.TrustDomain
 	}
-	return grpc.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, a.namespace, trustDomain, a.runtimeConfig.MaxRequestBodySize, a.runtimeConfig.EnableDomainSocket)
+	return grpc.NewServerConfig(a.runtimeConfig.ID, a.hostAddress, port, listenAddress, a.namespace, trustDomain, a.runtimeConfig.MaxRequestBodySize, a.runtimeConfig.EnableDomainSocket)
 }
 
 func (a *DaprRuntime) getGRPCAPI() grpc.API {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2616,6 +2616,8 @@ func NewTestDaprRuntimeWithProtocol(mode modes.DaprMode, protocol string, appPor
 		DefaultDaprHTTPPort,
 		0,
 		DefaultDaprAPIGRPCPort,
+		DefaultAPIListenAddress,
+		nil,
 		appPort,
 		DefaultProfilePort,
 		false,

--- a/pkg/runtime/wait.go
+++ b/pkg/runtime/wait.go
@@ -19,7 +19,7 @@ var (
 	urlFormat            string = "http://localhost:%s/v1.0/healthz/outbound"
 )
 
-func waitUntilDaprOutboundReady(daprHTTPPort string) {
+func waitUntilDaprOutboundReady(daprHTTPPort string) error {
 	outboundReadyHealthURL := fmt.Sprintf(urlFormat, daprHTTPPort)
 	client := &http.Client{
 		Timeout: time.Duration(requestTimeoutMillis) * time.Millisecond,
@@ -33,7 +33,7 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) {
 		err = checkIfOutboundReady(client, outboundReadyHealthURL)
 		if err == nil {
 			println("Dapr is outbound ready!")
-			return
+			return nil
 		}
 
 		if time.Now().After(lastPrintErrorTime) {
@@ -46,6 +46,7 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) {
 	}
 
 	println(fmt.Sprintf("timeout waiting for Dapr to become outbound ready. Last error: %v", err))
+	return err
 }
 
 func checkIfOutboundReady(client *http.Client, outboundReadyHealthURL string) error {

--- a/pkg/runtime/wait.go
+++ b/pkg/runtime/wait.go
@@ -19,7 +19,7 @@ var (
 	urlFormat            string = "http://localhost:%s/v1.0/healthz/outbound"
 )
 
-func waitUntilDaprOutboundReady(daprHTTPPort string) error {
+func waitUntilDaprOutboundReady(daprHTTPPort string) {
 	outboundReadyHealthURL := fmt.Sprintf(urlFormat, daprHTTPPort)
 	client := &http.Client{
 		Timeout: time.Duration(requestTimeoutMillis) * time.Millisecond,
@@ -33,7 +33,7 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) error {
 		err = checkIfOutboundReady(client, outboundReadyHealthURL)
 		if err == nil {
 			println("Dapr is outbound ready!")
-			return nil
+			return
 		}
 
 		if time.Now().After(lastPrintErrorTime) {
@@ -46,7 +46,6 @@ func waitUntilDaprOutboundReady(daprHTTPPort string) error {
 	}
 
 	println(fmt.Sprintf("timeout waiting for Dapr to become outbound ready. Last error: %v", err))
-	return err
 }
 
 func checkIfOutboundReady(client *http.Client, outboundReadyHealthURL string) error {


### PR DESCRIPTION
# Description

Includes the changes from #3429 and adds a `dapr-public-port` to expose the Metadata and Health APIs publicly.

Closes #2914
Closes #3475

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
