### PR TITLE
Fix devcontainer image not building

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Dapr Dev Environment",
 	// Update the container version when you publish dev-container
-	"image": "docker.io/daprio/dapr-dev:0.1.6",
+	"image": "docker.io/daprio/dapr-dev:0.1.6a",
 	// Replace with uncommented line below to build your own local copy of the image
 	// "dockerFile": "../docker/Dockerfile-dev",
 	"containerEnv": {

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -176,7 +176,7 @@ docker-windows-base-push: check-windows-version
 ################################################################################
 
 # Update whenever you upgrade dev container image
-DEV_CONTAINER_VERSION_TAG?=0.1.6
+DEV_CONTAINER_VERSION_TAG?=0.1.6a
 
 # Use this to pin a specific version of the Dapr CLI to a devcontainer
 DEV_CONTAINER_CLI_TAG?=1.6.0

--- a/docker/library-scripts/docker-in-docker-debian.sh
+++ b/docker/library-scripts/docker-in-docker-debian.sh
@@ -170,10 +170,10 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
 	# move the init process (PID 1) from the root group to the /init group,
 	# otherwise writing subtree_control fails with EBUSY.
 	sudoIf mkdir -p /sys/fs/cgroup/init
-	sudoIf echo 1 > /sys/fs/cgroup/init/cgroup.procs
+	sudoIf sh -c "xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || : "
 	# enable controllers
-	sudoIf sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
-		> /sys/fs/cgroup/cgroup.subtree_control
+	sudoIf sh -c "sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+		> /sys/fs/cgroup/cgroup.subtree_control"
 fi
 ## Dind wrapper over.
 


### PR DESCRIPTION
The devcontainer image was failing to build on a MacOS host when docker-in-docker was used, with a permission error.