### PR TITLE
refine actor timer test

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1100,6 +1100,8 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 		}
 	}
 
+	log.Debugf("create timer %q dueTime:%s period:%s repeats:%d ttl:%s",
+		req.Name, dueTime.String(), period.String(), repeats, ttl.String())
 	stop := make(chan bool, 1)
 	a.activeTimers.Store(timerKey, stop)
 

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -1116,7 +1116,7 @@ func TestTimerRepeats(t *testing.T) {
 		timerRepeats(ctx, t, "", "R3/PT2S", "", 3, 8*time.Second, 0)
 	})
 	t.Run("timer with dueTime deleted after 1 sec", func(t *testing.T) {
-		timerRepeats(ctx, t, time.Now().Add(2*time.Second).Format(time.RFC3339), "PT2S", "", 1, 6*time.Second, 3*time.Second)
+		timerRepeats(ctx, t, time.Now().Add(2*time.Second).Format(time.RFC3339), "PT4S", "", 1, 8*time.Second, 3*time.Second)
 	})
 	t.Run("timer without dueTime deleted after 1 sec", func(t *testing.T) {
 		timerRepeats(ctx, t, "", "PT2S", "", 1, 4*time.Second, time.Second)
@@ -1125,7 +1125,7 @@ func TestTimerRepeats(t *testing.T) {
 		timerRepeats(ctx, t, time.Now().Add(2*time.Second).Format(time.RFC3339), "PT2S", "3s", 2, 8*time.Second, 0)
 	})
 	t.Run("timer without dueTime ttl", func(t *testing.T) {
-		timerRepeats(ctx, t, "", "2s", time.Now().Add(3*time.Second).Format(time.RFC3339), 2, 6*time.Second, 0)
+		timerRepeats(ctx, t, "", "4s", time.Now().Add(6*time.Second).Format(time.RFC3339), 2, 10*time.Second, 0)
 	})
 }
 


### PR DESCRIPTION
# Description

Fixing intermittent test failure in actor timer.
The problem happens when the TTL is set in absolute time, while period is always set as duration.
The TTL is set before the test starts, but the timer is created during the test.
The problem happens when the machine running the test is at peak of activity, which causes some delay before the test starts. If the period is relatively short (2 seconds), then the TTL might expire before expected number of repetitions has occurred.
Suggested fix - increase the duration of the period

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
