### PR TITLE
Fix subscription retry logic

### DIFF
--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -82,6 +82,10 @@ func GetSubscriptionsHTTP(channel channel.AppChannel, log logger.Logger) ([]Subs
 		log.Debug("failed getting http subscriptions, starting retry")
 	}, func() {})
 
+	if err != nil {
+		return nil, err
+	}
+
 	switch resp.Status().Code {
 	case http.StatusOK:
 		_, body := resp.RawData()
@@ -151,6 +155,9 @@ func filterSubscriptions(subscriptions []Subscription, log logger.Logger) []Subs
 
 func getSubscriptionsBackoff() backoff.BackOff {
 	config := retry.DefaultConfig()
+	config.MaxRetries = 3
+	config.Duration = time.Second * 2
+	config.MaxElapsedTime = time.Second * 10
 	config.Policy = retry.PolicyExponential
 	return config.NewBackOff()
 }

--- a/pkg/runtime/pubsub/subscriptions_test.go
+++ b/pkg/runtime/pubsub/subscriptions_test.go
@@ -253,10 +253,15 @@ func TestDeclarativeSubscriptionsV2(t *testing.T) {
 type mockUnstableHTTPSubscriptions struct {
 	channel.AppChannel
 	callCount        int
+	alwaysError      bool
 	successThreshold int
 }
 
 func (m *mockUnstableHTTPSubscriptions) InvokeMethod(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
+	if m.alwaysError {
+		return nil, errors.New("error")
+	}
+
 	m.callCount++
 
 	if m.callCount < m.successThreshold {
@@ -363,6 +368,15 @@ func TestHTTPSubscriptions(t *testing.T) {
 			assert.Equal(t, "pubsub", subs[0].PubsubName)
 			assert.Equal(t, "testValue", subs[0].Metadata["testName"])
 		}
+	})
+
+	t.Run("error from app, retries exhausted", func(t *testing.T) {
+		m := mockUnstableHTTPSubscriptions{
+			alwaysError: true,
+		}
+
+		_, err := GetSubscriptionsHTTP(&m, log)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
This PR adds a missing error return statement and configures sane retries specific for subscribing to HTTP topics.

Fixes https://github.com/dapr/dapr/issues/4185.
