### PR TITLE
Should fix test failures due to #4783

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -679,12 +679,9 @@ func (a *DaprRuntime) beginPubSub(subscribeCtx context.Context, name string, ps 
 					pubsub:     name,
 				})
 			})
-			log.Infof("Error processing message %v: %v", cloudEvent, err)
 			if err != nil && err != context.Canceled {
 				// Sending msg to dead letter queue, if no DLQ is configured, return error for backwards compatibility(component level retry).
-				configured, _ := a.sendToDeadLetterIfConfigured(name, msg)
-				log.Infof("Error processing message %v: %v (DLQ configured? %v)", cloudEvent, err, configured)
-				if !configured {
+				if configured, _ := a.sendToDeadLetterIfConfigured(name, msg); !configured {
 					return err
 				}
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -679,9 +679,12 @@ func (a *DaprRuntime) beginPubSub(subscribeCtx context.Context, name string, ps 
 					pubsub:     name,
 				})
 			})
+			log.Infof("Error processing message %v: %v", cloudEvent, err)
 			if err != nil && err != context.Canceled {
 				// Sending msg to dead letter queue, if no DLQ is configured, return error for backwards compatibility(component level retry).
-				if configured, _ := a.sendToDeadLetterIfConfigured(name, msg); !configured {
+				configured, _ := a.sendToDeadLetterIfConfigured(name, msg)
+				log.Infof("Error processing message %v: %v (DLQ configured? %v)", cloudEvent, err, configured)
+				if !configured {
 					return err
 				}
 

--- a/tests/config/pubsub_no_resiliency.yaml
+++ b/tests/config/pubsub_no_resiliency.yaml
@@ -1,0 +1,25 @@
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: pubsubnoresiliency
+spec:
+
+  policies:
+
+    retries:
+      twoRetries:
+        policy: constant
+        maxRetries: 2
+      noRetries:
+        policy: constant
+        maxRetries: 0
+
+  targets:
+  
+    components:
+
+      messagebus:
+        inbound:
+          retry: noRetries
+        outbound:
+          retry: noRetries

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -317,6 +317,7 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/dapr_$(DAPR_TEST_QUERY_STATE_STORE)_state.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_tests_cluster_role_binding.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_$(DAPR_TEST_PUBSUB)_pubsub.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	$(KUBECTL) apply -f ./tests/config/pubsub_no_resiliency.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_kafka_bindings.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_kafka_bindings_custom_route.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/dapr_kafka_bindings_grpc.yaml --namespace $(DAPR_TEST_NAMESPACE)

--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -359,11 +359,12 @@ func validateMessagesReceivedBySubscriber(t *testing.T, publisherExternalURL str
 		}
 
 		log.Printf(
-			"subscriber received %d/%d messages on pubsub-a-topic, %d/%d on pubsub-b-topic and %d/%d on pubsub-c-topic and %d/%d on pubsub-raw-topic",
+			"subscriber received %d/%d messages on pubsub-a-topic, %d/%d on pubsub-b-topic and %d/%d on pubsub-c-topic, %d/%d on pubsub-raw-topic and %d/%d on dead letter topic",
 			len(appResp.ReceivedByTopicA), len(sentMessages.ReceivedByTopicA),
 			len(appResp.ReceivedByTopicB), len(sentMessages.ReceivedByTopicB),
 			len(appResp.ReceivedByTopicC), len(sentMessages.ReceivedByTopicC),
 			len(appResp.ReceivedByTopicRaw), len(sentMessages.ReceivedByTopicRaw),
+			len(appResp.ReceivedByTopicDeadLetter), len(sentMessages.ReceivedByTopicDeadLetter),
 		)
 
 		if len(appResp.ReceivedByTopicA) != len(sentMessages.ReceivedByTopicA) ||
@@ -372,7 +373,7 @@ func validateMessagesReceivedBySubscriber(t *testing.T, publisherExternalURL str
 			len(appResp.ReceivedByTopicRaw) != len(sentMessages.ReceivedByTopicRaw) ||
 			(validateDeadLetter && len(appResp.ReceivedByTopicDeadLetter) != len(sentMessages.ReceivedByTopicDeadLetter)) {
 			log.Printf("Differing lengths in received vs. sent messages, retrying.")
-			time.Sleep(5 * time.Second)
+			time.Sleep(10 * time.Second)
 		} else {
 			break
 		}

--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -167,6 +167,10 @@ func sendToPublisher(t *testing.T, publisherExternalURL string, topic string, pr
 }
 
 func testPublish(t *testing.T, publisherExternalURL string, protocol string) receivedMessagesResponse {
+	sentTopicDeadMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-dead-topic", protocol, nil, "")
+	require.NoError(t, err)
+	offset += numberOfMessagesToPublish + 1
+
 	sentTopicAMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-a-topic", protocol, nil, "")
 	require.NoError(t, err)
 	offset += numberOfMessagesToPublish + 1
@@ -183,10 +187,6 @@ func testPublish(t *testing.T, publisherExternalURL string, protocol string) rec
 		"rawPayload": "true",
 	}
 	sentTopicRawMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-raw-topic", protocol, metadata, "")
-	require.NoError(t, err)
-	offset += numberOfMessagesToPublish + 1
-
-	sentTopicDeadMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-dead-topic", protocol, nil, "")
 	require.NoError(t, err)
 	offset += numberOfMessagesToPublish + 1
 
@@ -265,6 +265,9 @@ func testValidateRedeliveryOrEmptyJSON(t *testing.T, publisherExternalURL, subsc
 		validateMessagesReceivedBySubscriber(t, publisherExternalURL, subscriberAppName, protocol, false, sentMessages)
 
 		callInitialize(t, publisherExternalURL, protocol)
+	} else {
+		// Sleep a few seconds to ensure there's time for all messages to be delivered at least once, so if they have to be sent to the DLQ, they can be before we change the desired response status
+		time.Sleep(5 * time.Second)
 	}
 
 	// set to respond with success


### PR DESCRIPTION
After further investigation, test failures were due to messages arriving a second or two too late. This increases the the sleep time so we give messages more time to be delivered.