### PR TITLE
Saves 'describe' output of K8s resources for E2E tests.

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -179,6 +179,10 @@ jobs:
       - name: Run E2E tests
         if: env.TEST_CLUSTER != ''
         run: make test-e2e-all
+      - name: Save control plane K8s resources
+        if: always() && env.TEST_CLUSTER != ''
+        run: |
+          make save-dapr-control-plane-k8s-resources
       - name: Save control plane logs
         if: always() && env.TEST_CLUSTER != ''
         run: |

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -272,6 +272,10 @@ delete-test-env-mongodb:
 # Install redis and kafka to test cluster
 setup-test-env: setup-test-env-kafka setup-test-env-redis setup-test-env-mongodb
 
+save-dapr-control-plane-k8s-resources:
+	mkdir -p '$(DAPR_CONTAINER_LOG_PATH)'
+	kubectl describe all -n $(DAPR_TEST_NAMESPACE) > '$(DAPR_CONTAINER_LOG_PATH)/control_plane_k8s_resources.txt'
+
 save-dapr-control-plane-k8s-logs:
 	mkdir -p '$(DAPR_CONTAINER_LOG_PATH)'
 	kubectl logs -l 'app.kubernetes.io/name=dapr' -n $(DAPR_TEST_NAMESPACE) > '$(DAPR_CONTAINER_LOG_PATH)/control_plane_containers.log'


### PR DESCRIPTION
Saves 'describe' output of K8s resources for E2E tests.

This is useful to debug deployment failures in E2E tests, mainly for Windows K8s.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
