### PR TITLE
Hotfix: Fix tracing sampler behavior

### DIFF
--- a/docs/release_notes/v1.9.3.md
+++ b/docs/release_notes/v1.9.3.md
@@ -1,0 +1,28 @@
+# Dapr 1.9.3
+ 
+## Fixes traces not being reported in certain circumstances
+ 
+### Problem
+ 
+With tracing enabled, Dapr operators can choose the sampling rate using the `spec.tracing.sampling` option in the Dapr configuration. In Dapr 1.9.0-1.9.2, when a request coming to the Dapr runtime contains a `traceparent` header, the decision on whether to sample the request or not is solely based on the "sampling bit" set in the header's value.
+ 
+This behavior was introduced with Dapr 1.9.0 during the transition to the new tracing framework based on the OpenTelemetry (OTEL) standard. Although this behavior is compliant with the W3C specs for distributed tracing, it caused Dapr to omit sending traces to the telemetry collector (e.g. Zipkin, Azure Monitor, etc) in many instances.
+ 
+### Impact
+ 
+The issue impacts users on Dapr 1.9.0-1.9.2 who have enabled collection of traces.
+ 
+Based on reports from Dapr users, developers building apps with ASP.NET Core seem to be particularly impacted, as the .NET Core framework can automatically include a `traceparent` header in every request made to the Dapr sidecar which has the "sampling bit" set to `0` (disabled).
+ 
+### Root cause
+ 
+Older versions of Dapr (before 1.9.0) ignored the "sampling bit" in the `traceparent` header when making decisions on whether to sample a request. That behavior changed in Dapr 1.9.0, where the decision made by the caller with the `traceparent` header determines the Dapr runtime's sampling choice too.
+ 
+### Solution
+ 
+We have patched the way Dapr makes decisions on whether to sample a request and submit the trace to the telemetry collector (e.g. Zipkin, Azure Monitor, etc). The new behavior consists of:
+ 
+- If the `traceparent` header has the "sampling bit" set to `1` (enabled), the request is always sampled.
+- If the "sampling bit" is `0` (disabled), Dapr decides on whether to sample the request based on its own internal policies. For example, with `spec.tracing.sampling` set to `1`, all requests are traced; instead, a value of `0` generates no trace. Numbers in-between 0 and 1 cause Dapr to sample only a fraction of requests.
+ 
+This behavior, while more lax, remains compliant with the W3C specs for distributed tracing.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -42,14 +42,14 @@ var (
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -42,14 +42,14 @@ var (
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/diagnostics/tracing_sampler.go
+++ b/pkg/diagnostics/tracing_sampler.go
@@ -1,0 +1,44 @@
+package diagnostics
+
+import (
+	"fmt"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
+)
+
+type DaprTraceSampler struct {
+	sdktrace.Sampler
+	ProbabilitySampler sdktrace.Sampler
+	SamplingRate       float64
+}
+
+/**
+ * Decisions for the Dapr sampler are as follows:
+ *  - parent has sample flag turned on -> sample
+ *  - parent has sample turned off -> fall back to probability-based sampling
+ */
+func (d *DaprTraceSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	psc := trace.SpanContextFromContext(p.ParentContext)
+	if psc.IsValid() && psc.IsSampled() {
+		// Parent is valid and specifies sampling flag is on -> sample
+		return sdktrace.AlwaysSample().ShouldSample(p)
+	}
+
+	// Parent is invalid or does not have sampling enabled -> sample probabilistically
+	return d.ProbabilitySampler.ShouldSample(p)
+}
+
+func (d *DaprTraceSampler) Description() string {
+	return fmt.Sprintf("DaprTraceSampler(P=%f)", d.SamplingRate)
+}
+
+func NewDaprTraceSampler(samplingRateString string) *DaprTraceSampler {
+	samplingRate := diagUtils.GetTraceSamplingRate(samplingRateString)
+	return &DaprTraceSampler{
+		SamplingRate:       samplingRate,
+		ProbabilitySampler: sdktrace.TraceIDRatioBased(samplingRate),
+	}
+}

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -287,6 +287,8 @@ func (o *otelFakeSpanProcessor) ForceFlush(ctx context.Context) error {
 
 // This was taken from the otel testing to generate IDs
 // origin: go.opentelemetry.io/otel/sdk@v1.11.1/trace/id_generator.go
+// Copyright: The OpenTelemetry Authors
+// License (Apache 2.0): https://github.com/open-telemetry/opentelemetry-go/blob/sdk/v1.11.1/LICENSE
 
 // IDGenerator allows custom generators for TraceID and SpanID.
 type IDGenerator interface {

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -15,10 +15,15 @@ package diagnostics
 
 import (
 	"context"
+	crand "crypto/rand"
+	"encoding/binary"
 	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/pkg/config"
 
@@ -138,7 +143,7 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 		assert.NotEqual(t, "00f067aa0ba902b7", fmt.Sprintf("%x", spanID[:]))
 	})
 
-	t.Run("traceparent is provided but sampling is disabled", func(t *testing.T) {
+	t.Run("traceparent is provided with sampling flag = 1 but sampling is disabled", func(t *testing.T) {
 		traceSpec := config.TracingSpec{SamplingRate: "0"}
 
 		scConfig := trace.SpanContextConfig{
@@ -154,6 +159,65 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 		assert.Nil(t, gotSp)
 		assert.NotNil(t, ctx)
 	})
+
+	t.Run("traceparent is provided with sampling flag = 0 and sampling is enabled (but not P=1.00)", func(t *testing.T) {
+		numTraces := 100000
+		sampledCount := runTraces(t, "test_trace", numTraces, "0.01", 0)
+		require.Greater(t, sampledCount, 0, "Expected to sample at least one span, but did not sample any!")
+		require.Less(t, sampledCount, numTraces, "Expected to sample fewer than the total number of traces, but sampled all of them!")
+	})
+
+	t.Run("traceparent is provided with sampling flag = 0 and sampling is enabled (and P=1.00)", func(t *testing.T) {
+		numTraces := 1000
+		sampledCount := runTraces(t, "test_trace", numTraces, "1.00", 0)
+		require.Equal(t, sampledCount, numTraces, "Expected to sample all traces (%d) but only sampled %d", numTraces, sampledCount)
+	})
+
+	t.Run("traceparent is provided with sampling flag = 1 and sampling is enabled (but not P=1.00)", func(t *testing.T) {
+		numTraces := 1000
+		sampledCount := runTraces(t, "test_trace", numTraces, "0.00001", 1)
+		require.Equal(t, sampledCount, numTraces, "Expected to sample all traces (%d) but only sampled %d", numTraces, sampledCount)
+	})
+}
+
+func runTraces(t *testing.T, test_name string, numTraces int, samplingRate string, parentTraceFlag int) int {
+	d := NewDaprTraceSampler(samplingRate)
+	tracerOptions := []sdktrace.TracerProviderOption{
+		sdktrace.WithSampler(d),
+	}
+
+	tp := sdktrace.NewTracerProvider(tracerOptions...)
+
+	tracerName := fmt.Sprintf("%s_%s", test_name, samplingRate)
+	otel.SetTracerProvider(tp)
+	tracer := otel.Tracer(tracerName)
+
+	// This is taken from otel's tests for the ratio sampler so we can generate IDs
+	idg := defaultIDGenerator()
+	sampledCount := 0
+
+	for i := 0; i < numTraces; i++ {
+		traceID, _ := idg.NewIDs(context.Background())
+		scConfig := trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},
+			TraceFlags: trace.TraceFlags(parentTraceFlag),
+		}
+
+		parent := trace.NewSpanContext(scConfig)
+
+		ctx := context.Background()
+		ctx = trace.ContextWithRemoteSpanContext(ctx, parent)
+		ctx, span := tracer.Start(ctx, "testTraceSpan", trace.WithSpanKind(trace.SpanKindClient))
+		assert.NotNil(t, span)
+		assert.NotNil(t, ctx)
+
+		if span.SpanContext().IsSampled() {
+			sampledCount += 1
+		}
+	}
+
+	return sampledCount
 }
 
 // This test would allow us to know when the span attribute keys are
@@ -220,4 +284,59 @@ func (o *otelFakeSpanProcessor) Shutdown(ctx context.Context) error {
 // ForceFlush implements the SpanProcessor interface.
 func (o *otelFakeSpanProcessor) ForceFlush(ctx context.Context) error {
 	return nil
+}
+
+// This was taken from the otel testing to generate IDs
+// origin: go.opentelemetry.io/otel/sdk@v1.11.1/trace/id_generator.go
+
+// IDGenerator allows custom generators for TraceID and SpanID.
+type IDGenerator interface {
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+
+	// NewIDs returns a new trace and span ID.
+	NewIDs(ctx context.Context) (trace.TraceID, trace.SpanID)
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+
+	// NewSpanID returns a ID for a new span in the trace with traceID.
+	NewSpanID(ctx context.Context, traceID trace.TraceID) trace.SpanID
+	// DO NOT CHANGE: any modification will not be backwards compatible and
+	// must never be done outside of a new major release.
+}
+
+type randomIDGenerator struct {
+	sync.Mutex
+	randSource *rand.Rand
+}
+
+var _ IDGenerator = &randomIDGenerator{}
+
+// NewSpanID returns a non-zero span ID from a randomly-chosen sequence.
+func (gen *randomIDGenerator) NewSpanID(ctx context.Context, traceID trace.TraceID) trace.SpanID {
+	gen.Lock()
+	defer gen.Unlock()
+	sid := trace.SpanID{}
+	_, _ = gen.randSource.Read(sid[:])
+	return sid
+}
+
+// NewIDs returns a non-zero trace ID and a non-zero span ID from a
+// randomly-chosen sequence.
+func (gen *randomIDGenerator) NewIDs(ctx context.Context) (trace.TraceID, trace.SpanID) {
+	gen.Lock()
+	defer gen.Unlock()
+	tid := trace.TraceID{}
+	_, _ = gen.randSource.Read(tid[:])
+	sid := trace.SpanID{}
+	_, _ = gen.randSource.Read(sid[:])
+	return tid, sid
+}
+
+func defaultIDGenerator() IDGenerator {
+	gen := &randomIDGenerator{}
+	var rngSeed int64
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
+	gen.randSource = rand.New(rand.NewSource(rngSeed))
+	return gen
 }

--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -68,11 +68,6 @@ func GetTraceSamplingRate(rate string) float64 {
 	return f
 }
 
-// TraceSampler returns Probability Sampler option.
-func TraceSampler(samplingRate string) sdktrace.Sampler {
-	return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(GetTraceSamplingRate(samplingRate)))
-}
-
 // IsTracingEnabled parses the given rate and returns false if sampling rate is explicitly set 0.
 func IsTracingEnabled(rate string) bool {
 	return GetTraceSamplingRate(rate) != 0

--- a/pkg/grpc/proxy/testserviceV1/test.v1.pb.go
+++ b/pkg/grpc/proxy/testserviceV1/test.v1.pb.go
@@ -6,11 +6,12 @@ package testserviceV1
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/tests/e2e/actor_activation/actor_activation_test.go
+++ b/tests/e2e/actor_activation/actor_activation_test.go
@@ -6,7 +6,9 @@ Copyright 2021 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/e2e/bindings/bindings_test.go
+++ b/tests/e2e/bindings/bindings_test.go
@@ -217,7 +217,8 @@ func testBindingsForApp(app struct {
 	inputApp     string
 	inputGRPCApp string
 	outputApp    string
-}) func(t *testing.T) {
+},
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		// setup
 		outputExternalURL := tr.Platform.AcquireAppExternalURL(app.outputApp)
@@ -281,6 +282,7 @@ func testBindingsForApp(app struct {
 		require.Equal(t, testMessages[0], decodedResponse.FailedMessage)
 	}
 }
+
 func TestBindings(t *testing.T) {
 	for idx := range bindingsApps {
 		app := bindingsApps[idx]

--- a/tests/e2e/runtime/runtime_test.go
+++ b/tests/e2e/runtime/runtime_test.go
@@ -6,7 +6,9 @@ Copyright 2021 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/e2e/stateapp/stateapp_test.go
+++ b/tests/e2e/stateapp/stateapp_test.go
@@ -380,19 +380,21 @@ func generateSpecificLengthSample(sizeInBytes int) requestResponse {
 	}
 }
 
-var tr *runner.TestRunner
-var stateStoreApps []struct {
-	name       string
-	stateStore string
-} = []struct {
-	name       string
-	stateStore string
-}{
-	{
-		name:       appName,
-		stateStore: "statestore",
-	},
-}
+var (
+	tr             *runner.TestRunner
+	stateStoreApps []struct {
+		name       string
+		stateStore string
+	} = []struct {
+		name       string
+		stateStore string
+	}{
+		{
+			name:       appName,
+			stateStore: "statestore",
+		},
+	}
+)
 
 func TestMain(m *testing.M) {
 	utils.SetupLogs("stateapp")
@@ -488,7 +490,6 @@ func TestStateApp(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func TestStateTransactionApps(t *testing.T) {

--- a/tests/perf/actor_timer/actor_timer_test.go
+++ b/tests/perf/actor_timer/actor_timer_test.go
@@ -6,7 +6,9 @@ Copyright 2021 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
# Dapr 1.9.3
 
## Fixes traces not being reported in certain circumstances
 
### Problem
 
With tracing enabled, Dapr operators can choose the sampling rate using the `spec.tracing.sampling` option in the Dapr configuration. In Dapr 1.9.0-1.9.2, when a request coming to the Dapr runtime contains a `traceparent` header, the decision on whether to sample the request or not is solely based on the "sampling bit" set in the header's value.
 
This behavior was introduced with Dapr 1.9.0 during the transition to the new tracing framework based on the OpenTelemetry (OTEL) standard. Although this behavior is compliant with the W3C specs for distributed tracing, it caused Dapr to omit sending traces to the telemetry collector (e.g. Zipkin, Azure Monitor, etc) in many instances.
 
### Impact
 
The issue impacts users on Dapr 1.9.0-1.9.2 who have enabled collection of traces.
 
Based on reports from Dapr users, developers building apps with ASP.NET Core seem to be particularly impacted, as the .NET Core framework can automatically include a `traceparent` header in every request made to the Dapr sidecar which has the "sampling bit" set to `0` (disabled).
 
### Root cause
 
Older versions of Dapr (before 1.9.0) ignored the "sampling bit" in the `traceparent` header when making decisions on whether to sample a request. That behavior changed in Dapr 1.9.0, where the decision made by the caller with the `traceparent` header determines the Dapr runtime's sampling choice too.
 
### Solution
 
We have patched the way Dapr makes decisions on whether to sample a request and submit the trace to the telemetry collector (e.g. Zipkin, Azure Monitor, etc). The new behavior consists of:
 
- If the `traceparent` header has the "sampling bit" set to `1` (enabled), the request is always sampled.
- If the "sampling bit" is `0` (disabled), Dapr decides on whether to sample the request based on its own internal policies. For example, with `spec.tracing.sampling` set to `1`, all requests are traced; instead, a value of `0` generates no trace. Numbers in-between 0 and 1 cause Dapr to sample only a fraction of requests.
 
This behavior, while more lax, remains compliant with the W3C specs for distributed tracing.
 