### PR TITLE
use addDate to support leap year & leap month

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1065,7 +1065,7 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 		repeats             int
 		dueTime, ttl        time.Time
 		period              time.Duration
-		yeads, months, days int
+		years, months, days int
 	)
 	a.activeTimersLock.Lock()
 	defer a.activeTimersLock.Unlock()
@@ -1092,7 +1092,7 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 
 	repeats = -1 // set to default
 	if len(req.Period) != 0 {
-		if yeads, months, days, period, repeats, err = parseDuration(req.Period); err != nil {
+		if years, months, days, period, repeats, err = parseDuration(req.Period); err != nil {
 			return errors.Wrap(err, "error parsing timer period")
 		}
 		// error on timers with zero repetitions
@@ -1161,11 +1161,11 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 				log.Errorf("could not find active timer %s", timerKey)
 				return
 			}
-			if repeats == 0 || (yeads == 0 && months == 0 && days == 0 && period == 0) {
+			if repeats == 0 || (years == 0 && months == 0 && days == 0 && period == 0) {
 				log.Infof("timer %s has been completed", timerKey)
 				break L
 			}
-			nextTime = nextTime.AddDate(yeads, months, days).Add(period)
+			nextTime = nextTime.AddDate(years, months, days).Add(period)
 			if nextTimer.Stop() {
 				<-nextTimer.C
 			}

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -681,6 +681,7 @@ func (a *actorsRuntime) startReminder(reminder *Reminder, stopChannel chan bool)
 	var (
 		nextTime, ttl            time.Time
 		period                   time.Duration
+		years, months, days      int
 		repeats, repetitionsLeft int
 	)
 
@@ -696,7 +697,7 @@ func (a *actorsRuntime) startReminder(reminder *Reminder, stopChannel chan bool)
 
 	repeats = -1 // set to default
 	if len(reminder.Period) != 0 {
-		if period, repeats, err = parseDuration(reminder.Period); err != nil {
+		if years, months, days, period, repeats, err = parseDuration(reminder.Period); err != nil {
 			return errors.Wrap(err, "error parsing reminder period")
 		}
 	}
@@ -712,13 +713,13 @@ func (a *actorsRuntime) startReminder(reminder *Reminder, stopChannel chan bool)
 			return errors.Wrap(err, "error parsing reminder last fired time")
 		}
 		repetitionsLeft = track.RepetitionLeft
-		nextTime = lastFiredTime.Add(period)
+		nextTime = lastFiredTime.AddDate(years, months, days).Add(period)
 	} else {
 		repetitionsLeft = repeats
 		nextTime = registeredTime
 	}
 
-	go func(reminder *Reminder, period time.Duration, nextTime, ttl time.Time, repetitionsLeft int, stop chan bool) {
+	go func(reminder *Reminder, years int, months int, days int, period time.Duration, nextTime, ttl time.Time, repetitionsLeft int, stop chan bool) {
 		var (
 			ttlTimer, nextTimer *time.Timer
 			ttlTimerC           <-chan time.Time
@@ -773,10 +774,10 @@ func (a *actorsRuntime) startReminder(reminder *Reminder, stopChannel chan bool)
 				log.Errorf("error updating reminder track: %v", err)
 			}
 			// if reminder is not repetitive, proceed with reminder deletion
-			if period == 0 {
+			if years == 0 && months == 0 && days == 0 && period == 0 {
 				break L
 			}
-			nextTime = nextTime.Add(period)
+			nextTime = nextTime.AddDate(years, months, days).Add(period)
 			if nextTimer.Stop() {
 				<-nextTimer.C
 			}
@@ -790,7 +791,7 @@ func (a *actorsRuntime) startReminder(reminder *Reminder, stopChannel chan bool)
 		if err != nil {
 			log.Errorf("error deleting reminder: %s", err)
 		}
-	}(reminder, period, nextTime, ttl, repetitionsLeft, stopChannel)
+	}(reminder, years, months, days, period, nextTime, ttl, repetitionsLeft, stopChannel)
 
 	return nil
 }
@@ -997,7 +998,7 @@ func (a *actorsRuntime) CreateReminder(ctx context.Context, req *CreateReminderR
 	reminder.RegisteredTime = dueTime.Format(time.RFC3339)
 
 	if len(req.Period) != 0 {
-		_, repeats, err = parseDuration(req.Period)
+		_, _, _, _, repeats, err = parseDuration(req.Period)
 		if err != nil {
 			return errors.Wrap(err, "error parsing reminder period")
 		}
@@ -1060,10 +1061,11 @@ func (a *actorsRuntime) CreateReminder(ctx context.Context, req *CreateReminderR
 
 func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest) error {
 	var (
-		err          error
-		repeats      int
-		dueTime, ttl time.Time
-		period       time.Duration
+		err                 error
+		repeats             int
+		dueTime, ttl        time.Time
+		period              time.Duration
+		yeads, months, days int
 	)
 	a.activeTimersLock.Lock()
 	defer a.activeTimersLock.Unlock()
@@ -1090,7 +1092,7 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 
 	repeats = -1 // set to default
 	if len(req.Period) != 0 {
-		if period, repeats, err = parseDuration(req.Period); err != nil {
+		if yeads, months, days, period, repeats, err = parseDuration(req.Period); err != nil {
 			return errors.Wrap(err, "error parsing timer period")
 		}
 		// error on timers with zero repetitions
@@ -1159,11 +1161,11 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 				log.Errorf("could not find active timer %s", timerKey)
 				return
 			}
-			if repeats == 0 || period == 0 {
+			if repeats == 0 || (yeads == 0 && months == 0 && days == 0 && period == 0) {
 				log.Infof("timer %s has been completed", timerKey)
 				break L
 			}
-			nextTime = nextTime.Add(period)
+			nextTime = nextTime.AddDate(yeads, months, days).Add(period)
 			if nextTimer.Stop() {
 				<-nextTimer.C
 			}
@@ -1629,12 +1631,12 @@ func ValidateHostEnvironment(mTLSEnabled bool, mode modes.DaprMode, namespace st
 	return nil
 }
 
-func parseISO8601Duration(from string) (time.Duration, int, error) {
+func parseISO8601Duration(from string) (int, int, int, time.Duration, int, error) {
 	match := pattern.FindStringSubmatch(from)
 	if match == nil {
-		return 0, 0, errors.Errorf("unsupported ISO8601 duration format %q", from)
+		return 0, 0, 0, 0, 0, errors.Errorf("unsupported ISO8601 duration format %q", from)
 	}
-	duration := time.Duration(0)
+	years, months, days, duration := 0, 0, 0, time.Duration(0)
 	// -1 signifies infinite repetition
 	repetition := -1
 	for i, name := range pattern.SubexpNames() {
@@ -1644,17 +1646,17 @@ func parseISO8601Duration(from string) (time.Duration, int, error) {
 		}
 		val, err := strconv.Atoi(part)
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, 0, 0, 0, err
 		}
 		switch name {
 		case "year":
-			duration += time.Hour * 24 * 365 * time.Duration(val)
+			years = val
 		case "month":
-			duration += time.Hour * 24 * 30 * time.Duration(val)
+			months = val
 		case "week":
-			duration += time.Hour * 24 * 7 * time.Duration(val)
+			days += 7 * val
 		case "day":
-			duration += time.Hour * 24 * time.Duration(val)
+			days += val
 		case "hour":
 			duration += time.Hour * time.Duration(val)
 		case "minute":
@@ -1664,25 +1666,25 @@ func parseISO8601Duration(from string) (time.Duration, int, error) {
 		case "repetition":
 			repetition = val
 		default:
-			return 0, 0, fmt.Errorf("unsupported ISO8601 duration field %s", name)
+			return 0, 0, 0, 0, 0, fmt.Errorf("unsupported ISO8601 duration field %s", name)
 		}
 	}
-	return duration, repetition, nil
+	return years, months, days, duration, repetition, nil
 }
 
 // parseDuration creates time.Duration from either:
 // - ISO8601 duration format,
 // - time.Duration string format.
-func parseDuration(from string) (time.Duration, int, error) {
-	d, r, err := parseISO8601Duration(from)
+func parseDuration(from string) (int, int, int, time.Duration, int, error) {
+	y, m, d, dur, r, err := parseISO8601Duration(from)
 	if err == nil {
-		return d, r, nil
+		return y, m, d, dur, r, nil
 	}
-	d, err = time.ParseDuration(from)
+	dur, err = time.ParseDuration(from)
 	if err == nil {
-		return d, -1, nil
+		return 0, 0, 0, dur, -1, nil
 	}
-	return 0, 0, errors.Errorf("unsupported duration format %q", from)
+	return 0, 0, 0, 0, 0, errors.Errorf("unsupported duration format %q", from)
 }
 
 // parseTime creates time.Duration from either:
@@ -1697,15 +1699,15 @@ func parseTime(from string, offset *time.Time) (time.Time, error) {
 	} else {
 		start = time.Now()
 	}
-	d, r, err := parseISO8601Duration(from)
+	y, m, d, dur, r, err := parseISO8601Duration(from)
 	if err == nil {
 		if r != -1 {
 			return time.Time{}, errors.Errorf("repetitions are not allowed")
 		}
-		return start.Add(d), nil
+		return start.AddDate(y, m, d).Add(dur), nil
 	}
-	if d, err = time.ParseDuration(from); err == nil {
-		return start.Add(d), nil
+	if dur, err = time.ParseDuration(from); err == nil {
+		return start.Add(dur), nil
 	}
 	if t, err := time.Parse(time.RFC3339, from); err == nil {
 		return t, nil

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -1710,29 +1710,38 @@ func TestHostValidation(t *testing.T) {
 
 func TestParseDuration(t *testing.T) {
 	t.Run("parse time.Duration", func(t *testing.T) {
-		duration, repetition, err := parseDuration("0h30m0s")
+		y, m, d, duration, repetition, err := parseDuration("0h30m0s")
 		assert.Nil(t, err)
 		assert.Equal(t, time.Minute*30, duration)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 0, m)
+		assert.Equal(t, 0, d)
 		assert.Equal(t, -1, repetition)
 	})
 	t.Run("parse ISO 8601 duration with repetition", func(t *testing.T) {
-		duration, repetition, err := parseDuration("R5/PT30M")
+		y, m, d, duration, repetition, err := parseDuration("R5/P10Y5M3DT30M")
 		assert.Nil(t, err)
+		assert.Equal(t, 10, y)
+		assert.Equal(t, 5, m)
+		assert.Equal(t, 3, d)
 		assert.Equal(t, time.Minute*30, duration)
 		assert.Equal(t, 5, repetition)
 	})
 	t.Run("parse ISO 8601 duration without repetition", func(t *testing.T) {
-		duration, repetition, err := parseDuration("P1MT2H10M3S")
+		y, m, d, duration, repetition, err := parseDuration("P1MT2H10M3S")
 		assert.Nil(t, err)
-		assert.Equal(t, time.Hour*24*30+time.Hour*2+time.Minute*10+time.Second*3, duration)
+		assert.Equal(t, 0, y)
+		assert.Equal(t, 1, m)
+		assert.Equal(t, 0, d)
+		assert.Equal(t, time.Hour*2+time.Minute*10+time.Second*3, duration)
 		assert.Equal(t, -1, repetition)
 	})
 	t.Run("parse RFC3339 datetime", func(t *testing.T) {
-		_, _, err := parseDuration(time.Now().Add(time.Minute).Format(time.RFC3339))
+		_, _, _, _, _, err := parseDuration(time.Now().Add(time.Minute).Format(time.RFC3339))
 		assert.NotNil(t, err)
 	})
 	t.Run("parse empty string", func(t *testing.T) {
-		_, _, err := parseDuration("")
+		_, _, _, _, _, err := parseDuration("")
 		assert.NotNil(t, err)
 	})
 }
@@ -1758,10 +1767,10 @@ func TestParseTime(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("parse ISO 8601 duration without repetition", func(t *testing.T) {
-		now := time.Now()
+		now, _ := time.Parse("2006-01-02 15:04:05", "2021-12-06 17:43:46")
 		offs := 5 * time.Second
 		start := now.Add(offs)
-		expected := start.Add(time.Hour*24*30 + time.Hour*2 + time.Minute*10 + time.Second*3)
+		expected := start.Add(time.Hour*24*31 + time.Hour*2 + time.Minute*10 + time.Second*3)
 		tm, err := parseTime("P1MT2H10M3S", &start)
 		assert.NoError(t, err)
 		assert.Equal(t, time.Duration(0), expected.Sub(tm))

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -1736,6 +1736,22 @@ func TestParseDuration(t *testing.T) {
 		assert.Equal(t, time.Hour*2+time.Minute*10+time.Second*3, duration)
 		assert.Equal(t, -1, repetition)
 	})
+	t.Run("parse ISO 8610 with leap yean", func(t *testing.T) {
+		y, m, d, dur, _, err := parseDuration("P1Y2M3D")
+		assert.Nil(t, err)
+
+		// 2020 is a leap year
+		start, _ := time.Parse("2006-01-02 15:04:05", "2020-02-03 11:12:13")
+		target := start.AddDate(y, m, d).Add(dur)
+		expect, _ := time.Parse("2006-01-02 15:04:05", "2021-04-06 11:12:13")
+		assert.Equal(t, time.Duration(0), target.Sub(expect))
+
+		// 2019 is not a leap year
+		start, _ = time.Parse("2006-01-02 15:04:05", "2019-02-03 11:12:13")
+		target = start.AddDate(y, m, d).Add(dur)
+		expect, _ = time.Parse("2006-01-02 15:04:05", "2020-04-06 11:12:13")
+		assert.Equal(t, time.Duration(0), target.Sub(expect))
+	})
 	t.Run("parse RFC3339 datetime", func(t *testing.T) {
 		_, _, _, _, _, err := parseDuration(time.Now().Add(time.Minute).Format(time.RFC3339))
 		assert.NotNil(t, err)

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -1736,7 +1736,7 @@ func TestParseDuration(t *testing.T) {
 		assert.Equal(t, time.Hour*2+time.Minute*10+time.Second*3, duration)
 		assert.Equal(t, -1, repetition)
 	})
-	t.Run("parse ISO 8610 with leap yean", func(t *testing.T) {
+	t.Run("parse ISO 8610 and calculate with leap year", func(t *testing.T) {
 		y, m, d, dur, _, err := parseDuration("P1Y2M3D")
 		assert.Nil(t, err)
 
@@ -1744,13 +1744,13 @@ func TestParseDuration(t *testing.T) {
 		start, _ := time.Parse("2006-01-02 15:04:05", "2020-02-03 11:12:13")
 		target := start.AddDate(y, m, d).Add(dur)
 		expect, _ := time.Parse("2006-01-02 15:04:05", "2021-04-06 11:12:13")
-		assert.Equal(t, time.Duration(0), target.Sub(expect))
+		assert.Equal(t, expect, target)
 
 		// 2019 is not a leap year
 		start, _ = time.Parse("2006-01-02 15:04:05", "2019-02-03 11:12:13")
 		target = start.AddDate(y, m, d).Add(dur)
 		expect, _ = time.Parse("2006-01-02 15:04:05", "2020-04-06 11:12:13")
-		assert.Equal(t, time.Duration(0), target.Sub(expect))
+		assert.Equal(t, expect, target)
 	})
 	t.Run("parse RFC3339 datetime", func(t *testing.T) {
 		_, _, _, _, _, err := parseDuration(time.Now().Add(time.Minute).Format(time.RFC3339))


### PR DESCRIPTION
# Description

In the original implementation logic, the number of years was directly converted to days. But without knowing the base time, it's impossible to know if it's a leap year. So the calculation is not accurate. As code below:
```go
		switch name {
		case "year":
			duration += time.Hour * 24 * 365 * time.Duration(val)
		case "month":
			duration += time.Hour * 24 * 30 * time.Duration(val)
		case "week":
			duration += time.Hour * 24 * 7 * time.Duration(val)
		case "day":
			duration += time.Hour * 24 * time.Duration(val)
		case "hour":
			duration += time.Hour * time.Duration(val)
		case "minute":
			duration += time.Minute * time.Duration(val)
		case "second":
			duration += time.Second * time.Duration(val)
		case "repetition":
			repetition = val
		default:
			return 0, 0, fmt.Errorf("unsupported ISO8601 duration field %s", name)
		}
```

So, return the years and duration at the same time, and invoke "AddDate(years, months, days)" & "Add(period)" to get the correct time.

## Issue reference
https://github.com/dapr/dapr/issues/3995

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
