### PR TITLE
Allows to skip E2E tests based on bash script condition.

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -533,8 +533,12 @@ jobs:
       - name: Show dapr configurations
         if: env.TEST_PREFIX != ''
         run: kubectl get configurations daprsystem -n ${{ env.DAPR_NAMESPACE }} -o yaml
+      - name: Determine if E2E tests should run
+        if: env.TEST_PREFIX != '' && env.TEST_CLOUD_ENV != ''
+        run: ./tests/test-infra/skip_${{ env.TEST_CLOUD_ENV }}.sh
+        shell: bash
       - name: Run E2E tests
-        if: env.TEST_PREFIX != ''
+        if: env.TEST_PREFIX != '' && env.SKIP_E2E != 'true'
         run: make test-e2e-all
       - name: Save control plane K8s resources
         if: always() && env.TEST_PREFIX != ''

--- a/tests/test-infra/skip_azure.sh
+++ b/tests/test-infra/skip_azure.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2022 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Allows skipping some E2E test runs on Azure based on OS and arch.
+# This is useful when we are still working to stabilize some targets.
+# This script allows the stabilization to take place prior to merging into master.
+if [ -n "$GITHUB_ENV" ] && [ "${{ env.TARGET_OS }}" = "linux" ] && [ "${{ env.TARGET_ARCH }}" != "arm" ]; then
+  echo "SKIP_E2E=true" >> $GITHUB_ENV
+fi


### PR DESCRIPTION
E2E tests on ARM64 are still flaky. This allows work to stabilize it to happen via PRs and only enable it again once proved stable for the first time.

Please reference the issue this PR will close: N/A
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
