### PR TITLE
Fix error handling causing error to be swallowed in reading reminders.

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1237,8 +1237,12 @@ func (a *actorsRuntime) getActorTypeMetadata(actorType string, migrate bool) (*A
 	resp, err := a.store.Get(&state.GetRequest{
 		Key: metadataKey,
 	})
-	if err != nil || len(resp.Data) == 0 {
-		// Metadata field does not exist or failed to read.
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Data) == 0 {
+		// Metadata field does not exist.
 		// We fallback to the default "zero" partition behavior.
 		actorMetadata := ActorMetadata{
 			ID: uuid.NewString(),

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1431,11 +1431,14 @@ func (a *actorsRuntime) getRemindersForActorType(actorType string, migrate bool)
 			}
 
 			var batch []Reminder
-			if len(resp.Data) > 0 {
-				err = json.Unmarshal(resp.Data, &batch)
-				if err != nil {
-					return nil, nil, fmt.Errorf("could not parse actor reminders partition %v: %w", resp.Key, err)
-				}
+			if len(resp.Data) == 0 {
+				// Empty content is also an error. Even with no reminder, an empty array as JSON should still be present.
+				return nil, nil, fmt.Errorf("could not find data for reminder partition %v: %w", resp.Key, err)
+			}
+
+			err = json.Unmarshal(resp.Data, &batch)
+			if err != nil {
+				return nil, nil, fmt.Errorf("could not parse actor reminders partition %v: %w", resp.Key, err)
 			}
 
 			for j := range batch {


### PR DESCRIPTION
# Description

Fix error handling causing error to be swallowed in reading reminders.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
