### PR TITLE
Make release notes script list authors while ignoring case

### DIFF
--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -227,6 +227,6 @@ with open(releaseNotePath, 'w') as file:
         dapr_changes=changesText,
         dapr_breaking_changes=breakingChangesText,
         warnings=warningsText,
-        dapr_contributors=", ".join(sorted(list(contributors))),
+        dapr_contributors=", ".join(sorted(list(contributors), key=str.casefold)),
         today=date.today().strftime("%Y-%m-%d")))
 print("Done.")


### PR DESCRIPTION
# Description

This change makes sure we list authors in the future ignoring case.

`e.g.` **berndverst** should come before **ItalyPaleAle** :) 