### PR TITLE
state store: query api to return error for encrypted store

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -587,6 +587,12 @@ func (a *api) QueryStateAlpha1(ctx context.Context, in *runtimev1pb.QueryStateRe
 		return ret, err
 	}
 
+	if encryption.EncryptedStateStore(in.StoreName) {
+		err = status.Errorf(codes.Aborted, messages.ErrStateQuery, in.GetStoreName(), "cannot query encrypted store")
+		apiServerLogger.Debug(err)
+		return ret, err
+	}
+
 	var req state.QueryRequest
 	if err = jsoniter.Unmarshal([]byte(in.GetQuery()), &req.Query); err != nil {
 		err = status.Errorf(codes.InvalidArgument, messages.ErrMalformedRequest, err.Error())
@@ -605,7 +611,6 @@ func (a *api) QueryStateAlpha1(ctx context.Context, in *runtimev1pb.QueryStateRe
 		return ret, nil
 	}
 
-	encrypted := encryption.EncryptedStateStore(in.StoreName)
 	ret.Results = make([]*runtimev1pb.QueryStateItem, len(resp.Results))
 	ret.Token = resp.Token
 	ret.Metadata = resp.Metadata
@@ -614,13 +619,6 @@ func (a *api) QueryStateAlpha1(ctx context.Context, in *runtimev1pb.QueryStateRe
 		ret.Results[i] = &runtimev1pb.QueryStateItem{
 			Key:  state_loader.GetOriginalStateKey(resp.Results[i].Key),
 			Data: resp.Results[i].Data,
-		}
-		if encrypted {
-			ret.Results[i].Data, err = encryption.TryDecryptValue(in.StoreName, resp.Results[i].Data)
-			if err != nil {
-				apiServerLogger.Debug("query error: %s", err)
-				ret.Results[i].Error = err.Error()
-			}
 		}
 	}
 

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
+	"github.com/dapr/dapr/pkg/encryption"
 	"github.com/dapr/dapr/pkg/messages"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
@@ -1848,6 +1849,32 @@ func TestStateStoreQuerierNotImplemented(t *testing.T) {
 		StoreName: "store1",
 	})
 	assert.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+func TestStateStoreQuerierEncrypted(t *testing.T) {
+	port, err := freeport.GetFreePort()
+	assert.NoError(t, err)
+
+	storeName := "encrypted-store1"
+	encryption.AddEncryptedStateStore(storeName, encryption.ComponentEncryptionKeys{})
+
+	server := startDaprAPIServer(
+		port,
+		&api{
+			id:          "fakeAPI",
+			stateStores: map[string]state.Store{storeName: &mockStateStoreQuerier{}},
+		},
+		"")
+	defer server.Stop()
+
+	clientConn := createTestClient(port)
+	defer clientConn.Close()
+
+	client := runtimev1pb.NewDaprClient(clientConn)
+	_, err = client.QueryStateAlpha1(context.Background(), &runtimev1pb.QueryStateRequest{
+		StoreName: storeName,
+	})
+	assert.Equal(t, codes.Aborted, status.Code(err))
 }
 
 func TestGetConfigurationAlpha1(t *testing.T) {

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -1673,6 +1673,13 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
+	if encryption.EncryptedStateStore(storeName) {
+		msg := NewErrorResponse("ERR_STATE_QUERY", fmt.Sprintf(messages.ErrStateQuery, storeName, "cannot query encrypted store"))
+		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
+		log.Debug(msg)
+		return
+	}
+
 	var req state.QueryRequest
 	if err = a.json.Unmarshal(reqCtx.PostBody(), &req.Query); err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err.Error()))
@@ -1694,8 +1701,6 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	encrypted := encryption.EncryptedStateStore(storeName)
-
 	qresp := QueryResponse{
 		Results:  make([]QueryItem, len(resp.Results)),
 		Token:    resp.Token,
@@ -1705,17 +1710,7 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 		qresp.Results[i].Key = state_loader.GetOriginalStateKey(resp.Results[i].Key)
 		qresp.Results[i].ETag = resp.Results[i].ETag
 		qresp.Results[i].Error = resp.Results[i].Error
-		if encrypted {
-			val, err := encryption.TryDecryptValue(storeName, resp.Results[i].Data)
-			if err != nil {
-				log.Debugf("query error: %s", err)
-				qresp.Results[i].Error = err.Error()
-				continue
-			}
-			qresp.Results[i].Data = jsoniter.RawMessage(val)
-		} else {
-			qresp.Results[i].Data = jsoniter.RawMessage(resp.Results[i].Data)
-		}
+		qresp.Results[i].Data = jsoniter.RawMessage(resp.Results[i].Data)
 	}
 
 	b, _ := a.json.Marshal(qresp)

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -55,6 +55,7 @@ import (
 	http_middleware_loader "github.com/dapr/dapr/pkg/components/middleware/http"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/dapr/pkg/encryption"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
@@ -2615,6 +2616,20 @@ func TestStateStoreQuerierNotEnabled(t *testing.T) {
 	resp := fakeServer.DoRequest("POST", "v1.0/state/store1/query", nil, nil)
 	// assert
 	assert.Equal(t, 405, resp.StatusCode)
+}
+
+func TestStateStoreQuerierEncrypted(t *testing.T) {
+	storeName := "encrypted-store1"
+	fakeServer := newFakeHTTPServer()
+	testAPI := &api{
+		stateStores: map[string]state.Store{storeName: fakeStateStoreQuerier{}},
+	}
+	encryption.AddEncryptedStateStore(storeName, encryption.ComponentEncryptionKeys{})
+	fakeServer.StartServer(testAPI.constructStateEndpoints())
+
+	resp := fakeServer.DoRequest("POST", "v1.0-alpha1/state/"+storeName+"/query", nil, nil)
+	// assert
+	assert.Equal(t, 400, resp.StatusCode)
 }
 
 const (


### PR DESCRIPTION

# Description

state store query API request should return error for encrypted store.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #4126

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#2100
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
