### PR TITLE
Fix failing UT for configuration api Unsubscribe

### DIFF
--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -1554,15 +1554,17 @@ func TestUnSubscribeConfiguration(t *testing.T) {
 				if count > retry {
 					break
 				}
+				count++
+				time.Sleep(time.Millisecond * 10)
 				rsp, recvErr := resp.Recv()
 				assert.NotNil(t, rsp)
 				assert.Nil(t, recvErr)
-				assert.Equal(t, tt.expectedResponse, rsp.Items)
+				if rsp.Items != nil {
+					assert.Equal(t, tt.expectedResponse, rsp.Items)
+				} else {
+					assert.Equal(t, mockSubscribeID, rsp.Id)
+				}
 				subscribeID = rsp.Id
-				count++
-				time.Sleep(time.Millisecond * 10)
-				_, recvErr = resp.Recv()
-				assert.Nil(t, recvErr)
 			}
 			assert.Nil(t, err, "Error should be nil")
 			_, err = client.UnsubscribeConfigurationAlpha1(context.Background(), &runtimev1pb.UnsubscribeConfigurationRequest{
@@ -1583,6 +1585,66 @@ func TestUnSubscribeConfiguration(t *testing.T) {
 				_, err = resp.Recv()
 			}
 			assert.Error(t, err, "Unsubscribed channel should returns EOF")
+		})
+	}
+}
+
+func TestUnsubscribeConfigurationErrScenario(t *testing.T) {
+	fakeConfigurationStore := &daprt.MockConfigurationStore{}
+	fakeConfigurationStore.On("Unsubscribe",
+		mock.AnythingOfType("*context.valueCtx"),
+		mock.MatchedBy(func(req *configuration.UnsubscribeRequest) bool {
+			return req.ID == mockSubscribeID
+		})).Return(nil)
+
+	fakeAPI := &api{
+		configurationSubscribe: make(map[string]chan struct{}),
+		id:                     "fakeAPI",
+		configurationStores:    map[string]configuration.Store{"store1": fakeConfigurationStore},
+		resiliency:             resiliency.New(nil),
+	}
+	port, _ := freeport.GetFreePort()
+	server := startDaprAPIServer(port, fakeAPI, "")
+	defer server.Stop()
+
+	clientConn := createTestClient(port)
+	defer clientConn.Close()
+
+	client := runtimev1pb.NewDaprClient(clientConn)
+
+	testCases := []struct {
+		testName         string
+		storeName        string
+		id               string
+		expectedResponse bool
+		expectedError    bool
+	}{
+		{
+			testName:         "Test unsubscribe",
+			storeName:        "store1",
+			id:               "",
+			expectedResponse: true,
+			expectedError:    false,
+		},
+		{
+			testName:         "Test unsubscribe with incorrect store name",
+			storeName:        "no-store",
+			id:               mockSubscribeID,
+			expectedResponse: false,
+			expectedError:    true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			req := &runtimev1pb.UnsubscribeConfigurationRequest{
+				StoreName: tt.storeName,
+				Id:        tt.id,
+			}
+
+			resp, err := client.UnsubscribeConfigurationAlpha1(context.Background(), req)
+			assert.Equal(t, tt.expectedResponse, resp != nil)
+			assert.Equal(t, tt.expectedError, err != nil)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Pravin Pushkar <ppushkar@microsoft.com>

# Description

Fix for failing UT for configuration api Unsubscribe.
Related to PR - https://github.com/dapr/dapr/pull/5161