### PR TITLE
PostgreSQL component breaking change note update

### DIFF
--- a/docs/release_notes/v1.5.0.md
+++ b/docs/release_notes/v1.5.0.md
@@ -285,5 +285,5 @@ This release of the PostgreSQL State Store component (Alpha) cannot fetch data c
 To fetch data created with previous versions please manually update the state store table (default name: `state`) schema.
 
 ```sql
-ALTER TABLE state ADD COLUMN isbinary boolean NOT NULL
+ALTER TABLE state ADD COLUMN isbinary BOOLEAN NOT NULL DEFAULT FALSE;
 ```


### PR DESCRIPTION
# Description

Change PostgreSQL breaking change note to update instructions for updating the state store table.