### PR TITLE
fix: duplicated subscribe

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1296,7 +1296,6 @@ func (a *api) SubscribeConfigurationAlpha1(request *runtimev1pb.SubscribeConfigu
 
 	ctx := context.TODO()
 	// TODO(@laurence) deal with failed subscription and retires
-	_ = store.Subscribe(context.Background(), req, handler.updateEventHandler)
 	err = store.Subscribe(ctx, req, handler.updateEventHandler)
 	if err != nil {
 		apiServerLogger.Debug(err)


### PR DESCRIPTION
# Description

This causes the configuration store to notify the app twice.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: dapr/components-contrib#1352

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
