### PR TITLE
Correctly reporting perf test results

### DIFF
--- a/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
+++ b/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
@@ -125,8 +125,8 @@ func TestPubsubPublishGrpcPerformance(t *testing.T) {
 	err = json.Unmarshal(baselineResp, &baselineResult)
 	require.NoError(t, err)
 
-	percentiles := map[int]string{1: "50th", 2: "75th", 3: "90th", 4: "99th"}
-	tp90Latency := 0.0
+	percentiles := []string{"50th", "75th", "90th", "99th"}
+	var tp90Latency float64
 
 	for k, v := range percentiles {
 		daprValue := daprResult.DurationHistogram.Percentiles[k].Value
@@ -160,5 +160,5 @@ func TestPubsubPublishGrpcPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 3.0)
+	require.LessOrEqual(t, tp90Latency, 2.0)
 }

--- a/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
+++ b/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
@@ -161,8 +161,8 @@ func TestServiceInvocationGrpcPerformance(t *testing.T) {
 	err = json.Unmarshal(baselineResp, &baselineResult)
 	require.NoError(t, err)
 
-	percentiles := map[int]string{1: "50th", 2: "75th", 3: "90th", 4: "99th"}
-	tp90Latency := 0.0
+	percentiles := []string{"50th", "75th", "90th", "99th"}
+	var tp90Latency float64
 
 	for k, v := range percentiles {
 		daprValue := daprResult.DurationHistogram.Percentiles[k].Value
@@ -196,5 +196,5 @@ func TestServiceInvocationGrpcPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 3.0)
+	require.LessOrEqual(t, tp90Latency, 2.0)
 }

--- a/tests/perf/service_invocation_http/service_invocation_http_test.go
+++ b/tests/perf/service_invocation_http/service_invocation_http_test.go
@@ -159,8 +159,8 @@ func TestServiceInvocationHTTPPerformance(t *testing.T) {
 	err = json.Unmarshal(baselineResp, &baselineResult)
 	require.NoError(t, err)
 
-	percentiles := map[int]string{1: "50th", 2: "75th", 3: "90th", 4: "99th"}
-	tp90Latency := 0.0
+	percentiles := []string{"50th", "75th", "90th", "99th"}
+	var tp90Latency float64
 
 	for k, v := range percentiles {
 		daprValue := daprResult.DurationHistogram.Percentiles[k].Value
@@ -194,5 +194,5 @@ func TestServiceInvocationHTTPPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 3.0)
+	require.LessOrEqual(t, tp90Latency, 2.0)
 }

--- a/tests/perf/state_get_grpc/state_get_grpc_test.go
+++ b/tests/perf/state_get_grpc/state_get_grpc_test.go
@@ -125,8 +125,8 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 	err = json.Unmarshal(baselineResp, &baselineResult)
 	require.NoError(t, err)
 
-	percentiles := map[int]string{1: "50th", 2: "75th", 3: "90th", 4: "99th"}
-	tp90Latency := 0.0
+	percentiles := []string{"50th", "75th", "90th", "99th"}
+	var tp90Latency float64
 
 	for k, v := range percentiles {
 		daprValue := daprResult.DurationHistogram.Percentiles[k].Value
@@ -160,5 +160,5 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 3.0)
+	require.LessOrEqual(t, tp90Latency, 2.0)
 }

--- a/tests/perf/state_get_http/state_get_http_test.go
+++ b/tests/perf/state_get_http/state_get_http_test.go
@@ -126,8 +126,8 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 	err = json.Unmarshal(baselineResp, &baselineResult)
 	require.NoError(t, err)
 
-	percentiles := map[int]string{1: "50th", 2: "75th", 3: "90th", 4: "99th"}
-	tp90Latency := 0.0
+	percentiles := []string{"50th", "75th", "90th", "99th"}
+	var tp90Latency float64
 
 	for k, v := range percentiles {
 		daprValue := daprResult.DurationHistogram.Percentiles[k].Value
@@ -161,5 +161,5 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 	require.Equal(t, 0, restarts)
 	require.True(t, daprResult.ActualQPS > float64(p.QPS)*0.99)
 	require.Greater(t, tp90Latency, 0.0)
-	require.LessOrEqual(t, tp90Latency, 3.0)
+	require.LessOrEqual(t, tp90Latency, 2.0)
 }


### PR DESCRIPTION
Previously, was misreporting results so that the 99th percentile was repoted as 90th.

Also restored the original perf targets