### PR TITLE
Bump to 1.5.0-rc.3 due to new dashboard rc

### DIFF
--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
-appVersion: "1.5.0-rc.2"
+appVersion: "1.5.0-rc.3"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: 1.5.0-rc.2
+version: 1.5.0-rc.3
 dependencies:
   - name: dapr_rbac
-    version: "1.5.0-rc.2"
+    version: "1.5.0-rc.3"
     repository: "file://dapr_rbac"
   - name: dapr_operator
-    version: "1.5.0-rc.2"
+    version: "1.5.0-rc.3"
     repository: "file://dapr_operator"
   - name: dapr_placement
-    version: "1.5.0-rc.2"
+    version: "1.5.0-rc.3"
     repository: "file://dapr_placement"
   - name: dapr_sidecar_injector
-    version: "1.5.0-rc.2"
+    version: "1.5.0-rc.3"
     repository: "file://dapr_sidecar_injector"
   - name: dapr_sentry
-    version: "1.5.0-rc.2"
+    version: "1.5.0-rc.3"
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
-    version: "0.8.0"
+    version: "0.9.0-rc.1"
     repository: "file://dapr_dashboard"

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -76,7 +76,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
 | `global.registry`                         | Docker image registry                                                   | `docker.io/daprio`      |
-| `global.tag`                              | Docker image version tag                                                | `1.5.0-rc.2`            |
+| `global.tag`                              | Docker image version tag                                                | `1.5.0-rc.3`            |
 | `global.logAsJson`                        | Json log format for control plane services                              | `false`                 |
 | `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
 | `global.imagePullSecrets`                 | Control plane service images pull secrets for docker registry            | `""`                   |

--- a/charts/dapr/charts/dapr_config/Chart.yaml
+++ b/charts/dapr/charts/dapr_config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr configuration
 name: dapr_config
-version: 1.5.0-rc.2
+version: 1.5.0-rc.3

--- a/charts/dapr/charts/dapr_dashboard/Chart.yaml
+++ b/charts/dapr/charts/dapr_dashboard/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Dashboard
 name: dapr_dashboard
-version: 0.8.0
+version: 0.9.0-rc.1

--- a/charts/dapr/charts/dapr_dashboard/values.yaml
+++ b/charts/dapr/charts/dapr_dashboard/values.yaml
@@ -4,7 +4,7 @@ logLevel: info
 image:
   registry: docker.io/daprio
   name: dashboard
-  tag: "0.8.0"
+  tag: "0.9.0-rc.1"
   imagePullSecrets: ""
 
 nameOverride: ""

--- a/charts/dapr/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: 1.5.0-rc.2
+version: 1.5.0-rc.3

--- a/charts/dapr/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr/charts/dapr_placement/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: 1.5.0-rc.2
+version: 1.5.0-rc.3
 

--- a/charts/dapr/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr/charts/dapr_rbac/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC components
 name: dapr_rbac
-version: 1.5.0-rc.2
+version: 1.5.0-rc.3
 

--- a/charts/dapr/charts/dapr_sentry/Chart.yaml
+++ b/charts/dapr/charts/dapr_sentry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Sentry
 name: dapr_sentry
-version: 1.5.0-rc.2
+version: 1.5.0-rc.3

--- a/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: 1.5.0-rc.2
+version: 1.5.0-rc.3

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "1.5.0-rc.2"
+  tag: "1.5.0-rc.3"
   dnsSuffix: ".cluster.local"
   logAsJson: false
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
# Description

Cutting 1.5.0-rc.3 to include new Dashboard 0.9.0-rc.1 (which includes support for Darwin Arm64 and customizable base paths)