### PR TITLE
Send response back to .NET Actor on error

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -138,6 +138,8 @@ const (
 	incompatibleStateStore = "state store does not support transactions which actors require to save state - please see https://docs.dapr.io/operations/components/setup-state-store/supported-state-stores/"
 )
 
+var ErrDaprResponseHeader = errors.New("error indicated via actor header response")
+
 // NewActors create a new actors runtime with given config.
 func NewActors(
 	stateStore state.Store,
@@ -330,7 +332,7 @@ func (a *actorsRuntime) Call(ctx context.Context, req *invokev1.InvokeMethodRequ
 		resp, err = a.callRemoteActorWithRetry(ctx, retry.DefaultLinearRetryCount, retry.DefaultLinearBackoffInterval, a.callRemoteActor, targetActorAddress, appID, req)
 	}
 
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrDaprResponseHeader) {
 		return nil, err
 	}
 	return resp, nil
@@ -434,7 +436,7 @@ func (a *actorsRuntime) callLocalActor(ctx context.Context, req *invokev1.Invoke
 
 	// The .NET SDK signifies Actor failure via a header instead of a bad response.
 	if _, ok := resp.Headers()["X-Daprerrorresponseheader"]; ok {
-		return nil, errors.Errorf("error from a .NET actor")
+		return resp, ErrDaprResponseHeader
 	}
 
 	return resp, nil


### PR DESCRIPTION
# Description 
Actors implemented in the .NET SDK communicate failures with a
header. Resiliency changed this to be an actual error which is a
change in behavior for .NET actors. This change reverts that as it
was not intentional and restores the intended behavior.

https://github.com/dapr/dapr/issues/4457

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: #4457 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
