### PR TITLE
Add e2e tests for resiliency in Bindings/Pubsub

### DIFF
--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -237,7 +237,7 @@ func FromFlags() (*DaprRuntime, error) {
 	// Config and resiliency need the operator client, only initiate once and only if we will actually use it.
 	var operatorClient operator_v1.OperatorClient
 	if *mode == string(modes.KubernetesMode) && *config != "" {
-		log.Infof("Initializing the operator client (config: %s | resiliency: %s)", *config)
+		log.Infof("Initializing the operator client (config: %s)", *config)
 		client, conn, clientErr := client.GetOperatorClient(*controlPlaneAddress, security.TLSServerName, runtimeConfig.CertChain)
 		if clientErr != nil {
 			return nil, clientErr

--- a/tests/apps/resiliencyapp/app.go
+++ b/tests/apps/resiliencyapp/app.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/any"
+
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+
+	"github.com/gorilla/mux"
+	"google.golang.org/grpc"
+)
+
+const (
+	appPort = 3000
+)
+
+type FailureMessage struct {
+	ID              string         `json:"id"`
+	MaxFailureCount *int           `json:"maxFailureCount,omitempty"`
+	Timeout         *time.Duration `json:"timeout,omitempty"`
+}
+
+type CallRecord struct {
+	Count    int
+	TimeSeen time.Time
+}
+
+var (
+	daprClient   runtimev1pb.DaprClient
+	callTracking map[string][]CallRecord
+)
+
+// Endpoint handling.
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println("indexHandler() called")
+	w.WriteHeader(http.StatusOK)
+}
+
+func resiliencyBindingHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		log.Println("resiliency binding input has been accepted")
+
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var message FailureMessage
+	json.NewDecoder(r.Body).Decode(&message)
+
+	log.Printf("Received message %+v\n", message)
+
+	callCount := 0
+	if records, ok := callTracking[message.ID]; ok {
+		callCount = records[len(records)-1].Count + 1
+	}
+
+	log.Printf("Seen %s %d times.", message.ID, callCount)
+
+	callTracking[message.ID] = append(callTracking[message.ID], CallRecord{Count: callCount, TimeSeen: time.Now()})
+	if message.MaxFailureCount != nil && callCount < *message.MaxFailureCount {
+		if message.Timeout != nil {
+			// This request can still succeed if the resiliency policy timeout is longer than this sleep.
+			time.Sleep(*message.Timeout)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// App startup/endpoint setup.
+func initGRPCClient() {
+	url := fmt.Sprintf("localhost:%d", 50001)
+	log.Printf("Connecting to dapr using url %s", url)
+	var grpcConn *grpc.ClientConn
+	for retries := 10; retries > 0; retries-- {
+		var err error
+		grpcConn, err = grpc.Dial(url, grpc.WithInsecure())
+		if err == nil {
+			break
+		}
+
+		if retries == 0 {
+			log.Printf("Could not connect to dapr: %v", err)
+			log.Panic(err)
+		}
+
+		log.Printf("Could not connect to dapr: %v, retrying...", err)
+		time.Sleep(5 * time.Second)
+	}
+
+	daprClient = runtimev1pb.NewDaprClient(grpcConn)
+}
+
+func appRouter() *mux.Router {
+	router := mux.NewRouter().StrictSlash(true)
+
+	router.HandleFunc("/", indexHandler).Methods("GET")
+	router.HandleFunc("/resiliencybinding", resiliencyBindingHandler).Methods("POST", "OPTIONS")
+	router.HandleFunc("/tests/getCallCount", TestGetCallCount).Methods("GET")
+	router.HandleFunc("/tests/getCallCountGRPC", TestGetCallCountGRPC).Methods("GET")
+	router.HandleFunc("/tests/invokeBinding/{binding}", TestInvokeOutputBinding).Methods("POST")
+
+	router.Use(mux.CORSMethodMiddleware(router))
+
+	return router
+}
+
+func main() {
+	log.Printf("Hello Dapr - listening on http://localhost:%d", appPort)
+	callTracking = map[string][]CallRecord{}
+	initGRPCClient()
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", appPort), appRouter()))
+}
+
+// Test Functions.
+func TestGetCallCount(w http.ResponseWriter, r *http.Request) {
+	log.Println("Getting call counts")
+	for key, val := range callTracking {
+		log.Printf("\t%s - Called %d times.\n", key, len(val))
+	}
+
+	b, err := json.Marshal(callTracking)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(b)
+}
+
+func TestGetCallCountGRPC(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Getting call counts for gRPC")
+
+	req := runtimev1pb.InvokeServiceRequest{
+		Id: "resiliencyappgrpc",
+		Message: &commonv1pb.InvokeRequest{
+			Method: "GetCallCount",
+			Data:   &any.Any{},
+			HttpExtension: &commonv1pb.HTTPExtension{
+				Verb: commonv1pb.HTTPExtension_POST,
+			},
+		},
+	}
+
+	resp, err := daprClient.InvokeService(context.Background(), &req)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(resp.Data.Value)
+}
+
+func TestInvokeOutputBinding(w http.ResponseWriter, r *http.Request) {
+	binding := mux.Vars(r)["binding"]
+	log.Printf("Making call to output binding %s.", binding)
+
+	var message FailureMessage
+	err := json.NewDecoder(r.Body).Decode(&message)
+	if err != nil {
+		log.Println("Could not parse message.")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	b, _ := json.Marshal(message)
+	req := &runtimev1pb.InvokeBindingRequest{
+		Name:      binding,
+		Operation: "create",
+		Data:      b,
+	}
+
+	_, err = daprClient.InvokeBinding(context.Background(), req)
+	if err != nil {
+		log.Printf("Error invoking binding: %s", err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/tests/apps/resiliencyapp_grpc/app.go
+++ b/tests/apps/resiliencyapp_grpc/app.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+const (
+	appPort = "3000"
+)
+
+// This is our app, which registers various gRPC calls.
+type server struct {
+	callTracking map[string][]CallRecord
+}
+
+type CallRecord struct {
+	Count    int
+	TimeSeen time.Time
+}
+
+type FailureMessage struct {
+	ID              string         `json:"id"`
+	MaxFailureCount *int           `json:"maxFailureCount,omitempty"`
+	Timeout         *time.Duration `json:"timeout,omitempty"`
+}
+
+// gRPC server definitions.
+func (s *server) OnInvoke(ctx context.Context, in *commonv1pb.InvokeRequest) (*commonv1pb.InvokeResponse, error) {
+	log.Printf("Got invoked method %s and data: %s\n", in.Method, string(in.GetData().Value))
+
+	resp := &commonv1pb.InvokeResponse{}
+
+	if in.Method == "GetCallCount" {
+		log.Println("Getting call counts")
+		for key, val := range s.callTracking {
+			log.Printf("\t%s - Called %d times.\n", key, len(val))
+		}
+		b, err := json.Marshal(s.callTracking)
+
+		if err != nil {
+			resp.Data = &anypb.Any{}
+		} else {
+			resp.Data = &anypb.Any{
+				Value: b,
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+// Dapr will call this method to get the list of topics the app wants to subscribe to.
+func (s *server) ListTopicSubscriptions(ctx context.Context, in *empty.Empty) (*runtimev1pb.ListTopicSubscriptionsResponse, error) {
+	log.Println("List Topic Subscription called")
+	return &runtimev1pb.ListTopicSubscriptionsResponse{
+		Subscriptions: []*runtimev1pb.TopicSubscription{},
+	}, nil
+}
+
+// This method is fired whenever a message has been published to a topic that has been subscribed. Dapr sends published messages in a CloudEvents 1.0 envelope.
+func (s *server) OnTopicEvent(ctx context.Context, in *runtimev1pb.TopicEventRequest) (*runtimev1pb.TopicEventResponse, error) {
+	log.Printf("Message arrived - Topic: %s, Message: %s\n", in.Topic, string(in.Data))
+
+	return &runtimev1pb.TopicEventResponse{
+		Status: runtimev1pb.TopicEventResponse_SUCCESS,
+	}, nil
+}
+
+func (s *server) ListInputBindings(ctx context.Context, in *empty.Empty) (*runtimev1pb.ListInputBindingsResponse, error) {
+	log.Println("List Input Bindings called")
+	return &runtimev1pb.ListInputBindingsResponse{
+		Bindings: []string{
+			"dapr-resiliency-binding-grpc",
+		},
+	}, nil
+}
+
+// This method gets invoked every time a new event is fired from a registered binding. The message carries the binding name, a payload and optional metadata.
+func (s *server) OnBindingEvent(ctx context.Context, in *runtimev1pb.BindingEventRequest) (*runtimev1pb.BindingEventResponse, error) {
+	log.Printf("Invoked from binding: %s - %s\n", in.Name, string(in.Data))
+
+	var message FailureMessage
+	err := json.Unmarshal(in.Data, &message)
+	if err != nil {
+		return nil, errors.New("failed to decode message")
+	}
+
+	callCount := 0
+	if records, ok := s.callTracking[message.ID]; ok {
+		callCount = records[len(records)-1].Count + 1
+	}
+
+	log.Printf("Seen %s %d times.", message.ID, callCount)
+
+	s.callTracking[message.ID] = append(s.callTracking[message.ID], CallRecord{Count: callCount, TimeSeen: time.Now()})
+
+	if message.MaxFailureCount != nil && callCount < *message.MaxFailureCount {
+		if message.Timeout != nil {
+			// This request can still succeed if the resiliency policy timeout is longer than this sleep.
+			log.Println("Sleeping.")
+			time.Sleep(*message.Timeout)
+		} else {
+			log.Println("Forcing failure.")
+			return nil, errors.New("forced failure")
+		}
+	}
+
+	return &runtimev1pb.BindingEventResponse{}, nil
+}
+
+// Init.
+func main() {
+	log.Printf("Initializing grpc")
+
+	/* #nosec */
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", appPort))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	/* #nosec */
+	s := grpc.NewServer()
+	runtimev1pb.RegisterAppCallbackServer(s, &server{
+		callTracking: map[string][]CallRecord{},
+	})
+
+	log.Println("Client starting...")
+
+	if err := s.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+}

--- a/tests/config/app_resiliency.yaml
+++ b/tests/config/app_resiliency.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: resiliencyconfig
+spec:
+  features:
+    - name: Resiliency
+      enabled: true

--- a/tests/config/resiliency.yaml
+++ b/tests/config/resiliency.yaml
@@ -1,0 +1,45 @@
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: resiliency
+spec:
+
+  policies:
+    timeouts:
+      fast: 500ms
+
+    retries:
+      fiveRetries:
+        policy: constant
+        duration: 10ms
+        maxRetries: 5
+
+    circuitBreakers:
+      simpleCB:
+          maxRequests: 1
+          interval: 8s
+          timeout: 45s
+          trip: consecutiveFailures > 8
+
+  targets:
+    apps:
+      # Will be populated as we add more tests.
+
+    components:
+      dapr-resiliency-binding:
+        inbound: 
+          timeout: fast
+          retry: fiveRetries
+          circuitBreaker: simpleCB
+        outbound:
+          timeout: fast
+          retry: fiveRetries
+
+      dapr-resiliency-binding-grpc:
+        inbound: 
+          timeout: fast
+          retry: fiveRetries
+          circuitBreaker: simpleCB
+        outbound:
+          timeout: fast
+          retry: fiveRetries

--- a/tests/config/resiliency.yaml
+++ b/tests/config/resiliency.yaml
@@ -43,3 +43,12 @@ spec:
         outbound:
           timeout: fast
           retry: fiveRetries
+
+      dapr-resiliency-pubsub:
+        inbound:
+          timeout: fast
+          retry: fiveRetries
+          circuitBreaker: simpleCB
+        outbound:
+          timeout: fast
+          retry: fiveRetries

--- a/tests/config/resiliency_kafka_bindings.yaml
+++ b/tests/config/resiliency_kafka_bindings.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: dapr-resiliency-binding
+spec:
+  type: bindings.kafka
+  initTimeout: 1m
+  version: v1
+  metadata:
+  # Kafka broker connection setting
+  - name: brokers
+    value: dapr-kafka:9092
+  # consumer configuration: topic and consumer group
+  - name: topics
+    value: resiliency-binding
+  - name: consumerGroup
+    value: group1
+  - name: route
+    value: /resiliencybinding
+  # publisher configuration: topic
+  - name: publishTopic
+    value: resiliency-binding
+  - name: authRequired
+    value: "false"

--- a/tests/config/resiliency_kafka_bindings_grpc.yaml
+++ b/tests/config/resiliency_kafka_bindings_grpc.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: dapr-resiliency-binding-grpc
+spec:
+  type: bindings.kafka
+  initTimeout: 1m
+  version: v1
+  metadata:
+  # Kafka broker connection setting
+  - name: brokers
+    value: dapr-kafka:9092
+  # consumer configuration: topic and consumer group
+  - name: topics
+    value: resiliency-binding-grpc
+  - name: consumerGroup
+    value: group1
+  - name: route
+    value: /resiliencybindinggrpc
+  # publisher configuration: topic
+  - name: publishTopic
+    value: resiliency-binding-grpc
+  - name: authRequired
+    value: "false"

--- a/tests/config/resiliency_kafka_bindings_grpc.yaml
+++ b/tests/config/resiliency_kafka_bindings_grpc.yaml
@@ -35,3 +35,5 @@ spec:
     value: resiliency-binding-grpc
   - name: authRequired
     value: "false"
+  - name: initialOffset
+    value: oldest

--- a/tests/config/resiliency_redis_pubsub.yaml
+++ b/tests/config/resiliency_redis_pubsub.yaml
@@ -14,26 +14,19 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: dapr-resiliency-binding
+  name: dapr-resiliency-pubsub
 spec:
-  type: bindings.kafka
+  type: pubsub.redis
   initTimeout: 1m
   version: v1
   metadata:
-  # Kafka broker connection setting
-  - name: brokers
-    value: dapr-kafka:9092
-  # consumer configuration: topic and consumer group
-  - name: topics
-    value: resiliency-binding
-  - name: consumerGroup
-    value: group1
-  - name: route
-    value: /resiliencybinding
-  # publisher configuration: topic
-  - name: publishTopic
-    value: resiliency-binding
-  - name: authRequired
-    value: "false"
-  - name: initialOffset
-    value: oldest
+  - name: redisHost
+    secretKeyRef:
+      name: redissecret
+      key: host
+  - name: redisPassword
+    value: ""
+  - name: processingTimeout
+    value: "0"
+  - name: redeliverInterval
+    value: "0"

--- a/tests/config/resiliency_servicebus_pubsub.yaml
+++ b/tests/config/resiliency_servicebus_pubsub.yaml
@@ -14,26 +14,31 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: dapr-resiliency-binding
+  name: dapr-resiliency-pubsub
 spec:
-  type: bindings.kafka
+  type: pubsub.azure.servicebus
   initTimeout: 1m
   version: v1
   metadata:
-  # Kafka broker connection setting
-  - name: brokers
-    value: dapr-kafka:9092
-  # consumer configuration: topic and consumer group
-  - name: topics
-    value: resiliency-binding
-  - name: consumerGroup
-    value: group1
-  - name: route
-    value: /resiliencybinding
-  # publisher configuration: topic
-  - name: publishTopic
-    value: resiliency-binding
-  - name: authRequired
-    value: "false"
-  - name: initialOffset
-    value: oldest
+  - name: connectionString
+    secretKeyRef:
+      name: servicebus-secret
+      key: connectionString
+  - name: handlerTimeoutInSec
+    value: 60
+  - name: timeoutInSec
+    value: 60
+  - name: lockDurationInSec
+    value: 5
+  - name: lockRenewalInSec
+    value: 5
+  - name: defaultMessageTimeToLiveInSec
+    value: 120
+  - name: maxConcurrentHandlers
+    value: 5
+  - name: prefetchCount
+    value: 20
+  - name: maxDeliveryCount
+    value: 1
+  - name: maxActiveMessages
+    value: 100

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -324,6 +324,7 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/resiliency.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/resiliency_kafka_bindings.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/resiliency_kafka_bindings_grpc.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/resiliency_$(DAPR_TEST_PUBSUB)_pubsub.yaml --namespace $(DAPR_TEST_NAMESPACE)
 
 	# Show the installed components
 	$(KUBECTL) get components --namespace $(DAPR_TEST_NAMESPACE)

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -41,6 +41,8 @@ runtime \
 runtime_init \
 middleware \
 job-publisher \
+resiliencyapp \
+resiliencyapp_grpc \
 
 # PERFORMANCE test app list
 PERF_TEST_APPS=actorfeatures actorjava tester service_invocation_http
@@ -318,6 +320,10 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/app_topic_subscription_routing.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/app_topic_subscription_routing_grpc.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/app_pubsub_routing.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/app_resiliency.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/resiliency.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/resiliency_kafka_bindings.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/resiliency_kafka_bindings_grpc.yaml --namespace $(DAPR_TEST_NAMESPACE)
 
 	# Show the installed components
 	$(KUBECTL) get components --namespace $(DAPR_TEST_NAMESPACE)

--- a/tests/e2e/resiliency/resiliency_test.go
+++ b/tests/e2e/resiliency/resiliency_test.go
@@ -1,0 +1,197 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resiliencyapp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dapr/dapr/tests/e2e/utils"
+	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
+	"github.com/dapr/dapr/tests/runner"
+
+	"github.com/google/uuid"
+
+	"github.com/stretchr/testify/require"
+)
+
+type FailureMessage struct {
+	ID              string         `json:"id"`
+	MaxFailureCount *int           `json:"maxFailureCount,omitempty"`
+	Timeout         *time.Duration `json:"timeout,omitempty"`
+}
+
+type CallRecord struct {
+	Count    int
+	TimeSeen time.Time
+}
+
+const (
+	// Number of times to call the endpoint to check for health.
+	numHealthChecks = 60
+)
+
+var tr *runner.TestRunner
+
+func TestMain(m *testing.M) {
+	testApps := []kube.AppDescription{
+		{
+			AppName:        "resiliencyapp",
+			DaprEnabled:    true,
+			ImageName:      "e2e-resiliencyapp",
+			Replicas:       1,
+			IngressEnabled: true,
+			MetricsEnabled: true,
+			Config:         "resiliencyconfig",
+		},
+		{
+			AppName:        "resiliencyappgrpc",
+			DaprEnabled:    true,
+			ImageName:      "e2e-resiliencyapp_grpc",
+			Replicas:       1,
+			IngressEnabled: true,
+			MetricsEnabled: true,
+			Config:         "resiliencyconfig",
+			AppProtocol:    "grpc",
+		},
+	}
+
+	tr = runner.NewTestRunner("resiliencytest", testApps, nil, nil)
+	os.Exit(tr.Start(m))
+}
+
+func TestInputBindingResiliency(t *testing.T) {
+	recoverableErrorCount := 3
+	failingErrorCount := 10
+	recoverableTimeout := time.Second * 2
+	testCases := []struct {
+		Name         string
+		FailureCount *int
+		Timeout      *time.Duration
+		shouldFail   bool
+		binding      string
+	}{
+		{
+			Name:         "Test sending input binding to app recovers from failure",
+			FailureCount: &recoverableErrorCount,
+			shouldFail:   false,
+			binding:      "dapr-resiliency-binding",
+		},
+		{
+			Name:         "Test sending input binding to app recovers from timeout",
+			FailureCount: &recoverableErrorCount,
+			Timeout:      &recoverableTimeout,
+			shouldFail:   false,
+			binding:      "dapr-resiliency-binding",
+		},
+		{
+			Name:         "Test exhausting retries leads to failure",
+			FailureCount: &failingErrorCount,
+			shouldFail:   true,
+			binding:      "dapr-resiliency-binding",
+		},
+		{
+			Name:         "Test sending input binding to grpc app recovers from failure",
+			FailureCount: &recoverableErrorCount,
+			shouldFail:   false,
+			binding:      "dapr-resiliency-binding-grpc",
+		},
+		{
+			Name:         "Test sending input binding to grpc app recovers from timeout",
+			FailureCount: &recoverableErrorCount,
+			Timeout:      &recoverableTimeout,
+			shouldFail:   false,
+			binding:      "dapr-resiliency-binding-grpc",
+		},
+		{
+			Name:         "Test exhausting retries leads to failure in grpc app",
+			FailureCount: &failingErrorCount,
+			shouldFail:   true,
+			binding:      "dapr-resiliency-binding-grpc",
+		},
+	}
+
+	// Get application URLs/wait for healthy.
+	externalURL := tr.Platform.AcquireAppExternalURL("resiliencyapp")
+	require.NotEmpty(t, externalURL, "resiliency external URL must not be empty!")
+	externalURLGRPC := tr.Platform.AcquireAppExternalURL("resiliencyappgrpc")
+	require.NotEmpty(t, externalURLGRPC, "resiliencygrpc external URL must not be empty!")
+	// This initial probe makes the test wait a little bit longer when needed,
+	// making this test less flaky due to delays in the deployment.
+	_, err := utils.HTTPGetNTimes(externalURL, numHealthChecks)
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			message := createFailureMessage(tc.FailureCount, tc.Timeout)
+			b, _ := json.Marshal(message)
+			_, code, err := utils.HTTPPostWithStatus(fmt.Sprintf("%s/tests/invokeBinding/%s", externalURL, tc.binding), b)
+			require.NoError(t, err)
+			require.Equal(t, 200, code)
+
+			// Let the binding propagate and give time for retries/timeout.
+			time.Sleep(time.Second * 5)
+
+			var callCount map[string][]CallRecord
+			var getCallsURL string
+			if strings.Contains(tc.binding, "grpc") {
+				getCallsURL = "tests/getCallCountGRPC"
+			} else {
+				getCallsURL = "tests/getCallCount"
+			}
+			resp, err := utils.HTTPGet(fmt.Sprintf("%s/%s", externalURL, getCallsURL))
+			require.NoError(t, err)
+
+			json.Unmarshal(resp, &callCount)
+			if tc.shouldFail {
+				// First call + 5 retries and no more.
+				require.GreaterOrEqual(t, len(callCount[message.ID]), 6, fmt.Sprintf("Call count mismatch for message %s", message.ID))
+
+				// TODO: Remove this once we can control Kafka's retry count.
+				// We have to do this because we can't currently control Kafka's retries. So, we make sure that anything past the resiliency
+				// retries have a wide enough gap in them to be considered OK.
+				if len(callCount[message.ID]) > 6 {
+					// This is the default Kafka retry time. Our policy time is 10ms so it should be much faster.
+					require.Greater(t, callCount[message.ID][6].TimeSeen.Sub(callCount[message.ID][5].TimeSeen), time.Millisecond*100)
+				}
+			} else {
+				// First call + 3 retries and recovery.
+				require.Equal(t, 4, len(callCount[message.ID]), fmt.Sprintf("Call count mismatch for message %s", message.ID))
+			}
+		})
+	}
+}
+
+func createFailureMessage(maxFailure *int, timeout *time.Duration) FailureMessage {
+	message := FailureMessage{
+		ID: uuid.New().String(),
+	}
+
+	if maxFailure != nil {
+		message.MaxFailureCount = maxFailure
+	}
+
+	if timeout != nil {
+		message.Timeout = timeout
+	}
+
+	return message
+}


### PR DESCRIPTION
# Description

This commit adds several e2e tests for resiliency in bindings/pubsub. This
is primarily focused on the app invocation (input bindings/pubsub subscriptions), though
output binding and publish are also covered by the policy.

This change also addresses the issues found by the e2e test.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: Resiliency

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
