### PR TITLE
Set `runAsNonRoot` and `readOnlyRootFilesystem` for daprd 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ ifneq ($(ADDITIONAL_HELM_SET),)
 endif
 docker-deploy-k8s: check-docker-env check-arch
 	$(info Deploying ${DAPR_REGISTRY}/${RELEASE_NAME}:${DAPR_TAG} to the current K8S context...)
-	$(HELM) install \
+	$(HELM) upgrade --install \
 		$(RELEASE_NAME) --namespace=$(DAPR_NAMESPACE) --wait --timeout 5m0s \
 		--set global.ha.enabled=$(HA_MODE) --set-string global.tag=$(DAPR_TAG)-$(TARGET_OS)-$(TARGET_ARCH) \
 		--set-string global.registry=$(DAPR_REGISTRY) --set global.logAsJson=true \

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -168,7 +168,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sidecar_injector.injectorImage.name` | Docker image name for sidecar injector service (`global.registry/dapr_sidecar_injector.injectorImage.name`) | `dapr`|
 | `dapr_sidecar_injector.webhookFailurePolicy` | Failure policy for the sidecar injector                              | `Ignore`                |
 | `dapr_sidecar_injector.runAsNonRoot`      | Boolean value for `securityContext.runAsNonRoot` for the Sidecar Injector container itself. You may have to set this to `false` when running in Minikube | `true` |
-| `dapr_sidecar_injector.runDaprdAsNonRoot` | When this boolean value is true (the default), the injected `daprd` containers have `runAsRoot: true`. You may have to set this to `false` when running Minikube | `true` |
+| `dapr_sidecar_injector.sidecarRunAsNonRoot` | When this boolean value is true (the default), the injected sidecar containers have `runAsRoot: true`. You may have to set this to `false` when running Minikube | `true` |
 | `dapr_sidecar_injector.resources`         | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_sidecar_injector.debug.enabled`     | Boolean value for enabling debug mode | `{}` |
 | `dapr_sidecar_injector.kubeClusterDomain` | Domain for this kubernetes cluster. If not set, will auto-detect the cluster domain through the `/etc/resolv.conf` file `search domains` content. | `cluster.local` |

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -167,7 +167,8 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sidecar_injector.image.name`        | Docker image name for Dapr runtime sidecar to inject into an application (`global.registry/dapr_sidecar_injector.image.name`) | `daprd`|
 | `dapr_sidecar_injector.injectorImage.name` | Docker image name for sidecar injector service (`global.registry/dapr_sidecar_injector.injectorImage.name`) | `dapr`|
 | `dapr_sidecar_injector.webhookFailurePolicy` | Failure policy for the sidecar injector                              | `Ignore`                |
-| `dapr_sidecar_injector.runAsNonRoot`      | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
+| `dapr_sidecar_injector.runAsNonRoot`      | Boolean value for `securityContext.runAsNonRoot` for the Sidecar Injector container itself. You may have to set this to `false` when running in Minikube | `true` |
+| `dapr_sidecar_injector.runDaprdAsNonRoot` | When this boolean value is true (the default), the injected `daprd` containers have `runAsRoot: true`. You may have to set this to `false` when running Minikube | `true` |
 | `dapr_sidecar_injector.resources`         | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_sidecar_injector.debug.enabled`     | Boolean value for enabling debug mode | `{}` |
 | `dapr_sidecar_injector.kubeClusterDomain` | Domain for this kubernetes cluster. If not set, will auto-detect the cluster domain through the `/etc/resolv.conf` file `search domains` content. | `cluster.local` |

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -169,6 +169,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sidecar_injector.webhookFailurePolicy` | Failure policy for the sidecar injector                              | `Ignore`                |
 | `dapr_sidecar_injector.runAsNonRoot`      | Boolean value for `securityContext.runAsNonRoot` for the Sidecar Injector container itself. You may have to set this to `false` when running in Minikube | `true` |
 | `dapr_sidecar_injector.sidecarRunAsNonRoot` | When this boolean value is true (the default), the injected sidecar containers have `runAsRoot: true`. You may have to set this to `false` when running Minikube | `true` |
+| `dapr_sidecar_injector.sidecarReadOnlyRootFilesystem` | When this boolean value is true (the default), the injected sidecar containers have `readOnlyRootFilesystem: true` | `true` |
 | `dapr_sidecar_injector.resources`         | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_sidecar_injector.debug.enabled`     | Boolean value for enabling debug mode | `{}` |
 | `dapr_sidecar_injector.kubeClusterDomain` | Domain for this kubernetes cluster. If not set, will auto-detect the cluster domain through the `/etc/resolv.conf` file `search domains` content. | `cluster.local` |

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -134,6 +134,10 @@ spec:
         - name: IGNORE_ENTRYPOINT_TOLERATIONS
           value: "{{ .Values.ignoreEntrypointTolerations }}"
 {{- end }}
+{{- if .Values.runDaprdAsNonRoot }}
+        - name: RUN_AS_NON_ROOT
+          value: "{{ .Values.runDaprdAsNonRoot }}"
+{{- end }}
         ports:
         - name: https
           containerPort: 4000

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -134,9 +134,9 @@ spec:
         - name: IGNORE_ENTRYPOINT_TOLERATIONS
           value: "{{ .Values.ignoreEntrypointTolerations }}"
 {{- end }}
-{{- if .Values.runDaprdAsNonRoot }}
-        - name: RUN_AS_NON_ROOT
-          value: "{{ .Values.runDaprdAsNonRoot }}"
+{{- if .Values.sidecarRunAsNonRoot }}
+        - name: SIDECAR_RUN_AS_NON_ROOT
+          value: "{{ .Values.sidecarRunAsNonRoot }}"
 {{- end }}
         ports:
         - name: https

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -138,6 +138,10 @@ spec:
         - name: SIDECAR_RUN_AS_NON_ROOT
           value: "{{ .Values.sidecarRunAsNonRoot }}"
 {{- end }}
+{{- if .Values.sidecarReadOnlyRootFilesystem }}
+        - name: SIDECAR_READ_ONLY_ROOT_FILESYSTEM
+          value: "{{ .Values.sidecarReadOnlyRootFilesystem }}"
+{{- end }}
         ports:
         - name: https
           containerPort: 4000

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 webhookFailurePolicy: Ignore
 sidecarImagePullPolicy: IfNotPresent
 runAsNonRoot: true
-runDaprdAsNonRoot: true
+sidecarRunAsNonRoot: true
 resources: {}
 kubeClusterDomain: cluster.local
 ignoreEntrypointTolerations: "[{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"alibabacloud.com/eci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"azure.com/aci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"aws\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"huawei.com/cci\\\"}]"

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -18,6 +18,7 @@ webhookFailurePolicy: Ignore
 sidecarImagePullPolicy: IfNotPresent
 runAsNonRoot: true
 sidecarRunAsNonRoot: true
+sidecarReadOnlyRootFilesystem: true
 resources: {}
 kubeClusterDomain: cluster.local
 ignoreEntrypointTolerations: "[{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"alibabacloud.com/eci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"azure.com/aci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"aws\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"huawei.com/cci\\\"}]"

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -17,6 +17,7 @@ fullnameOverride: ""
 webhookFailurePolicy: Ignore
 sidecarImagePullPolicy: IfNotPresent
 runAsNonRoot: true
+runDaprdAsNonRoot: true
 resources: {}
 kubeClusterDomain: cluster.local
 ignoreEntrypointTolerations: "[{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"alibabacloud.com/eci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"azure.com/aci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"aws\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"huawei.com/cci\\\"}]"

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -90,10 +90,18 @@ func (c *Config) GetIgnoreEntrypointTolerations() []corev1.Toleration {
 }
 
 func (c *Config) GetRunAsNonRoot() bool {
+	// Default is true if empty
+	if c.RunAsNonRoot == "" {
+		return true
+	}
 	return utils.IsTruthy(c.RunAsNonRoot)
 }
 
 func (c *Config) GetReadOnlyRootFilesystem() bool {
+	// Default is true if empty
+	if c.ReadOnlyRootFilesystem == "" {
+		return true
+	}
 	return utils.IsTruthy(c.ReadOnlyRootFilesystem)
 }
 

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	AllowedServiceAccounts      string `envconfig:"ALLOWED_SERVICE_ACCOUNTS"`
 	IgnoreEntrypointTolerations string `envconfig:"IGNORE_ENTRYPOINT_TOLERATIONS"`
 	RunAsNonRoot                string `envconfig:"SIDECAR_RUN_AS_NON_ROOT"`
+	ReadOnlyRootFilesystem      string `envconfig:"SIDECAR_READ_ONLY_ROOT_FILESYSTEM"`
 
 	parsedEntrypointTolerations []corev1.Toleration
 }
@@ -90,6 +91,10 @@ func (c *Config) GetIgnoreEntrypointTolerations() []corev1.Toleration {
 
 func (c *Config) GetRunAsNonRoot() bool {
 	return utils.IsTruthy(c.RunAsNonRoot)
+}
+
+func (c *Config) GetReadOnlyRootFilesystem() bool {
+	return utils.IsTruthy(c.ReadOnlyRootFilesystem)
 }
 
 func (c *Config) parseTolerationsJSON() {

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	KubeClusterDomain           string `envconfig:"KUBE_CLUSTER_DOMAIN"`
 	AllowedServiceAccounts      string `envconfig:"ALLOWED_SERVICE_ACCOUNTS"`
 	IgnoreEntrypointTolerations string `envconfig:"IGNORE_ENTRYPOINT_TOLERATIONS"`
-	RunAsNonRoot                string `envconfig:"RUN_AS_NON_ROOT"`
+	RunAsNonRoot                string `envconfig:"SIDECAR_RUN_AS_NON_ROOT"`
 
 	parsedEntrypointTolerations []corev1.Toleration
 }

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	KubeClusterDomain           string `envconfig:"KUBE_CLUSTER_DOMAIN"`
 	AllowedServiceAccounts      string `envconfig:"ALLOWED_SERVICE_ACCOUNTS"`
 	IgnoreEntrypointTolerations string `envconfig:"IGNORE_ENTRYPOINT_TOLERATIONS"`
+	RunAsNonRoot                string `envconfig:"RUN_AS_NON_ROOT"`
 
 	parsedEntrypointTolerations []corev1.Toleration
 }
@@ -85,6 +86,10 @@ func (c Config) GetPullPolicy() corev1.PullPolicy {
 
 func (c *Config) GetIgnoreEntrypointTolerations() []corev1.Toleration {
 	return c.parsedEntrypointTolerations
+}
+
+func (c *Config) GetRunAsNonRoot() bool {
+	return utils.IsTruthy(c.RunAsNonRoot)
 }
 
 func (c *Config) parseTolerationsJSON() {

--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -31,7 +31,7 @@ func TestGetInjectorConfig(t *testing.T) {
 		t.Setenv("ALLOWED_SERVICE_ACCOUNTS", "test-service-account1:test1,test-service-account2:test2")
 
 		cfg, err := GetConfig()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, "test-cert-file", cfg.TLSCertFile)
 		assert.Equal(t, "test-key-file", cfg.TLSKeyFile)
 		assert.Equal(t, "daprd-test-image", cfg.SidecarImage)
@@ -50,13 +50,47 @@ func TestGetInjectorConfig(t *testing.T) {
 		t.Setenv("KUBE_CLUSTER_DOMAIN", "")
 
 		cfg, err := GetConfig()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, "test-cert-file", cfg.TLSCertFile)
 		assert.Equal(t, "test-key-file", cfg.TLSKeyFile)
 		assert.Equal(t, "daprd-test-image", cfg.SidecarImage)
 		assert.Equal(t, "IfNotPresent", cfg.SidecarImagePullPolicy)
 		assert.Equal(t, "test-namespace", cfg.Namespace)
 		assert.NotEqual(t, "", cfg.KubeClusterDomain)
+	})
+
+	t.Run("sidecar run options not set", func(t *testing.T) {
+		t.Setenv("TLS_CERT_FILE", "test-cert-file")
+		t.Setenv("TLS_KEY_FILE", "test-key-file")
+		t.Setenv("SIDECAR_IMAGE", "daprd-test-image")
+		t.Setenv("NAMESPACE", "test-namespace")
+
+		// Default values are true
+		t.Setenv("SIDECAR_RUN_AS_NON_ROOT", "")
+		t.Setenv("SIDECAR_READ_ONLY_ROOT_FILESYSTEM", "")
+
+		cfg, err := GetConfig()
+		assert.NoError(t, err)
+		assert.True(t, cfg.GetRunAsNonRoot())
+		assert.True(t, cfg.GetReadOnlyRootFilesystem())
+
+		// Set to true explicitly
+		t.Setenv("SIDECAR_RUN_AS_NON_ROOT", "true")
+		t.Setenv("SIDECAR_READ_ONLY_ROOT_FILESYSTEM", "1")
+
+		cfg, err = GetConfig()
+		assert.NoError(t, err)
+		assert.True(t, cfg.GetRunAsNonRoot())
+		assert.True(t, cfg.GetReadOnlyRootFilesystem())
+
+		// Set to false
+		t.Setenv("SIDECAR_RUN_AS_NON_ROOT", "0")
+		t.Setenv("SIDECAR_READ_ONLY_ROOT_FILESYSTEM", "no")
+
+		cfg, err = GetConfig()
+		assert.NoError(t, err)
+		assert.False(t, cfg.GetRunAsNonRoot())
+		assert.False(t, cfg.GetReadOnlyRootFilesystem())
 	})
 }
 

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -95,7 +95,7 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 		TrustAnchors:                trustAnchors,
 		VolumeMounts:                sidecar.GetVolumeMounts(pod),
 		RunAsNonRoot:                i.config.GetRunAsNonRoot(),
-		ReadOnlyRootFilesystem:      true,
+		ReadOnlyRootFilesystem:      i.config.GetReadOnlyRootFilesystem(),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -94,6 +94,8 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 		Tolerations:                 pod.Spec.Tolerations,
 		TrustAnchors:                trustAnchors,
 		VolumeMounts:                sidecar.GetVolumeMounts(pod),
+		RunAsNonRoot:                i.config.GetRunAsNonRoot(),
+		ReadOnlyRootFilesystem:      true,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/injector/sidecar/container.go
+++ b/pkg/injector/sidecar/container.go
@@ -253,6 +253,13 @@ func GetSidecarContainer(cfg ContainerConfig) (*corev1.Container, error) {
 			container.SecurityContext.WindowsOptions = &corev1.WindowsSecurityContextOptions{
 				RunAsUserName: ptr.Of("ContainerAdministrator"),
 			}
+
+			// We also need to set RunAsNonRoot and ReadOnlyRootFilesystem to false, which would impact Linux too.
+			// The injector has no way to know if the pod is going to be deployed on Windows or Linux, so we need to err on the side of most compatibility.
+			// On Linux, our containers run with a non-root user, so the net effect shouldn't change: daprd is running as non-root and has no permission to write on the root FS.
+			// However certain security scanner may complain about this.
+			container.SecurityContext.RunAsNonRoot = ptr.Of(false)
+			container.SecurityContext.ReadOnlyRootFilesystem = ptr.Of(false)
 			break
 		}
 	}

--- a/pkg/injector/sidecar/container.go
+++ b/pkg/injector/sidecar/container.go
@@ -52,6 +52,8 @@ type ContainerConfig struct {
 	Tolerations                 []corev1.Toleration
 	TrustAnchors                string
 	VolumeMounts                []corev1.VolumeMount
+	RunAsNonRoot                bool
+	ReadOnlyRootFilesystem      bool
 }
 
 var (
@@ -191,8 +193,8 @@ func GetSidecarContainer(cfg ContainerConfig) (*corev1.Container, error) {
 		ImagePullPolicy: cfg.ImagePullPolicy,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.Of(false),
-			RunAsNonRoot:             ptr.Of(true),
-			ReadOnlyRootFilesystem:   ptr.Of(true),
+			RunAsNonRoot:             ptr.Of(cfg.RunAsNonRoot),
+			ReadOnlyRootFilesystem:   ptr.Of(cfg.ReadOnlyRootFilesystem),
 		},
 		Ports: ports,
 		Args:  append(cmd, args...),

--- a/pkg/injector/sidecar/container.go
+++ b/pkg/injector/sidecar/container.go
@@ -191,6 +191,8 @@ func GetSidecarContainer(cfg ContainerConfig) (*corev1.Container, error) {
 		ImagePullPolicy: cfg.ImagePullPolicy,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.Of(false),
+			RunAsNonRoot:             ptr.Of(true),
+			ReadOnlyRootFilesystem:   ptr.Of(true),
 		},
 		Ports: ports,
 		Args:  append(cmd, args...),


### PR DESCRIPTION
# Description

Changes the injector to set `runAsNonRoot` and `readOnlyRootFilesystem` to `true` for the `daprd` container by default.

New options in the Helm chart have been added to disable those additions. These are needed in certain cases such as when using a debug container.

- `dapr_sidecar_injector.sidecarRunAsNonRoot`
- `dapr_sidecar_injector.sidecarReadOnlyRootFilesystem`

This change shouldn't be a breaking change (aside from possible debug scenarios), as our production Docker containers were already running `daprd` as non-root user. Because of that, the process was already unable to write to the root filesystem anywhere.

## Issue reference

Fixes https://github.com/dapr/dapr/issues/5259

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing