### PR TITLE
bugfix: namespaced operator resources list

### DIFF
--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -201,7 +201,9 @@ func (a *apiServer) ListSubscriptionsV2(ctx context.Context, in *operatorv1pb.Li
 
 	// Only the latest/storage version needs to be returned.
 	var subsV2alpha1 subscriptionsapi_v2alpha1.SubscriptionList
-	if err := a.Client.List(ctx, &subsV2alpha1); err != nil {
+	if err := a.Client.List(ctx, &subsV2alpha1, &client.ListOptions{
+		Namespace: in.Namespace,
+	}); err != nil {
 		return nil, errors.Wrap(err, "error getting subscriptions")
 	}
 	for i := range subsV2alpha1.Items {
@@ -243,7 +245,9 @@ func (a *apiServer) ListResiliency(ctx context.Context, in *operatorv1pb.ListRes
 	}
 
 	var resiliencies resiliencyapi.ResiliencyList
-	if err := a.Client.List(ctx, &resiliencies); err != nil {
+	if err := a.Client.List(ctx, &resiliencies, &client.ListOptions{
+		Namespace: in.Namespace,
+	}); err != nil {
 		return nil, errors.Wrap(err, "error listing resiliencies")
 	}
 


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
I noticed a bug in dapr-operator `ListSubscriptionsV2` and `ListResiliency` APIs. 
According to dapr docs https://docs.dapr.io/operations/components/component-scopes/#namespaces , namespaces are also taken into account for dapr APIs scoping and the mentioned dapr-operator APIs didn't implement that properly.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
