### PR TITLE
Handle CEL expressions with more than one usage of a variable

### DIFF
--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -21,6 +21,7 @@ func (e *Expr) DecodeString(value string) (err error) {
 	var env *cel.Env
 
 	variables := make([]*expr_proto.Decl, 0, 10)
+	found := make(map[string]struct{}, 10)
 
 	for {
 		env, err = cel.NewEnv(cel.Declarations(variables...))
@@ -34,7 +35,11 @@ func (e *Expr) DecodeString(value string) (err error) {
 				if strings.HasPrefix(e.Message, missingVariableMessage) {
 					msg := e.Message[len(missingVariableMessage):]
 					msg = msg[0:strings.IndexRune(msg, '\'')]
+					if _, exists := found[msg]; exists {
+						continue
+					}
 					variables = append(variables, decls.NewVar(msg, decls.Any))
+					found[msg] = struct{}{}
 				} else {
 					return iss.Err()
 				}

--- a/pkg/expr/expr_test.go
+++ b/pkg/expr/expr_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestEval(t *testing.T) {
 	var e expr.Expr
-	code := `has(input.test) && result.test == 5678`
+	code := `(has(input.test) && input.test == 1234) || (has(result.test) && result.test == 5678)`
 	err := e.DecodeString(code)
 	require.NoError(t, err)
 	assert.Equal(t, code, e.String())
@@ -29,10 +29,10 @@ func TestEval(t *testing.T) {
 
 func TestJSONMarshal(t *testing.T) {
 	var e expr.Expr
-	exprBytes := []byte(`"has(input.test) && result.test == 5678"`)
+	exprBytes := []byte(`"(has(input.test) && input.test == 1234) || (has(result.test) && result.test == 5678)"`)
 	err := e.UnmarshalJSON(exprBytes)
 	require.NoError(t, err)
-	assert.Equal(t, `has(input.test) && result.test == 5678`, e.Expr())
+	assert.Equal(t, `(has(input.test) && input.test == 1234) || (has(result.test) && result.test == 5678)`, e.Expr())
 	_, err = e.MarshalJSON()
 	require.NoError(t, err)
 }
@@ -41,7 +41,7 @@ var result interface{}
 
 func BenchmarkEval(b *testing.B) {
 	var e expr.Expr
-	err := e.DecodeString(`has(input.test) && result.test == 5678`)
+	err := e.DecodeString(`(has(input.test) && input.test == 1234) || (has(result.test) && result.test == 5678)`)
 	require.NoError(b, err)
 	data := map[string]interface{}{
 		"input": map[string]interface{}{


### PR DESCRIPTION
# Description

Fixes handling CEL expressions with a root level variable that is used more than once

## Issue reference

Closes #3693

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

RELEASE NOTE: **FIX** Handle CEL expressions with more than one usage of a variable