### PR TITLE
build: add go.mod to perf test Dockerfile

### DIFF
--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -6,10 +6,8 @@
 FROM golang:1.17 as build_env
 
 WORKDIR /app
-COPY app.go .
-RUN go mod init app.dapr.io/main && \
-  go get -d -v && \
-  go build -o app .
+COPY app.go go.mod ./
+RUN go get -d -v && go build -o app .
 
 FROM debian:buster-slim
 WORKDIR /

--- a/tests/apps/perf/service_invocation_http/go.mod
+++ b/tests/apps/perf/service_invocation_http/go.mod
@@ -1,0 +1,3 @@
+module app
+
+go 1.17

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,10 +1,8 @@
 FROM golang:1.17 as build_env
 
 WORKDIR /app
-COPY app.go .
-RUN go mod init app.dapr.io/main && \
-  go get -d -v && \
-  go build -o tester .
+COPY app.go go.mod ./
+RUN go get -d -v && go build -o tester .
 
 FROM golang:1.17 as fortio_build_env
 

--- a/tests/apps/perf/tester/go.mod
+++ b/tests/apps/perf/tester/go.mod
@@ -1,0 +1,3 @@
+module app
+
+go 1.17


### PR DESCRIPTION
# Description

Starting from Go 1.16, module-aware mode is enabled by default (i.e.
GO111MODULE=on). This commit adds the missing `go.mod` files that were
missed by the previous pull requests.

:bowing_man: I'm sorry for missing the `go.mod` files in the previous PR. My bad.

## Issue reference

1. https://github.com/dapr/dapr/pull/3782#issuecomment-947942670
2. https://github.com/dapr/dapr/pull/3790

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
