### PR TITLE
Add built-in retries for runtime initialization

### DIFF
--- a/pkg/resiliency/resiliency_test.go
+++ b/pkg/resiliency/resiliency_test.go
@@ -294,9 +294,9 @@ func TestResiliencyScopeIsRespected(t *testing.T) {
 }
 
 func TestBuiltInPoliciesAreCreated(t *testing.T) {
-	r := FromConfigurations(log, &resiliency_v1alpha.Resiliency{})
-	assert.NotNil(t, r.retries[fmt.Sprintf("%s", BuiltInServiceRetries)])
-	retry := r.retries[fmt.Sprintf("%s", BuiltInServiceRetries)]
+	r := FromConfigurations(log)
+	assert.NotNil(t, r.retries[string(BuiltInServiceRetries)])
+	retry := r.retries[string(BuiltInServiceRetries)]
 	assert.Equal(t, int64(3), retry.MaxRetries)
 	assert.Equal(t, time.Second, retry.Duration)
 }
@@ -328,9 +328,10 @@ func TestResiliencyHasTargetDefined(t *testing.T) {
 }
 
 func TestResiliencyHasBuiltInPolicy(t *testing.T) {
-	r := FromConfigurations(log, &resiliency_v1alpha.Resiliency{})
+	r := FromConfigurations(log)
 	assert.NotNil(t, r)
 	assert.NotNil(t, r.BuiltInPolicy(context.Background(), BuiltInServiceRetries))
 	assert.NotNil(t, r.BuiltInPolicy(context.Background(), BuiltInActorRetries))
 	assert.NotNil(t, r.BuiltInPolicy(context.Background(), BuiltInActorReminderRetries))
+	assert.NotNil(t, r.BuiltInPolicy(context.Background(), BuiltInInitializationRetries))
 }

--- a/pkg/runtime/pubsub/subscriptions_test.go
+++ b/pkg/runtime/pubsub/subscriptions_test.go
@@ -24,6 +24,7 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/kit/logger"
 )
 
@@ -336,7 +337,7 @@ func (m *mockHTTPSubscriptions) InvokeMethod(ctx context.Context, req *invokev1.
 func TestHTTPSubscriptions(t *testing.T) {
 	t.Run("topics received, no errors", func(t *testing.T) {
 		m := mockHTTPSubscriptions{}
-		subs, err := GetSubscriptionsHTTP(&m, log)
+		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log), false)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
 			assert.Equal(t, "topic1", subs[0].Topic)
@@ -355,7 +356,7 @@ func TestHTTPSubscriptions(t *testing.T) {
 			successThreshold: 3,
 		}
 
-		subs, err := GetSubscriptionsHTTP(&m, log)
+		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log), false)
 		assert.Equal(t, m.successThreshold, m.callCount)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
@@ -375,7 +376,36 @@ func TestHTTPSubscriptions(t *testing.T) {
 			alwaysError: true,
 		}
 
-		_, err := GetSubscriptionsHTTP(&m, log)
+		_, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log), false)
+		require.Error(t, err)
+	})
+
+	t.Run("error from app, success after retries with resiliency", func(t *testing.T) {
+		m := mockUnstableHTTPSubscriptions{
+			successThreshold: 3,
+		}
+
+		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log), true)
+		assert.Equal(t, m.successThreshold, m.callCount)
+		require.NoError(t, err)
+		if assert.Len(t, subs, 1) {
+			assert.Equal(t, "topic1", subs[0].Topic)
+			if assert.Len(t, subs[0].Rules, 3) {
+				assert.Equal(t, "myroute.v3", subs[0].Rules[0].Path)
+				assert.Equal(t, "myroute.v2", subs[0].Rules[1].Path)
+				assert.Equal(t, "myroute", subs[0].Rules[2].Path)
+			}
+			assert.Equal(t, "pubsub", subs[0].PubsubName)
+			assert.Equal(t, "testValue", subs[0].Metadata["testName"])
+		}
+	})
+
+	t.Run("error from app, retries exhausted with resiliency", func(t *testing.T) {
+		m := mockUnstableHTTPSubscriptions{
+			alwaysError: true,
+		}
+
+		_, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log), true)
 		require.Error(t, err)
 	})
 }
@@ -458,7 +488,7 @@ func (m *mockGRPCSubscriptions) ListTopicSubscriptions(ctx context.Context, in *
 func TestGRPCSubscriptions(t *testing.T) {
 	t.Run("topics received, no errors", func(t *testing.T) {
 		m := mockGRPCSubscriptions{}
-		subs, err := GetSubscriptionsGRPC(&m, log)
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log), false)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
 			assert.Equal(t, "topic1", subs[0].Topic)
@@ -477,7 +507,7 @@ func TestGRPCSubscriptions(t *testing.T) {
 			successThreshold: 3,
 		}
 
-		subs, err := GetSubscriptionsGRPC(&m, log)
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log), false)
 		assert.Equal(t, m.successThreshold, m.callCount)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
@@ -498,7 +528,38 @@ func TestGRPCSubscriptions(t *testing.T) {
 			unimplemented:    true,
 		}
 
-		_, err := GetSubscriptionsGRPC(&m, log)
+		_, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log), false)
+		require.Error(t, err)
+		assert.Equal(t, 1, m.callCount)
+	})
+
+	t.Run("error from app, success after retries with resiliency", func(t *testing.T) {
+		m := mockUnstableGRPCSubscriptions{
+			successThreshold: 3,
+		}
+
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log), false)
+		assert.Equal(t, m.successThreshold, m.callCount)
+		require.NoError(t, err)
+		if assert.Len(t, subs, 1) {
+			assert.Equal(t, "topic1", subs[0].Topic)
+			if assert.Len(t, subs[0].Rules, 3) {
+				assert.Equal(t, "myroute.v3", subs[0].Rules[0].Path)
+				assert.Equal(t, "myroute.v2", subs[0].Rules[1].Path)
+				assert.Equal(t, "myroute", subs[0].Rules[2].Path)
+			}
+			assert.Equal(t, "pubsub", subs[0].PubsubName)
+			assert.Equal(t, "testValue", subs[0].Metadata["testName"])
+		}
+	})
+
+	t.Run("server is running, app returns unimplemented error, no retries with resiliency", func(t *testing.T) {
+		m := mockUnstableGRPCSubscriptions{
+			successThreshold: 3,
+			unimplemented:    true,
+		}
+
+		_, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log), false)
 		require.Error(t, err)
 		assert.Equal(t, 1, m.callCount)
 	})

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1456,11 +1456,12 @@ func (a *DaprRuntime) getTopicRoutes() (map[string]TopicRoute, error) {
 	var err error
 
 	// handle app subscriptions
+	resiliencyEnabled := config.IsFeatureEnabled(a.globalConfig.Spec.Features, config.Resiliency)
 	if a.runtimeConfig.ApplicationProtocol == HTTPProtocol {
-		subscriptions, err = runtime_pubsub.GetSubscriptionsHTTP(a.appChannel, log)
+		subscriptions, err = runtime_pubsub.GetSubscriptionsHTTP(a.appChannel, log, a.resiliency, resiliencyEnabled)
 	} else if a.runtimeConfig.ApplicationProtocol == GRPCProtocol {
 		client := runtimev1pb.NewAppCallbackClient(a.grpc.AppClient)
-		subscriptions, err = runtime_pubsub.GetSubscriptionsGRPC(client, log)
+		subscriptions, err = runtime_pubsub.GetSubscriptionsGRPC(client, log, a.resiliency, resiliencyEnabled)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

This commit adds built-in resiliency retries for getting
subscriptions from a starting application.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: #4609 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
