### PR TITLE
Return error instead of crashing when receiving grpc_proxy request on uninitialized daprd

### DIFF
--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -80,6 +80,10 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 	outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
 	appID := v[0]
 
+	if p.remoteAppFn == nil {
+		return ctx, nil, errors.Errorf("failed to proxy request: proxy not initialized. daprd startup may be incomplete.")
+	}
+
 	target, err := p.remoteAppFn(appID)
 	if err != nil {
 		return ctx, nil, err

--- a/pkg/messaging/grpc_proxy_test.go
+++ b/pkg/messaging/grpc_proxy_test.go
@@ -187,4 +187,18 @@ func TestIntercept(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, conn)
 	})
+
+	t.Run("SetRemoteAppFn never called", func(t *testing.T) {
+		p := NewProxy(connectionFn, "a", "a:123", 50005, nil)
+		p.SetTelemetryFn(func(ctx context.Context) context.Context {
+			return ctx
+		})
+
+		ctx := metadata.NewIncomingContext(context.TODO(), metadata.MD{diagnostics.GRPCProxyAppIDKey: []string{"a"}})
+		proxy := p.(*proxy)
+		_, conn, err := proxy.intercept(ctx, "/test")
+
+		assert.Error(t, err)
+		assert.Nil(t, conn)
+	})
 }


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

If a grpc proxy request comes in before daprd has completed initialization (for instance if daprd is blocked waiting on the app to start listening), daprd will crash. This change returns an error instead.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3982
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
