### PR TITLE
Cherry-pick into master: Added copying of scopes when converting subscriptions (#3919)

### DIFF
--- a/pkg/apis/subscriptions/v2alpha1/conversion.go
+++ b/pkg/apis/subscriptions/v2alpha1/conversion.go
@@ -28,6 +28,9 @@ func (s *Subscription) ConvertTo(dstRaw conversion.Hub) error {
 		return errors.New("expected to to convert to *v1alpha1.Subscription")
 	}
 
+	// Copy scopes
+	dst.Scopes = s.Scopes
+
 	// ObjectMeta
 	dst.ObjectMeta = s.ObjectMeta
 
@@ -51,6 +54,9 @@ func (s *Subscription) ConvertFrom(srcRaw conversion.Hub) error {
 	if !ok {
 		return errors.New("expected to to convert from *v1alpha1.Subscription")
 	}
+
+	// Copy scopes
+	s.Scopes = src.Scopes
 
 	// ObjectMeta
 	s.ObjectMeta = src.ObjectMeta

--- a/pkg/apis/subscriptions/v2alpha1/conversion_test.go
+++ b/pkg/apis/subscriptions/v2alpha1/conversion_test.go
@@ -13,6 +13,7 @@ import (
 func TestConversion(t *testing.T) {
 	// Test converting to and from v1alpha1
 	subscriptionV2 := v2alpha1.Subscription{
+		Scopes: []string{"app1", "app2"},
 		Spec: v2alpha1.SubscriptionSpec{
 			Pubsubname: "testPubSub",
 			Topic:      "topicName",


### PR DESCRIPTION
Cherry-pick into master: Added copying of scopes when converting subscriptions (#3919)