### PR TITLE
Add ut for injector handleRequest

### DIFF
--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -15,7 +15,7 @@ func TestGetInectorConfig(t *testing.T) {
 		os.Setenv("SIDECAR_IMAGE_PULL_POLICY", "Always")
 		os.Setenv("NAMESPACE", "test-namespace")
 		os.Setenv("KUBE_CLUSTER_DOMAIN", "cluster.local")
-		defer os.Clearenv()
+		defer clearenv()
 
 		cfg, err := GetConfig()
 		assert.Nil(t, err)
@@ -34,7 +34,7 @@ func TestGetInectorConfig(t *testing.T) {
 		os.Setenv("SIDECAR_IMAGE_PULL_POLICY", "IfNotPresent")
 		os.Setenv("NAMESPACE", "test-namespace")
 		os.Setenv("KUBE_CLUSTER_DOMAIN", "")
-		defer os.Clearenv()
+		defer clearenv()
 
 		cfg, err := GetConfig()
 		assert.Nil(t, err)
@@ -45,4 +45,13 @@ func TestGetInectorConfig(t *testing.T) {
 		assert.Equal(t, "test-namespace", cfg.Namespace)
 		assert.NotEqual(t, "", cfg.KubeClusterDomain)
 	})
+}
+
+func clearenv() {
+	os.Unsetenv("TLS_CERT_FILE")
+	os.Unsetenv("TLS_KEY_FILE")
+	os.Unsetenv("SIDECAR_IMAGE")
+	os.Unsetenv("SIDECAR_IMAGE_PULL_POLICY")
+	os.Unsetenv("NAMESPACE")
+	os.Unsetenv("KUBE_CLUSTER_DOMAIN")
 }

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -54,7 +54,7 @@ type injector struct {
 	config       Config
 	deserializer runtime.Decoder
 	server       *http.Server
-	kubeClient   *kubernetes.Clientset
+	kubeClient   kubernetes.Interface
 	daprClient   scheme.Interface
 	authUIDs     []string
 }
@@ -89,7 +89,7 @@ func getAppIDFromRequest(req *v1.AdmissionRequest) string {
 }
 
 // NewInjector returns a new Injector instance with the given config.
-func NewInjector(authUIDs []string, config Config, daprClient scheme.Interface, kubeClient *kubernetes.Clientset) Injector {
+func NewInjector(authUIDs []string, config Config, daprClient scheme.Interface, kubeClient kubernetes.Interface) Injector {
 	mux := http.NewServeMux()
 
 	i := &injector{
@@ -111,7 +111,7 @@ func NewInjector(authUIDs []string, config Config, daprClient scheme.Interface, 
 }
 
 // AllowedControllersServiceAccountUID returns an array of UID, list of allowed service account on the webhook handler.
-func AllowedControllersServiceAccountUID(ctx context.Context, kubeClient *kubernetes.Clientset) ([]string, error) {
+func AllowedControllersServiceAccountUID(ctx context.Context, kubeClient kubernetes.Interface) ([]string, error) {
 	allowedUids := []string{}
 	for i, allowedControllersServiceAccount := range allowedControllersServiceAccounts {
 		saUUID, err := getServiceAccount(ctx, kubeClient, allowedControllersServiceAccount)
@@ -129,7 +129,7 @@ func AllowedControllersServiceAccountUID(ctx context.Context, kubeClient *kubern
 	return allowedUids, nil
 }
 
-func getServiceAccount(ctx context.Context, kubeClient *kubernetes.Clientset, allowedControllersServiceAccount string) (string, error) {
+func getServiceAccount(ctx context.Context, kubeClient kubernetes.Interface, allowedControllersServiceAccount string) (string, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, getKubernetesServiceAccountTimeoutSeconds*time.Second)
 	defer cancel()
 

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -101,7 +101,7 @@ const (
 )
 
 func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
-	namespace, image, imagePullPolicy string, kubeClient *kubernetes.Clientset, daprClient scheme.Interface) ([]PatchOperation, error) {
+	namespace, image, imagePullPolicy string, kubeClient kubernetes.Interface, daprClient scheme.Interface) ([]PatchOperation, error) {
 	req := ar.Request
 	var pod corev1.Pod
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
@@ -233,7 +233,7 @@ LoopEnv:
 	return patchOps
 }
 
-func getTrustAnchorsAndCertChain(kubeClient *kubernetes.Clientset, namespace string) (string, string, string) {
+func getTrustAnchorsAndCertChain(kubeClient kubernetes.Interface, namespace string) (string, string, string) {
 	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), certs.KubeScrtName, meta_v1.GetOptions{})
 	if err != nil {
 		return "", "", ""


### PR DESCRIPTION
# Description
Add unit test for injector's function handleRequest.
Change injector's client from kubernetes.Clientset to kubernetes.Interface to let unit test mock test client.

## Issue reference

Please reference the issue this PR will close: #3708

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
