### PR TITLE
Stream logs after container restart

### DIFF
--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -305,13 +305,20 @@ func (c *KubeTestPlatform) SetAppEnv(name, key, value string) error {
 func (c *KubeTestPlatform) Restart(name string) error {
 	// To minic the restart behavior, scale to 0 and then scale to the original replicas.
 	app := c.AppResources.FindActiveResource(name)
-	originalReplicas := app.(*kube.AppManager).App().Replicas
+	m := app.(*kube.AppManager)
+	originalReplicas := m.App().Replicas
 
 	if err := c.Scale(name, 0); err != nil {
 		return err
 	}
 
-	return c.Scale(name, originalReplicas)
+	if err := c.Scale(name, originalReplicas); err != nil {
+		return err
+	}
+
+	m.StreamContainerLogs()
+
+	return nil
 }
 
 // PortForwardToApp opens a new connection to the app on a the target port and returns the local port or error.


### PR DESCRIPTION
# Description

Our test restart works by scaling to zero, and then scaling back up. We lose our log streams by doing this. This fix will restart the log stream after these pods are created.

## Issue reference


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
