### PR TITLE
Added --token-audience option to Sentry to support bound tokens

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -152,6 +152,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sentry.tls.issuer.certPEM`          | Issuer Certificate cert                                                 | `""`                    |
 | `dapr_sentry.tls.issuer.keyPEM`           | Issuer Private Key cert                                                 | `""`                    |
 | `dapr_sentry.tls.root.certPEM`            | Root Certificate cert                                                   | `""`                    |
+| `dapr_sentry.tokenAudience`               | Expected audience for tokens; multiple values can be separated by a comma. Defaults to the audience expected by the Kubernetes control plane if not set | `""` |
 | `dapr_sentry.trustDomain`                 | Trust domain (logical group to manage app trust relationship) for access control list | `cluster.local`  |
 | `dapr_sentry.runAsNonRoot`                | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
 | `dapr_sentry.resources`                   | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -148,6 +148,10 @@ spec:
 {{- end }}
         - "--trust-domain"
         - {{ .Values.tls.trustDomain }}
+{{- if .Values.tokenAudience }}
+        - "--token-audience"
+        - {{ .Values.tokenAudience }}
+{{- end }}
       serviceAccountName: dapr-operator
       volumes:
         - name: credentials

--- a/charts/dapr/charts/dapr_sentry/values.yaml
+++ b/charts/dapr/charts/dapr_sentry/values.yaml
@@ -10,6 +10,8 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+tokenAudience: ""
+
 ports:
   protocol: TCP
   port: 80

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -54,6 +54,7 @@ func main() {
 	flag.StringVar(&credentials.IssuerCertFilename, "issuer-certificate-filename", credentials.IssuerCertFilename, "Issuer certificate filename")
 	flag.StringVar(&credentials.IssuerKeyFilename, "issuer-key-filename", credentials.IssuerKeyFilename, "Issuer private key filename")
 	trustDomain := flag.String("trust-domain", "localhost", "The CA trust domain")
+	tokenAudience := flag.String("token-audience", "", "Expected audience for tokens; multiple values can be separated by a comma. Defaults to the audience expected by the Kubernetes control plane")
 
 	loggerOptions := logger.DefaultOptions()
 	loggerOptions.AttachCmdFlags(flag.StringVar, flag.BoolVar)
@@ -107,6 +108,9 @@ func main() {
 	config.IssuerKeyPath = issuerKeyPath
 	config.RootCertPath = rootCertPath
 	config.TrustDomain = *trustDomain
+	if *tokenAudience != "" {
+		config.TokenAudience = tokenAudience
+	}
 
 	watchDir := filepath.Dir(config.IssuerCertPath)
 

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -39,6 +39,7 @@ type SentryConfig struct {
 	RootCertPath     string
 	IssuerCertPath   string
 	IssuerKeyPath    string
+	TokenAudience    *string
 }
 
 var configGetters = map[string]func(string) (SentryConfig, error){

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -92,7 +92,7 @@ func (s *sentry) createCAServer() (ca.CertificateAuthority, identity.Validator) 
 	monitoring.IssuerCertExpiry(certExpiry)
 
 	// Create identity validator
-	v, validatorErr := createValidator()
+	v, validatorErr := s.createValidator()
 	if validatorErr != nil {
 		log.Fatalf("error creating validator: %s", validatorErr)
 	}
@@ -173,14 +173,14 @@ func watchCertExpiry(ctx context.Context, certAuth ca.CertificateAuthority) {
 	}
 }
 
-func createValidator() (identity.Validator, error) {
+func (s *sentry) createValidator() (identity.Validator, error) {
 	if config.IsKubernetesHosted() {
 		// we're in Kubernetes, create client and init a new serviceaccount token validator
 		kubeClient, err := k8s.GetClient()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create kubernetes client")
 		}
-		return kubernetes.NewValidator(kubeClient), nil
+		return kubernetes.NewValidator(kubeClient, s.conf.TokenAudience), nil
 	}
 	return selfhosted.NewValidator(), nil
 }


### PR DESCRIPTION
This allows specifying what audience Sentry looks for in tokens to support [bound tokens](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/1205-bound-service-account-tokens), and it's meant to work with `automountServiceAccountToken: false`.

This way, pods can be deployed with a token with a different audience than what Kubernetes uses for its APIs, allowing pods to interact with Sentry but not with the K8s API. It will help securing pods running on K8s.

The change works by adding a new CLI flag to the `sentry` command called `--token-audience`, which is a comma-separated list of audiences that Sentry should accept in tokens. If empty, Sentry will look for the default audience used by the specific K8s cluster (the same audience used by the K8s APIs).