### PR TITLE
Fixes a bug that incorrectly allowed the Dapr API HTTP Port or GRPC Port to be reused is the app port.

### DIFF
--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -160,6 +160,14 @@ func FromFlags() (*DaprRuntime, error) {
 		}
 	}
 
+	if applicationPort == daprHTTP {
+		return nil, errors.New("dapr api http port conflicts with app port")
+	}
+
+	if applicationPort == daprAPIGRPC {
+		return nil, errors.New("dapr api grpc port conflicts with app port")
+	}
+
 	var maxRequestBodySize int
 	if *daprHTTPMaxRequestSize != -1 {
 		maxRequestBodySize = *daprHTTPMaxRequestSize


### PR DESCRIPTION
Signed-off-by: crazyhzm <crazyhzm@gmail.com>

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fix https://github.com/dapr/dapr/issues/4531

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
