### PR TITLE
Added command line flag for health check port

### DIFF
--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -29,8 +29,10 @@ import (
 	"github.com/dapr/dapr/utils"
 )
 
-var log = logger.NewLogger("dapr.injector")
-var healthzPort int
+var (
+	log         = logger.NewLogger("dapr.injector")
+	healthzPort int
+)
 
 func main() {
 	log.Infof("starting Dapr Sidecar Injector -- version %s -- commit %s", version.Version(), version.Commit())

--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -30,10 +30,7 @@ import (
 )
 
 var log = logger.NewLogger("dapr.injector")
-
-const (
-	healthzPort = 8080
-)
+var healthzPort int
 
 func main() {
 	log.Infof("starting Dapr Sidecar Injector -- version %s -- commit %s", version.Version(), version.Commit())
@@ -76,6 +73,8 @@ func init() {
 
 	metricsExporter := metrics.NewExporter(metrics.DefaultMetricNamespace)
 	metricsExporter.Options().AttachCmdFlags(flag.StringVar, flag.BoolVar)
+
+	flag.IntVar(&healthzPort, "healthz-port", 8080, "The port used for health checks")
 
 	flag.Parse()
 


### PR DESCRIPTION
Signed-off-by: Abel Perez Martinez <abelperezok@gmail.com>

# Description

This pull request is a follow up from issue https://github.com/dapr/dapr/issues/4141 I changed the constant value `8080` and put a variable instead, this variable is populated from the command line flag `healthz-port` and defaults to `8080` if not passed in the command line. 

This is one first step towards offering more flexibility to deploy this injector in a wider range of setups. Once this change is in place, I'll submit another PR to allow passing this value via helm chart. 

## Issue reference

Please reference the issue this PR will close: #4141

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests N/A
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
