### PR TITLE
Updates to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,7 +57,6 @@
 		"--init"
 	],
 	"settings": {
-		"terminal.integrated.defaultProfile.linux": "bash",
 		"go.toolsManagement.checkForUpdates": "local",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,6 +61,6 @@
 		"go.useLanguageServer": true,
 		"go.gopath": "/go"
 	},
-	"workspaceFolder": "/go/src/github.com/dapr/dapr",
-	"workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/go/src/github.com/dapr/dapr",
+	"workspaceFolder": "/workspace/dapr",
+	"workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/workspace/dapr",
 }


### PR DESCRIPTION
1. Changed the workspace folder to the correct one
1. Removed the setting that makes bash the default shell in the dev container. VS Code / Codespaces will then default to whatever is the user's preferred shell.

(This does not require a new dev container image to be published)