### PR TITLE
/healthz/outbound should bypass API access rules too

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -413,16 +413,18 @@ func (a *api) constructShutdownEndpoints() []Endpoint {
 func (a *api) constructHealthzEndpoints() []Endpoint {
 	return []Endpoint{
 		{
-			Methods: []string{fasthttp.MethodGet},
-			Route:   "healthz",
-			Version: apiVersionV1,
-			Handler: a.onGetHealthz,
+			Methods:       []string{fasthttp.MethodGet},
+			Route:         "healthz",
+			Version:       apiVersionV1,
+			Handler:       a.onGetHealthz,
+			AlwaysAllowed: true,
 		},
 		{
-			Methods: []string{fasthttp.MethodGet},
-			Route:   "healthz/outbound",
-			Version: apiVersionV1,
-			Handler: a.onGetOutboundHealthz,
+			Methods:       []string{fasthttp.MethodGet},
+			Route:         "healthz/outbound",
+			Version:       apiVersionV1,
+			Handler:       a.onGetOutboundHealthz,
+			AlwaysAllowed: true,
 		},
 	}
 }

--- a/pkg/http/endpoint.go
+++ b/pkg/http/endpoint.go
@@ -28,4 +28,5 @@ type Endpoint struct {
 	Alias             string
 	KeepParamUnescape bool // keep the param in path unescaped
 	Handler           fasthttp.RequestHandler
+	AlwaysAllowed     bool // Endpoint is always allowed regardless of API access rules
 }

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -46,8 +46,6 @@ var (
 	infoLog = logger.NewLogger("dapr.runtime.http-info")
 )
 
-const protocol = "http"
-
 // Server is an interface for the Dapr HTTP server.
 type Server interface {
 	io.Closer
@@ -362,7 +360,7 @@ func (s *server) endpointAllowed(endpoint Endpoint) bool {
 	var httpRules []config.APIAccessRule
 
 	for _, rule := range s.apiSpec.Allowed {
-		if rule.Protocol == protocol {
+		if rule.Protocol == "http" {
 			httpRules = append(httpRules, rule)
 		}
 	}
@@ -371,7 +369,7 @@ func (s *server) endpointAllowed(endpoint Endpoint) bool {
 	}
 
 	for _, rule := range httpRules {
-		if (strings.Index(endpoint.Route, rule.Name) == 0 && endpoint.Version == rule.Version) || endpoint.Route == "healthz" {
+		if (strings.HasPrefix(endpoint.Route, rule.Name) && endpoint.Version == rule.Version) || endpoint.AlwaysAllowed {
 			return true
 		}
 	}

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -37,7 +37,10 @@ type mockHost struct {
 	hasCORS bool
 }
 
-const healthzEndpoint = "healthz"
+const (
+	healthzEndpoint         = "healthz"
+	healthzOutboundEndpoint = "healthz/outbound"
+)
 
 func (m *mockHost) mockHandler() fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
@@ -91,9 +94,10 @@ func TestAllowedAPISpec(t *testing.T) {
 
 		for _, e := range allOtherEndpoints {
 			valid := s.endpointAllowed(e)
-			if e.Route == healthzEndpoint {
+			switch e.Route {
+			case healthzEndpoint, healthzOutboundEndpoint:
 				assert.True(t, valid)
-			} else {
+			default:
 				assert.False(t, valid)
 			}
 		}
@@ -132,9 +136,10 @@ func TestAllowedAPISpec(t *testing.T) {
 
 		for _, e := range allOtherEndpoints {
 			valid := s.endpointAllowed(e)
-			if e.Route == healthzEndpoint {
+			switch e.Route {
+			case healthzEndpoint, healthzOutboundEndpoint:
 				assert.True(t, valid)
-			} else {
+			default:
 				assert.False(t, valid)
 			}
 		}
@@ -173,9 +178,10 @@ func TestAllowedAPISpec(t *testing.T) {
 
 		for _, e := range allOtherEndpoints {
 			valid := s.endpointAllowed(e)
-			if e.Route == healthzEndpoint {
+			switch e.Route {
+			case healthzEndpoint, healthzOutboundEndpoint:
 				assert.True(t, valid)
-			} else {
+			default:
 				assert.False(t, valid)
 			}
 		}
@@ -214,9 +220,10 @@ func TestAllowedAPISpec(t *testing.T) {
 
 		for _, e := range allOtherEndpoints {
 			valid := s.endpointAllowed(e)
-			if e.Route == healthzEndpoint {
+			switch e.Route {
+			case healthzEndpoint, healthzOutboundEndpoint:
 				assert.True(t, valid)
-			} else {
+			default:
 				assert.False(t, valid)
 			}
 		}
@@ -255,9 +262,10 @@ func TestAllowedAPISpec(t *testing.T) {
 
 		for _, e := range allOtherEndpoints {
 			valid := s.endpointAllowed(e)
-			if e.Route == healthzEndpoint {
+			switch e.Route {
+			case healthzEndpoint, healthzOutboundEndpoint:
 				assert.True(t, valid)
-			} else {
+			default:
 				assert.False(t, valid)
 			}
 		}
@@ -296,9 +304,10 @@ func TestAllowedAPISpec(t *testing.T) {
 
 		for _, e := range allOtherEndpoints {
 			valid := s.endpointAllowed(e)
-			if e.Route == healthzEndpoint {
+			switch e.Route {
+			case healthzEndpoint, healthzOutboundEndpoint:
 				assert.True(t, valid)
-			} else {
+			default:
 				assert.False(t, valid)
 			}
 		}
@@ -337,9 +346,10 @@ func TestAllowedAPISpec(t *testing.T) {
 
 		for _, e := range allOtherEndpoints {
 			valid := s.endpointAllowed(e)
-			if e.Route == healthzEndpoint {
+			switch e.Route {
+			case healthzEndpoint, healthzOutboundEndpoint:
 				assert.True(t, valid)
-			} else {
+			default:
 				assert.False(t, valid)
 			}
 		}


### PR DESCRIPTION
There's an obscure (ie. undocumented) route called in Dapr's HTTP server (not in gRPC) called `/healthz/outbound`, which seems to be used only by the .NET SDK to retrieve all secrets.

Just like the `/healthz` route should bypass API access rules, this route should always be allowed too.