### PR TITLE
delete shutdown GET API

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -342,7 +342,7 @@ func (a *api) constructMetadataEndpoints() []Endpoint {
 func (a *api) constructShutdownEndpoints() []Endpoint {
 	return []Endpoint{
 		{
-			Methods: []string{fasthttp.MethodGet, fasthttp.MethodPost},
+			Methods: []string{fasthttp.MethodPost},
 			Route:   "shutdown",
 			Version: apiVersionV1,
 			Handler: a.onShutdown,

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -234,16 +234,6 @@ func TestShutdownEndpoints(t *testing.T) {
 
 	t.Run("Shutdown successfully - 204", func(t *testing.T) {
 		apiPath := fmt.Sprintf("%s/shutdown", apiVersionV1)
-		resp := fakeServer.DoRequest("GET", apiPath, nil, nil)
-		assert.Equal(t, 204, resp.StatusCode, "success shutdown")
-		for i := 0; i < 5 && len(m.Calls) == 0; i++ {
-			<-time.After(200 * time.Millisecond)
-		}
-		m.AssertCalled(t, "shutdown")
-	})
-
-	t.Run("Shutdown supports POST - 204", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/shutdown", apiVersionV1)
 		resp := fakeServer.DoRequest("POST", apiPath, nil, nil)
 		assert.Equal(t, 204, resp.StatusCode, "success shutdown")
 		for i := 0; i < 5 && len(m.Calls) == 0; i++ {


### PR DESCRIPTION
Signed-off-by: Long <long0dai@foxmail.com>

# Description

Delete GET shutdown API as per deprecation notice:

https://docs.dapr.io/operations/support/support-release-policy/#announced-deprecations

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3651

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
