### PR TITLE
Automatically update Helm chart based on release tag

### DIFF
--- a/.github/scripts/set_helm_dapr_version.sh
+++ b/.github/scripts/set_helm_dapr_version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ -z $REL_VERSION ]; then
+  echo "REL_VERSION is not set. Exiting ..."
+  exit 1
+fi
+
+FILES=`grep -Hrl DAPR_VERSION charts`
+for file in $FILES; do
+  echo "Setting \"version: $REL_VERSION\" in $file ..."
+  sed -e "s/DAPR_VERSION/$REL_VERSION/" -i "$file"
+done

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -181,6 +181,8 @@ jobs:
           docker -v
       - name: Parse release version and set REL_VERSION
         run: python ./.github/scripts/get_release_version.py
+      - name: Update Helm chart files for release version ${{ env.REL_VERSION }}
+        run: ./.github/scripts/set_helm_dapr_version.sh
       - name: Generate helm chart manifest
         run: make manifest-gen DAPR_REGISTRY=${{ env.DOCKER_REGISTRY }} DAPR_TAG=$REL_VERSION
       - name: move helm chart manifest to artifact

--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
-appVersion: "1.6.0"
+appVersion: "DAPR_VERSION"
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: 1.6.0
+version: DAPR_VERSION
 dependencies:
   - name: dapr_rbac
-    version: "1.6.0"
+    version: "DAPR_VERSION"
     repository: "file://dapr_rbac"
   - name: dapr_operator
-    version: "1.6.0"
+    version: "DAPR_VERSION"
     repository: "file://dapr_operator"
   - name: dapr_placement
-    version: "1.6.0"
+    version: "DAPR_VERSION"
     repository: "file://dapr_placement"
   - name: dapr_sidecar_injector
-    version: "1.6.0"
+    version: "DAPR_VERSION"
     repository: "file://dapr_sidecar_injector"
   - name: dapr_sentry
-    version: "1.6.0"
+    version: "DAPR_VERSION"
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
     version: "0.9.0"

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -76,7 +76,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
 | `global.registry`                         | Docker image registry                                                   | `docker.io/daprio`      |
-| `global.tag`                              | Docker image version tag                                                | `1.6.0`            |
+| `global.tag`                              | Docker image version tag                                                | latest release          |
 | `global.logAsJson`                        | Json log format for control plane services                              | `false`                 |
 | `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
 | `global.imagePullSecrets`                 | Control plane service images pull secrets for docker registry            | `""`                   |

--- a/charts/dapr/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: 1.6.0
+version: DAPR_VERSION

--- a/charts/dapr/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr/charts/dapr_placement/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: 1.6.0
+version: DAPR_VERSION
 

--- a/charts/dapr/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr/charts/dapr_rbac/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC components
 name: dapr_rbac
-version: 1.6.0
+version: DAPR_VERSION
 

--- a/charts/dapr/charts/dapr_sentry/Chart.yaml
+++ b/charts/dapr/charts/dapr_sentry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Sentry
 name: dapr_sentry
-version: 1.6.0
+version: DAPR_VERSION

--- a/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: 1.6.0
+version: DAPR_VERSION

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "1.6.0"
+  tag: "DAPR_VERSION"
   dnsSuffix: ".cluster.local"
   logAsJson: false
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
# Description

This removes the need to create PRs to update helm chart prior to tagging a release. It uses the tag itself to automatically set the Helm chart version and image tags. The only exception is Dashboard that still needs to be tracked independently since it is a separate project.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
