### PR TITLE
Fix flakiness on get metadata e2e.

### DIFF
--- a/tests/e2e/actor_features/actor_features_test.go
+++ b/tests/e2e/actor_features/actor_features_test.go
@@ -607,13 +607,10 @@ func TestActorFeatures(t *testing.T) {
 		res, err := utils.HTTPGet(fmt.Sprintf(actorMetadataURLFormat, externalURL))
 		require.NoError(t, err)
 
-		var prevMetadata metadata
-		err = json.Unmarshal(res, &prevMetadata)
+		var previousMetadata metadata
+		err = json.Unmarshal(res, &previousMetadata)
 		require.NoError(t, err)
-		var prevActors int
-		if len(prevMetadata.Actors) > 0 {
-			prevActors = prevMetadata.Actors[0].Count
-		}
+		require.NotNil(t, previousMetadata)
 
 		// Each test needs to have a different actorID
 		actorIDBase := "1008Instance"
@@ -629,16 +626,17 @@ func TestActorFeatures(t *testing.T) {
 		res, err = utils.HTTPGet(fmt.Sprintf(actorMetadataURLFormat, externalURL))
 		require.NoError(t, err)
 
-		expected := metadata{
-			ID: appName,
-			Actors: []activeActorsCount{{
-				Type:  "testactorfeatures",
-				Count: prevActors + actorsToCheckMetadata,
-			}},
-		}
-		var actual metadata
-		err = json.Unmarshal(res, &actual)
+		var currentMetadata metadata
+		err = json.Unmarshal(res, &currentMetadata)
 		require.NoError(t, err)
-		require.Equal(t, expected, actual)
+		require.NotNil(t, currentMetadata)
+
+		require.Equal(t, appName, currentMetadata.ID)
+		require.Equal(t, appName, previousMetadata.ID)
+		require.Greater(t, len(previousMetadata.Actors), 0)
+		require.Greater(t, len(currentMetadata.Actors), 0)
+		require.Equal(t, "testactorfeatures", currentMetadata.Actors[0].Type)
+		require.Equal(t, "testactorfeatures", previousMetadata.Actors[0].Type)
+		require.Greater(t, currentMetadata.Actors[0].Count, previousMetadata.Actors[0].Count)
 	})
 }


### PR DESCRIPTION
Fix flakiness on get metadata e2e when there are additional tests running in parallel that can influence the actor count.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
