### PR TITLE
Is binding subscribed status code tweak

### DIFF
--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -161,11 +161,16 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 
 	elapsedMs := float64(time.Since(startRequest) / time.Millisecond)
 
+	if err != nil {
+		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, verb, req.Message().GetMethod(), strconv.Itoa(nethttp.StatusInternalServerError), int64(resp.Header.ContentLength()), elapsedMs)
+		return nil, err
+	}
+
 	if h.ch != nil {
 		<-h.ch
 	}
 
-	rsp := h.parseChannelResponse(req, resp, err)
+	rsp := h.parseChannelResponse(req, resp)
 	diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, verb, req.Message().GetMethod(), strconv.Itoa(int(rsp.Status().Code)), int64(resp.Header.ContentLength()), elapsedMs)
 
 	return rsp, nil
@@ -204,20 +209,14 @@ func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMeth
 	return channelReq
 }
 
-func (h *Channel) parseChannelResponse(req *invokev1.InvokeMethodRequest, resp *fasthttp.Response, respErr error) *invokev1.InvokeMethodResponse {
+func (h *Channel) parseChannelResponse(req *invokev1.InvokeMethodRequest, resp *fasthttp.Response) *invokev1.InvokeMethodResponse {
 	var statusCode int
 	var contentType string
 	var body []byte
 
-	if respErr != nil {
-		statusCode = fasthttp.StatusInternalServerError
-		contentType = string(invokev1.JSONContentType)
-		body = []byte(fmt.Sprintf("{\"error\": \"client error: %s\"}", respErr))
-	} else {
-		statusCode = resp.StatusCode()
-		contentType = (string)(resp.Header.ContentType())
-		body = resp.Body()
-	}
+	statusCode = resp.StatusCode()
+	contentType = (string)(resp.Header.ContentType())
+	body = resp.Body()
 
 	// Convert status code
 	rsp := invokev1.NewInvokeMethodResponse(int32(statusCode), "", nil)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -976,7 +976,12 @@ func (a *DaprRuntime) isAppSubscribedToBinding(binding string) bool {
 		// TODO: Propagate Context
 		ctx := context.Background()
 		resp, err := a.appChannel.InvokeMethod(ctx, req)
-		return err == nil && resp.Status().Code != nethttp.StatusNotFound
+		if err != nil {
+			return false
+		}
+		code := resp.Status().Code
+
+		return code/100 == 2 || code == nethttp.StatusMethodNotAllowed
 	}
 	return false
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -977,7 +977,7 @@ func (a *DaprRuntime) isAppSubscribedToBinding(binding string) bool {
 		ctx := context.Background()
 		resp, err := a.appChannel.InvokeMethod(ctx, req)
 		if err != nil {
-			return false
+			log.Fatalf("could not invoke OPTIONS method on input binding subscription endpoint %q: %w", path, err)
 		}
 		code := resp.Status().Code
 


### PR DESCRIPTION
# Description

This PR tweaks the HTTP status code check for testing if an application is subscribed to a binding.

In a future release the logic may be expanded to something like:

* Return `true` on `2XX || 405`,
* Return `false` on `4XX`,
* Retry ~5 times otherwise (`5XX` & network error).

## Issue reference

Closes #3472

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
