### PR TITLE
Watchdog: list pods from all namespaces

### DIFF
--- a/pkg/operator/watchdog.go
+++ b/pkg/operator/watchdog.go
@@ -123,7 +123,6 @@ func (dw *DaprWatchdog) listPods(ctx context.Context) {
 	// The client implements some level of caching anyways
 	pod := &corev1.PodList{}
 	err := dw.client.List(ctx, pod, &client.ListOptions{Namespace: ""})
-
 	if err != nil {
 		log.Errorf("Failed to list pods. Error: %v", err)
 		return


### PR DESCRIPTION
Currently the watch dog only lists pods from the namespace of the Dapr control plane, while it should list pods from all namespaces.

This PR changes the pod list operation to use all namespaces.

cc @ItalyPaleAle