### PR TITLE
[WIP] Enable pubsub custom metadata

### DIFF
--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -106,6 +106,19 @@ func (imr *InvokeMethodRequest) WithHTTPExtension(verb string, querystring strin
 	return imr
 }
 
+// WithCustomMetdata applies a metadata map to a InvokeMethodRequest
+func (imr *InvokeMethodRequest) WithCustomHTTPMetadata(md map[string]string) *InvokeMethodRequest {
+	for k, v := range md {
+		if imr.r.Metadata == nil {
+			imr.r.Metadata = make(map[string]*internalv1pb.ListStringValue)
+		}
+
+		imr.r.Metadata[k] = &internalv1pb.ListStringValue{Values: []string{v}}
+	}
+
+	return imr
+}
+
 // EncodeHTTPQueryString generates querystring for http using http extension object.
 func (imr *InvokeMethodRequest) EncodeHTTPQueryString() string {
 	m := imr.r.Message

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -442,3 +442,12 @@ func ProtobufToJSON(message protoreflect.ProtoMessage) ([]byte, error) {
 	}
 	return marshaler.Marshal(message)
 }
+
+func WithCustomGRPCMetadata(ctx context.Context, md map[string]string) context.Context {
+	// ToLower the keys to keep consistent with HTTP metadata
+	for k, v := range md {
+		ctx = metadata.AppendToOutgoingContext(ctx, strings.ToLower(k), v)
+	}
+
+	return ctx
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1227,6 +1227,7 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 	req := invokev1.NewInvokeMethodRequest(route.path)
 	req.WithHTTPExtension(nethttp.MethodPost, "")
 	req.WithRawData(msg.data, contenttype.CloudEventContentType)
+	req.WithCustomHTTPMetadata(msg.metadata)
 
 	if cloudEvent[pubsub.TraceIDField] != nil {
 		traceID := cloudEvent[pubsub.TraceIDField].(string)
@@ -1352,6 +1353,8 @@ func (a *DaprRuntime) publishMessageGRPC(ctx context.Context, msg *pubsubSubscri
 			log.Warnf("ignored non-string traceid value: %v", iTraceID)
 		}
 	}
+
+	ctx = invokev1.WithCustomGRPCMetadata(ctx, msg.metadata)
 
 	// call appcallback
 	clientV1 := runtimev1pb.NewAppCallbackClient(a.grpc.AppClient)


### PR DESCRIPTION
# Description
These changes allow pubsub components to add custom metadata to the request sent to the application. This is to enable the [components-contrib PR](https://github.com/dapr/components-contrib/pull/1071) - please see that thread for context.

## Issue reference
Please reference the issue this PR will close: TBD

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
