### PR TITLE
helm charts: increase failure threshold for liveness and readiness probes

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -79,7 +79,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /healthz
@@ -90,7 +90,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -21,9 +21,11 @@ resources: {}
 livenessProbe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  failureThreshold: 5
 readinessProbe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  failureThreshold: 5
 
 debug:
   enabled: false

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_deployment.yaml
@@ -46,7 +46,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /healthz
@@ -57,7 +57,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
 {{- end }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_placement/values.yaml
+++ b/charts/dapr/charts/dapr_placement/values.yaml
@@ -28,9 +28,11 @@ replicationFactor: 100
 livenessProbe:
   initialDelaySeconds: 10
   periodSeconds: 3
+  failureThreshold: 5
 readinessProbe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  failureThreshold: 5
 
 debug:
   enabled: false

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -63,7 +63,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /healthz
@@ -74,7 +74,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if contains "/" .Values.image.name }}
         image: "{{ .Values.image.name }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_sentry/values.yaml
+++ b/charts/dapr/charts/dapr_sentry/values.yaml
@@ -25,9 +25,11 @@ tls:
 livenessProbe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  failureThreshold: 5
 readinessProbe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  failureThreshold: 5
 
 debug:
   enabled: false

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -46,7 +46,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /healthz
@@ -57,7 +57,7 @@ spec:
           initialDelaySeconds: {{ .Values.debug.initialDelaySeconds }}
           {{- end }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          failureThreshold: 5
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- if contains "/" .Values.injectorImage.name }}
         image: "{{ .Values.injectorImage.name }}"
 {{- else }}

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -24,9 +24,11 @@ healthzPort: 8080
 livenessProbe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  failureThreshold: 5
 readinessProbe:
   initialDelaySeconds: 3
   periodSeconds: 3
+  failureThreshold: 5
 
 debug:
   enabled: false


### PR DESCRIPTION
# Description

helm charts: increase failure threshold for liveness and readiness probes in dapr placement deployment

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
