### PR TITLE
Reenable e2e test on linux amd64

### DIFF
--- a/tests/test-infra/skip_azure.sh
+++ b/tests/test-infra/skip_azure.sh
@@ -16,6 +16,6 @@
 # Allows skipping some E2E test runs on Azure based on OS and arch.
 # This is useful when we are still working to stabilize some targets.
 # This script allows the stabilization to take place prior to merging into master.
-if [ -n "$GITHUB_ENV" ] && [ "$TARGET_OS" = "linux" ] && [ "$TARGET_ARCH" != "arm" ]; then
+if [ -n "$GITHUB_ENV" ] && [ "$TARGET_OS" = "linux" ] && [ "$TARGET_ARCH" = "arm64" ]; then
   echo "SKIP_E2E=true" >> $GITHUB_ENV
 fi


### PR DESCRIPTION
Tested:

```txt
$ TARGET_OS=linux TARGET_ARCH=amd64 ./tests/test-infra/skip_azure.sh 
$ TARGET_OS=linux TARGET_ARCH=arm64 ./tests/test-infra/skip_azure.sh 
SKIP_E2E=true
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
