### PR TITLE
Fix circuit breaker handling for service invoke

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -50,6 +50,7 @@ import (
 	"github.com/dapr/dapr/pkg/messaging"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/resiliency/breaker"
 	runtime_pubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 )
 
@@ -1049,8 +1050,8 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 		return nil
 	})
 
-	// Special case for timeouts since they won't go through the rest of the logic.
-	if errors.Is(err, context.DeadlineExceeded) {
+	// Special case for timeouts/circuit breakers since they won't go through the rest of the logic.
+	if errors.Is(err, context.DeadlineExceeded) || breaker.IsErrorPermanent(err) {
 		respond(reqCtx, withError(500, NewErrorResponse("ERR_DIRECT_INVOKE", err.Error())))
 		return
 	}

--- a/tests/config/resiliency.yaml
+++ b/tests/config/resiliency.yaml
@@ -17,19 +17,20 @@ spec:
     circuitBreakers:
       simpleCB:
           maxRequests: 1
-          interval: 8s
-          timeout: 45s
-          trip: consecutiveFailures > 8
+          timeout: 30s
+          trip: consecutiveFailures > 15
 
   targets:
     apps:
       resiliencyapp:
         timeout: fast
         retry: fiveRetries
+        circuitBreaker: simpleCB
 
       resiliencyappgrpc:
         timeout: fast
         retry: fiveRetries
+        circuitBreaker: simpleCB
 
     actors:
       resiliencyActor:
@@ -41,7 +42,6 @@ spec:
         inbound: 
           timeout: fast
           retry: fiveRetries
-          circuitBreaker: simpleCB
         outbound:
           timeout: fast
           retry: fiveRetries
@@ -50,7 +50,6 @@ spec:
         inbound: 
           timeout: fast
           retry: fiveRetries
-          circuitBreaker: simpleCB
         outbound:
           timeout: fast
           retry: fiveRetries
@@ -59,7 +58,6 @@ spec:
         inbound:
           timeout: fast
           retry: fiveRetries
-          circuitBreaker: simpleCB
         outbound:
           timeout: fast
           retry: fiveRetries

--- a/tests/e2e/resiliency/resiliency_test.go
+++ b/tests/e2e/resiliency/resiliency_test.go
@@ -491,6 +491,74 @@ func TestActorResiliency(t *testing.T) {
 	}
 }
 
+func TestResiliencyCircuitBreakers(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		CallType string
+	}{
+		{
+			Name:     "Test http service invocation circuit breaker trips",
+			CallType: "http",
+		},
+		{
+			Name:     "Test grpc service invocation circuit breaker trips",
+			CallType: "grpc",
+		},
+		{
+			Name:     "Test grpc proxy invocation circuit breaker trips",
+			CallType: "grpc_proxy",
+		},
+	}
+
+	// Get application URLs/wait for healthy.
+	externalURL := tr.Platform.AcquireAppExternalURL("resiliencyapp")
+	require.NotEmpty(t, externalURL, "resiliency external URL must not be empty!")
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// Do a successful request to start to make sure our CB is cleared.
+			passingMessage := createFailureMessage(nil, nil)
+			passingBody, _ := json.Marshal(passingMessage)
+			_, code, err := utils.HTTPPostWithStatus(fmt.Sprintf("%s/tests/invokeService/%s", externalURL, tc.CallType), passingBody)
+			require.NoError(t, err)
+			require.Equal(t, 200, code)
+
+			failureCount := 20
+			message := createFailureMessage(&failureCount, nil)
+			b, _ := json.Marshal(message)
+			// The Circuit Breaker will trip after 15 consecutive errors each request is retried 5 times. Send the message 3 times to hit the breaker.
+			for i := 0; i < 3; i++ {
+				_, code, err := utils.HTTPPostWithStatus(fmt.Sprintf("%s/tests/invokeService/%s", externalURL, tc.CallType), b)
+				require.NoError(t, err)
+				require.Equal(t, 500, code)
+			}
+
+			// Validate the call count. Circuit Breaker trips at >15, so 16 should be max.
+			var callCount map[string][]CallRecord
+			getCallsURL := "tests/getCallCount"
+			if strings.Contains(tc.CallType, "grpc") {
+				getCallsURL = "tests/getCallCountGRPC"
+			}
+			resp, err := utils.HTTPGet(fmt.Sprintf("%s/%s", externalURL, getCallsURL))
+			require.NoError(t, err)
+			json.Unmarshal(resp, &callCount)
+			require.Equal(t, 16, len(callCount[message.ID]), fmt.Sprintf("Call count mismatch for message %s", message.ID))
+
+			// We shouldn't be able to call the app anymore.
+			body, code, err := utils.HTTPPostWithStatus(fmt.Sprintf("%s/tests/invokeService/%s", externalURL, "http"), b)
+			require.NoError(t, err)
+			require.Equal(t, 500, code)
+			require.Contains(t, string(body), "circuit breaker is open")
+
+			// We shouldn't even see a call recorded.
+			resp, err = utils.HTTPGet(fmt.Sprintf("%s/tests/getCallCount", externalURL))
+			require.NoError(t, err)
+			json.Unmarshal(resp, &callCount)
+			require.Equal(t, 16, len(callCount[message.ID]), fmt.Sprintf("Call count mismatch for message %s", message.ID))
+		})
+	}
+}
+
 func createFailureMessage(maxFailure *int, timeout *time.Duration) FailureMessage {
 	message := FailureMessage{
 		ID: uuid.New().String(),


### PR DESCRIPTION
# Description

Circuit breakers cause the resiliency policy to error out
at the highest level, much like a timeout. This error was not
handled in the APIs which caused a bad response to get sent
back to the user.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: #4454 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
