### PR TITLE
Updated golangci-lint-action to 3.1.0

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -98,7 +98,7 @@ jobs:
           fi
       - name: golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
-        uses: golangci/golangci-lint-action@v2.2.1
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: ${{ env.GOLANGCILINT_VER }}
       - name: Run go mod tidy check diff


### PR DESCRIPTION
In [version 3 of the Action](https://github.com/golangci/golangci-lint-action#compatibility), it does not try to re-install Go but it uses the currently-installed one.
This should fix issues with the CI failing on the linter because it was re-installing Go 1.18 over 1.17