### PR TITLE
Fixes for Mariner-based images

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -249,9 +249,10 @@ jobs:
 
           if [ "${{ env.TARGET_OS }}" = "linux" ] && [ "${{ env.TARGET_ARCH }}" != "arm" ]; then
             # For Linux, we use images based on Mariner
-            export DOCKERFILE=Dockerfile-mariner
+            DOCKERFILE=Dockerfile-mariner make docker-build
+          else
+            make docker-build
           fi
-          make docker-build
         shell: bash
       - name: Build e2e test apps
         if: env.TEST_PREFIX != ''
@@ -282,7 +283,12 @@ jobs:
       - name: Push all container images to the registry
         if: env.TEST_PREFIX != ''
         run: |
-          make docker-push
+          if [ "${{ env.TARGET_OS }}" = "linux" ] && [ "${{ env.TARGET_ARCH }}" != "arm" ]; then
+            # For Linux, we use images based on Mariner
+            DOCKERFILE=Dockerfile-mariner make docker-push
+          else
+            make docker-push
+          fi
           make push-e2e-app-all
         shell: bash
 

--- a/docker/Dockerfile-mariner
+++ b/docker/Dockerfile-mariner
@@ -35,5 +35,5 @@ FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:${MARINER_VERSION}
 ARG PKG_FILES
 COPY --from=builder /staging/ /
 WORKDIR /
-USER app
+USER 900
 COPY /$PKG_FILES /


### PR DESCRIPTION
- Use numeric USER to make runAsNonRoot work correctly
- Fixed E2E pipeline pushing image based on distroless

Thanks @shubham1172 for flagging the issue 