### PR TITLE
[WIP] Run e2e tests using a VPN Tunnel

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -22,9 +22,6 @@
 name: dapr-test
 
 on:
-  # Run every 2 hours
-  schedule:
-    - cron: '0 */2 * * *'
   # Manual trigger
   workflow_dispatch:
   # Dispatch on external events
@@ -404,6 +401,23 @@ jobs:
         if: env.TEST_PREFIX != '' && env.TEST_CLOUD_ENV != ''
         run: ./tests/test-infra/setup_${{ env.TEST_CLOUD_ENV }}.sh
         shell: bash
+      - name: Setup tailscale subnet router
+        if: env.TEST_PREFIX != ''
+        run: |
+          # Pod and service cidr used by tailscale subnet router
+          POD_CIDR=$(kubectl cluster-info dump | grep -m 1 cluster-cidr |grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}/[0-9]{1,3}")
+          SERVICE_CIDR=$(echo '{"apiVersion":"v1","kind":"Service","metadata":{"name":"tst"},"spec":{"clusterIP":"1.1.1.1","ports":[{"port":443}]}}' | kubectl apply -f - 2>&1 | sed 's/.*valid IPs is //')
+          POD_CIDR=${POD_CIDR} SERVICE_CIDR=${SERVICE_CIDR} make setup-tailscale
+          # Wait for tailscale pod to be ready
+          for i in 1 2 3 4 5; do echo "waiting for tailscale pod" && kubectl logs -l app=tailscale -n ${{ env.DAPR_NAMESPACE }} && kubectl get pods -l app=tailscale -n ${{ env.DAPR_NAMESPACE }} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}' == "True" && break || sleep 10; done
+          echo "tailscale pod is now ready"
+          sleep 5
+          kubectl logs -l app=tailscale -n ${{ env.DAPR_NAMESPACE }}
+      - name: Connect to tailscale VPN
+        uses: tailscale/github-action@e870a1112fcc1faeeeeea3c1b0ce544e5ad01844
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
+          version: 1.28.0
       - name: Preparing AKS cluster for test
         if: env.TEST_PREFIX != ''
         run: |
@@ -414,13 +428,7 @@ jobs:
             make setup-test-env-mongodb
           fi
           kubectl get pods -n ${{ env.DAPR_NAMESPACE }}
-          make setup-tailscale
         shell: bash
-      - name: Connect to tailscale
-        uses: tailscale/github-action@e870a1112fcc1faeeeeea3c1b0ce544e5ad01844
-        with:
-          authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
-          version: 1.26.2
       - name: Deploy dapr to AKS cluster
         if: env.TEST_PREFIX != ''
         env:

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -303,6 +303,7 @@ jobs:
       TARGET_ARCH: ${{ matrix.target_arch }}
       TEST_OUTPUT_FILE_PREFIX: "test_report"
       PULL_POLICY: IfNotPresent
+      TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -412,7 +413,12 @@ jobs:
             make setup-test-env-mongodb
           fi
           kubectl get pods -n ${{ env.DAPR_NAMESPACE }}
+          make setup-tailscale
         shell: bash
+      - name: Connect to tailscale
+        uses: tailscale/github-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
       - name: Deploy dapr to AKS cluster
         if: env.TEST_PREFIX != ''
         env:

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -304,6 +304,7 @@ jobs:
       TEST_OUTPUT_FILE_PREFIX: "test_report"
       PULL_POLICY: IfNotPresent
       TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY }}
+      TEST_E2E_USE_INTERNAL_IP: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -417,9 +417,10 @@ jobs:
           make setup-tailscale
         shell: bash
       - name: Connect to tailscale
-        uses: tailscale/github-action@v1
+        uses: tailscale/github-action@e870a1112fcc1faeeeeea3c1b0ce544e5ad01844
         with:
           authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
+          version: 1.26.2
       - name: Deploy dapr to AKS cluster
         if: env.TEST_PREFIX != ''
         env:

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -22,6 +22,9 @@
 name: dapr-test
 
 on:
+  # Run every 2 hours
+  schedule:
+    - cron: '0 */2 * * *'
   # Manual trigger
   workflow_dispatch:
   # Dispatch on external events
@@ -409,7 +412,13 @@ jobs:
           SERVICE_CIDR=$(echo '{"apiVersion":"v1","kind":"Service","metadata":{"name":"tst"},"spec":{"clusterIP":"1.1.1.1","ports":[{"port":443}]}}' | kubectl apply -f - 2>&1 | sed 's/.*valid IPs is //')
           POD_CIDR=${POD_CIDR} SERVICE_CIDR=${SERVICE_CIDR} make setup-tailscale
           # Wait for tailscale pod to be ready
-          for i in 1 2 3 4 5; do echo "waiting for tailscale pod" && kubectl logs -l app=tailscale -n ${{ env.DAPR_NAMESPACE }} && kubectl get pods -l app=tailscale -n ${{ env.DAPR_NAMESPACE }} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}' == "True" && break || sleep 10; done
+          for i in 1 2 3 4 5; do
+            echo "waiting for tailscale pod" && kubectl logs -l app=tailscale -n ${{ env.DAPR_NAMESPACE }} && [[ $(kubectl get pods -l app=tailscale -n ${{ env.DAPR_NAMESPACE }} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') == "True" ]] && break || sleep 10
+          done
+          if [[ $(kubectl get pods -l app=tailscale -n ${{ env.DAPR_NAMESPACE }} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; then
+            echo "tailscale pod couldn't be ready"
+            exit 1
+          fi
           echo "tailscale pod is now ready"
           sleep 5
           kubectl logs -l app=tailscale -n ${{ env.DAPR_NAMESPACE }}

--- a/tests/config/tailscale_key.yaml
+++ b/tests/config/tailscale_key.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-auth
+stringData:
+  TS_AUTH_KEY: "{{TS_AUTH_KEY}}"

--- a/tests/config/tailscale_role.yaml
+++ b/tests/config/tailscale_role.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["secrets"]
+    # Create can not be restricted to a resource name.
+    verbs: ["create"]
+  - apiGroups: [""] # "" indicates the core API group
+    resourceNames: ["tailscale"]
+    resources: ["secrets"]
+    verbs: ["get", "update"]

--- a/tests/config/tailscale_role.yaml
+++ b/tests/config/tailscale_role.yaml
@@ -11,6 +11,6 @@ rules:
     # Create can not be restricted to a resource name.
     verbs: ["create"]
   - apiGroups: [""] # "" indicates the core API group
-    resourceNames: ["tailscale"]
+    resourceNames: ["tailscale-auth"]
     resources: ["secrets"]
     verbs: ["get", "update"]

--- a/tests/config/tailscale_rolebinding.yaml
+++ b/tests/config/tailscale_rolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale
+subjects:
+  - kind: ServiceAccount
+    name: "tailscale"
+roleRef:
+  kind: Role
+  name: tailscale
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/config/tailscale_sa.yaml
+++ b/tests/config/tailscale_sa.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale

--- a/tests/config/tailscale_subnet_router.yaml
+++ b/tests/config/tailscale_subnet_router.yaml
@@ -32,7 +32,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: tailscale-auth
-              key: AUTH_KEY
+              key: TS_AUTH_KEY
         - name: TS_ROUTES
           value: "{{TS_ROUTES}}"
       securityContext:

--- a/tests/config/tailscale_subnet_router.yaml
+++ b/tests/config/tailscale_subnet_router.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: subnet-router
+  labels:
+    app: tailscale
+spec:
+  serviceAccountName: "tailscale"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+  containers:
+    - name: tailscale
+      imagePullPolicy: Always
+      image: "ghcr.io/tailscale/tailscale:latest"
+      env:
+        # Store the state in a k8s secret
+        - name: TS_KUBE_SECRET
+          value: "tailscale-auth"
+        - name: TS_USERSPACE
+          value: "true"
+        - name: TS_AUTH_KEY
+          valueFrom:
+            secretKeyRef:
+              name: tailscale-auth
+              key: AUTH_KEY
+        - name: TS_ROUTES
+          value: "{{TS_ROUTES}}"
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -15,8 +15,15 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
+)
+
+const (
+	// useServiceInternalIP is used to identify wether the connection between the kubernetes platform could be made using its internal ips.
+	useServiceInternalIP = "TEST_E2E_USE_INTERNAL_IP"
 )
 
 // AppDescription holds the deployment information of test app.
@@ -60,6 +67,11 @@ func (a AppDescription) String() string {
 	// This method overrides the default stringifier to use the custom JSON stringifier which hides ImageSecret
 	j, _ := json.Marshal(a)
 	return string(j)
+}
+
+// ShouldBeExposed returns if the app should be exposed as a loadbalancer/nodeport service.
+func (a AppDescription) ShouldBeExposed() bool {
+	return a.IngressEnabled && !strings.EqualFold(os.Getenv(useServiceInternalIP), "true")
 }
 
 func (a AppDescription) MarshalJSON() ([]byte, error) {

--- a/tests/platforms/kubernetes/app_description_test.go
+++ b/tests/platforms/kubernetes/app_description_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package kubernetes
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -47,6 +48,24 @@ func TestAppDescription_MarshalJSON(t *testing.T) {
 		}
 		if !reflect.DeepEqual(string(res), want) {
 			t.Errorf("AppDescription.MarshalJSON() = %v, want %v", string(res), want)
+		}
+	})
+
+	t.Run("use service internal ip", func(t *testing.T) {
+		defer os.Clearenv()
+		app := AppDescription{
+			IngressEnabled: true,
+		}
+		os.Setenv(useServiceInternalIP, "false")
+
+		if !app.ShouldBeExposed() {
+			t.Error("AppDescription.ShouldBeExposed() should evaluate to true when ingress is enabled and internal ip should not be used")
+		}
+
+		os.Setenv(useServiceInternalIP, "true")
+
+		if app.ShouldBeExposed() {
+			t.Error("AppDescription.ShouldBeExposed() should evaluate to false when internal ip should be used")
 		}
 	})
 }

--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -616,25 +616,26 @@ func (m *AppManager) WaitUntilServiceState(isState func(*apiv1.Service, error) b
 
 // AcquireExternalURLFromService gets external url from Service Object.
 func (m *AppManager) AcquireExternalURLFromService(svc *apiv1.Service) string {
-	if svc.Status.LoadBalancer.Ingress != nil && len(svc.Status.LoadBalancer.Ingress) > 0 && len(svc.Spec.Ports) > 0 {
-		address := ""
-		if svc.Status.LoadBalancer.Ingress[0].Hostname != "" {
-			address = svc.Status.LoadBalancer.Ingress[0].Hostname
+	svcPorts := svc.Spec.Ports
+	if len(svcPorts) == 0 {
+		return ""
+	}
+
+	svcFstPort, svcIngress := svcPorts[0], svc.Status.LoadBalancer.Ingress
+	// the default service address is the internal one
+	address, port := svc.Spec.ClusterIP, svcFstPort.Port
+	if svcIngress != nil && len(svcIngress) > 0 {
+		if svcIngress[0].Hostname != "" {
+			address = svcIngress[0].Hostname
 		} else {
-			address = svc.Status.LoadBalancer.Ingress[0].IP
+			address = svcIngress[0].IP
 		}
-		return fmt.Sprintf("%s:%d", address, svc.Spec.Ports[0].Port)
-	}
-
-	// TODO: Support the other local k8s clusters
-	if minikubeExternalIP := m.minikubeNodeIP(); minikubeExternalIP != "" {
+		// TODO: Support the other local k8s clusters
+	} else if minikubeExternalIP := m.minikubeNodeIP(); minikubeExternalIP != "" {
 		// if test cluster is minikube, external ip address is minikube node address
-		if len(svc.Spec.Ports) > 0 {
-			return fmt.Sprintf("%s:%d", minikubeExternalIP, svc.Spec.Ports[0].NodePort)
-		}
+		address, port = minikubeExternalIP, svcFstPort.NodePort
 	}
-
-	return ""
+	return fmt.Sprintf("%s:%d", address, port)
 }
 
 // IsServiceIngressReady returns true if external ip is available.

--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -648,11 +648,9 @@ func (m *AppManager) IsServiceIngressReady(svc *apiv1.Service, err error) bool {
 		return true
 	}
 
-	// TODO: Support the other local k8s clusters
-	if m.minikubeNodeIP() != "" {
-		if len(svc.Spec.Ports) > 0 {
-			return true
-		}
+	if len(svc.Spec.Ports) > 0 {
+		// TODO: Support the other local k8s clusters
+		return m.minikubeNodeIP() != "" || !m.app.ShouldBeExposed()
 	}
 
 	return false

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -247,7 +247,7 @@ func buildJobObject(namespace string, appDesc AppDescription) *batchv1.Job {
 func buildServiceObject(namespace string, appDesc AppDescription) *apiv1.Service {
 	serviceType := apiv1.ServiceTypeClusterIP
 
-	if appDesc.IngressEnabled {
+	if appDesc.ShouldBeExposed() {
 		serviceType = apiv1.ServiceTypeLoadBalancer
 	}
 


### PR DESCRIPTION
# Description

Now, the connection between the actions runner and the AKS clusters is over a VPN tunnel using [tailscale](https://tailscale.com/). To achieve that was required basically two main changes:

- Our AKS cluster is now configured using a tailscale basic subnet router configuration (allowing action runner to call internal IPs directly)
- The actions runner is connecting to tailscale using an Ephemeral Key (so that, when the actions runner finish its work, the node is basically discarded)
- The app manager now exposes the app private IP rather than external loadbalancer one.
## Issue reference

Please reference the issue this PR will close: #4962 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
