### PR TITLE
increase max allown latency added by sidecar to make perf test stable

### DIFF
--- a/tests/perf/pubsub_publish/pubsub_publish_test.go
+++ b/tests/perf/pubsub_publish/pubsub_publish_test.go
@@ -152,5 +152,5 @@ func TestPubsubPublishGrpcPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 2.0)
+	require.LessOrEqual(t, tp90Latency, 3.0)
 }

--- a/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
+++ b/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
@@ -179,5 +179,5 @@ func TestServiceInvocationGrpcPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 2.0)
+	require.LessOrEqual(t, tp90Latency, 3.0)
 }

--- a/tests/perf/service_invocation_http/service_invocation_http_test.go
+++ b/tests/perf/service_invocation_http/service_invocation_http_test.go
@@ -175,5 +175,5 @@ func TestServiceInvocationHTTPPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 2.0)
+	require.LessOrEqual(t, tp90Latency, 3.0)
 }

--- a/tests/perf/state_get/state_get_test.go
+++ b/tests/perf/state_get/state_get_test.go
@@ -152,5 +152,5 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 2.0)
+	require.LessOrEqual(t, tp90Latency, 3.0)
 }


### PR DESCRIPTION


Signed-off-by: Sky Ao <aoxiaojian@gmail.com>

# Description

As discribed in https://github.com/dapr/dapr/issues/4743: 

> step1: increase this latency added from 2ms to 3ms, so let the perf test to be stable. Now perf test still have some other problems, this change will help to split the problem of "low performance" from the problem of "perf test is not stable".

## Issue reference

https://github.com/dapr/dapr/issues/4743

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
