### PR TITLE
Explicit support for other AES key sizes

### DIFF
--- a/pkg/encryption/encryption_test.go
+++ b/pkg/encryption/encryption_test.go
@@ -87,7 +87,7 @@ func TestComponentEncryptionKey(t *testing.T) {
 
 		rand.Read(bytes)
 
-		secondaryKey := hex.EncodeToString(bytes)
+		secondaryKey := hex.EncodeToString(bytes[:16]) // 128-bit key
 
 		secretStore := &mockSecretStore{}
 		secretStore.Init(secretstores.Metadata{
@@ -168,25 +168,81 @@ func TestTryGetEncryptionKeyFromMetadataItem(t *testing.T) {
 
 func TestCreateCipher(t *testing.T) {
 	t.Run("invalid key", func(t *testing.T) {
-		gcm, err := createCipher(Key{
+		cipherObj, err := createCipher(Key{
 			Key: "123",
-		}, AES256Algorithm)
+		}, AESGCMAlgorithm)
 
-		assert.Nil(t, gcm)
+		assert.Nil(t, cipherObj)
 		assert.Error(t, err)
 	})
 
-	t.Run("valid key", func(t *testing.T) {
+	t.Run("valid 256-bit key", func(t *testing.T) {
 		bytes := make([]byte, 32)
 		rand.Read(bytes)
 
 		key := hex.EncodeToString(bytes)
 
-		gcm, err := createCipher(Key{
+		cipherObj, err := createCipher(Key{
 			Key: key,
-		}, AES256Algorithm)
+		}, AESGCMAlgorithm)
 
-		assert.NotNil(t, gcm)
+		assert.NotNil(t, cipherObj)
 		assert.NoError(t, err)
+	})
+
+	t.Run("valid 192-bit key", func(t *testing.T) {
+		bytes := make([]byte, 24)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESGCMAlgorithm)
+
+		assert.NotNil(t, cipherObj)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid 128-bit key", func(t *testing.T) {
+		bytes := make([]byte, 16)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESGCMAlgorithm)
+
+		assert.NotNil(t, cipherObj)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid key size", func(t *testing.T) {
+		bytes := make([]byte, 18)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESGCMAlgorithm)
+
+		assert.Nil(t, cipherObj)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid algorithm", func(t *testing.T) {
+		bytes := make([]byte, 32)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, "3DES")
+
+		assert.Nil(t, cipherObj)
+		assert.Error(t, err)
 	})
 }

--- a/pkg/encryption/state.go
+++ b/pkg/encryption/state.go
@@ -47,7 +47,7 @@ func EncryptedStateStore(storeName string) bool {
 // If no encryption keys exist, the function will return the bytes unmodified.
 func TryEncryptValue(storeName string, value []byte) ([]byte, error) {
 	keys := encryptedStateStores[storeName]
-	enc, err := encrypt(value, keys.Primary, AES256Algorithm)
+	enc, err := encrypt(value, keys.Primary)
 	if err != nil {
 		return value, err
 	}
@@ -76,5 +76,5 @@ func TryDecryptValue(storeName string, value []byte) ([]byte, error) {
 		key = keys.Secondary
 	}
 
-	return decrypt(value[:ind], key, AES256Algorithm)
+	return decrypt(value[:ind], key)
 }

--- a/pkg/encryption/state_test.go
+++ b/pkg/encryption/state_test.go
@@ -28,7 +28,7 @@ func TestAddEncryptedStateStore(t *testing.T) {
 		r := AddEncryptedStateStore("test", ComponentEncryptionKeys{
 			Primary: Key{
 				Name: "primary",
-				Key:  "123",
+				Key:  "1234",
 			},
 		})
 		assert.True(t, r)
@@ -40,7 +40,7 @@ func TestAddEncryptedStateStore(t *testing.T) {
 		r := AddEncryptedStateStore("test", ComponentEncryptionKeys{
 			Primary: Key{
 				Name: "primary",
-				Key:  "123",
+				Key:  "1234",
 			},
 		})
 
@@ -50,7 +50,7 @@ func TestAddEncryptedStateStore(t *testing.T) {
 		r = AddEncryptedStateStore("test", ComponentEncryptionKeys{
 			Primary: Key{
 				Name: "primary",
-				Key:  "123",
+				Key:  "1234",
 			},
 		})
 
@@ -78,8 +78,8 @@ func TestTryEncryptValue(t *testing.T) {
 			Key:  key,
 		}
 
-		gcm, _ := createCipher(pr, AES256Algorithm)
-		pr.gcm = gcm
+		cipherObj, _ := createCipher(pr, AESGCMAlgorithm)
+		pr.cipherObj = cipherObj
 
 		encryptedStateStores = map[string]ComponentEncryptionKeys{}
 		AddEncryptedStateStore("test", ComponentEncryptionKeys{
@@ -110,8 +110,8 @@ func TestTryEncryptValue(t *testing.T) {
 			Key:  primaryKey,
 		}
 
-		gcm, _ := createCipher(pr, AES256Algorithm)
-		pr.gcm = gcm
+		cipherObj, _ := createCipher(pr, AESGCMAlgorithm)
+		pr.cipherObj = cipherObj
 
 		encryptedStateStores = map[string]ComponentEncryptionKeys{}
 		AddEncryptedStateStore("test", ComponentEncryptionKeys{
@@ -147,8 +147,8 @@ func TestTryEncryptValue(t *testing.T) {
 			Key:  key,
 		}
 
-		gcm, _ := createCipher(pr, AES256Algorithm)
-		pr.gcm = gcm
+		cipherObj, _ := createCipher(pr, AESGCMAlgorithm)
+		pr.cipherObj = cipherObj
 
 		encryptedStateStores = map[string]ComponentEncryptionKeys{}
 		AddEncryptedStateStore("test", ComponentEncryptionKeys{
@@ -165,6 +165,38 @@ func TestTryEncryptValue(t *testing.T) {
 		dr, err := TryDecryptValue("test", r)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte(s), dr)
+	})
+
+	t.Run("state store with AES128 primary key, value encrypted and decrypted successfully", func(t *testing.T) {
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+
+		bytes := make([]byte, 16)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		pr := Key{
+			Name: "primary",
+			Key:  key,
+		}
+
+		cipherObj, _ := createCipher(pr, AESGCMAlgorithm)
+		pr.cipherObj = cipherObj
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Primary: pr,
+		})
+
+		v := []byte("hello world")
+		r, err := TryEncryptValue("test", v)
+
+		assert.NoError(t, err)
+		assert.NotEqual(t, v, r)
+
+		dr, err := TryDecryptValue("test", r)
+		assert.NoError(t, err)
+		assert.Equal(t, v, dr)
 	})
 }
 


### PR DESCRIPTION
# Description

See: #4341
This makes support for 128- and 192-bit keys (in addition to 256-bit) explicit in the code and tests.

## Issue reference

#4341
Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [x] End-to-end tests passing
* [X] Extended the documentation:  https://github.com/dapr/docs/pull/2259