### PR TITLE
ci: improve `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,8 @@ test: test-deps
 # Target: lint                                                                 #
 ################################################################################
 # Due to https://github.com/golangci/golangci-lint/issues/580, we need to add --fix for windows
+# Please use golangci-lint version v1.45.2 , otherwise you might encounter errors.
+# You can download version v1.45.2 at https://github.com/golangci/golangci-lint/releases/tag/v1.45.2
 .PHONY: lint
 lint:
 	$(GOLANGCI_LINT) run --timeout=20m
@@ -269,9 +271,9 @@ format: modtidy
 ################################################################################
 # Target: check                                                              #
 ################################################################################
-# TODO add lint
 .PHONY: check
-check: format test
+check: format test lint
+	git status && [[ -z `git status -s` ]]
 
 ################################################################################
 # Target: init-proto                                                            #

--- a/docs/development/developing-dapr.md
+++ b/docs/development/developing-dapr.md
@@ -51,6 +51,18 @@ You can build Dapr binaries with the `make` tool.
 make test
 ```
 
+## One-line command for local development
+
+```shell
+make check
+```
+This command will:
+- format, test and lint all the code 
+- check if you forget to `git commit` something.
+
+Note: To run linter locally, please use golangci-lint version v1.45.2, otherwise you might encounter errors.
+You can download version v1.45.2 [here](https://github.com/golangci/golangci-lint/releases/tag/v1.45.2) .
+
 ## Debug Dapr
 
 We highly recommend using VSCode with the [Go plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) for your productivity. If you want to use other code editors, please refer to the list of [editor plugins for Delve](https://github.com/go-delve/delve/blob/master/Documentation/EditorIntegration.md).


### PR DESCRIPTION
Signed-off-by: seeflood <349895584@qq.com>

# Description
Enhance the one-line command for local development.
After typing `make check`, it will:
- format, test and lint all the code 
- check if you forget to `git commit` something.

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #4610

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
