### PR TITLE
Changing AKS control plane SKU

### DIFF
--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -156,7 +156,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
   tags: {}
   sku: {
     name: 'Basic'
-    tier: 'Free'
+    tier: 'Paid'
   }
   identity: {
     type: 'SystemAssigned'


### PR DESCRIPTION
This seems to actually fix all issues with sidecar injectors randomly failing on AKS

Since this was implemented in my fork (where the watchdog is disabled), no test has failed with sidecar injection issues: https://github.com/ItalyPaleAle/dapr-ci-test/actions/workflows/dapr-test.yml (start from run 112) - the two failures are unrelated.