### PR TITLE
Added state storage for workflow execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0
 	github.com/jhump/protoreflect v1.13.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/microsoft/durabletask-go v0.1.1-0.20221029020629-feea77b22f39
+	github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0
 	github.com/jhump/protoreflect v1.13.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9
+	github.com/microsoft/durabletask-go v0.1.1-0.20221108194024-959ace8a17f8
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5

--- a/go.sum
+++ b/go.sum
@@ -1065,6 +1065,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
 github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9 h1:YuMqBioWLOtaQNsSrhzDXLaELzC/P9qrFBMYM+tjV/I=
 github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
+github.com/microsoft/durabletask-go v0.1.1-0.20221108194024-959ace8a17f8 h1:PNeAlEGPooBawmcKud1WQCx3LgCZZmWboe/CJRXwFiI=
+github.com/microsoft/durabletask-go v0.1.1-0.20221108194024-959ace8a17f8/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=

--- a/go.sum
+++ b/go.sum
@@ -1063,8 +1063,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
-github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9 h1:YuMqBioWLOtaQNsSrhzDXLaELzC/P9qrFBMYM+tjV/I=
-github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
 github.com/microsoft/durabletask-go v0.1.1-0.20221108194024-959ace8a17f8 h1:PNeAlEGPooBawmcKud1WQCx3LgCZZmWboe/CJRXwFiI=
 github.com/microsoft/durabletask-go v0.1.1-0.20221108194024-959ace8a17f8/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/go.sum
+++ b/go.sum
@@ -1063,8 +1063,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
-github.com/microsoft/durabletask-go v0.1.1-0.20221029020629-feea77b22f39 h1:6qjgvF419KluiPsUaK+nsU70E0bJxHfMDO4Cy8j/zpM=
-github.com/microsoft/durabletask-go v0.1.1-0.20221029020629-feea77b22f39/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
+github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9 h1:YuMqBioWLOtaQNsSrhzDXLaELzC/P9qrFBMYM+tjV/I=
+github.com/microsoft/durabletask-go v0.1.1-0.20221104210029-b17e1ae3c6b9/go.mod h1:aVBSXXq71muiS2FhKWq3qk6uS6VT3u4HbXy3BFSAENo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=

--- a/pkg/runtime/wfengine/README.md
+++ b/pkg/runtime/wfengine/README.md
@@ -71,7 +71,7 @@ Each workflow instance corresponds to a single `dapr.internal.wfengine.workflow`
 Each workflow actor saves its state using the following keys:
 
 * `metadata`: Contains meta information about the workflow as a JSON blob. Includes information such as the length of the inbox, the length of the history, and a UUID representing the workflow generation (for cases where the instance ID gets reused). The length information is used to determine which keys need to be read or written to when loading or saving workflow state updates.
-* `inbox-NNNNNN`: Multiple keys containing an ordered list of workflow inbox events. Each key holds the data for a single event. The inbox is effectively a FIFO queue of events that the workflow needs to process, with items removed from the earlier indeces and added to the end indices.
+* `inbox-NNNNNN`: Multiple keys containing an ordered list of workflow inbox events. Each key holds the data for a single event. The inbox is effectively a FIFO queue of events that the workflow needs to process, with items removed from the earlier indices and added to the end indices.
 * `history-NNNNNN`: Multiple keys containing an ordered list of history events. Each key holds the data for a single event. History events are only added and never removed, except in the case of "continue as new", where all history events are purged.
 * `customStatus`: Contains a user-defined workflow status value.
 

--- a/pkg/runtime/wfengine/activity.go
+++ b/pkg/runtime/wfengine/activity.go
@@ -32,8 +32,8 @@ type activityActor struct {
 	scheduler    workflowScheduler
 }
 
-// NewActivityActor creates an [actors.InternalActor] for executing workflow activity logic.
-func NewActivityActor(scheduler workflowScheduler) actors.InternalActor {
+// NewActivityActor creates an internal activity actor for executing workflow activity logic.
+func NewActivityActor(scheduler workflowScheduler) *activityActor {
 	return &activityActor{
 		scheduler: scheduler,
 	}

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -219,6 +219,22 @@ func TestStartWorkflowEngine(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// GetTestOptions returns an array of functions for configuring the workflow engine. Each
+// string returned by each function can be used as the name of the test configuration.
+func GetTestOptions() []func(wfe *wfengine.WorkflowEngine) string {
+	return []func(wfe *wfengine.WorkflowEngine) string{
+		func(wfe *wfengine.WorkflowEngine) string {
+			// caching enabled, etc.
+			return "default options"
+		},
+		func(wfe *wfengine.WorkflowEngine) string {
+			// disable caching to test recovery from failure
+			wfe.DisableWorkflowCaching(true)
+			return "caching disabled"
+		},
+	}
+}
+
 // TestEmptyWorkflow executes a no-op workflow end-to-end and verifies all workflow metadata is correctly initialized.
 func TestEmptyWorkflow(t *testing.T) {
 	r := task.NewTaskRegistry()
@@ -227,21 +243,25 @@ func TestEmptyWorkflow(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	client := startEngine(ctx, r)
-	preStartTime := time.Now().UTC()
-	id, err := client.ScheduleNewOrchestration(ctx, "EmptyWorkflow")
-	if assert.NoError(t, err) {
-		metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
-		if assert.NoError(t, err) {
-			assert.Equal(t, id, metadata.InstanceID)
-			assert.True(t, metadata.IsComplete())
-			assert.GreaterOrEqual(t, metadata.CreatedAt, preStartTime)
-			assert.GreaterOrEqual(t, metadata.LastUpdatedAt, metadata.CreatedAt)
-			assert.Empty(t, metadata.SerializedInput)
-			assert.Empty(t, metadata.SerializedOutput)
-			assert.Empty(t, metadata.SerializedCustomStatus)
-			assert.Nil(t, metadata.FailureDetails)
-		}
+	client, engine := startEngine(ctx, r)
+	for _, opt := range GetTestOptions() {
+		t.Run(opt(engine), func(t *testing.T) {
+			preStartTime := time.Now().UTC()
+			id, err := client.ScheduleNewOrchestration(ctx, "EmptyWorkflow")
+			if assert.NoError(t, err) {
+				metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
+				if assert.NoError(t, err) {
+					assert.Equal(t, id, metadata.InstanceID)
+					assert.True(t, metadata.IsComplete())
+					assert.GreaterOrEqual(t, metadata.CreatedAt, preStartTime)
+					assert.GreaterOrEqual(t, metadata.LastUpdatedAt, metadata.CreatedAt)
+					assert.Empty(t, metadata.SerializedInput)
+					assert.Empty(t, metadata.SerializedOutput)
+					assert.Empty(t, metadata.SerializedCustomStatus)
+					assert.Nil(t, metadata.FailureDetails)
+				}
+			}
+		})
 	}
 }
 
@@ -255,15 +275,18 @@ func TestSingleTimerWorkflow(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	client := startEngine(ctx, r)
-
-	id, err := client.ScheduleNewOrchestration(ctx, "SingleTimer")
-	if assert.NoError(t, err) {
-		metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
-		if assert.NoError(t, err) {
-			assert.True(t, metadata.IsComplete())
-			assert.GreaterOrEqual(t, metadata.LastUpdatedAt, metadata.CreatedAt)
-		}
+	client, engine := startEngine(ctx, r)
+	for _, opt := range GetTestOptions() {
+		t.Run(opt(engine), func(t *testing.T) {
+			id, err := client.ScheduleNewOrchestration(ctx, "SingleTimer")
+			if assert.NoError(t, err) {
+				metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
+				if assert.NoError(t, err) {
+					assert.True(t, metadata.IsComplete())
+					assert.GreaterOrEqual(t, metadata.LastUpdatedAt, metadata.CreatedAt)
+				}
+			}
+		})
 	}
 }
 
@@ -290,16 +313,19 @@ func TestSingleActivityWorkflow(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	client := startEngine(ctx, r)
-
-	id, err := client.ScheduleNewOrchestration(ctx, "SingleActivity", api.WithInput("世界"))
-	if assert.NoError(t, err) {
-		metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
-		if assert.NoError(t, err) {
-			assert.True(t, metadata.IsComplete())
-			assert.Equal(t, `"世界"`, metadata.SerializedInput)
-			assert.Equal(t, `"Hello, 世界!"`, metadata.SerializedOutput)
-		}
+	client, engine := startEngine(ctx, r)
+	for _, opt := range GetTestOptions() {
+		t.Run(opt(engine), func(t *testing.T) {
+			id, err := client.ScheduleNewOrchestration(ctx, "SingleActivity", api.WithInput("世界"))
+			if assert.NoError(t, err) {
+				metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
+				if assert.NoError(t, err) {
+					assert.True(t, metadata.IsComplete())
+					assert.Equal(t, `"世界"`, metadata.SerializedInput)
+					assert.Equal(t, `"Hello, 世界!"`, metadata.SerializedOutput)
+				}
+			}
+		})
 	}
 }
 
@@ -325,15 +351,18 @@ func TestActivityChainingWorkflow(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	client := startEngine(ctx, r)
-
-	id, err := client.ScheduleNewOrchestration(ctx, "ActivityChain")
-	if assert.NoError(t, err) {
-		metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
-		if assert.NoError(t, err) {
-			assert.True(t, metadata.IsComplete())
-			assert.Equal(t, `10`, metadata.SerializedOutput)
-		}
+	client, engine := startEngine(ctx, r)
+	for _, opt := range GetTestOptions() {
+		t.Run(opt(engine), func(t *testing.T) {
+			id, err := client.ScheduleNewOrchestration(ctx, "ActivityChain")
+			if assert.NoError(t, err) {
+				metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
+				if assert.NoError(t, err) {
+					assert.True(t, metadata.IsComplete())
+					assert.Equal(t, `10`, metadata.SerializedOutput)
+				}
+			}
+		})
 	}
 }
 
@@ -368,22 +397,25 @@ func TestConcurrentActivityExecution(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	client := startEngine(ctx, r)
+	client, engine := startEngine(ctx, r)
+	for _, opt := range GetTestOptions() {
+		t.Run(opt(engine), func(t *testing.T) {
+			id, err := client.ScheduleNewOrchestration(ctx, "ActivityFanOut")
+			if assert.NoError(t, err) {
+				metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
+				if assert.NoError(t, err) {
+					assert.True(t, metadata.IsComplete())
+					assert.Equal(t, `["9","8","7","6","5","4","3","2","1","0"]`, metadata.SerializedOutput)
 
-	id, err := client.ScheduleNewOrchestration(ctx, "ActivityFanOut")
-	if assert.NoError(t, err) {
-		metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
-		if assert.NoError(t, err) {
-			assert.True(t, metadata.IsComplete())
-			assert.Equal(t, `["9","8","7","6","5","4","3","2","1","0"]`, metadata.SerializedOutput)
-
-			// Because all the activities run in parallel, they should complete very quickly
-			assert.Less(t, metadata.LastUpdatedAt.Sub(metadata.CreatedAt), 3*time.Second)
-		}
+					// Because all the activities run in parallel, they should complete very quickly
+					assert.Less(t, metadata.LastUpdatedAt.Sub(metadata.CreatedAt), 3*time.Second)
+				}
+			}
+		})
 	}
 }
 
-func startEngine(ctx context.Context, r *task.TaskRegistry) backend.TaskHubClient {
+func startEngine(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, *wfengine.WorkflowEngine) {
 	var client backend.TaskHubClient
 	engine := getEngine()
 	engine.ConfigureExecutor(func(be backend.Backend) backend.Executor {
@@ -393,7 +425,7 @@ func startEngine(ctx context.Context, r *task.TaskRegistry) backend.TaskHubClien
 	if err := engine.Start(ctx); err != nil {
 		panic(err)
 	}
-	return client
+	return client, engine
 }
 
 func getEngine() *wfengine.WorkflowEngine {

--- a/pkg/runtime/wfengine/workflowstate.go
+++ b/pkg/runtime/wfengine/workflowstate.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package wfengine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dapr/dapr/pkg/actors"
+	"github.com/google/uuid"
+	"github.com/microsoft/durabletask-go/backend"
+)
+
+const (
+	inboxKeyPrefix   = "inbox"
+	historyKeyPrefix = "history"
+	customStatusKey  = "customStatus"
+	metadataKey      = "metadata"
+)
+
+type workflowState struct {
+	Inbox        []*backend.HistoryEvent
+	History      []*backend.HistoryEvent
+	CustomStatus string
+	Generation   uuid.UUID
+
+	// change tracking
+	inboxAddedCount     int
+	inboxRemovedCount   int
+	historyAddedCount   int
+	historyRemovedCount int
+}
+
+type workflowStateMetadata struct {
+	InboxLength   int
+	HistoryLength int
+	Generation    uuid.UUID
+}
+
+func NewWorkflowState(generation uuid.UUID) *workflowState {
+	return &workflowState{
+		Generation: generation,
+	}
+}
+
+func (state *workflowState) Reset() {
+	state.inboxRemovedCount += len(state.Inbox)
+	state.Inbox = nil
+	state.historyRemovedCount += len(state.History)
+	state.History = nil
+	state.CustomStatus = ""
+	state.Generation = uuid.New()
+}
+
+func (state *workflowState) ApplyRuntimeStateChanges(runtimeState *backend.OrchestrationRuntimeState) {
+	if runtimeState.ContinuedAsNew() {
+		state.historyRemovedCount += len(state.History)
+		state.History = nil
+	}
+
+	newHistoryEvents := runtimeState.NewEvents()
+	state.History = append(state.History, newHistoryEvents...)
+	state.historyAddedCount += len(newHistoryEvents)
+
+	state.CustomStatus = runtimeState.CustomStatus.GetValue()
+}
+
+func (state *workflowState) AddToInbox(e *backend.HistoryEvent) {
+	state.Inbox = append(state.Inbox, e)
+	state.inboxAddedCount++
+}
+
+func (state *workflowState) ClearInbox() {
+	state.inboxRemovedCount += len(state.Inbox)
+	state.Inbox = nil
+	state.inboxAddedCount = 0
+}
+
+func (s *workflowState) GetSaveRequest(actorID string) (*actors.TransactionalRequest, error) {
+	req := &actors.TransactionalRequest{
+		ActorType:  WorkflowActorType,
+		ActorID:    actorID,
+		Operations: make([]actors.TransactionalOperation, 0, 100),
+	}
+
+	if err := addStateOperations(req, inboxKeyPrefix, s.Inbox, s.inboxAddedCount, s.inboxRemovedCount); err != nil {
+		return nil, err
+	}
+
+	if err := addStateOperations(req, historyKeyPrefix, s.History, s.historyAddedCount, s.historyRemovedCount); err != nil {
+		return nil, err
+	}
+
+	req.Operations = append(req.Operations, actors.TransactionalOperation{
+		Operation: actors.Upsert,
+		Request:   actors.TransactionalUpsert{Key: customStatusKey, Value: s.CustomStatus},
+	})
+
+	metadata := workflowStateMetadata{
+		InboxLength:   len(s.Inbox),
+		HistoryLength: len(s.History),
+		Generation:    s.Generation,
+	}
+	req.Operations = append(req.Operations, actors.TransactionalOperation{
+		Operation: actors.Upsert,
+		Request:   actors.TransactionalUpsert{Key: metadataKey, Value: metadata},
+	})
+
+	return req, nil
+}
+
+func addStateOperations(req *actors.TransactionalRequest, keyPrefix string, events []*backend.HistoryEvent, addedCount int, removedCount int) error {
+	// TODO: Investigate whether Dapr state stores put limits on batch sizes. It seems some storage
+	//       providers have limits and we need to know if that impacts this algorithm:
+	//       https://learn.microsoft.com/azure/cosmos-db/nosql/transactional-batch#limitations
+	for i := len(events) - addedCount; i < len(events); i++ {
+		e := events[i]
+		data, err := backend.MarshalHistoryEvent(e)
+		if err != nil {
+			return err
+		}
+		req.Operations = append(req.Operations, actors.TransactionalOperation{
+			Operation: actors.Upsert,
+			Request:   actors.TransactionalUpsert{Key: getMultiEntryKeyName(keyPrefix, i), Value: data},
+		})
+	}
+	for i := len(events); i < removedCount; i++ {
+		req.Operations = append(req.Operations, actors.TransactionalOperation{
+			Operation: actors.Delete,
+			Request:   actors.TransactionalDelete{Key: getMultiEntryKeyName(keyPrefix, i)},
+		})
+	}
+	return nil
+}
+
+func LoadWorkflowState(ctx context.Context, actorRuntime actors.Actors, actorID string) (*workflowState, error) {
+	loadStartTime := time.Now()
+	loadedRecords := 0
+
+	req := actors.GetStateRequest{
+		ActorType: WorkflowActorType,
+		ActorID:   actorID,
+		Key:       metadataKey,
+	}
+	res, err := actorRuntime.GetState(ctx, &req)
+	loadedRecords++
+	if err != nil {
+		return nil, fmt.Errorf("failed to load workflow metadata: %w", err)
+	}
+	if len(res.Data) == 0 {
+		// no state found
+		return nil, nil
+	}
+	var metadata workflowStateMetadata
+	if err = json.Unmarshal(res.Data, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal workflow metadata: %w", err)
+	}
+	state := NewWorkflowState(metadata.Generation)
+	// CONSIDER: Do some of these loads in parallel
+	for i := 0; i < metadata.InboxLength; i++ {
+		req.Key = getMultiEntryKeyName(inboxKeyPrefix, i)
+		res, err = actorRuntime.GetState(ctx, &req)
+		loadedRecords++
+		if err != nil {
+			return nil, fmt.Errorf("failed to load workflow inbox state key '%s': %w", req.Key, err)
+		}
+		var historyBytes []byte
+		if err = json.Unmarshal(res.Data, &historyBytes); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal JSON from inbox state key entry: %w", err)
+		}
+		e, err := backend.UnmarshalHistoryEvent(historyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal history event from inbox state key entry: %w", err)
+		}
+		state.Inbox = append(state.Inbox, e)
+	}
+	for i := 0; i < metadata.HistoryLength; i++ {
+		req.Key = getMultiEntryKeyName(historyKeyPrefix, i)
+		res, err = actorRuntime.GetState(ctx, &req)
+		loadedRecords++
+		if err != nil {
+			return nil, fmt.Errorf("failed to load workflow inbox state key '%s': %w", req.Key, err)
+		}
+		var historyBytes []byte
+		if err = json.Unmarshal(res.Data, &historyBytes); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal JSON from inbox state key entry: %w", err)
+		}
+		e, err := backend.UnmarshalHistoryEvent(historyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal history event from inbox state key entry: %w", err)
+		}
+
+		state.History = append(state.History, e)
+	}
+
+	req.Key = customStatusKey
+	res, err = actorRuntime.GetState(ctx, &req)
+	loadedRecords++
+	if err != nil {
+		return nil, fmt.Errorf("failed to load workflow custom status key '%s': %w", req.Key, err)
+	}
+	if err = json.Unmarshal(res.Data, &state.CustomStatus); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON from inbox state key entry: %w", err)
+	}
+
+	wfLogger.Infof("%s: loaded %d state records in %v", actorID, loadedRecords, time.Since(loadStartTime))
+	return state, nil
+}
+
+func getMultiEntryKeyName(prefix string, i int) string {
+	return fmt.Sprintf("%s-%06d", prefix, i)
+}

--- a/pkg/runtime/wfengine/workflowstate.go
+++ b/pkg/runtime/wfengine/workflowstate.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dapr/dapr/pkg/actors"
 	"github.com/google/uuid"
 	"github.com/microsoft/durabletask-go/backend"
+
+	"github.com/dapr/dapr/pkg/actors"
 )
 
 const (
@@ -57,37 +58,37 @@ func NewWorkflowState(generation uuid.UUID) *workflowState {
 	}
 }
 
-func (state *workflowState) Reset() {
-	state.inboxRemovedCount += len(state.Inbox)
-	state.Inbox = nil
-	state.historyRemovedCount += len(state.History)
-	state.History = nil
-	state.CustomStatus = ""
-	state.Generation = uuid.New()
+func (s *workflowState) Reset() {
+	s.inboxRemovedCount += len(s.Inbox)
+	s.Inbox = nil
+	s.historyRemovedCount += len(s.History)
+	s.History = nil
+	s.CustomStatus = ""
+	s.Generation = uuid.New()
 }
 
-func (state *workflowState) ApplyRuntimeStateChanges(runtimeState *backend.OrchestrationRuntimeState) {
+func (s *workflowState) ApplyRuntimeStateChanges(runtimeState *backend.OrchestrationRuntimeState) {
 	if runtimeState.ContinuedAsNew() {
-		state.historyRemovedCount += len(state.History)
-		state.History = nil
+		s.historyRemovedCount += len(s.History)
+		s.History = nil
 	}
 
 	newHistoryEvents := runtimeState.NewEvents()
-	state.History = append(state.History, newHistoryEvents...)
-	state.historyAddedCount += len(newHistoryEvents)
+	s.History = append(s.History, newHistoryEvents...)
+	s.historyAddedCount += len(newHistoryEvents)
 
-	state.CustomStatus = runtimeState.CustomStatus.GetValue()
+	s.CustomStatus = runtimeState.CustomStatus.GetValue()
 }
 
-func (state *workflowState) AddToInbox(e *backend.HistoryEvent) {
-	state.Inbox = append(state.Inbox, e)
-	state.inboxAddedCount++
+func (s *workflowState) AddToInbox(e *backend.HistoryEvent) {
+	s.Inbox = append(s.Inbox, e)
+	s.inboxAddedCount++
 }
 
-func (state *workflowState) ClearInbox() {
-	state.inboxRemovedCount += len(state.Inbox)
-	state.Inbox = nil
-	state.inboxAddedCount = 0
+func (s *workflowState) ClearInbox() {
+	s.inboxRemovedCount += len(s.Inbox)
+	s.Inbox = nil
+	s.inboxAddedCount = 0
 }
 
 func (s *workflowState) GetSaveRequest(actorID string) (*actors.TransactionalRequest, error) {
@@ -182,7 +183,8 @@ func LoadWorkflowState(ctx context.Context, actorRuntime actors.Actors, actorID 
 		if err = json.Unmarshal(res.Data, &historyBytes); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal JSON from inbox state key entry: %w", err)
 		}
-		e, err := backend.UnmarshalHistoryEvent(historyBytes)
+		var e *backend.HistoryEvent
+		e, err = backend.UnmarshalHistoryEvent(historyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal history event from inbox state key entry: %w", err)
 		}
@@ -199,7 +201,8 @@ func LoadWorkflowState(ctx context.Context, actorRuntime actors.Actors, actorID 
 		if err = json.Unmarshal(res.Data, &historyBytes); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal JSON from inbox state key entry: %w", err)
 		}
-		e, err := backend.UnmarshalHistoryEvent(historyBytes)
+		var e *backend.HistoryEvent
+		e, err = backend.UnmarshalHistoryEvent(historyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal history event from inbox state key entry: %w", err)
 		}

--- a/pkg/runtime/wfengine/workflowstate.go
+++ b/pkg/runtime/wfengine/workflowstate.go
@@ -59,8 +59,10 @@ func NewWorkflowState(generation uuid.UUID) *workflowState {
 }
 
 func (s *workflowState) Reset() {
+	s.inboxAddedCount = 0
 	s.inboxRemovedCount += len(s.Inbox)
 	s.Inbox = nil
+	s.historyAddedCount = 0
 	s.historyRemovedCount += len(s.History)
 	s.History = nil
 	s.CustomStatus = ""
@@ -70,6 +72,7 @@ func (s *workflowState) Reset() {
 func (s *workflowState) ApplyRuntimeStateChanges(runtimeState *backend.OrchestrationRuntimeState) {
 	if runtimeState.ContinuedAsNew() {
 		s.historyRemovedCount += len(s.History)
+		s.historyAddedCount = 0
 		s.History = nil
 	}
 

--- a/pkg/runtime/wfengine/workflowstate_test.go
+++ b/pkg/runtime/wfengine/workflowstate_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dapr/kit/logger"
 	"github.com/google/uuid"
 	"github.com/microsoft/durabletask-go/api"
 	"github.com/microsoft/durabletask-go/backend"
@@ -28,6 +27,7 @@ import (
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/wfengine"
+	"github.com/dapr/kit/logger"
 )
 
 func TestNoWorkflowState(t *testing.T) {
@@ -121,7 +121,7 @@ func TestLoadSavedState(t *testing.T) {
 	assert.Equal(t, 0, deleteCount)
 
 	actors := getActorRuntime()
-	if err := actors.TransactionalStateOperation(context.Background(), req); !assert.NoError(t, err) {
+	if err = actors.TransactionalStateOperation(context.Background(), req); !assert.NoError(t, err) {
 		return
 	}
 
@@ -155,7 +155,7 @@ func TestResetLoadedState(t *testing.T) {
 	}
 
 	actorRuntime := getActorRuntime()
-	if err := actorRuntime.TransactionalStateOperation(context.Background(), req); !assert.NoError(t, err) {
+	if err = actorRuntime.TransactionalStateOperation(context.Background(), req); !assert.NoError(t, err) {
 		return
 	}
 

--- a/pkg/runtime/wfengine/workflowstate_test.go
+++ b/pkg/runtime/wfengine/workflowstate_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package wfengine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/kit/logger"
+	"github.com/google/uuid"
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/pkg/actors"
+	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/wfengine"
+)
+
+func TestNoWorkflowState(t *testing.T) {
+	actors := getActorRuntime()
+	state, err := wfengine.LoadWorkflowState(context.Background(), actors, "wf1")
+	assert.NoError(t, err)
+	assert.Nil(t, state)
+}
+
+func TestAddingToInbox(t *testing.T) {
+	state := wfengine.NewWorkflowState(uuid.New())
+	for i := 0; i < 10; i++ {
+		state.AddToInbox(&backend.HistoryEvent{})
+	}
+
+	req, err := state.GetSaveRequest("wf1")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "wf1", req.ActorID)
+		assert.Equal(t, wfengine.WorkflowActorType, req.ActorType)
+
+		upsertCount, deleteCount := countOperations(t, req)
+		assert.Equal(t, 12, upsertCount) // 10x inbox + metadata + customStatus
+		assert.Equal(t, 0, deleteCount)
+	}
+}
+
+func TestClearingInbox(t *testing.T) {
+	state := wfengine.NewWorkflowState(uuid.New())
+	for i := 0; i < 10; i++ {
+		// Simulate the loadng of inbox events from storage
+		state.Inbox = append(state.Inbox, &backend.HistoryEvent{})
+	}
+	state.ClearInbox()
+
+	req, err := state.GetSaveRequest("wf1")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "wf1", req.ActorID)
+		assert.Equal(t, wfengine.WorkflowActorType, req.ActorType)
+
+		upsertCount, deleteCount := countOperations(t, req)
+		assert.Equal(t, 2, upsertCount)  // metadata + customStatus
+		assert.Equal(t, 10, deleteCount) // the 10 inbox messages should get deleted
+	}
+}
+
+func TestAddingToHistory(t *testing.T) {
+	wfstate := wfengine.NewWorkflowState(uuid.New())
+	runtimeState := backend.NewOrchestrationRuntimeState(api.InstanceID("wf1"), nil)
+	for i := 0; i < 10; i++ {
+		if err := runtimeState.AddEvent(&backend.HistoryEvent{}); !assert.NoError(t, err) {
+			return
+		}
+	}
+	wfstate.ApplyRuntimeStateChanges(runtimeState)
+
+	req, err := wfstate.GetSaveRequest("wf1")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "wf1", req.ActorID)
+		assert.Equal(t, wfengine.WorkflowActorType, req.ActorType)
+
+		upsertCount, deleteCount := countOperations(t, req)
+		assert.Equal(t, 12, upsertCount) // 10x history + metadata + customStatus
+		assert.Equal(t, 0, deleteCount)
+	}
+}
+
+func TestLoadSavedState(t *testing.T) {
+	generation := uuid.New()
+	wfstate := wfengine.NewWorkflowState(generation)
+
+	runtimeState := backend.NewOrchestrationRuntimeState(api.InstanceID("wf1"), nil)
+	for i := 0; i < 10; i++ {
+		if err := runtimeState.AddEvent(&backend.HistoryEvent{}); !assert.NoError(t, err) {
+			return
+		}
+	}
+	wfstate.ApplyRuntimeStateChanges(runtimeState)
+	wfstate.CustomStatus = "my custom status"
+
+	for i := 0; i < 5; i++ {
+		wfstate.AddToInbox(&backend.HistoryEvent{})
+	}
+
+	req, err := wfstate.GetSaveRequest("wf1")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	upsertCount, deleteCount := countOperations(t, req)
+	assert.Equal(t, 17, upsertCount) // 10x history, 5x inbox, 1 metadata, 1 customStatus
+	assert.Equal(t, 0, deleteCount)
+
+	actors := getActorRuntime()
+	if err := actors.TransactionalStateOperation(context.Background(), req); !assert.NoError(t, err) {
+		return
+	}
+
+	wfstate, err = wfengine.LoadWorkflowState(context.Background(), actors, "wf1")
+	if assert.NoError(t, err) && assert.NotNil(t, wfstate) {
+		assert.Equal(t, "my custom status", wfstate.CustomStatus)
+		assert.Equal(t, generation, wfstate.Generation)
+		assert.Equal(t, 10, len(wfstate.History))
+		assert.Equal(t, 5, len(wfstate.Inbox))
+	}
+}
+
+func TestResetLoadedState(t *testing.T) {
+	wfstate := wfengine.NewWorkflowState(uuid.New())
+
+	runtimeState := backend.NewOrchestrationRuntimeState(api.InstanceID("wf1"), nil)
+	for i := 0; i < 10; i++ {
+		if err := runtimeState.AddEvent(&backend.HistoryEvent{}); !assert.NoError(t, err) {
+			return
+		}
+	}
+	wfstate.ApplyRuntimeStateChanges(runtimeState)
+
+	for i := 0; i < 5; i++ {
+		wfstate.AddToInbox(&backend.HistoryEvent{})
+	}
+
+	req, err := wfstate.GetSaveRequest("wf1")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	actorRuntime := getActorRuntime()
+	if err := actorRuntime.TransactionalStateOperation(context.Background(), req); !assert.NoError(t, err) {
+		return
+	}
+
+	wfstate, err = wfengine.LoadWorkflowState(context.Background(), actorRuntime, "wf1")
+	if assert.NoError(t, err) && assert.NotNil(t, wfstate) {
+		wfstate.Reset()
+		req, err := wfstate.GetSaveRequest("wf1")
+		if assert.NoError(t, err) {
+			assert.Equal(t, 17, len(req.Operations)) // history x10 + inbox x5 + metadata + customStatus
+			upsertCount, deleteCount := countOperations(t, req)
+			assert.Equal(t, 2, upsertCount)  // metadata + customStatus
+			assert.Equal(t, 15, deleteCount) // all history and inbox records are deleted
+		}
+	}
+}
+
+func getActorRuntime() actors.Actors {
+	store := fakeStore()
+	cfg := actors.NewConfig(actors.ConfigOpts{
+		AppID:              testAppID,
+		PlacementAddresses: []string{"placement:5050"},
+		AppConfig:          config.ApplicationConfig{},
+	})
+	actors := actors.NewActors(actors.ActorsOpts{
+		StateStore:     store,
+		Config:         cfg,
+		StateStoreName: "workflowStore",
+		MockPlacement:  NewMockPlacement(),
+		Resiliency:     resiliency.New(logger.NewLogger("test")),
+	})
+	return actors
+}
+
+func countOperations(t *testing.T, req *actors.TransactionalRequest) (int, int) {
+	upsertCount := 0
+	deleteCount := 0
+	for _, op := range req.Operations {
+		if op.Operation == actors.Upsert {
+			upsertCount++
+		} else if op.Operation == actors.Delete {
+			deleteCount++
+		} else {
+			assert.Fail(t, "unexpected operation type", op.Operation)
+		}
+	}
+	return upsertCount, deleteCount
+}


### PR DESCRIPTION
# Description

This PR enables state storage for the embedded workflow engine. Previously, state was only held in memory, which meant that workflows could only be used in one-box setups.

Details of the state-storage design can be found in the README.md updates. TL/DR version is this:

- State is stored using state storage actor APIs, so any state store supporting actors can be used
- Each workflow instance has its state spread out across multiple state store keys
- The design allows for arbitrarily large workflow histories

This PR also improves the existing workflow tests by having them run with and without caching. The default behavior is to run with caching, which effectively means we never read state from the state store. However, with caching _disabled_, the tests heavily exercise the state storage read path.

The version of `durabletask-go` was also updated to get a faster version of workflow status polling, using exponential backoff instead of hard-coded 1 second intervals. This significantly speeds up the workflow execution unit tests.

## Issue reference

This is a continuation of the implementation for the workflow engine proposed here: https://github.com/dapr/dapr/issues/4576

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] ~~Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]~~
* [ ] ~~Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]~~
* [ ] ~~Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]~~

Signed-off-by: Chris Gillum <cgillum@microsoft.com>