### PR TITLE
remove bulk publish serially and parallelism metadata

### DIFF
--- a/pkg/runtime/pubsub/default_bulkpub.go
+++ b/pkg/runtime/pubsub/default_bulkpub.go
@@ -41,9 +41,8 @@ func NewDefaultBulkPublisher(p contribPubsub.PubSub) *defaultBulkPublisher {
 	}
 }
 
-// BulkPublish publishes a list of messages to a topic as individual Publish requests.
-// BulkPublish publishes messages in parallel. This is faster, but does not guarantee
-// that messages are sent to the broker in the same order as specified in the request.
+// BulkPublish publishes a list of messages as parallel Publish requests to the topic in the incoming request.
+// There is no guarantee that messages sent to the broker are in the same order as specified in the request.
 func (p *defaultBulkPublisher) BulkPublish(_ context.Context, req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
 	statuses := make([]contribPubsub.BulkPublishResponseEntry, 0, len(req.Entries))
 

--- a/pkg/runtime/pubsub/default_bulkpub.go
+++ b/pkg/runtime/pubsub/default_bulkpub.go
@@ -20,13 +20,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	contribPubsub "github.com/dapr/components-contrib/pubsub"
-	"github.com/dapr/dapr/utils"
 )
 
 const (
-	bulkPublishSeriallyKey       string = "bulkPublishSerially"
-	bulkPublishMaxConcurrencyKey string = "bulkPublishMaxConcurrency"
-
 	defaultBulkPublishMaxConcurrency int = 100
 )
 
@@ -46,42 +42,17 @@ func NewDefaultBulkPublisher(p contribPubsub.PubSub) *defaultBulkPublisher {
 }
 
 // BulkPublish publishes a list of messages to a topic as individual Publish requests.
-// If 'bulkPublishSerially' metadata is set to true, the messages are sent to the broker serially,
-// in the same order. Otherwise they are sent to the broker as parallel Publish requests.
 func (p *defaultBulkPublisher) BulkPublish(_ context.Context, req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
-	if utils.IsTruthy(req.Metadata[bulkPublishSeriallyKey]) {
-		return p.bulkPublishSerial(req)
-	} else {
-		return p.bulkPublishParallel(req)
-	}
-}
-
-// bulkPublishSerial publishes messages in a serial order. This is slower, but ensures
-// that messages are sent to the broker in the same order as specified in the request.
-func (p *defaultBulkPublisher) bulkPublishSerial(req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
-	statuses := make([]contribPubsub.BulkPublishResponseEntry, 0, len(req.Entries))
-	var err error
-
-	for _, entry := range req.Entries {
-		status := p.bulkPublishSingleEntry(req.PubsubName, req.Topic, entry)
-		if status.Error != nil {
-			err = ErrBulkPublishFailure
-		}
-
-		statuses = append(statuses, status)
-	}
-
-	return contribPubsub.BulkPublishResponse{Statuses: statuses}, err
+	return p.bulkPublishParallel(req)
 }
 
 // bulkPublishParallel publishes messages in parallel. This is faster, but does not guarantee
 // that messages are sent to the broker in the same order as specified in the request.
 func (p *defaultBulkPublisher) bulkPublishParallel(req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
 	statuses := make([]contribPubsub.BulkPublishResponseEntry, 0, len(req.Entries))
-	maxConcurrency := utils.GetIntOrDefault(req.Metadata, bulkPublishMaxConcurrencyKey, defaultBulkPublishMaxConcurrency)
 
 	var eg errgroup.Group
-	eg.SetLimit(maxConcurrency)
+	eg.SetLimit(defaultBulkPublishMaxConcurrency)
 
 	statusChan := make(chan contribPubsub.BulkPublishResponseEntry, len(req.Entries))
 

--- a/pkg/runtime/pubsub/default_bulkpub.go
+++ b/pkg/runtime/pubsub/default_bulkpub.go
@@ -42,13 +42,9 @@ func NewDefaultBulkPublisher(p contribPubsub.PubSub) *defaultBulkPublisher {
 }
 
 // BulkPublish publishes a list of messages to a topic as individual Publish requests.
-func (p *defaultBulkPublisher) BulkPublish(_ context.Context, req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
-	return p.bulkPublishParallel(req)
-}
-
-// bulkPublishParallel publishes messages in parallel. This is faster, but does not guarantee
+// BulkPublish publishes messages in parallel. This is faster, but does not guarantee
 // that messages are sent to the broker in the same order as specified in the request.
-func (p *defaultBulkPublisher) bulkPublishParallel(req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
+func (p *defaultBulkPublisher) BulkPublish(_ context.Context, req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
 	statuses := make([]contribPubsub.BulkPublishResponseEntry, 0, len(req.Entries))
 
 	var eg errgroup.Group


### PR DESCRIPTION
Signed-off-by: Mukundan Sundararajan <65565396+mukundansundar@users.noreply.github.com>

# Description
Removes the `bulkPublishSerially` and max concurrency metadata.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #5367 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
