### PR TITLE
Use nanoserver image for windows-jdk test container build

### DIFF
--- a/docker/Dockerfile-windows-java-base
+++ b/docker/Dockerfile-windows-java-base
@@ -4,7 +4,7 @@ ARG JAVA_VERSION=11.0.12
 
 FROM openjdk:${JAVA_VERSION}-nanoserver-$WINDOWS_VERSION as jdkbase
 
-FROM mcr.microsoft.com/powershell:nanoserver-1809 
+FROM mcr.microsoft.com/powershell:nanoserver-$WINDOWS_VERSION
 
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]


### PR DESCRIPTION
# Description

While diagnosing an issue building the Windows jdk base for our java integration tests, we also figured out a way to use nanoserver + mvn which should theoretically really speed up our build/deploys.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
