### PR TITLE
Patch 1.3.1

### DIFF
--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
-appVersion: "1.3.0"
+appVersion: "1.3.1"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: 1.3.0
+version: 1.3.1
 dependencies:
   - name: dapr_rbac
-    version: "1.3.0"
+    version: "1.3.1"
     repository: "file://dapr_rbac"
   - name: dapr_operator
-    version: "1.3.0"
+    version: "1.3.1"
     repository: "file://dapr_operator"
   - name: dapr_placement
-    version: "1.3.0"
+    version: "1.3.1"
     repository: "file://dapr_placement"
   - name: dapr_sidecar_injector
-    version: "1.3.0"
+    version: "1.3.1"
     repository: "file://dapr_sidecar_injector"
   - name: dapr_sentry
-    version: "1.3.0"
+    version: "1.3.1"
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
     version: "0.7.0"

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -76,7 +76,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
 | `global.registry`                         | Docker image registry                                                   | `docker.io/daprio`      |
-| `global.tag`                              | Docker image version tag                                                | `1.3.0`                 |
+| `global.tag`                              | Docker image version tag                                                | `1.3.1`                 |
 | `global.logAsJson`                        | Json log format for control plane services                              | `false`                 |
 | `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
 | `global.imagePullSecret`                  | Control plane service image pull secret for docker registry             | `""`                    |

--- a/charts/dapr/charts/dapr_config/Chart.yaml
+++ b/charts/dapr/charts/dapr_config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr configuration
 name: dapr_config
-version: 1.3.0
+version: 1.3.1

--- a/charts/dapr/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: 1.3.0
+version: 1.3.1

--- a/charts/dapr/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr/charts/dapr_placement/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: 1.3.0
+version: 1.3.1

--- a/charts/dapr/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr/charts/dapr_rbac/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC components
 name: dapr_rbac
-version: 1.3.0
+version: 1.3.1

--- a/charts/dapr/charts/dapr_sentry/Chart.yaml
+++ b/charts/dapr/charts/dapr_sentry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Sentry
 name: dapr_sentry
-version: 1.3.0
+version: 1.3.1

--- a/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: 1.3.0
+version: 1.3.1

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "1.3.0"
+  tag: "1.3.1"
   dnsSuffix: ".cluster.local"
   logAsJson: false
   imagePullPolicy: IfNotPresent

--- a/docs/release_notes/v1.3.1.md
+++ b/docs/release_notes/v1.3.1.md
@@ -1,0 +1,23 @@
+  
+# Dapr 1.3.1
+
+## Fixes
+
+* Dapr sidecar crashes when Dapr Operator is down (https://github.com/dapr/dapr/issues/3665)
+
+### Overview
+
+This is a fix for a regression caused by making Dapr sidecar crash if it cannot reach the Dapr Operator. Dapr Operator can be down due to upgrades, for example, and should not impact running Dapr sidecars. Dapr guarantees zero downtime upgrades, and this bug violates this guarantee. 
+
+**DO NOT** upgrade from 1.3.0 to 1.3.1 or any other version without performing the following steps first:
+
+Upgrade sidecar injector
+```bash
+helm upgrade dapr dapr/dapr --set-string dapr_sidecar_injector.image.name=docker.io/daprio/daprd:1.3.1 -n dapr-system
+```
+
+Rollout deployments that use Dapr sidecar
+```bash
+kubectl rollout restart deploy/<name>
+```
+

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -542,13 +542,13 @@ func (a *DaprRuntime) beginComponentsUpdates() error {
 	go func() {
 		stream, err := a.operatorClient.ComponentUpdate(context.Background(), &emptypb.Empty{})
 		if err != nil {
-			log.Fatalf("error from operator stream: %s", err)
+			log.Errorf("error from operator stream: %s", err)
 			return
 		}
 		for {
 			c, err := stream.Recv()
 			if err != nil {
-				log.Fatalf("error from operator stream: %s", err)
+				log.Errorf("error from operator stream: %s", err)
 				return
 			}
 


### PR DESCRIPTION
# Description

* Dapr sidecar crashes when Dapr Operator is down (https://github.com/dapr/dapr/issues/3665)

### Overview

This is a fix for a regression caused by making Dapr sidecar crash if it cannot reach the Dapr Operator. Dapr Operator can be down due to upgrades, for example, and should not impact running Dapr sidecars. Dapr guarantees zero downtime upgrades, and this bug violates this guarantee. 

**DO NOT** upgrade from 1.3.0 to 1.3.1 or any other version without performing the following steps first:

Upgrade sidecar injector
```bash
helm upgrade dapr dapr/dapr --set-string dapr_sidecar_injector.image.name=docker.io/daprio/daprd:1.3.1 -n dapr-system
```

Rollout deployments that use Dapr sidecar
```bash
kubectl rollout restart deploy/<name>
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3665 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
