### PR TITLE
Pin contrib 1.7.1 and update release notes

### DIFF
--- a/docs/release_notes/v1.7.1.md
+++ b/docs/release_notes/v1.7.1.md
@@ -3,9 +3,13 @@
 ## Summary
 
 This hotfix release addresses a change made in how Actor Timers are validated during creation. Specifically, `DueTime` can be set to 0 to have a reminder fire immediately.
+Additionally, this hotfix addresses an issue in the Apache Pulsar Pubsub component preventing the use of namespaces when publishing to topics.
 
 ### Runtime
 * An Actor Timer with a `DueTime` of `0` will now pass validation allowing timers to fire immediately.
+
+### Components
+* The correct value the Pulsar topic is now specified on publishing, allowing the use of namespaces.
 
 ## Details
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1
 	github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/dapr/components-contrib v1.7.0-rc.4
+	github.com/dapr/components-contrib v1.7.1
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/fasthttp/router v1.3.8
 	github.com/fsnotify/fsnotify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz
 github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.7.0-rc.4 h1:wktFr7nLK5Jxr+v/I3Nru6xv4lyNJ8PqcC4IHF7z+H8=
-github.com/dapr/components-contrib v1.7.0-rc.4/go.mod h1:902HkXx3cCnxPmsoMSbbbfFYu2yoM7agS2PQ0ivyOmk=
+github.com/dapr/components-contrib v1.7.1 h1:fwNvG/YfF938seKGUqWOuFZgKcn7yMhhJ0l0+QUTikE=
+github.com/dapr/components-contrib v1.7.1/go.mod h1:902HkXx3cCnxPmsoMSbbbfFYu2yoM7agS2PQ0ivyOmk=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233/go.mod h1:y8r0VqUNKyd6xBXp7gQjwA59wlCLGfKzL5J8iJsN09w=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

Pins contrib 1.7.1 to address an issue with Apache Pulsar Pubsub.