### PR TITLE
bugfix: operator update service

### DIFF
--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -152,22 +152,22 @@ func (h *DaprHandler) ensureDaprServicePresent(ctx context.Context, namespace st
 		return err
 	}
 
-	mayDaprService := types.NamespacedName{
+	daprSvcName := types.NamespacedName{
 		Namespace: namespace,
 		Name:      h.daprServiceName(appID),
 	}
 	var daprSvc corev1.Service
-	if err := h.Get(ctx, mayDaprService, &daprSvc); err != nil {
+	if err := h.Get(ctx, daprSvcName, &daprSvc); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Debugf("no service for wrapper found, wrapper: %s/%s", namespace, mayDaprService.Name)
-			return h.createDaprService(ctx, mayDaprService, wrapper)
+			log.Debugf("no service for wrapper found, wrapper: %s/%s", namespace, daprSvcName.Name)
+			return h.createDaprService(ctx, daprSvcName, wrapper)
 		}
-		log.Errorf("unable to get service, %s, err: %s", mayDaprService, err)
+		log.Errorf("unable to get service, %s, err: %s", daprSvcName, err)
 		return err
 	}
 
-	if err := h.patchDaprService(ctx, mayDaprService, wrapper, daprSvc); err != nil {
-		log.Errorf("unable to update service, %s, err: %s", mayDaprService, err)
+	if err := h.patchDaprService(ctx, daprSvcName, wrapper, daprSvc); err != nil {
+		log.Errorf("unable to update service, %s, err: %s", daprSvcName, err)
 		return err
 	}
 

--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -166,7 +166,7 @@ func (h *DaprHandler) ensureDaprServicePresent(ctx context.Context, namespace st
 		return err
 	}
 
-	if err := h.patchDaprService(ctx, mayDaprService, wrapper); err != nil {
+	if err := h.patchDaprService(ctx, mayDaprService, wrapper, daprSvc); err != nil {
 		log.Errorf("unable to update service, %s, err: %s", mayDaprService, err)
 		return err
 	}
@@ -174,9 +174,11 @@ func (h *DaprHandler) ensureDaprServicePresent(ctx context.Context, namespace st
 	return nil
 }
 
-func (h *DaprHandler) patchDaprService(ctx context.Context, expectedService types.NamespacedName, wrapper ObjectWrapper) error {
+func (h *DaprHandler) patchDaprService(ctx context.Context, expectedService types.NamespacedName, wrapper ObjectWrapper, daprSvc corev1.Service) error {
 	appID := h.getAppID(wrapper)
 	service := h.createDaprServiceValues(ctx, expectedService, wrapper, appID)
+
+	service.ObjectMeta.ResourceVersion = daprSvc.ObjectMeta.ResourceVersion
 
 	if err := h.Update(ctx, service); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Fabian Martinez <46371672+famarting@users.noreply.github.com>

# Description

<!--
Please explain the changes you've made.
-->
I noticed a bug in dapr-operator where the logic to update the dapr service was always failing. The error in dapr-operator logs is like this:
```
time="2022-04-28T16:49:00.494301019Z" level=error msg="unable to update service, dapr-reproducer/nodeapp-dapr, err: Service \"nodeapp-dapr\" is invalid: metadata.resourceVersion: Invalid value: \"\": must be specified for an update" instance=dapr-operator-6888d8d845-5n7zj scope=dapr.operator.handlers type=log ver=1.7.2
```

I haven't found a proper way to test this automatically but here are the steps to reproduce the bug:
- follow https://github.com/dapr/quickstarts/tree/master/tutorials/hello-kubernetes
- then check dapr-operator logs i.e `kubectl -n dapr-system logs dapr-operator-6888d8d845-5n7zj`
- if the error doesn't show up yet try updating the nodeapp deployment i.e `kubectl label deployments.apps nodeapp test=foo`
- check dapr-operator logs again, the error `unable to update service` should be there

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
