### PR TITLE
Fix operator to only extract k8s secrets

### DIFF
--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -35,8 +35,9 @@ import (
 const serverPort = 6500
 
 const (
-	APIVersionV1alpha1 = "dapr.io/v1alpha1"
-	APIVersionV2alpha1 = "dapr.io/v2alpha1"
+	APIVersionV1alpha1    = "dapr.io/v1alpha1"
+	APIVersionV2alpha1    = "dapr.io/v2alpha1"
+	kubernetesSecretStore = "kubernetes"
 )
 
 var log = logger.NewLogger("dapr.operator.api")
@@ -138,7 +139,7 @@ func (a *apiServer) ListComponents(ctx context.Context, in *operatorv1pb.ListCom
 
 func processComponentSecrets(component *componentsapi.Component, namespace string, kubeClient client.Client) error {
 	for i, m := range component.Spec.Metadata {
-		if m.SecretKeyRef.Name != "" {
+		if m.SecretKeyRef.Name != "" && component.Auth.SecretStore == kubernetesSecretStore {
 			var secret corev1.Secret
 
 			err := kubeClient.Get(context.TODO(), types.NamespacedName{

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -139,7 +139,7 @@ func (a *apiServer) ListComponents(ctx context.Context, in *operatorv1pb.ListCom
 
 func processComponentSecrets(component *componentsapi.Component, namespace string, kubeClient client.Client) error {
 	for i, m := range component.Spec.Metadata {
-		if m.SecretKeyRef.Name != "" && component.Auth.SecretStore == kubernetesSecretStore {
+		if m.SecretKeyRef.Name != "" && (component.Auth.SecretStore == kubernetesSecretStore || component.Auth.SecretStore == "") {
 			var secret corev1.Secret
 
 			err := kubeClient.Get(context.TODO(), types.NamespacedName{

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -234,6 +234,12 @@ func (a *apiServer) ComponentUpdate(in *operatorv1pb.ComponentUpdateRequest, srv
 
 	for c := range updateChan {
 		go func(c *componentsapi.Component) {
+			err := processComponentSecrets(c, in.Namespace, a.Client)
+			if err != nil {
+				log.Warnf("error processing component %s secrets: %s", c.Name, err)
+				return
+			}
+
 			b, err := json.Marshal(&c)
 			if err != nil {
 				log.Warnf("error serializing component %s (%s): %s", c.GetName(), c.Spec.Type, err)

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -8,13 +8,14 @@ package api
 import (
 	"testing"
 
-	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
-	"github.com/dapr/dapr/pkg/client/clientset/versioned/scheme"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/client/clientset/versioned/scheme"
 )
 
 func TestProcessComponentSecrets(t *testing.T) {

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -1,0 +1,86 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation and Dapr Contributors.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package api
+
+import (
+	"testing"
+
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/client/clientset/versioned/scheme"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestProcessComponentSecrets(t *testing.T) {
+	t.Run("secret ref exists, not kubernetes secret store, no error", func(t *testing.T) {
+		c := componentsapi.Component{
+			Spec: componentsapi.ComponentSpec{
+				Metadata: []componentsapi.MetadataItem{
+					{
+						Name: "test1",
+						SecretKeyRef: componentsapi.SecretKeyRef{
+							Name: "secret1",
+							Key:  "key1",
+						},
+					},
+				},
+			},
+			Auth: componentsapi.Auth{
+				SecretStore: "secretstore",
+			},
+		}
+
+		err := processComponentSecrets(&c, "default", nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("secret ref exists, kubernetes secret store, secret extracted", func(t *testing.T) {
+		c := componentsapi.Component{
+			Spec: componentsapi.ComponentSpec{
+				Metadata: []componentsapi.MetadataItem{
+					{
+						Name: "test1",
+						SecretKeyRef: componentsapi.SecretKeyRef{
+							Name: "secret1",
+							Key:  "key1",
+						},
+					},
+				},
+			},
+			Auth: componentsapi.Auth{
+				SecretStore: kubernetesSecretStore,
+			},
+		}
+
+		s := runtime.NewScheme()
+		err := scheme.AddToScheme(s)
+		assert.NoError(t, err)
+
+		err = corev1.AddToScheme(s)
+		assert.NoError(t, err)
+
+		client := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key1": []byte("value1"),
+				},
+			}).
+			Build()
+
+		err = processComponentSecrets(&c, "default", client)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "value1", c.Spec.Metadata[0].Value.String())
+	})
+}


### PR DESCRIPTION
Fixes bug where operator would try to extract non-k8s secrets.
Also adds the component extraction for newly updated components. although this is not a working scenario yet, better to put this in place now.

Tests added to cover the operator secret extraction.