### PR TITLE
Change stale bot trigger from 30 to 60 days.

### DIFF
--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -42,24 +42,24 @@ jobs:
         repo-token: ${{ secrets.DAPR_BOT_TOKEN }}
         # Different amounts of days for issues/PRs are not currently supported but there is a PR
         # open for it: https://github.com/actions/stale/issues/214
-        days-before-stale: 30
+        days-before-stale: 60
         days-before-close: 7
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had activity in the
-          last 30 days. It will be closed in the next 7 days unless it is tagged (pinned, good first issue, help wanted or triaged/resolved) or other activity
+          last 60 days. It will be closed in the next 7 days unless it is tagged (pinned, good first issue, help wanted or triaged/resolved) or other activity
           occurs. Thank you for your contributions.
         close-issue-message: >
           This issue has been automatically closed because it has not had activity in the
-          last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as pinned, good first issue, help wanted or triaged/resolved.
+          last 67 days. If this issue is still valid, please ping a maintainer and ask them to label it as pinned, good first issue, help wanted or triaged/resolved.
           Thank you for your contributions.
         stale-pr-message: >
           This pull request has been automatically marked as stale because it has not had
-          activity in the last 30 days. It will be closed in 7 days if no further activity occurs. Please
+          activity in the last 60 days. It will be closed in 7 days if no further activity occurs. Please
           feel free to give a status update now, ping for review, or re-open when it's ready.
           Thank you for your contributions!
         close-pr-message: >
           This pull request has been automatically closed because it has not had
-          activity in the last 37 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+          activity in the last 67 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
           Thank you for your contributions!
         stale-issue-label: 'stale'
         exempt-issue-labels: 'pinned,good first issue,help wanted,triaged/resolved'


### PR DESCRIPTION
Dapr bot will mark issues and PRs as stale only after 60 days instead of 30.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
