### PR TITLE
placement: auto set port based on OS type

### DIFF
--- a/cmd/placement/config.go
+++ b/cmd/placement/config.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"flag"
+	"runtime"
 	"strings"
 
 	"github.com/dapr/kit/logger"
@@ -16,10 +17,11 @@ import (
 )
 
 const (
-	defaultCredentialsPath   = "/var/run/dapr/credentials"
-	defaultHealthzPort       = 8080
-	defaultPlacementPort     = 50005
-	defaultReplicationFactor = 100
+	defaultCredentialsPath    = "/var/run/dapr/credentials"
+	defaultHealthzPort        = 8080
+	defaultPlacementPort      = 50005
+	defaultPlacementPortOnWin = 6050
+	defaultReplicationFactor  = 100
 )
 
 type config struct {
@@ -56,6 +58,10 @@ func newConfig() *config {
 		healthzPort:   defaultHealthzPort,
 		certChainPath: defaultCredentialsPath,
 		tlsEnabled:    false,
+	}
+
+	if runtime.GOOS == "windows" {
+		cfg.placementPort = defaultPlacementPortOnWin
 	}
 
 	flag.StringVar(&cfg.raftID, "id", cfg.raftID, "Placement server ID.")

--- a/cmd/placement/config_test.go
+++ b/cmd/placement/config_test.go
@@ -6,12 +6,32 @@
 package main
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dapr/dapr/pkg/placement/raft"
 )
+
+func TestNewConfig(t *testing.T) {
+	t.Run("TestNewConfig with default value", func(t *testing.T) {
+		cfg := newConfig()
+		assert.Equal(t, cfg.raftID, "dapr-placement-0")
+		assert.Equal(t, cfg.raftPeerString, "dapr-placement-0=127.0.0.1:8201")
+		assert.Equal(t, cfg.raftPeers, []raft.PeerInfo{{ID: "dapr-placement-0", Address: "127.0.0.1:8201"}})
+		assert.Equal(t, cfg.raftInMemEnabled, true)
+		assert.Equal(t, cfg.raftLogStorePath, "")
+		assert.Equal(t, cfg.healthzPort, defaultHealthzPort)
+		assert.Equal(t, cfg.certChainPath, defaultCredentialsPath)
+		assert.Equal(t, cfg.tlsEnabled, false)
+		if runtime.GOOS == "windows" {
+			assert.Equal(t, cfg.placementPort, defaultPlacementPortOnWin)
+		} else {
+			assert.Equal(t, cfg.placementPort, defaultPlacementPort)
+		}
+	})
+}
 
 func TestParsePeersFromFlag(t *testing.T) {
 	peerAddressTests := []struct {


### PR DESCRIPTION
Signed-off-by: Long <long0dai@foxmail.com>

# Description

As https://github.com/dapr/cli/blob/master/README.md#slim-init said, the default port for placement is different in Win.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3613

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
