### PR TITLE
Release 1.8: Pin contrib v1.8.6 for mDNS fix

### DIFF
--- a/docs/release_notes/v1.8.6.md
+++ b/docs/release_notes/v1.8.6.md
@@ -1,0 +1,23 @@
+# Dapr 1.8.6
+
+### Fixes mDNS name resolver component not working on systems with IPv6 disabled
+
+#### Problem
+
+Users running Dapr in self-hosted mode and relying on the mDNS name resolver (the default when not running in Kubernetes) would encounter errors trying to perform service invocation if the system had IPv6 disabled.
+
+### Impact
+
+This issue impacts users who are:
+
+- running Dapr in self-hosted mode, *and*
+- using the default mDNS name resolver, *and*
+- have disabled IPv6 on the operating system
+
+#### Root cause
+
+When initializing a zeroconf (mDNS) client, Dapr required using both IPv4 and IPv6, and failed if either one of the two protocols was disabled on the host system.
+
+#### Solution
+
+We have improved error handling so Dapr gracefully falls back to using IPv4 if binding to IPv6 fails.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1
 	github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b
 	github.com/cenkalti/backoff/v4 v4.1.2
-	github.com/dapr/components-contrib v1.8.5-rc.1
+	github.com/dapr/components-contrib v1.8.6
 	github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233
 	github.com/fasthttp/router v1.3.8
 	github.com/fsnotify/fsnotify v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3E
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.8.5-rc.1 h1:NpYx6T6eGnIQrXdymKgy2NkRW/t30QhcbuQm9JtB5bY=
-github.com/dapr/components-contrib v1.8.5-rc.1/go.mod h1:jzbbblrpo1fad70N64TOzsdMXQKcderhM9JuUhe+Ndo=
+github.com/dapr/components-contrib v1.8.6 h1:y8dBfQ+37vDUFl9/xu0aoGwN4CEDbuC8/Z7JDom2Fm4=
+github.com/dapr/components-contrib v1.8.6/go.mod h1:jzbbblrpo1fad70N64TOzsdMXQKcderhM9JuUhe+Ndo=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233 h1:M0dWIG8kUxEFU57IqTWeqptNqlBsfosFgsA5Ov7rJ8g=
 github.com/dapr/kit v0.0.2-0.20210614175626-b9074b64d233/go.mod h1:y8r0VqUNKyd6xBXp7gQjwA59wlCLGfKzL5J8iJsN09w=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

Release 1.8: Pin contrib v1.8.6 for mDNS fix