### PR TITLE
Hotfix 1.9.2 for panics in gRPC events with tracing disabled

### DIFF
--- a/docs/release_notes/v1.9.2.md
+++ b/docs/release_notes/v1.9.2.md
@@ -19,4 +19,4 @@ Dapr 1.9.0 added support for tracing with OpenTelemetry, which uses a new SDK ve
 
 #### Solution
 
-We have added the missing `nil` checks to correctly handle the case where tracing is diabled.
+We have added the missing `nil` checks to correctly handle the case where tracing is disabled.

--- a/docs/release_notes/v1.9.2.md
+++ b/docs/release_notes/v1.9.2.md
@@ -1,0 +1,22 @@
+# Dapr 1.9.2
+
+### Fixes panics when using pubsub subscriptions or input bindings via gRPC with tracing disabled
+
+#### Problem
+
+Users who disabled tracing and are subscribing to Dapr pubsub components via gRPC or using input bindings via gRPC will encounter panics when an event is attempted to be delivered.
+
+### Impact
+
+This issue impacts users who:
+
+- Disabled tracing (sampling rate is set to 0, not the default Dapr config sets this to 1)
+- Use input bindings via gRPC and/or subscribe to pubsub components via gRPC
+
+#### Root cause
+
+A code refactor of a tracing utility function previously required by changes in our upstream tracing libraries changed the return signature from a pointer to a value. Several `nil` checks were missing in the code resulting in panics. This previously presented no concern because a method call on a nil pointer is a `no-op` in Go.
+
+#### Solution
+
+We have added the missing `nil` checks to correctly handle the case where tracing is diabled.

--- a/docs/release_notes/v1.9.2.md
+++ b/docs/release_notes/v1.9.2.md
@@ -10,12 +10,12 @@ Users who disabled tracing and are subscribing to Dapr pubsub components via gRP
 
 This issue impacts users who:
 
-- Disabled tracing (sampling rate is set to 0, not the default Dapr config sets this to 1)
+- Disabled tracing by setting samplingRate to "0" in Dapr's configuration (by default, the value is "1")
 - Use input bindings via gRPC and/or subscribe to pubsub components via gRPC
 
 #### Root cause
 
-A code refactor of a tracing utility function previously required by changes in our upstream tracing libraries changed the return signature from a pointer to a value. Several `nil` checks were missing in the code resulting in panics. This previously presented no concern because a method call on a nil pointer is a `no-op` in Go.
+Dapr 1.9.0 added support for tracing with OpenTelemetry, which uses a new SDK version. During the upgrade, an error was introduced causing a panic when tracing was disabled, due to a missing "nil-check".
 
 #### Solution
 

--- a/tests/config/redis_override.yaml
+++ b/tests/config/redis_override.yaml
@@ -16,7 +16,7 @@ auth:
 
 image:
   repository: redislabs/rejson
-  tag: latest
+  tag: 2.0.11
 
 architecture: standalone
 


### PR DESCRIPTION
# Description

Hotfix for panics when tracing is disabled and events are delivered via gRPC.