### PR TITLE
Component denylist

### DIFF
--- a/pkg/components/secretstores/registry.go
+++ b/pkg/components/secretstores/registry.go
@@ -19,9 +19,11 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/secretstores"
-
 	"github.com/dapr/dapr/pkg/components"
 )
+
+// Name of the built-in Kubernetes secret store component.
+const BuiltinKubernetesSecretStore = "kubernetes"
 
 type (
 	// SecretStore is a secret store component definition.

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -49,34 +49,35 @@ const (
 
 // Config holds the Dapr Runtime configuration.
 type Config struct {
-	ID                           string
-	HTTPPort                     int
-	PublicPort                   *int
-	ProfilePort                  int
-	EnableProfiling              bool
-	APIGRPCPort                  int
-	InternalGRPCPort             int
-	ApplicationPort              int
-	APIListenAddresses           []string
-	ApplicationProtocol          Protocol
-	Mode                         modes.DaprMode
-	PlacementAddresses           []string
-	GlobalConfig                 string
-	AllowedOrigins               string
-	Standalone                   config.StandaloneConfig
-	Kubernetes                   config.KubernetesConfig
-	MaxConcurrency               int
-	mtlsEnabled                  bool
-	SentryServiceAddress         string
-	CertChain                    *credentials.CertChain
-	AppSSL                       bool
-	MaxRequestBodySize           int
-	UnixDomainSocket             string
-	ReadBufferSize               int
-	StreamRequestBody            bool
-	GracefulShutdownDuration     time.Duration
-	EnableAPILogging             bool
-	DisableBuiltinK8sSecretStore bool
+	ID                             string
+	HTTPPort                       int
+	PublicPort                     *int
+	ProfilePort                    int
+	EnableProfiling                bool
+	APIGRPCPort                    int
+	InternalGRPCPort               int
+	ApplicationPort                int
+	APIListenAddresses             []string
+	ApplicationProtocol            Protocol
+	Mode                           modes.DaprMode
+	PlacementAddresses             []string
+	GlobalConfig                   string
+	AllowedOrigins                 string
+	Standalone                     config.StandaloneConfig
+	Kubernetes                     config.KubernetesConfig
+	MaxConcurrency                 int
+	mtlsEnabled                    bool
+	SentryServiceAddress           string
+	CertChain                      *credentials.CertChain
+	AppSSL                         bool
+	MaxRequestBodySize             int
+	UnixDomainSocket               string
+	ReadBufferSize                 int
+	StreamRequestBody              bool
+	GracefulShutdownDuration       time.Duration
+	EnableAPILogging               bool
+	DisableBuiltinK8sSecretStore   bool
+	AdditionalComponentAuthorizers []ComponentAuthorizer
 }
 
 // NewRuntimeConfig returns a new runtime config.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -116,7 +116,6 @@ const (
 	lockComponent                   ComponentCategory = "lock"
 	defaultComponentInitTimeout                       = time.Second * 5
 	defaultGracefulShutdownDuration                   = time.Second * 5
-	kubernetesSecretStore                             = "kubernetes"
 )
 
 var componentCategoriesNeedProcess = []ComponentCategory{
@@ -143,6 +142,10 @@ type Route struct {
 type TopicRoute struct {
 	routes map[string]Route
 }
+
+// Type of function that determines if a component is authorized.
+// The function receives the component and must return true if the component is authorized.
+type ComponentAuthorizer func(component components_v1alpha1.Component) bool
 
 // DaprRuntime holds all the core components of the runtime.
 type DaprRuntime struct {
@@ -187,6 +190,7 @@ type DaprRuntime struct {
 	inputBindingRoutes     map[string]string
 	shutdownC              chan error
 	apiClosers             []io.Closer
+	componentAuthorizers   []ComponentAuthorizer
 
 	secretsConfiguration map[string]config.SecretsScope
 
@@ -232,7 +236,7 @@ type pubsubSubscribedMessage struct {
 // NewDaprRuntime returns a new runtime with the given runtime config and global config.
 func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, accessControlList *config.AccessControlList, resiliencyProvider resiliency.Provider) *DaprRuntime {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &DaprRuntime{
+	rt := &DaprRuntime{
 		ctx:                    ctx,
 		cancel:                 cancel,
 		runtimeConfig:          runtimeConfig,
@@ -272,11 +276,13 @@ func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, a
 
 		resiliency: resiliencyProvider,
 	}
+	rt.componentAuthorizers = append([]ComponentAuthorizer{rt.namespaceComponentAuthorizer}, runtimeConfig.AdditionalComponentAuthorizers...)
+	return rt
 }
 
 // Run performs initialization of the runtime with the runtime and global configurations.
 func (a *DaprRuntime) Run(opts ...Option) error {
-	start := time.Now().UTC()
+	start := time.Now()
 	log.Infof("%s mode configured", a.runtimeConfig.Mode)
 	log.Infof("app id: %s", a.runtimeConfig.ID)
 
@@ -290,7 +296,7 @@ func (a *DaprRuntime) Run(opts ...Option) error {
 		return err
 	}
 
-	d := time.Since(start).Seconds() * 1000
+	d := time.Since(start).Milliseconds()
 	log.Infof("dapr initialized. Status: Running. Init Elapsed %vms", d)
 
 	if a.daprHTTPAPI != nil {
@@ -392,9 +398,8 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 			log.Warnf("failed to watch component updates: %s", err)
 		}
 	}
-	if !a.runtimeConfig.DisableBuiltinK8sSecretStore {
-		a.appendBuiltinSecretStore()
-	}
+
+	a.appendBuiltinSecretStore()
 	err = a.loadComponents(opts)
 	if err != nil {
 		log.Warnf("failed to load components: %s", err)
@@ -1904,17 +1909,28 @@ func (a *DaprRuntime) initActors() error {
 }
 
 func (a *DaprRuntime) getAuthorizedComponents(components []components_v1alpha1.Component) []components_v1alpha1.Component {
-	authorized := []components_v1alpha1.Component{}
+	authorized := make([]components_v1alpha1.Component, len(components))
 
+	i := 0
 	for _, c := range components {
 		if a.isComponentAuthorized(c) {
-			authorized = append(authorized, c)
+			authorized[i] = c
+			i++
 		}
 	}
-	return authorized
+	return authorized[0:i]
 }
 
 func (a *DaprRuntime) isComponentAuthorized(component components_v1alpha1.Component) bool {
+	for _, auth := range a.componentAuthorizers {
+		if !auth(component) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *DaprRuntime) namespaceComponentAuthorizer(component components_v1alpha1.Component) bool {
 	if a.namespace == "" || (a.namespace != "" && component.ObjectMeta.Namespace == a.namespace) {
 		if len(component.Scopes) == 0 {
 			return true
@@ -1955,8 +1971,7 @@ func (a *DaprRuntime) loadComponents(opts *runtimeOpts) error {
 	authorizedComps := a.getAuthorizedComponents(comps)
 
 	a.componentsLock.Lock()
-	a.components = make([]components_v1alpha1.Component, len(authorizedComps))
-	copy(a.components, authorizedComps)
+	a.components = authorizedComps
 	a.componentsLock.Unlock()
 
 	for _, comp := range authorizedComps {
@@ -2218,11 +2233,9 @@ func (a *DaprRuntime) processComponentSecrets(component components_v1alpha1.Comp
 
 		// If running in Kubernetes, do not fetch secrets from the Kubernetes secret store as they will be populated by the operator.
 		// Instead, base64 decode the secret values into their real self.
-		if a.runtimeConfig.Mode == modes.KubernetesMode && secretStoreName == kubernetesSecretStore {
-			val := m.Value.Raw
-
+		if a.runtimeConfig.Mode == modes.KubernetesMode && secretStoreName == secretstores_loader.BuiltinKubernetesSecretStore {
 			var jsonVal string
-			err := json.Unmarshal(val, &jsonVal)
+			err := json.Unmarshal(m.Value.Raw, &jsonVal)
 			if err != nil {
 				log.Errorf("error decoding secret: %s", err)
 				continue
@@ -2304,7 +2317,7 @@ func (a *DaprRuntime) blockUntilAppIsReady() {
 	log.Infof("application protocol: %s. waiting on port %v.  This will block until the app is listening on that port.", string(a.runtimeConfig.ApplicationProtocol), a.runtimeConfig.ApplicationPort)
 
 	for {
-		conn, _ := net.DialTimeout("tcp", net.JoinHostPort("localhost", fmt.Sprintf("%v", a.runtimeConfig.ApplicationPort)), time.Millisecond*500)
+		conn, _ := net.DialTimeout("tcp", net.JoinHostPort("localhost", strconv.Itoa(a.runtimeConfig.ApplicationPort)), time.Millisecond*500)
 		if conn != nil {
 			conn.Close()
 			break
@@ -2363,26 +2376,23 @@ func (a *DaprRuntime) createAppChannel() error {
 }
 
 func (a *DaprRuntime) appendBuiltinSecretStore() {
-	for _, comp := range a.builtinSecretStore() {
-		a.pendingComponents <- comp
+	if a.runtimeConfig.DisableBuiltinK8sSecretStore {
+		return
 	}
-}
 
-func (a *DaprRuntime) builtinSecretStore() []components_v1alpha1.Component {
-	// Preload Kubernetes secretstore
 	switch a.runtimeConfig.Mode {
 	case modes.KubernetesMode:
-		return []components_v1alpha1.Component{{
+		// Preload Kubernetes secretstore
+		a.pendingComponents <- components_v1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "kubernetes",
+				Name: secretstores_loader.BuiltinKubernetesSecretStore,
 			},
 			Spec: components_v1alpha1.ComponentSpec{
 				Type:    "secretstores.kubernetes",
 				Version: components.FirstStableVersion,
 			},
-		}}
+		}
 	}
-	return nil
 }
 
 func (a *DaprRuntime) initSecretStore(c components_v1alpha1.Component) error {


### PR DESCRIPTION
This PR adds the ability to create a denylist that forbids loading certain types of components. This is passed as an environmental variable (for the daprd container) called `DENY_COMPONENTS`.

The denylist is a comma-spearated list of component identifiers. For example:

```
DENY_COMPONENTS="bindings.smtp,bindings.kubernetes"
```

Disables the "bindings.smtp" and "bindings.kubernetes" components. It's possible to specify a version too, to disable that version only (if the version is not specified, all versions are disabled):

```
DENY_COMPONENTS="bindings.kubernetes/v1"
```

The goal is being able to disable certain components from being instantiated. This issue fixes https://github.com/dapr/dapr/issues/4692 although it is done in a much softer way, including a denylist only and using env vars instead of annotations. Additionally, it prevents components from being loaded, but does not prevent them from being registered.