### PR TITLE
Hide sensitive data in e2e test logs

### DIFF
--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -13,29 +13,55 @@ limitations under the License.
 
 package kubernetes
 
+import (
+	"encoding/json"
+)
+
 // AppDescription holds the deployment information of test app.
 type AppDescription struct {
-	AppName           string
-	AppPort           int
-	AppProtocol       string
-	AppEnv            map[string]string
-	DaprEnabled       bool
-	ImageName         string
-	ImageSecret       string
-	RegistryName      string
-	Replicas          int32
-	IngressEnabled    bool
-	MetricsEnabled    bool // This controls the setting for the dapr.io/enable-metrics annotation
-	MetricsPort       string
-	Config            string
-	AppCPULimit       string
-	AppCPURequest     string
-	AppMemoryLimit    string
-	AppMemoryRequest  string
-	DaprCPULimit      string
-	DaprCPURequest    string
-	DaprMemoryLimit   string
-	DaprMemoryRequest string
-	Namespace         *string
-	IsJob             bool
+	AppName           string            `json:",omitempty"`
+	AppPort           int               `json:",omitempty"`
+	AppProtocol       string            `json:",omitempty"`
+	AppEnv            map[string]string `json:",omitempty"`
+	DaprEnabled       bool              `json:",omitempty"`
+	ImageName         string            `json:",omitempty"`
+	ImageSecret       string            `json:",omitempty"`
+	RegistryName      string            `json:",omitempty"`
+	Replicas          int32             `json:",omitempty"`
+	IngressEnabled    bool              `json:",omitempty"`
+	MetricsEnabled    bool              `json:",omitempty"` // This controls the setting for the dapr.io/enable-metrics annotation
+	MetricsPort       string            `json:",omitempty"`
+	Config            string            `json:",omitempty"`
+	AppCPULimit       string            `json:",omitempty"`
+	AppCPURequest     string            `json:",omitempty"`
+	AppMemoryLimit    string            `json:",omitempty"`
+	AppMemoryRequest  string            `json:",omitempty"`
+	DaprCPULimit      string            `json:",omitempty"`
+	DaprCPURequest    string            `json:",omitempty"`
+	DaprMemoryLimit   string            `json:",omitempty"`
+	DaprMemoryRequest string            `json:",omitempty"`
+	Namespace         *string           `json:",omitempty"`
+	IsJob             bool              `json:",omitempty"`
+}
+
+func (a AppDescription) String() string {
+	// AppDescription objects can contain credentials in ImageSecret which should not be exposed in logs.
+	// This method overrides the default stringifier to use the custom JSON stringifier which hides ImageSecret
+	j, _ := json.Marshal(a)
+	return string(j)
+}
+
+func (a AppDescription) MarshalJSON() ([]byte, error) {
+	imageSecret := a.ImageSecret
+	if imageSecret != "" {
+		imageSecret = "***"
+	}
+	type Alias AppDescription
+	return json.Marshal(&struct {
+		ImageSecret string `json:",omitempty"`
+		*Alias
+	}{
+		Alias:       (*Alias)(&a),
+		ImageSecret: imageSecret,
+	})
 }

--- a/tests/platforms/kubernetes/app_description_test.go
+++ b/tests/platforms/kubernetes/app_description_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppDescription_MarshalJSON(t *testing.T) {
+	t.Run("no secret", func(t *testing.T) {
+		a := AppDescription{
+			AppName:     "testapp",
+			ImageSecret: "",
+		}
+		want := `{"AppName":"testapp"}`
+		res, err := a.MarshalJSON()
+		if err != nil {
+			t.Errorf("AppDescription.MarshalJSON() error = %v", err)
+			return
+		}
+		if !reflect.DeepEqual(string(res), want) {
+			t.Errorf("AppDescription.MarshalJSON() = %v, want %v", string(res), want)
+		}
+	})
+	t.Run("hide secret", func(t *testing.T) {
+		a := AppDescription{
+			AppName:     "testapp",
+			ImageSecret: "SECRETVALUE",
+		}
+		want := `{"ImageSecret":"***","AppName":"testapp"}`
+		res, err := a.MarshalJSON()
+		if err != nil {
+			t.Errorf("AppDescription.MarshalJSON() error = %v", err)
+			return
+		}
+		if !reflect.DeepEqual(string(res), want) {
+			t.Errorf("AppDescription.MarshalJSON() = %v, want %v", string(res), want)
+		}
+	})
+}


### PR DESCRIPTION
# Description

In E2E tests, the `AppDescription` object can contain sensitive data in the `ImageSecret` property, which contains base64-encoded (so, not encrypted) credentials for Docker registries. These were often printed out in the logs during E2E tests; this PR changes the marshallers to hide them.

Note: `ImageSecret` is NOT used in the e2e tests in this repo.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing