### PR TITLE
[WIP] Use encoding/json instead of json-iterator/go

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -15,7 +15,6 @@ package actors
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	nethttp "net/http"
@@ -28,7 +27,6 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
@@ -38,6 +36,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/dapr/kit/logger"
 
 	"github.com/dapr/dapr/pkg/actors/internal"
@@ -1406,7 +1405,7 @@ func (a *actorsRuntime) getRemindersForActorType(actorType string, migrate bool)
 						return
 					}
 
-					r.Data = jsoniter.RawMessage(resp.Data)
+					r.Data = json.RawMessage(resp.Data)
 					r.ETag = resp.ETag
 					r.Metadata = resp.Metadata
 				}

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -15,7 +15,6 @@ package actors
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -24,7 +23,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -35,6 +33,7 @@ import (
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/health"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
 )
@@ -1479,7 +1478,7 @@ func TestGetState(t *testing.T) {
 	fakeData := strconv.Quote("fakeData")
 
 	var val interface{}
-	jsoniter.ConfigFastest.Unmarshal([]byte(fakeData), &val)
+	json.Unmarshal([]byte(fakeData), &val)
 
 	fakeCallAndActivateActor(testActorRuntime, actorType, actorID)
 
@@ -1516,7 +1515,7 @@ func TestDeleteState(t *testing.T) {
 	fakeData := strconv.Quote("fakeData")
 
 	var val interface{}
-	jsoniter.ConfigFastest.Unmarshal([]byte(fakeData), &val)
+	json.Unmarshal([]byte(fakeData), &val)
 
 	fakeCallAndActivateActor(testActorRuntime, actorType, actorID)
 

--- a/pkg/channel/grpc/grpc_channel_test.go
+++ b/pkg/channel/grpc/grpc_channel_test.go
@@ -15,7 +15,7 @@ package grpc
 
 import (
 	"context"
-	"encoding/json"
+
 	"fmt"
 	"io"
 	"net"
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	auth "github.com/dapr/dapr/pkg/runtime/security"

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -16,6 +16,7 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -23,7 +24,6 @@ import (
 
 	nethttp "net/http"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/valyala/fasthttp"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"google.golang.org/grpc/codes"
@@ -55,7 +55,6 @@ type Channel struct {
 	ch                  chan int
 	tracingSpec         config.TracingSpec
 	appHeaderToken      string
-	json                jsoniter.API
 	maxResponseBodySize int
 }
 
@@ -78,7 +77,6 @@ func CreateLocalChannel(port, maxConcurrency int, spec config.TracingSpec, sslEn
 		baseAddress:         fmt.Sprintf("%s://%s:%d", scheme, channel.DefaultChannelAddress, port),
 		tracingSpec:         spec,
 		appHeaderToken:      auth.GetAppToken(),
-		json:                jsoniter.ConfigFastest,
 		maxResponseBodySize: maxRequestBodySize,
 	}
 
@@ -132,7 +130,7 @@ func (h *Channel) GetAppConfig() (*config.ApplicationConfig, error) {
 		fallthrough
 	default:
 		_, body := resp.RawData()
-		if err = h.json.Unmarshal(body, &config); err != nil {
+		if err = json.Unmarshal(body, &config); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -16,7 +16,6 @@ package http
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -33,6 +32,7 @@ import (
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -15,7 +15,6 @@ package http
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +25,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 )
 

--- a/pkg/channel/testing/grpc_channel_server_mock.go
+++ b/pkg/channel/testing/grpc_channel_server_mock.go
@@ -15,12 +15,12 @@ package testing
 
 import (
 	context "context"
-	"encoding/json"
 
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/dapr/dapr/pkg/json"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 )

--- a/pkg/components/kubernetes_loader.go
+++ b/pkg/components/kubernetes_loader.go
@@ -15,11 +15,11 @@ package components
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/dapr/kit/logger"
 
 	components_v1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"

--- a/pkg/components/kubernetes_loader_test.go
+++ b/pkg/components/kubernetes_loader_test.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	subscriptions "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	config "github.com/dapr/dapr/pkg/config/modes"
+	"github.com/dapr/dapr/pkg/json"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 )
 

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -15,12 +15,12 @@ package config
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/dapr/dapr/pkg/json"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -1,9 +1,9 @@
 package expr
 
 import (
-	"encoding/json"
 	"strings"
 
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
 	expr_proto "google.golang.org/genproto/googleapis/api/expr/v1alpha1"

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -15,7 +15,6 @@ package grpc
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -47,6 +46,7 @@ import (
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/dapr/dapr/pkg/encryption"
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/dapr/dapr/pkg/messages"
 	"github.com/dapr/dapr/pkg/messaging"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -15,6 +15,7 @@ package grpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -25,7 +26,6 @@ import (
 	"github.com/dapr/components-contrib/configuration"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -285,7 +285,7 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 		features := thepubsub.Features()
 		pubsub.ApplyMetadata(envelope, features, in.Metadata)
 
-		data, err = jsoniter.ConfigFastest.Marshal(envelope)
+		data, err = json.Marshal(envelope)
 		if err != nil {
 			err = status.Errorf(codes.InvalidArgument, messages.ErrPubsubCloudEventsSer, topic, pubsubName, err.Error())
 			apiServerLogger.Debug(err)
@@ -623,7 +623,7 @@ func (a *api) QueryStateAlpha1(ctx context.Context, in *runtimev1pb.QueryStateRe
 	}
 
 	var req state.QueryRequest
-	if err = jsoniter.Unmarshal([]byte(in.GetQuery()), &req.Query); err != nil {
+	if err = json.Unmarshal([]byte(in.GetQuery()), &req.Query); err != nil {
 		err = status.Errorf(codes.InvalidArgument, messages.ErrMalformedRequest, err.Error())
 		apiServerLogger.Debug(err)
 		return ret, err

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -17,7 +17,6 @@ package http
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/agrea/ptr"
 	routing "github.com/fasthttp/router"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -56,6 +54,7 @@ import (
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/encryption"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
@@ -88,7 +87,6 @@ func TestPubSubEndpoints(t *testing.T) {
 				return &daprt.MockPubSub{}
 			},
 		},
-		json: jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructPubSubEndpoints())
 
@@ -233,7 +231,6 @@ func TestShutdownEndpoints(t *testing.T) {
 	m := mock.Mock{}
 	m.On("shutdown", mock.Anything).Return()
 	testAPI := &api{
-		json: jsoniter.ConfigFastest,
 		shutdown: func() {
 			m.MethodCalled("shutdown")
 		},
@@ -296,7 +293,6 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 			}
 			return &bindings.InvokeResponse{Data: []byte("testresponse")}, nil
 		},
-		json: jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructBindingsEndpoints())
 
@@ -380,7 +376,6 @@ func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 
 	testAPI := &api{
 		sendToOutputBindingFn: func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) { return nil, nil },
-		json:                  jsoniter.ConfigFastest,
 		tracingSpec:           spec,
 	}
 	fakeServer.StartServerWithTracing(spec, testAPI.constructBindingsEndpoints())
@@ -445,7 +440,6 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	testAPI := &api{
 		directMessaging: mockDirectMessaging,
-		json:            jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructDirectMessagingEndpoints())
 
@@ -852,7 +846,6 @@ func TestV1ActorEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	testAPI := &api{
 		actor: nil,
-		json:  jsoniter.ConfigFastest,
 	}
 
 	fakeServer.StartServer(testAPI.constructActorEndpoints())
@@ -1601,7 +1594,6 @@ func TestV1MetadataEndpoint(t *testing.T) {
 				},
 			}
 		},
-		json: jsoniter.ConfigFastest,
 	}
 
 	fakeServer.StartServer(testAPI.constructMetadataEndpoints())
@@ -1651,7 +1643,6 @@ func TestV1ActorEndpointsWithTracer(t *testing.T) {
 
 	testAPI := &api{
 		actor:       nil,
-		json:        jsoniter.ConfigFastest,
 		tracingSpec: spec,
 	}
 
@@ -2302,7 +2293,6 @@ func TestV1StateEndpoints(t *testing.T) {
 	testAPI := &api{
 		stateStores:              fakeStores,
 		transactionalStateStores: fakeTransactionalStores,
-		json:                     jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructStateEndpoints())
 	storeName := "store1"
@@ -2520,7 +2510,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		expectedResponses := []BulkGetResponse{
 			{
 				Key:   "good-key",
-				Data:  jsoniter.RawMessage("life is good"),
+				Data:  json.RawMessage("life is good"),
 				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
@@ -2553,7 +2543,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		expectedResponses := []BulkGetResponse{
 			{
 				Key:   "good-key",
-				Data:  jsoniter.RawMessage("life is good"),
+				Data:  json.RawMessage("life is good"),
 				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
@@ -2803,7 +2793,6 @@ func TestV1SecretEndpoints(t *testing.T) {
 	testAPI := &api{
 		secretsConfiguration: secretsConfiguration,
 		secretStores:         fakeStores,
-		json:                 jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructSecretEndpoints())
 	storeName := "store1"
@@ -2920,7 +2909,6 @@ func TestV1HealthzEndpoint(t *testing.T) {
 
 	testAPI := &api{
 		actor: nil,
-		json:  jsoniter.ConfigFastest,
 	}
 
 	fakeServer.StartServer(testAPI.constructHealthzEndpoints())
@@ -2957,7 +2945,6 @@ func TestV1TransactionEndpoints(t *testing.T) {
 	testAPI := &api{
 		stateStores:              fakeStores,
 		transactionalStateStores: fakeTransactionalStores,
-		json:                     jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructStateEndpoints())
 	fakeBodyObject := map[string]interface{}{"data": "fakeData"}

--- a/pkg/http/responses.go
+++ b/pkg/http/responses.go
@@ -14,9 +14,7 @@ limitations under the License.
 package http
 
 import (
-	"encoding/json"
-
-	jsoniter "github.com/json-iterator/go"
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/valyala/fasthttp"
 )
 
@@ -28,11 +26,11 @@ const (
 
 // BulkGetResponse is the response object for a state bulk get operation.
 type BulkGetResponse struct {
-	Key      string              `json:"key"`
-	Data     jsoniter.RawMessage `json:"data,omitempty"`
-	ETag     *string             `json:"etag,omitempty"`
-	Metadata map[string]string   `json:"metadata,omitempty"`
-	Error    string              `json:"error,omitempty"`
+	Key      string            `json:"key"`
+	Data     json.RawMessage   `json:"data,omitempty"`
+	ETag     *string           `json:"etag,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+	Error    string            `json:"error,omitempty"`
 }
 
 // QueryResponse is the response object for querying state.
@@ -44,10 +42,10 @@ type QueryResponse struct {
 
 // QueryItem is an object representing a single entry in query results.
 type QueryItem struct {
-	Key   string              `json:"key"`
-	Data  jsoniter.RawMessage `json:"data"`
-	ETag  *string             `json:"etag,omitempty"`
-	Error string              `json:"error,omitempty"`
+	Key   string          `json:"key"`
+	Data  json.RawMessage `json:"data"`
+	ETag  *string         `json:"etag,omitempty"`
+	Error string          `json:"error,omitempty"`
 }
 
 type option = func(ctx *fasthttp.RequestCtx)

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -15,7 +15,6 @@ package injector
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,6 +31,7 @@ import (
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	"github.com/dapr/dapr/pkg/injector/monitoring"
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/dapr/dapr/utils"
 )
 

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -15,7 +15,6 @@ package injector
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,6 +31,7 @@ import (
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/dapr/dapr/pkg/client/clientset/versioned/fake"
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -15,7 +15,6 @@ package injector
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path"
 	"strconv"
@@ -31,6 +30,7 @@ import (
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	"github.com/dapr/dapr/pkg/credentials"
+	"github.com/dapr/dapr/pkg/json"
 	auth "github.com/dapr/dapr/pkg/runtime/security"
 	"github.com/dapr/dapr/pkg/sentry/certs"
 	"github.com/dapr/dapr/pkg/validation"

--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	ejson "encoding/json"
+	"io"
+)
+
+// RawMessage is a wrapper around encoding/json's RawMessage
+// that is a raw encoded JSON value.
+type RawMessage ejson.RawMessage
+
+// Marshal is a wrapper around encoding/json's Marshal
+// that returns the JSON encoding of v.
+func Marshal(v interface{}) ([]byte, error) {
+	return ejson.Marshal(v)
+}
+
+// Unmarshal is a wrapper around encoding/json's Unmarshal
+// that parses the JSON-encoded data and stores the result
+// in the value pointed to by v.
+func Unmarshal(data []byte, v interface{}) error {
+	return ejson.Unmarshal(data, v)
+}
+
+// NewDecoder is a wrapper around encoding/json's NewDecoder
+// that returns a new decoder that reads from r.
+func NewDecoder(r io.Reader) *ejson.Decoder {
+	return ejson.NewDecoder(r)
+}
+
+// NewEncoder is a wrapper around encoding/json's NewEncoder
+// that returns a new encoder that writes to w.
+func NewEncoder(w io.Writer) *ejson.Encoder {
+	return ejson.NewEncoder(w)
+}

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -15,7 +15,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"sync"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/dapr/kit/logger"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -16,7 +16,6 @@ package api
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 
 	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/client/clientset/versioned/scheme"
+	"github.com/dapr/dapr/pkg/json"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 )
 

--- a/pkg/operator/webhooks.go
+++ b/pkg/operator/webhooks.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"os"
 	"strings"
 
@@ -18,6 +17,7 @@ import (
 
 	subscriptionsapi_v1alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	subscriptionsapi_v2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const webhookCAName = "dapr-webhook-ca"

--- a/pkg/runtime/pubsub/cloudevents_test.go
+++ b/pkg/runtime/pubsub/cloudevents_test.go
@@ -14,10 +14,11 @@ limitations under the License.
 package pubsub
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 func TestNewCloudEvent(t *testing.T) {

--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -2,7 +2,6 @@ package pubsub
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -23,6 +22,7 @@ import (
 	subscriptionsapi_v2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/expr"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"

--- a/pkg/runtime/pubsub/subscriptions_test.go
+++ b/pkg/runtime/pubsub/subscriptions_test.go
@@ -2,7 +2,6 @@ package pubsub
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -21,6 +20,7 @@ import (
 	subscriptionsapi_v1alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	subscriptionsapi_v2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/pkg/channel"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -16,7 +16,6 @@ package runtime
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -36,7 +35,6 @@ import (
 	"contrib.go.opencensus.io/exporter/zipkin"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	jsoniter "github.com/json-iterator/go"
 	openzipkin "github.com/openzipkin/zipkin-go"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter/http"
 	"github.com/pkg/errors"
@@ -74,6 +72,7 @@ import (
 	"github.com/dapr/dapr/pkg/encryption"
 	"github.com/dapr/dapr/pkg/grpc"
 	"github.com/dapr/dapr/pkg/http"
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/dapr/dapr/pkg/messaging"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	http_middleware "github.com/dapr/dapr/pkg/middleware/http"
@@ -158,7 +157,6 @@ type DaprRuntime struct {
 	pubSubRegistry         pubsub_loader.Registry
 	pubSubs                map[string]pubsub.PubSub
 	nameResolver           nr.Resolver
-	json                   jsoniter.API
 	httpMiddlewareRegistry http_middleware_loader.Registry
 	hostAddress            string
 	actorStateStoreName    string
@@ -225,7 +223,6 @@ func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, a
 		components:             make([]components_v1alpha1.Component, 0),
 		actorStateStoreLock:    &sync.RWMutex{},
 		grpc:                   grpc.NewGRPCManager(runtimeConfig.Mode),
-		json:                   jsoniter.ConfigFastest,
 		inputBindings:          map[string]bindings.InputBinding{},
 		outputBindings:         map[string]bindings.OutputBinding{},
 		secretStores:           map[string]secretstores.SecretStore{},
@@ -566,14 +563,14 @@ func (a *DaprRuntime) beginPubSub(name string, ps pubsub.PubSub) error {
 			data := msg.Data
 			if rawPayload {
 				cloudEvent = pubsub.FromRawPayload(msg.Data, msg.Topic, name)
-				data, err = a.json.Marshal(cloudEvent)
+				data, err = json.Marshal(cloudEvent)
 				if err != nil {
 					log.Errorf("error serializing cloud event in pubsub %s and topic %s: %s", name, msg.Topic, err)
 					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, pubsubName, strings.ToLower(string(pubsub.Retry)), msg.Topic, 0)
 					return err
 				}
 			} else {
-				err = a.json.Unmarshal(msg.Data, &cloudEvent)
+				err = json.Unmarshal(msg.Data, &cloudEvent)
 				if err != nil {
 					log.Errorf("error deserializing cloud event in pubsub %s and topic %s: %s", name, msg.Topic, err)
 					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, pubsubName, strings.ToLower(string(pubsub.Retry)), msg.Topic, 0)
@@ -841,7 +838,7 @@ func (a *DaprRuntime) onAppResponse(response *bindings.AppResponse) error {
 	}
 
 	if len(response.To) > 0 {
-		b, err := a.json.Marshal(&response.Data)
+		b, err := json.Marshal(&response.Data)
 		if err != nil {
 			return err
 		}
@@ -908,7 +905,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 				appResponseBody = resp.Data
 
 				var d interface{}
-				err := a.json.Unmarshal(resp.Data, &d)
+				err := json.Unmarshal(resp.Data, &d)
 				if err == nil {
 					response.Data = d
 				}
@@ -1502,7 +1499,7 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 	if (statusCode >= 200) && (statusCode <= 299) {
 		// Any 2xx is considered a success.
 		var appResponse pubsub.AppResponse
-		err := a.json.Unmarshal(body, &appResponse)
+		err := json.Unmarshal(body, &appResponse)
 		if err != nil {
 			log.Debugf("skipping status check due to error parsing result from pub/sub event %v", cloudEvent[pubsub.IDField])
 			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
@@ -1588,7 +1585,7 @@ func (a *DaprRuntime) publishMessageGRPC(ctx context.Context, msg *pubsubSubscri
 				return ErrUnexpectedEnvelopeData
 			}
 		} else if contenttype.IsJSONContentType(envelope.DataContentType) {
-			envelope.Data, _ = a.json.Marshal(data)
+			envelope.Data, _ = json.Marshal(data)
 		}
 	}
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -35,7 +34,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/phayes/freeport"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -68,6 +66,7 @@ import (
 	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/dapr/dapr/pkg/encryption"
 	"github.com/dapr/dapr/pkg/expr"
+	"github.com/dapr/dapr/pkg/json"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
@@ -2326,7 +2325,6 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 		// assert
 		var cloudEvent map[string]interface{}
-		json := jsoniter.ConfigFastest
 		json.Unmarshal(testPubSubMessage.data, &cloudEvent)
 		expectedClientError := errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent["id"].(string))
 		assert.Equal(t, expectedClientError.Error(), err.Error())
@@ -2454,7 +2452,6 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 		// assert
 		var cloudEvent map[string]interface{}
-		json := jsoniter.ConfigFastest
 		json.Unmarshal(testPubSubMessage.data, &cloudEvent)
 		expectedClientError := errors.Errorf("retriable error returned from app while processing pub/sub event %v, topic: %v, body: Internal Error. status code returned: 500", cloudEvent["id"].(string), cloudEvent["topic"])
 		assert.Equal(t, expectedClientError.Error(), err.Error())

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"os"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	dapr_config "github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/json"
 	"github.com/dapr/dapr/utils"
 )
 

--- a/pkg/testing/app_mock.go
+++ b/pkg/testing/app_mock.go
@@ -16,7 +16,6 @@ package testing
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -25,6 +24,8 @@ import (
 	"os/signal"
 	"strconv"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 // KeyValState is a key value struct for state.

--- a/tests/apps/actorapp/app.go
+++ b/tests/apps/actorapp/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -24,6 +23,8 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/actorclientapp/app.go
+++ b/tests/apps/actorclientapp/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -24,6 +23,8 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/actorfeatures/app.go
+++ b/tests/apps/actorfeatures/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,6 +27,8 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/actorinvocationapp/app.go
+++ b/tests/apps/actorinvocationapp/app.go
@@ -15,13 +15,14 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 
 	"github.com/gorilla/mux"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/actorload/cmd/stateactor/main.go
+++ b/tests/apps/actorload/cmd/stateactor/main.go
@@ -14,7 +14,6 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"log"
 	"os"
@@ -24,6 +23,8 @@ import (
 	cl "actorload/pkg/actor/client"
 	http_client "actorload/pkg/actor/client/http"
 	rt "actorload/pkg/actor/runtime"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/actorload/cmd/stateactor/service/response.go
+++ b/tests/apps/actorload/cmd/stateactor/service/response.go
@@ -14,8 +14,9 @@ limitations under the License.
 package service
 
 import (
-	"encoding/json"
 	"io"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 // ActorResponse is the default response body contract.

--- a/tests/apps/actorload/cmd/stateactor/service/server.go
+++ b/tests/apps/actorload/cmd/stateactor/service/server.go
@@ -15,7 +15,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,6 +28,8 @@ import (
 	actor_rt "actorload/pkg/actor/runtime"
 
 	"github.com/go-chi/chi"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 type ActorActivationHandler func(actorType, actorID string) error

--- a/tests/apps/actorreentrancy/app.go
+++ b/tests/apps/actorreentrancy/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -28,6 +27,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/binding_input/app.go
+++ b/tests/apps/binding_input/app.go
@@ -14,13 +14,14 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"sync"
 
 	"github.com/gorilla/mux"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const appPort = 3000

--- a/tests/apps/binding_input_grpc/app.go
+++ b/tests/apps/binding_input_grpc/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -24,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/empty"
 
+	"github.com/dapr/dapr/pkg/json"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 

--- a/tests/apps/binding_output/app.go
+++ b/tests/apps/binding_output/app.go
@@ -16,12 +16,12 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"time"
 
+	"github.com/dapr/dapr/pkg/json"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/golang/protobuf/ptypes/any"

--- a/tests/apps/hellodapr/app.go
+++ b/tests/apps/hellodapr/app.go
@@ -14,12 +14,13 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 )

--- a/tests/apps/job-publisher/app.go
+++ b/tests/apps/job-publisher/app.go
@@ -15,12 +15,13 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/middleware/app.go
+++ b/tests/apps/middleware/app.go
@@ -15,11 +15,12 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 )

--- a/tests/apps/perf/actorfeatures/app.go
+++ b/tests/apps/perf/actorfeatures/app.go
@@ -14,11 +14,12 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 )

--- a/tests/apps/perf/tester/app.go
+++ b/tests/apps/perf/tester/app.go
@@ -14,13 +14,14 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 // TODO: change to take from "github.com/dapr/dapr/tests/perf" once in repository. otherwise fails on go get step in Dockerfile.

--- a/tests/apps/pubsub-publisher/app.go
+++ b/tests/apps/pubsub-publisher/app.go
@@ -16,7 +16,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -24,6 +23,8 @@ import (
 	net_url "net/url"
 	"strings"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"

--- a/tests/apps/pubsub-subscriber-routing/app.go
+++ b/tests/apps/pubsub-subscriber-routing/app.go
@@ -15,13 +15,14 @@ package main
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"sync"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/tests/apps/pubsub-subscriber-routing_grpc/app.go
+++ b/tests/apps/pubsub-subscriber-routing_grpc/app.go
@@ -15,11 +15,12 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
 	"sync"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/anypb"

--- a/tests/apps/pubsub-subscriber/app.go
+++ b/tests/apps/pubsub-subscriber/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +22,8 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/tests/apps/pubsub-subscriber_grpc/app.go
+++ b/tests/apps/pubsub-subscriber_grpc/app.go
@@ -15,13 +15,14 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net"
 	"strings"
 	"sync"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"

--- a/tests/apps/runtime/app.go
+++ b/tests/apps/runtime/app.go
@@ -15,13 +15,14 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc"

--- a/tests/apps/runtime_init/app.go
+++ b/tests/apps/runtime_init/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+
+	"github.com/dapr/dapr/pkg/json"
 )
 
 const (

--- a/tests/apps/secretapp/app.go
+++ b/tests/apps/secretapp/app.go
@@ -14,13 +14,14 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 )

--- a/tests/apps/service_invocation/app.go
+++ b/tests/apps/service_invocation/app.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	guuid "github.com/google/uuid"
 	"github.com/gorilla/mux"

--- a/tests/apps/service_invocation_grpc/app.go
+++ b/tests/apps/service_invocation_grpc/app.go
@@ -15,10 +15,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"go.opencensus.io/trace"
 	"go.opencensus.io/trace/propagation"

--- a/tests/apps/service_invocation_grpc_proxy_client/app.go
+++ b/tests/apps/service_invocation_grpc_proxy_client/app.go
@@ -15,11 +15,12 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"google.golang.org/grpc"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"

--- a/tests/apps/stateapp/app.go
+++ b/tests/apps/stateapp/app.go
@@ -16,7 +16,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -26,6 +25,8 @@ import (
 	"os"
 	"path"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	"github.com/gorilla/mux"
 	jsoniter "github.com/json-iterator/go"

--- a/tests/e2e/actor_activation/actor_activation_test.go
+++ b/tests/e2e/actor_activation/actor_activation_test.go
@@ -16,8 +16,8 @@ limitations under the License.
 package activation
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 	"time"

--- a/tests/e2e/actor_features/actor_features_test.go
+++ b/tests/e2e/actor_features/actor_features_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package features
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"strconv"
 	"testing"

--- a/tests/e2e/actor_invocation/actor_invocation_test.go
+++ b/tests/e2e/actor_invocation/actor_invocation_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package actor_invocation_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 

--- a/tests/e2e/actor_reentrancy/actor_reentrancy_test.go
+++ b/tests/e2e/actor_reentrancy/actor_reentrancy_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package reentrancy
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package actor_reminder_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"sync"
 	"testing"

--- a/tests/e2e/actor_reminder_partition/actor_reminder_partition_test.go
+++ b/tests/e2e/actor_reminder_partition/actor_reminder_partition_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package actor_reminder_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"strconv"
 	"testing"

--- a/tests/e2e/allowlists/allowlists_service_invocation_test.go
+++ b/tests/e2e/allowlists/allowlists_service_invocation_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package allowlists_service_invocation_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 

--- a/tests/e2e/bindings/bindings_test.go
+++ b/tests/e2e/bindings/bindings_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package bindings_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"net/http"
 	"os"
 	"testing"

--- a/tests/e2e/hellodapr/hellodapr_test.go
+++ b/tests/e2e/hellodapr/hellodapr_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package hellodapr_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 

--- a/tests/e2e/job/job_test.go
+++ b/tests/e2e/job/job_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package job
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"log"
 	"os"
 	"testing"

--- a/tests/e2e/metrics/metrics_test.go
+++ b/tests/e2e/metrics/metrics_test.go
@@ -18,8 +18,8 @@ package metrics_e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"io"
 	"net/http"
 	"os"

--- a/tests/e2e/middleware/middleware_test.go
+++ b/tests/e2e/middleware/middleware_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package middleware_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 

--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package pubsubapp_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"log"
 	"math/rand"
 	"net/http"

--- a/tests/e2e/pubsub_grpc/pubsub_grpc_test.go
+++ b/tests/e2e/pubsub_grpc/pubsub_grpc_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package pubsubapp
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"log"
 	"math/rand"
 	"net/http"

--- a/tests/e2e/pubsub_routing/pubsub_routing_test.go
+++ b/tests/e2e/pubsub_routing/pubsub_routing_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package pubsubapp_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"log"
 	"math/rand"
 	"net/http"

--- a/tests/e2e/pubsub_routing_grpc/pubsub_routing_grpc_test.go
+++ b/tests/e2e/pubsub_routing_grpc/pubsub_routing_grpc_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package pubsubapp
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"log"
 	"math/rand"
 	"net/http"

--- a/tests/e2e/runtime/runtime_test.go
+++ b/tests/e2e/runtime/runtime_test.go
@@ -16,8 +16,8 @@ limitations under the License.
 package runtime_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"io"
 	"log"
 	"net/http"

--- a/tests/e2e/secretapp/secretapp_test.go
+++ b/tests/e2e/secretapp/secretapp_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package secretapp_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"reflect"
 	"testing"

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -18,8 +18,8 @@ package serviceinvocation_tests
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"strings"
 	"testing"

--- a/tests/e2e/stateapp/stateapp_test.go
+++ b/tests/e2e/stateapp/stateapp_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package stateapp_e2e
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"reflect"
 	"strings"

--- a/tests/perf/actor_activation/actor_activation_test.go
+++ b/tests/perf/actor_activation/actor_activation_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package actor_timer_with_state_perf
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 

--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package actor_reminder_perf
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 	"time"

--- a/tests/perf/actor_timer/actor_timer_test.go
+++ b/tests/perf/actor_timer/actor_timer_test.go
@@ -16,8 +16,8 @@ limitations under the License.
 package actor_timer_with_state_perf
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 	"time"

--- a/tests/perf/service_invocation_http/service_invocation_http_test.go
+++ b/tests/perf/service_invocation_http/service_invocation_http_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package service_invocation_http_perf
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dapr/dapr/pkg/json"
 	"os"
 	"testing"
 

--- a/tests/perf/utils/helpers.go
+++ b/tests/perf/utils/helpers.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -26,6 +25,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/dapr/dapr/pkg/json"
 
 	guuid "github.com/google/uuid"
 


### PR DESCRIPTION
# Description

Signed-off-by: Shubham Sharma <shubhash@microsoft.com>
Co-authored-by: Huei Feng <hueifeng2020@outlook.com>

This PR moves away from https://github.com/json-iterator/go to go's std lib encoding/json. It also fixes the serialization bug mentioned in the referenced issue using `Decoder.UseNumber` [docs](https://pkg.go.dev/encoding/json#Decoder.UseNumber).

This PR is based on #4093

## Issue reference

Please reference the issue this PR will close: #3837

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
