### PR TITLE
Add default resiliency policies for components

### DIFF
--- a/pkg/diagnostics/resiliency_monitoring_test.go
+++ b/pkg/diagnostics/resiliency_monitoring_test.go
@@ -88,7 +88,7 @@ func TestResiliencyCountMonitoring(t *testing.T) {
 			appID: testAppID,
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, testStateStoreName)
-				_ = r.ComponentOutboundPolicy(context.TODO(), testStateStoreName)
+				_ = r.ComponentOutboundPolicy(context.TODO(), testStateStoreName, resiliency.Statestore)
 			},
 			wantTags: []tag.Tag{
 				newTag("app_id", testAppID),
@@ -105,7 +105,7 @@ func TestResiliencyCountMonitoring(t *testing.T) {
 			appID: testAppID,
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, testStateStoreName)
-				_ = r.ComponentInboundPolicy(context.TODO(), testStateStoreName)
+				_ = r.ComponentInboundPolicy(context.TODO(), testStateStoreName, resiliency.Statestore)
 			},
 			wantTags: []tag.Tag{
 				newTag("app_id", testAppID),

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -591,7 +591,7 @@ func (a *api) GetBulkState(ctx context.Context, in *runtimev1pb.GetBulkStateRequ
 	start := time.Now()
 	var bulkGet bool
 	var responses []state.BulkGetResponse
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Statestore)
 	err = policy(func(ctx context.Context) (rErr error) {
 		bulkGet, responses, rErr = store.BulkGet(reqs)
 		return rErr
@@ -698,7 +698,7 @@ func (a *api) GetState(ctx context.Context, in *runtimev1pb.GetStateRequest) (*r
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Statestore)
 	var getResponse *state.GetResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		getResponse, rErr = store.Get(&req)
@@ -783,7 +783,7 @@ func (a *api) SaveState(ctx context.Context, in *runtimev1pb.SaveStateRequest) (
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Statestore)
 	err = policy(func(ctx context.Context) error {
 		return store.BulkSet(reqs)
 	})
@@ -830,7 +830,7 @@ func (a *api) QueryStateAlpha1(ctx context.Context, in *runtimev1pb.QueryStateRe
 	req.Metadata = in.GetMetadata()
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Statestore)
 	var resp *state.QueryResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		resp, rErr = querier.Query(&req)
@@ -905,7 +905,7 @@ func (a *api) DeleteState(ctx context.Context, in *runtimev1pb.DeleteStateReques
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Statestore)
 	err = policy(func(ctx context.Context) error {
 		return store.Delete(&req)
 	})
@@ -951,7 +951,7 @@ func (a *api) DeleteBulkState(ctx context.Context, in *runtimev1pb.DeleteBulkSta
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Statestore)
 	err = policy(func(ctx context.Context) error {
 		return store.BulkDelete(reqs)
 	})
@@ -993,7 +993,7 @@ func (a *api) GetSecret(ctx context.Context, in *runtimev1pb.GetSecretRequest) (
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, secretStoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, secretStoreName, resiliency.Secretstore)
 	var getResponse secretstores.GetSecretResponse
 	err := policy(func(ctx context.Context) (rErr error) {
 		getResponse, rErr = a.secretStores[secretStoreName].GetSecret(req)
@@ -1036,7 +1036,7 @@ func (a *api) GetBulkSecret(ctx context.Context, in *runtimev1pb.GetBulkSecretRe
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, secretStoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, secretStoreName, resiliency.Secretstore)
 	var getResponse secretstores.BulkGetSecretResponse
 	err := policy(func(ctx context.Context) (rErr error) {
 		getResponse, rErr = a.secretStores[secretStoreName].BulkGetSecret(req)
@@ -1185,7 +1185,7 @@ func (a *api) ExecuteStateTransaction(ctx context.Context, in *runtimev1pb.Execu
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Statestore)
 	err := policy(func(ctx context.Context) error {
 		return transactionalStore.Multi(&state.TransactionalStateRequest{
 			Operations: operations,
@@ -1564,7 +1564,7 @@ func (a *api) GetConfigurationAlpha1(ctx context.Context, in *runtimev1pb.GetCon
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, in.StoreName, resiliency.Configuration)
 	var getResponse *configuration.GetResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		getResponse, rErr = store.Get(ctx, &req)
@@ -1674,7 +1674,7 @@ func (a *api) SubscribeConfigurationAlpha1(request *runtimev1pb.SubscribeConfigu
 
 	// TODO(@laurence) deal with failed subscription and retires
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(newCtx, request.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(newCtx, request.StoreName, resiliency.Configuration)
 	var id string
 	err = policy(func(ctx context.Context) (rErr error) {
 		id, rErr = store.Subscribe(ctx, req, handler.updateEventHandler)
@@ -1721,7 +1721,7 @@ func (a *api) UnsubscribeConfigurationAlpha1(ctx context.Context, request *runti
 	delete(a.configurationSubscribe, subscribeID)
 	close(stop)
 
-	policy := a.resiliency.ComponentOutboundPolicy(ctx, request.StoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(ctx, request.StoreName, resiliency.Configuration)
 
 	start := time.Now()
 	err = policy(func(ctx context.Context) error {

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -574,7 +574,7 @@ func (a *api) onBulkGetState(reqCtx *fasthttp.RequestCtx) {
 	start := time.Now()
 	var bulkGet bool
 	var responses []state.BulkGetResponse
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Statestore)
 	rErr := policy(func(ctx context.Context) (rErr error) {
 		bulkGet, responses, rErr = store.BulkGet(reqs)
 		return rErr
@@ -725,7 +725,7 @@ func (a *api) onGetState(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Statestore)
 	var resp *state.GetResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		resp, rErr = store.Get(&req)
@@ -803,7 +803,7 @@ func (h *configurationEventHandler) updateEventHandler(ctx context.Context, e *c
 		eventBody, _ := json.Marshal(e)
 		req.WithRawData(eventBody, invokev1.JSONContentType)
 
-		policy := h.res.ComponentInboundPolicy(ctx, h.storeName)
+		policy := h.res.ComponentInboundPolicy(ctx, h.storeName, resiliency.Configuration)
 		err := policy(func(ctx context.Context) (err error) {
 			resp, err := h.appChannel.InvokeMethod(ctx, req)
 			if err != nil {
@@ -838,7 +838,7 @@ func (a *api) onLock(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Lock)
 
 	var resp *lock.TryLockResponse
 	req.ResourceID, err = lockLoader.GetModifiedLockKey(req.ResourceID, storeName, a.id)
@@ -880,7 +880,7 @@ func (a *api) onUnlock(reqCtx *fasthttp.RequestCtx) {
 		return
 	}
 
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Lock)
 
 	var resp *lock.UnlockResponse
 	req.ResourceID, err = lockLoader.GetModifiedLockKey(req.ResourceID, storeName, a.id)
@@ -930,7 +930,7 @@ func (a *api) onSubscribeConfiguration(reqCtx *fasthttp.RequestCtx) {
 		}
 
 		start := time.Now()
-		policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+		policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Configuration)
 		var getResponse *configuration.GetResponse
 		err = policy(func(ctx context.Context) (rErr error) {
 			getResponse, rErr = store.Get(ctx, getConfigurationReq)
@@ -967,7 +967,7 @@ func (a *api) onSubscribeConfiguration(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Configuration)
 	var subscribeID string
 	err = policy(func(ctx context.Context) (rErr error) {
 		subscribeID, rErr = store.Subscribe(ctx, &req, handler.updateEventHandler)
@@ -1001,7 +1001,7 @@ func (a *api) onUnsubscribeConfiguration(reqCtx *fasthttp.RequestCtx) {
 		ID: subscribeID,
 	}
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Configuration)
 	err = policy(func(ctx context.Context) (rErr error) {
 		return store.Unsubscribe(ctx, &req)
 	})
@@ -1044,7 +1044,7 @@ func (a *api) onGetConfiguration(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Configuration)
 	var getResponse *configuration.GetResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		getResponse, rErr = store.Get(ctx, &req)
@@ -1119,7 +1119,7 @@ func (a *api) onDeleteState(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Statestore)
 	err = policy(func(ctx context.Context) error {
 		return store.Delete(&req)
 	})
@@ -1161,7 +1161,7 @@ func (a *api) onGetSecret(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, secretStoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, secretStoreName, resiliency.Secretstore)
 	var resp secretstores.GetSecretResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		resp, rErr = store.GetSecret(req)
@@ -1202,7 +1202,7 @@ func (a *api) onBulkGetSecret(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, secretStoreName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, secretStoreName, resiliency.Secretstore)
 	var resp secretstores.BulkGetSecretResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		resp, rErr = store.BulkGetSecret(req)
@@ -1312,7 +1312,7 @@ func (a *api) onPostState(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Statestore)
 	err = policy(func(ctx context.Context) error {
 		return store.BulkSet(reqs)
 	})
@@ -2189,7 +2189,7 @@ func (a *api) onPostStateTransaction(reqCtx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Statestore)
 	err := policy(func(ctx context.Context) error {
 		return transactionalStore.Multi(&state.TransactionalStateRequest{
 			Operations: operations,
@@ -2241,7 +2241,7 @@ func (a *api) onQueryState(reqCtx *fasthttp.RequestCtx) {
 	req.Metadata = getMetadataFromRequest(reqCtx)
 
 	start := time.Now()
-	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName)
+	policy := a.resiliency.ComponentOutboundPolicy(reqCtx, storeName, resiliency.Statestore)
 	var resp *state.QueryResponse
 	err = policy(func(ctx context.Context) (rErr error) {
 		resp, rErr = querier.Query(&req)

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -159,7 +159,7 @@ func (d *directMessaging) invokeWithRetry(
 ) (*invokev1.InvokeMethodResponse, error) {
 	// TODO: Once resiliency is out of preview, we can have this be the only path.
 	if d.isResiliencyEnabled {
-		if d.resiliency.GetPolicy(app.id, resiliency.Endpoint) == nil {
+		if d.resiliency.GetPolicy(app.id, &resiliency.EndpointPolicy{}) == nil {
 			retriesExhaustedPath := false // Used to track final error state.
 			nullifyResponsePath := false  // Used to track final response state.
 			policy := d.resiliency.BuiltInPolicy(ctx, resiliency.BuiltInServiceRetries)

--- a/pkg/resiliency/noop.go
+++ b/pkg/resiliency/noop.go
@@ -52,14 +52,14 @@ func (*NoOp) ActorPostLockPolicy(ctx context.Context, actorType string, id strin
 }
 
 // ComponentInboundPolicy returns a NoOp inbound policy runner for a component.
-func (*NoOp) ComponentInboundPolicy(ctx context.Context, name string) Runner {
+func (*NoOp) ComponentInboundPolicy(ctx context.Context, name string, componentName ComponentType) Runner {
 	return func(oper Operation) error {
 		return oper(ctx)
 	}
 }
 
 // ComponentOutboundPolicy returns a NoOp outbound policy runner for a component.
-func (*NoOp) ComponentOutboundPolicy(ctx context.Context, name string) Runner {
+func (*NoOp) ComponentOutboundPolicy(ctx context.Context, name string, componentName ComponentType) Runner {
 	return func(oper Operation) error {
 		return oper(ctx)
 	}

--- a/pkg/resiliency/noop_test.go
+++ b/pkg/resiliency/noop_test.go
@@ -72,26 +72,26 @@ func TestNoOp(t *testing.T) {
 		{
 			name: "component output",
 			fn: func(ctx context.Context) Runner {
-				return policy.ComponentOutboundPolicy(ctx, "test")
+				return policy.ComponentOutboundPolicy(ctx, "test", "Statestore")
 			},
 		},
 		{
 			name: "component outbound error",
 			fn: func(ctx context.Context) Runner {
-				return policy.ComponentOutboundPolicy(ctx, "test")
+				return policy.ComponentOutboundPolicy(ctx, "test", "Statestore")
 			},
 			err: errors.New("component outbound error"),
 		},
 		{
 			name: "component inbound",
 			fn: func(ctx context.Context) Runner {
-				return policy.ComponentInboundPolicy(ctx, "test")
+				return policy.ComponentInboundPolicy(ctx, "test", "Statestore")
 			},
 		},
 		{
 			name: "component inbound error",
 			fn: func(ctx context.Context) Runner {
-				return policy.ComponentInboundPolicy(ctx, "test")
+				return policy.ComponentInboundPolicy(ctx, "test", "Statestore")
 			},
 			err: errors.New("component inbound error"),
 		},

--- a/pkg/resiliency/resiliency.go
+++ b/pkg/resiliency/resiliency.go
@@ -57,11 +57,15 @@ const (
 	DefaultRetryTemplate          DefaultPolicyTemplate = "Default%sRetryPolicy"
 	DefaultTimeoutTemplate        DefaultPolicyTemplate = "Default%sTimeoutPolicy"
 	DefaultCircuitBreakerTemplate DefaultPolicyTemplate = "Default%sCircuitBreakerPolicy"
-	Endpoint                      PolicyType            = "App"
-	Component                     PolicyType            = "Component"
-	ComponentInbound              PolicyType            = "Component.inbound"
-	ComponentOutbound             PolicyType            = "Component.outbound"
-	Actor                         PolicyType            = "Actor"
+	Endpoint                      PolicyTypeName        = "App"
+	Component                     PolicyTypeName        = "Component"
+	Actor                         PolicyTypeName        = "Actor"
+	Binding                       ComponentType         = "Binding"
+	Configuration                 ComponentType         = "Configuration"
+	Lock                          ComponentType         = "Lock"
+	Pubsub                        ComponentType         = "Pubsub"
+	Secretstore                   ComponentType         = "Secretstore"
+	Statestore                    ComponentType         = "Statestore"
 )
 
 // ActorCircuitBreakerScope indicates the scope of the circuit breaker for an actor.
@@ -89,9 +93,9 @@ type (
 		// ActorPolicy returns the policy for an actor instance to be used after the lock is acquired.
 		ActorPostLockPolicy(ctx context.Context, actorType string, id string) Runner
 		// ComponentOutboundPolicy returns the outbound policy for a component.
-		ComponentOutboundPolicy(ctx context.Context, name string) Runner
+		ComponentOutboundPolicy(ctx context.Context, name string, componentType ComponentType) Runner
 		// ComponentInboundPolicy returns the inbound policy for a component.
-		ComponentInboundPolicy(ctx context.Context, name string) Runner
+		ComponentInboundPolicy(ctx context.Context, name string, componentType ComponentType) Runner
 		// BuiltInPolicy are used to replace existing retries in Dapr which may not bind specifically to one of the above categories.
 		BuiltInPolicy(ctx context.Context, name BuiltInPolicyName) Runner
 		// GetPolicy returns the policy that applies to the target, or nil if there is none.
@@ -167,7 +171,21 @@ type (
 
 	DefaultPolicyTemplate string
 	BuiltInPolicyName     string
-	PolicyType            string
+	PolicyTypeName        string
+
+	// PolicyTypes have to return an array of their possible levels.
+	// Ex. [App], [Actor], [Component, Inbound|Outbound, ComponentType]
+	PolicyType interface {
+		getPolicyLevels() []string
+		getPolicyTypeName() PolicyTypeName
+	}
+	EndpointPolicy  struct{}
+	ActorPolicy     struct{}
+	ComponentType   string
+	ComponentPolicy struct {
+		componentType      ComponentType
+		componentDirection string
+	}
 )
 
 // Ensure `*Resiliency` satisfies the `Provider` interface.
@@ -557,7 +575,7 @@ func (r *Resiliency) EndpointPolicy(ctx context.Context, app string, endpoint st
 			diag.DefaultResiliencyMonitoring.PolicyExecuted(r.name, r.namespace, diag.CircuitBreakerPolicy)
 		}
 	} else {
-		if defaultNames, ok := r.getDefaultPolicy(Endpoint); ok {
+		if defaultNames, ok := r.getDefaultPolicy(&EndpointPolicy{}); ok {
 			r.log.Debugf("Found Default Policy for Endpoint %s: %+v", app, defaultNames)
 			if defaultNames.Retry != "" {
 				rc = r.retries[defaultNames.Retry]
@@ -642,7 +660,7 @@ func (r *Resiliency) ActorPreLockPolicy(ctx context.Context, actorType string, i
 			diag.DefaultResiliencyMonitoring.PolicyExecuted(r.name, r.namespace, diag.CircuitBreakerPolicy)
 		}
 	} else {
-		if defaultNames, ok := r.getDefaultPolicy(Actor); ok {
+		if defaultNames, ok := r.getDefaultPolicy(&ActorPolicy{}); ok {
 			r.log.Debugf("Found Default Policy for Actor type %s: %+v", actorType, defaultNames)
 			if defaultNames.Retry != "" {
 				rc = r.retries[defaultNames.Retry]
@@ -701,7 +719,7 @@ func (r *Resiliency) ActorPostLockPolicy(ctx context.Context, actorType string, 
 			diag.DefaultResiliencyMonitoring.PolicyExecuted(r.name, r.namespace, diag.TimeoutPolicy)
 		}
 	} else {
-		if defaultPolicies, ok := r.getDefaultPolicy(Actor); ok {
+		if defaultPolicies, ok := r.getDefaultPolicy(&ActorPolicy{}); ok {
 			r.log.Debugf("Found Default Policy for Actor type %s: %+v", actorType, defaultPolicies)
 			if defaultPolicies.Timeout != "" {
 				t = r.timeouts[defaultPolicies.Timeout]
@@ -713,7 +731,7 @@ func (r *Resiliency) ActorPostLockPolicy(ctx context.Context, actorType string, 
 }
 
 // ComponentOutboundPolicy returns the outbound policy for a component.
-func (r *Resiliency) ComponentOutboundPolicy(ctx context.Context, name string) Runner {
+func (r *Resiliency) ComponentOutboundPolicy(ctx context.Context, name string, componentType ComponentType) Runner {
 	var t time.Duration
 	var rc *retry.Config
 	var cb *breaker.CircuitBreaker
@@ -737,13 +755,27 @@ func (r *Resiliency) ComponentOutboundPolicy(ctx context.Context, name string) R
 			cb = r.componentCBs.Get(r.log, name, template)
 			diag.DefaultResiliencyMonitoring.PolicyExecuted(r.name, r.namespace, diag.CircuitBreakerPolicy)
 		}
+	} else {
+		if defaultPolicies, ok := r.getDefaultPolicy(&ComponentPolicy{componentType: componentType, componentDirection: "Outbound"}); ok {
+			r.log.Debugf("Found Default Policy for Component: %s: %+v", name, defaultPolicies)
+			if defaultPolicies.Timeout != "" {
+				t = r.timeouts[defaultPolicies.Timeout]
+			}
+			if defaultPolicies.Retry != "" {
+				rc = r.retries[defaultPolicies.Retry]
+			}
+			if defaultPolicies.CircuitBreaker != "" {
+				template := r.circuitBreakers[defaultPolicies.CircuitBreaker]
+				cb = r.componentCBs.Get(r.log, name, template)
+			}
+		}
 	}
 
 	return Policy(ctx, r.log, operationName, t, rc, cb)
 }
 
 // ComponentInboundPolicy returns the inbound policy for a component.
-func (r *Resiliency) ComponentInboundPolicy(ctx context.Context, name string) Runner {
+func (r *Resiliency) ComponentInboundPolicy(ctx context.Context, name string, componentType ComponentType) Runner {
 	var t time.Duration
 	var rc *retry.Config
 	var cb *breaker.CircuitBreaker
@@ -767,6 +799,20 @@ func (r *Resiliency) ComponentInboundPolicy(ctx context.Context, name string) Ru
 			cb = r.componentCBs.Get(r.log, name, template)
 			diag.DefaultResiliencyMonitoring.PolicyExecuted(r.name, r.namespace, diag.CircuitBreakerPolicy)
 		}
+	} else {
+		if defaultPolicies, ok := r.getDefaultPolicy(&ComponentPolicy{componentType: componentType, componentDirection: "Inbound"}); ok {
+			r.log.Debugf("Found Default Policy for Component: %s: %+v", name, defaultPolicies)
+			if defaultPolicies.Timeout != "" {
+				t = r.timeouts[defaultPolicies.Timeout]
+			}
+			if defaultPolicies.Retry != "" {
+				rc = r.retries[defaultPolicies.Retry]
+			}
+			if defaultPolicies.CircuitBreaker != "" {
+				template := r.circuitBreakers[defaultPolicies.CircuitBreaker]
+				cb = r.componentCBs.Get(r.log, name, template)
+			}
+		}
 	}
 
 	return Policy(ctx, r.log, operationName, t, rc, cb)
@@ -786,27 +832,26 @@ func (r *Resiliency) GetPolicy(target string, policyType PolicyType) *PolicyDesc
 		policyName PolicyNames
 		exists     bool
 	)
-	switch policyType {
+	switch policyType.getPolicyTypeName() {
 	case Endpoint:
 		policyName, exists = r.apps[target]
-	case ComponentInbound:
+	case Component:
 		var componentPolicy ComponentPolicyNames
 		componentPolicy, exists = r.components[target]
 		if exists {
-			policyName = PolicyNames{
-				Retry:          componentPolicy.Inbound.Retry,
-				CircuitBreaker: componentPolicy.Inbound.CircuitBreaker,
-				Timeout:        componentPolicy.Inbound.Timeout,
-			}
-		}
-	case ComponentOutbound:
-		var componentPolicy ComponentPolicyNames
-		componentPolicy, exists = r.components[target]
-		if exists {
-			policyName = PolicyNames{
-				Retry:          componentPolicy.Outbound.Retry,
-				CircuitBreaker: componentPolicy.Outbound.CircuitBreaker,
-				Timeout:        componentPolicy.Outbound.Timeout,
+			policy, _ := policyType.(*ComponentPolicy)
+			if policy.componentDirection == "Inbound" {
+				policyName = PolicyNames{
+					Retry:          componentPolicy.Inbound.Retry,
+					CircuitBreaker: componentPolicy.Inbound.CircuitBreaker,
+					Timeout:        componentPolicy.Inbound.Timeout,
+				}
+			} else {
+				policyName = PolicyNames{
+					Retry:          componentPolicy.Outbound.Retry,
+					CircuitBreaker: componentPolicy.Outbound.CircuitBreaker,
+					Timeout:        componentPolicy.Outbound.Timeout,
+				}
 			}
 		}
 	case Actor:
@@ -852,37 +897,54 @@ func (r *Resiliency) getDefaultPolicy(policyType PolicyType) (PolicyNames, bool)
 }
 
 func (r *Resiliency) getDefaultRetryPolicy(policyType PolicyType) string {
-	typeTemplate, topLevelTemplate := r.expandPolicyTemplate(policyType, DefaultRetryTemplate)
-	if _, ok := r.retries[typeTemplate]; ok {
-		return typeTemplate
-	} else if _, ok := r.retries[topLevelTemplate]; ok {
+	typeTemplates, topLevelTemplate := r.expandPolicyTemplate(policyType, DefaultRetryTemplate)
+	for _, typeTemplate := range typeTemplates {
+		if _, ok := r.retries[typeTemplate]; ok {
+			return typeTemplate
+		}
+	}
+
+	if _, ok := r.retries[topLevelTemplate]; ok {
 		return topLevelTemplate
 	}
 	return ""
 }
 
 func (r *Resiliency) getDefaultTimeoutPolicy(policyType PolicyType) string {
-	typeTemplate, topLevelTemplate := r.expandPolicyTemplate(policyType, DefaultTimeoutTemplate)
-	if _, ok := r.timeouts[typeTemplate]; ok {
-		return typeTemplate
-	} else if _, ok := r.timeouts[topLevelTemplate]; ok {
+	typeTemplates, topLevelTemplate := r.expandPolicyTemplate(policyType, DefaultTimeoutTemplate)
+	for _, typeTemplate := range typeTemplates {
+		if _, ok := r.timeouts[typeTemplate]; ok {
+			return typeTemplate
+		}
+	}
+
+	if _, ok := r.timeouts[topLevelTemplate]; ok {
 		return topLevelTemplate
 	}
 	return ""
 }
 
 func (r *Resiliency) getDefaultCircuitBreakerPolicy(policyType PolicyType) string {
-	typeTemplate, topLevelTemplate := r.expandPolicyTemplate(policyType, DefaultCircuitBreakerTemplate)
-	if _, ok := r.circuitBreakers[typeTemplate]; ok {
-		return typeTemplate
-	} else if _, ok := r.circuitBreakers[topLevelTemplate]; ok {
+	typeTemplates, topLevelTemplate := r.expandPolicyTemplate(policyType, DefaultCircuitBreakerTemplate)
+	for _, typeTemplate := range typeTemplates {
+		if _, ok := r.circuitBreakers[typeTemplate]; ok {
+			return typeTemplate
+		}
+	}
+
+	if _, ok := r.circuitBreakers[topLevelTemplate]; ok {
 		return topLevelTemplate
 	}
 	return ""
 }
 
-func (r *Resiliency) expandPolicyTemplate(policyType PolicyType, template DefaultPolicyTemplate) (string, string) {
-	return fmt.Sprintf(string(template), policyType), fmt.Sprintf(string(template), "")
+func (r *Resiliency) expandPolicyTemplate(policyType PolicyType, template DefaultPolicyTemplate) ([]string, string) {
+	policyLevels := policyType.getPolicyLevels()
+	typeTemplates := make([]string, len(policyLevels))
+	for i, level := range policyLevels {
+		typeTemplates[i] = fmt.Sprintf(string(template), level)
+	}
+	return typeTemplates, fmt.Sprintf(string(template), "")
 }
 
 // Get returns a cached circuit breaker if one exists.
@@ -972,4 +1034,40 @@ func filterResiliencyConfigs(resiliences []*resiliencyV1alpha.Resiliency, runtim
 	}
 
 	return filteredResiliencies
+}
+
+func (*EndpointPolicy) getPolicyLevels() []string {
+	return []string{"App"}
+}
+
+func (*EndpointPolicy) getPolicyTypeName() PolicyTypeName {
+	return Endpoint
+}
+
+func (*ActorPolicy) getPolicyLevels() []string {
+	return []string{"Actor"}
+}
+
+func (*ActorPolicy) getPolicyTypeName() PolicyTypeName {
+	return Actor
+}
+
+func (p *ComponentPolicy) getPolicyLevels() []string {
+	return []string{
+		fmt.Sprintf("%sComponent%s", p.componentType, p.componentDirection),
+		fmt.Sprintf("Component%s", p.componentDirection),
+		"Component",
+	}
+}
+
+func (*ComponentPolicy) getPolicyTypeName() PolicyTypeName {
+	return Component
+}
+
+var ComponentInboundPolicy = ComponentPolicy{
+	componentDirection: "Inbound",
+}
+
+var ComponentOutboundPolicy = ComponentPolicy{
+	componentDirection: "Outbound",
 }


### PR DESCRIPTION
# Description

This commit adds default policies for components. These are
stratified into several levels:

 - Component with component type and direction
 - Component with direction
 - Component
 - Default

Each component type can specify their own policy or rely on the
various fallback procedures.

https://github.com/dapr/dapr/issues/4852

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: #4852 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
