### PR TITLE
Update pluggable interfaces to include `GetComponentMetadata` method

### DIFF
--- a/pkg/components/bindings/input_pluggable.go
+++ b/pkg/components/bindings/input_pluggable.go
@@ -129,7 +129,7 @@ func (b *grpcInputBinding) Read(ctx context.Context, handler bindings.Handler) e
 
 // Returns the component metadata options
 func (b *grpcInputBinding) GetComponentMetadata() map[string]string {
-	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	// GetComponentMetadata does not apply to pluggable components as there is no standard metadata to return
 	return map[string]string{}
 }
 

--- a/pkg/components/bindings/input_pluggable.go
+++ b/pkg/components/bindings/input_pluggable.go
@@ -127,6 +127,12 @@ func (b *grpcInputBinding) Read(ctx context.Context, handler bindings.Handler) e
 	return nil
 }
 
+// Returns the component metadata options
+func (b *grpcInputBinding) GetComponentMetadata() map[string]string {
+	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	return map[string]string{}
+}
+
 // inputFromConnector creates a new GRPC inputbinding using the given underlying connector.
 func inputFromConnector(l logger.Logger, connector *pluggable.GRPCConnector[proto.InputBindingClient]) *grpcInputBinding {
 	return &grpcInputBinding{

--- a/pkg/components/bindings/output_pluggable.go
+++ b/pkg/components/bindings/output_pluggable.go
@@ -92,7 +92,7 @@ func (b *grpcOutputBinding) Invoke(ctx context.Context, req *bindings.InvokeRequ
 
 // Returns the component metadata options
 func (b *grpcOutputBinding) GetComponentMetadata() map[string]string {
-	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	// GetComponentMetadata does not apply to pluggable components as there is no standard metadata to return
 	return map[string]string{}
 }
 

--- a/pkg/components/bindings/output_pluggable.go
+++ b/pkg/components/bindings/output_pluggable.go
@@ -90,6 +90,12 @@ func (b *grpcOutputBinding) Invoke(ctx context.Context, req *bindings.InvokeRequ
 	}, nil
 }
 
+// Returns the component metadata options
+func (b *grpcOutputBinding) GetComponentMetadata() map[string]string {
+	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	return map[string]string{}
+}
+
 // outputFromConnector creates a new GRPC outputbinding using the given underlying connector.
 func outputFromConnector(_ logger.Logger, connector *pluggable.GRPCConnector[proto.OutputBindingClient]) *grpcOutputBinding {
 	return &grpcOutputBinding{

--- a/pkg/components/pubsub/pluggable.go
+++ b/pkg/components/pubsub/pluggable.go
@@ -187,7 +187,7 @@ func (p *grpcPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 
 // Returns the component metadata options
 func (p *grpcPubSub) GetComponentMetadata() map[string]string {
-	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	// GetComponentMetadata does not apply to pluggable components as there is no standard metadata to return
 	return map[string]string{}
 }
 

--- a/pkg/components/pubsub/pluggable.go
+++ b/pkg/components/pubsub/pluggable.go
@@ -185,6 +185,12 @@ func (p *grpcPubSub) Subscribe(ctx context.Context, req pubsub.SubscribeRequest,
 	return p.pullMessages(ctx, subscription, handler)
 }
 
+// Returns the component metadata options
+func (p *grpcPubSub) GetComponentMetadata() map[string]string {
+	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	return map[string]string{}
+}
+
 // fromConnector creates a new GRPC pubsub using the given underlying connector.
 func fromConnector(l logger.Logger, connector *pluggable.GRPCConnector[proto.PubSubClient]) *grpcPubSub {
 	return &grpcPubSub{

--- a/pkg/components/state/pluggable.go
+++ b/pkg/components/state/pluggable.go
@@ -79,6 +79,12 @@ func (ss *grpcStateStore) Features() []state.Feature {
 	return ss.features
 }
 
+// Returns the component metadata options
+func (ss *grpcStateStore) GetComponentMetadata() map[string]string {
+	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	return map[string]string{}
+}
+
 // Delete performs a delete operation.
 func (ss *grpcStateStore) Delete(req *state.DeleteRequest) error {
 	_, err := ss.Client.Delete(ss.Context, toDeleteRequest(req))

--- a/pkg/components/state/pluggable.go
+++ b/pkg/components/state/pluggable.go
@@ -81,7 +81,7 @@ func (ss *grpcStateStore) Features() []state.Feature {
 
 // Returns the component metadata options
 func (ss *grpcStateStore) GetComponentMetadata() map[string]string {
-	// Component Metadata does not apply to pluggable components as there is no standard metdata
+	// GetComponentMetadata does not apply to pluggable components as there is no standard metadata to return
 	return map[string]string{}
 }
 


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Update pluggable interfaces to include `GetComponentMetadata` method

This method was introduced in Contrib to allow to inspect available component metadata options in a standardized manner.