### PR TITLE
Fixed create timer duetime

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1086,6 +1086,9 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 		if dueTime, err = parseTime(req.DueTime, nil); err != nil {
 			return errors.Wrap(err, "error parsing timer due time")
 		}
+		if dueTime.Before(time.Now()) {
+			return errors.Errorf("timer %s has already expired: dueTime: %s TTL: %s", timerKey, req.DueTime, req.TTL)
+		}
 	} else {
 		dueTime = time.Now()
 	}


### PR DESCRIPTION
 # Description
If the timer is created at a previous time, we should not create it.
e.g.   dueTime: "-0h0m0s"
 
 
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
