### PR TITLE
Changed imagePullPolicy for E2E tests

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -249,6 +249,7 @@ jobs:
       GOARCH: amd64
       AZURE_STORAGE_ACCOUNT: ${{ secrets.PERF_AZURE_STORAGE_ACCOUNT }}
       AZURE_STORAGE_ACCESS_KEY: ${{ secrets.PERF_AZURE_STORAGE_KEY }}
+      PULL_POLICY: IfNotPresent
     steps:
       - name: Setup test output
         run: |

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -303,6 +303,7 @@ jobs:
       TARGET_OS: ${{ matrix.target_os }}
       TARGET_ARCH: ${{ matrix.target_arch }}
       TEST_OUTPUT_FILE_PREFIX: "test_report"
+      PULL_POLICY: IfNotPresent
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -54,6 +54,7 @@ jobs:
       GOVER: 1.18
       # Container registry where to cache e2e test images
       DAPR_CACHE_REGISTRY: "dapre2eacr.azurecr.io"
+      PULL_POLICY: IfNotPresent
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:


### PR DESCRIPTION
Based on feedback from the AKS team, while debugging the tests. It does seem that `imagePullPolicy: Always` is unnecessary because the clusters are all new.