### PR TITLE
Reduce placement blocking client

### DIFF
--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -299,9 +299,11 @@ func (p *Service) performTableDissemination() {
 func (p *Service) performTablesUpdate(hosts []placementGRPCStream, newTable *v1pb.PlacementTables) {
 	// TODO: error from disseminationOperation needs to be handle properly.
 	// Otherwise, each Dapr runtime will have inconsistent hashing table.
-	p.disseminateOperation(hosts, "lock", nil)
-	p.disseminateOperation(hosts, "update", newTable)
-	p.disseminateOperation(hosts, "unlock", nil)
+	for _, host := range hosts {
+		p.disseminateOperation([]placementGRPCStream{host}, "lock", nil)
+		p.disseminateOperation([]placementGRPCStream{host}, "update", nil)
+		p.disseminateOperation([]placementGRPCStream{host}, "unlock", nil)
+	}
 }
 
 func (p *Service) disseminateOperation(targets []placementGRPCStream, operation string, tables *v1pb.PlacementTables) error {


### PR DESCRIPTION
Signed-off-by: ls-2018 <acejilam@gamil.com>

# Description
Existing logic: an actor Type change ,eg A; will replace all the actor runtime [client] saved by the actor information
then.

1. Send a lock to all hosts, if a client calls an actor A; wait for `WaitUntilPlacementTableIsReady` to finish;
2. Then this will cause all the client calls in the cluster to block;
3. If the process is as it is, then only one client calling actor A will block,other client calls do not block
 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
