### PR TITLE
fixed make check-proto-version in windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ FORCE_INMEM ?= true
 LATEST_RELEASE ?=
 
 PROTOC ?=protoc
-
+# name of protoc-gen-go when protoc-gen-go --version is run.
+PROTOC_GEN_GO_NAME = "protoc-gen-go"
 ifdef REL_VERSION
 	DAPR_VERSION := $(REL_VERSION)
 else
@@ -58,8 +59,11 @@ else ifeq ($(LOCAL_OS),Darwin)
    TARGET_OS_LOCAL = darwin
 else
    TARGET_OS_LOCAL ?= windows
+   PROTOC_GEN_GO_NAME := "protoc-gen-go.exe"
 endif
 export GOOS ?= $(TARGET_OS_LOCAL)
+
+PROTOC_GEN_GO_NAME+= "v1.25.0"
 
 # Default docker container and e2e test targst.
 TARGET_OS ?= linux
@@ -299,7 +303,7 @@ check-proto-version: ## Checking the version of proto related tools
 	@test "$(shell protoc-gen-go-grpc --version)" = "protoc-gen-go-grpc 1.1.0" \
 	|| { echo "please use protoc-gen-go-grpc 1.1.0 to generate proto, see https://github.com/dapr/dapr/blob/master/dapr/README.md#proto-client-generation"; exit 1; }
 
-	@test "$(shell protoc-gen-go --version 2>&1)" = "protoc-gen-go v1.25.0" \
+	@test "$(shell protoc-gen-go --version 2>&1)" = "$(PROTOC_GEN_GO_NAME)" \
 	|| { echo "please use protoc-gen-go v1.25.0 to generate proto, see https://github.com/dapr/dapr/blob/master/dapr/README.md#proto-client-generation"; exit 1; }
 
 ################################################################################


### PR DESCRIPTION
# Description
`make gen-proto` failed on windows because `check-proto-version` target failed to execute.
<!--
Please explain the changes you've made.
-->
Fixed the target `check-proto-version`
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3833 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
