### PR TITLE
copy redis v6 image from dockerhub to ghcr

### DIFF
--- a/.github/workflows/dapr-3rdparty-images.yaml
+++ b/.github/workflows/dapr-3rdparty-images.yaml
@@ -46,6 +46,13 @@ jobs:
           src: redis:latest
           dst: |
             ghcr.io/${{ github.repository_owner }}/3rdparty/redis:latest
+      - # copy 3rd party redis v6 image from dockerhub to ghcr
+        name: Push Image (redis) to target registries
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: redis:6
+          dst: |
+            ghcr.io/${{ github.repository_owner }}/3rdparty/redis:6
       - # copy 3rd party rejson image from dockerhub to ghcr
         name: Push Image (rejson) to target registries
         uses: akhilerm/tag-push-action@v2.0.0


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <65565396+mukundansundar@users.noreply.github.com>

# Description

WRT to the change made in CLI to restrict Redis version to compatible version 6, this PR adds ability to copy version 6 of redid as a separate tag into GHCR. 
https://github.com/dapr/cli/pull/1046

Till this PR is merged and workflow run, `dapr init` with GHCR will fail. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: CLI hotfix
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
