### PR TITLE
Use windows-2019 instead of windows-latest on GH actions.

### DIFF
--- a/.github/workflows/dapr-base-containers.yaml
+++ b/.github/workflows/dapr-base-containers.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     name: Build base windows images
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       WINDOWS_VERSION: 1809
       TARGET_OS: windows

--- a/.github/workflows/dapr-test-apps.yml
+++ b/.github/workflows/dapr-test-apps.yml
@@ -30,17 +30,17 @@ jobs:
       GOPROXY: https://proxy.golang.org
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
         target_arch: [arm, arm64, amd64]
         include:
           - os: ubuntu-latest
             target_os: linux
-          - os: windows-latest
+          - os: windows-2019
             target_os: windows
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             target_arch: arm
-          - os: windows-latest
+          - os: windows-2019
             target_arch: arm64
     steps:
       - name: Set up Go ${{ env.GOVER }}

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -42,12 +42,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
         target_arch: [amd64]
         include:
           - os: ubuntu-latest
             target_os: linux
-          - os: windows-latest
+          - os: windows-2019
             target_os: windows
     steps:
       - name: Set up container log path

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -40,19 +40,19 @@ jobs:
       TEST_OUTPUT_FILE_PREFIX: test_report
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-2019, macOS-latest]
         target_arch: [arm, arm64, amd64]
         include:
           - os: ubuntu-latest
             target_os: linux
-          - os: windows-latest
+          - os: windows-2019
             target_os: windows
           - os: macOS-latest
             target_os: darwin
         exclude:
-          - os: windows-latest
+          - os: windows-2019
             target_arch: arm
-          - os: windows-latest
+          - os: windows-2019
             target_arch: arm64
           - os: macOS-latest
             target_arch: arm


### PR DESCRIPTION
GH actions seems to have moved to windows 2022 for the windows-latest label as per the logs from one of the recent PRs. So, I am fixing our GH actions to windows-2019 since that is where it all works today.

This is another example of why fixing to `latest` is a bad idea since it is a moving target and we cannot guarantee forward compatibility with our build and tests.


Use windows-2019 instead of windows-latest on GH actions.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
