### PR TITLE
Watchdog: list pods in all namespaces

### DIFF
--- a/pkg/operator/watchdog.go
+++ b/pkg/operator/watchdog.go
@@ -134,9 +134,11 @@ func (dw *DaprWatchdog) listPods(ctx context.Context) {
 			continue
 		}
 
+		logName := v.Namespace + "/" + v.Name
+
 		// Filter for pods with the dapr.io/enabled annotation
 		if daprEnabled, ok := v.Annotations[daprEnabledAnnotationKey]; !ok || !utils.IsTruthy(daprEnabled) {
-			log.Debugf("Skipping pod %s: %s is not true", v.Name, daprEnabledAnnotationKey)
+			log.Debugf("Skipping pod %s: %s is not true", logName, daprEnabledAnnotationKey)
 			continue
 		}
 
@@ -149,19 +151,19 @@ func (dw *DaprWatchdog) listPods(ctx context.Context) {
 			}
 		}
 		if hasSidecar {
-			log.Debugf("Found Dapr sidecar in pod %s", v.Name)
+			log.Debugf("Found Dapr sidecar in pod %s", logName)
 			continue
 		}
 
 		// Pod doesn't have a sidecar, so we need to kill it so it can be restarted and have the sidecar injected
-		log.Warnf("Pod %s does not have the Dapr sidecar and will be deleted", v.Name)
+		log.Warnf("Pod %s does not have the Dapr sidecar and will be deleted", logName)
 		err = dw.client.Delete(ctx, &v)
 		if err != nil {
-			log.Errorf("Failed to delete pod %s. Error: %v", v.Name, err)
+			log.Errorf("Failed to delete pod %s. Error: %v", logName, err)
 			continue
 		}
 
-		log.Infof("Deleted pod %s", v.Name)
+		log.Infof("Deleted pod %s", logName)
 
 		log.Debugf("Taking a pod restart token")
 		before := time.Now()

--- a/pkg/operator/watchdog.go
+++ b/pkg/operator/watchdog.go
@@ -122,9 +122,7 @@ func (dw *DaprWatchdog) listPods(ctx context.Context) {
 	// We are not using pagination because we may be deleting pods during the iterations
 	// The client implements some level of caching anyways
 	pod := &corev1.PodList{}
-	err := dw.client.List(ctx, pod,
-		client.InNamespace(GetNamespace()),
-	)
+	err := dw.client.List(ctx, pod)
 	if err != nil {
 		log.Errorf("Failed to list pods. Error: %v", err)
 		return


### PR DESCRIPTION
Changed sidecar watchdog to list pods in all namespaces.

See: https://github.com/dapr/dapr/pull/4764#discussion_r906876547

Manually verified:

```
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod daprdev/dapr-sidecar-injector-b766c8cf-2ngxn: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437762346Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod daprdev/dapr-placement-server-0: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437770646Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod daprdev/dapr-placement-server-2: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437778546Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod kube-system/coredns-87688dc49-rfkg5: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437787746Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod kube-system/konnectivity-agent-5b5f4d77b7-vxxxz: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437796646Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod kube-system/metrics-server-948cff58d-4jlpw: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437804946Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod daprdev/dapr-dashboard-559979c787-dq54g: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437813546Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod kube-system/kube-proxy-jvvzb: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437821645Z","type":"log","ver":"edge"}
{"instance":"dapr-operator-667f7cf775-w5rd4","level":"debug","msg":"Skipping pod kube-system/kube-proxy-spnnj: dapr.io/enabled is not true","scope":"dapr.operator","time":"2022-06-27T15:41:02.437829245Z","type":"log","ver":"edge"}
```

CC: @yaron2 