### PR TITLE
Fix detection of OS where E2E tests are running on

### DIFF
--- a/tests/e2e/actor_sdks/actor_sdks_test.go
+++ b/tests/e2e/actor_sdks/actor_sdks_test.go
@@ -19,7 +19,6 @@ package actor_sdks_e2e
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
@@ -84,7 +83,7 @@ func TestMain(m *testing.M) {
 
 	// Disables PHP test for Windows temporarily due to issues with its Windows container.
 	// See https://github.com/dapr/dapr/issues/2953
-	if runtime.GOOS != "windows" {
+	if utils.TestTargetOS() != "windows" {
 		apps = append(apps,
 			kube.AppDescription{
 				AppName:          "actorphp",
@@ -106,7 +105,7 @@ func TestActorInvocationCrossSDKs(t *testing.T) {
 	actorTypes := []string{"DotNetCarActor", "JavaCarActor", "PythonCarActor"}
 	// Disables PHP test for Windows temporarily due to issues with its Windows container.
 	// See https://github.com/dapr/dapr/issues/2953
-	if runtime.GOOS != "windows" {
+	if utils.TestTargetOS() != "windows" {
 		actorTypes = append(actorTypes, "PHPCarActor")
 	}
 

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -19,16 +19,23 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"runtime"
 	"strings"
 	"time"
 
 	guuid "github.com/google/uuid"
 )
 
-// DefaultProbeTimeout is the a timeout used in HTTPGetNTimes() and
-// HTTPGetRawNTimes() to avoid cases where early requests hang and
-// block all subsequent requests.
-const DefaultProbeTimeout = 30 * time.Second
+const (
+	// DefaultProbeTimeout is the a timeout used in HTTPGetNTimes() and
+	// HTTPGetRawNTimes() to avoid cases where early requests hang and
+	// block all subsequent requests.
+	DefaultProbeTimeout = 30 * time.Second
+
+	// Environment variable for setting the target OS where tests are running on.
+	TargetOsEnvVar = "TARGET_OS"
+)
 
 // SimpleKeyValue can be used to simplify code, providing simple key-value pairs.
 type SimpleKeyValue struct {
@@ -262,4 +269,14 @@ func extractBody(r io.ReadCloser) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+// TestTargetOS returns the name of the OS that the tests are targeting (which could be different from the local OS).
+func TestTargetOS() string {
+	// Check if we have an env var first
+	if v, ok := os.LookupEnv(TargetOsEnvVar); ok {
+		return v
+	}
+	// Fallback to the runtime
+	return runtime.GOOS
 }


### PR DESCRIPTION
When running E2E tests, certain tests are disabled on Windows because of bugs in the platform. The OS detection used `runtime.GOOS` which identifies the runtime of the host where the "test controller" is running on. However, the test controller may be running on a different OS than the target (e.g. running tests on a Windows cluster while on Linux or macOS). This should fix the detection by relying on the `TARGET_OS` env var first.
