### PR TITLE
E2E tests: Upgrade AKS version to 1.22.15

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -38,9 +38,9 @@ env:
   # Configure proxy for Go modules
   GOPROXY: https://proxy.golang.org
   # Version of kubectl
-  KUBECTLVER: "v1.22.6"
+  KUBECTLVER: "v1.25.2"
   # Version of Helm
-  HELMVER: "v3.7.2"
+  HELMVER: "v3.10.0"
   # Kubernetes namespace to use
   DAPR_NAMESPACE: "dapr-tests"
   # Timeout for tests

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -38,11 +38,11 @@ env:
   # Configure proxy for Go modules
   GOPROXY: https://proxy.golang.org
   # Version of kubectl
-  KUBECTLVER: "v1.22.6"
+  KUBECTLVER: "v1.25.2"
   # If not empty, uses cloud resources for testing
   TEST_CLOUD_ENV: "azure"
   # Version of Helm
-  HELMVER: "v3.7.2"
+  HELMVER: "v3.10.0"
   # Kubernetes namespace to use
   DAPR_NAMESPACE: "dapr-tests"
   # Timeout for tests
@@ -177,7 +177,7 @@ jobs:
             | --- | --- | --- |
             | Linux | `Dapr-E2E-${{ env.TEST_PREFIX }}l` | ${{ env.REGION1 }} |
             | Windows | `Dapr-E2E-${{ env.TEST_PREFIX }}w` | ${{ env.REGION2 }} |
-            | Linux_arm64 | `Dapr-E2E-${{ env.TEST_PREFIX }}la` | ${{ env.REGION3 }} |
+            | Linux/arm64 | `Dapr-E2E-${{ env.TEST_PREFIX }}la` | ${{ env.REGION3 }} |
       - name: Update PR comment for failure
         if: failure() && env.PR_NUMBER != ''
         uses: artursouza/sticky-pull-request-comment@v2.2.0
@@ -193,7 +193,7 @@ jobs:
             | --- | --- | --- |
             | Linux | `Dapr-E2E-${{ env.TEST_PREFIX }}l` | ${{ env.REGION1 }} |
             | Windows | `Dapr-E2E-${{ env.TEST_PREFIX }}w` | ${{ env.REGION2 }} |
-            | Linux_arm64 | `Dapr-E2E-${{ env.TEST_PREFIX }}la` | ${{ env.REGION3 }} |
+            | Linux/arm64 | `Dapr-E2E-${{ env.TEST_PREFIX }}la` | ${{ env.REGION3 }} |
 
             Please check the logs for details on the failure.
 

--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -43,7 +43,7 @@ param diagStorageResourceId string = ''
 var osDiskSizeGB = 0
 
 // Version of Kubernetes
-var kubernetesVersion = '1.22.6'
+var kubernetesVersion = '1.22.15'
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
   name: '${namePrefix}acr'


### PR DESCRIPTION
Our E2E tests were using AKS with Kubernetes version 1.22.6, which is now deprecated and causing [test failures](https://github.com/dapr/dapr/actions/runs/3176401587/jobs/5175654931). This upgrades to 1.22.15, the most up-to-date in the 1.22.x branch. 

**Note:** eventually we will need to upgrade to a newer version such as 1.24. However, upgrades to 1.23 and higher in the past gave us a lot of issues (#5056) on Windows. This is because starting with AKS 1.23, the container runtime on Windows changed to containerd, which was buggy in our tests. We'll need to try again.

PS: Also upgrade the version of kubectl and Helm