### PR TITLE
Add delay after failed API auth

### DIFF
--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -65,6 +65,7 @@ import (
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
+	"github.com/dapr/dapr/pkg/runtime/security"
 	daprt "github.com/dapr/dapr/pkg/testing"
 	testtrace "github.com/dapr/dapr/pkg/testing/trace"
 	"github.com/dapr/kit/logger"
@@ -278,8 +279,10 @@ func startDaprAPIServer(port int, testAPIServer *api, token string) *grpc.Server
 
 	opts := []grpc.ServerOption{}
 	if token != "" {
+		authToken := &security.APIToken{}
+		authToken.InitWithToken(token)
 		opts = append(opts,
-			grpc.UnaryInterceptor(setAPIAuthenticationMiddlewareUnary(token, "dapr-api-token")),
+			grpc.UnaryInterceptor(setAPIAuthenticationMiddlewareUnary(authToken, "dapr-api-token")),
 		)
 	}
 

--- a/pkg/grpc/auth.go
+++ b/pkg/grpc/auth.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"crypto/subtle"
 	"net/http"
 
 	"google.golang.org/grpc"
@@ -24,7 +25,7 @@ func setAPIAuthenticationMiddlewareUnary(apiToken, authHeader string) grpc.Unary
 			return nil, err
 		}
 
-		if token[0] != apiToken {
+		if subtle.ConstantTimeCompare([]byte(token[0]), []byte(apiToken)) == 0 {
 			err := v1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "authentication error: api token mismatch")
 			return nil, err
 		}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -14,6 +14,7 @@ limitations under the License.
 package http
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"net"
@@ -261,7 +262,7 @@ func useAPIAuthentication(next fasthttp.RequestHandler) fasthttp.RequestHandler 
 
 	return func(ctx *fasthttp.RequestCtx) {
 		v := ctx.Request.Header.Peek(auth.APITokenHeader)
-		if auth.ExcludedRoute(string(ctx.Request.URI().FullURI())) || string(v) == token {
+		if auth.ExcludedRoute(string(ctx.Request.URI().FullURI())) || subtle.ConstantTimeCompare(v, []byte(token)) == 1 {
 			ctx.Request.Header.Del(auth.APITokenHeader)
 			next(ctx)
 		} else {

--- a/pkg/runtime/security/token.go
+++ b/pkg/runtime/security/token.go
@@ -1,8 +1,11 @@
 package security
 
 import (
+	"crypto/subtle"
 	"os"
 	"strings"
+	"sync"
+	"time"
 )
 
 /* #nosec. */
@@ -16,9 +19,53 @@ const (
 
 var excludedRoutes = []string{"/healthz"}
 
-// GetAPIToken returns the value of the api token from an environment variable.
-func GetAPIToken() string {
-	return os.Getenv(APITokenEnvVar)
+// Default delay on requests after a failed auth, in ms.
+const DefaultDelayOnFailed = 2000
+
+// APIToken manages authentication via a shared API token from an environment variable.
+type APIToken struct {
+	// How long to pause the next request after a failed auth.
+	DelayOnFailed time.Duration
+
+	token             []byte
+	lastAttemptFailed bool
+	mu                sync.Mutex
+}
+
+// Init the object, reading from the environment.
+func (a *APIToken) Init() {
+	a.token = []byte(os.Getenv(APITokenEnvVar))
+	if a.DelayOnFailed == 0 {
+		a.DelayOnFailed = time.Duration(DefaultDelayOnFailed) * time.Millisecond
+	}
+}
+
+// InitWithToken inits the object, setting a specific token.
+// This is mostly used for testing.
+func (a *APIToken) InitWithToken(val string) {
+	a.token = []byte(val)
+	if a.DelayOnFailed == 0 {
+		a.DelayOnFailed = time.Duration(DefaultDelayOnFailed) * time.Millisecond
+	}
+}
+
+// HasAPIToken returns true if Dapr is configured with an API token from an environment variable.
+func (a *APIToken) HasAPIToken() bool {
+	return len(a.token) > 0
+}
+
+// CheckAPIToken returns true if the passed API token matches the one configured for Dapr through an environment variable.
+// Note that if the previous auth attempt failed (from anyone), this adds a delay before responding, to slow down attackers.
+func (a *APIToken) CheckAPIToken(token []byte) bool {
+	a.mu.Lock()
+	if a.lastAttemptFailed {
+		// Slow down attackers if the previous attempt failed
+		time.Sleep(a.DelayOnFailed)
+	}
+	res := subtle.ConstantTimeCompare(a.token, token) == 1
+	a.lastAttemptFailed = !res
+	a.mu.Unlock()
+	return res
 }
 
 // GetAppToken returns the value of the app api token from an environment variable.
@@ -26,7 +73,7 @@ func GetAppToken() string {
 	return os.Getenv(AppAPITokenEnvVar)
 }
 
-// ExcludedRoute returns whether a given route should be excluded from a token check.
+// ExcludedRoute returns whether a given HTTP route should be excluded from a token check.
 func ExcludedRoute(route string) bool {
 	for _, r := range excludedRoutes {
 		if strings.Contains(route, r) {

--- a/pkg/runtime/security/token.go
+++ b/pkg/runtime/security/token.go
@@ -1,7 +1,7 @@
 package security
 
 import (
-	"crypto/subtle"
+	"bytes"
 	"os"
 	"strings"
 	"sync"
@@ -62,7 +62,7 @@ func (a *APIToken) CheckAPIToken(token []byte) bool {
 		// Slow down attackers if the previous attempt failed
 		time.Sleep(a.DelayOnFailed)
 	}
-	res := subtle.ConstantTimeCompare(a.token, token) == 1
+	res := bytes.Compare(a.token, token) == 0
 	a.lastAttemptFailed = !res
 	a.mu.Unlock()
 	return res

--- a/pkg/runtime/security/token_test.go
+++ b/pkg/runtime/security/token_test.go
@@ -74,7 +74,7 @@ func TestAPIToken(t *testing.T) {
 			if test.shouldDelay {
 				assert.GreaterOrEqual(t, elapsed, delay.Milliseconds())
 			} else {
-				assert.Less(t, elapsed, int64(delay.Milliseconds()-100))
+				assert.Less(t, elapsed, delay.Milliseconds()-100)
 			}
 		}
 	})

--- a/pkg/runtime/security/token_test.go
+++ b/pkg/runtime/security/token_test.go
@@ -43,9 +43,9 @@ func TestAPIToken(t *testing.T) {
 
 	t.Run("delays after failed auth", func(t *testing.T) {
 		token := "123456"
-		delay := 500
+		delay := 500 * time.Millisecond
 		apitoken := &APIToken{
-			DelayOnFailed: time.Duration(delay) * time.Millisecond,
+			DelayOnFailed: delay,
 		}
 		apitoken.InitWithToken(token)
 
@@ -72,9 +72,9 @@ func TestAPIToken(t *testing.T) {
 			elapsed := time.Since(start).Milliseconds()
 			assert.Equal(t, test.shouldOk, res)
 			if test.shouldDelay {
-				assert.GreaterOrEqual(t, elapsed, int64(delay))
+				assert.GreaterOrEqual(t, elapsed, delay.Milliseconds())
 			} else {
-				assert.Less(t, elapsed, int64(delay-100))
+				assert.Less(t, elapsed, int64(delay.Milliseconds()-100))
 			}
 		}
 	})

--- a/pkg/runtime/security/token_test.go
+++ b/pkg/runtime/security/token_test.go
@@ -2,23 +2,81 @@ package security
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAPIToken(t *testing.T) {
-	t.Run("existing token", func(t *testing.T) {
-		/* #nosec */
-		token := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1OTA1NTQ1NzMsImV4cCI6MTYyMjA5MDU3MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.QLFl8ZqC48DOsT7SmXA794nivmqGgylzjrUu6JhXPW4"
+	t.Run("init with token from env", func(t *testing.T) {
+		token := "123456"
 		t.Setenv(APITokenEnvVar, token)
 
-		apitoken := GetAPIToken()
-		assert.Equal(t, token, apitoken)
+		apitoken := &APIToken{}
+		apitoken.Init()
+		assert.Equal(t, token, string(apitoken.token))
+		assert.True(t, apitoken.HasAPIToken())
 	})
 
-	t.Run("non-existent token", func(t *testing.T) {
-		token := GetAPIToken()
-		assert.Equal(t, "", token)
+	t.Run("init with token from string", func(t *testing.T) {
+		token := "123456"
+		apitoken := &APIToken{}
+		apitoken.InitWithToken(token)
+		assert.Equal(t, token, string(apitoken.token))
+		assert.True(t, apitoken.HasAPIToken())
+	})
+
+	t.Run("init with non-existent token", func(t *testing.T) {
+		apitoken := &APIToken{}
+		apitoken.Init()
+		assert.Equal(t, "", string(apitoken.token))
+		assert.False(t, apitoken.HasAPIToken())
+	})
+
+	t.Run("validating tokens", func(t *testing.T) {
+		token := "123456"
+		apitoken := &APIToken{}
+		apitoken.InitWithToken(token)
+		assert.True(t, apitoken.CheckAPIToken([]byte(token)))
+		assert.False(t, apitoken.CheckAPIToken([]byte("invalid")))
+	})
+
+	t.Run("delays after failed auth", func(t *testing.T) {
+		token := "123456"
+		delay := 500
+		apitoken := &APIToken{
+			DelayOnFailed: time.Duration(delay) * time.Millisecond,
+		}
+		apitoken.InitWithToken(token)
+
+		tests := []struct {
+			token       string
+			shouldOk    bool
+			shouldDelay bool
+		}{
+			{token: token, shouldOk: true, shouldDelay: false},
+			{token: token, shouldOk: true, shouldDelay: false},
+			{token: "foo", shouldOk: false, shouldDelay: false},
+			{token: "foo", shouldOk: false, shouldDelay: true},
+			{token: token, shouldOk: true, shouldDelay: true},
+			{token: token, shouldOk: true, shouldDelay: false},
+			{token: token, shouldOk: true, shouldDelay: false},
+			{token: "foo", shouldOk: false, shouldDelay: false},
+			{token: "foo", shouldOk: false, shouldDelay: true},
+			{token: token, shouldOk: true, shouldDelay: true},
+			{token: token, shouldOk: true, shouldDelay: false},
+		}
+		for _, test := range tests {
+			start := time.Now()
+			res := apitoken.CheckAPIToken([]byte(test.token))
+			elapsed := time.Since(start).Milliseconds()
+			assert.Equal(t, test.shouldOk, res)
+			if test.shouldDelay {
+				assert.GreaterOrEqual(t, elapsed, int64(delay))
+			} else {
+				assert.Less(t, elapsed, int64(delay-100))
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
# Description

The goal of this PR is to prevent brute-force attacks on the API token auth.

It works by making the request _after_ a failed auth slower (regardless of whether that request's auth is valid or not), by pausing before processing it (currently the delay is set to 0.8 seconds, but that can be tweaked). This makes brute force attacks longer and less practical, increasing the likelihood that an admin would notice the failed attempts in the logs before the attack is successful.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [x] End-to-end tests passing
