### PR TITLE
add mqtt to e2e-pubsub-test and fix wildcard subscription

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -3499,10 +3499,8 @@ func stopRuntime(t *testing.T, rt *DaprRuntime) {
 func TestFindMatchingRoute(t *testing.T) {
 	r, err := createRoutingRule(`event.type == "MyEventType"`, "mypath")
 	require.NoError(t, err)
-	route := Route{
-		rules: []*runtime_pubsub.Rule{r},
-	}
-	path, shouldProcess, err := findMatchingRoute(&route, map[string]interface{}{
+	rules := []*runtime_pubsub.Rule{r}
+	path, shouldProcess, err := findMatchingRoute(rules, map[string]interface{}{
 		"type": "MyEventType",
 	}, true)
 	require.NoError(t, err)

--- a/tests/apps/pubsub-subscriber/app.go
+++ b/tests/apps/pubsub-subscriber/app.go
@@ -29,12 +29,13 @@ import (
 )
 
 const (
-	appPort   = 3000
-	pubsubA   = "pubsub-a-topic-http"
-	pubsubB   = "pubsub-b-topic-http"
-	pubsubC   = "pubsub-c-topic-http"
-	pubsubJob = "pubsub-job-topic-http"
-	pubsubRaw = "pubsub-raw-topic-http"
+	appPort    = 3000
+	pubsubA    = "pubsub-a-topic-http"
+	pubsubB    = "pubsub-b-topic-http"
+	pubsubC    = "pubsub-c-topic-http"
+	pubsubJob  = "pubsub-job-topic-http"
+	pubsubRaw  = "pubsub-raw-topic-http"
+	pubsubMqtt = "pubsub-mqtt-topic-http"
 )
 
 type appResponse struct {
@@ -46,11 +47,12 @@ type appResponse struct {
 }
 
 type receivedMessagesResponse struct {
-	ReceivedByTopicA   []string `json:"pubsub-a-topic"`
-	ReceivedByTopicB   []string `json:"pubsub-b-topic"`
-	ReceivedByTopicC   []string `json:"pubsub-c-topic"`
-	ReceivedByTopicJob []string `json:"pubsub-job-topic"`
-	ReceivedByTopicRaw []string `json:"pubsub-raw-topic"`
+	ReceivedByTopicA    []string `json:"pubsub-a-topic"`
+	ReceivedByTopicB    []string `json:"pubsub-b-topic"`
+	ReceivedByTopicC    []string `json:"pubsub-c-topic"`
+	ReceivedByTopicJob  []string `json:"pubsub-job-topic"`
+	ReceivedByTopicRaw  []string `json:"pubsub-raw-topic"`
+	ReceivedByTopicMqtt []string `json:"pubsub-mqtt-topic"`
 }
 
 type subscription struct {
@@ -78,13 +80,14 @@ const (
 
 var (
 	// using sets to make the test idempotent on multiple delivery of same message
-	receivedMessagesA   sets.String
-	receivedMessagesB   sets.String
-	receivedMessagesC   sets.String
-	receivedMessagesJob sets.String
-	receivedMessagesRaw sets.String
-	desiredResponse     respondWith
-	lock                sync.Mutex
+	receivedMessagesA    sets.String
+	receivedMessagesB    sets.String
+	receivedMessagesC    sets.String
+	receivedMessagesJob  sets.String
+	receivedMessagesRaw  sets.String
+	receivedMessagesMqtt sets.String
+	desiredResponse      respondWith
+	lock                 sync.Mutex
 )
 
 // indexHandler is the handler for root path
@@ -127,6 +130,11 @@ func configureSubscribeHandler(w http.ResponseWriter, _ *http.Request) {
 			Metadata: map[string]string{
 				"rawPayload": "true",
 			},
+		},
+		{
+			PubsubName: "mqtt-pubsub",
+			Topic:      "#",
+			Route:      pubsubMqtt,
 		},
 	}
 	log.Printf("configureSubscribeHandler subscribing to:%v\n", t)
@@ -229,6 +237,8 @@ func subscribeHandler(w http.ResponseWriter, r *http.Request) {
 		receivedMessagesJob.Insert(msg)
 	} else if strings.HasSuffix(r.URL.String(), pubsubRaw) && !receivedMessagesRaw.Has(msg) {
 		receivedMessagesRaw.Insert(msg)
+	} else if strings.HasSuffix(r.URL.String(), pubsubMqtt) && !receivedMessagesMqtt.Has(msg) {
+		receivedMessagesMqtt.Insert(msg)
 	} else {
 		// This case is triggered when there is multiple redelivery of same message or a message
 		// is thre for an unknown URL path
@@ -304,11 +314,12 @@ func getReceivedMessages(w http.ResponseWriter, _ *http.Request) {
 	log.Println("Enter getReceivedMessages")
 
 	response := receivedMessagesResponse{
-		ReceivedByTopicA:   unique(receivedMessagesA.List()),
-		ReceivedByTopicB:   unique(receivedMessagesB.List()),
-		ReceivedByTopicC:   unique(receivedMessagesC.List()),
-		ReceivedByTopicJob: unique(receivedMessagesJob.List()),
-		ReceivedByTopicRaw: unique(receivedMessagesRaw.List()),
+		ReceivedByTopicA:    unique(receivedMessagesA.List()),
+		ReceivedByTopicB:    unique(receivedMessagesB.List()),
+		ReceivedByTopicC:    unique(receivedMessagesC.List()),
+		ReceivedByTopicJob:  unique(receivedMessagesJob.List()),
+		ReceivedByTopicRaw:  unique(receivedMessagesRaw.List()),
+		ReceivedByTopicMqtt: unique(receivedMessagesMqtt.List()),
 	}
 
 	log.Printf("receivedMessagesResponse=%s", response)
@@ -344,6 +355,7 @@ func initializeSets() {
 	receivedMessagesC = sets.NewString()
 	receivedMessagesJob = sets.NewString()
 	receivedMessagesRaw = sets.NewString()
+	receivedMessagesMqtt = sets.NewString()
 }
 
 // appRouter initializes restful api router
@@ -373,6 +385,7 @@ func appRouter() *mux.Router {
 	router.HandleFunc("/"+pubsubC, subscribeHandler).Methods("POST")
 	router.HandleFunc("/"+pubsubJob, subscribeHandler).Methods("POST")
 	router.HandleFunc("/"+pubsubRaw, subscribeHandler).Methods("POST")
+	router.HandleFunc("/"+pubsubMqtt, subscribeHandler).Methods("POST")
 	router.Use(mux.CORSMethodMiddleware(router))
 
 	return router

--- a/tests/config/dapr_mqtt_pubsub.yaml
+++ b/tests/config/dapr_mqtt_pubsub.yaml
@@ -1,0 +1,18 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mqtt-pubsub
+spec:
+  type: pubsub.mqtt
+  version: v1
+  metadata:
+  - name: url
+    value: "tcp://mosquitto.dapr-tests.svc.cluster.local:1883"
+  - name: qos
+    value: 1
+  - name: retain
+    value: "false"
+  - name: cleanSession
+    value: "true"
+  - name: backOffMaxRetries
+    value: "-1"

--- a/tests/config/mosquitto.yaml
+++ b/tests/config/mosquitto.yaml
@@ -1,0 +1,36 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: mosquitto
+spec:
+  ports:
+  - protocol: TCP
+    port: 1883
+    targetPort: 1883
+  selector:
+    run: mosquitto
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mosquitto
+spec:
+  selector:
+    matchLabels:
+      run: mosquitto
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: mosquitto
+    spec:
+      containers:
+        - args:
+            - mosquitto
+            - -c
+            - /mosquitto-no-auth.conf
+          image: eclipse-mosquitto
+          name: mosquitto
+          ports:
+            - containerPort: 1883

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -313,6 +313,8 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/app_topic_subscription_routing.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/app_topic_subscription_routing_grpc.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/app_pubsub_routing.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/mosquitto.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/dapr_mqtt_pubsub.yaml --namespace $(DAPR_TEST_NAMESPACE)
 
 	# Show the installed components
 	$(KUBECTL) get components --namespace $(DAPR_TEST_NAMESPACE)


### PR DESCRIPTION
Signed-off-by: Paul Thiele <thielepaul@gmail.com>

# Description

Added mosquitto as a mqtt message broker to the e2e tests and added a mqtt subscription to e2e pubsub test.

## Issue reference

Please reference the issue this PR will close: #3920

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
