### PR TITLE
Dapr bot provides more updates during e2e tests

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -1,7 +1,8 @@
 name: dapr-bot
 
 on:
-  issue_comment: {types: created}
+  issue_comment:
+    types: [created]
 
 jobs:
   daprbot:
@@ -119,33 +120,6 @@ jobs:
                   
                   console.log(`Trigger E2E test for ${JSON.stringify(testPayload)}`);
                 }
-              } else if (commentBody.indexOf("/build-windows-base") == 0) {
-                // Get pull request
-                const pull = await github.pulls.get({
-                  owner: issue.owner,
-                  repo: issue.repo,
-                  pull_number: issue.number
-                });
-
-                if (pull && pull.data) {
-                  // Get commit id and repo from pull head
-                  const testPayload = {
-                    pull_head_ref: pull.data.head.sha,
-                    pull_head_repo: pull.data.head.repo.full_name,
-                    command: "windows-base",
-                    issue: issue,
-                  };
-
-                  // Fire repository_dispatch event to trigger e2e test
-                  await github.repos.createDispatchEvent({
-                    owner: issue.owner,
-                    repo: issue.repo,
-                    event_type: "windows-base",
-                    client_payload: testPayload,
-                  });
-
-                  console.log(`Trigger a build of the windows base image ${JSON.stringify(testPayload)}`);
-                }
               } else if (commentBody.indexOf("/ok-to-perf") == 0) {
                 // Get pull request
                 const pull = await github.pulls.get({
@@ -169,7 +143,7 @@ jobs:
                     event_type: "perf-test",
                     client_payload: perfPayload,
                   });
-                  
+
                   console.log(`Trigger Perf test for ${JSON.stringify(perfPayload)}`);
                 }
               }

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -352,7 +352,7 @@ jobs:
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
-            ## ✅ Build succeeded for ${{ runner.os }}
+            ## ✅ Build succeeded for ${{ matrix.target_os }}/${{ matrix.target_arch }}
 
             - Image tag: `${{ env.DAPR_TAG }}`
             - Test image tag: `${{ env.DAPR_TEST_TAG }}`
@@ -365,7 +365,7 @@ jobs:
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
-            ## ❌ Build failed for ${{ runner.os }}
+            ## ❌ Build failed for ${{ matrix.target_os }}/${{ matrix.target_arch }}
 
             Please check the logs for details on the error.
 
@@ -567,7 +567,7 @@ jobs:
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
-            ## ✅ Tests succeeded on ${{ runner.os }}
+            ## ✅ Tests succeeded on ${{ matrix.target_os }}/${{ matrix.target_arch }}
 
             - Image tag: `${{ env.DAPR_TAG }}`
             - Test image tag: `${{ env.DAPR_TEST_TAG }}`
@@ -580,7 +580,7 @@ jobs:
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
-            ## ❌ Tests failed on ${{ runner.os }}
+            ## ❌ Tests failed on ${{ matrix.target_os }}/${{ matrix.target_arch }}
 
             Please check the logs for details on the error.
       - name: Update PR comment for cancellation
@@ -592,7 +592,7 @@ jobs:
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
-            ## ⚠️ Tests cancelled for ${{ runner.os }}
+            ## ⚠️ Tests cancelled for ${{ matrix.target_os }}/${{ matrix.target_arch }}
 
             The Action has been canceled
 

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -95,6 +95,8 @@ jobs:
             # Dapr E2E test
 
             🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+
+            Commit ref: ${{ env.CHECKOUT_REF }}
       - name: Check out code
         if: env.CHECKOUT_REPO != ''
         uses: actions/checkout@v2

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -52,11 +52,13 @@ env:
   AZURE_REGIONS: "westus3"
   # Container registry where to cache e2e test images
   DAPR_CACHE_REGISTRY: "dapre2eacr.azurecr.io"
+  # Whether to collect TCP dumps
+  TCP_DUMPS: false
 
 jobs:
   deploy-infrastructure:
     name: Deploy test infrastructure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up for scheduled test
         if: github.event_name != 'repository_dispatch'
@@ -66,7 +68,7 @@ jobs:
         shell: bash
       - name: Parse test payload
         if: github.event_name == 'repository_dispatch'
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@v6.2.0
         with:
           github-token: ${{secrets.DAPR_BOT_TOKEN}}
           script: |
@@ -76,8 +78,23 @@ jobs:
               // Set environment variables
               fs.appendFileSync(process.env.GITHUB_ENV,
                 `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
-                `CHECKOUT_REF=${testPayload.pull_head_ref}`);
+                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
+                `PR_NUMBER=${testPayload.issue.number}`
+              );
             }
+      - name: Create PR comment
+        if: env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          hide: true
+          hide_classify: OUTDATED
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            # Dapr E2E test
+
+            🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
       - name: Check out code
         if: env.CHECKOUT_REPO != ''
         uses: actions/checkout@v2
@@ -106,8 +123,10 @@ jobs:
           REGIONS_SIZE=${#REGIONS[@]}
           REGIONS_IDX=$(($RANDOM % $REGIONS_SIZE))
           REGION1=${REGIONS[$REGIONS_IDX]}
+          echo "REGION1=${REGION1}" >> $GITHUB_ENV
           REGIONS_IDX=$(($RANDOM % $REGIONS_SIZE))
           REGION2=${REGIONS[$REGIONS_IDX]}
+          echo "REGION2=${REGION2}" >> $GITHUB_ENV
           echo "Deploying to Azure regions: Linux=${REGION1} Windows=${REGION2}"
 
           # Tags
@@ -136,6 +155,38 @@ jobs:
           # Exit with error if failed
           $success || exit 1
         shell: bash
+      - name: Update PR comment for success
+        if: success() && env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ✅ Infrastructure deployed
+
+            | Cluster | Resource group name | Azure region |
+            | --- | --- | --- |
+            | Linux | `Dapr-E2E-${{ env.TEST_PREFIX }}l` | ${{ env.REGION1 }} |
+            | Windows | `Dapr-E2E-${{ env.TEST_PREFIX }}w` | ${{ env.REGION2 }} |
+      - name: Update PR comment for failure
+        if: failure() && env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ❌ Infrastructure deployment failed
+
+            | Cluster | Resource group name | Azure region |
+            | --- | --- | --- |
+            | Linux | `Dapr-E2E-${{ env.TEST_PREFIX }}l` | ${{ env.REGION1 }} |
+            | Windows | `Dapr-E2E-${{ env.TEST_PREFIX }}w` | ${{ env.REGION2 }} |
+
+            Please check the logs for details on the failure.
 
   build:
     name: Build for  ${{ matrix.target_os }}
@@ -148,10 +199,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
         target_arch: [amd64]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target_os: linux
           - os: windows-2019
             target_os: windows
@@ -164,7 +215,7 @@ jobs:
         shell: bash
       - name: Parse test payload
         if: github.event_name == 'repository_dispatch'
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@v6.2.0
         with:
           github-token: ${{secrets.DAPR_BOT_TOKEN}}
           script: |
@@ -174,7 +225,9 @@ jobs:
               // Set environment variables
               fs.appendFileSync(process.env.GITHUB_ENV,
                 `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
-                `CHECKOUT_REF=${testPayload.pull_head_ref}`);
+                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
+                `PR_NUMBER=${testPayload.issue.number}`
+              );
             }
       # In windows-2019 images, WSL comes with bash.exe (but no distribution) and that causes issues
       # See: https://github.community/t/wsl-not-available-for-hosted-windows-machine/124389
@@ -290,6 +343,31 @@ jobs:
         run: |
           make build-push-e2e-app-all
         shell: bash
+      - name: Update PR comment for success
+        if: success() && env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ✅ Build succeeded for ${{ runner.os }}
+
+            - Image tag: `${{ env.DAPR_TAG }}`
+            - Test image tag: `${{ env.DAPR_TEST_TAG }}`
+      - name: Update PR comment for failure
+        if: failure() && env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ❌ Build failed for ${{ runner.os }}
+
+            Please check the logs for details on the error.
 
   test-e2e:
     name: End-to-end ${{ matrix.target_os }} tests
@@ -297,7 +375,7 @@ jobs:
       - build
       - deploy-infrastructure
     # Always run on Linux as the local OS is irrelevant and this is faster
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       TARGET_OS: ${{ matrix.target_os }}
       TARGET_ARCH: ${{ matrix.target_arch }}
@@ -322,7 +400,7 @@ jobs:
         shell: bash
       - name: Parse test payload
         if: github.event_name == 'repository_dispatch'
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@v6.2.0
         with:
           github-token: ${{secrets.DAPR_BOT_TOKEN}}
           script: |
@@ -332,7 +410,9 @@ jobs:
               // Set environment variables
               fs.appendFileSync(process.env.GITHUB_ENV,
                 `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
-                `CHECKOUT_REF=${testPayload.pull_head_ref}`);
+                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
+                `PR_NUMBER=${testPayload.issue.number}`
+              );
             }
       - name: Set up Go ${{ env.GOVER }}
         if: env.CHECKOUT_REPO != ''
@@ -388,6 +468,7 @@ jobs:
           echo "TEST_RESOURCE_GROUP=Dapr-E2E-${TEST_PREFIX}" >> $GITHUB_ENV
         shell: bash
       - name: Enable tcpdump
+        if: env.TCP_DUMPS == 'true'
         run: |
           sudo tcpdump -nn -i any -w sntp.cap &
           sleep 1
@@ -436,7 +517,7 @@ jobs:
         run: |
           make save-dapr-control-plane-k8s-logs
       - name: Stop tcpdump
-        if: always()
+        if: always() && env.TCP_DUMPS == 'true'
         run: |
           sleep 1
           sudo kill -2 $(pgrep tcpdump)
@@ -445,12 +526,15 @@ jobs:
       - name: Compress logs
         if: always()
         run: |
-          gzip --fast -r ${{ env.DAPR_CONTAINER_LOG_PATH }}
-          gzip --fast -r ${{ env.DAPR_TEST_LOG_PATH }}
-          gzip --fast sntp.cap
+          test -f ${{ env.DAPR_CONTAINER_LOG_PATH }} && \
+            gzip --fast -r ${{ env.DAPR_CONTAINER_LOG_PATH }}
+          test -f ${{ env.DAPR_TEST_LOG_PATH }} && \
+            gzip --fast -r ${{ env.DAPR_TEST_LOG_PATH }}
+          test -f sntp.cap && \
+            gzip --fast sntp.cap
         shell: bash
       - name: Upload tcpdump
-        if: always()
+        if: always() && env.TCP_DUMPS == 'true'
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.target_os }}_${{ matrix.target_arch }}_tcpdump
@@ -474,45 +558,47 @@ jobs:
           #TODO: .json suffix can be removed from artifact name after test analytics scripts are updated
           name: ${{ matrix.target_os }}_${{ matrix.target_arch }}_e2e.json
           path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_e2e.*
-      - name: Add test result comment to PR
-        if: always() && github.event_name == 'repository_dispatch' && env.TEST_PREFIX != ''
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        uses: actions/github-script@0.3.0
+      - name: Update PR comment for success
+        if: success() && env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
         with:
-          github-token: ${{secrets.DAPR_BOT_TOKEN}}
-          script: |
-            const testPayload = context.payload.client_payload;
-            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
-            const jobStatus = jobContext.status.toLowerCase();
-            const targetOs = process.env.TARGET_OS;
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ✅ Tests succeeded on ${{ runner.os }}
 
-            console.log(`Current Job Status: ${jobStatus}`);
+            - Image tag: `${{ env.DAPR_TAG }}`
+            - Test image tag: `${{ env.DAPR_TEST_TAG }}`
+      - name: Update PR comment for failure
+        if: failure() && env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ❌ Tests failed on ${{ runner.os }}
 
-            var message = "";
+            Please check the logs for details on the error.
+      - name: Update PR comment for cancellation
+        if: cancelled() && env.PR_NUMBER != ''
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ⚠️ Tests cancelled for ${{ runner.os }}
 
-            const checkLink = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-
-            if (jobStatus == "cancelled") {
-              message = `End-to-end tests cancelled on ${targetOs}. Please check the [build logs](${checkLink})`;
-            } else if (jobStatus == "success") {
-              message = `Congrats! All [end-to-end tests](${checkLink}) have passed on ${targetOs}. Thanks for your contribution!`;
-            } else if (jobStatus == "failure") {
-              message = `End-to-end tests failed on ${targetOs}. Please check the [build logs](${checkLink})`;
-            }
-
-            if (message) {
-              await github.issues.createComment({
-                owner: testPayload.issue.owner,
-                repo: testPayload.issue.repo,
-                issue_number: testPayload.issue.number,
-                body: message
-              });
-            }
+            The Action has been canceled
 
   cleanup:
     name: Clean up Azure resources
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - test-e2e
     if: always()


### PR DESCRIPTION
# Description

As requested by @artursouza, this updates the "/ok-to-test" flow to report more updates.

Fixes these errors:

1. Bot did not post anything if the build failed or the Azure resources failed to deploy
2. Bot did not put a link to the running Action to better track progress

It changes the behavior of "/ok-to-test" by posting a message as soon as the workflow starts, with a link to the workflow run.
<img width="930" alt="image" src="https://user-images.githubusercontent.com/43508/190157155-23394d5a-7d4e-4f5a-b80a-8d136489a42c.png">

The message is then updated (not reposted, to avoid spam!) with the progress once the Azure deployment completes, the build succeeds, and tests complete. It also provides useful information for debugging, such as the name of the Resource Group which correlates with the logs in Azure Monitor.

<img width="931" alt="image" src="https://user-images.githubusercontent.com/43508/190157469-9a458844-7145-41dd-9bf3-238d31330d55.png">
<img width="904" alt="image" src="https://user-images.githubusercontent.com/43508/190157513-65bfdb69-1aae-42db-923f-5d7b5f96f91b.png">
<img width="728" alt="image" src="https://user-images.githubusercontent.com/43508/190157561-501225b4-2efe-4f41-8902-05ad5a2c530a.png">

(test failures here are due to the environment inside my fork)