### PR TITLE
Allow sidecar image to be specified via K8s annotation in app's Deplo…

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -60,6 +60,7 @@ const (
 	daprReadinessProbeTimeoutKey      = "dapr.io/sidecar-readiness-probe-timeout-seconds"
 	daprReadinessProbePeriodKey       = "dapr.io/sidecar-readiness-probe-period-seconds"
 	daprReadinessProbeThresholdKey    = "dapr.io/sidecar-readiness-probe-threshold"
+	daprImage                         = "dapr.io/sidecar-image"
 	daprAppSSLKey                     = "dapr.io/app-ssl"
 	daprMaxRequestBodySize            = "dapr.io/http-max-request-size"
 	daprReadBufferSize                = "dapr.io/http-read-buffer-size"
@@ -596,6 +597,10 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 			"/daprd",
 			"--",
 		}, args...)
+	}
+
+	if image := getStringAnnotation(annotations, daprImage); image != "" {
+		daprSidecarImage = image
 	}
 
 	c := &corev1.Container{

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -126,6 +126,8 @@ func TestGetSideCarContainer(t *testing.T) {
 		assert.Equal(t, "secret", container.Env[5].ValueFrom.SecretKeyRef.Name)
 		// DAPR_APP_TOKEN
 		assert.Equal(t, "appsecret", container.Env[6].ValueFrom.SecretKeyRef.Name)
+		// default image
+		assert.Equal(t, "darpio/dapr", container.Image)
 		assert.EqualValues(t, expectedArgs, container.Args)
 		assert.Equal(t, corev1.PullAlways, container.ImagePullPolicy)
 	})
@@ -213,6 +215,17 @@ func TestGetSideCarContainer(t *testing.T) {
 		}
 
 		assert.EqualValues(t, expectedArgs, container.Args)
+	})
+
+	t.Run("get sidecar container override image", func(t *testing.T) {
+		image := "daprio/overvide"
+		annotations := map[string]string{
+			daprImage: image,
+		}
+
+		container, _ := getSidecarContainer(annotations, "app_id", "darpio/dapr", "Always", "dapr-system", "controlplane:9000", "placement:50000", nil, "", "", "", "sentry:50000", true, "pod_identity")
+
+		assert.Equal(t, image, container.Image)
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Long <long.dai@intel.com>

# Description

Allow sidecar image to be specified via K8s annotation in app's Deployment.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3745


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
