### PR TITLE
Make helm chart examples work out of the box

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -35,14 +35,14 @@ For more details on initializing Helm, [read the Helm docs](https://helm.sh/docs
 
 2. Install the Dapr chart on your cluster in the dapr-system namespace:
     ```
-    helm install dapr dapr/dapr --namespace dapr-system --wait
+    helm install dapr dapr/dapr --namespace dapr-system --create-namespace --wait
     ```
 
 ## Verify installation
 
 Once the chart is installed, verify the Dapr control plane system service pods are running in the `dapr-system` namespace:
 ```
-kubectl get pods --namespace dapr-system
+kubectl get pods --namespace dapr-system --create-namespace
 ```
 
 ## Uninstall the Chart
@@ -173,7 +173,7 @@ The Helm chart has the follow configuration options that can be supplied:
 This command creates three replicas of each control plane pod for an HA deployment (with the exception of the Placement pod) in the dapr-system namespace:
 
 ```
-helm install dapr dapr/dapr --namespace dapr-system --set global.ha.enabled=true --wait
+helm install dapr dapr/dapr --namespace dapr-system --create-namespace --set global.ha.enabled=true --wait
 ```
 
 ## Example of installing edge version of Dapr
@@ -181,7 +181,7 @@ helm install dapr dapr/dapr --namespace dapr-system --set global.ha.enabled=true
 This command deploys the latest `edge` version of Dapr to `dapr-system` namespace. This is useful if you want to deploy the latest version of Dapr to test a feature or some capability in your Kubernetes cluster.
 
 ```
-helm install dapr dapr/dapr --namespace dapr-system --set-string global.tag=edge --wait
+helm install dapr dapr/dapr --namespace dapr-system --create-namespace --set-string global.tag=edge --wait
 ```
 
 ## Example of installing dapr on Minikube
@@ -209,7 +209,7 @@ global:
 
 Install dapr:
 ```bash
-helm install dapr dapr/dapr --namespace dapr-system --values values.yml --wait
+helm install dapr dapr/dapr --namespace dapr-system --create-namespace --values values.yml --wait
 ```
 
 ## Example of debugging dapr
@@ -233,7 +233,7 @@ dapr_operator:
 
 Step into dapr project, and install dapr:
 ```bash
-helm install dapr charts/dapr --namespace dapr-system --values values.yml --wait
+helm install dapr charts/dapr --namespace dapr-system --create-namespace --values values.yml --wait
 ```
 
 Find the target dapr-operator pod:
@@ -247,5 +247,5 @@ kubectl port-forward dapr-operator-5c99475ffc-m9z9f 40000:40000 -n dapr-system
 ```
 ## Example of using nodeSelector option
 ```
-helm install dapr dapr/dapr --namespace dapr-system --set global.nodeSelector.myLabel=myValue --wait
+helm install dapr dapr/dapr --namespace dapr-system --create-namespace --set global.nodeSelector.myLabel=myValue --wait
 ```


### PR DESCRIPTION
# Description
Currently the examples for the Dapr Helm chart use a custom namespace (`--namespace dapr-system`).
The example assumes the user already has that namespace in his cluster, causing the examples to fail in the case the namespace doesn't exist.

I added the `--create-namespace` flag to all chart examples so the examples will work out of the box.
<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3943 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [x] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [x] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
