### PR TITLE
Add resiliency tests for gRPC and fix flaky test

### DIFF
--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -45,7 +45,9 @@ import (
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/components-contrib/state"
 	components_v1alpha "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
+	state_loader "github.com/dapr/dapr/pkg/components/state"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	diag_utils "github.com/dapr/dapr/pkg/diagnostics/utils"
@@ -70,6 +72,52 @@ const (
 	goodKey2            = "good-key2"
 	mockSubscribeID     = "mockId"
 )
+
+var testResiliency = &v1alpha1.Resiliency{
+	Spec: v1alpha1.ResiliencySpec{
+		Policies: v1alpha1.Policies{
+			Retries: map[string]v1alpha1.Retry{
+				"singleRetry": {
+					MaxRetries:  1,
+					MaxInterval: "100ms",
+					Policy:      "constant",
+					Duration:    "10ms",
+				},
+			},
+			Timeouts: map[string]string{
+				"fast": "100ms",
+			},
+		},
+		Targets: v1alpha1.Targets{
+			Apps: map[string]v1alpha1.EndpointPolicyNames{
+				"failingApp": {
+					Retry:   "singleRetry",
+					Timeout: "fast",
+				},
+			},
+			Components: map[string]v1alpha1.ComponentPolicyNames{
+				"failSecret": {
+					Outbound: v1alpha1.PolicyNames{
+						Retry:   "singleRetry",
+						Timeout: "fast",
+					},
+				},
+				"failStore": {
+					Outbound: v1alpha1.PolicyNames{
+						Retry:   "singleRetry",
+						Timeout: "fast",
+					},
+				},
+				"failConfig": {
+					Outbound: v1alpha1.PolicyNames{
+						Retry:   "singleRetry",
+						Timeout: "fast",
+					},
+				},
+			},
+		},
+	},
+}
 
 type mockGRPCAPI struct{}
 
@@ -2418,6 +2466,517 @@ func TestSubscribeConfigurationAlpha1(t *testing.T) {
 		assert.Equal(t, "val1", r.Items[0].Value)
 		assert.Equal(t, "key2", r.Items[1].Key)
 		assert.Equal(t, "val2", r.Items[1].Value)
+	})
+}
+
+func TestStateAPIWithResiliency(t *testing.T) {
+	failingStore := &daprt.FailingStatestore{
+		Failure: daprt.Failure{
+			Fails: map[string]int{
+				"failingGetKey":        1,
+				"failingSetKey":        1,
+				"failingDeleteKey":     1,
+				"failingBulkGetKey":    1,
+				"failingBulkSetKey":    1,
+				"failingBulkDeleteKey": 1,
+				"failingMultiKey":      1,
+				"failingQueryKey":      1,
+			},
+			Timeouts: map[string]time.Duration{
+				"timeoutGetKey":        time.Second * 10,
+				"timeoutSetKey":        time.Second * 10,
+				"timeoutDeleteKey":     time.Second * 10,
+				"timeoutBulkGetKey":    time.Second * 10,
+				"timeoutBulkSetKey":    time.Second * 10,
+				"timeoutBulkDeleteKey": time.Second * 10,
+				"timeoutMultiKey":      time.Second * 10,
+				"timeoutQueryKey":      time.Second * 10,
+			},
+			CallCount: map[string]int{},
+		},
+	}
+
+	state_loader.SaveStateConfiguration("failStore", map[string]string{"keyPrefix": "none"})
+
+	fakeAPI := &api{
+		id:                       "fakeAPI",
+		stateStores:              map[string]state.Store{"failStore": failingStore},
+		transactionalStateStores: map[string]state.TransactionalStore{"failStore": failingStore},
+		resiliency:               resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), testResiliency),
+	}
+	port, _ := freeport.GetFreePort()
+	server := startDaprAPIServer(port, fakeAPI, "")
+	defer server.Stop()
+
+	clientConn := createTestClient(port)
+	defer clientConn.Close()
+
+	client := runtimev1pb.NewDaprClient(clientConn)
+
+	t.Run("get state request retries with resiliency", func(t *testing.T) {
+		_, err := client.GetState(context.Background(), &runtimev1pb.GetStateRequest{
+			StoreName: "failStore",
+			Key:       "failingGetKey",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingGetKey"])
+	})
+
+	t.Run("get state request times out with resiliency", func(t *testing.T) {
+		start := time.Now()
+		_, err := client.GetState(context.Background(), &runtimev1pb.GetStateRequest{
+			StoreName: "failStore",
+			Key:       "timeoutGetKey",
+		})
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutGetKey"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+
+	t.Run("set state request retries with resiliency", func(t *testing.T) {
+		_, err := client.SaveState(context.Background(), &runtimev1pb.SaveStateRequest{
+			StoreName: "failStore",
+			States: []*commonv1pb.StateItem{
+				{
+					Key:   "failingSetKey",
+					Value: []byte("TestData"),
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingSetKey"])
+	})
+
+	t.Run("set state request times out with resiliency", func(t *testing.T) {
+		start := time.Now()
+		_, err := client.SaveState(context.Background(), &runtimev1pb.SaveStateRequest{
+			StoreName: "failStore",
+			States: []*commonv1pb.StateItem{
+				{
+					Key:   "timeoutSetKey",
+					Value: []byte("TestData"),
+				},
+			},
+		})
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutSetKey"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+
+	t.Run("delete state request retries with resiliency", func(t *testing.T) {
+		_, err := client.DeleteState(context.Background(), &runtimev1pb.DeleteStateRequest{
+			StoreName: "failStore",
+			Key:       "failingDeleteKey",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingDeleteKey"])
+	})
+
+	t.Run("delete state request times out with resiliency", func(t *testing.T) {
+		start := time.Now()
+		_, err := client.DeleteState(context.Background(), &runtimev1pb.DeleteStateRequest{
+			StoreName: "failStore",
+			Key:       "timeoutDeleteKey",
+		})
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutDeleteKey"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+
+	t.Run("bulk state get can recover from one bad key with resiliency retries", func(t *testing.T) {
+		_, err := client.GetBulkState(context.Background(), &runtimev1pb.GetBulkStateRequest{
+			StoreName: "failStore",
+			Keys:      []string{"failingBulkGetKey", "goodBulkGetKey"},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingBulkGetKey"])
+		assert.Equal(t, 1, failingStore.Failure.CallCount["goodBulkGetKey"])
+	})
+
+	t.Run("bulk state get times out on single with resiliency", func(t *testing.T) {
+		start := time.Now()
+		resp, err := client.GetBulkState(context.Background(), &runtimev1pb.GetBulkStateRequest{
+			StoreName: "failStore",
+			Keys:      []string{"timeoutBulkGetKey", "goodTimeoutBulkGetKey"},
+		})
+		end := time.Now()
+
+		assert.NoError(t, err)
+		assert.Len(t, resp.Items, 2)
+		for _, item := range resp.Items {
+			if item.Key == "timeoutBulkGetKey" {
+				assert.NotEmpty(t, item.Error)
+				assert.Contains(t, item.Error, "context deadline exceeded")
+			} else {
+				assert.Empty(t, item.Error)
+			}
+		}
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutBulkGetKey"])
+		assert.Equal(t, 1, failingStore.Failure.CallCount["goodTimeoutBulkGetKey"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+
+	t.Run("bulk state set recovers from single key failure with resiliency", func(t *testing.T) {
+		_, err := client.SaveState(context.Background(), &runtimev1pb.SaveStateRequest{
+			StoreName: "failStore",
+			States: []*commonv1pb.StateItem{
+				{
+					Key:   "failingBulkSetKey",
+					Value: []byte("TestData"),
+				},
+				{
+					Key:   "goodBulkSetKey",
+					Value: []byte("TestData"),
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingBulkSetKey"])
+		assert.Equal(t, 1, failingStore.Failure.CallCount["goodBulkSetKey"])
+	})
+
+	t.Run("bulk state set times out with resiliency", func(t *testing.T) {
+		start := time.Now()
+		_, err := client.SaveState(context.Background(), &runtimev1pb.SaveStateRequest{
+			StoreName: "failStore",
+			States: []*commonv1pb.StateItem{
+				{
+					Key:   "timeoutBulkSetKey",
+					Value: []byte("TestData"),
+				},
+				{
+					Key:   "goodTimeoutBulkSetKey",
+					Value: []byte("TestData"),
+				},
+			},
+		})
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutBulkSetKey"])
+		assert.Equal(t, 0, failingStore.Failure.CallCount["goodTimeoutBulkSetKey"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+
+	t.Run("state transaction passes after retries with resiliency", func(t *testing.T) {
+		_, err := client.ExecuteStateTransaction(context.Background(), &runtimev1pb.ExecuteStateTransactionRequest{
+			StoreName: "failStore",
+			Operations: []*runtimev1pb.TransactionalStateOperation{
+				{
+					OperationType: string(state.Delete),
+					Request: &commonv1pb.StateItem{
+						Key: "failingMultiKey",
+					},
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingMultiKey"])
+	})
+
+	t.Run("state transaction times out with resiliency", func(t *testing.T) {
+		_, err := client.ExecuteStateTransaction(context.Background(), &runtimev1pb.ExecuteStateTransactionRequest{
+			StoreName: "failStore",
+			Operations: []*runtimev1pb.TransactionalStateOperation{
+				{
+					OperationType: string(state.Delete),
+					Request: &commonv1pb.StateItem{
+						Key: "timeoutMultiKey",
+					},
+				},
+			},
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutMultiKey"])
+	})
+
+	t.Run("state query retries with resiliency", func(t *testing.T) {
+		_, err := client.QueryStateAlpha1(context.Background(), &runtimev1pb.QueryStateRequest{
+			StoreName: "failStore",
+			Query:     queryTestRequestOK,
+			Metadata:  map[string]string{"key": "failingQueryKey"},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingQueryKey"])
+	})
+
+	t.Run("state query times out with resiliency", func(t *testing.T) {
+		_, err := client.QueryStateAlpha1(context.Background(), &runtimev1pb.QueryStateRequest{
+			StoreName: "failStore",
+			Query:     queryTestRequestOK,
+			Metadata:  map[string]string{"key": "timeoutQueryKey"},
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutQueryKey"])
+	})
+}
+
+func TestConfigurationAPIWithResiliency(t *testing.T) {
+	failingConfigStore := daprt.FailingConfigurationStore{
+		Failure: daprt.Failure{
+			Fails: map[string]int{
+				"failingGetKey":         1,
+				"failingSubscribeKey":   1,
+				"failingUnsubscribeKey": 1,
+			},
+			Timeouts: map[string]time.Duration{
+				"timeoutGetKey":         time.Second * 10,
+				"timeoutSubscribeKey":   time.Second * 10,
+				"timeoutUnsubscribeKey": time.Second * 10,
+			},
+			CallCount: map[string]int{},
+		},
+	}
+
+	fakeAPI := &api{
+		id:                     "fakeAPI",
+		configurationStores:    map[string]configuration.Store{"failConfig": &failingConfigStore},
+		configurationSubscribe: map[string]chan struct{}{},
+		resiliency:             resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), testResiliency),
+	}
+	port, _ := freeport.GetFreePort()
+	server := startDaprAPIServer(port, fakeAPI, "")
+	defer server.Stop()
+
+	clientConn := createTestClient(port)
+	defer clientConn.Close()
+
+	client := runtimev1pb.NewDaprClient(clientConn)
+
+	t.Run("test get configuration retries with resiliency", func(t *testing.T) {
+		_, err := client.GetConfigurationAlpha1(context.Background(), &runtimev1pb.GetConfigurationRequest{
+			StoreName: "failConfig",
+			Keys:      []string{},
+			Metadata:  map[string]string{"key": "failingGetKey"},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["failingGetKey"])
+	})
+
+	t.Run("test get configuration fails due to timeout with resiliency", func(t *testing.T) {
+		_, err := client.GetConfigurationAlpha1(context.Background(), &runtimev1pb.GetConfigurationRequest{
+			StoreName: "failConfig",
+			Keys:      []string{},
+			Metadata:  map[string]string{"key": "timeoutGetKey"},
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["timeoutGetKey"])
+	})
+
+	t.Run("test subscribe configuration retries with resiliency", func(t *testing.T) {
+		resp, err := client.SubscribeConfigurationAlpha1(context.Background(), &runtimev1pb.SubscribeConfigurationRequest{
+			StoreName: "failConfig",
+			Keys:      []string{},
+			Metadata:  map[string]string{"key": "failingSubscribeKey"},
+		})
+		assert.NoError(t, err)
+
+		_, err = resp.Recv()
+		assert.NoError(t, err)
+		// Subscribe now calls Get first so we have an extra call.
+		assert.Equal(t, 3, failingConfigStore.Failure.CallCount["failingSubscribeKey"])
+	})
+
+	t.Run("test subscribe configuration fails due to timeout with resiliency", func(t *testing.T) {
+		resp, err := client.SubscribeConfigurationAlpha1(context.Background(), &runtimev1pb.SubscribeConfigurationRequest{
+			StoreName: "failConfig",
+			Keys:      []string{},
+			Metadata:  map[string]string{"key": "timeoutSubscribeKey"},
+		})
+		assert.NoError(t, err)
+
+		_, err = resp.Recv()
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["timeoutSubscribeKey"])
+	})
+
+	t.Run("test unsubscribe configuration retries with resiliency", func(t *testing.T) {
+		fakeAPI.configurationSubscribe["failingUnsubscribeKey"] = make(chan struct{})
+
+		_, err := client.UnsubscribeConfigurationAlpha1(context.Background(), &runtimev1pb.UnsubscribeConfigurationRequest{
+			StoreName: "failConfig",
+			Id:        "failingUnsubscribeKey",
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["failingUnsubscribeKey"])
+	})
+
+	t.Run("test unsubscribe configuration fails due to timeout with resiliency", func(t *testing.T) {
+		fakeAPI.configurationSubscribe["timeoutUnsubscribeKey"] = make(chan struct{})
+
+		_, err := client.UnsubscribeConfigurationAlpha1(context.Background(), &runtimev1pb.UnsubscribeConfigurationRequest{
+			StoreName: "failConfig",
+			Id:        "timeoutUnsubscribeKey",
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["timeoutUnsubscribeKey"])
+	})
+}
+
+func TestSecretAPIWithResiliency(t *testing.T) {
+	failingStore := daprt.FailingSecretStore{
+		Failure: daprt.Failure{
+			Fails:     map[string]int{"key": 1, "bulk": 1},
+			Timeouts:  map[string]time.Duration{"timeout": time.Second * 10, "bulkTimeout": time.Second * 10},
+			CallCount: map[string]int{},
+		},
+	}
+
+	// Setup Dapr API server
+	fakeAPI := &api{
+		id:           "fakeAPI",
+		secretStores: map[string]secretstores.SecretStore{"failSecret": failingStore},
+		resiliency:   resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), testResiliency),
+	}
+	// Run test server
+	port, _ := freeport.GetFreePort()
+	server := startDaprAPIServer(port, fakeAPI, "")
+	defer server.Stop()
+
+	// Create gRPC test client
+	clientConn := createTestClient(port)
+	defer clientConn.Close()
+
+	// act
+	client := runtimev1pb.NewDaprClient(clientConn)
+
+	t.Run("Get secret - retries on initial failure with resiliency", func(t *testing.T) {
+		_, err := client.GetSecret(context.Background(), &runtimev1pb.GetSecretRequest{
+			StoreName: "failSecret",
+			Key:       "key",
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["key"])
+	})
+
+	t.Run("Get secret - timeout before request ends", func(t *testing.T) {
+		// Store sleeps for 10 seconds, let's make sure our timeout takes less time than that.
+		start := time.Now()
+		_, err := client.GetSecret(context.Background(), &runtimev1pb.GetSecretRequest{
+			StoreName: "failSecret",
+			Key:       "timeout",
+		})
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["timeout"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+
+	t.Run("Get bulk secret - retries on initial failure with resiliency", func(t *testing.T) {
+		_, err := client.GetBulkSecret(context.Background(), &runtimev1pb.GetBulkSecretRequest{
+			StoreName: "failSecret",
+			Metadata:  map[string]string{"key": "bulk"},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["bulk"])
+	})
+
+	t.Run("Get bulk secret - timeout before request ends", func(t *testing.T) {
+		start := time.Now()
+		_, err := client.GetBulkSecret(context.Background(), &runtimev1pb.GetBulkSecretRequest{
+			StoreName: "failSecret",
+			Metadata:  map[string]string{"key": "bulkTimeout"},
+		})
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingStore.Failure.CallCount["bulkTimeout"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+}
+
+func TestServiceInvocationWithResiliency(t *testing.T) {
+	failingDirectMessaging := &daprt.FailingDirectMessaging{
+		Failure: daprt.Failure{
+			Fails: map[string]int{
+				"failingKey":      1,
+				"extraFailingKey": 3,
+			},
+			Timeouts: map[string]time.Duration{
+				"timeoutKey": time.Second * 10,
+			},
+			CallCount: map[string]int{},
+		},
+	}
+
+	// Setup Dapr API server
+	fakeAPI := &api{
+		id:              "fakeAPI",
+		directMessaging: failingDirectMessaging,
+		resiliency:      resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), testResiliency),
+	}
+
+	// Run test server
+	port, _ := freeport.GetFreePort()
+	server := startDaprAPIServer(port, fakeAPI, "")
+	defer server.Stop()
+
+	// Create gRPC test client
+	clientConn := createTestClient(port)
+	defer clientConn.Close()
+
+	// act
+	client := runtimev1pb.NewDaprClient(clientConn)
+
+	t.Run("Test invoke direct message retries with resiliency", func(t *testing.T) {
+		_, err := client.InvokeService(context.Background(), &runtimev1pb.InvokeServiceRequest{
+			Id: "failingApp",
+			Message: &commonv1pb.InvokeRequest{
+				Method: "test",
+				Data:   &anypb.Any{Value: []byte("failingKey")},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["failingKey"])
+	})
+
+	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {
+		start := time.Now()
+		_, err := client.InvokeService(context.Background(), &runtimev1pb.InvokeServiceRequest{
+			Id: "failingApp",
+			Message: &commonv1pb.InvokeRequest{
+				Method: "test",
+				Data:   &anypb.Any{Value: []byte("timeoutKey")},
+			},
+		})
+		end := time.Now()
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["timeoutKey"])
+		assert.Less(t, end.Sub(start), time.Second*10)
+	})
+
+	t.Run("Test invoke direct messages fails after exhausting retries", func(t *testing.T) {
+		_, err := client.InvokeService(context.Background(), &runtimev1pb.InvokeServiceRequest{
+			Id: "failingApp",
+			Message: &commonv1pb.InvokeRequest{
+				Method: "test",
+				Data:   &anypb.Any{Value: []byte("extraFailingKey")},
+			},
+		})
+
+		assert.Error(t, err)
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["extraFailingKey"])
 	})
 }
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -2840,7 +2840,7 @@ func TestV1StateEndpoints(t *testing.T) {
 
 		resp := fakeServer.DoRequest("DELETE", apiPath, nil, nil)
 		assert.Equal(t, 204, resp.StatusCode) // No body in the response.
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount["failingDeleteKey"])
 	})
 
 	t.Run("delete state request times out with resiliency", func(t *testing.T) {

--- a/pkg/resiliency/breaker/circuitbreaker_test.go
+++ b/pkg/resiliency/breaker/circuitbreaker_test.go
@@ -35,7 +35,7 @@ func TestCircuitBreaker(t *testing.T) {
 	cb := breaker.CircuitBreaker{ // nolint:exhaustivestruct
 		Name:    "test",
 		Trip:    &trip,
-		Timeout: 10 * time.Millisecond,
+		Timeout: 100 * time.Millisecond,
 	}
 	cb.Initialize(log)
 	for i := 0; i < 3; i++ {
@@ -47,7 +47,7 @@ func TestCircuitBreaker(t *testing.T) {
 		return nil
 	})
 	assert.EqualError(t, err, "circuit breaker is open")
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	err = cb.Execute(func() error {
 		return nil
 	})


### PR DESCRIPTION
# Description

This commit adds the tests the HTTP API has to the gRPC API. It also
fixes a flaky test for resiliency on windows.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: Resiliency

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
