### PR TITLE
Port devcontainer updates for v1.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Dapr Dev Environment",
 	// Update the container version when you publish dev-container
-	"image": "docker.io/daprio/dapr-dev:0.1.3",
+	"image": "docker.io/daprio/dapr-dev:0.1.4",
 	// Replace with uncommented line below to build your own local copy of the image
 	// "dockerFile": "../docker/Dockerfile-dev",
 	"containerEnv": {

--- a/.github/workflows/dapr-dev-container.yml
+++ b/.github/workflows/dapr-dev-container.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     paths:
       - 'docker/Dockerfile-dev'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -19,6 +19,7 @@ ARG USER_GID=$USER_UID
 ARG KUBECTL_VERSION="latest"
 ARG HELM_VERSION="latest"
 ARG MINIKUBE_VERSION="latest"
+ARG DAPR_CLI_VERSION=""
 
 # Configure environment variables and pathing for dev tools.
 # Defaults to bash shell since the Dapr tutorials assume it, but zsh is optionally installed.
@@ -53,7 +54,7 @@ RUN apt-get update \
     && mv /tmp/staging/protoc/bin/* /usr/local/bin \
     #
     # Install Dapr CLI.
-    && wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash \
+    && wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s "${DAPR_CLI_VERSION}" \
     #
     # Copy devcontainer init, Docker bind-mount and GOPATH setup scripts
     && mv -f -t /usr/local/share/ /tmp/staging/docker-bind-mount.sh /tmp/staging/devcontainer-init.sh /tmp/staging/setup-gopath.sh \

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -163,7 +163,7 @@ docker-windows-base-push: check-windows-version
 DEV_CONTAINER_VERSION_TAG?=0.1.4
 
 # Use this to pin a specific version of the Dapr CLI to a devcontainer
-DEV_CONTAINER_CLI_TAG?=1.3.0
+DEV_CONTAINER_CLI_TAG?=1.4.0
 
 # Dapr container image name
 DEV_CONTAINER_IMAGE_NAME=dapr-dev

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -162,6 +162,9 @@ docker-windows-base-push: check-windows-version
 # Update whenever you upgrade dev container image
 DEV_CONTAINER_VERSION_TAG?=0.1.4
 
+# Use this to pin a specific version of the Dapr CLI to a devcontainer
+DEV_CONTAINER_CLI_TAG?=1.3.0
+
 # Dapr container image name
 DEV_CONTAINER_IMAGE_NAME=dapr-dev
 
@@ -177,9 +180,9 @@ build-dev-container:
 ifeq ($(DAPR_REGISTRY),)
 	$(info DAPR_REGISTRY environment variable not set, tagging image without registry prefix.)
 	$(info `make tag-dev-container` should be run with DAPR_REGISTRY before `make push-dev-container.)
-	$(DOCKER) build -f $(DOCKERFILE_DIR)/$(DEV_CONTAINER_DOCKERFILE) $(DOCKERFILE_DIR)/. -t $(DEV_CONTAINER_IMAGE_NAME):$(DEV_CONTAINER_VERSION_TAG)
+	$(DOCKER) build --build-arg DAPR_CLI_VERSION=$(DEV_CONTAINER_CLI_TAG) -f $(DOCKERFILE_DIR)/$(DEV_CONTAINER_DOCKERFILE) $(DOCKERFILE_DIR)/. -t $(DEV_CONTAINER_IMAGE_NAME):$(DEV_CONTAINER_VERSION_TAG)
 else
-	$(DOCKER) build -f $(DOCKERFILE_DIR)/$(DEV_CONTAINER_DOCKERFILE) $(DOCKERFILE_DIR)/. -t $(DAPR_REGISTRY)/$(DEV_CONTAINER_IMAGE_NAME):$(DEV_CONTAINER_VERSION_TAG)
+	$(DOCKER) build --build-arg DAPR_CLI_VERSION=$(DEV_CONTAINER_CLI_TAG) -f $(DOCKERFILE_DIR)/$(DEV_CONTAINER_DOCKERFILE) $(DOCKERFILE_DIR)/. -t $(DAPR_REGISTRY)/$(DEV_CONTAINER_IMAGE_NAME):$(DEV_CONTAINER_VERSION_TAG)
 endif
 
 tag-dev-container: check-docker-env-for-dev-container

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -160,7 +160,7 @@ docker-windows-base-push: check-windows-version
 ################################################################################
 
 # Update whenever you upgrade dev container image
-DEV_CONTAINER_VERSION_TAG?=0.1.3
+DEV_CONTAINER_VERSION_TAG?=0.1.4
 
 # Dapr container image name
 DEV_CONTAINER_IMAGE_NAME=dapr-dev


### PR DESCRIPTION
# Description

Port changes for 1.4 devcontainer to release-1.4 branch:
- Update DEV_CONTAINER_VERSION_TAG to 0.1.4
- Add workflow_dispatch trigger to dapr-dev-container.yml
- Pin Dapr CLI version for devcontainer image
- Update v1.4 devcontainer to 0.1.4 dapr-dev image

## Issue reference

Addendum to #3626

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
