### PR TITLE
Fix crash backoff when upgrading to v1.4.3 via Helm without applying the latest CRDs first

### DIFF
--- a/pkg/operator/webhooks.go
+++ b/pkg/operator/webhooks.go
@@ -118,8 +118,11 @@ func patchCRDs(ctx context.Context, conf *rest.Config, crdNames ...string) {
 			continue
 		}
 
-		if crd.Spec.Conversion.Webhook.ClientConfig == nil {
-			log.Errorf("CRD %q does not have an existing webhook client config", crdName)
+		if crd == nil ||
+			crd.Spec.Conversion == nil ||
+			crd.Spec.Conversion.Webhook == nil ||
+			crd.Spec.Conversion.Webhook.ClientConfig == nil {
+			log.Errorf("CRD %q does not have an existing webhook client config. Applying resources of this type will fail.", crdName)
 
 			continue
 		}


### PR DESCRIPTION
# Description

This PR fixes the nil reference panic when CRD does not contain a webhook conversion placeholder.

## Issue reference

Closes #3756

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
