### PR TITLE
[Hotfix] Use the correct version of backoff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 )
 
 require (
-	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 )
@@ -146,6 +145,7 @@ require (
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/camunda/zeebe/clients/go/v8 v8.0.3 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coreos/go-oidc v2.1.0+incompatible // indirect
 	github.com/creasty/defaults v1.5.2 // indirect

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
 	"google.golang.org/grpc"

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -31,7 +31,7 @@ import (
 	"github.com/dapr/components-contrib/lock"
 	lock_loader "github.com/dapr/dapr/pkg/components/lock"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 
 	"contrib.go.opencensus.io/exporter/zipkin"
 	"github.com/google/uuid"


### PR DESCRIPTION
In two files, including (critically) `pkg/messaging/direct_messaging.go`, the `github.com/cenkalti/backoff` package was imported referencing the wrong module, missing `/v4` at the end. This caused an older version of the package (2.2.1) to be used instead.

Because of that, every time we returned `backoff.Permanent` (such as within `invokeWithRetry`), the permanent error was ignored. This caused a variety of issues including retrying when  up to a panic.

For example, when invoking `CallLocal` over gRPC and receiving an UNAUTHENTICATED or UNAVAILABLE error, then a connection error, the policy would retry even though that error was meant to be permanent.

Worse, when the response was for example UNIMPLEMENTED or another gRPC error code, which should have been a permanent error, the policy would have retried regardless and eventually (due to a chain of events), daprd would have panicked.