### PR TITLE
Bring secretstore resiliency to match others

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -742,10 +742,9 @@ func (a *api) GetSecret(ctx context.Context, in *runtimev1pb.GetSecretRequest) (
 	}
 
 	policy := a.resiliency.ComponentPolicy(ctx, secretStoreName)
-	getResponse := secretstores.GetSecretResponse{}
-	err := policy(func(ctx context.Context) error {
-		resp, rErr := a.secretStores[secretStoreName].GetSecret(req)
-		getResponse = resp
+	var getResponse secretstores.GetSecretResponse
+	err := policy(func(ctx context.Context) (rErr error) {
+		getResponse, rErr = a.secretStores[secretStoreName].GetSecret(req)
 		return rErr
 	})
 	if err != nil {
@@ -781,10 +780,9 @@ func (a *api) GetBulkSecret(ctx context.Context, in *runtimev1pb.GetBulkSecretRe
 	}
 
 	policy := a.resiliency.ComponentPolicy(ctx, secretStoreName)
-	getResponse := secretstores.BulkGetSecretResponse{}
-	err := policy(func(ctx context.Context) error {
-		resp, rErr := a.secretStores[secretStoreName].BulkGetSecret(req)
-		getResponse = resp
+	var getResponse secretstores.BulkGetSecretResponse
+	err := policy(func(ctx context.Context) (rErr error) {
+		getResponse, rErr = a.secretStores[secretStoreName].BulkGetSecret(req)
 		return rErr
 	})
 	if err != nil {

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -719,10 +719,9 @@ func (a *api) onGetSecret(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	policy := a.resiliency.ComponentPolicy(reqCtx, secretStoreName)
-	resp := secretstores.GetSecretResponse{}
-	err = policy(func(ctx context.Context) error {
-		r, rErr := store.GetSecret(req)
-		resp = r
+	var resp secretstores.GetSecretResponse
+	err = policy(func(ctx context.Context) (rErr error) {
+		resp, rErr = store.GetSecret(req)
 		return rErr
 	})
 	if err != nil {
@@ -756,10 +755,9 @@ func (a *api) onBulkGetSecret(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	policy := a.resiliency.ComponentPolicy(reqCtx, secretStoreName)
-	resp := secretstores.BulkGetSecretResponse{}
-	err = policy(func(ctx context.Context) error {
-		r, rErr := store.BulkGetSecret(req)
-		resp = r
+	var resp secretstores.BulkGetSecretResponse
+	err = policy(func(ctx context.Context) (rErr error) {
+		resp, rErr = store.BulkGetSecret(req)
 		return rErr
 	})
 	if err != nil {

--- a/pkg/resiliency/policy_test.go
+++ b/pkg/resiliency/policy_test.go
@@ -82,7 +82,7 @@ func TestPolicyTimeout(t *testing.T) {
 		{
 			name:      "Timeout OK",
 			sleepTime: time.Millisecond * 5,
-			timeout:   time.Millisecond * 10,
+			timeout:   time.Millisecond * 50,
 			expected:  true,
 		},
 	}


### PR DESCRIPTION
# Description

This commit changes the secretstore resiliency calls to match
the other building blocks. This is primarily a style change.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: Resiliency

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
