### PR TITLE
config subscribe all fix for grpc

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1849,27 +1849,7 @@ func (a *api) SubscribeConfigurationAlpha1(request *runtimev1pb.SubscribeConfigu
 	newCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// empty list means subscribing to all configuration keys
-	if len(request.Keys) == 0 {
-		getConfigurationReq := &runtimev1pb.GetConfigurationRequest{
-			StoreName: request.StoreName,
-			Keys:      []string{},
-			Metadata:  request.GetMetadata(),
-		}
-		resp, err2 := a.GetConfigurationAlpha1(newCtx, getConfigurationReq)
-		if err2 != nil {
-			err2 = status.Errorf(codes.Internal, fmt.Sprintf(messages.ErrConfigurationGet, request.Keys, request.StoreName, err2))
-			apiServerLogger.Debug(err2)
-			return err2
-		}
-
-		items := resp.GetItems()
-		for key := range items {
-			if _, ok := a.configurationSubscribe[fmt.Sprintf("%s||%s", request.StoreName, key)]; !ok {
-				subscribeKeys = append(subscribeKeys, key)
-			}
-		}
-	} else {
+	if len(request.Keys) > 0 {
 		subscribeKeys = append(subscribeKeys, request.Keys...)
 	}
 

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -3060,8 +3060,8 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 
 		_, err = resp.Recv()
 		assert.NoError(t, err)
-		// Subscribe now calls Get first so we have an extra call.
-		assert.Equal(t, 3, failingConfigStore.Failure.CallCount("failingSubscribeKey"))
+
+		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("failingSubscribeKey"))
 	})
 
 	t.Run("test subscribe configuration fails due to timeout with resiliency", func(t *testing.T) {

--- a/pkg/testing/store_mock.go
+++ b/pkg/testing/store_mock.go
@@ -118,6 +118,10 @@ func (f *FailingConfigurationStore) Init(metadata configuration.Metadata) error 
 }
 
 func (f *FailingConfigurationStore) Subscribe(ctx context.Context, req *configuration.SubscribeRequest, handler configuration.UpdateHandler) (string, error) {
+	if err := f.Failure.PerformFailure(req.Metadata["key"]); err != nil {
+		return "", err
+	}
+
 	handler(ctx, &configuration.UpdateEvent{
 		Items: map[string]*configuration.Item{
 			req.Metadata["key"]: {
@@ -125,9 +129,7 @@ func (f *FailingConfigurationStore) Subscribe(ctx context.Context, req *configur
 			},
 		},
 	})
-	if err := f.Failure.PerformFailure(req.Metadata["key"]); err != nil {
-		return "", err
-	}
+	
 	return "subscribeID", nil
 }
 


### PR DESCRIPTION
Signed-off-by: shivam <shivamkm07@gmail.com>

# Description

Fixes Subscribe to all keys not notifying changes for new keys for grpc. Fix for http was added in 1.9: https://github.com/dapr/dapr/pull/5317

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #5183 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
