### PR TITLE
Add prometheus.io/probe annotation to Dapr service

### DIFF
--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -194,7 +194,8 @@ func (h *DaprHandler) createDaprServiceValues(ctx context.Context, expectedServi
 	}
 
 	if enableMetrics {
-		annotations["prometheus.io/scrape"] = "true"
+		annotations["prometheus.io/probe"] = "true"
+		annotations["prometheus.io/scrape"] = "true" // WARN: deprecated as of v1.7 please use prometheus.io/probe instead.
 		annotations["prometheus.io/port"] = strconv.Itoa(metricsPort)
 		annotations["prometheus.io/path"] = "/"
 	}


### PR DESCRIPTION
Signed-off-by: Joni Collinge <jonathancollinge@live.com>

# Description
Add prometheus.io/probe annotation to Dapr service.
Requires deprecation notice regarding `prometheus.io/scrape` annotation.

## Issue reference
Please reference the issue this PR will close: #4272 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
