### PR TITLE
Some fixes for dev container and running Go code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	// Update the container version when you publish dev-container
 	"image": "ghcr.io/dapr/dapr-dev:0.1.8",
 	// Replace with uncommented line below to build your own local copy of the image
-	// "dockerFile": "../docker/Dockerfile-dev",
+	//"dockerFile": "../docker/Dockerfile-dev",
 	"containerEnv": {
 		// Uncomment to overwrite devcontainer .kube/config and .minikube certs with the localhost versions
 		// each time the devcontainer starts, if the respective .kube-localhost/config and .minikube-localhost

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -14,6 +14,7 @@ ARG MINIKUBE_VERSION="latest"
 ARG DAPR_CLI_VERSION="latest"
 ARG PROTOC_VERSION="21.1"
 ARG PROTOC_GEN_GO_VERSION="1.28"
+ARG PROTOC_GEN_GO_GRPC_VERSION="1.2"
 ARG GOLANGCI_LINT_VERSION="1.45.2"
 
 # This Dockerfile adds a non-root 'dapr' user with sudo access. However, for Linux,
@@ -28,6 +29,7 @@ ARG USER_GID=$USER_UID
 ENV GO111MODULE=auto
 ENV CGO_ENABLED=0
 ENV DOCKER_BUILDKIT=1
+ENV DAPR_DEFAULT_IMAGE_REGISTRY=GHCR
 
 # Setup image using library scripts and configure non-root user.
 COPY library-scripts/* custom-scripts/* first-run-notice.txt /tmp/staging/
@@ -46,10 +48,10 @@ RUN apt-get update \
     && bash /tmp/staging/kubectl-helm-debian.sh "${KUBECTL_VERSION}" "${HELM_VERSION}" "${MINIKUBE_VERSION}" \
     #
     # Install Go tools.
-    && bash /tmp/staging/go-debian.sh "none" "/usr/local/go" "${GOPATH}" "${USERNAME}" "false" \
+    && bash /tmp/staging/go-debian.sh "none" "/usr/local/go" "/go" "${USERNAME}" "false" \
     #
     # Install tools for Dapr.
-    && bash /tmp/staging/install-dapr-tools.sh "${DAPR_CLI_VERSION}" "${PROTOC_VERSION}" "${PROTOC_GEN_GO_VERSION}" "${GOLANGCI_LINT_VERSION}" \
+    && bash /tmp/staging/install-dapr-tools.sh "${USERNAME}" "/usr/local/go" "/go" "${DAPR_CLI_VERSION}" "${PROTOC_VERSION}" "${PROTOC_GEN_GO_VERSION}" "${PROTOC_GEN_GO_GRPC_VERSION}" "${GOLANGCI_LINT_VERSION}" \
     #
     # Install the GitHub CLI.
     && bash /tmp/staging/github-debian.sh "latest" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,6 +20,7 @@ The Dev Container can be rebuilt with custom options. Relevant args (and their d
 * `DAPR_CLI_VERSION` (default: `latest`)
 * `PROTOC_VERSION` (default: `21.1`)
 * `PROTOC_GEN_GO_VERSION` (default: `1.28`)
+* `PROTOC_GEN_GO_GRPC_VERSION` (default: `1.2`)
 * `GOLANGCI_LINT_VERSION` (default: `1.45.2`)
 
 ### Setup multi-arch Docker builds

--- a/docker/custom-scripts/install-dapr-tools.sh
+++ b/docker/custom-scripts/install-dapr-tools.sh
@@ -12,12 +12,16 @@
 # limitations under the License.
 #
 #
-# Syntax: ./install-dapr-tools.sh [DAPR_CLI_VERSION] [PROTOC_VERSION] [PROTOC_GEN_GO_VERSION] [GOLANGCI_LINT_VERSION]
+# Syntax: ./install-dapr-tools.sh [USERNAME] [GOROOT] [GOPATH] [DAPR_CLI_VERSION] [PROTOC_VERSION] [PROTOC_GEN_GO_VERSION] [PROTOC_GEN_GO_GRPC_VERSION] [GOLANGCI_LINT_VERSION]
 
-DAPR_CLI_VERSION=${1:-""}
-PROTOC_VERSION=${2:-"21.1"}
-PROTOC_GEN_GO_VERSION=${3:-"1.28"}
-GOLANGCI_LINT_VERSION=${4:-"1.45.2"}
+USERNAME=${1:-"dapr"}
+GOROOT=${2:-"/usr/local/go"}
+GOPATH=${3:-"/go"}
+DAPR_CLI_VERSION=${4:-""}
+PROTOC_VERSION=${5:-"21.1"}
+PROTOC_GEN_GO_VERSION=${6:-"1.28"}
+PROTOC_GEN_GO_GRPC_VERSION=${7:-"1.2"}
+GOLANGCI_LINT_VERSION=${8:-"1.45.2"}
 
 set -e
 
@@ -53,6 +57,15 @@ unzip -o "${PROTOC_ZIP}" -d /usr/local 'include/*'
 chmod -R 755 /usr/local/include/google/protobuf
 rm -f "${PROTOC_ZIP}"
 
-# Install protoc-gen-go and golangci-lint
-go install "google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOC_GEN_GO_VERSION}"
-go install "github.com/golangci/golangci-lint/cmd/golangci-lint@v${GOLANGCI_LINT_VERSION}"
+# Install protoc-gen-go and protoc-gen-go-grpc
+# Must be installed as the non-root user
+export GOBIN="${GOPATH}/bin"
+sudo -u ${USERNAME} --preserve-env=GOPATH,GOBIN,GOROOT \
+    go install "google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOC_GEN_GO_VERSION}"
+sudo -u ${USERNAME} --preserve-env=GOPATH,GOBIN,GOROOT \
+    go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${PROTOC_GEN_GO_GRPC_VERSION}"
+
+# Install golangci-lint using the recommended method (best to avoid using go install according to their docs)
+# Must be installed as the non-root user
+sudo -u ${USERNAME} --preserve-env=GOLANGCI_LINT_VERSION,GOPATH,GOBIN,GOROOT \
+    sh -c 'curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOBIN}" "v${GOLANGCI_LINT_VERSION}"'


### PR DESCRIPTION
Fixed a few issues in the 1.8 dev container:

1. Fixed: there was a permission issue in the GOROOT so Go could not fetch modules.
2. Installing protoc-gen-go-grpc too, which was missing and it's required to rebuild protos
3. Switched Dapr CLI to use GHCR by default
4. Installing golangci-lint from pre-compiled binaries as that's what is recommended by the project's authors