### PR TITLE
Disable caching for the linter in the 1.5 branch

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -89,6 +89,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2.2.1
         with:
           version: ${{ env.GOLANGCILINT_VER }}
+          skip-cache: true
       - name: Run go mod tidy check diff
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
         run: make modtidy check-diff


### PR DESCRIPTION
# Description

Disable the cache in the linter -- it's causing a problem in the 1.5 release builds 

