### PR TITLE
Return Active Actors count in gRPC metadata API

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1480,6 +1480,16 @@ func (a *api) GetMetadata(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.
 	temp[daprRuntimeVersionKey] = a.daprRunTimeVersion
 	registeredComponents := make([]*runtimev1pb.RegisteredComponents, 0, len(a.components))
 	componentsCapabilties := a.getComponentsCapabilitesFn()
+	activeActorsCount := []*runtimev1pb.ActiveActorsCount{}
+	if a.actor != nil {
+		for _, actorTypeCount := range a.actor.GetActiveActorsCount(ctx) {
+			activeActorsCount = append(activeActorsCount, &runtimev1pb.ActiveActorsCount{
+				Type:  actorTypeCount.Type,
+				Count: int32(actorTypeCount.Count),
+			})
+		}
+	}
+
 	for _, comp := range a.components {
 		registeredComp := &runtimev1pb.RegisteredComponents{
 			Name:         comp.Name,
@@ -1492,6 +1502,7 @@ func (a *api) GetMetadata(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.
 	response := &runtimev1pb.GetMetadataResponse{
 		ExtendedMetadata:     temp,
 		RegisteredComponents: registeredComponents,
+		ActiveActorsCount:    activeActorsCount,
 	}
 	return response, nil
 }

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/actors"
 	components_v1alpha "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
@@ -2057,8 +2058,16 @@ func TestGetMetadata(t *testing.T) {
 	port, _ := freeport.GetFreePort()
 	fakeComponent := components_v1alpha.Component{}
 	fakeComponent.Name = "testComponent"
+
+	mockActors := new(actors.MockActors)
+	mockActors.On("GetActiveActorsCount").Return(actors.ActiveActorsCount{
+		Count: 10,
+		Type:  "abcd",
+	})
+
 	fakeAPI := &api{
 		id:         "fakeAPI",
+		actor:      mockActors,
 		components: []components_v1alpha.Component{fakeComponent},
 		getComponentsCapabilitesFn: func() map[string][]string {
 			capsMap := make(map[string][]string)
@@ -2082,6 +2091,8 @@ func TestGetMetadata(t *testing.T) {
 	assert.Equal(t, response.ExtendedMetadata["testKey"], "testValue")
 	assert.Len(t, response.RegisteredComponents[0].Capabilities, 1, "One capabilities should be returned")
 	assert.Equal(t, response.RegisteredComponents[0].Capabilities[0], "mock.feat.testComponent")
+	assert.Equal(t, response.GetActiveActorsCount()[0].Type, "abcd")
+	assert.Equal(t, response.GetActiveActorsCount()[0].Count, int32(10))
 }
 
 func TestSetMetadata(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Even though the actors API is http only, the Metadata API can provide information about hosted actors via gRPC. This change includes the missing information about active actors.

Note that some SDKs such as Python generally query APIs via gRPC and hence this implementation is necessary.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing