### PR TITLE
Return empty tracestate instead of nil on failure

### DIFF
--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -170,7 +170,8 @@ func TraceStateFromW3CString(h string) *trace.TraceState {
 
 	ts, err := trace.ParseTraceState(h)
 	if err != nil {
-		return nil
+		ts = trace.TraceState{}
+		return &ts
 	}
 
 	return &ts

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -101,6 +101,12 @@ func TestTraceStateFromW3CString(t *testing.T) {
 		got := TraceStateFromW3CString(scText)
 		assert.Equal(t, ts, *got)
 	})
+	t.Run("invalid Tracestate", func(t *testing.T) {
+		ts := trace.TraceState{}
+		// A non-parsable tracestate should equate back to an empty one.
+		got := TraceStateFromW3CString("bad tracestate")
+		assert.Equal(t, ts, *got)
+	})
 }
 
 func TestStartInternalCallbackSpan(t *testing.T) {


### PR DESCRIPTION
# Description

When parsing a tracestate, we return an empty tracestate if there are any issues with the parsing. We then ignored the error and return nil. This caused an NPE when attempting to use the tracestate later on. This change utilizes the empty tracestate instead.

https://github.com/dapr/dapr/issues/5304

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

Please reference the issue this PR will close: #5304 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
