### PR TITLE
Dev container for 1.8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Dapr Dev Environment",
 	// Update the container version when you publish dev-container
-	"image": "docker.io/daprio/dapr-dev:0.1.8",
+	"image": "ghcr.io/dapr/dapr-dev:0.1.8",
 	// Replace with uncommented line below to build your own local copy of the image
 	// "dockerFile": "../docker/Dockerfile-dev",
 	"containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Dapr Dev Environment",
 	// Update the container version when you publish dev-container
-	"image": "docker.io/daprio/dapr-dev:0.1.7",
+	"image": "docker.io/daprio/dapr-dev:0.1.8",
 	// Replace with uncommented line below to build your own local copy of the image
 	// "dockerFile": "../docker/Dockerfile-dev",
 	"containerEnv": {

--- a/.github/workflows/dapr-dev-container.yml
+++ b/.github/workflows/dapr-dev-container.yml
@@ -14,16 +14,6 @@
 name: dapr-dev-container
 
 on:
-  push:
-    paths:
-      - 'docker/Dockerfile-dev'
-      - 'docker/library-scrips/**'
-      - 'docker/custom-scrips/**'
-  pull_request:
-    paths:
-      - 'docker/Dockerfile-dev'
-      - 'docker/library-scrips/**'
-      - 'docker/custom-scrips/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dapr-dev-container.yml
+++ b/.github/workflows/dapr-dev-container.yml
@@ -25,6 +25,12 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+      - name: Set REPO_OWNER
+        shell: bash
+        run: |
+          REPO_OWNER=${{ github.repository_owner }}
+          # Lowercase the value
+          echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_ENV}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -32,12 +38,23 @@ jobs:
           platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: docker login
+      - name: Docker Hub login
         if: github.event_name != 'pull_request'
         run: |
           docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
-      - name: build multi-arch dev container
+      - name: GitHub Container Registry login
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build multi-arch dev container
         run: make build-dev-container-all-arch
-      - name: push multi-arch dev container
+      - name: Push multi-arch dev container to Docker Hub
         if: github.event_name != 'pull_request'
         run: make push-dev-container-all-arch DAPR_REGISTRY=${{ env.DOCKER_REGISTRY }}
+      # If the images were built for Docker Hub, this step is cached
+      - name: Push multi-arch dev container to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        run: make push-dev-container-all-arch DAPR_REGISTRY="ghcr.io/${{ env.REPO_OWNER }}"

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -174,10 +174,10 @@ docker-windows-base-push: check-windows-version
 ################################################################################
 
 # Update whenever you upgrade dev container image
-DEV_CONTAINER_VERSION_TAG?=0.1.7
+DEV_CONTAINER_VERSION_TAG?=0.1.8
 
 # Use this to pin a specific version of the Dapr CLI to a devcontainer
-DEV_CONTAINER_CLI_TAG?=1.7.0
+DEV_CONTAINER_CLI_TAG?=1.8.0
 
 # Dapr container image name
 DEV_CONTAINER_IMAGE_NAME=dapr-dev


### PR DESCRIPTION
Updates the dev container for 1.8

Also pushes the dev container to GHCR, and that's the new default

**Note:** In the past we had issues with the dev container being overwritten every time a release came out. Because of that, the dev container has been broken for a few weeks because it uses Go 1.17 and we need 1.18. I changed the workflow to ran manually only.