### PR TITLE
fix build target clean-test-env

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -336,7 +336,7 @@ setup-test-components: setup-app-configurations
 # Clean up test environment
 clean-test-env:
 	./tests/test-infra/clean_up.sh $(DAPR_TEST_NAMESPACE)
-	./tests/test-infra/clean_up.sh $(DAPR_TEST_NAMESPACE)-2
+	./tests/test-infra/clean_up.sh $(DAPR_TEST_SECONDARY_NAMESPACE)
 
 # Setup kind
 setup-kind:


### PR DESCRIPTION
Signed-off-by: Sky Ao <aoxiaojian@gmail.com>

# Description

Since we define DAPR_TEST_SECONDARY_NAMESPACE and use in target create-test-namespace and delete-test-namespace, we should also use it in clean-test-env.

This is a small change. It should be typo or forget to change.

## Issue reference



## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
