### PR TITLE
Add diagnostic logs support for new arm64 cluster in e2e tests.

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -18,6 +18,8 @@
 # Optional secrets:
 # - AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID: Resource ID of the Log Analytics Workspace where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.OperationalInsights/workspaces/<workspace name>`)
 # - AZURE_DIAG_STORAGE_ID: Resource ID of the Azure Storage account where to store certain diagnostic logs (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.Storage/storageAccounts/<storage account name>`)
+# - AZURE_ARM_DIAG_LOG_ANALYTICS_WORKSPACE_ID: Resource ID of the Log Analytics Workspace where to store certain diagnostic logs for Arm64 (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.OperationalInsights/workspaces/<workspace name>`)
+# - AZURE_ARM_DIAG_STORAGE_ID: Resource ID of the Azure Storage account where to store certain diagnostic logs for Arm64 (e.g. `/subscriptions/<subscription>/resourcegroups/<resource group>/providers/Microsoft.Storage/storageAccounts/<storage account name>`)
 
 name: dapr-test
 
@@ -151,6 +153,8 @@ jobs:
                 dateTag="${DATE_TAG}" \
                 diagLogAnalyticsWorkspaceResourceId="${{ secrets.AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID }}" \
                 diagStorageResourceId="${{ secrets.AZURE_DIAG_STORAGE_ID }}" \
+                armDiagLogAnalyticsWorkspaceResourceId="${{ secrets.AZURE_ARM__DIAG_LOG_ANALYTICS_WORKSPACE_ID }}" \
+                armDiagStorageResourceId="${{ secrets.AZURE_ARM_DIAG_STORAGE_ID }}" \
               && success=true \
               && break \
               || sleep 120

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -153,7 +153,7 @@ jobs:
                 dateTag="${DATE_TAG}" \
                 diagLogAnalyticsWorkspaceResourceId="${{ secrets.AZURE_DIAG_LOG_ANALYTICS_WORKSPACE_ID }}" \
                 diagStorageResourceId="${{ secrets.AZURE_DIAG_STORAGE_ID }}" \
-                armDiagLogAnalyticsWorkspaceResourceId="${{ secrets.AZURE_ARM__DIAG_LOG_ANALYTICS_WORKSPACE_ID }}" \
+                armDiagLogAnalyticsWorkspaceResourceId="${{ secrets.AZURE_ARM_DIAG_LOG_ANALYTICS_WORKSPACE_ID }}" \
                 armDiagStorageResourceId="${{ secrets.AZURE_ARM_DIAG_STORAGE_ID }}" \
               && success=true \
               && break \

--- a/tests/test-infra/azure-all.bicep
+++ b/tests/test-infra/azure-all.bicep
@@ -38,6 +38,12 @@ param diagLogAnalyticsWorkspaceResourceId string = ''
 @description('If set, sends certain diagnostic logs to Azure Storage')
 param diagStorageResourceId string = ''
 
+@description('If set, sends certain Arm64 diagnostic logs to Log Analytics')
+param armDiagLogAnalyticsWorkspaceResourceId string = ''
+
+@description('If set, sends certain Arm64 diagnostic logs to Azure Storage')
+param armDiagStorageResourceId string = ''
+
 @description('If enabled, deploy Cosmos DB')
 param enableCosmosDB bool = true
 
@@ -106,8 +112,8 @@ module armCluster 'azure.bicep' = {
     location: location3
     enableWindows: false
     enableArm : true
-    diagLogAnalyticsWorkspaceResourceId: diagLogAnalyticsWorkspaceResourceId
-    diagStorageResourceId: diagStorageResourceId
+    diagLogAnalyticsWorkspaceResourceId: armDiagLogAnalyticsWorkspaceResourceId
+    diagStorageResourceId: armDiagStorageResourceId
     enableCosmosDB: enableCosmosDB
     enableServiceBus: enableServiceBus
   }


### PR DESCRIPTION
Signed-off-by: Addison Juarez <adjuarez@microsoft.com>

# Description

With adding the arm64 cluster to our e2e tests we also need to add a second instance of log analytics to support the arm64 aks cluster which is hosted in a different region. This change also requires 2 new github secrets to be added **AZURE_ARM_DIAG_LOG_ANALYTICS_WORKSPACE_ID** and **AZURE_ARM_DIAG_STORAGE_ID**.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
