### PR TITLE
Changed QPS target for actor_reminder perf test

### DIFF
--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -157,5 +157,5 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)
 	require.Equal(t, 0, restarts)
-	require.True(t, daprResult.ActualQPS > 57)
+	require.True(t, daprResult.ActualQPS > 55)
 }


### PR DESCRIPTION
This changes the QPS target for the actor_reminder perf test to 55. We have observed that this is a more appropriate value when using AKS with Availability Zones, which is the recommended thing in production.