### PR TITLE
gRPC stream tracing: Ignore dapr api calls

### DIFF
--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -102,7 +102,7 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 func GRPCTraceStreamServerInterceptor(appID string, spec config.TracingSpec) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if strings.Index(info.FullMethod, daprPackagePrefix) == 0 {
-			return nil
+			return handler(srv, ss)
 		}
 
 		var span *trace.Span

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -36,6 +36,7 @@ import (
 const (
 	grpcTraceContextKey = "grpc-trace-bin"
 	GRPCProxyAppIDKey   = "dapr-app-id"
+	daprPackagePrefix   = "/dapr.proto"
 )
 
 // GRPCTraceUnaryServerInterceptor sets the trace context or starts the trace client span based on request.
@@ -100,6 +101,10 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 // GRPCTraceStreamServerInterceptor sets the trace context or starts the trace client span based on request.
 func GRPCTraceStreamServerInterceptor(appID string, spec config.TracingSpec) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if strings.Index(info.FullMethod, daprPackagePrefix) == 0 {
+			return nil
+		}
+
 		var span *trace.Span
 		spanName := info.FullMethod
 

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -187,6 +187,57 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 	})
 }
 
+func TestGRPCTraceStreamServerInterceptor(t *testing.T) {
+	interceptor := GRPCTraceStreamServerInterceptor("test", config.TracingSpec{})
+
+	t.Run("invalid proxy request, return nil", func(t *testing.T) {
+		ctx := context.TODO()
+		fakeInfo := &grpc.StreamServerInfo{
+			FullMethod: "/dapr.proto.runtime.v1.Dapr/GetState",
+		}
+
+		err := interceptor(ctx, nil, fakeInfo, nil)
+		assert.Nil(t, err)
+	})
+
+	t.Run("valid proxy request without app id, return error", func(t *testing.T) {
+		ctx := context.TODO()
+		fakeInfo := &grpc.StreamServerInfo{
+			FullMethod: "/myapp.v1.DoSomething",
+		}
+
+		err := interceptor(ctx, &fakeStream{}, fakeInfo, nil)
+		assert.Error(t, err)
+	})
+}
+
+type fakeStream struct {
+}
+
+func (f *fakeStream) Context() context.Context {
+	return context.TODO()
+}
+
+func (f *fakeStream) SetHeader(metadata.MD) error {
+	return nil
+}
+
+func (f *fakeStream) SendHeader(metadata.MD) error {
+	return nil
+}
+
+func (f *fakeStream) SetTrailer(metadata.MD) {
+
+}
+
+func (f *fakeStream) SendMsg(m interface{}) error {
+	return nil
+}
+
+func (f *fakeStream) RecvMsg(m interface{}) error {
+	return nil
+}
+
 func TestSpanContextSerialization(t *testing.T) {
 	wantSc := trace.SpanContext{
 		TraceID:      trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -211,8 +211,7 @@ func TestGRPCTraceStreamServerInterceptor(t *testing.T) {
 	})
 }
 
-type fakeStream struct {
-}
+type fakeStream struct{}
 
 func (f *fakeStream) Context() context.Context {
 	return context.TODO()
@@ -227,7 +226,6 @@ func (f *fakeStream) SendHeader(metadata.MD) error {
 }
 
 func (f *fakeStream) SetTrailer(metadata.MD) {
-
 }
 
 func (f *fakeStream) SendMsg(m interface{}) error {

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -196,7 +196,11 @@ func TestGRPCTraceStreamServerInterceptor(t *testing.T) {
 			FullMethod: "/dapr.proto.runtime.v1.Dapr/GetState",
 		}
 
-		err := interceptor(ctx, nil, fakeInfo, nil)
+		h := func(srv interface{}, stream grpc.ServerStream) error {
+			return nil
+		}
+
+		err := interceptor(ctx, nil, fakeInfo, h)
 		assert.Nil(t, err)
 	})
 


### PR DESCRIPTION
The Configuration API's subscribe method introduced a gRPC streaming method to Dapr for the first time.

Consequently, the tracing middleware for gRPC proxying (which relies on gRPC streaming) needed an update to only handle requests that are meant for proxying, ie. not Dapr API calls.
