### PR TITLE
gRPC service invocation: do not unwrap error twice

### DIFF
--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -193,8 +193,7 @@ func (d *directMessaging) invokeWithRetry(
 				resp = nil
 			}
 
-			// We're safe to Unwrap here because it's either nil or a permanent error which contains the Unwrap method.
-			return resp, errors.Unwrap(err)
+			return resp, err
 		}
 		return fn(ctx, app.id, app.namespace, app.address, req)
 	}


### PR DESCRIPTION
Do not unwrap error, which is already un-wrapped by backoff. Otherwise, nil is returned.