### PR TITLE
test: upgrade perf test Dockerfile to Go 1.17

### DIFF
--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM golang:1.15 as build_env
+FROM golang:1.17 as build_env
 
 WORKDIR /app
 COPY app.go .

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.15 as build_env
+FROM golang:1.17 as build_env
 
 WORKDIR /app
 COPY app.go .
 RUN go get -d -v
 RUN go build -o tester .
 
-FROM golang:1.15 as fortio_build_env
+FROM golang:1.17 as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/fortio/fortio/branches/master" skipcache


### PR DESCRIPTION
# Description
We have replaced all usage of `io/ioutil` functions (https://github.com/dapr/dapr/pull/3782) to the new definitons in `io` and `os` packages, and therefore the minimum version of Go required is now 1.16. This PR upgrades the performance test Dockerfile to use Go 1.17 since dapr has been upgraded to Go 1.17 (#3558).

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

@artursouza  https://github.com/dapr/dapr/pull/3782#issuecomment-947942670

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
