### PR TITLE
Fix log format

### DIFF
--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -128,7 +128,7 @@ func loadCertChains(certChainPath string) *credentials.CertChain {
 		log.Infof("starting watch for certs on filesystem: %s", certChainPath)
 		err := fswatcher.Watch(ctx, tlsCreds.Path(), fsevent)
 		if err != nil {
-			log.Fatal("error starting watch on filesystem: %s", err)
+			log.Fatalf("error starting watch on filesystem: %s", err)
 		}
 		close(fsevent)
 		if ctx.Err() == context.DeadlineExceeded {

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -80,18 +80,18 @@ func NewAPIServer(client client.Client) Server {
 
 // Run starts a new gRPC server.
 func (a *apiServer) Run(ctx context.Context, certChain *dapr_credentials.CertChain, onReady func()) {
-	log.Info("starting gRPC server on port %d", serverPort)
+	log.Infof("starting gRPC server on port %d", serverPort)
 
 	opts, err := dapr_credentials.GetServerOptions(certChain)
 	if err != nil {
-		log.Fatal("error creating gRPC options: %v", err)
+		log.Fatalf("error creating gRPC options: %v", err)
 	}
 	s := grpc.NewServer(opts...)
 	operatorv1pb.RegisterOperatorServer(s, a)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", serverPort))
 	if err != nil {
-		log.Fatal("error starting tcp listener: %v", err)
+		log.Fatalf("error starting tcp listener: %v", err)
 	}
 
 	if onReady != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -168,7 +168,7 @@ func (o *operator) loadCertChain(ctx context.Context) (certChain *credentials.Ce
 		log.Infof("starting watch for certs on filesystem: %s", o.config.Credentials.Path())
 		err := fswatcher.Watch(watchCtx, o.config.Credentials.Path(), fsevent)
 		if err != nil {
-			log.Fatal("error starting watch on filesystem: %s", err)
+			log.Fatalf("error starting watch on filesystem: %s", err)
 		}
 		close(fsevent)
 		if watchCtx.Err() == context.DeadlineExceeded {


### PR DESCRIPTION
Signed-off-by: sunzhaochang <zhchsun1992@gmail.com>

# Description

There are some misuses about log method, such as Fatal and Fatalf, etc.

This caused some wrong log format, like `starting gRPC server on port %d6500` log in operator.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
