### PR TITLE
Add exponential backoff to topic subscriptions calls

### DIFF
--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -10,13 +10,14 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/dapr/kit/retry"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/kit/retry"
 
 	subscriptionsapi_v1alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	subscriptionsapi_v2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"

--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -170,22 +170,22 @@ func GetSubscriptionsGRPC(channel runtimev1pb.AppCallbackClient, log logger.Logg
 		// Unexpected response: both GRPC and HTTP have to log the same level.
 		log.Errorf(getTopicsError, err)
 		return nil, err
+	}
+
+	if resp == nil || resp.Subscriptions == nil || len(resp.Subscriptions) == 0 {
+		log.Debug(noSubscriptionsError)
 	} else {
-		if resp == nil || resp.Subscriptions == nil || len(resp.Subscriptions) == 0 {
-			log.Debug(noSubscriptionsError)
-		} else {
-			for _, s := range resp.Subscriptions {
-				rules, err := parseRoutingRulesGRPC(s.Routes)
-				if err != nil {
-					return nil, err
-				}
-				subscriptions = append(subscriptions, Subscription{
-					PubsubName: s.PubsubName,
-					Topic:      s.GetTopic(),
-					Metadata:   s.GetMetadata(),
-					Rules:      rules,
-				})
+		for _, s := range resp.Subscriptions {
+			rules, err := parseRoutingRulesGRPC(s.Routes)
+			if err != nil {
+				return nil, err
 			}
+			subscriptions = append(subscriptions, Subscription{
+				PubsubName: s.PubsubName,
+				Topic:      s.GetTopic(),
+				Metadata:   s.GetMetadata(),
+				Rules:      rules,
+			})
 		}
 	}
 

--- a/tests/apps/service_invocation_grpc_proxy_server/service.yaml
+++ b/tests/apps/service_invocation_grpc_proxy_server/service.yaml
@@ -20,7 +20,6 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "grpcproxyserver"
         dapr.io/app-port: "50051"
-        dapr.io/app-protocol: "grpc"
     spec:
       containers:
       - name: service-invocation-grpc-proxy-server


### PR DESCRIPTION
Closes https://github.com/dapr/dapr/issues/3839.

This PR adds exponential retries to the methods that get topic subscriptions from the app using HTTP and gRPC and adds test cases.
