### PR TITLE
Added option to capture diagnostic logs from AKS

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -16,7 +16,7 @@
 # - PERF_AZURE_STORAGE_ACCOUNT and PERF_AZURE_STORAGE_KEY: Credentials for the Storage Account where to store the result of perf tests
 # - DAPR_BOT_TOKEN: Token for the Dapr bot
 #
-# Optional secets:
+# Optional secrets:
 # - AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID: Resource ID of the Log Analytics Workspace where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.OperationalInsights/workspaces/<workspace name>`)
 # - AZURE_DIAG_STORAGE_ID: Resource ID of the Azure Storage account where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.Storage/storageAccounts/<storage account name>`)
 

--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -15,6 +15,10 @@
 # - AZURE_CREDENTIALS: JSON object containing the Azure service principal credentials. Docs: https://github.com/Azure/login#configure-a-service-principal-with-a-secret
 # - PERF_AZURE_STORAGE_ACCOUNT and PERF_AZURE_STORAGE_KEY: Credentials for the Storage Account where to store the result of perf tests
 # - DAPR_BOT_TOKEN: Token for the Dapr bot
+#
+# Optional secets:
+# - AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID: Resource ID of the Log Analytics Workspace where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.OperationalInsights/workspaces/<workspace name>`)
+# - AZURE_DIAG_STORAGE_ID: Resource ID of the Azure Storage account where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.Storage/storageAccounts/<storage account name>`)
 
 name: dapr-perf
 
@@ -122,6 +126,8 @@ jobs:
                 namePrefix="${{ env.TEST_PREFIX }}" \
                 location=${REGION} \
                 linuxVMSize=Standard_D8s_v4 \
+                diagLogAnalyticsWorkspaceResourceId="${{ secrets.AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID }}" \
+                diagStorageResourceId="${{ secrets.AZURE_DIAG_STORAGE_ID }}" \
             && break || sleep 120
           done
         shell: bash

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -15,7 +15,7 @@
 # - AZURE_CREDENTIALS: JSON object containing the Azure service principal credentials. Docs: https://github.com/Azure/login#configure-a-service-principal-with-a-secret
 # - DAPR_BOT_TOKEN: Token for the Dapr bot
 #
-# Optional secets:
+# Optional secrets:
 # - AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID: Resource ID of the Log Analytics Workspace where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.OperationalInsights/workspaces/<workspace name>`)
 # - AZURE_DIAG_STORAGE_ID: Resource ID of the Azure Storage account where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.Storage/storageAccounts/<storage account name>`)
 

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -14,6 +14,10 @@
 # Required secrets:
 # - AZURE_CREDENTIALS: JSON object containing the Azure service principal credentials. Docs: https://github.com/Azure/login#configure-a-service-principal-with-a-secret
 # - DAPR_BOT_TOKEN: Token for the Dapr bot
+#
+# Optional secets:
+# - AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID: Resource ID of the Log Analytics Workspace where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.OperationalInsights/workspaces/<workspace name>`)
+# - AZURE_DIAG_STORAGE_ID: Resource ID of the Azure Storage account where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.Storage/storageAccounts/<storage account name>`)
 
 name: dapr-test
 
@@ -123,6 +127,8 @@ jobs:
                 location1=${REGION1} \
                 location2=${REGION2} \
                 dateTag="${DATE_TAG}" \
+                diagLogAnalyticsWorkspaceResourceId="${{ secrets.AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID }}" \
+                diagStorageResourceId="${{ secrets.AZURE_DIAG_STORAGE_ID }}" \
               && success=true \
               && break \
               || sleep 120

--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -293,3 +293,46 @@ make create-test-namespace
 ```
 
 After this, run the E2E tests as per instructions above, making sure to use the newly-created Azure Container Registry as Docker registry (make sure you maintain the environmental variables set in the steps above).
+
+### Collect container and diagnostic logs from AKS
+
+You can optionally configure AKS to collect certain logs, including:
+
+- All container logs, sent to Azure Log Analytics
+- Diagnostic logs (`kube-apiserver` and `kube-controller-manager`), sent to Azure Log Analytics
+- Audit logs (`kube-audit`), sent to Azure Storage
+
+To do that, first provision the required resources by deploying the `azure-aks-diagnostic.bicep` template (this template is not part of the `azure.bicep` or `azure-all.bicep` templates, as it's considered shared infrastructure):
+
+```sh
+# Name of the resource group where to deploy the diagnostic resources
+DIAG_RESOURCE_GROUP="MyDaprTestLogs"
+
+# Name prefix for the diagnostic resources (should be globally-unique)
+DIAG_NAME_PREFIX="mydaprdiag42"
+
+# Create a resource group
+az group create \
+  --resource-group "${DIAG_RESOURCE_GROUP}" \
+  --location "${AZURE_REGION}"
+
+# Deploy the test infrastructure
+az deployment group create \
+  --resource-group "${DIAG_RESOURCE_GROUP}" \
+  --template-file ./tests/test-infra/azure-aks-diagnostic.bicep \
+  --parameters name=${DIAG_NAME_PREFIX} location=${AZURE_REGION}
+```
+
+The output of the last command includes two values that are resource IDs:
+
+- `diagLogAnalyticsWorkspaceResourceId`, for example: `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.OperationalInsights/workspaces/<workspace name>`
+- `diagStorageResourceId`, for example: `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.Storage/storageAccounts/<storage account name>`
+
+Use those values as parameters when deploying the `azure.bicep` or `azure-all.bicep` templates. For example:
+
+```sh
+az deployment group create \
+  --resource-group "${TEST_RESOURCE_GROUP}" \
+  --template-file ./tests/test-infra/azure.bicep \
+  --parameters namePrefix=${TEST_PREFIX} location=${AZURE_REGION} enableWindows=${ENABLE_WINDOWS} diagLogAnalyticsWorkspaceResourceId=... diagStorageResourceId=...
+```

--- a/tests/test-infra/azure-aks-diagnostic.bicep
+++ b/tests/test-infra/azure-aks-diagnostic.bicep
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@description('Name for the resources')
+param name string
+
+@description('Location of the resources')
+param location string = resourceGroup().location
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' = {
+  name: '${name}la'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+    workspaceCapping: {
+      dailyQuotaGb: 7
+    }
+  }
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-08-01' = {
+  name: '${name}sa'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+  }
+}
+
+output diagLogAnalyticsWorkspaceResourceId string = logAnalyticsWorkspace.id
+output diagStorageResourceId string = storageAccount.id

--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -26,6 +26,12 @@ param linuxVMSize string = 'Standard_DS2_v2'
 @description('VM size to use for Windows nodes, if enabled')
 param windowsVMSize string = 'Standard_DS3_v2'
 
+@description('If set, sends certain diagnostic logs to Log Analytics')
+param diagLogAnalyticsWorkspaceResourceId string = ''
+
+@description('If set, sends certain diagnostic logs to Azure Storage')
+param diagStorageResourceId string = ''
+
 // Disk size (in GB) for each of the agent pool nodes
 // 0 applies the default
 var osDiskSizeGB = 0
@@ -137,6 +143,14 @@ resource aks 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
       azureKeyvaultSecretsProvider: {
         enabled: false
       }
+      omsagent: diagLogAnalyticsWorkspaceResourceId == '' ? {
+        enabled: false
+      } : {
+        enabled: true
+        config: {
+          logAnalyticsWorkspaceResourceID: diagLogAnalyticsWorkspaceResourceId
+        }
+      }
     }
   }
   tags: {}
@@ -181,6 +195,50 @@ resource roleAssignVNet 'Microsoft.Authorization/roleAssignments@2020-04-01-prev
     principalId: aks.identity.principalId
   }
   scope: aksVNet::defaultSubnet
+}
+
+resource aksDiagnosticLogAnalytics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (diagLogAnalyticsWorkspaceResourceId != '') {
+  name: 'loganalytics'
+  scope: aks
+  properties: {
+    logs: [
+      {
+        category: 'kube-apiserver'
+        enabled: true
+      }
+      {
+        category: 'kube-controller-manager'
+        enabled: true
+      }
+    ]
+    workspaceId: diagLogAnalyticsWorkspaceResourceId
+  }
+}
+
+resource aksDiagnosticStorage 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (diagStorageResourceId != '') {
+  name: 'storage'
+  scope: aks
+  properties: {
+    logs: [
+      {
+        category: 'kube-apiserver'
+        enabled: true
+        retentionPolicy: {
+          days: 15
+          enabled: true
+        }
+      }
+      {
+        category: 'kube-audit'
+        enabled: true
+        retentionPolicy: {
+          days: 15
+          enabled: true
+        }
+      }
+    ]
+    storageAccountId: diagStorageResourceId
+  }
 }
 
 output controlPlaneFQDN string = aks.properties.fqdn

--- a/tests/test-infra/azure-all.bicep
+++ b/tests/test-infra/azure-all.bicep
@@ -29,6 +29,12 @@ param location2 string
 @description('Optional value for the date tag for resource groups')
 param dateTag string = ''
 
+@description('If set, sends certain diagnostic logs to Log Analytics')
+param diagLogAnalyticsWorkspaceResourceId string = ''
+
+@description('If set, sends certain diagnostic logs to Azure Storage')
+param diagStorageResourceId string = ''
+
 // Deploy the Linux cluster in the first location
 resource linuxResources 'Microsoft.Resources/resourceGroups@2020-10-01' = {
   name: 'Dapr-E2E-${namePrefix}l'
@@ -44,6 +50,8 @@ module linuxCluster 'azure.bicep' = {
     namePrefix: '${namePrefix}l'
     location: location1
     enableWindows: false
+    diagLogAnalyticsWorkspaceResourceId: diagLogAnalyticsWorkspaceResourceId
+    diagStorageResourceId: diagStorageResourceId
   }
 }
 
@@ -62,5 +70,7 @@ module windowsCluster 'azure.bicep' = {
     namePrefix: '${namePrefix}w'
     location: location2
     enableWindows: true
+    diagLogAnalyticsWorkspaceResourceId: diagLogAnalyticsWorkspaceResourceId
+    diagStorageResourceId: diagStorageResourceId
   }
 }

--- a/tests/test-infra/azure.bicep
+++ b/tests/test-infra/azure.bicep
@@ -23,6 +23,12 @@ param location string = resourceGroup().location
 @description('If enabled, add a Windows pool')
 param enableWindows bool = false
 
+@description('If set, sends certain diagnostic logs to Log Analytics')
+param diagLogAnalyticsWorkspaceResourceId string = ''
+
+@description('If set, sends certain diagnostic logs to Azure Storage')
+param diagStorageResourceId string = ''
+
 // Deploy an AKS cluster
 module aksModule './azure-aks.bicep' = {
   name: 'azure-aks'
@@ -30,6 +36,8 @@ module aksModule './azure-aks.bicep' = {
     namePrefix: namePrefix
     location: location
     enableWindows: enableWindows
+    diagLogAnalyticsWorkspaceResourceId: diagLogAnalyticsWorkspaceResourceId
+    diagStorageResourceId: diagStorageResourceId
   }
 }
 


### PR DESCRIPTION
This PR adds the ability to collect diagnostic logs from E2E and Perf tests on AKS.

These logs include:

- All container logs, sent to Azure Log Analytics. This is better than our current log collection as it captures logs for crashed containers and even after the test has stopped running.
- Diagnostic logs (`kube-apiserver` and `kube-controller-manager`), sent to Azure Log Analytics.
- Audit logs (`kube-audit`), sent to Azure Storage.

These logs are particularly useful for debugging issues with E2E and Perf tests on AKS.

Note that the infrastructure where logs are collected (the Log Analytics workspace and Storage account) is static and pre-deployed, and it's not deployed as part of each test (otherwise the logs would get deleted automatically too!). Data is persisted for a short number of days only (30 for Log Analytics, 14 for Azure Storage). Because those logs could contain sensitive information (audit logs include a lot of secrets!), they are not exported from the places where they are stored.

**Note:** I've already deployed the infrastructure in our test Azure subscription. To make the diagnostic logs work in our Actions runs, a STC member will need to add two secrets to the dapr/dapr repo: `AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID` and `AZURE_DIAG_STORAGE_ID` (I can provide the values privately). The pipelines will work even without those secrets, but diagnostic logs won't be collected