### PR TITLE
Attempting to improve unit tests reliability

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4070,6 +4070,7 @@ func TestStopWithErrors(t *testing.T) {
 func stopRuntime(t *testing.T, rt *DaprRuntime) {
 	rt.stopActor()
 	assert.NoError(t, rt.shutdownOutputComponents())
+	time.Sleep(100 * time.Millisecond)
 }
 
 func TestFindMatchingRoute(t *testing.T) {
@@ -4101,12 +4102,12 @@ func createRoutingRule(match, path string) (*runtime_pubsub.Rule, error) {
 }
 
 func TestComponentsCallback(t *testing.T) {
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "OK")
 	}))
-	defer svr.Close()
+	defer srv.Close()
 
-	u, err := url.Parse(svr.URL)
+	u, err := url.Parse(srv.URL)
 	require.NoError(t, err)
 	port, _ := strconv.Atoi(u.Port())
 	rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, "http", port)


### PR DESCRIPTION
This PR (tries to) improve the reliability of two unit tests that seem flaky:

1. gRPC proxying, for example: https://github.com/dapr/dapr/runs/7458717722?check_suite_focus=true The improvement here is to change how we wait for all parallel tests to complete and slightly increase the timeout
2. Runtime, for example: https://github.com/dapr/dapr/runs/7476223997?check_suite_focus=true The improvement here is to add a small sleep after each runtime is stopped with the hope that it gives the system more time to clean up ports that were being used