### PR TITLE
optimize/crds: change level from error to warn

### DIFF
--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -233,7 +233,7 @@ func DeclarativeSelfHosted(componentsPath string, log logger.Logger) []Subscript
 			filePath := filepath.Join(componentsPath, f.Name())
 			b, err := os.ReadFile(filePath)
 			if err != nil {
-				log.Errorf("failed to read file %s: %s", filePath, err)
+				log.Warnf("failed to read file %s: %s", filePath, err)
 				continue
 			}
 


### PR DESCRIPTION
Signed-off-by: 1046102779 <seachen@tencent.com>

In k8s, it is possible to mount the file in a softlink through configmap. 

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/20457624/172636568-57e7f678-446f-4a37-99c0-6a81fa4b0e1c.png">


<img width="762" alt="image" src="https://user-images.githubusercontent.com/20457624/172636432-2761e325-7701-465b-8cbd-f27e04afa26f.png">
