### PR TITLE
Charts - Supports to customize livenessProbe and readinessProbe

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -86,22 +86,22 @@ spec:
             path: /healthz
             port: 8080
 {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
 {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
 {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
 {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           failureThreshold: 5
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"

--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -18,6 +18,13 @@ ports:
 
 resources: {}
 
+livenessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 3
+readinessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 3
+
 debug:
   enabled: false
   port: 40000

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -41,22 +41,22 @@ spec:
             path: /healthz
             port: 8080
 {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 10
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
 {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
 {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
 {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           failureThreshold: 5
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"

--- a/charts/dapr/charts/dapr_placement/values.yaml
+++ b/charts/dapr/charts/dapr_placement/values.yaml
@@ -25,6 +25,13 @@ volumeclaims:
 
 replicationFactor: 100
 
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 3
+readinessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 3
+
 debug:
   enabled: false
   port: 40000

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -70,22 +70,22 @@ spec:
             path: /healthz
             port: 8080
           {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
           {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           failureThreshold: 5
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"

--- a/charts/dapr/charts/dapr_sentry/values.yaml
+++ b/charts/dapr/charts/dapr_sentry/values.yaml
@@ -22,6 +22,13 @@ tls:
     certPEM: ""
   trustDomain: cluster.local
 
+livenessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 3
+readinessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 3
+
 debug:
   enabled: false
   port: 40000

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -50,22 +50,22 @@ spec:
             path: /healthz
             port: 8080
           {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
           {{- if eq .Values.debug.enabled false }}
-          initialDelaySeconds: 3
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           {{- else }}
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
-          periodSeconds: 3
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           failureThreshold: 5
 {{- if contains "/" .Values.injectorImage.name }}
         image: "{{ .Values.injectorImage.name }}"

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -19,6 +19,13 @@ runAsNonRoot: true
 resources: {}
 kubeClusterDomain: cluster.local
 
+livenessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 3
+readinessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 3
+
 debug:
   enabled: false
   port: 40000


### PR DESCRIPTION
# Description

When I use Argo CD to deploy the Dapr, some components (Operator and Placement) need more time to start.
Sometimes the Argo CD may kill/restart the pods because of the health check.

So I think it's a easy and safe way to increase the initial delay and period seconds

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
