### PR TITLE
Fix cleanup pipeline

### DIFF
--- a/.github/workflows/dapr-test-azure-cleanup.yml
+++ b/.github/workflows/dapr-test-azure-cleanup.yml
@@ -43,13 +43,15 @@ jobs:
             for line in $(az group list --query "$QUERY" | jq -c '.[]')
             do
               RG_DATE_STR=$(echo "$line" | jq -r ".date")
-              RG_DATE=$(date --date "$RG_DATE_STR" +'%s')
-              RG_NAME=$(echo "$line" | jq -r ".name")
-              if [ $RG_DATE -lt $DELETE_BEFORE_DATE ] ; then
-                echo "DELETING Resource Group ${RG_NAME} that was deployed on ${RG_DATE_STR}"
-                az group delete --no-wait --yes --name "${RG_NAME}" || true
-              else
-                echo "Keeping Resource Group ${RG_NAME} that was deployed on ${RG_DATE_STR}"
+              if [ "$RG_DATE_STR" != "null" ]; then
+                RG_DATE=$(date --date "$RG_DATE_STR" +'%s')
+                RG_NAME=$(echo "$line" | jq -r ".name")
+                if [ $RG_DATE -lt $DELETE_BEFORE_DATE ] ; then
+                    echo "DELETING Resource Group ${RG_NAME} that was deployed on ${RG_DATE_STR}"
+                    az group delete --no-wait --yes --name "${RG_NAME}" || true
+                else
+                    echo "Keeping Resource Group ${RG_NAME} that was deployed on ${RG_DATE_STR}"
+                fi
               fi
             done
           )


### PR DESCRIPTION
The "Cleanup Azure test resources" has been failing for a week: https://github.com/dapr/dapr/actions/workflows/dapr-test-azure-cleanup.yml

Root cause: a resource group (containing shared infrastructure) was deployed with name starting with `Dapr-E2E-`, although that is not generated by GitHub Actions. That RG does not have a tag like what GH Actions expects, so the pipeline was failing.

This PR fixes the pipeline by ignoring resource groups without a date tag.