### PR TITLE
Remove error for Actor Timer DueTime in the past (#4518)

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1074,9 +1074,6 @@ func (a *actorsRuntime) CreateTimer(ctx context.Context, req *CreateTimerRequest
 		if dueTime, err = parseTime(req.DueTime, nil); err != nil {
 			return errors.Wrap(err, "error parsing timer due time")
 		}
-		if dueTime.Before(time.Now()) {
-			return errors.Errorf("timer %s has already expired: dueTime: %s TTL: %s", timerKey, req.DueTime, req.TTL)
-		}
 	} else {
 		dueTime = time.Now()
 	}

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -1006,6 +1006,29 @@ func TestGetReminder(t *testing.T) {
 	assert.Equal(t, r.DueTime, "1s")
 }
 
+func TestCreateTimerDueTimes(t *testing.T) {
+	testActorsRuntime := newTestActorsRuntime()
+	actorType, actorID := getTestActorTypeAndID()
+	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID)
+	t.Run("test create timer with positive DueTime", func(t *testing.T) {
+		timer := createTimerData(actorID, actorType, "positiveTimer", "1s", "2s", "", "callback", "testTimer")
+		err := testActorsRuntime.CreateTimer(context.Background(), &timer)
+		assert.Nil(t, err)
+	})
+
+	t.Run("test create timer with 0 DueTime", func(t *testing.T) {
+		timer := createTimerData(actorID, actorType, "positiveTimer", "1s", "0s", "", "callback", "testTimer")
+		err := testActorsRuntime.CreateTimer(context.Background(), &timer)
+		assert.Nil(t, err)
+	})
+
+	t.Run("test create timer with no DueTime", func(t *testing.T) {
+		timer := createTimerData(actorID, actorType, "positiveTimer", "1s", "", "", "callback", "testTimer")
+		err := testActorsRuntime.CreateTimer(context.Background(), &timer)
+		assert.Nil(t, err)
+	})
+}
+
 func TestDeleteTimer(t *testing.T) {
 	testActorsRuntime := newTestActorsRuntime()
 	actorType, actorID := getTestActorTypeAndID()


### PR DESCRIPTION
# Description

The DueTime of an Actor Timer signifies the first time it should
fire. An omitted or 0 DueTime means fire immediately. A check was
introduced that forced a failure if the DueTime was in the past.
However, when the time was 0, it was seen as in the past as the
evaluation logic used multiple time.Now instances.

Regardless, the semantic behavior of this did not make sense as
a DueTime in the past should still just mean fire immediately. This
commit removes that check allowing for this behavior. This is also
how Actor Reminders work.

https://github.com/dapr/dapr/issues/4514

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: #4514

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
