### PR TITLE
Workflow engine "black box" tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0
 	github.com/jhump/protoreflect v1.13.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/microsoft/durabletask-go v0.1.1-0.20221003221839-ca528f837da0
+	github.com/microsoft/durabletask-go v0.1.1-0.20221029020629-feea77b22f39
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5

--- a/go.sum
+++ b/go.sum
@@ -1053,8 +1053,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
-github.com/microsoft/durabletask-go v0.1.1-0.20221003221839-ca528f837da0 h1:c4SSVCGJgZZNM01uPnor7ltdZVH5BU+2DG1a4OXayAc=
-github.com/microsoft/durabletask-go v0.1.1-0.20221003221839-ca528f837da0/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
+github.com/microsoft/durabletask-go v0.1.1-0.20221029020629-feea77b22f39 h1:6qjgvF419KluiPsUaK+nsU70E0bJxHfMDO4Cy8j/zpM=
+github.com/microsoft/durabletask-go v0.1.1-0.20221029020629-feea77b22f39/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=

--- a/pkg/runtime/wfengine/activity.go
+++ b/pkg/runtime/wfengine/activity.go
@@ -83,7 +83,9 @@ func (a *activityActor) InvokeReminder(ctx context.Context, actorID string, remi
 	//       introduce some kind of heartbeat protocol to help identify such cases.
 	callback := make(chan bool)
 	wi.Properties[CallbackChannelProperty] = callback
-	a.scheduler.ScheduleActivity(wi)
+	if err = a.scheduler.ScheduleActivity(ctx, wi); err != nil {
+		return fmt.Errorf("failed to schedule an activity execution: %w", err)
+	}
 
 loop:
 	for {


### PR DESCRIPTION
## Change Summary

This PR includes several incremental improvements to the embedded workflow engine implementation:

- Updated to latest version of Durable Task dependency
- Increased max per-node concurrency from 1 to 100
- Made actor placement service mockable
- Added several workflow unit tests
- Fixed internal actor concurrency issues
- Added timeout to internal workflow and activity scheduling

### New Workflow Engine Tests

The biggest change is the addition of workflow unit tests. These are run as part of unit test executions, but they are designed more like integration tests in that they define a full workflow using Durable Task primitives and execute it to completion. Here's an example:

```go
// TestSingleActivityWorkflow executes a workflow that calls a single activity and completes. The input
// passed to the workflow is also passed to the activity, and the activity's return value is also returned
// by the workflow, allowing the test to verify input and output handling, as well as activity execution.
func TestSingleActivityWorkflow(t *testing.T) {
	r := task.NewTaskRegistry()
	r.AddOrchestratorN("SingleActivity", func(ctx *task.OrchestrationContext) (any, error) {
		var input string
		if err := ctx.GetInput(&input); err != nil {
			return nil, err
		}
		var output string
		err := ctx.CallActivity("SayHello", input).Await(&output)
		return output, err
	})
	r.AddActivityN("SayHello", func(ctx task.ActivityContext) (any, error) {
		var name string
		if err := ctx.GetInput(&name); err != nil {
			return nil, err
		}
		return fmt.Sprintf("Hello, %s!", name), nil
	})

	ctx := context.Background()
	client := startEngine(ctx, r)

	id, err := client.ScheduleNewOrchestration(ctx, "SingleActivity", api.WithInput("世界"))
	if assert.NoError(t, err) {
		metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
		if assert.NoError(t, err) {
			assert.True(t, metadata.IsComplete())
			assert.Equal(t, `"世界"`, metadata.SerializedInput)
			assert.Equal(t, `"Hello, 世界!"`, metadata.SerializedOutput)
		}
	}
}
```
The workflow is defined and managed using public APIs defined in https://github.com/microsoft/durabletask-go. These APIs are very similar to the ones that will be exposed by the Dapr WF SDKs (in fact, the Dapr WF Go SDK will likely use these exact APIs internally).

This "black box" approach to testing workflows was intentionally chosen to ensure our tests are reflective of the code that developers will actually write. It also makes the code more resilient to internal code refactoring.

Note that rather than going through the gRPC layer, these workflows and the client that manages them interface more directly with the internal workflow actors. 

**Production:**
<samp>[client] ---(grpc)--> [durabletask] --> [actors] ---(grpc)--> [workflows]</samp>

**These tests:**
<samp>[client] --> [durabletask] --> [actors] --> [workflows]</samp>

## Mockable Placement service

In order to execute these kinds of black-box tests, we needed the placement service to be mockable. This PR therefore adds a new `PlacementService` interface and allows it to be set when constructing the actor runtime.

```go
// PlacementService allows for interacting with the actor placement service.
type PlacementService interface {
	Start()
	Stop()
	WaitUntilPlacementTableIsReady()
	LookupActor(actorType, actorID string) (host string, appID string)
}
```

With the placement service being made mockable, it's now possible to do broader testing of actor behavior.

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [x] ~~Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]~~
* [x] ~~Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]~~
* [x] ~~Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]~~

Signed-off-by: Chris Gillum <cgillum@microsoft.com>