### PR TITLE
Replace github.com/golang/protobuf with google.golang.org/protobuf

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -273,7 +273,3 @@ linters:
     - containedctx
     - gosimple
     - forbidigo
-issues:
-  exclude:
-    # staticcheck
-    - 'SA1019: package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead'

--- a/Makefile
+++ b/Makefile
@@ -281,9 +281,6 @@ endef
 $(foreach MODFILE,$(MODFILES),$(eval $(call modtidy-target,$(MODFILE))))
 
 # Enumerate all generated modtidy targets
-# Note that the order of execution matters: root and tests/certification go.mod
-# are dependencies in each certification test. This order is preserved by the
-# tree walk when finding the go.mod files.
 TIDY_MODFILES:=$(foreach ITEM,$(MODFILES),modtidy-$(ITEM))
 
 # Define modtidy-all action trigger to run make on all generated modtidy targets

--- a/docker/library-scripts/go-debian.sh
+++ b/docker/library-scripts/go-debian.sh
@@ -225,7 +225,7 @@ GO_TOOLS="\
     github.com/go-delve/delve/cmd/dlv@latest \
     github.com/josharian/impl@latest \
     github.com/fatih/gomodifytags@latest \
-    github.com/golang/protobuf/protoc-gen-go@latest \
+    google.golang.org/protobuf/cmd/protoc-gen-go@latest \
     github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     echo "Installing common Go tools..."

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/protobuf v1.5.2
 	github.com/google/cel-go v0.9.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
@@ -197,6 +196,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/dapr/components-contrib/configuration"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -879,7 +878,7 @@ func (a *api) DeleteState(ctx context.Context, in *runtimev1pb.DeleteStateReques
 
 	key, err := state_loader.GetModifiedStateKey(in.Key, in.StoreName, a.id)
 	if err != nil {
-		return &empty.Empty{}, err
+		return &emptypb.Empty{}, err
 	}
 	req := state.DeleteRequest{
 		Key:      key,
@@ -907,23 +906,23 @@ func (a *api) DeleteState(ctx context.Context, in *runtimev1pb.DeleteStateReques
 	if err != nil {
 		err = a.stateErrorResponse(err, messages.ErrStateDelete, in.Key, err.Error())
 		apiServerLogger.Debug(err)
-		return &empty.Empty{}, err
+		return &emptypb.Empty{}, err
 	}
-	return &empty.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
-func (a *api) DeleteBulkState(ctx context.Context, in *runtimev1pb.DeleteBulkStateRequest) (*empty.Empty, error) {
+func (a *api) DeleteBulkState(ctx context.Context, in *runtimev1pb.DeleteBulkStateRequest) (*emptypb.Empty, error) {
 	store, err := a.getStateStore(in.StoreName)
 	if err != nil {
 		apiServerLogger.Debug(err)
-		return &empty.Empty{}, err
+		return &emptypb.Empty{}, err
 	}
 
 	reqs := make([]state.DeleteRequest, 0, len(in.States))
 	for _, item := range in.States {
 		key, err1 := state_loader.GetModifiedStateKey(item.Key, in.StoreName, a.id)
 		if err1 != nil {
-			return &empty.Empty{}, err1
+			return &emptypb.Empty{}, err1
 		}
 		req := state.DeleteRequest{
 			Key:      key,

--- a/pkg/grpc/proxy/codec/codec.go
+++ b/pkg/grpc/proxy/codec/codec.go
@@ -4,8 +4,8 @@
 package codec
 
 import (
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
+	"google.golang.org/protobuf/proto"
 )
 
 // Name is the name by which the proxy codec is registered in the encoding codec registry

--- a/tests/apps/actorload/go.mod
+++ b/tests/apps/actorload/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/DataDog/sketches-go v0.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/protobuf v1.5.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/prometheus/client_golang v1.9.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/tests/apps/actorload/go.sum
+++ b/tests/apps/actorload/go.sum
@@ -96,9 +96,8 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
-github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/tests/apps/binding_input_grpc/app.go
+++ b/tests/apps/binding_input_grpc/app.go
@@ -21,8 +21,8 @@ import (
 	"net"
 	"sync"
 
-	"github.com/golang/protobuf/ptypes/any"
-	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -129,7 +129,7 @@ func (s *server) GetReceivedTopics(ctx context.Context, in *commonv1pb.InvokeReq
 		log.Printf("Could not encode response: %s", err.Error())
 		return &commonv1pb.InvokeResponse{}, err
 	}
-	data := any.Any{
+	data := anypb.Any{
 		Value: rawResp,
 	}
 	return &commonv1pb.InvokeResponse{
@@ -138,7 +138,7 @@ func (s *server) GetReceivedTopics(ctx context.Context, in *commonv1pb.InvokeReq
 }
 
 // Dapr will call this method to get the list of topics the app wants to subscribe to.
-func (s *server) ListTopicSubscriptions(ctx context.Context, in *empty.Empty) (*pb.ListTopicSubscriptionsResponse, error) {
+func (s *server) ListTopicSubscriptions(ctx context.Context, in *emptypb.Empty) (*pb.ListTopicSubscriptionsResponse, error) {
 	log.Println("List Topic Subscription called")
 	return &pb.ListTopicSubscriptionsResponse{
 		Subscriptions: []*pb.TopicSubscription{},
@@ -168,7 +168,7 @@ func (s *server) OnTopicEvent(ctx context.Context, in *pb.TopicEventRequest) (*p
 	}, nil
 }
 
-func (s *server) ListInputBindings(ctx context.Context, in *empty.Empty) (*pb.ListInputBindingsResponse, error) {
+func (s *server) ListInputBindings(ctx context.Context, in *emptypb.Empty) (*pb.ListInputBindingsResponse, error) {
 	log.Println("List Input Bindings called")
 	return &pb.ListInputBindingsResponse{
 		Bindings: []string{

--- a/tests/apps/binding_output/app.go
+++ b/tests/apps/binding_output/app.go
@@ -22,9 +22,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -135,7 +135,7 @@ func getReceivedTopicsGRPC(w http.ResponseWriter, r *http.Request) {
 		Id: "bindinginputgrpc",
 		Message: &commonv1pb.InvokeRequest{
 			Method: "GetReceivedTopics",
-			Data:   &any.Any{},
+			Data:   &anypb.Any{},
 			HttpExtension: &commonv1pb.HTTPExtension{
 				Verb: commonv1pb.HTTPExtension_POST,
 			},

--- a/tests/apps/resiliencyapp/app.go
+++ b/tests/apps/resiliencyapp/app.go
@@ -23,8 +23,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/any"
-
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/apps/utils"
@@ -347,7 +345,7 @@ func TestGetCallCountGRPC(w http.ResponseWriter, r *http.Request) {
 		Id: "resiliencyappgrpc",
 		Message: &commonv1pb.InvokeRequest{
 			Method: "GetCallCount",
-			Data:   &any.Any{},
+			Data:   &anypb.Any{},
 			HttpExtension: &commonv1pb.HTTPExtension{
 				Verb: commonv1pb.HTTPExtension_POST,
 			},

--- a/tests/apps/resiliencyapp/go.mod
+++ b/tests/apps/resiliencyapp/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/dapr/dapr v1.7.4
-	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	google.golang.org/grpc v1.47.0
 	google.golang.org/grpc/examples v0.0.0-20220314230434-84793b56f63c
@@ -12,6 +11,7 @@ require (
 )
 
 require (
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/tests/apps/resiliencyapp_grpc/app.go
+++ b/tests/apps/resiliencyapp_grpc/app.go
@@ -22,14 +22,13 @@ import (
 	"net"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
-
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 
 	"google.golang.org/grpc"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const (
@@ -138,7 +137,7 @@ func (s *server) OnInvoke(ctx context.Context, in *commonv1pb.InvokeRequest) (*c
 }
 
 // Dapr will call this method to get the list of topics the app wants to subscribe to.
-func (s *server) ListTopicSubscriptions(ctx context.Context, in *empty.Empty) (*runtimev1pb.ListTopicSubscriptionsResponse, error) {
+func (s *server) ListTopicSubscriptions(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.ListTopicSubscriptionsResponse, error) {
 	log.Println("List Topic Subscription called")
 	return &runtimev1pb.ListTopicSubscriptionsResponse{
 		Subscriptions: []*runtimev1pb.TopicSubscription{
@@ -185,7 +184,7 @@ func (s *server) OnTopicEvent(ctx context.Context, in *runtimev1pb.TopicEventReq
 	}, nil
 }
 
-func (s *server) ListInputBindings(ctx context.Context, in *empty.Empty) (*runtimev1pb.ListInputBindingsResponse, error) {
+func (s *server) ListInputBindings(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.ListInputBindingsResponse, error) {
 	log.Println("List Input Bindings called")
 	return &runtimev1pb.ListInputBindingsResponse{
 		Bindings: []string{

--- a/tests/apps/resiliencyapp_grpc/go.mod
+++ b/tests/apps/resiliencyapp_grpc/go.mod
@@ -4,13 +4,13 @@ go 1.18
 
 require (
 	github.com/dapr/dapr v1.7.4
-	github.com/golang/protobuf v1.5.2
 	google.golang.org/grpc v1.47.0
 	google.golang.org/grpc/examples v0.0.0-20220314230434-84793b56f63c
 	google.golang.org/protobuf v1.28.0
 )
 
 require (
+	github.com/golang/protobuf v1.5.2 // indirect
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
Fixes #4813

Module `github.com/golang/protobuf` is deprecated and needs to be replaced with `google.golang.org/protobuf`.

Note that while `github.com/golang/protobuf` is now fully-removed from dapr/dapr, it's still an indirect dependency for now.