### PR TITLE
Fixed all race conditions in tests in multiple packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,19 @@ TEST_WITH_RACE=./pkg/acl/... \
 ./pkg/encryption/... \
 ./pkg/expr/... \
 ./pkg/fswatcher/... \
+./pkg/grpc/... \
+./pkg/health/... \
+./pkg/http/... \
+./pkg/injector/... \
+./pkg/messages/... \
+./pkg/messaging/... \
+./pkg/metrics/... \
+./pkg/middleware/... \
+./pkg/modes/... \
+./pkg/operator/... \
+./pkg/placement/... \
+./pkg/proto/... \
+./pkg/resiliency/... \
 ./pkg/runtime/...
 
 .PHONY: test-race

--- a/Makefile
+++ b/Makefile
@@ -280,9 +280,24 @@ test: test-deps
 		go test ./tests/...
 
 ################################################################################
+# Target: test-race                                                            #
+################################################################################
+# Note that we are expliciting maintaing an allow-list of packages that should be tested
+# with "-race", as many packags aren't passing those tests yet.
+# Eventually, the goal is to be able to have all packages pass tests with "-race"
+# Note: CGO is required for tests with "-race"
+TEST_WITH_RACE=./pkg/actors \
+./pkg/apphealth \
+./pkg/runtime
+
+.PHONY: test-race
+test-race:
+	echo "$(TEST_WITH_RACE)" | xargs \
+		go test -race
+
+################################################################################
 # Target: lint                                                                 #
 ################################################################################
-# Due to https://github.com/golangci/golangci-lint/issues/580, we need to add --fix for windows
 # Please use golangci-lint version v1.48.0 , otherwise you might encounter errors.
 # You can download version v1.48.0 at https://github.com/golangci/golangci-lint/releases/tag/v1.48.0
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -286,14 +286,24 @@ test: test-deps
 # with "-race", as many packags aren't passing those tests yet.
 # Eventually, the goal is to be able to have all packages pass tests with "-race"
 # Note: CGO is required for tests with "-race"
-TEST_WITH_RACE=./pkg/actors \
-./pkg/apphealth \
-./pkg/runtime
+TEST_WITH_RACE=./pkg/acl/... \
+./pkg/actors \
+./pkg/apis/... \
+./pkg/apphealth/... \
+./pkg/channel/... \
+./pkg/client/... \
+./pkg/components/... \
+./pkg/concurrency/... \
+./pkg/diagnostics/... \
+./pkg/encryption/... \
+./pkg/expr/... \
+./pkg/fswatcher/... \
+./pkg/runtime/...
 
 .PHONY: test-race
 test-race:
 	echo "$(TEST_WITH_RACE)" | xargs \
-		go test -race
+		go test -tags=unit -race
 
 ################################################################################
 # Target: lint                                                                 #

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -2233,28 +2233,29 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 	actorType := "failingActor"
 	actorID := "failingId"
 	failingState := &daprt.FailingStatestore{
-		Failure: daprt.Failure{
+		Failure: daprt.NewFailure(
 			// Transform the keys into actor format.
-			Fails: map[string]int{
+			map[string]int{
 				constructCompositeKey(TestAppID, actorType, actorID, "failingGetStateKey"): 1,
 				constructCompositeKey(TestAppID, actorType, actorID, "failingMultiKey"):    1,
 				constructCompositeKey("actors", actorType):                                 1, // Default reminder key.
 			},
-			Timeouts: map[string]time.Duration{
+			map[string]time.Duration{
 				constructCompositeKey(TestAppID, actorType, actorID, "timeoutGetStateKey"): time.Second * 10,
 				constructCompositeKey(TestAppID, actorType, actorID, "timeoutMultiKey"):    time.Second * 10,
 				constructCompositeKey("actors", actorType):                                 time.Second * 10, // Default reminder key.
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 	}
 	failingAppChannel := &daprt.FailingAppChannel{
-		Failure: daprt.Failure{
-			Timeouts: map[string]time.Duration{
+		Failure: daprt.NewFailure(
+			nil,
+			map[string]time.Duration{
 				"timeoutId": time.Second * 10,
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 		KeyFunc: func(req *invokev1.InvokeMethodRequest) string {
 			return req.Actor().ActorId
 		},
@@ -2276,7 +2277,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
-		assert.Equal(t, 1, failingAppChannel.Failure.CallCount["timeoutId"])
+		assert.Equal(t, 1, failingAppChannel.Failure.CallCount("timeoutId"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2290,7 +2291,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 
 		callKey := constructCompositeKey(TestAppID, actorType, actorID, "failingGetStateKey")
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingState.Failure.CallCount[callKey])
+		assert.Equal(t, 2, failingState.Failure.CallCount(callKey))
 	})
 
 	t.Run("test get state times out with resiliency", func(t *testing.T) {
@@ -2305,7 +2306,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 
 		callKey := constructCompositeKey(TestAppID, actorType, actorID, "timeoutGetStateKey")
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingState.Failure.CallCount[callKey])
+		assert.Equal(t, 2, failingState.Failure.CallCount(callKey))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2327,7 +2328,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 
 		callKey := constructCompositeKey(TestAppID, actorType, actorID, "failingMultiKey")
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingState.Failure.CallCount[callKey])
+		assert.Equal(t, 2, failingState.Failure.CallCount(callKey))
 	})
 
 	t.Run("test state transaction times out with resiliency", func(t *testing.T) {
@@ -2350,7 +2351,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 
 		callKey := constructCompositeKey(TestAppID, actorType, actorID, "timeoutMultiKey")
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingState.Failure.CallCount[callKey])
+		assert.Equal(t, 2, failingState.Failure.CallCount(callKey))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2362,7 +2363,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 
 		callKey := constructCompositeKey("actors", actorType)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingState.Failure.CallCount[callKey])
+		assert.Equal(t, 2, failingState.Failure.CallCount(callKey))
 
 		// Key will no longer fail, so now we can check the timeout.
 		start := time.Now()
@@ -2373,7 +2374,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 4, failingState.Failure.CallCount[callKey]) // Should be called 2 more times.
+		assert.Equal(t, 4, failingState.Failure.CallCount(callKey)) // Should be called 2 more times.
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 }

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -948,7 +948,9 @@ func reminderRepeats(ctx context.Context, t *testing.T, dueTime, period, ttl str
 		return
 	}
 	assert.NoError(t, err)
+	testActorsRuntime.remindersLock.RLock()
 	assert.Equal(t, 1, len(testActorsRuntime.reminders[actorType]))
+	testActorsRuntime.remindersLock.RUnlock()
 
 	cnt := 0
 	var (

--- a/pkg/grpc/api_actor_test.go
+++ b/pkg/grpc/api_actor_test.go
@@ -279,12 +279,13 @@ func TestInvokeActor(t *testing.T) {
 
 func TestInvokeActorWithResiliency(t *testing.T) {
 	failingActors := actors.FailingActors{
-		Failure: daprt.Failure{
-			Fails: map[string]int{
+		Failure: daprt.NewFailure(
+			map[string]int{
 				"failingActor": 1,
 			},
-			CallCount: map[string]int{},
-		},
+			nil,
+			map[string]int{},
+		),
 	}
 
 	port, _ := freeport.GetFreePort()
@@ -307,6 +308,6 @@ func TestInvokeActorWithResiliency(t *testing.T) {
 		_, err := client.InvokeActor(context.Background(), req)
 		assert.NoError(t, err)
 		assert.Equal(t, codes.OK, status.Code(err))
-		assert.Equal(t, 2, failingActors.Failure.CallCount["failingActor"])
+		assert.Equal(t, 2, failingActors.Failure.CallCount("failingActor"))
 	})
 }

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -2570,8 +2570,8 @@ func TestSubscribeConfigurationAlpha1(t *testing.T) {
 
 func TestStateAPIWithResiliency(t *testing.T) {
 	failingStore := &daprt.FailingStatestore{
-		Failure: daprt.Failure{
-			Fails: map[string]int{
+		Failure: daprt.NewFailure(
+			map[string]int{
 				"failingGetKey":        1,
 				"failingSetKey":        1,
 				"failingDeleteKey":     1,
@@ -2581,7 +2581,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 				"failingMultiKey":      1,
 				"failingQueryKey":      1,
 			},
-			Timeouts: map[string]time.Duration{
+			map[string]time.Duration{
 				"timeoutGetKey":        time.Second * 10,
 				"timeoutSetKey":        time.Second * 10,
 				"timeoutDeleteKey":     time.Second * 10,
@@ -2591,8 +2591,8 @@ func TestStateAPIWithResiliency(t *testing.T) {
 				"timeoutMultiKey":      time.Second * 10,
 				"timeoutQueryKey":      time.Second * 10,
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 	}
 
 	stateLoader.SaveStateConfiguration("failStore", map[string]string{"keyPrefix": "none"})
@@ -2618,7 +2618,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 			Key:       "failingGetKey",
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingGetKey"))
 	})
 
 	t.Run("get state request times out with resiliency", func(t *testing.T) {
@@ -2630,7 +2630,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutGetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2645,7 +2645,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingSetKey"))
 	})
 
 	t.Run("set state request times out with resiliency", func(t *testing.T) {
@@ -2662,7 +2662,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutSetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2672,7 +2672,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 			Key:       "failingDeleteKey",
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingDeleteKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingDeleteKey"))
 	})
 
 	t.Run("delete state request times out with resiliency", func(t *testing.T) {
@@ -2684,7 +2684,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutDeleteKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutDeleteKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2695,8 +2695,8 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingBulkGetKey"])
-		assert.Equal(t, 1, failingStore.Failure.CallCount["goodBulkGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingBulkGetKey"))
+		assert.Equal(t, 1, failingStore.Failure.CallCount("goodBulkGetKey"))
 	})
 
 	t.Run("bulk state get times out on single with resiliency", func(t *testing.T) {
@@ -2717,8 +2717,8 @@ func TestStateAPIWithResiliency(t *testing.T) {
 				assert.Empty(t, item.Error)
 			}
 		}
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutBulkGetKey"])
-		assert.Equal(t, 1, failingStore.Failure.CallCount["goodTimeoutBulkGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutBulkGetKey"))
+		assert.Equal(t, 1, failingStore.Failure.CallCount("goodTimeoutBulkGetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2738,8 +2738,8 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingBulkSetKey"])
-		assert.Equal(t, 1, failingStore.Failure.CallCount["goodBulkSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingBulkSetKey"))
+		assert.Equal(t, 1, failingStore.Failure.CallCount("goodBulkSetKey"))
 	})
 
 	t.Run("bulk state set times out with resiliency", func(t *testing.T) {
@@ -2760,8 +2760,8 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutBulkSetKey"])
-		assert.Equal(t, 0, failingStore.Failure.CallCount["goodTimeoutBulkSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutBulkSetKey"))
+		assert.Equal(t, 0, failingStore.Failure.CallCount("goodTimeoutBulkSetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2779,7 +2779,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingMultiKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingMultiKey"))
 	})
 
 	t.Run("state transaction times out with resiliency", func(t *testing.T) {
@@ -2796,7 +2796,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutMultiKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutMultiKey"))
 	})
 
 	t.Run("state query retries with resiliency", func(t *testing.T) {
@@ -2807,7 +2807,7 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingQueryKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingQueryKey"))
 	})
 
 	t.Run("state query times out with resiliency", func(t *testing.T) {
@@ -2818,25 +2818,25 @@ func TestStateAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutQueryKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutQueryKey"))
 	})
 }
 
 func TestConfigurationAPIWithResiliency(t *testing.T) {
 	failingConfigStore := daprt.FailingConfigurationStore{
-		Failure: daprt.Failure{
-			Fails: map[string]int{
+		Failure: daprt.NewFailure(
+			map[string]int{
 				"failingGetKey":         1,
 				"failingSubscribeKey":   1,
 				"failingUnsubscribeKey": 1,
 			},
-			Timeouts: map[string]time.Duration{
+			map[string]time.Duration{
 				"timeoutGetKey":         time.Second * 10,
 				"timeoutSubscribeKey":   time.Second * 10,
 				"timeoutUnsubscribeKey": time.Second * 10,
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 	}
 
 	fakeAPI := &api{
@@ -2862,7 +2862,7 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["failingGetKey"])
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("failingGetKey"))
 	})
 
 	t.Run("test get configuration fails due to timeout with resiliency", func(t *testing.T) {
@@ -2873,7 +2873,7 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["timeoutGetKey"])
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("timeoutGetKey"))
 	})
 
 	t.Run("test subscribe configuration retries with resiliency", func(t *testing.T) {
@@ -2887,7 +2887,7 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 		_, err = resp.Recv()
 		assert.NoError(t, err)
 		// Subscribe now calls Get first so we have an extra call.
-		assert.Equal(t, 3, failingConfigStore.Failure.CallCount["failingSubscribeKey"])
+		assert.Equal(t, 3, failingConfigStore.Failure.CallCount("failingSubscribeKey"))
 	})
 
 	t.Run("test subscribe configuration fails due to timeout with resiliency", func(t *testing.T) {
@@ -2900,7 +2900,7 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 
 		_, err = resp.Recv()
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["timeoutSubscribeKey"])
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("timeoutSubscribeKey"))
 	})
 
 	t.Run("test unsubscribe configuration retries with resiliency", func(t *testing.T) {
@@ -2912,7 +2912,7 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["failingUnsubscribeKey"])
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("failingUnsubscribeKey"))
 	})
 
 	t.Run("test unsubscribe configuration fails due to timeout with resiliency", func(t *testing.T) {
@@ -2924,17 +2924,17 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingConfigStore.Failure.CallCount["timeoutUnsubscribeKey"])
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("timeoutUnsubscribeKey"))
 	})
 }
 
 func TestSecretAPIWithResiliency(t *testing.T) {
 	failingStore := daprt.FailingSecretStore{
-		Failure: daprt.Failure{
-			Fails:     map[string]int{"key": 1, "bulk": 1},
-			Timeouts:  map[string]time.Duration{"timeout": time.Second * 10, "bulkTimeout": time.Second * 10},
-			CallCount: map[string]int{},
-		},
+		Failure: daprt.NewFailure(
+			map[string]int{"key": 1, "bulk": 1},
+			map[string]time.Duration{"timeout": time.Second * 10, "bulkTimeout": time.Second * 10},
+			map[string]int{},
+		),
 	}
 
 	// Setup Dapr API server
@@ -2962,7 +2962,7 @@ func TestSecretAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["key"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("key"))
 	})
 
 	t.Run("Get secret - timeout before request ends", func(t *testing.T) {
@@ -2975,7 +2975,7 @@ func TestSecretAPIWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeout"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeout"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -2986,7 +2986,7 @@ func TestSecretAPIWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["bulk"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("bulk"))
 	})
 
 	t.Run("Get bulk secret - timeout before request ends", func(t *testing.T) {
@@ -2998,24 +2998,24 @@ func TestSecretAPIWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["bulkTimeout"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("bulkTimeout"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 }
 
 func TestServiceInvocationWithResiliency(t *testing.T) {
 	failingDirectMessaging := &daprt.FailingDirectMessaging{
-		Failure: daprt.Failure{
-			Fails: map[string]int{
+		Failure: daprt.NewFailure(
+			map[string]int{
 				"failingKey":        1,
 				"extraFailingKey":   3,
 				"circuitBreakerKey": 10,
 			},
-			Timeouts: map[string]time.Duration{
+			map[string]time.Duration{
 				"timeoutKey": time.Second * 10,
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 	}
 
 	// Setup Dapr API server
@@ -3047,7 +3047,7 @@ func TestServiceInvocationWithResiliency(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["failingKey"])
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey"))
 	})
 
 	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {
@@ -3062,7 +3062,7 @@ func TestServiceInvocationWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["timeoutKey"])
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("timeoutKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -3076,7 +3076,7 @@ func TestServiceInvocationWithResiliency(t *testing.T) {
 		})
 
 		assert.Error(t, err)
-		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["extraFailingKey"])
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("extraFailingKey"))
 	})
 
 	t.Run("Test invoke direct messages opens circuit breaker after consecutive failures", func(t *testing.T) {
@@ -3089,7 +3089,7 @@ func TestServiceInvocationWithResiliency(t *testing.T) {
 			},
 		})
 		assert.Error(t, err)
-		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount["circuitBreakerKey"])
+		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount("circuitBreakerKey"))
 
 		// Additional requests should fail due to the circuit breaker.
 		_, err = client.InvokeService(context.Background(), &runtimev1pb.InvokeServiceRequest{
@@ -3101,7 +3101,7 @@ func TestServiceInvocationWithResiliency(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "circuit breaker is open")
-		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount["circuitBreakerKey"])
+		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount("circuitBreakerKey"))
 	})
 }
 

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -2904,7 +2904,9 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 	})
 
 	t.Run("test unsubscribe configuration retries with resiliency", func(t *testing.T) {
+		fakeAPI.configurationSubscribeLock.Lock()
 		fakeAPI.configurationSubscribe["failingUnsubscribeKey"] = make(chan struct{})
+		fakeAPI.configurationSubscribeLock.Unlock()
 
 		_, err := client.UnsubscribeConfigurationAlpha1(context.Background(), &runtimev1pb.UnsubscribeConfigurationRequest{
 			StoreName: "failConfig",
@@ -2916,7 +2918,9 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 	})
 
 	t.Run("test unsubscribe configuration fails due to timeout with resiliency", func(t *testing.T) {
+		fakeAPI.configurationSubscribeLock.Lock()
 		fakeAPI.configurationSubscribe["timeoutUnsubscribeKey"] = make(chan struct{})
+		fakeAPI.configurationSubscribeLock.Unlock()
 
 		_, err := client.UnsubscribeConfigurationAlpha1(context.Background(), &runtimev1pb.UnsubscribeConfigurationRequest{
 			StoreName: "failConfig",

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -916,17 +916,17 @@ func TestV1DirectMessagingEndpointsWithTracer(t *testing.T) {
 
 func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 	failingDirectMessaging := &daprt.FailingDirectMessaging{
-		Failure: daprt.Failure{
-			Fails: map[string]int{
+		Failure: daprt.NewFailure(
+			map[string]int{
 				"failingKey":        1,
 				"extraFailingKey":   3,
 				"circuitBreakerKey": 10,
 			},
-			Timeouts: map[string]time.Duration{
+			map[string]time.Duration{
 				"timeoutKey": time.Second * 10,
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 	}
 
 	fakeServer := newFakeHTTPServer()
@@ -948,7 +948,7 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil)
 
 		assert.Equal(t, 200, resp.StatusCode)
-		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["failingKey"])
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey"))
 	})
 
 	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {
@@ -965,7 +965,7 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		end := time.Now()
 
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["timeoutKey"])
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("timeoutKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -981,7 +981,7 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil)
 
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount["extraFailingKey"])
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("extraFailingKey"))
 	})
 
 	t.Run("Test invoke direct messages can trip circuit breaker", func(t *testing.T) {
@@ -995,13 +995,13 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		// Circuit Breaker trips on the 5th failure, stopping retries.
 		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil)
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount["circuitBreakerKey"])
+		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount("circuitBreakerKey"))
 
 		// Request occurs when the circuit breaker is open, which shouldn't even hit the app.
 		resp = fakeServer.DoRequest("POST", apiPath, fakeData, nil)
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.Contains(t, string(resp.RawBody), "circuit breaker is open", "Should have received a circuit breaker open error.")
-		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount["circuitBreakerKey"])
+		assert.Equal(t, 5, failingDirectMessaging.Failure.CallCount("circuitBreakerKey"))
 	})
 
 	fakeServer.Shutdown()
@@ -1715,15 +1715,15 @@ func TestV1ActorEndpoints(t *testing.T) {
 	})
 
 	failingActors := &actors.FailingActors{
-		Failure: daprt.Failure{
-			Fails: map[string]int{
+		Failure: daprt.NewFailure(
+			map[string]int{
 				"failingId": 1,
 			},
-			Timeouts: map[string]time.Duration{
+			map[string]time.Duration{
 				"timeoutId": time.Second * 10,
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 	}
 
 	t.Run("Direct Message - retries with resiliency", func(t *testing.T) {
@@ -1733,7 +1733,7 @@ func TestV1ActorEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, nil, nil)
 
 		assert.Equal(t, 200, resp.StatusCode)
-		assert.Equal(t, 2, failingActors.Failure.CallCount["failingId"])
+		assert.Equal(t, 2, failingActors.Failure.CallCount("failingId"))
 	})
 
 	fakeServer.Shutdown()
@@ -2836,8 +2836,8 @@ func TestV1StateEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	var fakeStore state.Store = fakeStateStoreQuerier{}
 	failingStore := &daprt.FailingStatestore{
-		Failure: daprt.Failure{
-			Fails: map[string]int{
+		Failure: daprt.NewFailure(
+			map[string]int{
 				"failingGetKey":        1,
 				"failingSetKey":        1,
 				"failingDeleteKey":     1,
@@ -2847,7 +2847,7 @@ func TestV1StateEndpoints(t *testing.T) {
 				"failingMultiKey":      1,
 				"failingQueryKey":      1,
 			},
-			Timeouts: map[string]time.Duration{
+			map[string]time.Duration{
 				"timeoutGetKey":        time.Second * 10,
 				"timeoutSetKey":        time.Second * 10,
 				"timeoutDeleteKey":     time.Second * 10,
@@ -2857,8 +2857,8 @@ func TestV1StateEndpoints(t *testing.T) {
 				"timeoutMultiKey":      time.Second * 10,
 				"timeoutQueryKey":      time.Second * 10,
 			},
-			CallCount: map[string]int{},
-		},
+			map[string]int{},
+		),
 	}
 	fakeStores := map[string]state.Store{
 		"store1":    fakeStore,
@@ -3166,7 +3166,7 @@ func TestV1StateEndpoints(t *testing.T) {
 
 		resp := fakeServer.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 204, resp.StatusCode) // No body in the response.
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingGetKey"))
 	})
 
 	t.Run("get state request times out with resiliency", func(t *testing.T) {
@@ -3177,7 +3177,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		end := time.Now()
 
 		assert.Equal(t, 500, resp.StatusCode) // No body in the response.
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutGetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -3191,7 +3191,7 @@ func TestV1StateEndpoints(t *testing.T) {
 
 		resp := fakeServer.DoRequest("POST", apiPath, b, nil)
 		assert.Equal(t, 204, resp.StatusCode) // No body in the response.
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingSetKey"))
 	})
 
 	t.Run("set state request times out with resiliency", func(t *testing.T) {
@@ -3207,7 +3207,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		end := time.Now()
 
 		assert.Equal(t, 500, resp.StatusCode) // No body in the response.
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutSetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -3216,7 +3216,7 @@ func TestV1StateEndpoints(t *testing.T) {
 
 		resp := fakeServer.DoRequest("DELETE", apiPath, nil, nil)
 		assert.Equal(t, 204, resp.StatusCode) // No body in the response.
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingDeleteKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingDeleteKey"))
 	})
 
 	t.Run("delete state request times out with resiliency", func(t *testing.T) {
@@ -3227,7 +3227,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		end := time.Now()
 
 		assert.Equal(t, 500, resp.StatusCode) // No body in the response.
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutDeleteKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutDeleteKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -3241,8 +3241,8 @@ func TestV1StateEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, body, nil)
 
 		assert.Equal(t, 200, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingBulkGetKey"])
-		assert.Equal(t, 1, failingStore.Failure.CallCount["goodBulkGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingBulkGetKey"))
+		assert.Equal(t, 1, failingStore.Failure.CallCount("goodBulkGetKey"))
 	})
 
 	t.Run("bulk state get times out on single with resiliency", func(t *testing.T) {
@@ -3263,8 +3263,8 @@ func TestV1StateEndpoints(t *testing.T) {
 		assert.Len(t, bulkResponse, 2)
 		assert.NotEmpty(t, bulkResponse[0].Error)
 		assert.Empty(t, bulkResponse[1].Error)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutBulkGetKey"])
-		assert.Equal(t, 1, failingStore.Failure.CallCount["goodTimeoutBulkGetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutBulkGetKey"))
+		assert.Equal(t, 1, failingStore.Failure.CallCount("goodTimeoutBulkGetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -3284,8 +3284,8 @@ func TestV1StateEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, b, nil)
 
 		assert.Equal(t, 204, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingBulkSetKey"])
-		assert.Equal(t, 1, failingStore.Failure.CallCount["goodBulkSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingBulkSetKey"))
+		assert.Equal(t, 1, failingStore.Failure.CallCount("goodBulkSetKey"))
 	})
 
 	t.Run("bulk state set times out with resiliency", func(t *testing.T) {
@@ -3306,8 +3306,8 @@ func TestV1StateEndpoints(t *testing.T) {
 		end := time.Now()
 
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutBulkSetKey"])
-		assert.Equal(t, 0, failingStore.Failure.CallCount["goodTimeoutBulkSetKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutBulkSetKey"))
+		assert.Equal(t, 0, failingStore.Failure.CallCount("goodTimeoutBulkSetKey"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -3329,7 +3329,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, b, nil)
 
 		assert.Equal(t, 204, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingMultiKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingMultiKey"))
 	})
 
 	t.Run("state transaction times out with resiliency", func(t *testing.T) {
@@ -3350,7 +3350,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, b, nil)
 
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutMultiKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutMultiKey"))
 	})
 
 	t.Run("state query retries with resiliency", func(t *testing.T) {
@@ -3362,7 +3362,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, b, nil)
 
 		assert.Equal(t, 204, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["failingQueryKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("failingQueryKey"))
 	})
 
 	t.Run("state query times out with resiliency", func(t *testing.T) {
@@ -3374,7 +3374,7 @@ func TestV1StateEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, b, nil)
 
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeoutQueryKey"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeoutQueryKey"))
 	})
 }
 
@@ -3568,11 +3568,11 @@ func TestV1SecretEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	fakeStore := daprt.FakeSecretStore{}
 	failingStore := daprt.FailingSecretStore{
-		Failure: daprt.Failure{
-			Fails:     map[string]int{"key": 1, "bulk": 1},
-			Timeouts:  map[string]time.Duration{"timeout": time.Second * 10, "bulkTimeout": time.Second * 10},
-			CallCount: map[string]int{},
-		},
+		Failure: daprt.NewFailure(
+			map[string]int{"key": 1, "bulk": 1},
+			map[string]time.Duration{"timeout": time.Second * 10, "bulkTimeout": time.Second * 10},
+			map[string]int{},
+		),
 	}
 	fakeStores := map[string]secretstores.SecretStore{
 		"store1":     fakeStore,
@@ -3716,7 +3716,7 @@ func TestV1SecretEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("GET", apiPath, nil, nil)
 
 		assert.Equal(t, 200, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["key"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("key"))
 	})
 
 	t.Run("Get secret - timeout before request ends", func(t *testing.T) {
@@ -3728,7 +3728,7 @@ func TestV1SecretEndpoints(t *testing.T) {
 		end := time.Now()
 
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["timeout"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("timeout"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 
@@ -3738,7 +3738,7 @@ func TestV1SecretEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("GET", apiPath, nil, map[string]string{"metadata.key": "bulk"})
 
 		assert.Equal(t, 200, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["bulk"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("bulk"))
 	})
 
 	t.Run("Get bulk secret - timeout before request ends", func(t *testing.T) {
@@ -3749,7 +3749,7 @@ func TestV1SecretEndpoints(t *testing.T) {
 		end := time.Now()
 
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.Equal(t, 2, failingStore.Failure.CallCount["bulkTimeout"])
+		assert.Equal(t, 2, failingStore.Failure.CallCount("bulkTimeout"))
 		assert.Less(t, end.Sub(start), time.Second*10)
 	})
 }

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,11 +38,11 @@ import (
 
 type mockComponentUpdateServer struct {
 	grpc.ServerStream
-	Calls int
+	Calls atomic.Int64
 }
 
 func (m *mockComponentUpdateServer) Send(*operatorv1pb.ComponentUpdateEvent) error {
-	m.Calls++
+	m.Calls.Add(1)
 	return nil
 }
 
@@ -202,6 +203,9 @@ func TestComponentUpdate(t *testing.T) {
 			// Send a component update, give sidecar time to register
 			time.Sleep(time.Millisecond * 500)
 
+			api.connLock.Lock()
+			defer api.connLock.Unlock()
+
 			for _, connUpdateChan := range api.allConnUpdateChan {
 				connUpdateChan <- &c
 
@@ -244,6 +248,9 @@ func TestComponentUpdate(t *testing.T) {
 			// Send a component update, give sidecar time to register
 			time.Sleep(time.Millisecond * 500)
 
+			api.connLock.Lock()
+			defer api.connLock.Unlock()
+
 			for _, connUpdateChan := range api.allConnUpdateChan {
 				connUpdateChan <- &c
 
@@ -258,7 +265,7 @@ func TestComponentUpdate(t *testing.T) {
 			Namespace: "ns1",
 		}, mockSidecar)
 
-		assert.Equal(t, 1, mockSidecar.Calls)
+		assert.Equal(t, int64(1), mockSidecar.Calls.Load())
 	})
 }
 

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -220,7 +220,7 @@ func TestComponentUpdate(t *testing.T) {
 			Namespace: "ns2",
 		}, mockSidecar)
 
-		assert.Zero(t, mockSidecar.Calls)
+		assert.Equal(t, int64(0), mockSidecar.Calls.Load())
 	})
 
 	t.Run("sidecar is updated when component namespace is a match", func(t *testing.T) {

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -295,6 +295,7 @@ func PerformTableUpdateCostTime() (wastedTime int64) {
 	const testClients = 100
 	serverAddress, testServer, cleanup := newTestPlacementServer(testRaftServer)
 	testServer.hasLeadership.Store(true)
+	overArrLock := sync.Mutex{}
 	var overArr [testClients]int64
 	// arrange.
 	var clientConns []*grpc.ClientConn
@@ -332,7 +333,9 @@ func PerformTableUpdateCostTime() (wastedTime int64) {
 							if clientID == 1 {
 								fmt.Println("client 1 unlock", time.Now())
 							}
+							overArrLock.Lock()
 							overArr[clientID] = time.Since(start).Milliseconds()
+							overArrLock.Unlock()
 						}
 					}
 				}
@@ -352,7 +355,10 @@ func PerformTableUpdateCostTime() (wastedTime int64) {
 	}
 	// Wait until clientStreams[clientID].Recv() in client go routine received new table.
 	for {
-		if len(testServer.streamConnPool) == testClients {
+		testServer.streamConnPoolLock.Lock()
+		l := len(testServer.streamConnPool)
+		testServer.streamConnPoolLock.Unlock()
+		if l == testClients {
 			break
 		}
 	}
@@ -378,11 +384,13 @@ func PerformTableUpdateCostTime() (wastedTime int64) {
 	startFlag.Store(false)
 	time.Sleep(time.Second) // wait client recv
 	var max int64
+	overArrLock.Lock()
 	for _, cost := range &overArr {
 		if cost > max {
 			max = cost
 		}
 	}
+	overArrLock.Unlock()
 	// clean up resources.
 	for i := 0; i < testClients; i++ {
 		clientStreams[i].CloseSend()

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -173,7 +173,10 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 			assert.Equal(t, host.Name, memberChange.host.Name)
 			assert.Equal(t, host.Id, memberChange.host.AppID)
 			assert.EqualValues(t, host.Entities, memberChange.host.Entities)
-			assert.Equal(t, 1, len(testServer.streamConnPool))
+			testServer.streamConnPoolLock.Lock()
+			l := len(testServer.streamConnPool)
+			testServer.streamConnPoolLock.Unlock()
+			assert.Equal(t, 1, l)
 
 		case <-time.After(testStreamSendLatency):
 			require.True(t, false, "no membership change")

--- a/pkg/resiliency/policy.go
+++ b/pkg/resiliency/policy.go
@@ -45,7 +45,7 @@ func Policy(ctx context.Context, log logger.Logger, operationName string, t time
 				ctx, cancel := context.WithTimeout(ctx, t)
 				defer cancel()
 
-				done := make(chan error, 1)
+				done := make(chan error)
 				go func() {
 					done <- operCopy(ctx)
 				}()

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1749,9 +1749,9 @@ func (a *DaprRuntime) initPubSub(c componentsV1alpha1.Component) error {
 // This method is used by the HTTP and gRPC APIs.
 func (a *DaprRuntime) Publish(req *pubsub.PublishRequest) error {
 	a.topicsLock.RLock()
-	defer a.topicsLock.RUnlock()
-
 	ps, ok := a.pubSubs[req.PubsubName]
+	a.topicsLock.RUnlock()
+
 	if !ok {
 		return runtimePubsub.NotFoundError{PubsubName: req.PubsubName}
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -182,7 +182,7 @@ type DaprRuntime struct {
 	operatorClient         operatorv1pb.OperatorClient
 	pubsubCtx              context.Context
 	pubsubCancel           context.CancelFunc
-	topicsLock             *sync.Mutex
+	topicsLock             *sync.RWMutex
 	topicRoutes            map[string]TopicRoutes        // Key is "componentName"
 	topicCtxCancels        map[string]context.CancelFunc // Key is "componentName||topicName"
 	inputBindingRoutes     map[string]string
@@ -259,7 +259,7 @@ func NewDaprRuntime(runtimeConfig *Config, globalConfig *config.Configuration, a
 		secretStores:               map[string]secretstores.SecretStore{},
 		stateStores:                map[string]state.Store{},
 		pubSubs:                    map[string]pubsubItem{},
-		topicsLock:                 &sync.Mutex{},
+		topicsLock:                 &sync.RWMutex{},
 		inputBindingRoutes:         map[string]string{},
 		secretsConfiguration:       map[string]config.SecretsScope{},
 		configurationStores:        map[string]configuration.Store{},
@@ -662,13 +662,13 @@ func (a *DaprRuntime) sendToDeadLetter(name string, msg *pubsub.NewMessage, dead
 func (a *DaprRuntime) subscribeTopic(parentCtx context.Context, name string, topic string, route TopicRouteElem) error {
 	subKey := pubsubTopicKey(name, topic)
 
+	a.topicsLock.Lock()
+	defer a.topicsLock.Unlock()
+
 	allowed := a.isPubSubOperationAllowed(name, topic, a.pubSubs[name].scopedSubscriptions)
 	if !allowed {
 		return fmt.Errorf("subscription to topic '%s' on pubsub '%s' is not allowed", topic, name)
 	}
-
-	a.topicsLock.Lock()
-	defer a.topicsLock.Unlock()
 
 	log.Debugf("subscribing to topic='%s' on pubsub='%s'", topic, name)
 
@@ -1207,29 +1207,28 @@ func (a *DaprRuntime) sendBindingEventToApp(bindingName string, data []byte, met
 		req.WithMetadata(reqMetadata)
 
 		var resp *invokev1.InvokeMethodResponse
-		respErr := false
+		respErr := errors.New("error sending binding event to application")
 		policy := a.resiliency.ComponentInboundPolicy(ctx, bindingName, resiliency.Binding)
 		err := policy(func(ctx context.Context) (err error) {
-			respErr = false
 			resp, err = a.appChannel.InvokeMethod(ctx, req)
 			if err != nil {
 				return err
 			}
 
 			if resp != nil && resp.Status().Code != nethttp.StatusOK {
-				respErr = true
-				return errors.Errorf("Error sending binding event to application, status %d", resp.Status().Code)
+				return fmt.Errorf("%w, status %d", respErr, resp.Status().Code)
 			}
 			return nil
 		})
-		if err != nil && !respErr {
+		if err != nil && !errors.Is(err, respErr) {
 			return nil, errors.Wrap(err, "error invoking app")
 		}
 
 		if span != nil {
 			m := diag.ConstructInputBindingSpanAttributes(
 				bindingName,
-				fmt.Sprintf("%s /%s", nethttp.MethodPost, bindingName))
+				nethttp.MethodPost+" /"+bindingName,
+			)
 			diag.AddAttributesToSpan(span, m)
 			diag.UpdateSpanStatusFromHTTPStatus(span, int(resp.Status().Code))
 			span.End()
@@ -1749,6 +1748,9 @@ func (a *DaprRuntime) initPubSub(c componentsV1alpha1.Component) error {
 // And then forward them to the Pub/Sub component.
 // This method is used by the HTTP and gRPC APIs.
 func (a *DaprRuntime) Publish(req *pubsub.PublishRequest) error {
+	a.topicsLock.RLock()
+	defer a.topicsLock.RUnlock()
+
 	ps, ok := a.pubSubs[req.PubsubName]
 	if !ok {
 		return runtimePubsub.NotFoundError{PubsubName: req.PubsubName}

--- a/pkg/testing/failure_mock.go
+++ b/pkg/testing/failure_mock.go
@@ -39,11 +39,11 @@ func (f *Failure) PerformFailure(key string) error {
 	f.lock.Lock()
 	f.callCount[key]++
 	f.lock.Unlock()
-	if val, ok := f.fails[key]; ok {
-		if val > 0 {
-			f.lock.Lock()
+	if _, ok := f.fails[key]; ok {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+		if f.fails[key] > 0 {
 			f.fails[key]--
-			f.lock.Unlock()
 			return errors.New("forced failure")
 		}
 		delete(f.fails, key)

--- a/pkg/testing/failure_mock.go
+++ b/pkg/testing/failure_mock.go
@@ -19,33 +19,45 @@ import (
 	"time"
 )
 
+func NewFailure(fails map[string]int, timeouts map[string]time.Duration, callCount map[string]int) Failure {
+	return Failure{
+		fails:     fails,
+		timeouts:  timeouts,
+		callCount: callCount,
+		lock:      &sync.RWMutex{},
+	}
+}
+
 type Failure struct {
-	Fails     map[string]int
-	Timeouts  map[string]time.Duration
-	CallCount map[string]int
-	lock      *sync.Mutex
+	fails     map[string]int
+	timeouts  map[string]time.Duration
+	callCount map[string]int
+	lock      *sync.RWMutex
 }
 
 func (f *Failure) PerformFailure(key string) error {
-	if f.lock == nil {
-		f.lock = &sync.Mutex{}
-	}
 	f.lock.Lock()
-	f.CallCount[key]++
+	f.callCount[key]++
 	f.lock.Unlock()
-	if val, ok := f.Fails[key]; ok {
+	if val, ok := f.fails[key]; ok {
 		if val > 0 {
 			f.lock.Lock()
-			f.Fails[key]--
+			f.fails[key]--
 			f.lock.Unlock()
 			return errors.New("forced failure")
 		}
-		delete(f.Fails, key)
+		delete(f.fails, key)
 		return nil
 	}
 
-	if val, ok := f.Timeouts[key]; ok {
+	if val, ok := f.timeouts[key]; ok {
 		time.Sleep(val)
 	}
 	return nil
+}
+
+func (f *Failure) CallCount(key string) int {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.callCount[key]
 }

--- a/pkg/testing/failure_mock.go
+++ b/pkg/testing/failure_mock.go
@@ -39,16 +39,19 @@ func (f *Failure) PerformFailure(key string) error {
 	f.lock.Lock()
 	f.callCount[key]++
 	f.lock.Unlock()
-	if _, ok := f.fails[key]; ok {
-		f.lock.Lock()
-		defer f.lock.Unlock()
-		if f.fails[key] > 0 {
+
+	f.lock.Lock()
+	if v, ok := f.fails[key]; ok {
+		if v > 0 {
 			f.fails[key]--
+			f.lock.Unlock()
 			return errors.New("forced failure")
 		}
 		delete(f.fails, key)
+		f.lock.Unlock()
 		return nil
 	}
+	f.lock.Unlock()
 
 	if val, ok := f.timeouts[key]; ok {
 		time.Sleep(val)

--- a/pkg/testing/pubsub_mock.go
+++ b/pkg/testing/pubsub_mock.go
@@ -103,13 +103,14 @@ func (m *InMemoryPubsub) Init(metadata pubsub.Metadata) error {
 
 // Publish is a mock publish method.
 func (m *InMemoryPubsub) Publish(req *pubsub.PublishRequest) error {
-	var send chan *pubsub.NewMessage
 	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	var send chan *pubsub.NewMessage
 	t, ok := m.subscribedTopics[req.Topic]
 	if ok && t.send != nil {
 		send = t.send
 	}
-	m.lock.Unlock()
 
 	if send != nil {
 		send <- &pubsub.NewMessage{
@@ -147,12 +148,12 @@ func (m *InMemoryPubsub) Subscribe(parentCtx context.Context, req pubsub.Subscri
 					go m.handler(req.Topic, msg)
 				}
 			case <-ctx.Done():
-				close(ch)
 				m.lock.Lock()
+				close(ch)
 				delete(m.subscribedTopics, req.Topic)
 				m.onSubscribedTopicsChanged()
-				m.lock.Unlock()
 				m.MethodCalled("unsubscribed", req.Topic)
+				m.lock.Unlock()
 				return
 			}
 		}
@@ -164,11 +165,13 @@ func (m *InMemoryPubsub) Subscribe(parentCtx context.Context, req pubsub.Subscri
 
 // Close is a mock close method.
 func (m *InMemoryPubsub) Close() error {
+	m.lock.Lock()
 	if len(m.subscribedTopics) > 0 {
 		for _, f := range m.subscribedTopics {
 			f.cancel()
 		}
 	}
+	m.lock.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Fixes #5289

Fixes race conditions in multiple packages (most notably pkg/runtime and pkg/actors, among others), so running `go test -race .` reports no errors.