### PR TITLE
Pin redislabs/rejson to 2.0.11

### DIFF
--- a/tests/config/redis_override.yaml
+++ b/tests/config/redis_override.yaml
@@ -16,7 +16,7 @@ auth:
 
 image:
   repository: redislabs/rejson
-  tag: latest
+  tag: 2.0.11
 
 architecture: standalone
 


### PR DESCRIPTION
E2E tests are currently failing because the redis image fails to deploy.

Looks like 4 days ago (when our tests started failing), [redislabs/rejson](https://hub.docker.com/r/redislabs/rejson/) version 2.4.0 was published, and that image doesn't include the "redissearch" library anymore. Because our Helm chart for Redis references `redislabs/rejson:latest`, it broke.

This PR rolls back the version to 2.0.11 which is the latest one to include the redissearch library. The previous version, 2.2.0, doesn't include it either.

Because 2.2.0 was released 3 months ago, it's entirely unclear to me why our tests didn't break earlier.

PS: This is probably another sign that we need to migrate to some other Helm chart for Redis. In addition to the fact that our current charts don't run on arm64.