### PR TITLE
FOSSA workflow should not run on forks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -28,6 +28,7 @@ on:
   workflow_dispatch: {}
 jobs:
   fossa-scan:
+    if: github.repository_owner == 'dapr' # FOSSA is not intended to run on forks.
     runs-on: ubuntu-latest
     env:
       FOSSA_API_KEY: b88e1f4287c3108c8751bf106fb46db6 # This is a push-only token that is safe to be exposed.


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

If FOSSA workflows run on forks, it creates a new project on FOSSA. The workflow was introduced in #4269

## Issue reference

None.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* (NA) Code compiles correctly
* (NA) Created/updated tests
* (NA) Unit tests passing
* (NA) End-to-end tests passing
* (NA) Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* (NA) Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* (NA) Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
