### PR TITLE
Fix dead letter unit test failed occasionally

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2896,11 +2896,12 @@ func TestPubSubDeadLetter(t *testing.T) {
 		})
 		assert.Nil(t, err)
 		pubsubIns := rt.pubSubs[testDeadLetterPubsub].(*mockSubscribePubSub)
-		assert.Equal(t, 1, pubsubIns.pubCount["topic0"])
-		// Ensure the message is sent to dead letter topic.
-		assert.Equal(t, 1, pubsubIns.pubCount["topic1"])
-		// get config from app, send to topic0 path twice, send to topic1 path twice
-		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 5)
+		// Consider of resiliency, publish message may retry in some cases, make sure the pub count is greater than 1.
+		assert.True(t, pubsubIns.pubCount["topic0"] >= 1)
+		// Make sure every message that is sent to topic0 is sent to its dead letter topic1.
+		assert.Equal(t, pubsubIns.pubCount["topic0"], pubsubIns.pubCount["topic1"])
+		// Except of the one getting config from app, make sure each publish will result to twice subscribe call
+		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1+2*pubsubIns.pubCount["topic0"]+2*pubsubIns.pubCount["topic1"])
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: zhangchao <zchao9100@gmail.com>

# Description

Fix dead letter unit test failed occasionally.
Change the assert to fit both publish retry occurs or not.

## Issue reference

Please reference the issue this PR will close: #4580 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
