### PR TITLE
Speedup placement hosts update

### DIFF
--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -216,6 +216,8 @@ func (p *Service) processRaftStateCommand(stopCh chan struct{}) {
 	// of raft apply command.
 	logApplyConcurrency := make(chan struct{}, raftApplyCommandMaxConcurrency)
 
+	processingTicker := time.NewTicker(10 * time.Second)
+
 	for {
 		select {
 		case <-stopCh:
@@ -223,6 +225,10 @@ func (p *Service) processRaftStateCommand(stopCh chan struct{}) {
 
 		case <-p.shutdownCh:
 			return
+
+		case <-processingTicker.C:
+			log.Infof("process raft state command: nothing happened...")
+			continue
 
 		case op := <-p.membershipCh:
 			switch op.cmdType {
@@ -307,11 +313,55 @@ func (p *Service) performTableDissemination() {
 func (p *Service) performTablesUpdate(hosts []placementGRPCStream, newTable *v1pb.PlacementTables) {
 	// TODO: error from disseminationOperation needs to be handle properly.
 	// Otherwise, each Dapr runtime will have inconsistent hashing table.
+	startedAt := time.Now()
+
+	var wg sync.WaitGroup
 	for _, host := range hosts {
-		p.disseminateOperation([]placementGRPCStream{host}, "lock", nil)
-		p.disseminateOperation([]placementGRPCStream{host}, "update", newTable)
-		p.disseminateOperation([]placementGRPCStream{host}, "unlock", nil)
+		wg.Add(1)
+
+		go func(h placementGRPCStream) {
+			defer wg.Done()
+
+			timeoutC := make(chan bool)
+			stopC := make(chan bool)
+			step := ""
+			isTimeout := false
+
+			go func() {
+				defer close(stopC)
+
+				timeoutC <- true
+				step = "lock"
+				p.disseminateOperation([]placementGRPCStream{h}, "lock", nil)
+				if isTimeout {
+					return
+				}
+				step = "update"
+				p.disseminateOperation([]placementGRPCStream{h}, "update", newTable)
+				if isTimeout {
+					return
+				}
+				step = "unlock"
+				p.disseminateOperation([]placementGRPCStream{h}, "unlock", nil)
+			}()
+
+			<-timeoutC
+
+			select {
+			case <-time.After(10 * time.Second):
+				// timeout
+				isTimeout = true
+				log.Errorf("performTablesUpdate(%v) timeout 10s at step %v!!!", h, step)
+				return
+			case <-stopC:
+				// NOTE normal
+				return
+			}
+		}(host)
 	}
+	wg.Wait()
+
+	log.Debugf("performTablesUpdate succeed %v", time.Since(startedAt))
 }
 
 func (p *Service) disseminateOperation(targets []placementGRPCStream, operation string, tables *v1pb.PlacementTables) error {
@@ -321,7 +371,6 @@ func (p *Service) disseminateOperation(targets []placementGRPCStream, operation 
 	}
 	var err error
 	for _, s := range targets {
-
 		config := retry.DefaultConfig()
 		config.MaxRetries = 3
 		backoff := config.NewBackOff()
@@ -330,8 +379,8 @@ func (p *Service) disseminateOperation(targets []placementGRPCStream, operation 
 				// Check stream in stream pool, if stream is not available, skip to next.
 				if !p.hasStreamConn(s) {
 					remoteAddr := "n/a"
-					if peer, ok := peer.FromContext(s.Context()); ok {
-						remoteAddr = peer.Addr.String()
+					if _peer, ok := peer.FromContext(s.Context()); ok {
+						remoteAddr = _peer.Addr.String()
 					}
 					log.Debugf("runtime host (%q) is disconnected with server. go with next dissemination (operation: %s).", remoteAddr, operation)
 					return nil
@@ -340,8 +389,8 @@ func (p *Service) disseminateOperation(targets []placementGRPCStream, operation 
 				err = s.Send(o)
 				if err != nil {
 					remoteAddr := "n/a"
-					if peer, ok := peer.FromContext(s.Context()); ok {
-						remoteAddr = peer.Addr.String()
+					if _peer, ok := peer.FromContext(s.Context()); ok {
+						remoteAddr = _peer.Addr.String()
 					}
 					log.Errorf("error updating runtime host (%q) on %q operation: %s", remoteAddr, operation, err)
 					return err

--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -227,7 +227,7 @@ func (p *Service) processRaftStateCommand(stopCh chan struct{}) {
 			return
 
 		case <-processingTicker.C:
-			log.Infof("process raft state command: nothing happened...")
+			log.Debugf("process raft state command: nothing happened...")
 			continue
 
 		case op := <-p.membershipCh:

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -286,3 +286,14 @@ func (p *Service) deleteStreamConn(conn placementGRPCStream) {
 	}
 	p.streamConnPoolLock.Unlock()
 }
+
+func (p *Service) hasStreamConn(conn placementGRPCStream) bool {
+	p.streamConnPoolLock.Lock()
+	defer p.streamConnPoolLock.Unlock()
+	for _, c := range p.streamConnPool {
+		if c == conn {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -288,8 +288,9 @@ func (p *Service) deleteStreamConn(conn placementGRPCStream) {
 }
 
 func (p *Service) hasStreamConn(conn placementGRPCStream) bool {
-	p.streamConnPoolLock.Lock()
-	defer p.streamConnPoolLock.Unlock()
+	p.streamConnPoolLock.RLock()
+	defer p.streamConnPoolLock.RUnlock()
+
 	for _, c := range p.streamConnPool {
 		if c == conn {
 			return true


### PR DESCRIPTION
Main changes:
1. add dead grpc stream detection, skip the update for terminated pods
2. update and wait all hosts parallel instead of sequential
3. table updates will wait for at most 10s and continue to next update, preventing the cluster being blocked by single update.


Discussion 1: about the 10s timeout
The `disseminateOperation` may block for a very long time, possible blocked in the `err = s.Send(o)`.

When this happened, a single host stream connection will block the whole cluster table updates, causing large cluster downtime.

The code shows the runtime client have a 5s auto unlock, so it seems it's not making things worse if the server ignore and continue the next table updates after 10s.


Discussion 2: about the table updates design choice
1. all hosts locks sequential -> all hosts updates sequential -> all hosts unlock sequential
2. all locks have a 5s auto unlock

This implementation actually makes me very confusing.

1. Doing all things sequential make the performance very bad under hundreds or more of pods
2. then that combined with client 5s auto unlock, if anything blocks the procedure in the middle, 5s later all locks auto unlocked, and data inconsistent may occur. In the same time the table update goroutine in the placement service also blocks for a very long time, about ~15s, sometimes even longer (retry 3 times with backoff 5s).

It seems the current implementation lost both consistency and performance.

An alternative approach will be using 2 WaitGroup, first wg parallel all `lock + update`, wait for complete, then start 2nd wg to parallel `unlock`, this will make the cluster state more consistent, if that's important enough.
