### PR TITLE
Add tekton pipelines support

### DIFF
--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -50,6 +50,7 @@ var allowedControllersServiceAccounts = []string{
 	"job-controller",
 	"statefulset-controller",
 	"daemon-set-controller",
+	"tekton-pipelines-controller",
 }
 
 // Injector is the interface for the Dapr runtime sidecar injection component.


### PR DESCRIPTION
This PR adds support to inject Dapr sidecars when using the [Tekton](https://tekton.dev/) project.

The reasoning to put this in `1.7` is:

1. This is an extremely low risk contribution
2. We are expecting at least one additional RC
3. This unblocks a major enterprise (name cannot be publicly disclosed)
4. This will potentially unblock many other users as Tekton is quite popular