### PR TITLE
Updated Helm version in Actions dapr-test and dapr

### DIFF
--- a/.github/scripts/set_helm_dapr_version.sh
+++ b/.github/scripts/set_helm_dapr_version.sh
@@ -41,5 +41,5 @@ if [ "$REL_VERSION" == "edge" ]; then
   DAPR_VERSION_HELM="0.0.0"
 fi
 
-replace_all "DAPR_VERSION_TAG" "$DAPR_VERSION_TAG"
-replace_all "DAPR_VERSION_HELM" "$DAPR_VERSION_HELM"
+replace_all "'edge'" "'$DAPR_VERSION_TAG'"
+replace_all "'0.0.0'" "'$DAPR_VERSION_HELM'"

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -32,7 +32,7 @@ jobs:
       DAPR_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       DAPR_TEST_REGISTRY: ${{ secrets.DOCKER_TEST_REGISTRY }}
       TEST_CLOUD_ENV: azure
-      HELMVER: v3.4.0
+      HELMVER: v3.7.2
       DAPR_NAMESPACE: dapr-tests
       MAX_TEST_TIMEOUT: 5400
       TARGET_OS: ${{ matrix.target_os }}
@@ -151,12 +151,6 @@ jobs:
           make setup-test-env-redis
           make setup-test-env-kafka
           kubectl get pods -n ${{ env.DAPR_NAMESPACE }}
-      - name: Upload Helm charts folder
-        if: always()
-        uses: actions/upload-artifact@master
-        with:
-          name: ${{ matrix.target_os }}_${{ matrix.target_arch }}_helm_charts
-          path: ./charts/
       - name: Deploy dapr to ${{ env.TEST_CLUSTER }} cluster
         if: env.TEST_CLUSTER != ''
         run: make docker-deploy-k8s

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -173,7 +173,7 @@ jobs:
       HELM_PACKAGE_DIR: helm
       DAPR_VERSION_ARTIFACT: dapr_version
       DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
-      HELMVER: v3.2.1
+      HELMVER: v3.7.2
     runs-on: ubuntu-latest
     steps:
       - name: Set up Helm ${{ env.HELMVER }}

--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
-appVersion: "DAPR_VERSION_HELM"
+appVersion: '0.0.0'
 description: A Helm chart for Dapr on Kubernetes
 name: dapr
-version: DAPR_VERSION_HELM
+version: '0.0.0'
 dependencies:
   - name: dapr_rbac
-    version: "DAPR_VERSION_HELM"
+    version: '0.0.0'
     repository: "file://dapr_rbac"
   - name: dapr_operator
-    version: "DAPR_VERSION_HELM"
+    version: '0.0.0'
     repository: "file://dapr_operator"
   - name: dapr_placement
-    version: "DAPR_VERSION_HELM"
+    version: '0.0.0'
     repository: "file://dapr_placement"
   - name: dapr_sidecar_injector
-    version: "DAPR_VERSION_HELM"
+    version: '0.0.0'
     repository: "file://dapr_sidecar_injector"
   - name: dapr_sentry
-    version: "DAPR_VERSION_HELM"
+    version: '0.0.0'
     repository: "file://dapr_sentry"
   - name: dapr_dashboard
     version: "0.9.0"

--- a/charts/dapr/charts/dapr_config/Chart.yaml
+++ b/charts/dapr/charts/dapr_config/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr configuration
 name: dapr_config
-version: DAPR_VERSION_HELM
+version: '0.0.0'

--- a/charts/dapr/charts/dapr_operator/Chart.yaml
+++ b/charts/dapr/charts/dapr_operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes Operator
 name: dapr_operator
-version: DAPR_VERSION_HELM
+version: '0.0.0'

--- a/charts/dapr/charts/dapr_placement/Chart.yaml
+++ b/charts/dapr/charts/dapr_placement/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes placement
 name: dapr_placement
-version: DAPR_VERSION_HELM
+version: '0.0.0'
 

--- a/charts/dapr/charts/dapr_rbac/Chart.yaml
+++ b/charts/dapr/charts/dapr_rbac/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Kubernetes RBAC components
 name: dapr_rbac
-version: DAPR_VERSION_HELM
+version: '0.0.0'
 

--- a/charts/dapr/charts/dapr_sentry/Chart.yaml
+++ b/charts/dapr/charts/dapr_sentry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Dapr Sentry
 name: dapr_sentry
-version: DAPR_VERSION_HELM
+version: '0.0.0'

--- a/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the Dapr sidecar injector
 name: dapr_sidecar_injector
-version: DAPR_VERSION_HELM
+version: '0.0.0'

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: docker.io/daprio
-  tag: "DAPR_VERSION_TAG"
+  tag: 'edge'
   dnsSuffix: ".cluster.local"
   logAsJson: false
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Updates Helm version to normalize across the runs, to 3.7.2
Also changes the placeholder versions used in the charts. This PR should make the tests work correctly, both CI and E2E, with recent versions of Helm too.
Another benefit is that when running tests locally, it's not necessary to invoke the set_helm_dapr_version.sh script anymore, which could have left the working directory in a dirty state.

Also reverts #4333 that was for debugging only

CC: @artursouza 