### PR TITLE
Improve to support building amd64 images on m1 macbook

### DIFF
--- a/tests/apps/perf/actorfeatures/Dockerfile
+++ b/tests/apps/perf/actorfeatures/Dockerfile
@@ -13,12 +13,14 @@
 
 FROM golang:1.17 as build_env
 
+ARG GOARCH_ARG=amd64
+
 WORKDIR /app
 COPY app.go .
 COPY go.mod .
 COPY go.sum .
 RUN go get -d -v
-RUN go build -o app .
+RUN GOOS=linux GOARCH=$GOARCH_ARG go build -o app .
 
 FROM debian:buster-slim
 WORKDIR /

--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -13,9 +13,11 @@
 
 FROM golang:1.17 as build_env
 
+ARG GOARCH_ARG=amd64
+
 WORKDIR /app
 COPY app.go go.mod ./
-RUN go get -d -v && go build -o app .
+RUN go get -d -v && GOOS=linux GOARCH=$GOARCH_ARG go build -o app .
 
 FROM debian:buster-slim
 WORKDIR /

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,15 +1,19 @@
 FROM golang:1.17 as build_env
 
+ARG GOARCH_ARG=amd64
+
 WORKDIR /app
 COPY app.go go.mod ./
-RUN go get -d -v && go build -o tester .
+RUN go get -d -v && GOOS=linux GOARCH=$GOARCH_ARG go build -o tester .
 
 FROM golang:1.17 as fortio_build_env
+
+ARG GOARCH_ARG=amd64
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/fortio/fortio/branches/master" skipcache
 RUN git clone https://github.com/fortio/fortio.git
-RUN cd fortio && git checkout v1.16.1 && go build
+RUN cd fortio && git checkout v1.16.1 && GOOS=linux GOARCH=$GOARCH_ARG go build
 
 FROM debian:buster-slim
 #RUN apt update

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -135,7 +135,7 @@ $(foreach ITEM,$(E2E_TEST_APPS),$(eval $(call genTestAppImageKindPush,$(ITEM))))
 define genPerfTestAppImageBuild
 .PHONY: build-perf-app-$(1)
 build-perf-app-$(1): check-e2e-env
-	$(DOCKER) build -f $(PERF_TESTAPP_DIR)/$(1)/$(DOCKERFILE) $(PERF_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/perf-$(1):$(DAPR_TEST_TAG)
+	$(DOCKER) build -f $(PERF_TESTAPP_DIR)/$(1)/$(DOCKERFILE) $(PERF_TESTAPP_DIR)/$(1)/. -t $(DAPR_TEST_REGISTRY)/perf-$(1):$(DAPR_TEST_TAG) --build-arg GOARCH_ARG=$(GOARCH)
 endef
 
 # Generate perf app image build targets


### PR DESCRIPTION
Signed-off-by: Sky Ao <aoxiaojian@gmail.com>

# Description

Support to build amd64 images in m1 macbook and run k8s in somewhere (like aks).

## Issue reference

https://github.com/dapr/dapr/issues/4426

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
