### PR TITLE
Add dlv-dap to devcontainer image

### DIFF
--- a/docker/custom-scripts/install-go-tools.sh
+++ b/docker/custom-scripts/install-go-tools.sh
@@ -42,6 +42,9 @@ mkdir -p /usr/local/etc/vscode-dev-containers ${TARGET_GOPATH}/bin
 # Install Go tools w/module support using v1.16 `go install`
 (echo "${GO_TOOLS}" | xargs -n 1 go install -v )2>&1 | tee -a /usr/local/etc/vscode-dev-containers/gotools.log
 
+# Set up `dlv` as `dlv-dap` for VSCode go debugging
+cp ${TARGET_GOPATH}/bin/dlv ${TARGET_GOPATH}/bin/dlv-dap
+
 # Install golangci-lint
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${TARGET_GOPATH}/bin 2>&1
 


### PR DESCRIPTION
# Description

Clone `dlv` to `$GOPATH/bin/dlv-dap` as part of `install-go-tools.sh` so that Visual Studio Code golang debugging can use it as the go debug adapter without requiring an additional install. 

## Issue reference

Fixes #3632

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
