### PR TITLE
Return Application ID in grpc Metadata API.

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1470,16 +1470,16 @@ func (a *api) SetActorRuntime(actor actors.Actors) {
 }
 
 func (a *api) GetMetadata(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.GetMetadataResponse, error) {
-	temp := make(map[string]string)
+	extendedMetadata := make(map[string]string)
 
 	// Copy synchronously so it can be serialized to JSON.
 	a.extendedMetadata.Range(func(key, value interface{}) bool {
-		temp[key.(string)] = value.(string)
+		extendedMetadata[key.(string)] = value.(string)
 		return true
 	})
-	temp[daprRuntimeVersionKey] = a.daprRunTimeVersion
+	extendedMetadata[daprRuntimeVersionKey] = a.daprRunTimeVersion
 	registeredComponents := make([]*runtimev1pb.RegisteredComponents, 0, len(a.components))
-	componentsCapabilties := a.getComponentsCapabilitesFn()
+	componentsCapabilities := a.getComponentsCapabilitesFn()
 	activeActorsCount := []*runtimev1pb.ActiveActorsCount{}
 	if a.actor != nil {
 		for _, actorTypeCount := range a.actor.GetActiveActorsCount(ctx) {
@@ -1495,19 +1495,20 @@ func (a *api) GetMetadata(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.
 			Name:         comp.Name,
 			Version:      comp.Spec.Version,
 			Type:         comp.Spec.Type,
-			Capabilities: getOrDefaultCapabilites(componentsCapabilties, comp.Name),
+			Capabilities: getOrDefaultCapabilities(componentsCapabilities, comp.Name),
 		}
 		registeredComponents = append(registeredComponents, registeredComp)
 	}
 	response := &runtimev1pb.GetMetadataResponse{
-		ExtendedMetadata:     temp,
+		Id:                   a.id,
+		ExtendedMetadata:     extendedMetadata,
 		RegisteredComponents: registeredComponents,
 		ActiveActorsCount:    activeActorsCount,
 	}
 	return response, nil
 }
 
-func getOrDefaultCapabilites(dict map[string][]string, key string) []string {
+func getOrDefaultCapabilities(dict map[string][]string, key string) []string {
 	if val, ok := dict[key]; ok {
 		return val
 	}

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -2085,6 +2085,7 @@ func TestGetMetadata(t *testing.T) {
 	client := runtimev1pb.NewDaprClient(clientConn)
 	response, err := client.GetMetadata(context.Background(), &emptypb.Empty{})
 	assert.NoError(t, err, "Expected no error")
+	assert.Equal(t, response.Id, "fakeAPI")
 	assert.Len(t, response.RegisteredComponents, 1, "One component should be returned")
 	assert.Equal(t, response.RegisteredComponents[0].Name, "testComponent")
 	assert.Contains(t, response.ExtendedMetadata, "testKey")


### PR DESCRIPTION
# Description

While building the GRPC response for the Metadata API, the `Id` field is left unset:

https://github.com/dapr/dapr/blob/f99ab6662a5f8cc004fa4380b09b10caf610237d/pkg/grpc/api.go#L1502-L1506

This deviates from what is done in the HTTP counterpart of the API:

https://github.com/dapr/dapr/blob/f99ab6662a5f8cc004fa4380b09b10caf610237d/pkg/http/api.go#L1855

This PR addresses this and updates the corresponding unit test to verify it.

## Issue reference

Please reference the issue this PR will close: #5038

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [x] ~~Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
* [x] ~~Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
* [x] ~~Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_~~
