### PR TITLE
fix nil pointer error with api-logging enabled

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -107,6 +107,7 @@ func NewInternalServer(api API, config ServerConfig, tracingSpec config.TracingS
 		renewMutex:       &sync.Mutex{},
 		kind:             internalServer,
 		logger:           internalServerLogger,
+		infoLogger:       apiServerInfoLogger,
 		maxConnectionAge: getDefaultMaxAgeDuration(),
 		proxy:            proxy,
 	}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -315,7 +315,7 @@ func shouldRenewCert(certExpiryDate time.Time, certDuration time.Duration) bool 
 func (s *server) getGRPCAPILoggingInfo() grpc_go.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc_go.UnaryServerInfo, handler grpc_go.UnaryHandler) (interface{}, error) {
 		if s.infoLogger != nil && info != nil {
-			s.infoLogger.Info("gRPC API Called: ", *info)
+			s.infoLogger.Info("gRPC API Called: ", info.FullMethod)
 		}
 		return handler(ctx, req)
 	}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -107,7 +107,6 @@ func NewInternalServer(api API, config ServerConfig, tracingSpec config.TracingS
 		renewMutex:       &sync.Mutex{},
 		kind:             internalServer,
 		logger:           internalServerLogger,
-		infoLogger:       apiServerInfoLogger,
 		maxConnectionAge: getDefaultMaxAgeDuration(),
 		proxy:            proxy,
 	}
@@ -315,7 +314,7 @@ func shouldRenewCert(certExpiryDate time.Time, certDuration time.Duration) bool 
 
 func (s *server) getGRPCAPILoggingInfo() grpc_go.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc_go.UnaryServerInfo, handler grpc_go.UnaryHandler) (interface{}, error) {
-		if info != nil {
+		if s.infoLogger != nil && info != nil {
 			s.infoLogger.Info("gRPC API Called: ", *info)
 		}
 		return handler(ctx, req)

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -77,6 +77,7 @@ func buildDaprAnnotations(appDesc AppDescription) map[string]string {
 			"dapr.io/sidecar-readiness-probe-threshold": "15",
 			"dapr.io/sidecar-liveness-probe-threshold":  "15",
 			"dapr.io/enable-metrics":                    strconv.FormatBool(appDesc.MetricsEnabled),
+			"dapr.io/enable-api-logging":                "true",
 		}
 		if !appDesc.IsJob {
 			annotationObject["dapr.io/app-port"] = fmt.Sprintf("%d", appDesc.AppPort)


### PR DESCRIPTION
Fixes https://github.com/dapr/dapr/issues/4544.

This PR also enabled API logging for all e2e tests.

### Root Cause Analysis

Service Invocation calls go through the internal gRPC server on the callee side. The `infoLogger` was not set on the internal server, which caused a nil pointer panic error for service invocation calls.
