### PR TITLE
Improve the error message

### DIFF
--- a/pkg/messages/api_errors.go
+++ b/pkg/messages/api_errors.go
@@ -38,7 +38,7 @@ const (
 	ErrChannelInvoke         = "error invoking app channel: %s"
 
 	// Actor.
-	ErrActorRuntimeNotFound      = "actor runtime is not configured"
+	ErrActorRuntimeNotFound      = "the state store is not configured to use the actor runtime. Have you set the - name: actorStateStore value: \"true\" in your state store component file?"
 	ErrActorInstanceMissing      = "actor instance is missing"
 	ErrActorInvoke               = "error invoke actor method: %s"
 	ErrActorReminderCreate       = "error creating actor reminder: %s"


### PR DESCRIPTION
# Description

Improve the error message for when a state store has not been set for actor usage and actors are used

## Issue reference

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/4273

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
