### PR TITLE
AWS SNS/SQS pubsub should be named pubsub.aws.snssqs

### DIFF
--- a/cmd/daprd/main.go
+++ b/cmd/daprd/main.go
@@ -74,7 +74,7 @@ import (
 
 	// Pub/Sub.
 	pubs "github.com/dapr/components-contrib/pubsub"
-	pubsub_snssqs "github.com/dapr/components-contrib/pubsub/aws/snssqs"
+	pubsub_aws_snssqs "github.com/dapr/components-contrib/pubsub/aws/snssqs"
 	pubsub_eventhubs "github.com/dapr/components-contrib/pubsub/azure/eventhubs"
 	"github.com/dapr/components-contrib/pubsub/azure/servicebus"
 	pubsub_gcp "github.com/dapr/components-contrib/pubsub/gcp/pubsub"
@@ -284,6 +284,9 @@ func main() {
 			}),
 		),
 		runtime.WithPubSubs(
+			pubsub_loader.New([]string{"aws.snssqs", "snssqs"}, func() pubs.PubSub {
+				return pubsub_aws_snssqs.NewSnsSqs(logContrib)
+			}),
 			pubsub_loader.New("azure.eventhubs", func() pubs.PubSub {
 				return pubsub_eventhubs.NewAzureEventHubs(logContrib)
 			}),
@@ -316,9 +319,6 @@ func main() {
 			}),
 			pubsub_loader.New("redis", func() pubs.PubSub {
 				return pubsub_redis.NewRedisStreams(logContrib)
-			}),
-			pubsub_loader.New("snssqs", func() pubs.PubSub {
-				return pubsub_snssqs.NewSnsSqs(logContrib)
 			}),
 			pubsub_loader.New("in-memory", func() pubs.PubSub {
 				return pubsub_inmemory.New(logContrib)

--- a/pkg/components/secretstores/registry.go
+++ b/pkg/components/secretstores/registry.go
@@ -36,6 +36,10 @@ type (
 		Create(name, version string) (secretstores.SecretStore, error)
 	}
 
+	stringOrSliceOfStrings interface {
+		string | []string
+	}
+
 	secretStoreRegistry struct {
 		secretStores map[string]func() secretstores.SecretStore
 	}

--- a/pkg/components/state/registry.go
+++ b/pkg/components/state/registry.go
@@ -40,6 +40,10 @@ type Registry interface {
 	Create(name, version string) (state.Store, error)
 }
 
+type stringOrSliceOfStrings interface {
+	string | []string
+}
+
 type stateStoreRegistry struct {
 	stateStores map[string]func() state.Store
 }


### PR DESCRIPTION
# Description

Following our conventions, the name for the AWS SNS/SQS pubsub component should have been `pubsub.aws.snssqs` rather than `pubsub.snssqs` (in some parts of our codebase we did use `pubsub.aws.snssqs`, although docs always included `pubsub.snssqs`)

This PR adds supports for aliases in component names so it's possible to support both the new and old names (for backwards compatibility).

I will open a docs PR to update the recommended name to use.

## Issue reference

Fixes dapr/components-contrib#1753

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_ @ItalyPaleAle  TBD
