### PR TITLE
Updates to injector and operator's startup/shutdown

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"flag"
-	"time"
 
 	"k8s.io/klog"
 
@@ -51,10 +50,6 @@ func main() {
 	go operator.RunWebhooks(ctx, !disableLeaderElection)
 
 	<-ctx.Done() // Wait for SIGTERM and SIGINT.
-
-	shutdownDuration := 5 * time.Second
-	log.Infof("allowing %s for graceful shutdown to complete", shutdownDuration)
-	<-time.After(shutdownDuration)
 }
 
 func init() {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -46,9 +46,9 @@ func main() {
 	log.Infof("starting Dapr Operator -- version %s -- commit %s", version.Version(), version.Commit())
 
 	ctx := signals.Context()
+
 	go operator.NewOperator(config, certChainPath, !disableLeaderElection).Run(ctx)
-	// The webhooks use their own controller context and stops on SIGTERM and SIGINT.
-	go operator.RunWebhooks(!disableLeaderElection)
+	go operator.RunWebhooks(ctx, !disableLeaderElection)
 
 	<-ctx.Done() // Wait for SIGTERM and SIGINT.
 

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -184,6 +184,8 @@ func (i *injector) Run(ctx context.Context, onReady func()) {
 	}
 
 	ln.Close()
+
+	log.Info("Sidecar injector stopped")
 }
 
 func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -55,7 +56,7 @@ var allowedControllersServiceAccounts = []string{
 
 // Injector is the interface for the Dapr runtime sidecar injection component.
 type Injector interface {
-	Run(ctx context.Context)
+	Run(ctx context.Context, onReady func())
 }
 
 type injector struct {
@@ -67,9 +68,9 @@ type injector struct {
 	authUIDs     []string
 }
 
-// toAdmissionResponse is a helper function to create an AdmissionResponse
+// errorToAdmissionResponse is a helper function to create an AdmissionResponse
 // with an embedded error.
-func toAdmissionResponse(err error) *v1.AdmissionResponse {
+func errorToAdmissionResponse(err error) *v1.AdmissionResponse {
 	return &v1.AdmissionResponse{
 		Result: &metav1.Status{
 			Message: err.Error(),
@@ -149,9 +150,7 @@ func getServiceAccount(ctx context.Context, kubeClient kubernetes.Interface, all
 	return string(sa.ObjectMeta.UID), nil
 }
 
-func (i *injector) Run(ctx context.Context) {
-	doneCh := make(chan struct{})
-
+func (i *injector) Run(ctx context.Context, onReady func()) {
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -161,28 +160,42 @@ func (i *injector) Run(ctx context.Context) {
 				time.Second*5,
 			)
 			defer cancel()
-			i.server.Shutdown(shutdownCtx) // nolint: errcheck
-		case <-doneCh:
+			err := i.server.Shutdown(shutdownCtx)
+			if err != nil {
+				log.Errorf("Error while shutting down injector: %v", err)
+			}
 		}
 	}()
 
+	ln, err := net.Listen("tcp", i.server.Addr)
+	if err != nil {
+		log.Fatalf("Eror while creating listener: %v", err)
+	}
+
 	log.Infof("Sidecar injector is listening on %s, patching Dapr-enabled pods", i.server.Addr)
-	err := i.server.ListenAndServeTLS(i.config.TLSCertFile, i.config.TLSKeyFile)
+
+	if onReady != nil {
+		onReady()
+	}
+
+	err = i.server.ServeTLS(ln, i.config.TLSCertFile, i.config.TLSKeyFile)
 	if err != http.ErrServerClosed {
 		log.Errorf("Sidecar injector error: %s", err)
 	}
-	close(doneCh)
+
+	ln.Close()
 }
 
 func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
 	monitoring.RecordSidecarInjectionRequestsCount()
 
 	var body []byte
+	var err error
 	if r.Body != nil {
-		if data, err := io.ReadAll(r.Body); err == nil {
-			body = data
+		defer r.Body.Close()
+		body, err = io.ReadAll(r.Body)
+		if err != nil {
+			body = nil
 		}
 	}
 	if len(body) == 0 {
@@ -194,18 +207,12 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 	contentType := r.Header.Get("Content-Type")
 	if contentType != runtime.ContentTypeJSON {
 		log.Errorf("Content-Type=%s, expect %s", contentType, runtime.ContentTypeJSON)
-		http.Error(
-			w,
-			fmt.Sprintf("invalid Content-Type, expect `%s`", runtime.ContentTypeJSON),
-			http.StatusUnsupportedMediaType,
-		)
-
+		errStr := fmt.Sprintf("invalid Content-Type, expected `%s`", runtime.ContentTypeJSON)
+		http.Error(w, errStr, http.StatusUnsupportedMediaType)
 		return
 	}
 
-	var admissionResponse *v1.AdmissionResponse
 	var patchOps []PatchOperation
-	var err error
 	patchedSuccessfully := false
 
 	ar := v1.AdmissionReview{}
@@ -227,8 +234,9 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 	diagAppID := getAppIDFromRequest(ar.Request)
 
+	var admissionResponse *v1.AdmissionResponse
 	if err != nil {
-		admissionResponse = toAdmissionResponse(err)
+		admissionResponse = errorToAdmissionResponse(err)
 		log.Errorf("Sidecar injector failed to inject for app '%s'. Error: %s", diagAppID, err)
 		monitoring.RecordFailedSidecarInjectionCount(diagAppID, "patch")
 	} else if len(patchOps) == 0 {
@@ -239,7 +247,7 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 		var patchBytes []byte
 		patchBytes, err = json.Marshal(patchOps)
 		if err != nil {
-			admissionResponse = toAdmissionResponse(err)
+			admissionResponse = errorToAdmissionResponse(err)
 		} else {
 			admissionResponse = &v1.AdmissionResponse{
 				Allowed: true,
@@ -252,37 +260,36 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	admissionReview := v1.AdmissionReview{}
-	if admissionResponse != nil {
-		admissionReview.Response = admissionResponse
-		if ar.Request != nil {
-			admissionReview.Response.UID = ar.Request.UID
-			admissionReview.SetGroupVersionKind(*gvk)
-		}
+	admissionReview := v1.AdmissionReview{
+		Response: admissionResponse,
+	}
+	if admissionResponse != nil && ar.Request != nil {
+		admissionReview.Response.UID = ar.Request.UID
+		admissionReview.SetGroupVersionKind(*gvk)
 	}
 
-	log.Infof("ready to write response ...")
+	// log.Debug("ready to write response ...")
+
 	respBytes, err := json.Marshal(admissionReview)
 	if err != nil {
-		http.Error(
-			w,
-			err.Error(),
-			http.StatusInternalServerError,
-		)
-
-		log.Errorf("Sidecar injector failed to inject for app '%s'. Can't deserialize response: %s", diagAppID, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Errorf("Sidecar injector failed to inject for app '%s'. Can't serialize response: %s", diagAppID, err)
 		monitoring.RecordFailedSidecarInjectionCount(diagAppID, "response")
+		return
 	}
 	w.Header().Set("Content-Type", runtime.ContentTypeJSON)
-	if _, err := w.Write(respBytes); err != nil {
-		log.Error(err)
+	_, err = w.Write(respBytes)
+	if err != nil {
+		log.Errorf("Sidecar injector failed to inject for app '%s'. Failed to write response: %v", diagAppID, err)
+		monitoring.RecordFailedSidecarInjectionCount(diagAppID, "write_response")
+		return
+	}
+
+	if patchedSuccessfully {
+		log.Infof("Sidecar injector succeeded injection for app '%s'", diagAppID)
+		monitoring.RecordSuccessfulSidecarInjectionCount(diagAppID)
 	} else {
-		if patchedSuccessfully {
-			log.Infof("Sidecar injector succeeded injection for app '%s'", diagAppID)
-			monitoring.RecordSuccessfulSidecarInjectionCount(diagAppID)
-		} else {
-			log.Errorf("Admission succeeded, but pod was not patched. No sidecar injected for '%s'", diagAppID)
-			monitoring.RecordFailedSidecarInjectionCount(diagAppID, "pod_patch")
-		}
+		log.Errorf("Admission succeeded, but pod was not patched. No sidecar injected for '%s'", diagAppID)
+		monitoring.RecordFailedSidecarInjectionCount(diagAppID, "pod_patch")
 	}
 }

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -57,7 +58,7 @@ var log = logger.NewLogger("dapr.operator.api")
 
 // Server runs the Dapr API server for components and configurations.
 type Server interface {
-	Run(certChain *dapr_credentials.CertChain)
+	Run(ctx context.Context, certChain *dapr_credentials.CertChain, onReady func())
 	OnComponentUpdated(component *componentsapi.Component)
 }
 
@@ -78,22 +79,50 @@ func NewAPIServer(client client.Client) Server {
 }
 
 // Run starts a new gRPC server.
-func (a *apiServer) Run(certChain *dapr_credentials.CertChain) {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", serverPort))
-	if err != nil {
-		log.Fatal("error starting tcp listener: %s", err)
-	}
+func (a *apiServer) Run(ctx context.Context, certChain *dapr_credentials.CertChain, onReady func()) {
+	log.Info("starting gRPC server on port %d", serverPort)
 
 	opts, err := dapr_credentials.GetServerOptions(certChain)
 	if err != nil {
-		log.Fatal("error creating gRPC options: %s", err)
+		log.Fatal("error creating gRPC options: %v", err)
 	}
 	s := grpc.NewServer(opts...)
 	operatorv1pb.RegisterOperatorServer(s, a)
 
-	log.Info("starting gRPC server")
-	if err := s.Serve(lis); err != nil {
-		log.Fatalf("gRPC server error: %v", err)
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", serverPort))
+	if err != nil {
+		log.Fatal("error starting tcp listener: %v", err)
+	}
+
+	if onReady != nil {
+		onReady()
+	}
+
+	go func() {
+		if shutdownErr := s.Serve(lis); shutdownErr != nil {
+			log.Fatalf("gRPC server error: %v", shutdownErr)
+		}
+	}()
+
+	// Block until context is done
+	<-ctx.Done()
+
+	// Graceful shutdown
+	stopCh := make(chan struct{})
+	go func() {
+		s.GracefulStop()
+		close(stopCh)
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		// Forceful shutdown after 5 seconds
+		s.Stop()
+	case <-stopCh:
+	}
+
+	err = lis.Close()
+	if err != nil {
+		log.Errorf("failed to close tcp listener: %v", err)
 	}
 }
 

--- a/pkg/operator/webhooks.go
+++ b/pkg/operator/webhooks.go
@@ -22,7 +22,7 @@ import (
 
 const webhookCAName = "dapr-webhook-ca"
 
-func RunWebhooks(enableLeaderElection bool) {
+func RunWebhooks(ctx context.Context, enableLeaderElection bool) {
 	conf, err := ctrl.GetConfig()
 	if err != nil {
 		log.Fatalf("unable to get controller runtime configuration, err: %s", err)
@@ -62,8 +62,6 @@ func RunWebhooks(enableLeaderElection bool) {
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		log.Fatalf("unable to set up ready check: %v", err)
 	}
-
-	ctx := ctrl.SetupSignalHandler()
 
 	go patchCRDs(ctx, conf, "subscriptions.dapr.io")
 


### PR DESCRIPTION
This PR makes some minor, incremental improvements to the injector and operator services startup and shutdown sequences.

Injector:

1. Make sure app is not reported as healthy until the server is actually started
2. Fixed graceful shutdown ending abruptly
3. Improved error logging
4. Passing context to webhook server

Operator:

1. Remove 5 seconds wait after shutdown. Per docs:
   > If LeaderElection is used, the binary must be exited immediately after this returns, otherwise components that need leader election might continue to run after the leader lock was lost.
3. Report ready on healthz server only after server has started

Also:

1. Improve healthz server shutdown: the use of doneCh was preventing the graceful shutdown