### PR TITLE
Stop tests on Azure while the infrastructure can't be used

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -14,10 +14,10 @@
 name: dapr-perf
 
 on:
-  schedule:
-    - cron: '0 */2 * * *'
-  repository_dispatch:
-    types: [perf-test]
+  #schedule:
+  #  - cron: '0 */2 * * *'
+  #repository_dispatch:
+  #  types: [perf-test]
   workflow_dispatch:
 jobs:
   test-perf:

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -14,10 +14,11 @@
 name: dapr-test
 
 on:
-  schedule:
-    - cron: '0 */2 * * *'
-  repository_dispatch:
-    types: [e2e-test]
+  #schedule:
+  #  - cron: '0 */2 * * *'
+  #repository_dispatch:
+  #  types: [e2e-test]
+  workflow_dispatch:
 
 jobs:
   test-e2e:


### PR DESCRIPTION
All tests that are running on Azure are currently failing because of a change in policy from MSIT.

This PR halts the e2e and perf tests until we can fix the test environment. There's no point in continuing to run tests if they're guaranteed to fail,  each time using 5 hours of compute time on GH Actions (which generate useless carbon emissions).