### PR TITLE
Use the ca-certs bundle that's part of distroless

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,6 @@
-FROM alpine:latest as alpine
-RUN apk add -U --no-cache ca-certificates
 # current directory must be ./dist
 
 FROM gcr.io/distroless/static:nonroot
 ARG PKG_FILES
 WORKDIR /
-COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY /$PKG_FILES /

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,14 +1,11 @@
+# current directory must be ./dist
+
 FROM golang:latest AS golang
 ENV GOPROXY=https://goproxy.io,direct
 RUN CGO_ENABLED=0 go get -ldflags '-s -w -extldflags -static' github.com/go-delve/delve/cmd/dlv
-
-FROM alpine:latest as alpine
-RUN apk add -U --no-cache ca-certificates
-# current directory must be ./dist
 
 FROM gcr.io/distroless/static:nonroot
 ARG PKG_FILES
 WORKDIR /
 COPY --from=golang /go/bin/dlv /
-COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY /$PKG_FILES /


### PR DESCRIPTION
# Description

The production Dockerfile (and the debug one) are currently copying the ca-certs bundle from the Alpine image. This seems to be a leftover from [when the base image was "scratch"](https://github.com/dapr/dapr/commit/5a5ad32661fc1c91d4f7cc02b7e3060bf36171ce#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddc).

As we are now using distroless for base images, copying the ca-certs bundle isn't necessary anymore: the distroless images do contain their own CA certificates, which are maintained by Google.

This change should help streamlining our production Docker images, also simplifying the analysis of the software supply chain that ends up in our binaries.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Docker images build
* [x] End-to-end tests passing