### PR TITLE
[WIP] Use encoding/json instead of json-iterator/go and fix serialization bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/raft v1.2.0
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
-	github.com/json-iterator/go v1.1.12
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.4.1

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
@@ -1406,7 +1406,7 @@ func (a *actorsRuntime) getRemindersForActorType(actorType string, migrate bool)
 						return
 					}
 
-					r.Data = jsoniter.RawMessage(resp.Data)
+					r.Data = json.RawMessage(resp.Data)
 					r.ETag = resp.ETag
 					r.Metadata = resp.Metadata
 				}

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	jsoniter "github.com/json-iterator/go"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -1479,7 +1479,7 @@ func TestGetState(t *testing.T) {
 	fakeData := strconv.Quote("fakeData")
 
 	var val interface{}
-	jsoniter.ConfigFastest.Unmarshal([]byte(fakeData), &val)
+	json.Unmarshal([]byte(fakeData), &val)
 
 	fakeCallAndActivateActor(testActorRuntime, actorType, actorID)
 
@@ -1516,7 +1516,7 @@ func TestDeleteState(t *testing.T) {
 	fakeData := strconv.Quote("fakeData")
 
 	var val interface{}
-	jsoniter.ConfigFastest.Unmarshal([]byte(fakeData), &val)
+	json.Unmarshal([]byte(fakeData), &val)
 
 	fakeCallAndActivateActor(testActorRuntime, actorType, actorID)
 

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -16,6 +16,7 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -23,7 +24,6 @@ import (
 
 	nethttp "net/http"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/valyala/fasthttp"
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"google.golang.org/grpc/codes"
@@ -55,7 +55,6 @@ type Channel struct {
 	ch                  chan int
 	tracingSpec         config.TracingSpec
 	appHeaderToken      string
-	json                jsoniter.API
 	maxResponseBodySize int
 }
 
@@ -78,7 +77,6 @@ func CreateLocalChannel(port, maxConcurrency int, spec config.TracingSpec, sslEn
 		baseAddress:         fmt.Sprintf("%s://%s:%d", scheme, channel.DefaultChannelAddress, port),
 		tracingSpec:         spec,
 		appHeaderToken:      auth.GetAppToken(),
-		json:                jsoniter.ConfigFastest,
 		maxResponseBodySize: maxRequestBodySize,
 	}
 
@@ -132,7 +130,7 @@ func (h *Channel) GetAppConfig() (*config.ApplicationConfig, error) {
 		fallthrough
 	default:
 		_, body := resp.RawData()
-		if err = h.json.Unmarshal(body, &config); err != nil {
+		if err = json.Unmarshal(body, &config); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -15,6 +15,7 @@ package grpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -25,7 +26,6 @@ import (
 	"github.com/dapr/components-contrib/configuration"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -286,7 +286,7 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 		features := thepubsub.Features()
 		pubsub.ApplyMetadata(envelope, features, in.Metadata)
 
-		data, err = jsoniter.ConfigFastest.Marshal(envelope)
+		data, err = json.Marshal(envelope)
 		if err != nil {
 			err = status.Errorf(codes.InvalidArgument, messages.ErrPubsubCloudEventsSer, topic, pubsubName, err.Error())
 			apiServerLogger.Debug(err)
@@ -566,7 +566,7 @@ func (a *api) SaveState(ctx context.Context, in *runtimev1pb.SaveStateRequest) (
 		}
 
 		if contentType, ok := req.Metadata[contrib_metadata.ContentType]; ok && contentType == contenttype.JSONContentType {
-			if err1 = jsoniter.Unmarshal(s.Value, &req.Value); err1 != nil {
+			if err1 = json.Unmarshal(s.Value, &req.Value); err1 != nil {
 				return &emptypb.Empty{}, err1
 			}
 		} else {
@@ -632,7 +632,7 @@ func (a *api) QueryStateAlpha1(ctx context.Context, in *runtimev1pb.QueryStateRe
 	}
 
 	var req state.QueryRequest
-	if err = jsoniter.Unmarshal([]byte(in.GetQuery()), &req.Query); err != nil {
+	if err = json.Unmarshal([]byte(in.GetQuery()), &req.Query); err != nil {
 		err = status.Errorf(codes.InvalidArgument, messages.ErrMalformedRequest, err.Error())
 		apiServerLogger.Debug(err)
 		return ret, err

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -522,7 +522,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 				log.Debugf("bulk get: error getting key %s: %s", bulkResp[i].Key, responses[i].Error)
 				bulkResp[i].Error = responses[i].Error
 			} else {
-				bulkResp[i].Data = []byte(responses[i].Data)
+				bulkResp[i].Data = responses[i].Data
 				bulkResp[i].ETag = responses[i].ETag
 				bulkResp[i].Metadata = responses[i].Metadata
 			}
@@ -552,7 +552,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 					log.Debugf("bulk get: error getting key %s: %s", r.Key, err)
 					r.Error = err.Error()
 				} else if resp != nil {
-					r.Data = []byte(resp.Data)
+					r.Data = resp.Data
 					r.ETag = resp.ETag
 					r.Metadata = resp.Metadata
 				}
@@ -1789,7 +1789,7 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 		qresp.Results[i].Key = state_loader.GetOriginalStateKey(resp.Results[i].Key)
 		qresp.Results[i].ETag = resp.Results[i].ETag
 		qresp.Results[i].Error = resp.Results[i].Error
-		qresp.Results[i].Data = []byte(resp.Results[i].Data)
+		qresp.Results[i].Data = resp.Results[i].Data
 	}
 
 	b, _ := json.Marshal(qresp)

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -522,7 +522,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 				log.Debugf("bulk get: error getting key %s: %s", bulkResp[i].Key, responses[i].Error)
 				bulkResp[i].Error = responses[i].Error
 			} else {
-				bulkResp[i].Data = json.RawMessage(responses[i].Data)
+				bulkResp[i].Data = []byte(responses[i].Data)
 				bulkResp[i].ETag = responses[i].ETag
 				bulkResp[i].Metadata = responses[i].Metadata
 			}
@@ -552,7 +552,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 					log.Debugf("bulk get: error getting key %s: %s", r.Key, err)
 					r.Error = err.Error()
 				} else if resp != nil {
-					r.Data = json.RawMessage(resp.Data)
+					r.Data = []byte(resp.Data)
 					r.ETag = resp.ETag
 					r.Metadata = resp.Metadata
 				}
@@ -1789,7 +1789,7 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 		qresp.Results[i].Key = state_loader.GetOriginalStateKey(resp.Results[i].Key)
 		qresp.Results[i].ETag = resp.Results[i].ETag
 		qresp.Results[i].Error = resp.Results[i].Error
-		qresp.Results[i].Data = json.RawMessage(resp.Results[i].Data)
+		qresp.Results[i].Data = []byte(resp.Results[i].Data)
 	}
 
 	b, _ := json.Marshal(qresp)

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -92,10 +92,10 @@ type registeredComponent struct {
 }
 
 type metadata struct {
-	ID                   string                      `json:"id"`
-	ActiveActorsCount    []actors.ActiveActorsCount  `json:"actors"`
-	Extended             map[interface{}]interface{} `json:"extended"`
-	RegisteredComponents []registeredComponent       `json:"components"`
+	ID                   string                     `json:"id"`
+	ActiveActorsCount    []actors.ActiveActorsCount `json:"actors"`
+	Extended             map[string]interface{}     `json:"extended"`
+	RegisteredComponents []registeredComponent      `json:"components"`
 }
 
 const (
@@ -1358,11 +1358,11 @@ func (a *api) onGetActorState(reqCtx *fasthttp.RequestCtx) {
 }
 
 func (a *api) onGetMetadata(reqCtx *fasthttp.RequestCtx) {
-	temp := make(map[interface{}]interface{})
+	temp := make(map[string]interface{})
 
 	// Copy synchronously so it can be serialized to JSON.
 	a.extendedMetadata.Range(func(key, value interface{}) bool {
-		temp[key] = value
+		temp[key.(string)] = value
 
 		return true
 	})

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -16,6 +16,7 @@ package http
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -23,7 +24,7 @@ import (
 	"time"
 
 	"github.com/fasthttp/router"
-	jsoniter "github.com/json-iterator/go"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
@@ -73,7 +74,6 @@ type api struct {
 	transactionalStateStores map[string]state.TransactionalStore
 	secretStores             map[string]secretstores.SecretStore
 	secretsConfiguration     map[string]config.SecretsScope
-	json                     jsoniter.API
 	actor                    actors.Actors
 	pubsubAdapter            runtime_pubsub.Adapter
 	sendToOutputBindingFn    func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
@@ -147,7 +147,6 @@ func NewAPI(
 		transactionalStateStores: transactionalStateStores,
 		secretStores:             secretStores,
 		secretsConfiguration:     secretsConfiguration,
-		json:                     jsoniter.ConfigFastest,
 		actor:                    actor,
 		pubsubAdapter:            pubsubAdapter,
 		sendToOutputBindingFn:    sendToOutputBindingFn,
@@ -397,7 +396,7 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 	body := reqCtx.PostBody()
 
 	var req OutputBindingRequest
-	err := a.json.Unmarshal(body, &req)
+	err := json.Unmarshal(body, &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err))
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
@@ -405,7 +404,7 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	b, err := a.json.Marshal(req.Data)
+	b, err := json.Marshal(req.Data)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST_DATA", fmt.Sprintf(messages.ErrMalformedRequestData, err))
 		respond(reqCtx, withError(fasthttp.StatusInternalServerError, msg))
@@ -460,7 +459,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	var req BulkGetRequest
-	err = a.json.Unmarshal(reqCtx.PostBody(), &req)
+	err = json.Unmarshal(reqCtx.PostBody(), &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err))
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
@@ -480,7 +479,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 
 	bulkResp := make([]BulkGetResponse, len(req.Keys))
 	if len(req.Keys) == 0 {
-		b, _ := a.json.Marshal(bulkResp)
+		b, _ := json.Marshal(bulkResp)
 		respond(reqCtx, withJSON(fasthttp.StatusOK, b))
 		return
 	}
@@ -523,7 +522,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 				log.Debugf("bulk get: error getting key %s: %s", bulkResp[i].Key, responses[i].Error)
 				bulkResp[i].Error = responses[i].Error
 			} else {
-				bulkResp[i].Data = jsoniter.RawMessage(responses[i].Data)
+				bulkResp[i].Data = json.RawMessage(responses[i].Data)
 				bulkResp[i].ETag = responses[i].ETag
 				bulkResp[i].Metadata = responses[i].Metadata
 			}
@@ -553,7 +552,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 					log.Debugf("bulk get: error getting key %s: %s", r.Key, err)
 					r.Error = err.Error()
 				} else if resp != nil {
-					r.Data = jsoniter.RawMessage(resp.Data)
+					r.Data = json.RawMessage(resp.Data)
 					r.ETag = resp.ETag
 					r.Metadata = resp.Metadata
 				}
@@ -577,7 +576,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 		}
 	}
 
-	b, _ := a.json.Marshal(bulkResp)
+	b, _ := json.Marshal(bulkResp)
 	respond(reqCtx, withJSON(fasthttp.StatusOK, b))
 }
 
@@ -764,7 +763,7 @@ func (a *api) onGetSecret(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	respBytes, _ := a.json.Marshal(resp.Data)
+	respBytes, _ := json.Marshal(resp.Data)
 	respond(reqCtx, withJSON(fasthttp.StatusOK, respBytes))
 }
 
@@ -809,7 +808,7 @@ func (a *api) onBulkGetSecret(reqCtx *fasthttp.RequestCtx) {
 		}
 	}
 
-	respBytes, _ := a.json.Marshal(filteredSecrets)
+	respBytes, _ := json.Marshal(filteredSecrets)
 	respond(reqCtx, withJSON(fasthttp.StatusOK, respBytes))
 }
 
@@ -838,7 +837,7 @@ func (a *api) onPostState(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	reqs := []state.SetRequest{}
-	err = a.json.Unmarshal(reqCtx.PostBody(), &reqs)
+	err = json.Unmarshal(reqCtx.PostBody(), &reqs)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", err.Error())
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
@@ -1039,7 +1038,7 @@ func (a *api) onCreateActorReminder(reqCtx *fasthttp.RequestCtx) {
 	name := reqCtx.UserValue(nameParam).(string)
 
 	var req actors.CreateReminderRequest
-	err := a.json.Unmarshal(reqCtx.PostBody(), &req)
+	err := json.Unmarshal(reqCtx.PostBody(), &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err))
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
@@ -1073,7 +1072,7 @@ func (a *api) onRenameActorReminder(reqCtx *fasthttp.RequestCtx) {
 	name := reqCtx.UserValue(nameParam).(string)
 
 	var req actors.RenameReminderRequest
-	err := a.json.Unmarshal(reqCtx.PostBody(), &req)
+	err := json.Unmarshal(reqCtx.PostBody(), &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err))
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
@@ -1108,7 +1107,7 @@ func (a *api) onCreateActorTimer(reqCtx *fasthttp.RequestCtx) {
 	name := reqCtx.UserValue(nameParam).(string)
 
 	var req actors.CreateTimerRequest
-	err := a.json.Unmarshal(reqCtx.PostBody(), &req)
+	err := json.Unmarshal(reqCtx.PostBody(), &req)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err))
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
@@ -1171,7 +1170,7 @@ func (a *api) onActorStateTransaction(reqCtx *fasthttp.RequestCtx) {
 	body := reqCtx.PostBody()
 
 	var ops []actors.TransactionalOperation
-	err := a.json.Unmarshal(body, &ops)
+	err := json.Unmarshal(body, &ops)
 	if err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", err.Error())
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
@@ -1230,7 +1229,7 @@ func (a *api) onGetActorReminder(reqCtx *fasthttp.RequestCtx) {
 		log.Debug(msg)
 		return
 	}
-	b, err := a.json.Marshal(resp)
+	b, err := json.Marshal(resp)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_GET", fmt.Sprintf(messages.ErrActorReminderGet, err))
 		respond(reqCtx, withError(fasthttp.StatusInternalServerError, msg))
@@ -1392,7 +1391,7 @@ func (a *api) onGetMetadata(reqCtx *fasthttp.RequestCtx) {
 		RegisteredComponents: registeredComponents,
 	}
 
-	mtdBytes, err := a.json.Marshal(mtd)
+	mtdBytes, err := json.Marshal(mtd)
 	if err != nil {
 		msg := NewErrorResponse("ERR_METADATA_GET", fmt.Sprintf(messages.ErrMetadataGet, err))
 		respond(reqCtx, withError(fasthttp.StatusInternalServerError, msg))
@@ -1500,7 +1499,7 @@ func (a *api) onPublish(reqCtx *fasthttp.RequestCtx) {
 
 		pubsub.ApplyMetadata(envelope, features, metadata)
 
-		data, err = a.json.Marshal(envelope)
+		data, err = json.Marshal(envelope)
 		if err != nil {
 			msg := NewErrorResponse("ERR_PUBSUB_CLOUD_EVENTS_SER",
 				fmt.Sprintf(messages.ErrPubsubCloudEventsSer, topic, pubsubName, err.Error()))
@@ -1618,7 +1617,7 @@ func (a *api) onPostStateTransaction(reqCtx *fasthttp.RequestCtx) {
 
 	body := reqCtx.PostBody()
 	var req state.TransactionalStateRequest
-	if err := a.json.Unmarshal(body, &req); err != nil {
+	if err := json.Unmarshal(body, &req); err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err.Error()))
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
 		log.Debug(msg)
@@ -1756,7 +1755,7 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	var req state.QueryRequest
-	if err = a.json.Unmarshal(reqCtx.PostBody(), &req.Query); err != nil {
+	if err = json.Unmarshal(reqCtx.PostBody(), &req.Query); err != nil {
 		msg := NewErrorResponse("ERR_MALFORMED_REQUEST", fmt.Sprintf(messages.ErrMalformedRequest, err.Error()))
 		respond(reqCtx, withError(fasthttp.StatusBadRequest, msg))
 		log.Debug(msg)
@@ -1790,10 +1789,10 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 		qresp.Results[i].Key = state_loader.GetOriginalStateKey(resp.Results[i].Key)
 		qresp.Results[i].ETag = resp.Results[i].ETag
 		qresp.Results[i].Error = resp.Results[i].Error
-		qresp.Results[i].Data = jsoniter.RawMessage(resp.Results[i].Data)
+		qresp.Results[i].Data = json.RawMessage(resp.Results[i].Data)
 	}
 
-	b, _ := a.json.Marshal(qresp)
+	b, _ := json.Marshal(qresp)
 	respond(reqCtx, withJSON(fasthttp.StatusOK, b))
 }
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/agrea/ptr"
 	routing "github.com/fasthttp/router"
-	jsoniter "github.com/json-iterator/go"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -88,7 +88,6 @@ func TestPubSubEndpoints(t *testing.T) {
 				return &daprt.MockPubSub{}
 			},
 		},
-		json: jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructPubSubEndpoints())
 
@@ -233,7 +232,6 @@ func TestShutdownEndpoints(t *testing.T) {
 	m := mock.Mock{}
 	m.On("shutdown", mock.Anything).Return()
 	testAPI := &api{
-		json: jsoniter.ConfigFastest,
 		shutdown: func() {
 			m.MethodCalled("shutdown")
 		},
@@ -296,7 +294,6 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 			}
 			return &bindings.InvokeResponse{Data: []byte("testresponse")}, nil
 		},
-		json: jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructBindingsEndpoints())
 
@@ -380,7 +377,6 @@ func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 
 	testAPI := &api{
 		sendToOutputBindingFn: func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error) { return nil, nil },
-		json:                  jsoniter.ConfigFastest,
 		tracingSpec:           spec,
 	}
 	fakeServer.StartServerWithTracing(spec, testAPI.constructBindingsEndpoints())
@@ -445,7 +441,6 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	testAPI := &api{
 		directMessaging: mockDirectMessaging,
-		json:            jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructDirectMessagingEndpoints())
 
@@ -852,7 +847,6 @@ func TestV1ActorEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	testAPI := &api{
 		actor: nil,
-		json:  jsoniter.ConfigFastest,
 	}
 
 	fakeServer.StartServer(testAPI.constructActorEndpoints())
@@ -1601,7 +1595,6 @@ func TestV1MetadataEndpoint(t *testing.T) {
 				},
 			}
 		},
-		json: jsoniter.ConfigFastest,
 	}
 
 	fakeServer.StartServer(testAPI.constructMetadataEndpoints())
@@ -1651,7 +1644,6 @@ func TestV1ActorEndpointsWithTracer(t *testing.T) {
 
 	testAPI := &api{
 		actor:       nil,
-		json:        jsoniter.ConfigFastest,
 		tracingSpec: spec,
 	}
 
@@ -2302,7 +2294,6 @@ func TestV1StateEndpoints(t *testing.T) {
 	testAPI := &api{
 		stateStores:              fakeStores,
 		transactionalStateStores: fakeTransactionalStores,
-		json:                     jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructStateEndpoints())
 	storeName := "store1"
@@ -2520,7 +2511,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		expectedResponses := []BulkGetResponse{
 			{
 				Key:   "good-key",
-				Data:  jsoniter.RawMessage("life is good"),
+				Data:  json.RawMessage("life is good"),
 				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
@@ -2553,7 +2544,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		expectedResponses := []BulkGetResponse{
 			{
 				Key:   "good-key",
-				Data:  jsoniter.RawMessage("life is good"),
+				Data:  json.RawMessage("life is good"),
 				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
@@ -2803,7 +2794,6 @@ func TestV1SecretEndpoints(t *testing.T) {
 	testAPI := &api{
 		secretsConfiguration: secretsConfiguration,
 		secretStores:         fakeStores,
-		json:                 jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructSecretEndpoints())
 	storeName := "store1"
@@ -2920,7 +2910,6 @@ func TestV1HealthzEndpoint(t *testing.T) {
 
 	testAPI := &api{
 		actor: nil,
-		json:  jsoniter.ConfigFastest,
 	}
 
 	fakeServer.StartServer(testAPI.constructHealthzEndpoints())
@@ -2957,7 +2946,6 @@ func TestV1TransactionEndpoints(t *testing.T) {
 	testAPI := &api{
 		stateStores:              fakeStores,
 		transactionalStateStores: fakeTransactionalStores,
-		json:                     jsoniter.ConfigFastest,
 	}
 	fakeServer.StartServer(testAPI.constructStateEndpoints())
 	fakeBodyObject := map[string]interface{}{"data": "fakeData"}

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -2511,7 +2511,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		expectedResponses := []BulkGetResponse{
 			{
 				Key:   "good-key",
-				Data:  json.RawMessage("life is good"),
+				Data:  []byte("life is good"),
 				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
@@ -2544,7 +2544,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		expectedResponses := []BulkGetResponse{
 			{
 				Key:   "good-key",
-				Data:  json.RawMessage("life is good"),
+				Data:  []byte("life is good"),
 				ETag:  ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 				Error: "",
 			},
@@ -2699,7 +2699,7 @@ func (c fakeStateStore) Delete(req *state.DeleteRequest) error {
 func (c fakeStateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
 	if req.Key == "good-key" {
 		return &state.GetResponse{
-			Data: []byte("\"bGlmZSBpcyBnb29k\""),
+			Data: []byte("life is good"),
 			ETag: ptr.String("`~!@#$%^&*()_+-={}[]|\\:\";'<>?,./'"),
 		}, nil
 	}

--- a/pkg/http/responses.go
+++ b/pkg/http/responses.go
@@ -28,7 +28,7 @@ const (
 // BulkGetResponse is the response object for a state bulk get operation.
 type BulkGetResponse struct {
 	Key      string            `json:"key"`
-	Data     json.RawMessage   `json:"data,omitempty"`
+	Data     []byte            `json:"data,omitempty"`
 	ETag     *string           `json:"etag,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`
 	Error    string            `json:"error,omitempty"`
@@ -43,10 +43,10 @@ type QueryResponse struct {
 
 // QueryItem is an object representing a single entry in query results.
 type QueryItem struct {
-	Key   string          `json:"key"`
-	Data  json.RawMessage `json:"data"`
-	ETag  *string         `json:"etag,omitempty"`
-	Error string          `json:"error,omitempty"`
+	Key   string  `json:"key"`
+	Data  []byte  `json:"data"`
+	ETag  *string `json:"etag,omitempty"`
+	Error string  `json:"error,omitempty"`
 }
 
 type option = func(ctx *fasthttp.RequestCtx)

--- a/pkg/http/responses.go
+++ b/pkg/http/responses.go
@@ -16,7 +16,6 @@ package http
 import (
 	"encoding/json"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/valyala/fasthttp"
 )
 
@@ -28,11 +27,11 @@ const (
 
 // BulkGetResponse is the response object for a state bulk get operation.
 type BulkGetResponse struct {
-	Key      string              `json:"key"`
-	Data     jsoniter.RawMessage `json:"data,omitempty"`
-	ETag     *string             `json:"etag,omitempty"`
-	Metadata map[string]string   `json:"metadata,omitempty"`
-	Error    string              `json:"error,omitempty"`
+	Key      string            `json:"key"`
+	Data     json.RawMessage   `json:"data,omitempty"`
+	ETag     *string           `json:"etag,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+	Error    string            `json:"error,omitempty"`
 }
 
 // QueryResponse is the response object for querying state.
@@ -44,10 +43,10 @@ type QueryResponse struct {
 
 // QueryItem is an object representing a single entry in query results.
 type QueryItem struct {
-	Key   string              `json:"key"`
-	Data  jsoniter.RawMessage `json:"data"`
-	ETag  *string             `json:"etag,omitempty"`
-	Error string              `json:"error,omitempty"`
+	Key   string          `json:"key"`
+	Data  json.RawMessage `json:"data"`
+	ETag  *string         `json:"etag,omitempty"`
+	Error string          `json:"error,omitempty"`
 }
 
 type option = func(ctx *fasthttp.RequestCtx)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -36,7 +36,6 @@ import (
 	"contrib.go.opencensus.io/exporter/zipkin"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	jsoniter "github.com/json-iterator/go"
 	openzipkin "github.com/openzipkin/zipkin-go"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter/http"
 	"github.com/pkg/errors"
@@ -158,7 +157,6 @@ type DaprRuntime struct {
 	pubSubRegistry         pubsub_loader.Registry
 	pubSubs                map[string]pubsub.PubSub
 	nameResolver           nr.Resolver
-	json                   jsoniter.API
 	httpMiddlewareRegistry http_middleware_loader.Registry
 	hostAddress            string
 	actorStateStoreName    string
@@ -225,7 +223,6 @@ func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, a
 		components:             make([]components_v1alpha1.Component, 0),
 		actorStateStoreLock:    &sync.RWMutex{},
 		grpc:                   grpc.NewGRPCManager(runtimeConfig.Mode),
-		json:                   jsoniter.ConfigFastest,
 		inputBindings:          map[string]bindings.InputBinding{},
 		outputBindings:         map[string]bindings.OutputBinding{},
 		secretStores:           map[string]secretstores.SecretStore{},
@@ -566,14 +563,14 @@ func (a *DaprRuntime) beginPubSub(name string, ps pubsub.PubSub) error {
 			data := msg.Data
 			if rawPayload {
 				cloudEvent = pubsub.FromRawPayload(msg.Data, msg.Topic, name)
-				data, err = a.json.Marshal(cloudEvent)
+				data, err = json.Marshal(cloudEvent)
 				if err != nil {
 					log.Errorf("error serializing cloud event in pubsub %s and topic %s: %s", name, msg.Topic, err)
 					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, pubsubName, strings.ToLower(string(pubsub.Retry)), msg.Topic, 0)
 					return err
 				}
 			} else {
-				err = a.json.Unmarshal(msg.Data, &cloudEvent)
+				err = json.Unmarshal(msg.Data, &cloudEvent)
 				if err != nil {
 					log.Errorf("error deserializing cloud event in pubsub %s and topic %s: %s", name, msg.Topic, err)
 					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, pubsubName, strings.ToLower(string(pubsub.Retry)), msg.Topic, 0)
@@ -841,7 +838,7 @@ func (a *DaprRuntime) onAppResponse(response *bindings.AppResponse) error {
 	}
 
 	if len(response.To) > 0 {
-		b, err := a.json.Marshal(&response.Data)
+		b, err := json.Marshal(&response.Data)
 		if err != nil {
 			return err
 		}
@@ -908,7 +905,7 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 				appResponseBody = resp.Data
 
 				var d interface{}
-				err := a.json.Unmarshal(resp.Data, &d)
+				err := json.Unmarshal(resp.Data, &d)
 				if err == nil {
 					response.Data = d
 				}
@@ -1502,7 +1499,7 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 	if (statusCode >= 200) && (statusCode <= 299) {
 		// Any 2xx is considered a success.
 		var appResponse pubsub.AppResponse
-		err := a.json.Unmarshal(body, &appResponse)
+		err := json.Unmarshal(body, &appResponse)
 		if err != nil {
 			log.Debugf("skipping status check due to error parsing result from pub/sub event %v", cloudEvent[pubsub.IDField])
 			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
@@ -1588,7 +1585,7 @@ func (a *DaprRuntime) publishMessageGRPC(ctx context.Context, msg *pubsubSubscri
 				return ErrUnexpectedEnvelopeData
 			}
 		} else if contenttype.IsJSONContentType(envelope.DataContentType) {
-			envelope.Data, _ = a.json.Marshal(data)
+			envelope.Data, _ = json.Marshal(data)
 		}
 	}
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	jsoniter "github.com/json-iterator/go"
+
 	"github.com/phayes/freeport"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -2326,7 +2326,6 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 		// assert
 		var cloudEvent map[string]interface{}
-		json := jsoniter.ConfigFastest
 		json.Unmarshal(testPubSubMessage.data, &cloudEvent)
 		expectedClientError := errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent["id"].(string))
 		assert.Equal(t, expectedClientError.Error(), err.Error())
@@ -2454,7 +2453,6 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 		// assert
 		var cloudEvent map[string]interface{}
-		json := jsoniter.ConfigFastest
 		json.Unmarshal(testPubSubMessage.data, &cloudEvent)
 		expectedClientError := errors.Errorf("retriable error returned from app while processing pub/sub event %v, topic: %v, body: Internal Error. status code returned: 500", cloudEvent["id"].(string), cloudEvent["topic"])
 		assert.Equal(t, expectedClientError.Error(), err.Error())

--- a/tests/apps/stateapp/app.go
+++ b/tests/apps/stateapp/app.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/grpc"
 
 	daprhttp "github.com/dapr/dapr/pkg/http"
@@ -364,7 +363,7 @@ func executeQuery(query []byte, statestore string, meta map[string]string) ([]da
 	}
 
 	var qres daprhttp.QueryResponse
-	err = jsoniter.Unmarshal(body, &qres)
+	err = json.Unmarshal(body, &qres)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal query response from Dapr: %s", err.Error())
 	}

--- a/tests/apps/stateapp/app.go
+++ b/tests/apps/stateapp/app.go
@@ -71,9 +71,9 @@ type bulkGetRequest struct {
 
 // bulkGetResponse is the response object from Dapr for a bulk get operation.
 type bulkGetResponse struct {
-	Key  string      `json:"key"`
-	Data interface{} `json:"data"`
-	ETag string      `json:"etag"`
+	Key  string `json:"key"`
+	Data []byte `json:"data"`
+	ETag string `json:"etag"`
 }
 
 // requestResponse represents a request or response for the APIs in this app.
@@ -252,11 +252,7 @@ func getBulk(states []daprState, statestore string) ([]daprState, error) {
 
 	for _, i := range resp {
 		var as appState
-		b, err := json.Marshal(i.Data)
-		if err != nil {
-			return nil, fmt.Errorf("could not marshal return data: %s", err)
-		}
-		json.Unmarshal(b, &as)
+		json.Unmarshal(i.Data, &as)
 
 		output = append(output, daprState{
 			Key:   i.Key,


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

This PR moves away from https://github.com/json-iterator/go to go's std library - encoding/json. It also fixes the serialization bug mentioned in the referenced issue using `Decoder.UseNumber` [docs](https://pkg.go.dev/encoding/json#Decoder.UseNumber).

This PR is based on #4093

## Note to maintainers
Please squash commit this PR with the following:
> Signed-off-by: Shubham Sharma <shubhash@microsoft.com>
Co-authored-by: Huei Feng <hueifeng2020@outlook.com>


## Issue reference

Please reference the issue this PR will close: #3837

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
