### PR TITLE
Fix tracing sampler

### DIFF
--- a/pkg/diagnostics/tracing_sampler.go
+++ b/pkg/diagnostics/tracing_sampler.go
@@ -1,0 +1,44 @@
+package diagnostics
+
+import (
+	"fmt"
+
+	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type DaprTraceSampler struct {
+	sdktrace.Sampler
+	ProbabilitySampler sdktrace.Sampler
+	SamplingRate       float64
+}
+
+/**
+ * Decisions for the Dapr sampler are as follows:
+ *  - parent has sample flag turned on -> sample
+ *  - parent has sample turned off -> fall back to probability-based sampling
+ */
+func (d *DaprTraceSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+
+	psc := trace.SpanContextFromContext(p.ParentContext)
+	if psc.IsValid() && psc.IsSampled() {
+		// Parent is valid and specifies sampling flag is on -> sample
+		return sdktrace.AlwaysSample().ShouldSample(p)
+	}
+
+	// Parent is invalid or does not have sampling enabled -> sample probabilistically
+	return d.ProbabilitySampler.ShouldSample(p)
+}
+
+func (d *DaprTraceSampler) Description() string {
+	return fmt.Sprintf("DaprTraceSampler(P=%f)", d.SamplingRate)
+}
+
+func NewDaprTraceSampler(samplingRateString string) *DaprTraceSampler {
+	samplingRate := diagUtils.GetTraceSamplingRate(samplingRateString)
+	return &DaprTraceSampler{
+		SamplingRate:       samplingRate,
+		ProbabilitySampler: sdktrace.TraceIDRatioBased(samplingRate),
+	}
+}

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -15,10 +15,15 @@ package diagnostics
 
 import (
 	"context"
+	crand "crypto/rand"
+	"encoding/binary"
 	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/pkg/config"
 
@@ -138,7 +143,7 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 		assert.NotEqual(t, "00f067aa0ba902b7", fmt.Sprintf("%x", spanID[:]))
 	})
 
-	t.Run("traceparent is provided but sampling is disabled", func(t *testing.T) {
+	t.Run("traceparent is provided with sampling flag = 1 but sampling is disabled", func(t *testing.T) {
 		traceSpec := config.TracingSpec{SamplingRate: "0"}
 
 		scConfig := trace.SpanContextConfig{
@@ -154,6 +159,66 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 		assert.Nil(t, gotSp)
 		assert.NotNil(t, ctx)
 	})
+
+	t.Run("traceparent is provided with sampling flag = 0 and sampling is enabled (but not P=1.00)", func(t *testing.T) {
+		numTraces := 100000
+		sampledCount := runTraces(t, "test_trace", numTraces, "0.01", 0)
+		require.Greater(t, sampledCount, 0, "Expected to sample at least one span, but did not sample any!")
+		require.Less(t, sampledCount, numTraces, "Expected to sample fewer than the total number of traces, but sampled all of them!")
+	})
+
+	t.Run("traceparent is provided with sampling flag = 0 and sampling is enabled (and P=1.00)", func(t *testing.T) {
+		numTraces := 1000
+		sampledCount := runTraces(t, "test_trace", numTraces, "1.00", 0)
+		require.Equal(t, sampledCount, numTraces, "Expected to sample all traces (%d) but only sampled %d", numTraces, sampledCount)
+	})
+
+	t.Run("traceparent is provided with sampling flag = 1 and sampling is enabled (but not P=1.00)", func(t *testing.T) {
+		numTraces := 1000
+		sampledCount := runTraces(t, "test_trace", numTraces, "0.00001", 1)
+		require.Equal(t, sampledCount, numTraces, "Expected to sample all traces (%d) but only sampled %d", numTraces, sampledCount)
+	})
+
+}
+
+func runTraces(t *testing.T, test_name string, numTraces int, samplingRate string, parentTraceFlag int) int {
+	d := NewDaprTraceSampler(samplingRate)
+	tracerOptions := []sdktrace.TracerProviderOption{
+		sdktrace.WithSampler(d),
+	}
+
+	tp := sdktrace.NewTracerProvider(tracerOptions...)
+
+	tracerName := fmt.Sprintf("%s_%s", test_name, samplingRate)
+	otel.SetTracerProvider(tp)
+	tracer := otel.Tracer(tracerName)
+
+	// This is taken from otel's tests for the ratio sampler so we can generate IDs
+	idg := defaultIDGenerator()
+	sampledCount := 0
+
+	for i := 0; i < numTraces; i++ {
+		traceID, _ := idg.NewIDs(context.Background())
+		scConfig := trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
+			TraceFlags: trace.TraceFlags(parentTraceFlag),
+		}
+
+		parent := trace.NewSpanContext(scConfig)
+
+		ctx := context.Background()
+		ctx = trace.ContextWithRemoteSpanContext(ctx, parent)
+		ctx, span := tracer.Start(ctx, "testTraceSpan", trace.WithSpanKind(trace.SpanKindClient))
+		assert.NotNil(t, span)
+		assert.NotNil(t, ctx)
+
+		if span.SpanContext().IsSampled() {
+			sampledCount += 1
+		}
+	}
+
+	return sampledCount
 }
 
 // This test would allow us to know when the span attribute keys are
@@ -220,4 +285,59 @@ func (o *otelFakeSpanProcessor) Shutdown(ctx context.Context) error {
 // ForceFlush implements the SpanProcessor interface.
 func (o *otelFakeSpanProcessor) ForceFlush(ctx context.Context) error {
 	return nil
+}
+
+// This was taken from the otel testing to generate IDs
+// origin: go.opentelemetry.io/otel/sdk@v1.11.1/trace/id_generator.go
+
+// IDGenerator allows custom generators for TraceID and SpanID.
+type IDGenerator interface {
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+
+	// NewIDs returns a new trace and span ID.
+	NewIDs(ctx context.Context) (trace.TraceID, trace.SpanID)
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+
+	// NewSpanID returns a ID for a new span in the trace with traceID.
+	NewSpanID(ctx context.Context, traceID trace.TraceID) trace.SpanID
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+}
+
+type randomIDGenerator struct {
+	sync.Mutex
+	randSource *rand.Rand
+}
+
+var _ IDGenerator = &randomIDGenerator{}
+
+// NewSpanID returns a non-zero span ID from a randomly-chosen sequence.
+func (gen *randomIDGenerator) NewSpanID(ctx context.Context, traceID trace.TraceID) trace.SpanID {
+	gen.Lock()
+	defer gen.Unlock()
+	sid := trace.SpanID{}
+	_, _ = gen.randSource.Read(sid[:])
+	return sid
+}
+
+// NewIDs returns a non-zero trace ID and a non-zero span ID from a
+// randomly-chosen sequence.
+func (gen *randomIDGenerator) NewIDs(ctx context.Context) (trace.TraceID, trace.SpanID) {
+	gen.Lock()
+	defer gen.Unlock()
+	tid := trace.TraceID{}
+	_, _ = gen.randSource.Read(tid[:])
+	sid := trace.SpanID{}
+	_, _ = gen.randSource.Read(sid[:])
+	return tid, sid
+}
+
+func defaultIDGenerator() IDGenerator {
+	gen := &randomIDGenerator{}
+	var rngSeed int64
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
+	gen.randSource = rand.New(rand.NewSource(rngSeed))
+	return gen
 }

--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -68,11 +68,6 @@ func GetTraceSamplingRate(rate string) float64 {
 	return f
 }
 
-// TraceSampler returns Probability Sampler option.
-func TraceSampler(samplingRate string) sdktrace.Sampler {
-	return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(GetTraceSamplingRate(samplingRate)))
-}
-
 // IsTracingEnabled parses the given rate and returns false if sampling rate is explicitly set 0.
 func IsTracingEnabled(rate string) bool {
 	return GetTraceSamplingRate(rate) != 0

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -333,14 +333,16 @@ func (a *DaprRuntime) getOperatorClient() (operatorv1pb.OperatorClient, error) {
 // setupTracing set up the trace exporters. Technically we don't need to pass `hostAddress` in,
 // but we do so here to explicitly call out the dependency on having `hostAddress` computed.
 func (a *DaprRuntime) setupTracing(hostAddress string, tpStore tracerProviderStore) error {
+	tracingSpec := a.globalConfig.Spec.TracingSpec
+
 	// Register stdout trace exporter if user wants to debug requests or log as Info level.
-	if a.globalConfig.Spec.TracingSpec.Stdout {
+	if tracingSpec.Stdout {
 		tpStore.RegisterExporter(diagUtils.NewStdOutExporter())
 	}
 
 	// Register zipkin trace exporter if ZipkinSpec is specified
-	if a.globalConfig.Spec.TracingSpec.Zipkin.EndpointAddress != "" {
-		zipkinExporter, err := zipkin.New(a.globalConfig.Spec.TracingSpec.Zipkin.EndpointAddress)
+	if tracingSpec.Zipkin.EndpointAddress != "" {
+		zipkinExporter, err := zipkin.New(tracingSpec.Zipkin.EndpointAddress)
 		if err != nil {
 			return err
 		}
@@ -348,13 +350,13 @@ func (a *DaprRuntime) setupTracing(hostAddress string, tpStore tracerProviderSto
 	}
 
 	// Register otel trace exporter if OtelSpec is specified
-	if a.globalConfig.Spec.TracingSpec.Otel.EndpointAddress != "" && a.globalConfig.Spec.TracingSpec.Otel.Protocol != "" {
-		endpoint := a.globalConfig.Spec.TracingSpec.Otel.EndpointAddress
-		protocol := a.globalConfig.Spec.TracingSpec.Otel.Protocol
+	if tracingSpec.Otel.EndpointAddress != "" && tracingSpec.Otel.Protocol != "" {
+		endpoint := tracingSpec.Otel.EndpointAddress
+		protocol := tracingSpec.Otel.Protocol
 		if protocol != "http" && protocol != "grpc" {
 			return fmt.Errorf("invalid protocol %v provided for Otel endpoint", protocol)
 		}
-		isSecure := a.globalConfig.Spec.TracingSpec.Otel.IsSecure
+		isSecure := tracingSpec.Otel.IsSecure
 
 		var client otlptrace.Client
 		if protocol == "http" {
@@ -386,7 +388,10 @@ func (a *DaprRuntime) setupTracing(hostAddress string, tpStore tracerProviderSto
 	tpStore.RegisterResource(r)
 
 	// Register a trace sampler based on Sampling settings
-	tpStore.RegisterSampler(diagUtils.TraceSampler(a.globalConfig.Spec.TracingSpec.SamplingRate))
+	daprTraceSampler := diag.NewDaprTraceSampler(tracingSpec.SamplingRate)
+	log.Infof("Dapr trace sampler initialized: %s", daprTraceSampler.Description())
+
+	tpStore.RegisterSampler(daprTraceSampler)
 
 	tpStore.RegisterTracerProvider()
 


### PR DESCRIPTION
Addresses #5443 in that when a traceparent header is passed into Dapr and the sampling flag is zero, we will use the sampling rate instead of not sampling at all.

# Description

Added a DaprTraceSampler that has the logic we use for handling sampling decisions - this deviates somewhat from the previous implementation in that if the parent header exists and is supposed to be sampled then we will follow suit, otherwise we will make a determination based on sampling rate.

## Issue reference

Please reference the issue this PR will close: #5443

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing

