### PR TITLE
Fix configuration subscribe method

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1276,7 +1276,6 @@ func (a *api) SubscribeConfigurationAlpha1(request *runtimev1pb.SubscribeConfigu
 	subscribeKeys := request.Keys
 	unsubscribedKeys := make([]string, 0)
 	a.configurationSubscribeLock.Lock()
-	defer a.configurationSubscribeLock.Unlock()
 
 	for _, k := range subscribeKeys {
 		if _, ok := a.configurationSubscribe[fmt.Sprintf("%s||%s", request.StoreName, k)]; !ok {

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/configuration"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/components-contrib/state"
@@ -1840,4 +1843,118 @@ func TestStateStoreQuerierNotImplemented(t *testing.T) {
 		StoreName: "store1",
 	})
 	assert.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+func TestGetConfigurationAlpha1(t *testing.T) {
+	t.Run("get configuration item", func(t *testing.T) {
+		port, err := freeport.GetFreePort()
+		assert.NoError(t, err)
+
+		server := startDaprAPIServer(
+			port,
+			&api{
+				id:                  "fakeAPI",
+				configurationStores: map[string]configuration.Store{"store1": &mockConfigStore{}},
+			},
+			"")
+		defer server.Stop()
+
+		clientConn := createTestClient(port)
+		defer clientConn.Close()
+
+		client := runtimev1pb.NewDaprClient(clientConn)
+		r, err := client.GetConfigurationAlpha1(context.TODO(), &runtimev1pb.GetConfigurationRequest{
+			StoreName: "store1",
+			Keys: []string{
+				"key1",
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, r.Items)
+		assert.Len(t, r.Items, 1)
+		assert.Equal(t, "key1", r.Items[0].Key)
+		assert.Equal(t, "val1", r.Items[0].Value)
+	})
+}
+
+func TestSubscribeConfigurationAlpha1(t *testing.T) {
+	t.Run("get configuration item", func(t *testing.T) {
+		port, err := freeport.GetFreePort()
+		assert.NoError(t, err)
+
+		server := startDaprAPIServer(
+			port,
+			&api{
+				id:                         "fakeAPI",
+				configurationStores:        map[string]configuration.Store{"store1": &mockConfigStore{}},
+				configurationSubscribe:     map[string]bool{},
+				configurationSubscribeLock: sync.Mutex{},
+			},
+			"")
+		defer server.Stop()
+
+		clientConn := createTestClient(port)
+		defer clientConn.Close()
+
+		ctx := context.TODO()
+		client := runtimev1pb.NewDaprClient(clientConn)
+		s, err := client.SubscribeConfigurationAlpha1(ctx, &runtimev1pb.SubscribeConfigurationRequest{
+			StoreName: "store1",
+			Keys: []string{
+				"key1",
+			},
+		})
+
+		assert.NoError(t, err)
+
+		var r = &runtimev1pb.SubscribeConfigurationResponse{}
+
+		for {
+			update, err := s.Recv()
+			if err == io.EOF {
+				break
+			}
+
+			if update != nil {
+				r = update
+				break
+			}
+		}
+
+		assert.NotNil(t, r)
+		assert.Len(t, r.Items, 1)
+		assert.Equal(t, "key1", r.Items[0].Key)
+		assert.Equal(t, "val1", r.Items[0].Value)
+	})
+}
+
+type mockConfigStore struct {
+}
+
+func (m *mockConfigStore) Init(metadata configuration.Metadata) error {
+	return nil
+}
+
+func (m *mockConfigStore) Get(ctx context.Context, req *configuration.GetRequest) (*configuration.GetResponse, error) {
+	return &configuration.GetResponse{
+		Items: []*configuration.Item{
+			{
+				Key:   req.Keys[0],
+				Value: "val1",
+			},
+		},
+	}, nil
+}
+
+func (m *mockConfigStore) Subscribe(ctx context.Context, req *configuration.SubscribeRequest, handler configuration.UpdateHandler) error {
+	handler(ctx, &configuration.UpdateEvent{
+		Items: []*configuration.Item{
+			{
+				Key:   "key1",
+				Value: "val1",
+			},
+		},
+	})
+	return nil
 }

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -1908,7 +1908,7 @@ func TestSubscribeConfigurationAlpha1(t *testing.T) {
 
 		assert.NoError(t, err)
 
-		var r = &runtimev1pb.SubscribeConfigurationResponse{}
+		r := &runtimev1pb.SubscribeConfigurationResponse{}
 
 		for {
 			update, err := s.Recv()
@@ -1929,8 +1929,7 @@ func TestSubscribeConfigurationAlpha1(t *testing.T) {
 	})
 }
 
-type mockConfigStore struct {
-}
+type mockConfigStore struct{}
 
 func (m *mockConfigStore) Init(metadata configuration.Metadata) error {
 	return nil

--- a/tests/apps/actorphp/Dockerfile
+++ b/tests/apps/actorphp/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-cli
+FROM php:8.0.0-cli
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN apt-get update && apt-get install -y wget git unzip && apt-get clean


### PR DESCRIPTION
Fixes https://github.com/dapr/dapr/issues/3970.

This PR does the following:

1. Fixes crash every time `SubscribeConfigurationAlpha1` is called by initializing the `configurationSubscribe` slice properly
2. Enables a long running stream update
3. Adds basic error handling
4. Removes the redundant requirement for app channel since this is a client-side stream gRPC 
5. Adds unit tests
