### PR TITLE
bugfix(appmanager): pod name be cleared

### DIFF
--- a/tests/platforms/kubernetes/appmanager.go
+++ b/tests/platforms/kubernetes/appmanager.go
@@ -311,12 +311,11 @@ func (m *AppManager) WaitUntilDeploymentState(isState func(*appsv1.Deployment, e
 		podStatus := map[string][]apiv1.ContainerStatus{}
 		if err == nil {
 			for i, pod := range podList.Items {
+				podStatus[pod.Name] = pod.Status.ContainerStatuses
 				// Reset Spec and ObjectMeta which could contain sensitive info like credentials
 				pod.Spec.Reset()
 				pod.ObjectMeta.Reset()
 				podList.Items[i] = pod
-
-				podStatus[pod.Name] = pod.Status.ContainerStatuses
 			}
 			j, _ := json.Marshal(podList)
 			log.Printf("deployment %s relate pods: %s", m.app.AppName, string(j))


### PR DESCRIPTION
Signed-off-by: 1046102779 <seachen@tencent.com>

# Description
The map key (`pod name`) was empty  in the following log, because pod.ObjectMeta was reset. And empty key will override all keys and the map always len(map)=1.

pod status: map[:[{Name:allowlists-callee-http State:{Waiting:nil Running:&ContainerStateRunning{StartedAt:2022-10-11 12:54:47 +0000 UTC,} Terminated:nil} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:true RestartCount:0 Image:localhost:5000/dapr/e2e-service_invocation:dev-linux-amd64 ImageID:localhost:5000/dapr/e2e-service_invocation@sha256:33e007849f31354895d756b81df89db69f9c461f628c4a17907615624eb84fa5 ContainerID:containerd://d0a03db8ac31de8313c9e2cf7a446cd4c4e8d4036758289bb57a79e5ec29e26d Started:0xc0002c9efa} {Name:daprd State:{Waiting:&ContainerStateWaiting{Reason:CrashLoopBackOff,Message:back-off 5m0s restarting failed container=daprd pod=allowlists-callee-http-84c5d9d445-p8bfs_dapr-tests(fbb9d105-39ff-4b9a-9a9b-9749219c4c0d),} Running:nil Terminated:nil} LastTerminationState:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:1,Signal:0,Reason:Error,Message:,StartedAt:2022-10-11 13:00:32 +0000 UTC,FinishedAt:2022-10-11 13:00:33 +0000 UTC,ContainerID:containerd://56f2476bf37ba40a01fbbd470e19d312704b73b71de3c1add1e0b94b7c291def,}} Ready:false RestartCount:6 Image:localhost:5000/dapr/daprd:dev-linux-amd64 ImageID:localhost:5000/dapr/daprd@sha256:b49e9340018007d567ac9df91e839397a3d555e385a306d2d49d1576e62af2fd ContainerID:containerd://56f2476bf37ba40a01fbbd470e19d312704b73b71de3c1add1e0b94b7c291def Started:0xc0002c9f35}]]

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
