### PR TITLE
Allow lock components to define aliases

### DIFF
--- a/pkg/components/lock/registry.go
+++ b/pkg/components/lock/registry.go
@@ -15,12 +15,8 @@ type Lock struct {
 }
 
 func New(name string, f func() lock.Store, aliases ...string) Lock {
-	names := []string{name}
-	if len(aliases) > 0 {
-		names = append(names, aliases...)
-	}
 	return Lock{
-		Names:         names,
+		Names:         append(aliases, name),
 		FactoryMethod: f,
 	}
 }

--- a/pkg/components/lock/registry.go
+++ b/pkg/components/lock/registry.go
@@ -10,13 +10,17 @@ import (
 )
 
 type Lock struct {
-	Name          string
+	Names         []string
 	FactoryMethod func() lock.Store
 }
 
-func New(name string, f func() lock.Store) Lock {
+func New(name string, f func() lock.Store, aliases ...string) Lock {
+	names := []string{name}
+	if len(aliases) > 0 {
+		names = append(names, aliases...)
+	}
 	return Lock{
-		Name:          name,
+		Names:         names,
 		FactoryMethod: f,
 	}
 }
@@ -40,7 +44,9 @@ func NewRegistry() Registry {
 // The key is the name of the state store, eg. redis.
 func (r *lockRegistry) Register(fs ...Lock) {
 	for _, f := range fs {
-		r.stores[createFullName(f.Name)] = f.FactoryMethod
+		for _, name := range f.Names {
+			r.stores[createFullName(name)] = f.FactoryMethod
+		}
 	}
 }
 

--- a/pkg/components/lock/registry_test.go
+++ b/pkg/components/lock/registry_test.go
@@ -40,3 +40,13 @@ func TestNewFactory(t *testing.T) {
 	f := New("", nil)
 	assert.NotNil(t, f)
 }
+
+func TestAliasing(t *testing.T) {
+	const alias = "my-alias"
+	r := NewRegistry()
+	r.Register(New("", func() lock.Store {
+		return nil
+	}, alias))
+	_, err := r.Create("lock."+alias, "")
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Lock component is the only component that doesn't support aliasing. This PR adds the support to it.

## Issue reference

Please reference the issue this PR will close: #5030 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [] End-to-end tests passing
* [] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
