### PR TITLE
Improvements to E2E tests

### DIFF
--- a/tests/config/mongodb_override.yaml
+++ b/tests/config/mongodb_override.yaml
@@ -17,3 +17,16 @@ persistentVolume:
   enabled: false
 tls:
   enabled: false
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/os
+            operator: In
+            values:
+            - linux
+          - key: kubernetes.io/arch
+            operator: In
+            values:
+            - amd64

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -49,7 +49,7 @@ type StateTransactionKeyValue struct {
 	OperationType string
 }
 
-var httpClient = newHTTPClient()
+var httpClient = newHTTPClient(0)
 
 // GenerateRandomStringKeys generates random string keys (values are nil).
 func GenerateRandomStringKeys(num int) []SimpleKeyValue {
@@ -84,21 +84,20 @@ func GenerateRandomStringKeyValues(num int) []SimpleKeyValue {
 	return GenerateRandomStringValues(keys)
 }
 
-func newHTTPClient() http.Client {
-	doOnce.Do(func() {
-		defaultClient = http.Client{
-			Timeout: time.Second * 15,
-			Transport: &http.Transport{
-				// Sometimes, the first connection to ingress endpoint takes longer than 1 minute (e.g. AKS)
-				Dial: (&net.Dialer{
-					Timeout:   5 * time.Minute,
-					KeepAlive: 6 * time.Minute,
-				}).Dial,
-			},
-		}
-	})
-
-	return defaultClient
+func newHTTPClient(t time.Duration) http.Client {
+	if t == 0 {
+		t = time.Second * 15
+	}
+	return http.Client{
+		Timeout: t,
+		Transport: &http.Transport{
+			// Sometimes, the first connection to ingress endpoint takes longer than 1 minute (e.g. AKS)
+			Dial: (&net.Dialer{
+				Timeout:   5 * time.Minute,
+				KeepAlive: 6 * time.Minute,
+			}).Dial,
+		},
+	}
 }
 
 // HTTPGetNTimes calls the url n times and returns the first success
@@ -168,10 +167,11 @@ func HTTPGetRawNTimes(url string, n int) (*http.Response, error) {
 
 // HTTPGetRaw is a helper to make GET request call to url.
 func httpGetRaw(url string, t time.Duration) (*http.Response, error) {
+	client := httpClient
 	if t != 0 {
-		httpClient.Timeout = t
+		client = newHTTPClient(t)
 	}
-	resp, err := httpClient.Get(sanitizeHTTPURL(url))
+	resp, err := client.Get(sanitizeHTTPURL(url))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -20,15 +20,9 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	guuid "github.com/google/uuid"
-)
-
-var (
-	doOnce        sync.Once
-	defaultClient http.Client
 )
 
 // DefaultProbeTimeout is the a timeout used in HTTPGetNTimes() and

--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -278,7 +278,9 @@ func (m *AppManager) WaitUntilDeploymentState(isState func(*appsv1.Deployment, e
 
 	waitErr := wait.PollImmediate(PollInterval, PollTimeout, func() (bool, error) {
 		var err error
-		lastDeployment, err = deploymentsClient.Get(context.TODO(), m.app.AppName, metav1.GetOptions{})
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		lastDeployment, err = deploymentsClient.Get(ctx, m.app.AppName, metav1.GetOptions{})
 		done := isState(lastDeployment, err)
 		if !done && err != nil {
 			return true, err
@@ -337,7 +339,10 @@ func (m *AppManager) IsJobCompleted(job *batchv1.Job, err error) bool {
 
 // IsDeploymentDone returns true if deployment object completes pod deployments.
 func (m *AppManager) IsDeploymentDone(deployment *appsv1.Deployment, err error) bool {
-	return err == nil && deployment.Generation == deployment.Status.ObservedGeneration && deployment.Status.ReadyReplicas == m.app.Replicas && deployment.Status.AvailableReplicas == m.app.Replicas
+	return err == nil &&
+		deployment.Generation == deployment.Status.ObservedGeneration &&
+		deployment.Status.ReadyReplicas == m.app.Replicas &&
+		deployment.Status.AvailableReplicas == m.app.Replicas
 }
 
 // IsJobDeleted returns true if job does not exist.


### PR DESCRIPTION
# Description

1. Force MongoDB to be installed on Linux nodes when a cluster has Windows nodes too
2. Updated docs for running E2E tests:
   - Include the requirement to start MongoDB
   - Explain how to run some tests only
   - Explain how to generate DAPR_TEST_REGISTRY_SECRET if needed
   - Other minor fixes and Improvements
3. Small improvement to `AppManager.WaitUntilDeploymentState` that should help avoiding the method to hang in rare cases
4. In `tests/e2e/utils/helpers.go`, avoid modifying a global object

## Issue reference

This PR was the result of the investigation for #4375

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing