### PR TITLE
Add caller's and callee's app-ids in headers for service to service invocation

### DIFF
--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -246,6 +246,7 @@ func (d *directMessaging) invokeRemote(ctx context.Context, appID, namespace, ap
 
 	d.addForwardedHeadersToMetadata(req)
 	d.addDestinationAppIDHeaderToMetadata(appID, req)
+	d.addCallerAndCalleeAppIDHeaderToMetadata(d.appID, appID, req)
 
 	clientV1 := internalv1pb.NewServiceInvocationClient(conn)
 
@@ -263,6 +264,15 @@ func (d *directMessaging) invokeRemote(ctx context.Context, appID, namespace, ap
 func (d *directMessaging) addDestinationAppIDHeaderToMetadata(appID string, req *invokev1.InvokeMethodRequest) {
 	req.Metadata()[invokev1.DestinationIDHeader] = &internalv1pb.ListStringValue{
 		Values: []string{appID},
+	}
+}
+
+func (d *directMessaging) addCallerAndCalleeAppIDHeaderToMetadata(callerAppID, calleeAppID string, req *invokev1.InvokeMethodRequest) {
+	req.Metadata()[invokev1.CallerIDHeader] = &internalv1pb.ListStringValue{
+		Values: []string{callerAppID},
+	}
+	req.Metadata()[invokev1.CalleeIDHeader] = &internalv1pb.ListStringValue{
+		Values: []string{calleeAppID},
 	}
 }
 

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -39,6 +39,22 @@ func TestDestinationHeaders(t *testing.T) {
 	})
 }
 
+func TestCallerAndCalleeHeaders(t *testing.T) {
+	t.Run("caller and callee header present", func(t *testing.T) {
+		callerAppID := "caller-app"
+		calleeAppID := "callee-app"
+		req := invokev1.NewInvokeMethodRequest("GET")
+		req.WithMetadata(map[string][]string{})
+
+		dm := newDirectMessaging()
+		dm.addCallerAndCalleeAppIDHeaderToMetadata(callerAppID, calleeAppID, req)
+		actualCallerAppID := req.Metadata()[invokev1.CallerIDHeader]
+		actualCalleeAppID := req.Metadata()[invokev1.CalleeIDHeader]
+		assert.Equal(t, callerAppID, actualCallerAppID.Values[0])
+		assert.Equal(t, calleeAppID, actualCalleeAppID.Values[0])
+	})
+}
+
 func TestForwardedHeaders(t *testing.T) {
 	t.Run("forwarded headers present", func(t *testing.T) {
 		req := invokev1.NewInvokeMethodRequest("GET")

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/pkg/acl"
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/diagnostics"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/proto/common/v1"
 )
 
@@ -105,6 +106,7 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 	// proxy to a remote daprd
 	conn, teardown, cErr := p.connectionFactory(outCtx, target.address, target.id, target.namespace, false, false, false, grpc.WithDefaultCallOptions(grpc.CallContentSubtype((&codec.Proxy{}).Name())))
 	outCtx = p.telemetryFn(outCtx)
+	outCtx = metadata.AppendToOutgoingContext(outCtx, invokev1.CallerIDHeader, p.appID, invokev1.CalleeIDHeader, target.id)
 
 	return outCtx, conn, &grpcProxy.ProxyTarget{ID: target.id, Namespace: target.namespace, Address: target.address}, teardown, cErr
 }

--- a/pkg/messaging/grpc_proxy_test.go
+++ b/pkg/messaging/grpc_proxy_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/diagnostics"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 )
 
@@ -184,6 +185,8 @@ func TestIntercept(t *testing.T) {
 
 		md, _ := metadata.FromOutgoingContext(ctx)
 		assert.Equal(t, "b", md["a"][0])
+		assert.Equal(t, "a", md[invokev1.CallerIDHeader][0])
+		assert.Equal(t, "b", md[invokev1.CalleeIDHeader][0])
 	})
 
 	t.Run("access policies applied", func(t *testing.T) {

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -66,8 +66,8 @@ const (
 	errorInfoHTTPCodeMetadata  = "http.code"
 	errorInfoHTTPErrorMetadata = "http.error_message"
 
-	CallerIDHeader = "caller-app-id"
-	CalleeIDHeader = "callee-app-id"
+	CallerIDHeader = DaprHeaderPrefix + "caller-app-id"
+	CalleeIDHeader = DaprHeaderPrefix + "callee-app-id"
 )
 
 // DaprInternalMetadata is the metadata type to transfer HTTP header and gRPC metadata

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -65,6 +65,9 @@ const (
 	errorInfoDomain            = "dapr.io"
 	errorInfoHTTPCodeMetadata  = "http.code"
 	errorInfoHTTPErrorMetadata = "http.error_message"
+
+	CallerIDHeader = "caller-app-id"
+	CalleeIDHeader = "callee-app-id"
 )
 
 // DaprInternalMetadata is the metadata type to transfer HTTP header and gRPC metadata

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/tests/e2e/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
@@ -492,6 +493,9 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, hostname, requestHeaders["x-forwarded-host"][0])
 		assert.Equal(t, expectedForwarded, requestHeaders["forwarded"][0])
 
+		assert.Equal(t, "serviceinvocation-caller", requestHeaders[invokev1.CallerIDHeader][0])
+		assert.Equal(t, "grpcapp", requestHeaders[invokev1.CalleeIDHeader][0])
+
 		assert.Equal(t, "application/grpc", responseHeaders["content-type"][0])
 		assert.Equal(t, "DaprTest-Response-Value-1", responseHeaders["daprtest-response-1"][0])
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["daprtest-response-2"][0])
@@ -546,6 +550,8 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, hostIP, requestHeaders["X-Forwarded-For"][0])
 		assert.Equal(t, hostname, requestHeaders["X-Forwarded-Host"][0])
 		assert.Equal(t, expectedForwarded, requestHeaders["Forwarded"][0])
+		assert.Equal(t, "serviceinvocation-caller", requestHeaders["Caller-App-Id"][0])
+		assert.Equal(t, "serviceinvocation-callee-0", requestHeaders["Callee-App-Id"][0])
 
 		assert.NotNil(t, responseHeaders["dapr-content-length"][0])
 		assert.Equal(t, "application/grpc", responseHeaders["content-type"][0])
@@ -610,6 +616,9 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, hostIP, requestHeaders["x-forwarded-for"][0])
 		assert.Equal(t, hostname, requestHeaders["x-forwarded-host"][0])
 		assert.Equal(t, expectedForwarded, requestHeaders["forwarded"][0])
+
+		assert.Equal(t, "serviceinvocation-caller", requestHeaders[invokev1.CallerIDHeader][0])
+		assert.Equal(t, "grpcapp", requestHeaders[invokev1.CalleeIDHeader][0])
 
 		assert.NotNil(t, responseHeaders["Content-Length"][0])
 		assert.True(t, strings.HasPrefix(responseHeaders["Content-Type"][0], "application/json"))
@@ -862,6 +871,8 @@ func verifyHTTPToHTTP(t *testing.T, hostIP string, hostname string, url string, 
 	assert.Equal(t, hostIP, requestHeaders["X-Forwarded-For"][0])
 	assert.Equal(t, hostname, requestHeaders["X-Forwarded-Host"][0])
 	assert.Equal(t, expectedForwarded, requestHeaders["Forwarded"][0])
+	assert.Equal(t, "serviceinvocation-caller", requestHeaders["Caller-App-Id"][0])
+	assert.Equal(t, "serviceinvocation-callee-0", requestHeaders["Callee-App-Id"][0])
 
 	assert.NotNil(t, responseHeaders["Content-Length"][0])
 	assert.True(t, strings.HasPrefix(responseHeaders["Content-Type"][0], "application/json"))

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -550,8 +550,8 @@ func TestHeaders(t *testing.T) {
 		assert.Equal(t, hostIP, requestHeaders["X-Forwarded-For"][0])
 		assert.Equal(t, hostname, requestHeaders["X-Forwarded-Host"][0])
 		assert.Equal(t, expectedForwarded, requestHeaders["Forwarded"][0])
-		assert.Equal(t, "serviceinvocation-caller", requestHeaders["Caller-App-Id"][0])
-		assert.Equal(t, "serviceinvocation-callee-0", requestHeaders["Callee-App-Id"][0])
+		assert.Equal(t, "serviceinvocation-caller", requestHeaders["Dapr-Caller-App-Id"][0])
+		assert.Equal(t, "serviceinvocation-callee-0", requestHeaders["Dapr-Callee-App-Id"][0])
 
 		assert.NotNil(t, responseHeaders["dapr-content-length"][0])
 		assert.Equal(t, "application/grpc", responseHeaders["content-type"][0])
@@ -871,8 +871,8 @@ func verifyHTTPToHTTP(t *testing.T, hostIP string, hostname string, url string, 
 	assert.Equal(t, hostIP, requestHeaders["X-Forwarded-For"][0])
 	assert.Equal(t, hostname, requestHeaders["X-Forwarded-Host"][0])
 	assert.Equal(t, expectedForwarded, requestHeaders["Forwarded"][0])
-	assert.Equal(t, "serviceinvocation-caller", requestHeaders["Caller-App-Id"][0])
-	assert.Equal(t, "serviceinvocation-callee-0", requestHeaders["Callee-App-Id"][0])
+	assert.Equal(t, "serviceinvocation-caller", requestHeaders["Dapr-Caller-App-Id"][0])
+	assert.Equal(t, "serviceinvocation-callee-0", requestHeaders["Dapr-Callee-App-Id"][0])
 
 	assert.NotNil(t, responseHeaders["Content-Length"][0])
 	assert.True(t, strings.HasPrefix(responseHeaders["Content-Type"][0], "application/json"))


### PR DESCRIPTION

Signed-off-by: sunzhaochang <zhchsun1992@gmail.com>

# Description

Add caller's and callee's app-ids in headers for service to service invocation.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #5155 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
