### PR TITLE
Add hooks to load resiliency into runtime

### DIFF
--- a/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/ClusterRoleBinding.yaml
@@ -30,13 +30,13 @@ metadata:
   name: dapr-operator-admin
 rules:
 - apiGroups: ["*"]
-  resources: ["customresourcedefinitions", "serviceaccounts", "deployments", "services", "configmaps", "secrets", "components", "configurations", "subscriptions", "leases"]
+  resources: ["customresourcedefinitions", "serviceaccounts", "deployments", "services", "configmaps", "secrets", "components", "configurations", "subscriptions", "leases", "resiliencies"]
   verbs: ["get"]
 - apiGroups: ["*"]
-  resources: ["deployments", "services", "components", "configurations", "subscriptions", "leases", "secrets"]
+  resources: ["deployments", "services", "components", "configurations", "subscriptions", "leases", "secrets", "resiliencies"]
   verbs: ["list"]
 - apiGroups: ["*"]
-  resources: ["deployments", "services", "components", "configurations", "subscriptions", "leases", "secrets"]
+  resources: ["deployments", "services", "components", "configurations", "subscriptions", "leases", "secrets", "resiliencies"]
   verbs: ["watch"]
 - apiGroups: ["*"]
   resources: ["services", "secrets", "subscriptions", "configmaps", "leases", "services/finalizers", "deployments/finalizers"]

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -430,6 +430,12 @@ func TestAppSSL(t *testing.T) {
 	})
 }
 
+func TestGetResiliency(t *testing.T) {
+	m := map[string]string{daprResiliencyKey: "resiliency1"}
+	r := getResiliency(m)
+	assert.Equal(t, "resiliency1", r)
+}
+
 func TestHandleRequest(t *testing.T) {
 	authID := "test-auth-id"
 

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -65,6 +65,7 @@ const (
 	daprMaxRequestBodySize            = "dapr.io/http-max-request-size"
 	daprReadBufferSize                = "dapr.io/http-read-buffer-size"
 	daprHTTPStreamRequestBody         = "dapr.io/http-stream-request-body"
+	daprResiliencyKey                 = "dapr.io/resiliency"
 	containersPath                    = "/spec/containers"
 	sidecarHTTPPort                   = 3500
 	sidecarAPIGRPCPort                = 50001
@@ -294,6 +295,10 @@ func getAppPort(annotations map[string]string) (int32, error) {
 
 func getConfig(annotations map[string]string) string {
 	return getStringAnnotation(annotations, daprConfigKey)
+}
+
+func getResiliency(annotations map[string]string) string {
+	return getStringAnnotation(annotations, daprResiliencyKey)
 }
 
 func getProtocol(annotations map[string]string) string {
@@ -575,6 +580,7 @@ func getSidecarContainer(annotations map[string]string, id, daprSidecarImage, im
 		"--metrics-port", fmt.Sprintf("%v", metricsPort),
 		"--dapr-http-max-request-size", fmt.Sprintf("%v", requestBodySize),
 		"--dapr-http-read-buffer-size", fmt.Sprintf("%v", readBufferSize),
+		"--resiliency", getResiliency(annotations),
 	}
 
 	debugEnabled := getEnableDebug(annotations)

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -116,6 +116,7 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--metrics-port", "9090",
 			"--dapr-http-max-request-size", "-1",
 			"--dapr-http-read-buffer-size", "-1",
+			"--resiliency", "",
 			"--log-as-json",
 			"--enable-mtls",
 		}
@@ -171,6 +172,7 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--metrics-port", "9090",
 			"--dapr-http-max-request-size", "-1",
 			"--dapr-http-read-buffer-size", "-1",
+			"--resiliency", "",
 			"--log-as-json",
 			"--enable-mtls",
 		}
@@ -211,6 +213,7 @@ func TestGetSideCarContainer(t *testing.T) {
 			"--metrics-port", "9090",
 			"--dapr-http-max-request-size", "-1",
 			"--dapr-http-read-buffer-size", "-1",
+			"--resiliency", "",
 			"--enable-mtls",
 		}
 
@@ -226,6 +229,21 @@ func TestGetSideCarContainer(t *testing.T) {
 		container, _ := getSidecarContainer(annotations, "app_id", "darpio/dapr", "Always", "dapr-system", "controlplane:9000", "placement:50000", nil, "", "", "", "sentry:50000", true, "pod_identity")
 
 		assert.Equal(t, image, container.Image)
+	})
+
+	t.Run("get sidecar container with resiliency", func(t *testing.T) {
+		resiliency := "resiliencyConfig"
+		annotations := map[string]string{
+			daprResiliencyKey: resiliency,
+		}
+
+		container, _ := getSidecarContainer(annotations, "app_id", "darpio/dapr", "Always", "dapr-system", "controlplane:9000", "placement:50000", nil, "", "", "", "sentry:50000", true, "pod_identity")
+
+		for i, val := range container.Args {
+			if val == "--resiliency" {
+				assert.Equal(t, container.Args[i+1], resiliency)
+			}
+		}
 	})
 }
 

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -30,6 +30,7 @@ import (
 
 	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	configurationapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	resiliencyapi "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
 	subscriptionsapi_v2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	dapr_credentials "github.com/dapr/dapr/pkg/credentials"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
@@ -203,6 +204,22 @@ func (a *apiServer) ListSubscriptions(ctx context.Context, in *emptypb.Empty) (*
 	}
 
 	return resp, nil
+}
+
+// GetResiliency returns a specified resiliency object.
+func (a *apiServer) GetResiliency(ctx context.Context, in *operatorv1pb.GetResiliencyRequest) (*operatorv1pb.GetResiliencyResponse, error) {
+	key := types.NamespacedName{Namespace: in.Namespace, Name: in.Name}
+	var resiliencyConfig resiliencyapi.Resiliency
+	if err := a.Client.Get(ctx, key, &resiliencyConfig); err != nil {
+		return nil, errors.Wrap(err, "error getting configuration")
+	}
+	b, err := json.Marshal(&resiliencyConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "error marshalling configuration")
+	}
+	return &operatorv1pb.GetResiliencyResponse{
+		Resiliency: b,
+	}, nil
 }
 
 // ComponentUpdate updates Dapr sidecars whenever a component in the cluster is modified.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -17,6 +17,7 @@ import (
 
 	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	configurationapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	resiliencyapi "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
 	subscriptionsapi_v1alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	subscriptionsapi_v2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/pkg/credentials"
@@ -58,6 +59,7 @@ func init() {
 
 	_ = componentsapi.AddToScheme(scheme)
 	_ = configurationapi.AddToScheme(scheme)
+	_ = resiliencyapi.AddToScheme(scheme)
 	_ = subscriptionsapi_v1alpha1.AddToScheme(scheme)
 	_ = subscriptionsapi_v2alpha1.AddToScheme(scheme)
 }

--- a/pkg/resiliency/testdata/resiliency.yaml
+++ b/pkg/resiliency/testdata/resiliency.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Resiliency
 metadata:
-  name: daprResiliency
+  name: resiliency
 # Like in the Subscriptions CRD, scopes lists the Dapr App IDs that this
 # configuration applies to.
 scopes:

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -73,6 +73,7 @@ import (
 	"github.com/dapr/dapr/pkg/operator/client"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/pkg/runtime/security"
 	"github.com/dapr/dapr/pkg/scopes"
@@ -177,6 +178,8 @@ type DaprRuntime struct {
 
 	proxy messaging.Proxy
 
+	resiliencyConfig *resiliency.Resiliency
+
 	// TODO: Remove feature flag once feature is ratified
 	featureRoutingEnabled bool
 }
@@ -206,7 +209,7 @@ type pubsubSubscribedMessage struct {
 }
 
 // NewDaprRuntime returns a new runtime with the given runtime config and global config.
-func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, accessControlList *config.AccessControlList) *DaprRuntime {
+func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, accessControlList *config.AccessControlList, resiliencyConfig *resiliency.Resiliency) *DaprRuntime {
 	return &DaprRuntime{
 		runtimeConfig:          runtimeConfig,
 		globalConfig:           globalConfig,
@@ -239,6 +242,8 @@ func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, a
 		pendingComponents:          make(chan components_v1alpha1.Component),
 		pendingComponentDependents: map[string][]components_v1alpha1.Component{},
 		shutdownC:                  make(chan error, 1),
+
+		resiliencyConfig: resiliencyConfig,
 	}
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -64,6 +64,7 @@ import (
 	"github.com/dapr/dapr/pkg/modes"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/pkg/runtime/security"
 	"github.com/dapr/dapr/pkg/scopes"
@@ -141,7 +142,7 @@ func NewMockKubernetesStoreWithInitCallback(cb func()) secretstores.SecretStore 
 
 func TestNewRuntime(t *testing.T) {
 	// act
-	r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{})
+	r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 
 	// assert
 	assert.NotNil(t, r, "runtime must be initiated")
@@ -2638,7 +2639,7 @@ func NewTestDaprRuntimeWithProtocol(mode modes.DaprMode, protocol string, appPor
 		4,
 		false)
 
-	return NewDaprRuntime(testRuntimeConfig, &config.Configuration{}, &config.AccessControlList{})
+	return NewDaprRuntime(testRuntimeConfig, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 }
 
 func TestMTLS(t *testing.T) {
@@ -3010,7 +3011,7 @@ func (m *mockPublishPubSub) Features() []pubsub.Feature {
 
 func TestInitActors(t *testing.T) {
 	t.Run("missing namespace on kubernetes", func(t *testing.T) {
-		r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{})
+		r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 		defer stopRuntime(t, r)
 		r.namespace = ""
 		r.runtimeConfig.mtlsEnabled = true
@@ -3020,7 +3021,7 @@ func TestInitActors(t *testing.T) {
 	})
 
 	t.Run("actors hosted = true", func(t *testing.T) {
-		r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{})
+		r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 		defer stopRuntime(t, r)
 		r.appConfig = config.ApplicationConfig{
 			Entities: []string{"actor1"},
@@ -3031,7 +3032,7 @@ func TestInitActors(t *testing.T) {
 	})
 
 	t.Run("actors hosted = false", func(t *testing.T) {
-		r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{})
+		r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 		defer stopRuntime(t, r)
 
 		hosted := r.hostingActors()
@@ -3041,7 +3042,7 @@ func TestInitActors(t *testing.T) {
 
 func TestInitBindings(t *testing.T) {
 	t.Run("single input binding", func(t *testing.T) {
-		r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{})
+		r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 		defer stopRuntime(t, r)
 		r.bindingsRegistry.RegisterInputBindings(
 			bindings_loader.NewInput("testInputBinding", func() bindings.InputBinding {
@@ -3057,7 +3058,7 @@ func TestInitBindings(t *testing.T) {
 	})
 
 	t.Run("single output binding", func(t *testing.T) {
-		r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{})
+		r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 		defer stopRuntime(t, r)
 		r.bindingsRegistry.RegisterOutputBindings(
 			bindings_loader.NewOutput("testOutputBinding", func() bindings.OutputBinding {
@@ -3073,7 +3074,7 @@ func TestInitBindings(t *testing.T) {
 	})
 
 	t.Run("one input binding, one output binding", func(t *testing.T) {
-		r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{})
+		r := NewDaprRuntime(&Config{}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 		defer stopRuntime(t, r)
 		r.bindingsRegistry.RegisterInputBindings(
 			bindings_loader.NewInput("testinput", func() bindings.InputBinding {
@@ -3162,7 +3163,7 @@ func TestActorReentrancyConfig(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{})
+			r := NewDaprRuntime(&Config{Mode: modes.KubernetesMode}, &config.Configuration{}, &config.AccessControlList{}, &resiliency.Resiliency{})
 
 			mockAppChannel := new(channelt.MockAppChannel)
 			r.appChannel = mockAppChannel


### PR DESCRIPTION
# Description

This commit adds the hooks to load a resiliency configuration into
the runtime when an app starts for both standalone and k8s.

The configuration is not used anywhere, it is simply loaded.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Partial: #3586 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
