### PR TITLE
Release 1.8.3 (cherry-pick 4938 into release-1.8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ else
 endif
 export GOOS ?= $(TARGET_OS_LOCAL)
 
-PROTOC_GEN_GO_NAME+= "v1.28.0"
+PROTOC_GEN_GO_VERSION = v1.28.0
+PROTOC_GEN_GO_NAME+= $(PROTOC_GEN_GO_VERSION)
 
 ifeq ($(TARGET_OS_LOCAL),windows)
 	BUILD_TOOLS_BIN ?= build-tools.exe
@@ -323,7 +324,7 @@ check: format test lint
 ################################################################################
 .PHONY: init-proto
 init-proto:
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 
 ################################################################################

--- a/docs/release_notes/v1.8.3.md
+++ b/docs/release_notes/v1.8.3.md
@@ -1,0 +1,19 @@
+# Dapr 1.8.3
+
+### Fixes panic when invoking a non-existent service with Resiliency enabled
+
+#### Problem
+
+Dapr 1.8.0 introduced an error that causes a panic in the runtime when attempting to invoke a service that does not exist (and with dealing with a few other error cases) and the `Resiliency` preview feature is enabled–even if no resiliency policies are configured.
+
+### Impact
+
+This issue impacts all users that have enabled the `Resiliency` preview feature in Dapr 1.8.0–1.8.2, even when no resiliency policies are configured.
+
+#### Root cause
+
+Due to incorrect handling of errors in the direct messaging package, certain types of errors were discarded and the affected method returned a non-error response, eventually causing receivers to panic.
+
+#### Solution
+
+We have fixed the handling of the errors in the direct messaging package when `Resiliency` is enabled, resolving the issue that could have caused a panic in case of errors.

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -193,8 +193,7 @@ func (d *directMessaging) invokeWithRetry(
 				resp = nil
 			}
 
-			// We're safe to Unwrap here because it's either nil or a permanent error which contains the Unwrap method.
-			return resp, errors.Unwrap(err)
+			return resp, err
 		}
 		return fn(ctx, app.id, app.namespace, app.address, req)
 	}

--- a/tests/apps/resiliencyapp/app.go
+++ b/tests/apps/resiliencyapp/app.go
@@ -42,6 +42,7 @@ type FailureMessage struct {
 	ID              string         `json:"id"`
 	MaxFailureCount *int           `json:"maxFailureCount,omitempty"`
 	Timeout         *time.Duration `json:"timeout,omitempty"`
+	ResponseCode    *int           `json:"responseCode,omitempty"`
 }
 
 type CallRecord struct {
@@ -217,6 +218,10 @@ func resiliencyServiceInvocationHandler(w http.ResponseWriter, r *http.Request) 
 	log.Printf("Seen %s %d times.", message.ID, callCount)
 
 	callTracking[message.ID] = append(callTracking[message.ID], CallRecord{Count: callCount, TimeSeen: time.Now()})
+	if message.ResponseCode != nil {
+		w.WriteHeader(*message.ResponseCode)
+		return
+	}
 	if message.MaxFailureCount != nil && callCount < *message.MaxFailureCount {
 		if message.Timeout != nil {
 			// This request can still succeed if the resiliency policy timeout is longer than this sleep.
@@ -419,8 +424,17 @@ func TestInvokeService(w http.ResponseWriter, r *http.Request) {
 	protocol := mux.Vars(r)["protocol"]
 	log.Printf("Invoking resiliency service with %s", protocol)
 
+	targetApp := r.URL.Query().Get("target_app")
+	targetMethod := r.URL.Query().Get("target_method")
+
 	if protocol == "http" {
-		url := "http://localhost:3500/v1.0/invoke/resiliencyapp/method/resiliencyInvocation"
+		if targetApp == "" {
+			targetApp = "resiliencyapp"
+		}
+		if targetMethod == "" {
+			targetMethod = "resiliencyInvocation"
+		}
+		url := fmt.Sprintf("http://localhost:3500/v1.0/invoke/%s/method/%s", targetApp, targetMethod)
 
 		req, _ := http.NewRequest("POST", url, r.Body)
 		defer r.Body.Close()
@@ -438,6 +452,13 @@ func TestInvokeService(w http.ResponseWriter, r *http.Request) {
 			w.Write(b)
 		}
 	} else if protocol == "grpc" {
+		if targetApp == "" {
+			targetApp = "resiliencyappgrpc"
+		}
+		if targetMethod == "" {
+			targetMethod = "grpcInvoke"
+		}
+
 		var message FailureMessage
 		err := json.NewDecoder(r.Body).Decode(&message)
 		if err != nil {
@@ -448,9 +469,9 @@ func TestInvokeService(w http.ResponseWriter, r *http.Request) {
 		b, _ := json.Marshal(message)
 
 		req := &runtimev1pb.InvokeServiceRequest{
-			Id: "resiliencyappgrpc",
+			Id: targetApp,
 			Message: &commonv1pb.InvokeRequest{
-				Method: "grpcInvoke",
+				Method: targetMethod,
 				Data: &anypb.Any{
 					Value: b,
 				},


### PR DESCRIPTION
This PR cherry-picks #4938 into release-1.8.3 (with no further code changes).

It also includes release notes for 1.8.3 and an updated E2E test to catch regressions in the future (fixes #4929)

PS: Had to pin a specific minor revision of protoc-gen-go or the CI was failing as it was downloading a newer patch version