### PR TITLE
Core WF engine features: activities, timers, sub-workflows, etc.

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2131,9 +2131,8 @@ func (a *DaprRuntime) initActors() error {
 		AppConfig:          a.appConfig,
 	})
 
-	internalActors := make(map[string]actors.InternalActor)
-	internalActors[wfengine.WorkflowActorType] = a.workflowEngine.WorkflowActor
-	internalActors[wfengine.ActivityActorType] = a.workflowEngine.ActivityActor
+	// The workflow engine registers internal actors that drive workflow execution.
+	internalActors := a.workflowEngine.InternalActors()
 
 	act := actors.NewActors(actors.ActorsOpts{
 		StateStore:       a.stateStores[a.actorStateStoreName],

--- a/pkg/runtime/wfengine/activity.go
+++ b/pkg/runtime/wfengine/activity.go
@@ -16,9 +16,15 @@ package wfengine
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
 
 	"github.com/dapr/dapr/pkg/actors"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 )
 
 type activityActor struct {
@@ -38,14 +44,72 @@ func (a *activityActor) SetActorRuntime(actorsRuntime actors.Actors) {
 	a.actorRuntime = actorsRuntime
 }
 
-// InvokeMethod implements actors.InternalActor
-func (*activityActor) InvokeMethod(ctx context.Context, actorID string, methodName string, data []byte) (any, error) {
-	return nil, errors.New("TODO")
+// InvokeMethod implements actors.InternalActor and schedules the background execution of a workflow activity.
+// Activities are scheduled by workflows and can execute for arbitrary lengths of time. Instead of executing
+// activity logic directly, InvokeMethod creates a reminder that executes the activity logic. InvokeMethod
+// returns immediately after creating the reminder, enabling the workflow to continue processing other events
+// in parallel.
+func (a *activityActor) InvokeMethod(ctx context.Context, actorID string, methodName string, data []byte) (any, error) {
+	// This actor doesn't define any methods, and uses the method name and payload as the reminder name and payload.
+	err := a.createReliableReminder(ctx, actorID, methodName, data)
+	return nil, err
 }
 
-// InvokeReminder implements actors.InternalActor
-func (*activityActor) InvokeReminder(ctx context.Context, actorID string, reminderName string, params []byte) error {
-	return errors.New("TODO")
+// InvokeReminder implements actors.InternalActor and executes the activity logic.
+// TODO: Need to review how errors for reminders are handled.
+func (a *activityActor) InvokeReminder(ctx context.Context, actorID string, reminderName string, data any, dueTime string, period string) error {
+	taskEvent, err := backend.UnmarshalHistoryEvent(data.([]byte))
+	if err != nil {
+		return err
+	}
+
+	endIndex := strings.LastIndex(actorID, "#")
+	if endIndex < 0 {
+		return fmt.Errorf("invalid activity actor ID: %s", actorID)
+	}
+	workflowID := actorID[0:endIndex]
+
+	wi := &backend.ActivityWorkItem{
+		SequenceNumber: int64(taskEvent.EventId),
+		InstanceID:     api.InstanceID(workflowID),
+		NewEvent:       taskEvent,
+		Properties:     make(map[string]interface{}),
+	}
+
+	// Executing activity code is a one-way operation. We must wait for the app code to report its completion, which
+	// will trigger this callback channel.
+	// TODO: Need to come up with a design for timeouts. Some activities may need to run for hours but we also need
+	//       to handle the case where the app crashes and never responds to the workflow. It may be necessary to
+	//       introduce some kind of heartbeat protocol to help identify such cases.
+	callback := make(chan bool)
+	wi.Properties[CallbackChannelProperty] = callback
+	a.scheduler.ScheduleActivity(wi)
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Minute):
+			wfLogger.Warnf("%s: still waiting for '%s' to complete...", actorID, reminderName)
+		case <-callback:
+			break loop
+		}
+	}
+
+	// publish the result back to the workflow actor as a new event to be processed
+	resultData, err := backend.MarshalHistoryEvent(wi.Result)
+	if err != nil {
+		return err
+	}
+	req := invokev1.
+		NewInvokeMethodRequest(AddWorkflowEventMethod).
+		WithActor(WorkflowActorType, workflowID).
+		WithRawData(resultData, invokev1.OctetStreamContentType)
+	if _, err := a.actorRuntime.Call(ctx, req); err != nil {
+		return err
+	}
+	return nil
 }
 
 // InvokeTimer implements actors.InternalActor
@@ -55,5 +119,17 @@ func (*activityActor) InvokeTimer(ctx context.Context, actorID string, timerName
 
 // DeactivateActor implements actors.InternalActor
 func (*activityActor) DeactivateActor(ctx context.Context, actorID string) error {
-	return nil // nothing to do
+	return nil // nothing to do - this actor maintains no state
+}
+
+func (a *activityActor) createReliableReminder(ctx context.Context, actorID string, name string, data any) error {
+	wfLogger.Debugf("%s: creating '%s' reminder for immediate execution", actorID, name)
+	return a.actorRuntime.CreateReminder(ctx, &actors.CreateReminderRequest{
+		ActorType: ActivityActorType,
+		ActorID:   actorID,
+		Data:      data,
+		DueTime:   "0s",
+		Name:      name,
+		Period:    "", // TODO: Add configurable period to enable durability
+	})
 }

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -55,6 +55,14 @@ func NewWorkflowEngine() *WorkflowEngine {
 	return engine
 }
 
+// InternalActors returns a map of internal actors that are used to implement workflows
+func (wfe *WorkflowEngine) InternalActors() map[string]actors.InternalActor {
+	internalActors := make(map[string]actors.InternalActor)
+	internalActors[WorkflowActorType] = wfe.WorkflowActor
+	internalActors[ActivityActorType] = wfe.ActivityActor
+	return internalActors
+}
+
 func (wfe *WorkflowEngine) ConfigureGrpc(grpcServer *grpc.Server) {
 	wfLogger.Info("configuring workflow engine gRPC endpoint")
 	wfe.executor = backend.NewGrpcExecutor(grpcServer, wfe.backend, wfLogger)

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// wfengine_test is a suite of integration tests that verify workflow
+// engine behavior using only exported APIs.
+package wfengine_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/actors"
+	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/runtime/wfengine"
+)
+
+// The fake state store code was copied from actors_test.go.
+// TODO: Find a way to share the code instead of copying it, if it makes sense to do so.
+
+type fakeStateStoreItem struct {
+	data []byte
+	etag *string
+}
+
+type fakeStateStore struct {
+	items map[string]*fakeStateStoreItem
+	lock  *sync.RWMutex
+}
+
+func fakeStore() state.Store {
+	return &fakeStateStore{
+		items: map[string]*fakeStateStoreItem{},
+		lock:  &sync.RWMutex{},
+	}
+}
+
+func (f *fakeStateStore) newItem(data []byte) *fakeStateStoreItem {
+	etag, _ := uuid.NewRandom()
+	etagString := etag.String()
+	return &fakeStateStoreItem{
+		data: data,
+		etag: &etagString,
+	}
+}
+
+func (f *fakeStateStore) Init(metadata state.Metadata) error {
+	return nil
+}
+
+func (f *fakeStateStore) Ping() error {
+	return nil
+}
+
+func (f *fakeStateStore) Features() []state.Feature {
+	return []state.Feature{state.FeatureETag, state.FeatureTransactional}
+}
+
+func (f *fakeStateStore) Delete(req *state.DeleteRequest) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	delete(f.items, req.Key)
+
+	return nil
+}
+
+func (f *fakeStateStore) BulkDelete(req []state.DeleteRequest) error {
+	return nil
+}
+
+func (f *fakeStateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	item := f.items[req.Key]
+
+	if item == nil {
+		return &state.GetResponse{Data: nil, ETag: nil}, nil
+	}
+
+	return &state.GetResponse{Data: item.data, ETag: item.etag}, nil
+}
+
+func (f *fakeStateStore) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+	res := []state.BulkGetResponse{}
+	for _, oneRequest := range req {
+		oneResponse, err := f.Get(&state.GetRequest{
+			Key:      oneRequest.Key,
+			Metadata: oneRequest.Metadata,
+			Options:  oneRequest.Options,
+		})
+		if err != nil {
+			return false, nil, err
+		}
+
+		res = append(res, state.BulkGetResponse{
+			Key:  oneRequest.Key,
+			Data: oneResponse.Data,
+			ETag: oneResponse.ETag,
+		})
+	}
+
+	return true, res, nil
+}
+
+func (f *fakeStateStore) Set(req *state.SetRequest) error {
+	b, _ := json.Marshal(&req.Value)
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.items[req.Key] = f.newItem(b)
+
+	return nil
+}
+
+func (f *fakeStateStore) BulkSet(req []state.SetRequest) error {
+	return nil
+}
+
+func (f *fakeStateStore) Multi(request *state.TransactionalStateRequest) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	// First we check all eTags
+	for _, o := range request.Operations {
+		var eTag *string
+		key := ""
+		if o.Operation == state.Upsert {
+			key = o.Request.(state.SetRequest).Key
+			eTag = o.Request.(state.SetRequest).ETag
+		} else if o.Operation == state.Delete {
+			key = o.Request.(state.DeleteRequest).Key
+			eTag = o.Request.(state.DeleteRequest).ETag
+		}
+		item := f.items[key]
+		if eTag != nil && item != nil {
+			if *eTag != *item.etag {
+				return fmt.Errorf("etag does not match for key %v", key)
+			}
+		}
+		if eTag != nil && item == nil {
+			return fmt.Errorf("etag does not match for key not found %v", key)
+		}
+	}
+
+	// Now we can perform the operation.
+	for _, o := range request.Operations {
+		if o.Operation == state.Upsert {
+			req := o.Request.(state.SetRequest)
+			b, _ := json.Marshal(req.Value)
+			f.items[req.Key] = f.newItem(b)
+		} else if o.Operation == state.Delete {
+			req := o.Request.(state.DeleteRequest)
+			delete(f.items, req.Key)
+		}
+	}
+
+	return nil
+}
+
+// TestStartWorkflowEngine validates that starting the workflow engine returns no errors.
+func TestStartWorkflowEngine(t *testing.T) {
+	ctx := context.Background()
+	engine := wfengine.NewWorkflowEngine()
+	store := fakeStore()
+	cfg := actors.NewConfig(actors.ConfigOpts{
+		AppID:              "wf-app",
+		PlacementAddresses: []string{"placement:5050"},
+		AppConfig:          config.ApplicationConfig{},
+	})
+	actors := actors.NewActors(actors.ActorsOpts{
+		StateStore:     store,
+		Config:         cfg,
+		StateStoreName: "workflowStore",
+		InternalActors: engine.InternalActors(),
+	})
+	engine.SetActorRuntime(actors)
+
+	grpcServer := grpc.NewServer()
+	engine.ConfigureGrpc(grpcServer)
+	err := engine.Start(ctx)
+	assert.NoError(t, err)
+}
+
+// TODO: Integration tests that actually run workflows (requires a Go SDK of some kind)


### PR DESCRIPTION
Signed-off-by: Chris Gillum <cgillum@microsoft.com>

# Description

In https://github.com/dapr/dapr/pull/5301, we did the initial introduction of the workflow engine into the Dapr sidecar. The engine didn't implement any features - it could only run "no-op" workflows.

This PR introduces the following core features into the workflow engine:

- Activities
- Durable timers
- Sub-workflows
- Custom status payloads
- External event processing
- Continue-as-new
- App-level retry policies

This PR also adds more testing and fixes some issues that were discovered with internal actors. For example:

- The deactivation path for internal actors was broken, but now is fixed
- Reminders were unable to preserve data payload fidelity due to JSON roundtripping. For example, `[]byte` values were changed to `string` and `int32` values were changed to `float32`. To fix this, reminder serialization is changed to use `encoding/gob` instead of `encoding/json`. This change is only for internal actors. There's no change for external actors.

Lastly, this PR adds some starter code for wfengine black-box testing (see wfengine-test.go). It only tests startup right now, but more tests will be added over time.

External integration testing was done by taking the [Durable Task .NET SDK integration tests](https://github.com/microsoft/durabletask-dotnet/tree/7fb1ba464f42f675f10ddf46d43f1573abde240d/test/DurableTask.Sdk.Tests) and configuring them to talk to the Dapr sidecar. All runtime tests are passing.

## Issue reference

This is one step of many in the workflow engine proposal: https://github.com/dapr/dapr/issues/4576

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
