### PR TITLE
use different logger for api log level and set output level

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -38,7 +38,10 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var log = logger.NewLogger("dapr.runtime.http")
+var (
+	log    = logger.NewLogger("dapr.runtime.http")
+	apiLog = logger.NewLogger("dapr.runtime.http.api")
+)
 
 const protocol = "http"
 
@@ -73,11 +76,10 @@ func NewServer(api API, config ServerConfig, tracingSpec config.TracingSpec, met
 
 // StartNonBlocking starts a new server in a goroutine.
 func (s *server) StartNonBlocking() error {
-	handler :=
-		useAPIAuthentication(
-			s.useCors(
-				s.useComponents(
-					s.useRouter())))
+	handler := useAPIAuthentication(
+		s.useCors(
+			s.useComponents(
+				s.useRouter())))
 
 	handler = s.useMetrics(handler)
 	handler = s.useTracing(handler)
@@ -85,8 +87,10 @@ func (s *server) StartNonBlocking() error {
 	apiLogLevel := s.config.APILoglevel
 
 	if strings.EqualFold(apiLogLevel, "info") {
+		apiLog.SetOutputLevel(logger.InfoLevel)
 		handler = s.apiLoggingInfo(handler)
 	} else if strings.EqualFold(apiLogLevel, "debug") {
+		apiLog.SetOutputLevel(logger.DebugLevel)
 		handler = s.apiLoggingDebug(handler)
 	}
 
@@ -218,14 +222,15 @@ func (s *server) useMetrics(next fasthttp.RequestHandler) fasthttp.RequestHandle
 
 func (s *server) apiLoggingInfo(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
-		log.Infof("HTTP API Called: %s %s", ctx.Method(), ctx.Path())
+		apiLog.Infof("HTTP API Called: %s %s", ctx.Method(), ctx.Path())
 		next(ctx)
 	}
 }
 
 func (s *server) apiLoggingDebug(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
-		log.Debugf("HTTP API Called: %s %s", ctx.Method(), ctx.Path())
+		apiLog.Error("Calling debug debug debug")
+		apiLog.Debugf("HTTP API Called: %s %s", ctx.Method(), ctx.Path())
 		next(ctx)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <65565396+mukundansundar@users.noreply.github.com>

# Description

There is one log-level defined for all the logs within Dapr runtime. `--log-level` 

Another one was added recently `--api-log-level`. If API logs are to be treated differently from the the other logs, then they must use a different logger. 

The current implementation without this PR does not set the output level correctly for the `HTTP API Called` or the `gRPC API called ` log properly. 
So only if `--log-level` flag is given for `daprd` or in `dapr run` the current logs are printed correctly. 

This PR defines a separate logger for API logs and based on the input `--api-log-level` flag, the output level of the logger is set correctly. 

With this change, using the `--api-log-level` flag is independent of the `--log-level` flag. 
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
