### PR TITLE
[1.7 HOTFIX] Stopgap measure for pubsub routing issue

### DIFF
--- a/docs/release_notes/v1.7.4.md
+++ b/docs/release_notes/v1.7.4.md
@@ -1,0 +1,31 @@
+# Dapr 1.7.4
+
+### Fixes PubSub messages delivered to wrong handler
+
+#### Problem
+
+We have discovered an issue with 3 PubSub Dapr components that causes messages to be routed to the wrong handler:
+
+- AWS SNS/SQS
+- Kafka
+- MQTT
+
+Applications that use those components to listen to multiple topics may find that all messages are routed to the same handler, regardless of the topic the message.
+
+This issue impacts the 1.7 branch of Dapr only (versions 1.7.0 through 1.7.3).
+
+#### Root cause
+
+When listening for messages on multiple topics, each one with a different handler, the 3 PubSub components listed above incorrectly route all messages to a single handler (usually, the last one that was added).
+
+Prior to 1.7, the Dapr runtime would re-route messages to the correct handler, even though the components themselves were routing them incorrectly. This behavior was (correctly) removed in 1.7.0, which uncovered the issues in the underlying implementation of the 3 PubSub components listed above.
+
+#### Solution
+
+This release includes a mitigation that makes the runtime route messages again, essentially restoring the behavior of Dapr 1.6 in this specific part.
+
+A more complete fix, which includes correcting the behavior of the 3 PubSub components listed above, will be included in a future Dapr release in the 1.8 branch.
+
+### More details
+
+You can see more details in [dapr/dapr#4685](https://github.com/dapr/dapr/issues/4685).


### PR DESCRIPTION
Trying my best to explain this, as it's a bit complicated :)

3 PubSub components have/had issues with routing messages, as they are/were routing messages to the same handler. These are being fixed (or have already been fixed) in components-contrib in the master branch:

- Kafka (Stable): dapr/components-contrib#1755
- AWS SNS/SQS (Beta): dapr/components-contrib#1754
- MQTT (Beta): dapr/components-contrib#1737

These bugs in the components have been around for some time, but they were not causing any visible issue because of another "bug" (?), which was fixed in the runtime with #4220, which landed in 1.7.0.

Before #4220, the runtime would route pubsub messages again, so even if components delivered messages to the wrong handler, the runtime would re-route them to the correct handler. This should not have been needed, and in fact #4220 removed this "re-routing". However, by removing this, now the bugs in the 3 components above are surfaced.

#4220 + the 3 PRs above in components-contrib are **the correct** fixes to this issue. Additionally, dapr/components-contrib#1743 will include conformance tests in components-contrib that will prevent regressions in the future.

**However**, backporting the fixes from those 3 PRs into 1.7 would be very challenging, as those PRs were built on top of other significant changes, so that a backport into a hotfix would be too risky.

Thus, this PR contains a stopgap measure that temporarily re-implements a router for PubSub messages inside the runtime. It's a very low-risk change that will "mask up" the bugs in the components.

**This PR should not be merged into master, as it's only a stopgap for 1.7**. For master (and 1.8+) we should implement the "real fixes" described above.

PS: I'll add a test as well, with a separate PR, as tests should be merged in both release-1.7 and master