### PR TITLE
Add Windows Dockerfile for gRPC resiliency app

### DIFF
--- a/tests/apps/resiliencyapp/Dockerfile-windows
+++ b/tests/apps/resiliencyapp/Dockerfile-windows
@@ -1,0 +1,21 @@
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM golang:1.17-nanoserver
+
+WORKDIR /app
+COPY . .
+RUN go get -d -v
+RUN go build -o app.exe .
+
+CMD ["app.exe"]

--- a/tests/apps/resiliencyapp_grpc/Dockerfile-windows
+++ b/tests/apps/resiliencyapp_grpc/Dockerfile-windows
@@ -1,0 +1,21 @@
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM golang:1.17-nanoserver
+
+WORKDIR /app
+COPY . .
+RUN go get -d -v
+RUN go build -o app.exe .
+
+CMD ["app.exe"]


### PR DESCRIPTION
# Description

The gRPC proxy test app has a custom go.mod to bring in some
example code. It needs a dockerfile to build successfully but did
not have one for windows.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: Resiliency Chore

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
