### PR TITLE
fix grpc span status on error

### DIFF
--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -193,9 +193,8 @@ func UpdateSpanStatusFromGRPCError(span trace.Span, err error) {
 		return
 	}
 
-	_, ok := status.FromError(err)
-	if ok {
-		span.SetStatus(otelcodes.Ok, "")
+	if e, ok := status.FromError(err); ok {
+		span.SetStatus(otelcodes.Error, e.Message())
 	} else {
 		span.SetStatus(otelcodes.Error, err.Error())
 	}

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -24,11 +24,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
 	"go.opentelemetry.io/otel"
+	otelcodes "go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/dapr/pkg/config"
 	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
@@ -192,6 +195,50 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 		assertHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
 			span = diagUtils.SpanFromContext(ctx)
 			return nil, errors.New("fake error")
+		}
+
+		interceptor(ctx, fakeReq, fakeInfo, assertHandler)
+
+		sc := span.SpanContext()
+		spanString := fmt.Sprintf("%v", span)
+		assert.True(t, strings.Contains(spanString, "CallLocal/targetID/method1"))
+		traceID := sc.TraceID()
+		spanID := sc.SpanID()
+		assert.NotEmpty(t, fmt.Sprintf("%x", traceID[:]))
+		assert.NotEmpty(t, fmt.Sprintf("%x", spanID[:]))
+	})
+
+	t.Run("InvokeService call with grpc status error", func(t *testing.T) {
+		// set a new tracer provider with a callback on span completion to check that the span errors out
+		checkErrorStatusOnSpan := func(s sdktrace.ReadOnlySpan) {
+			assert.Equal(t, otelcodes.Error, s.Status().Code, "expected span status to be an error")
+		}
+
+		tp := sdktrace.NewTracerProvider(
+			sdktrace.WithBatcher(exp),
+			sdktrace.WithSpanProcessor(newOtelFakeSpanProcessor(checkErrorStatusOnSpan)),
+		)
+		oldTracerProvider := otel.GetTracerProvider()
+		defer func() {
+			_ = tp.Shutdown(context.Background())
+			// reset tracer provider to older one once the test completes
+			otel.SetTracerProvider(oldTracerProvider)
+		}()
+		otel.SetTracerProvider(tp)
+
+		fakeInfo := &grpc.UnaryServerInfo{
+			FullMethod: "/dapr.proto.runtime.v1.Dapr/InvokeService",
+		}
+		fakeReq := &runtimev1pb.InvokeServiceRequest{
+			Id:      "targetID",
+			Message: &commonv1pb.InvokeRequest{Method: "method1"},
+		}
+
+		var span trace.Span
+		assertHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			span = diagUtils.SpanFromContext(ctx)
+			// mocking an error that is returned from the gRPC API -- see pkg/grpc/api.go file
+			return nil, status.Error(codes.Internal, errors.New("fake status error").Error())
 		}
 
 		interceptor(ctx, fakeReq, fakeInfo, assertHandler)

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -184,3 +184,34 @@ func (e *otelFakeExporter) ExportSpans(ctx context.Context, spans []sdktrace.Rea
 func (e *otelFakeExporter) Shutdown(ctx context.Context) error {
 	return nil
 }
+
+// Otel Fake Span Processor implements an open telemetry span processor that calls a call back in the OnEnd method.
+type otelFakeSpanProcessor struct {
+	cb func(s sdktrace.ReadOnlySpan)
+}
+
+// newOtelFakeSpanProcessor returns an Open Telemetry Fake Span Processor
+func newOtelFakeSpanProcessor(f func(s sdktrace.ReadOnlySpan)) *otelFakeSpanProcessor {
+	return &otelFakeSpanProcessor{
+		cb: f,
+	}
+}
+
+// OnStart implements the SpanProcessor interface.
+func (o *otelFakeSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {
+}
+
+// OnEnd  implements the SpanProcessor interface and calls the callback function provided on init
+func (o *otelFakeSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
+	o.cb(s)
+}
+
+// Shutdown implements the SpanProcessor interface.
+func (o *otelFakeSpanProcessor) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+// ForceFlush implements the SpanProcessor interface.
+func (o *otelFakeSpanProcessor) ForceFlush(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <65565396+mukundansundar@users.noreply.github.com>

# Description

There is an issue with how spans on errors are marked with status OK. This is introduced after the merge of https://github.com/dapr/dapr/pull/4808/files#diff-002e27e695eeb6f9bb7cd3deacebd2dc97dffe0e2d3ac0fbcc38113f98afbab7R198

Before this PR fix: 
Assume that the backend kafka component is not there ... the gRPC publish event call fails. When we see in Zipkin:
<img width="1728" alt="Screen Shot 2022-09-14 at 8 18 32 AM" src="https://user-images.githubusercontent.com/65565396/190047382-9ea13a23-6434-4a0b-9562-2c61161ca16d.png">
 

This PR fixes this issue and add a unit test for that particular code path.
Now trace in Zipkin is the following: 
<img width="1725" alt="Screen Shot 2022-09-14 at 8 18 54 AM" src="https://user-images.githubusercontent.com/65565396/190047440-db3fb8d4-c9f2-47c1-958e-28824b67dff6.png">


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

related to #2836 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
