### PR TITLE
Fix default content type

### DIFF
--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -179,6 +179,7 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 
 	// Send request to user application
 	resp := fasthttp.AcquireResponse()
+
 	err := h.client.Do(channelReq, resp)
 	defer func() {
 		fasthttp.ReleaseRequest(channelReq)
@@ -248,6 +249,8 @@ func (h *Channel) parseChannelResponse(req *invokev1.InvokeMethodRequest, resp *
 	var body []byte
 
 	statusCode = resp.StatusCode()
+
+	resp.Header.SetNoDefaultContentType(true)
 	contentType = (string)(resp.Header.ContentType())
 	body = resp.Body()
 

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -219,13 +219,13 @@ func TestInvokeWithHeaders(t *testing.T) {
 
 func TestContentType(t *testing.T) {
 	ctx := context.Background()
-	t.Run("default application/json", func(t *testing.T) {
+	t.Run("no default content type on GET", func(t *testing.T) {
 		handler := &testContentTypeHandler{}
 		testServer := httptest.NewServer(handler)
 		c := Channel{baseAddress: testServer.URL, client: &fasthttp.Client{}}
 		req := invokev1.NewInvokeMethodRequest("method")
 		req.WithRawData(nil, "")
-		req.WithHTTPExtension(http.MethodPost, "")
+		req.WithHTTPExtension(http.MethodGet, "")
 
 		// act
 		resp, err := c.InvokeMethod(ctx, req)
@@ -233,8 +233,8 @@ func TestContentType(t *testing.T) {
 		// assert
 		assert.NoError(t, err)
 		contentType, body := resp.RawData()
-		assert.Equal(t, "text/plain; charset=utf-8", contentType)
-		assert.Equal(t, []byte("application/json"), body)
+		assert.Equal(t, "", contentType)
+		assert.Equal(t, []byte{}, body)
 		testServer.Close()
 	})
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -137,8 +137,9 @@ func (s *server) StartNonBlocking() error {
 		publicHandler = s.useTracing(publicHandler)
 
 		healthServer := &fasthttp.Server{
-			Handler:            publicHandler,
-			MaxRequestBodySize: s.config.MaxRequestBodySize * 1024 * 1024,
+			Handler:              publicHandler,
+			MaxRequestBodySize:   s.config.MaxRequestBodySize * 1024 * 1024,
+			NoDefaultContentType: true,
 		}
 		s.servers = append(s.servers, healthServer)
 

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -91,9 +91,6 @@ func (imr *InvokeMethodRequest) WithFastHTTPHeaders(header *fasthttp.RequestHead
 
 // WithRawData sets message data and content_type.
 func (imr *InvokeMethodRequest) WithRawData(data []byte, contentType string) *InvokeMethodRequest {
-	if contentType == "" {
-		contentType = JSONContentType
-	}
 	imr.r.Message.ContentType = contentType
 	imr.r.Message.Data = &anypb.Any{Value: data}
 	return imr
@@ -172,13 +169,7 @@ func (imr *InvokeMethodRequest) RawData() (string, []byte) {
 	}
 
 	contentType := m.GetContentType()
-	dataTypeURL := m.GetData().GetTypeUrl()
 	dataValue := m.GetData().GetValue()
-
-	// set content_type to application/json only if typeurl is unset and data is given
-	if contentType == "" && (dataTypeURL == "" && dataValue != nil) {
-		contentType = JSONContentType
-	}
 
 	return contentType, dataValue
 }

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -114,8 +114,9 @@ func TestData(t *testing.T) {
 	t.Run("contenttype is unset", func(t *testing.T) {
 		resp := NewInvokeMethodRequest("test_method")
 		resp.WithRawData([]byte("test"), "")
-		contentType, bData := resp.RawData()
-		assert.Equal(t, "application/json", contentType)
+		_, bData := resp.RawData()
+		contentType := resp.r.Message.ContentType
+		assert.Equal(t, "", contentType)
 		assert.Equal(t, []byte("test"), bData)
 	})
 

--- a/pkg/messaging/v1/invoke_method_response.go
+++ b/pkg/messaging/v1/invoke_method_response.go
@@ -56,10 +56,6 @@ func (imr *InvokeMethodResponse) WithMessage(pb *commonv1pb.InvokeResponse) *Inv
 
 // WithRawData sets Message using byte data and content type.
 func (imr *InvokeMethodResponse) WithRawData(data []byte, contentType string) *InvokeMethodResponse {
-	if contentType == "" {
-		contentType = JSONContentType
-	}
-
 	imr.r.Message.ContentType = contentType
 
 	// Clone data to prevent GC from deallocating data
@@ -136,11 +132,6 @@ func (imr *InvokeMethodResponse) RawData() (string, []byte) {
 	contentType := m.GetContentType()
 	dataTypeURL := m.GetData().GetTypeUrl()
 	dataValue := m.GetData().GetValue()
-
-	// set content_type to application/json only if typeurl is unset and data is given
-	if contentType == "" && (dataTypeURL == "" && dataValue != nil) {
-		contentType = JSONContentType
-	}
 
 	if dataTypeURL != "" {
 		contentType = ProtobufContentType

--- a/pkg/messaging/v1/invoke_method_response_test.go
+++ b/pkg/messaging/v1/invoke_method_response_test.go
@@ -68,7 +68,8 @@ func TestResponseData(t *testing.T) {
 	t.Run("contenttype is set", func(t *testing.T) {
 		resp := NewInvokeMethodResponse(0, "OK", nil)
 		resp.WithRawData([]byte("test"), "application/json")
-		contentType, bData := resp.RawData()
+		_, bData := resp.RawData()
+		contentType := resp.r.Message.ContentType
 		assert.Equal(t, "application/json", contentType)
 		assert.Equal(t, []byte("test"), bData)
 	})
@@ -76,8 +77,9 @@ func TestResponseData(t *testing.T) {
 	t.Run("contenttype is unset", func(t *testing.T) {
 		resp := NewInvokeMethodResponse(0, "OK", nil)
 		resp.WithRawData([]byte("test"), "")
-		contentType, bData := resp.RawData()
-		assert.Equal(t, "application/json", contentType)
+		_, bData := resp.RawData()
+		contentType := resp.r.Message.ContentType
+		assert.Equal(t, "", contentType)
 		assert.Equal(t, []byte("test"), bData)
 	})
 

--- a/tests/apps/service_invocation/app.go
+++ b/tests/apps/service_invocation/app.go
@@ -275,6 +275,7 @@ func invokeServiceWithBodyHeader(remoteApp, method string, data []byte, headers 
 		req.Header.Add(k, v)
 	}
 
+	req.Header.Add("Content-Type", "application/json")
 	return httpClient.Do(req)
 }
 
@@ -294,6 +295,7 @@ func invokeServiceWithDaprAppIDHeader(remoteApp, method string, data []byte, hea
 		req.Header.Add(k, v)
 	}
 
+	req.Header.Add("Content-Type", "application/json")
 	return httpClient.Do(req)
 }
 


### PR DESCRIPTION
Fixes https://github.com/dapr/dapr/issues/4469.

This PR does the following:

1. Removes original and wrong intention of using `application/json` as a default content-type if non was supplied by the user
2. Fixes the default setting of `text/plain` content type by FastHTTP which prevented the original intention from taking place
3. Modifies tests to account for the correct behavior

As requested by @artursouza and agreed upon by myself, we'll be merging this to the `1.7` branch.
