### PR TITLE
Fix dead letter topic keeping message in original topic

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -690,6 +690,8 @@ func (a *DaprRuntime) beginPubSub(subscribeCtx context.Context, name string, ps 
 				if configured, _ := a.sendToDeadLetterIfConfigured(name, msg); !configured {
 					return err
 				}
+
+				return nil
 			}
 			return err
 		}); err != nil {
@@ -1698,10 +1700,8 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 		err := json.Unmarshal(body, &appResponse)
 		if err != nil {
 			log.Debugf("skipping status check due to error parsing result from pub/sub event %v", cloudEvent[pubsub.IDField])
-			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
-			// Return no error so message does not get reprocessed.
-			err = nil
-			return err
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Success)), msg.topic, elapsed)
+			return nil
 		}
 
 		switch appResponse.Status {

--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -397,7 +397,7 @@ func validateMessagesReceivedBySubscriber(t *testing.T, publisherExternalURL str
 		// only error response is expected to validate dead letter
 		sort.Strings(sentMessages.ReceivedByTopicDeadLetter)
 		sort.Strings(appResp.ReceivedByTopicDeadLetter)
-		assert.Equal(t, sentMessages.ReceivedByTopicDead, appResp.ReceivedByTopicDead, "different messages received in Topic Dead")
+		assert.Equal(t, sentMessages.ReceivedByTopicDeadLetter, appResp.ReceivedByTopicDeadLetter, "different messages received in Topic Dead")
 	}
 }
 


### PR DESCRIPTION
This PR adds a missing return statement that caused messages dropped into the dead letter topic to be kept and retried on the original topic.

Also adds a minor change for code readability and fixes wrong metric from `Retry` to `Success` when the app returns `2xx`.

