### PR TITLE
Update Debug Image installation of dlv

### DIFF
--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -2,7 +2,7 @@
 
 FROM golang:latest AS golang
 ENV GOPROXY=https://goproxy.io,direct
-RUN CGO_ENABLED=0 go get -ldflags '-s -w -extldflags -static' github.com/go-delve/delve/cmd/dlv
+RUN CGO_ENABLED=0 go install -ldflags '-s -w -extldflags -static' github.com/go-delve/delve/cmd/dlv@latest
 
 FROM gcr.io/distroless/static:nonroot
 ARG PKG_FILES


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Since Go 1.18 `go install` must be used to install go libraries outside of modules. This change is required to install `dlv` correctly. Additionally installing outside of modules requiring specifying a specific version. This change picks the tag associated with the latest release to install.
