### PR TITLE
Hotfix for actor subsystem initialization in 1.7 (and possibly others)

### DIFF
--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,6 +1,6 @@
 # current directory must be ./dist
 
-FROM golang:latest AS golang
+FROM golang:1.17 AS golang
 ENV GOPROXY=https://goproxy.io,direct
 RUN CGO_ENABLED=0 go get -ldflags '-s -w -extldflags -static' github.com/go-delve/delve/cmd/dlv
 

--- a/docs/release_notes/v1.7.3.md
+++ b/docs/release_notes/v1.7.3.md
@@ -4,7 +4,7 @@
 
 #### Problem
 
-The Actor API fails to initialize without an actor state store component being provided. This is the correct behavior for services that register actors, as they require state storage, but clients that invoke actors should operate with or without an actor state store. 
+All Actor APIs return errors without an actor state store component being provided. This is the correct behavior for services that register actors, as they require state storage, but clients that invoke actors should operate with or without an actor state store. 
 
 #### Root cause
 

--- a/docs/release_notes/v1.7.3.md
+++ b/docs/release_notes/v1.7.3.md
@@ -1,0 +1,15 @@
+# Dapr 1.7.3
+
+### Fixes incorrect actor state-store configuration behavior
+
+#### Problem
+
+Omitting a state store configuration will cause the actor subsystem to fail to initialize. This is the correct behavior for services providing actors but this not for services acting as consumers / clients of actors that other services provide. A service acting purely as a consumer does not need state storage and should initiazlize correctly in order to invoke actors elsewhere. 
+
+#### Root cause
+
+Absence of a state store causes the actor subsystem to throw an error, regardless of whether or not the service is providing hosted actors.
+
+#### Solution
+
+Thix fix changes the actor runtime initialization logic such that, when there is no state store available, the actor subsystem will successfully initialize for consumers but will fail for services with hosted actors. 

--- a/docs/release_notes/v1.7.3.md
+++ b/docs/release_notes/v1.7.3.md
@@ -4,12 +4,13 @@
 
 #### Problem
 
-Omitting a state store configuration will cause the actor subsystem to fail to initialize. This is the correct behavior for services providing actors but this not for services acting as consumers / clients of actors that other services provide. A service acting purely as a consumer does not need state storage and should initiazlize correctly in order to invoke actors elsewhere. 
+The Actor API fails to initialize without an actor state store component being provided. This is the correct behavior for services that register actors, as they require state storage, but clients that invoke actors should operate with or without an actor state store. 
 
 #### Root cause
 
-Absence of a state store causes the actor subsystem to throw an error, regardless of whether or not the service is providing hosted actors.
+The code that initializes the Actor API raises an error when there is no actor state storage component available, regardless of whether or not the service
+registers actors. 
 
 #### Solution
 
-Thix fix changes the actor runtime initialization logic such that, when there is no state store available, the actor subsystem will successfully initialize for consumers but will fail for services with hosted actors. 
+Thix fix changes the actor runtime initialization logic such that, when there is no actor state store available, the API will initialize correctly as long as the service does not register actors. As a result, the Actor API will be available to services acting only as clients (i.e invoking actors) with or without an actor state store component; the Actor API will continue to be unavailable in those services that register actors without providing an actor state store component.

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -192,7 +192,8 @@ func (a *actorsRuntime) Init() error {
 
 	if len(a.config.HostedActorTypes) > 0 {
 		if a.store == nil {
-			log.Warn("actors: state store must be present to initialize the actor runtime")
+			// If we have hosted actors and no store, we can't initialize the actor runtime
+			return fmt.Errorf("hosted actors: state store must be present to initialize the actor runtime")
 		} else {
 			features := a.store.Features()
 			if !state.FeatureETag.IsPresent(features) || !state.FeatureTransactional.IsPresent(features) {

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -194,11 +194,11 @@ func (a *actorsRuntime) Init() error {
 		if a.store == nil {
 			// If we have hosted actors and no store, we can't initialize the actor runtime
 			return fmt.Errorf("hosted actors: state store must be present to initialize the actor runtime")
-		} else {
-			features := a.store.Features()
-			if !state.FeatureETag.IsPresent(features) || !state.FeatureTransactional.IsPresent(features) {
-				return errors.New(incompatibleStateStore)
-			}
+		}
+
+		features := a.store.Features()
+		if !state.FeatureETag.IsPresent(features) || !state.FeatureTransactional.IsPresent(features) {
+			return errors.New(incompatibleStateStore)
 		}
 	}
 

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -331,7 +331,6 @@ func newTestActorsRuntimeWithMockAndNoStore(appChannel channel.AppChannel) *acto
 	return a.(*actorsRuntime)
 }
 
-
 func newTestActorsRuntimeWithMockAndActorMetadataPartition(appChannel channel.AppChannel) *actorsRuntime {
 	spec := config.TracingSpec{SamplingRate: "1"}
 	store := fakeStore()

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -322,6 +322,16 @@ func newTestActorsRuntimeWithMock(appChannel channel.AppChannel) *actorsRuntime 
 	return a.(*actorsRuntime)
 }
 
+func newTestActorsRuntimeWithMockAndNoStore(appChannel channel.AppChannel) *actorsRuntime {
+	spec := config.TracingSpec{SamplingRate: "1"}
+	var store state.Store = nil
+	config := NewConfig("", TestAppID, []string{""}, 0, "", config.ApplicationConfig{})
+	a := NewActors(store, appChannel, nil, config, nil, spec, nil, resiliency.New(log), "actorStore")
+
+	return a.(*actorsRuntime)
+}
+
+
 func newTestActorsRuntimeWithMockAndActorMetadataPartition(appChannel channel.AppChannel) *actorsRuntime {
 	spec := config.TracingSpec{SamplingRate: "1"}
 	store := fakeStore()
@@ -344,6 +354,12 @@ func newTestActorsRuntimeWithMockAndActorMetadataPartition(appChannel channel.Ap
 	}, resiliency.New(log), "actorStore")
 
 	return a.(*actorsRuntime)
+}
+
+func newTestActorsRuntimeWithoutStore() *actorsRuntime {
+	appChannel := new(mockAppChannel)
+
+	return newTestActorsRuntimeWithMockAndNoStore(appChannel)
 }
 
 func newTestActorsRuntime() *actorsRuntime {
@@ -1825,6 +1841,30 @@ func TestActorsAppHealthCheck(t *testing.T) {
 
 	time.Sleep(time.Second * 2)
 	assert.False(t, testActorRuntime.appHealthy.Load())
+}
+
+func TestHostedActorsWithoutStateStore(t *testing.T) {
+	testActorRuntime := newTestActorsRuntimeWithoutStore()
+	testActorRuntime.config.HostedActorTypes = []string{"actor1"}
+	go testActorRuntime.startAppHealthCheck(
+		health.WithFailureThreshold(1),
+		health.WithInterval(1*time.Second),
+		health.WithRequestTimeout(100*time.Millisecond))
+
+	time.Sleep(time.Second * 2)
+	assert.False(t, testActorRuntime.appHealthy.Load())
+}
+
+func TestNoHostedActorsWithoutStateStore(t *testing.T) {
+	testActorRuntime := newTestActorsRuntimeWithoutStore()
+	testActorRuntime.config.HostedActorTypes = []string{}
+	go testActorRuntime.startAppHealthCheck(
+		health.WithFailureThreshold(1),
+		health.WithInterval(1*time.Second),
+		health.WithRequestTimeout(100*time.Millisecond))
+
+	time.Sleep(time.Second * 2)
+	assert.True(t, testActorRuntime.appHealthy.Load())
 }
 
 func TestShutdown(t *testing.T) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1768,7 +1768,7 @@ func (a *DaprRuntime) initActors() error {
 	a.actorStateStoreLock.Lock()
 	defer a.actorStateStoreLock.Unlock()
 	if a.actorStateStoreName == "" {
-		log.Warn("actors: state store is not configured - this is okay for clients but services with hosted actors will fail to initialize!")
+		log.Info("actors: state store is not configured - this is okay for clients but services with hosted actors will fail to initialize!")
 	}
 	actorConfig := actors.NewConfig(a.hostAddress, a.runtimeConfig.ID, a.runtimeConfig.PlacementAddresses, a.runtimeConfig.InternalGRPCPort, a.namespace, a.appConfig)
 	act := actors.NewActors(a.stateStores[a.actorStateStoreName], a.appChannel, a.grpc.GetGRPCConnection, actorConfig, a.runtimeConfig.CertChain, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.Features, a.resiliency, a.actorStateStoreName)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -457,11 +457,11 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 
 	err = a.initActors()
 	if err != nil {
-		log.Warnf("failed to init actors: %s", err)
+		log.Warnf("failed to init actors: %v", err)
+	} else {
+		a.daprHTTPAPI.SetActorRuntime(a.actor)
+		grpcAPI.SetActorRuntime(a.actor)
 	}
-
-	a.daprHTTPAPI.SetActorRuntime(a.actor)
-	grpcAPI.SetActorRuntime(a.actor)
 
 	// TODO: Remove feature flag once feature is ratified
 	a.featureRoutingEnabled = config.IsFeatureEnabled(a.globalConfig.Spec.Features, config.PubSubRouting)
@@ -1768,12 +1768,14 @@ func (a *DaprRuntime) initActors() error {
 	a.actorStateStoreLock.Lock()
 	defer a.actorStateStoreLock.Unlock()
 	if a.actorStateStoreName == "" {
-		return errors.New("no actor state store defined")
+		log.Warn("actors: state store is not configured - this is okay for clients but services with hosted actors will fail to initialize!")
 	}
 	actorConfig := actors.NewConfig(a.hostAddress, a.runtimeConfig.ID, a.runtimeConfig.PlacementAddresses, a.runtimeConfig.InternalGRPCPort, a.namespace, a.appConfig)
 	act := actors.NewActors(a.stateStores[a.actorStateStoreName], a.appChannel, a.grpc.GetGRPCConnection, actorConfig, a.runtimeConfig.CertChain, a.globalConfig.Spec.TracingSpec, a.globalConfig.Spec.Features, a.resiliency, a.actorStateStoreName)
 	err = act.Init()
-	a.actor = act
+	if err == nil {
+		a.actor = act
+	}
 	return err
 }
 

--- a/tests/config/dapr_cosmosdb_state.yaml
+++ b/tests/config/dapr_cosmosdb_state.yaml
@@ -32,5 +32,4 @@ spec:
     value: dapre2e
   - name: collection
     value: items
-  - name: actorStateStore
-    value: true
+

--- a/tests/config/dapr_cosmosdb_state_actorstore.yaml
+++ b/tests/config/dapr_cosmosdb_state_actorstore.yaml
@@ -14,15 +14,36 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: statestore
+  name: statestore-actors
 spec:
-  type: state.redis
+  type: state.azure.cosmosdb
   version: v1
   initTimeout: 1m
   metadata:
-  - name: redisHost
+  - name: masterKey
     secretKeyRef:
-      name: redissecret
-      key: host
-  - name: redisPassword
-    value: ""
+      name: cosmosdb-secret
+      key: primaryMasterKey
+  - name: url
+    secretKeyRef:
+      name: cosmosdb-secret
+      key: url
+  - name: database
+    value: dapre2e
+  - name: collection
+    value: items
+  - name: actorStateStore
+    value: true
+scopes:
+- actor1
+- actor2
+- actorapp
+- actorfeatures
+- reentrantactor
+- actorreminder
+- actorreminderpartition
+- actorinvocationapp
+- actorjava
+- actordotnet
+- actorpython
+- actorphp

--- a/tests/config/dapr_cosmosdb_state_actorstore.yaml
+++ b/tests/config/dapr_cosmosdb_state_actorstore.yaml
@@ -47,3 +47,5 @@ scopes:
 - actordotnet
 - actorpython
 - actorphp
+- resiliencyapp
+- resiliencyappgrpc

--- a/tests/config/dapr_cosmosdb_state_actorstore.yaml
+++ b/tests/config/dapr_cosmosdb_state_actorstore.yaml
@@ -35,6 +35,7 @@ spec:
   - name: actorStateStore
     value: true
 scopes:
+# actortestclient is deliberately omitted to ensure that `actor_features_test` works without a state store
 - actor1
 - actor2
 - actorapp

--- a/tests/config/dapr_redis_state_actorstore.yaml
+++ b/tests/config/dapr_redis_state_actorstore.yaml
@@ -29,6 +29,7 @@ spec:
   - name: actorStateStore
     value: true
 scopes:
+# actortestclient is deliberately omitted to ensure that `actor_features_test` works without a state store
 - actor1
 - actor2 
 - actorapp

--- a/tests/config/dapr_redis_state_actorstore.yaml
+++ b/tests/config/dapr_redis_state_actorstore.yaml
@@ -14,7 +14,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: statestore
+  name: statestore-actors
 spec:
   type: state.redis
   version: v1
@@ -26,3 +26,18 @@ spec:
       key: host
   - name: redisPassword
     value: ""
+  - name: actorStateStore
+    value: true
+scopes:
+- actor1
+- actor2 
+- actorapp
+- actorfeatures
+- reentrantactor
+- actorreminder
+- actorreminderpartition
+- actorinvocationapp
+- actorjava
+- actordotnet
+- actorpython
+- actorphp

--- a/tests/config/dapr_redis_state_actorstore.yaml
+++ b/tests/config/dapr_redis_state_actorstore.yaml
@@ -41,3 +41,5 @@ scopes:
 - actordotnet
 - actorpython
 - actorphp
+- resiliencyapp
+- resiliencyappgrpc

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -297,6 +297,7 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/kubernetes_secret_config.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/kubernetes_redis_secret.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_$(DAPR_TEST_STATE_STORE)_state.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/dapr_$(DAPR_TEST_STATE_STORE)_state_actorstore.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_$(DAPR_TEST_QUERY_STATE_STORE)_state.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_tests_cluster_role_binding.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_$(DAPR_TEST_PUBSUB)_pubsub.yaml --namespace $(DAPR_TEST_NAMESPACE)

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -48,6 +48,7 @@ const (
 	actorInvokeURLFormat         = "%s/test/" + actorName + "/%s/%s/%s" // URL to invoke a Dapr's actor method in test app.
 	actorlogsURLFormat           = "%s/test/logs"                       // URL to fetch logs from test app.
 	shutdownURLFormat            = "%s/test/shutdown"                   // URL to shutdown sidecar and app.
+	misconfiguredAppName         = "actor-reminder-no-state-store"      // Actor-reminder app without a state store (should fail to start)
 )
 
 // represents a response for the APIs in this app.
@@ -129,10 +130,50 @@ func TestMain(m *testing.M) {
 				"TEST_APP_ACTOR_TYPE": actorName,
 			},
 		},
+		{
+			AppName:        misconfiguredAppName,
+			DaprEnabled:    true,
+			ImageName:      "e2e-actorfeatures",
+			Replicas:       1,
+			IngressEnabled: true,
+			MetricsEnabled: true,
+			DaprCPULimit:   "2.0",
+			DaprCPURequest: "0.1",
+			AppCPULimit:    "2.0",
+			AppCPURequest:  "0.1",
+			AppEnv: map[string]string{
+				"TEST_APP_ACTOR_TYPE": actorName,
+			},
+		},
 	}
 
 	tr = runner.NewTestRunner(appName, testApps, nil, nil)
 	os.Exit(tr.Start(m))
+}
+
+func TestActorMissingStateStore(t *testing.T) {
+	externalURL := tr.Platform.AcquireAppExternalURL(misconfiguredAppName)
+	require.NotEmpty(t, externalURL, "external URL must not be empty!")
+
+	// This initial probe makes the test wait a little bit longer when needed,
+	// making this test less flaky due to delays in the deployment.
+	t.Logf("Checking if app is healthy ...")
+	_, err := utils.HTTPGetNTimes(externalURL, numHealthChecks)
+	require.NoError(t, err)
+
+	// Set reminder
+	reminder := actorReminder{
+		Data:    "reminderdata",
+		DueTime: "1s",
+		Period:  "1s",
+	}
+	reminderBody, err := json.Marshal(reminder)
+	require.NoError(t, err)
+
+	t.Run("Actor service should 500 when no state store is available.", func(t *testing.T) {
+		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, "bogon-actor", "reminders", "failed-reminder"), reminderBody)
+		require.Error(t, err)
+	})
 }
 
 func TestActorReminder(t *testing.T) {

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -171,8 +171,9 @@ func TestActorMissingStateStore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Actor service should 500 when no state store is available.", func(t *testing.T) {
-		_, err = utils.HTTPPost(fmt.Sprintf(actorInvokeURLFormat, externalURL, "bogon-actor", "reminders", "failed-reminder"), reminderBody)
-		require.Error(t, err)
+		_, statusCode, err := utils.HTTPPostWithStatus(fmt.Sprintf(actorInvokeURLFormat, externalURL, "bogon-actor", "reminders", "failed-reminder"), reminderBody)
+		require.NoError(t, err)
+		require.True(t, statusCode == 500)
 	})
 }
 


### PR DESCRIPTION
# Description

Changes the actor initialization subsystem to fail when there is no state store only when there are hosted actors. When there are hosted actors and no state store, don't initialize the actor subsystem. Moved actor state storage into a separate (identically configured) component for Cosmos and Redis and scoped it to only tests needing actor state storage. 

Added a test to the actor_reminder to verify that it gets a 500 when trying to call a service that has hosted actors but no state store available, and also ensure that actor clients can work without a state store. 

## Issue reference


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#2441

/cc @artursouza 
