### PR TITLE
Updates to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,7 +57,6 @@
 		"--init"
 	],
 	"settings": {
-		"terminal.integrated.defaultProfile.linux": "bash",
 		"go.toolsManagement.checkForUpdates": "local",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,6 +61,6 @@
 		"go.useLanguageServer": true,
 		"go.gopath": "/go"
 	},
-	"workspaceFolder": "/go/src/github.com/dapr/dapr",
-	"workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/go/src/github.com/dapr/dapr",
+	"workspaceFolder": "/workspace/dapr",
+	"workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/workspace/dapr",
 }

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -64,6 +64,9 @@ RUN apt-get update \
     && mkdir -p /usr/local/etc/vscode-dev-containers/ \
     && mv -f /tmp/staging/first-run-notice.txt /usr/local/etc/vscode-dev-containers/ \
     #
+    # Set permissions for the workspace folder
+    && chown ${USERNAME}:${USERNAME} /workspace \
+    #
     # Clean up packages and the staging folder.
     && apt-get autoremove -y && apt-get clean -y && rm -rf /tmp/staging
 


### PR DESCRIPTION
Fixes some minor teething issues with the new image:

1. Setting permissions to the `/workspace` folder to the dapr user
2. Changed the workspace folder to the correct one
3. Removed the setting that makes bash the default shell in the dev container. VS Code / Codespaces will then default to whatever is the user's preferred shell.