### PR TITLE
Fix performance tests

### DIFF
--- a/tests/config/dapr_cosmosdb_state_actorstore.yaml
+++ b/tests/config/dapr_cosmosdb_state_actorstore.yaml
@@ -50,3 +50,9 @@ scopes:
 - actorphp
 - resiliencyapp
 - resiliencyappgrpc
+- perf-actor-activation-service
+- perf-actor-activation-client
+- perf-actor-reminder-service
+- perf-actor-reminder-client
+- perf-actor-timer-service
+- perf-actor-timer-client

--- a/tests/config/dapr_redis_state_actorstore.yaml
+++ b/tests/config/dapr_redis_state_actorstore.yaml
@@ -44,3 +44,9 @@ scopes:
 - actorphp
 - resiliencyapp
 - resiliencyappgrpc
+- perf-actor-activation-service
+- perf-actor-activation-client
+- perf-actor-reminder-service
+- perf-actor-reminder-client
+- perf-actor-timer-service
+- perf-actor-timer-client

--- a/tests/perf/actor_activation/actor_activation_test.go
+++ b/tests/perf/actor_activation/actor_activation_test.go
@@ -30,7 +30,9 @@ import (
 )
 
 const (
-	numHealthChecks = 60 // Number of times to check for endpoint health per app.
+	numHealthChecks        = 60 // Number of times to check for endpoint health per app.
+	serviceApplicationName = "perf-actor-activation-service"
+	clientApplicationName  = "perf-actor-activation-client"
 )
 
 var tr *runner.TestRunner
@@ -40,7 +42,7 @@ func TestMain(m *testing.M) {
 
 	testApps := []kube.AppDescription{
 		{
-			AppName:           "testapp",
+			AppName:           serviceApplicationName,
 			DaprEnabled:       true,
 			ImageName:         "perf-actorjava",
 			Replicas:          1,
@@ -57,7 +59,7 @@ func TestMain(m *testing.M) {
 			AppMemoryRequest:  "2500Mi",
 		},
 		{
-			AppName:           "tester",
+			AppName:           clientApplicationName,
 			DaprEnabled:       true,
 			ImageName:         "perf-tester",
 			Replicas:          1,
@@ -83,7 +85,7 @@ func TestActorActivate(t *testing.T) {
 	p := perf.Params()
 
 	// Get the ingress external url of test app
-	testAppURL := tr.Platform.AcquireAppExternalURL("testapp")
+	testAppURL := tr.Platform.AcquireAppExternalURL(serviceApplicationName)
 	require.NotEmpty(t, testAppURL, "test app external URL must not be empty")
 
 	// Check if test app endpoint is available
@@ -92,7 +94,7 @@ func TestActorActivate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get the ingress external url of tester app
-	testerAppURL := tr.Platform.AcquireAppExternalURL("tester")
+	testerAppURL := tr.Platform.AcquireAppExternalURL(clientApplicationName)
 	require.NotEmpty(t, testerAppURL, "tester app external URL must not be empty")
 
 	// Check if tester app endpoint is available
@@ -113,16 +115,16 @@ func TestActorActivate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, daprResp)
 
-	appUsage, err := tr.Platform.GetAppUsage("testapp")
+	appUsage, err := tr.Platform.GetAppUsage(serviceApplicationName)
 	require.NoError(t, err)
 
-	sidecarUsage, err := tr.Platform.GetSidecarUsage("testapp")
+	sidecarUsage, err := tr.Platform.GetSidecarUsage(serviceApplicationName)
 	require.NoError(t, err)
 
-	restarts, err := tr.Platform.GetTotalRestarts("testapp")
+	restarts, err := tr.Platform.GetTotalRestarts(serviceApplicationName)
 	require.NoError(t, err)
 
-	testerRestarts, err := tr.Platform.GetTotalRestarts("tester")
+	testerRestarts, err := tr.Platform.GetTotalRestarts(clientApplicationName)
 	require.NoError(t, err)
 
 	t.Logf("dapr test results: %s", string(daprResp))

--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -31,8 +31,10 @@ import (
 )
 
 const (
-	numHealthChecks = 60 // Number of times to check for endpoint health per app.
-	actorType       = "PerfTestActorReminder"
+	numHealthChecks        = 60 // Number of times to check for endpoint health per app.
+	actorType              = "PerfTestActorReminder"
+	serviceApplicationName = "perf-actor-reminder-service"
+	clientApplicationName  = "perf-actor-reminder-client"
 )
 
 var tr *runner.TestRunner
@@ -42,7 +44,7 @@ func TestMain(m *testing.M) {
 
 	testApps := []kube.AppDescription{
 		{
-			AppName:           "testapp",
+			AppName:           serviceApplicationName,
 			DaprEnabled:       true,
 			ImageName:         "perf-actorfeatures",
 			Replicas:          1,
@@ -61,7 +63,7 @@ func TestMain(m *testing.M) {
 			},
 		},
 		{
-			AppName:           "tester",
+			AppName:           clientApplicationName,
 			DaprEnabled:       true,
 			ImageName:         "perf-tester",
 			Replicas:          1,
@@ -86,7 +88,7 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 	p := perf.Params()
 
 	// Get the ingress external url of test app
-	testAppURL := tr.Platform.AcquireAppExternalURL("testapp")
+	testAppURL := tr.Platform.AcquireAppExternalURL(serviceApplicationName)
 	require.NotEmpty(t, testAppURL, "test app external URL must not be empty")
 
 	// Check if test app endpoint is available
@@ -95,7 +97,7 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get the ingress external url of tester app
-	testerAppURL := tr.Platform.AcquireAppExternalURL("tester")
+	testerAppURL := tr.Platform.AcquireAppExternalURL(clientApplicationName)
 	require.NotEmpty(t, testerAppURL, "tester app external URL must not be empty")
 
 	// Check if tester app endpoint is available
@@ -119,13 +121,13 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 	// Let test run for 10 minutes triggering the timers and collect metrics.
 	time.Sleep(10 * time.Minute)
 
-	appUsage, err := tr.Platform.GetAppUsage("testapp")
+	appUsage, err := tr.Platform.GetAppUsage(serviceApplicationName)
 	require.NoError(t, err)
 
-	sidecarUsage, err := tr.Platform.GetSidecarUsage("testapp")
+	sidecarUsage, err := tr.Platform.GetSidecarUsage(serviceApplicationName)
 	require.NoError(t, err)
 
-	restarts, err := tr.Platform.GetTotalRestarts("testapp")
+	restarts, err := tr.Platform.GetTotalRestarts(serviceApplicationName)
 	require.NoError(t, err)
 
 	t.Logf("dapr test results: %s", string(daprResp))


### PR DESCRIPTION

# Description

Converted app name magic strings to constants in perf tests and added their identifiers to actor state store configurations so that the performance tests utilizing actors can run. 

Signed-off-by: John Ewart <johnewart@microsoft.com>

/cc @skyao 