### PR TITLE
Add e2e tests for actor resiliency

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -403,27 +403,38 @@ func (a *actorsRuntime) callLocalActor(ctx context.Context, req *invokev1.Invoke
 	defer act.unlock()
 
 	// Replace method to actors method.
+	originalMethod := req.Message().Method
 	req.Message().Method = fmt.Sprintf("actors/%s/%s/method/%s", actorTypeID.GetActorType(), actorTypeID.GetActorId(), req.Message().Method)
+
+	// Reset the method so we can perform retries.
+	defer func() { req.Message().Method = originalMethod }()
+
 	// Original code overrides method with PUT. Why?
 	if req.Message().GetHttpExtension() == nil {
 		req.WithHTTPExtension(nethttp.MethodPut, "")
 	} else {
 		req.Message().HttpExtension.Verb = commonv1pb.HTTPExtension_PUT
 	}
-	resp, err := a.appChannel.InvokeMethod(ctx, req)
+
+	policy := a.resiliency.ActorPostLockPolicy(ctx, act.actorType, act.actorID)
+	var resp *invokev1.InvokeMethodResponse
+	err = policy(func(ctx context.Context) (rErr error) {
+		resp, rErr = a.appChannel.InvokeMethod(ctx, req)
+		return rErr
+	})
+
 	if err != nil {
 		return nil, err
 	}
 
 	_, respData := resp.RawData()
-
 	if resp.Status().Code != nethttp.StatusOK {
 		return nil, errors.Errorf("error from actor service: %s", string(respData))
 	}
 
 	// The .NET SDK signifies Actor failure via a header instead of a bad response.
 	if _, ok := resp.Headers()["X-Daprerrorresponseheader"]; ok {
-		return nil, errors.Errorf("Error from a .NET Actor")
+		return nil, errors.Errorf("error from a .NET actor")
 	}
 
 	return resp, nil
@@ -860,7 +871,7 @@ func (a *actorsRuntime) executeReminder(reminder *Reminder) error {
 	req.WithActor(reminder.ActorType, reminder.ActorID)
 	req.WithRawData(b, invokev1.JSONContentType)
 
-	policy := a.resiliency.ActorPolicy(context.Background(), reminder.ActorType, reminder.ActorID)
+	policy := a.resiliency.ActorPreLockPolicy(context.Background(), reminder.ActorType, reminder.ActorID)
 	return policy(func(ctx context.Context) error {
 		_, err := a.callLocalActor(context.Background(), req)
 		return err
@@ -1220,7 +1231,7 @@ func (a *actorsRuntime) executeTimer(actorType, actorID, name, dueTime, period, 
 	req.WithActor(actorType, actorID)
 	req.WithRawData(b, invokev1.JSONContentType)
 
-	policy := a.resiliency.ActorPolicy(context.Background(), actorType, actorID)
+	policy := a.resiliency.ActorPreLockPolicy(context.Background(), actorType, actorID)
 	err = policy(func(ctx context.Context) error {
 		_, err = a.callLocalActor(ctx, req)
 		return err

--- a/pkg/actors/actors_mock.go
+++ b/pkg/actors/actors_mock.go
@@ -238,8 +238,7 @@ type FailingActors struct {
 }
 
 func (f *FailingActors) Call(ctx context.Context, req *v1.InvokeMethodRequest) (*v1.InvokeMethodResponse, error) {
-	err := f.Failure.PerformFailure(req.Actor().ActorId)
-	if err != nil {
+	if err := f.Failure.PerformFailure(req.Actor().ActorId); err != nil {
 		return nil, err
 	}
 	resp := v1.NewInvokeMethodResponse(200, "Success", nil)

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -84,6 +84,11 @@ var testResiliency = &v1alpha1.Resiliency{
 			},
 		},
 		Targets: v1alpha1.Targets{
+			Actors: map[string]v1alpha1.ActorPolicyNames{
+				"failingActorType": {
+					Timeout: "fast",
+				},
+			},
 			Components: map[string]v1alpha1.ComponentPolicyNames{
 				"failStore": {
 					Outbound: v1alpha1.PolicyNames{
@@ -2154,7 +2159,7 @@ func TestReentrancyStackLimitPerActor(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestActorsRuntimeResliency(t *testing.T) {
+func TestActorsRuntimeResiliency(t *testing.T) {
 	actorType := "failingActor"
 	actorID := "failingId"
 	failingState := &daprt.FailingStatestore{
@@ -2173,13 +2178,37 @@ func TestActorsRuntimeResliency(t *testing.T) {
 			CallCount: map[string]int{},
 		},
 	}
-	failingAppChannel := &daprt.FailingAppChannel{}
+	failingAppChannel := &daprt.FailingAppChannel{
+		Failure: daprt.Failure{
+			Timeouts: map[string]time.Duration{
+				"timeoutId": time.Second * 10,
+			},
+			CallCount: map[string]int{},
+		},
+		KeyFunc: func(req *invokev1.InvokeMethodRequest) string {
+			return req.Actor().ActorId
+		},
+	}
 	builder := runtimeBuilder{
 		appChannel:     failingAppChannel,
 		actorStore:     failingState,
 		actorStoreName: "failStore",
 	}
 	runtime := builder.buildActorRuntime()
+
+	t.Run("callLocalActor times out with resiliency", func(t *testing.T) {
+		req := invokev1.NewInvokeMethodRequest("actorMethod")
+		req.WithActor("failingActorType", "timeoutId")
+
+		start := time.Now()
+		resp, err := runtime.callLocalActor(context.Background(), req)
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, 1, failingAppChannel.Failure.CallCount["timeoutId"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
 
 	t.Run("test get state retries with resiliency", func(t *testing.T) {
 		req := &GetStateRequest{

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -1702,19 +1702,6 @@ func TestV1ActorEndpoints(t *testing.T) {
 		assert.Equal(t, 2, failingActors.Failure.CallCount["failingId"])
 	})
 
-	t.Run("Direct Message - times out with resiliency", func(t *testing.T) {
-		testAPI.actor = failingActors
-
-		apiPath := fmt.Sprintf("v1.0/actors/failingActorType/%s/method/method1", "timeoutId")
-		start := time.Now()
-		resp := fakeServer.DoRequest("POST", apiPath, nil, nil)
-		end := time.Now()
-
-		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingActors.Failure.CallCount["timeoutId"])
-		assert.Less(t, end.Sub(start), time.Second*10)
-	})
-
 	fakeServer.Shutdown()
 }
 

--- a/pkg/resiliency/noop.go
+++ b/pkg/resiliency/noop.go
@@ -37,8 +37,15 @@ func (*NoOp) EndpointPolicy(ctx context.Context, service string, endpoint string
 	}
 }
 
-// ActorPolicy returns a NoOp policy runner for an actor instance.
-func (*NoOp) ActorPolicy(ctx context.Context, actorType string, id string) Runner {
+// ActorPreLockPolicy returns a NoOp policy runner for an actor instance.
+func (*NoOp) ActorPreLockPolicy(ctx context.Context, actorType string, id string) Runner {
+	return func(oper Operation) error {
+		return oper(ctx)
+	}
+}
+
+// ActorPostLockPolicy returns a NoOp policy runner for an actor instance.
+func (*NoOp) ActorPostLockPolicy(ctx context.Context, actorType string, id string) Runner {
 	return func(oper Operation) error {
 		return oper(ctx)
 	}

--- a/pkg/resiliency/noop_test.go
+++ b/pkg/resiliency/noop_test.go
@@ -59,13 +59,13 @@ func TestNoOp(t *testing.T) {
 		{
 			name: "actor",
 			fn: func(ctx context.Context) Runner {
-				return policy.ActorPolicy(ctx, "test", "test")
+				return policy.ActorPreLockPolicy(ctx, "test", "test")
 			},
 		},
 		{
 			name: "actor error",
 			fn: func(ctx context.Context) Runner {
-				return policy.ActorPolicy(ctx, "test", "test")
+				return policy.ActorPreLockPolicy(ctx, "test", "test")
 			},
 			err: errors.New("actor error"),
 		},

--- a/pkg/resiliency/resiliency.go
+++ b/pkg/resiliency/resiliency.go
@@ -62,8 +62,10 @@ type (
 	Provider interface {
 		// EndpointPolicy returns the policy for a service endpoint.
 		EndpointPolicy(ctx context.Context, service string, endpoint string) Runner
-		// ActorPolicy returns the policy for an actor instance.
-		ActorPolicy(ctx context.Context, actorType string, id string) Runner
+		// ActorPolicy returns the policy for an actor instance to be used before the lock is acquired.
+		ActorPreLockPolicy(ctx context.Context, actorType string, id string) Runner
+		// ActorPolicy returns the policy for an actor instance to be used after the lock is acquired.
+		ActorPostLockPolicy(ctx context.Context, actorType string, id string) Runner
 		// ComponentOutboundPolicy returns the outbound policy for a component.
 		ComponentOutboundPolicy(ctx context.Context, name string) Runner
 		// ComponentInboundPolicy returns the inbound policy for a component.
@@ -85,9 +87,8 @@ type (
 		componentCBs  *circuitBreakerInstances
 
 		apps       map[string]PolicyNames
-		actors     map[string]ActorPolicyNames
+		actors     map[string]ActorPolicies
 		components map[string]ComponentPolicyNames
-		routes     map[string]PolicyNames
 	}
 
 	// circuitBreakerInstances stores circuit breaker state for components
@@ -111,10 +112,22 @@ type (
 		CircuitBreaker string
 	}
 
-	// ActorPolicyNames add the circuit breaker scope to PolicyNames.
-	ActorPolicyNames struct {
-		PolicyNames
+	// Actors have different behavior before and after locking.
+	ActorPolicies struct {
+		PreLockPolicies  ActorPreLockPolicyNames
+		PostLockPolicies ActorPostLockPolicyNames
+	}
+
+	// Policy used before an actor is locked. It does not include a timeout as we want to wait forever for the actor.
+	ActorPreLockPolicyNames struct {
+		Retry               string
+		CircuitBreaker      string
 		CircuitBreakerScope ActorCircuitBreakerScope
+	}
+
+	// Policy used after an actor is locked. It only uses timeout as retry/circuit breaker is handled before locking.
+	ActorPostLockPolicyNames struct {
+		Timeout string
 	}
 )
 
@@ -210,9 +223,8 @@ func New(log logger.Logger) *Resiliency {
 			cbs: make(map[string]*breaker.CircuitBreaker, 10),
 		},
 		apps:       make(map[string]PolicyNames),
-		actors:     make(map[string]ActorPolicyNames),
+		actors:     make(map[string]ActorPolicies),
 		components: make(map[string]ComponentPolicyNames),
-		routes:     make(map[string]PolicyNames),
 	}
 }
 
@@ -285,18 +297,38 @@ func (r *Resiliency) decodeTargets(c *resiliency_v1alpha.Resiliency) (err error)
 	}
 
 	for name, t := range targets.Actors {
-		scope, err := ParseActorCircuitBreakerScope(t.CircuitBreakerScope)
-		if err != nil {
-			return err
+		if t.CircuitBreakerScope == "" && t.CircuitBreaker != "" {
+			return fmt.Errorf("actor circuit breakers must include scope")
 		}
-		r.actors[name] = ActorPolicyNames{
-			PolicyNames: PolicyNames{
-				Timeout:        t.Timeout,
-				Retry:          t.Retry,
-				CircuitBreaker: t.CircuitBreaker,
-			},
-			CircuitBreakerScope: scope,
+
+		if t.CircuitBreaker != "" {
+			scope, cErr := ParseActorCircuitBreakerScope(t.CircuitBreakerScope)
+			if cErr != nil {
+				return cErr
+			}
+
+			r.actors[name] = ActorPolicies{
+				PreLockPolicies: ActorPreLockPolicyNames{
+					Retry:               t.Retry,
+					CircuitBreaker:      t.CircuitBreaker,
+					CircuitBreakerScope: scope,
+				},
+				PostLockPolicies: ActorPostLockPolicyNames{
+					Timeout: t.Timeout,
+				},
+			}
+		} else {
+			r.actors[name] = ActorPolicies{
+				PreLockPolicies: ActorPreLockPolicyNames{
+					Retry:          t.Retry,
+					CircuitBreaker: "",
+				},
+				PostLockPolicies: ActorPostLockPolicyNames{
+					Timeout: t.Timeout,
+				},
+			}
 		}
+
 		if t.CircuitBreakerCacheSize == 0 {
 			t.CircuitBreakerCacheSize = defaultActorCacheSize
 		}
@@ -368,8 +400,8 @@ func (r *Resiliency) EndpointPolicy(ctx context.Context, app string, endpoint st
 	return Policy(ctx, r.log, operationName, t, rc, cb)
 }
 
-// ActorPolicy returns the policy for an actor instance.
-func (r *Resiliency) ActorPolicy(ctx context.Context, actorType string, id string) Runner {
+// ActorPreLockPolicy returns the policy for an actor instance to be used before an actor lock is acquired.
+func (r *Resiliency) ActorPreLockPolicy(ctx context.Context, actorType string, id string) Runner {
 	var t time.Duration
 	var rc *retry.Config
 	var cb *breaker.CircuitBreaker
@@ -377,11 +409,8 @@ func (r *Resiliency) ActorPolicy(ctx context.Context, actorType string, id strin
 	if r == nil {
 		return Policy(ctx, r.log, operationName, t, rc, cb)
 	}
-	policyNames, ok := r.actors[actorType]
-	if ok {
-		if policyNames.Timeout != "" {
-			t = r.timeouts[policyNames.Timeout]
-		}
+	actorPolicies, ok := r.actors[actorType]
+	if policyNames := actorPolicies.PreLockPolicies; ok {
 		if policyNames.Retry != "" {
 			rc = r.retries[policyNames.Retry]
 		}
@@ -413,6 +442,25 @@ func (r *Resiliency) ActorPolicy(ctx context.Context, actorType string, id strin
 					}
 				}
 			}
+		}
+	}
+
+	return Policy(ctx, r.log, operationName, t, rc, cb)
+}
+
+// ActorPostLockPolicy returns the policy for an actor instance to be used after an actor lock is acquired.
+func (r *Resiliency) ActorPostLockPolicy(ctx context.Context, actorType string, id string) Runner {
+	var t time.Duration
+	var rc *retry.Config
+	var cb *breaker.CircuitBreaker
+	operationName := fmt.Sprintf("actor[%s, %s]", actorType, id)
+	if r == nil {
+		return Policy(ctx, r.log, operationName, t, rc, cb)
+	}
+	actorPolicies, ok := r.actors[actorType]
+	if policyNames := actorPolicies.PostLockPolicies; ok {
+		if policyNames.Timeout != "" {
+			t = r.timeouts[policyNames.Timeout]
 		}
 	}
 

--- a/pkg/resiliency/resiliency_test.go
+++ b/pkg/resiliency/resiliency_test.go
@@ -184,7 +184,13 @@ func TestPoliciesForTargets(t *testing.T) {
 		{
 			name: "actor",
 			create: func(r *Resiliency) Runner {
-				return r.ActorPolicy(ctx, "myActorType", "id")
+				return r.ActorPreLockPolicy(ctx, "myActorType", "id")
+			},
+		},
+		{
+			name: "actor post lock",
+			create: func(r *Resiliency) Runner {
+				return r.ActorPostLockPolicy(ctx, "myActorType", "id")
 			},
 		},
 	}

--- a/tests/apps/resiliencyapp/app.go
+++ b/tests/apps/resiliencyapp/app.go
@@ -67,6 +67,16 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func healthz(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func unknownHandler(w http.ResponseWriter, r *http.Request) {
+	// Just some debugging, if this is printed the app isn't setup correctly.
+	log.Printf("Unknown route called: %s", r.RequestURI)
+	w.WriteHeader(http.StatusNotFound)
+}
+
 func configureSubscribeHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println("/dapr/subscribe called")
 
@@ -82,6 +92,22 @@ func configureSubscribeHandler(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	b, err := json.Marshal(subscriptions)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(b)
+}
+
+func actorConfigHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println("/dapr/config called")
+	daprConfig := struct {
+		Entities []string
+	}{
+		Entities: []string{"resiliencyActor"},
+	}
+
+	b, err := json.Marshal(daprConfig)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -202,6 +228,34 @@ func resiliencyServiceInvocationHandler(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 }
 
+func resiliencyActorMethodHandler(w http.ResponseWriter, r *http.Request) {
+	var message FailureMessage
+	json.NewDecoder(r.Body).Decode(&message)
+
+	log.Printf("Actor received message %+v\n", message)
+
+	callCount := 0
+	if records, ok := callTracking[message.ID]; ok {
+		callCount = records[len(records)-1].Count + 1
+	}
+
+	log.Printf("Seen %s %d times.", message.ID, callCount)
+
+	callTracking[message.ID] = append(callTracking[message.ID], CallRecord{Count: callCount, TimeSeen: time.Now()})
+	if message.MaxFailureCount != nil && callCount < *message.MaxFailureCount {
+		if message.Timeout != nil {
+			// This request can still succeed if the resiliency policy timeout is longer than this sleep.
+			log.Printf("Sleeping: %v", *message.Timeout)
+			time.Sleep(*message.Timeout)
+		} else {
+			log.Println("Forcing failure.")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 // App startup/endpoint setup.
 func initGRPCClient() {
 	url := fmt.Sprintf("localhost:%d", 50001)
@@ -228,11 +282,11 @@ func initGRPCClient() {
 
 func newHTTPClient() *http.Client {
 	dialer := &net.Dialer{ //nolint:exhaustivestruct
-		Timeout: 5 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 	netTransport := &http.Transport{ //nolint:exhaustivestruct
 		DialContext:         dialer.DialContext,
-		TLSHandshakeTimeout: 5 * time.Second,
+		TLSHandshakeTimeout: 30 * time.Second,
 	}
 
 	return &http.Client{ //nolint:exhaustivestruct
@@ -248,11 +302,14 @@ func appRouter() *mux.Router {
 
 	// Calls from dapr.
 	router.HandleFunc("/dapr/subscribe", configureSubscribeHandler).Methods("GET")
+	router.HandleFunc("/dapr/config", actorConfigHandler).Methods("GET")
+	router.HandleFunc("/healthz", healthz).Methods("GET")
 
 	// Handling events/methods.
 	router.HandleFunc("/resiliencybinding", resiliencyBindingHandler).Methods("POST", "OPTIONS")
 	router.HandleFunc("/resiliency-topic-http", resiliencyPubsubHandler).Methods("POST")
 	router.HandleFunc("/resiliencyInvocation", resiliencyServiceInvocationHandler).Methods("POST")
+	router.HandleFunc("/actors/{actorType}/{id}/method/{method}", resiliencyActorMethodHandler).Methods("PUT")
 
 	// Test functions.
 	router.HandleFunc("/tests/getCallCount", TestGetCallCount).Methods("GET")
@@ -260,6 +317,9 @@ func appRouter() *mux.Router {
 	router.HandleFunc("/tests/invokeBinding/{binding}", TestInvokeOutputBinding).Methods("POST")
 	router.HandleFunc("/tests/publishMessage/{pubsub}/{topic}", TestPublishMessage).Methods("POST")
 	router.HandleFunc("/tests/invokeService/{protocol}", TestInvokeService).Methods("POST")
+	router.HandleFunc("/tests/invokeActor/{protocol}", TestInvokeActorMethod).Methods("POST")
+
+	router.NotFoundHandler = router.NewRoute().HandlerFunc(unknownHandler).GetHandler()
 
 	router.Use(mux.CORSMethodMiddleware(router))
 
@@ -438,4 +498,50 @@ func TestInvokeService(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+}
+
+func TestInvokeActorMethod(w http.ResponseWriter, r *http.Request) {
+	protocol := mux.Vars(r)["protocol"]
+	log.Printf("Invoking resiliency actor with %s", protocol)
+
+	if protocol == "http" {
+		client := &http.Client{
+			Timeout: 1 * time.Minute,
+		}
+		url := "http://localhost:3500/v1.0/actors/resiliencyActor/1/method/resiliencyMethod"
+
+		req, _ := http.NewRequest("PUT", url, r.Body)
+		defer r.Body.Close()
+
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Printf("An error occurred calling actors: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(resp.StatusCode)
+	} else if protocol == "grpc" {
+		var message FailureMessage
+		err := json.NewDecoder(r.Body).Decode(&message)
+		if err != nil {
+			log.Println("Could not parse message.")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		b, _ := json.Marshal(message)
+
+		req := &runtimev1pb.InvokeActorRequest{
+			ActorType: "resiliencyActor",
+			ActorId:   "1",
+			Method:    "resiliencyMethod",
+			Data:      b,
+		}
+
+		_, err = daprClient.InvokeActor(r.Context(), req)
+		if err != nil {
+			log.Printf("An error occurred calling actors: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
 }

--- a/tests/config/resiliency.yaml
+++ b/tests/config/resiliency.yaml
@@ -31,6 +31,11 @@ spec:
         timeout: fast
         retry: fiveRetries
 
+    actors:
+      resiliencyActor:
+        timeout: fast
+        retry: fiveRetries
+
     components:
       dapr-resiliency-binding:
         inbound: 

--- a/tests/e2e/resiliency/resiliency_test.go
+++ b/tests/e2e/resiliency/resiliency_test.go
@@ -393,6 +393,104 @@ func TestServiceInvocationResiliency(t *testing.T) {
 	}
 }
 
+func TestActorResiliency(t *testing.T) {
+	recoverableErrorCount := 3
+	failingErrorCount := 10
+	recoverableTimeout := time.Second * 2
+	testCases := []struct {
+		Name         string
+		FailureCount *int
+		Timeout      *time.Duration
+		shouldFail   bool
+		protocol     string
+	}{
+		{
+			Name:         "Test invoking actor recovers from failure",
+			FailureCount: &recoverableErrorCount,
+			shouldFail:   false,
+			protocol:     "http",
+		},
+		{
+			Name:         "Test invoking actor recovers from timeout",
+			FailureCount: &recoverableErrorCount,
+			Timeout:      &recoverableTimeout,
+			shouldFail:   false,
+			protocol:     "http",
+		},
+		{
+			Name:         "Test exhausting retries leads to failure",
+			FailureCount: &failingErrorCount,
+			shouldFail:   true,
+			protocol:     "http",
+		},
+		{
+			Name:         "Test invoking actor with grpc recovers from failure",
+			FailureCount: &recoverableErrorCount,
+			shouldFail:   false,
+			protocol:     "grpc",
+		},
+		{
+			Name:         "Test invoking actor with grpc recovers from timeout",
+			FailureCount: &recoverableErrorCount,
+			Timeout:      &recoverableTimeout,
+			shouldFail:   false,
+			protocol:     "grpc",
+		},
+		{
+			Name:         "Test exhausting retries leads to failure in grpc actor call",
+			FailureCount: &failingErrorCount,
+			shouldFail:   true,
+			protocol:     "grpc",
+		},
+	}
+
+	// Get application URLs/wait for healthy.
+	externalURL := tr.Platform.AcquireAppExternalURL("resiliencyapp")
+	require.NotEmpty(t, externalURL, "resiliency external URL must not be empty!")
+	// This initial probe makes the test wait a little bit longer when needed,
+	// making this test less flaky due to delays in the deployment.
+	_, err := utils.HTTPGetNTimes(externalURL, numHealthChecks)
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			message := createFailureMessage(tc.FailureCount, tc.Timeout)
+			b, _ := json.Marshal(message)
+			_, code, err := utils.HTTPPostWithStatus(fmt.Sprintf("%s/tests/invokeActor/%s", externalURL, tc.protocol), b)
+			require.NoError(t, err)
+			if !tc.shouldFail {
+				require.Equal(t, 200, code)
+			} else {
+				require.Equal(t, 500, code)
+			}
+
+			// Let the binding propagate and give time for retries/timeout.
+			time.Sleep(time.Second * 5)
+
+			var callCount map[string][]CallRecord
+			resp, err := utils.HTTPGet(fmt.Sprintf("%s/tests/getCallCount", externalURL))
+			require.NoError(t, err)
+
+			json.Unmarshal(resp, &callCount)
+			if tc.shouldFail {
+				// First call + 5 retries and no more.
+				require.GreaterOrEqual(t, len(callCount[message.ID]), 6, fmt.Sprintf("Call count mismatch for message %s", message.ID))
+
+				// TODO: Remove this once we can control Kafka's retry count.
+				// We have to do this because we can't currently control Kafka's retries. So, we make sure that anything past the resiliency
+				// retries have a wide enough gap in them to be considered OK.
+				if len(callCount[message.ID]) > 6 {
+					// This is the default Kafka retry time. Our policy time is 10ms so it should be much faster.
+					require.Greater(t, callCount[message.ID][6].TimeSeen.Sub(callCount[message.ID][5].TimeSeen), time.Millisecond*100)
+				}
+			} else {
+				// First call + 3 retries and recovery.
+				require.Equal(t, 4, len(callCount[message.ID]), fmt.Sprintf("Call count mismatch for message %s", message.ID))
+			}
+		})
+	}
+}
+
 func createFailureMessage(maxFailure *int, timeout *time.Duration) FailureMessage {
 	message := FailureMessage{
 		ID: uuid.New().String(),


### PR DESCRIPTION
# Description

This commit adds some tests for actors using resiliency. It also
includes several fixes for actors as well as a change that splits
actor policies.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: Resiliency

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
