### PR TITLE
New GH Action to mirror 3rd party container images

### DIFF
--- a/.github/workflows/dapr-3rdparty-container.yaml
+++ b/.github/workflows/dapr-3rdparty-container.yaml
@@ -1,0 +1,41 @@
+name: Cache Docker 3rd Party Images
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # trigger on the 1st of every month at midnight
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+      - # ghcr logins for pushing image after testing
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_ID }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASS }}
+      - # copy 3rd party zookeeper image from dockerhub to ghcr
+        name: Push Image (zookeeper) to target registries
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: wurstmeister/zookeeper:latest
+          dst: |
+            ghcr.io/${{ secrets.DOCKER_REGISTRY_ID }}/3rdparty/zookeeper:latest
+      - # copy 3rd party kafka image from dockerhub to ghcr
+        name: Push Image (kafka) to target registries
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: wurstmeister/kafka:latest
+          dst: |
+            ghcr.io/${{ secrets.DOCKER_REGISTRY_ID }}/3rdparty/kakfa:latest

--- a/.github/workflows/dapr-3rdparty-container.yaml
+++ b/.github/workflows/dapr-3rdparty-container.yaml
@@ -31,11 +31,25 @@ jobs:
         with:
           src: wurstmeister/zookeeper:latest
           dst: |
-            ghcr.io/${{ secrets.DOCKER_REGISTRY_ID }}/3rdparty/zookeeper:latest
+            ghcr.io/${{ github.repository_owner }}/3rdparty/zookeeper:latest
       - # copy 3rd party kafka image from dockerhub to ghcr
         name: Push Image (kafka) to target registries
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: wurstmeister/kafka:latest
           dst: |
-            ghcr.io/${{ secrets.DOCKER_REGISTRY_ID }}/3rdparty/kakfa:latest
+            ghcr.io/${{ github.repository_owner }}/3rdparty/kakfa:latest
+      - # copy 3rd party redis image from dockerhub to ghcr
+        name: Push Image (redis) to target registries
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: redis:latest
+          dst: |
+            ghcr.io/${{ github.repository_owner }}/3rdparty/redis:latest
+      - # copy 3rd party zipkin image from dockerhub to ghcr
+        name: Push Image (zipkin) to target registries
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: openzipkin/zipkin:latest
+          dst: |
+            ghcr.io/${{ github.repository_owner }}/3rdparty/zipkin:latest

--- a/.github/workflows/dapr-3rdparty-container.yaml
+++ b/.github/workflows/dapr-3rdparty-container.yaml
@@ -1,4 +1,4 @@
-name: Cache Docker 3rd Party Images
+name: dapr-mirror-containers
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker:
+  mirror:
     runs-on: ubuntu-latest
     steps:
       - 


### PR DESCRIPTION
# Description
A common source of test failures is root caused by pulling a public image from docker hub public registries. This implements a best practice of moving all 3rdParty container images to private registries. The `dapr-mirror-containers` action will trigger monthly to stay current.

Pull locations must also be updated separately. The pull location will only work after at least one successful run of the action workflow. Please expect the first verification test in prod to fail, and rerun. The mirror action itself should succeed right away.

I'm keeping this in draft until we review all 3rdParty images needed, e.g. zipkin for CLI?

Signed-off-by: Paul Yuknewicz <paulyuk@microsoft.com>


## Issue reference

Please reference the issue this PR will close: #4355 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [x] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [x] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

There is no doc impact, it's just a CI/CD action.