### PR TITLE
Add comment to explain how to replace components-contrib for dev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -372,3 +372,11 @@ replace (
 )
 
 replace github.com/eclipse/paho.mqtt.golang => github.com/shivamkm07/paho.mqtt.golang v1.3.6-0.20220106130409-e28a1db639f8
+
+// Uncomment for local development for testing with changes in the components-contrib repository.
+// Don't commit with this uncommented!
+//
+// replace github.com/dapr/components-contrib => ../components-contrib
+//
+// Then, run `make modtidy` in this repository.
+// This ensures that go.mod and go.sum are up-to-date.


### PR DESCRIPTION
Small quality-of-life change to help contributors (especially first-time contributors). Inspired by what's in [components-contrib](https://github.com/dapr/components-contrib/blob/master/tests/certification/pubsub/mqtt/go.mod#L127-L130).