### PR TITLE
Fixed issue with tracing not working in HTTP service invocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/dapr/components-contrib v1.9.1-0.20221111215803-c92827c3defc
 	github.com/dapr/kit v0.0.3-0.20221102045011-c213121f0b4f
-	github.com/fasthttp/router v1.4.12
+	github.com/fasthttp/router v1.4.13
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/gogo/protobuf v1.3.2
@@ -253,7 +253,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible // indirect
-	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/klauspost/compress v1.15.12 // indirect
 	github.com/knadh/koanf v1.4.1 // indirect
 	github.com/kubemq-io/kubemq-go v1.7.6 // indirect
 	github.com/kubemq-io/protobuf v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJ
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fasthttp-contrib/sessions v0.0.0-20160905201309-74f6ac73d5d5 h1:M4CVMQ5ueVmGZAtkW2bsO+ftesCYpfxl27JTqtzKBzE=
 github.com/fasthttp-contrib/sessions v0.0.0-20160905201309-74f6ac73d5d5/go.mod h1:MQXNGeXkpojWTxbN7vXoE3f7EmlA11MlJbsrJpVBINA=
-github.com/fasthttp/router v1.4.12 h1:QEgK+UKARaC1bAzJgnIhdUMay6nwp+YFq6VGPlyKN1o=
-github.com/fasthttp/router v1.4.12/go.mod h1:41Qdc4Z4T2pWVVtATHCnoUnOtxdBoeKEYJTXhHwbxCQ=
+github.com/fasthttp/router v1.4.13 h1:42M7+7tNO6clb5seb4HhXlBIX1lnNv8DLhiT6jUv75A=
+github.com/fasthttp/router v1.4.13/go.mod h1:mVhHMaSQA2Hi1HeuL/ZMuZpsZWk5bya75EpaDr3fO7E=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239/go.mod h1:Gdwt2ce0yfBxPvZrHkprdPPTTS3N5rwmLE8T22KBXlw=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -991,10 +991,9 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
-github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=
-github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
+github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/knadh/koanf v1.4.1 h1:Z0VGW/uo8NJmjd+L1Dc3S5frq6c62w5xQ9Yf4Mg3wFQ=
 github.com/knadh/koanf v1.4.1/go.mod h1:1cfH5223ZeZUOs8FU2UdTmaNfHpqgtjV0+NHjRO43gs=
 github.com/koding/multiconfig v0.0.0-20171124222453-69c27309b2d7/go.mod h1:Y2SaZf2Rzd0pXkLVhLlCiAXFCLSXAIbTKDivVgff/AM=
@@ -1475,7 +1474,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasthttp v1.40.0/go.mod h1:t/G+3rLek+CyY9bnIE+YlMRddxVAAGjhxndDB4i4C0I=
 github.com/valyala/fasthttp v1.41.0 h1:zeR0Z1my1wDHTRiamBCXVglQdbUwgb9uWG3k1HQz6jY=
 github.com/valyala/fasthttp v1.41.0/go.mod h1:f6VbjjoI3z1NDOZOv17o6RvtRSWxC77seBFc2uWtgiY=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -15,7 +15,6 @@ package diagnostics
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	grpcMiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -266,18 +265,18 @@ func spanAttributesMapFromGRPC(appID string, req interface{}, rpcMethod string) 
 
 		// Rename spanname
 		if s.GetActor() == nil {
-			m[daprAPISpanNameInternal] = fmt.Sprintf("CallLocal/%s/%s", appID, s.Message.GetMethod())
+			m[daprAPISpanNameInternal] = "CallLocal/" + appID + "/" + s.Message.GetMethod()
 			m[daprAPIInvokeMethod] = s.Message.GetMethod()
 		} else {
-			m[daprAPISpanNameInternal] = fmt.Sprintf("CallActor/%s/%s", s.GetActor().GetActorType(), s.Message.GetMethod())
-			m[daprAPIActorTypeID] = fmt.Sprintf("%s.%s", s.GetActor().GetActorType(), s.GetActor().GetActorId())
+			m[daprAPISpanNameInternal] = "CallActor/" + s.GetActor().GetActorType() + "/" + s.Message.GetMethod()
+			m[daprAPIActorTypeID] = s.GetActor().GetActorType() + "." + s.GetActor().GetActorId()
 		}
 
 	// Dapr APIs
 	case *runtimev1pb.InvokeServiceRequest:
 		m[gRPCServiceSpanAttributeKey] = daprGRPCServiceInvocationService
 		m[netPeerNameSpanAttributeKey] = s.GetId()
-		m[daprAPISpanNameInternal] = fmt.Sprintf("CallLocal/%s/%s", s.GetId(), s.Message.GetMethod())
+		m[daprAPISpanNameInternal] = "CallLocal/" + s.GetId() + "/" + s.Message.GetMethod()
 
 	case *runtimev1pb.PublishEventRequest:
 		m[gRPCServiceSpanAttributeKey] = daprGRPCDaprService

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
-	"github.com/valyala/fasthttp/fasthttpadaptor"
 	"github.com/valyala/fasthttp/pprofhandler"
 
 	"github.com/dapr/dapr/pkg/config"
@@ -37,6 +36,7 @@ import (
 	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
 	auth "github.com/dapr/dapr/pkg/runtime/security"
 	authConsts "github.com/dapr/dapr/pkg/runtime/security/consts"
+	"github.com/dapr/dapr/utils/fasthttpadaptor"
 	"github.com/dapr/dapr/utils/nethttpadaptor"
 	"github.com/dapr/kit/logger"
 )
@@ -328,12 +328,10 @@ func (s *server) getRouter(endpoints []Endpoint) *routing.Router {
 			continue
 		}
 
-		path := fmt.Sprintf("/%s/%s", e.Version, e.Route)
-		s.handle(e, parameterFinder, path, router)
+		s.handle(e, parameterFinder, "/"+e.Version+"/"+e.Route, router)
 
 		if e.Alias != "" {
-			path = fmt.Sprintf("/%s", e.Alias)
-			s.handle(e, parameterFinder, path, router)
+			s.handle(e, parameterFinder, "/"+e.Alias, router)
 		}
 	}
 
@@ -341,10 +339,11 @@ func (s *server) getRouter(endpoints []Endpoint) *routing.Router {
 }
 
 func (s *server) handle(e Endpoint, parameterFinder *regexp.Regexp, path string, router *routing.Router) {
+	pathIncludesParameters := parameterFinder.MatchString(path)
+
 	for _, m := range e.Methods {
 		handler := e.Handler
 
-		pathIncludesParameters := parameterFinder.MatchString(path)
 		if pathIncludesParameters && !e.KeepParamUnescape {
 			handler = s.unescapeRequestParametersHandler(handler)
 		}

--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.3 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/klauspost/compress v1.15.12 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/tests/apps/pluggable_kafka-bindings/go.sum
+++ b/tests/apps/pluggable_kafka-bindings/go.sum
@@ -51,8 +51,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.3 h1:iTonLeSJOn7MVUtyMT+arAn5AKAPrkilzhGw8wE
 github.com/jcmturner/gokrb5/v8 v8.4.3/go.mod h1:dqRwJGXznQrzw6cWmyo6kH+E7jksEQG/CyVWsJEsJO0=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=
-github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
+github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 h1:BpfhmLKZf+SjVanKKhCgf3bg+511DmU9eDQTen7LLbY=
 github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=

--- a/utils/fasthttpadaptor/README.md
+++ b/utils/fasthttpadaptor/README.md
@@ -1,0 +1,17 @@
+# fasthttpadaptor
+
+This package contains a fork of https://github.com/valyala/fasthttp/tree/v1.41.0/fasthttpadaptor with some Dapr-specific changes.
+
+These changes are only needed to support the hybrid state in which Dapr's HTTP server is using fasthttp, and the HTTP channel (and its middlewares) are using net/http. This package will be obsolete when #4979 is addressed.
+
+## License
+
+> The MIT License (MIT)
+> 
+> Copyright (c) 2015-present Aliaksandr Valialkin, VertaMedia, Kirill Danshin, Erik Dubbelboer, FastHTTP Authors
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/utils/fasthttpadaptor/adaptor.go
+++ b/utils/fasthttpadaptor/adaptor.go
@@ -1,0 +1,123 @@
+// Package fasthttpadaptor provides helper functions for converting net/http
+// request handlers to fasthttp request handlers.
+package fasthttpadaptor
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/valyala/fasthttp"
+)
+
+// NewFastHTTPHandlerFunc wraps net/http handler func to fasthttp
+// request handler, so it can be passed to fasthttp server.
+//
+// While this function may be used for easy switching from net/http to fasthttp,
+// it has the following drawbacks comparing to using manually written fasthttp
+// request handler:
+//
+//   - A lot of useful functionality provided by fasthttp is missing
+//     from net/http handler.
+//   - net/http -> fasthttp handler conversion has some overhead,
+//     so the returned handler will be always slower than manually written
+//     fasthttp handler.
+//
+// So it is advisable using this function only for quick net/http -> fasthttp
+// switching. Then manually convert net/http handlers to fasthttp handlers
+// according to https://github.com/valyala/fasthttp#switching-from-nethttp-to-fasthttp .
+func NewFastHTTPHandlerFunc(h http.HandlerFunc) fasthttp.RequestHandler {
+	return NewFastHTTPHandler(h)
+}
+
+// NewFastHTTPHandler wraps net/http handler to fasthttp request handler,
+// so it can be passed to fasthttp server.
+//
+// While this function may be used for easy switching from net/http to fasthttp,
+// it has the following drawbacks comparing to using manually written fasthttp
+// request handler:
+//
+//   - A lot of useful functionality provided by fasthttp is missing
+//     from net/http handler.
+//   - net/http -> fasthttp handler conversion has some overhead,
+//     so the returned handler will be always slower than manually written
+//     fasthttp handler.
+//
+// So it is advisable using this function only for quick net/http -> fasthttp
+// switching. Then manually convert net/http handlers to fasthttp handlers
+// according to https://github.com/valyala/fasthttp#switching-from-nethttp-to-fasthttp .
+func NewFastHTTPHandler(h http.Handler) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		var r http.Request
+		if err := ConvertRequest(ctx, &r, true); err != nil {
+			ctx.Logger().Printf("cannot parse requestURI %q: %v", r.RequestURI, err)
+			ctx.Error("Internal Server Error", fasthttp.StatusInternalServerError)
+			return
+		}
+
+		w := NetHTTPResponseWriter{w: ctx.Response.BodyWriter()}
+		h.ServeHTTP(&w, r.WithContext(ctx))
+
+		ctx.SetStatusCode(w.StatusCode())
+		haveContentType := false
+		for k, vv := range w.Header() {
+			if k == fasthttp.HeaderContentType {
+				haveContentType = true
+			}
+
+			for _, v := range vv {
+				ctx.Response.Header.Add(k, v)
+			}
+		}
+		if !haveContentType {
+			// From net/http.ResponseWriter.Write:
+			// If the Header does not contain a Content-Type line, Write adds a Content-Type set
+			// to the result of passing the initial 512 bytes of written data to DetectContentType.
+			l := 512
+			b := ctx.Response.Body()
+			if len(b) < 512 {
+				l = len(b)
+			}
+			ctx.Response.Header.Set(fasthttp.HeaderContentType, http.DetectContentType(b[:l]))
+		}
+
+		for k, v := range w.userValues {
+			ctx.SetUserValue(k, v)
+		}
+	}
+}
+
+type NetHTTPResponseWriter struct {
+	statusCode int
+	h          http.Header
+	w          io.Writer
+	userValues map[any]any
+}
+
+func (w *NetHTTPResponseWriter) StatusCode() int {
+	if w.statusCode == 0 {
+		return http.StatusOK
+	}
+	return w.statusCode
+}
+
+func (w *NetHTTPResponseWriter) Header() http.Header {
+	if w.h == nil {
+		w.h = make(http.Header)
+	}
+	return w.h
+}
+
+func (w *NetHTTPResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (w *NetHTTPResponseWriter) Write(p []byte) (int, error) {
+	return w.w.Write(p)
+}
+
+func (w *NetHTTPResponseWriter) SetUserValue(key any, value any) {
+	if w.userValues == nil {
+		w.userValues = map[any]any{}
+	}
+	w.userValues[key] = value
+}

--- a/utils/fasthttpadaptor/adaptor_test.go
+++ b/utils/fasthttpadaptor/adaptor_test.go
@@ -1,0 +1,145 @@
+package fasthttpadaptor
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+func TestNewFastHTTPHandler(t *testing.T) {
+	t.Parallel()
+
+	expectedMethod := fasthttp.MethodPost
+	expectedProto := "HTTP/1.1"
+	expectedProtoMajor := 1
+	expectedProtoMinor := 1
+	expectedRequestURI := "/foo/bar?baz=123"
+	expectedBody := "<!doctype html><html>"
+	expectedContentLength := len(expectedBody)
+	expectedHost := "foobar.com"
+	expectedRemoteAddr := "1.2.3.4:6789"
+	expectedHeader := map[string]string{
+		"Foo-Bar":         "baz",
+		"Abc":             "defg",
+		"XXX-Remote-Addr": "123.43.4543.345",
+	}
+	expectedURL, err := url.ParseRequestURI(expectedRequestURI)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedContextKey := "contextKey"
+	expectedContextValue := "contextValue"
+	expectedContentType := "text/html; charset=utf-8"
+
+	callsCount := 0
+	nethttpH := func(w http.ResponseWriter, r *http.Request) {
+		callsCount++
+		if r.Method != expectedMethod {
+			t.Fatalf("unexpected method %q. Expecting %q", r.Method, expectedMethod)
+		}
+		if r.Proto != expectedProto {
+			t.Fatalf("unexpected proto %q. Expecting %q", r.Proto, expectedProto)
+		}
+		if r.ProtoMajor != expectedProtoMajor {
+			t.Fatalf("unexpected protoMajor %d. Expecting %d", r.ProtoMajor, expectedProtoMajor)
+		}
+		if r.ProtoMinor != expectedProtoMinor {
+			t.Fatalf("unexpected protoMinor %d. Expecting %d", r.ProtoMinor, expectedProtoMinor)
+		}
+		if r.RequestURI != expectedRequestURI {
+			t.Fatalf("unexpected requestURI %q. Expecting %q", r.RequestURI, expectedRequestURI)
+		}
+		if r.ContentLength != int64(expectedContentLength) {
+			t.Fatalf("unexpected contentLength %d. Expecting %d", r.ContentLength, expectedContentLength)
+		}
+		if len(r.TransferEncoding) != 0 {
+			t.Fatalf("unexpected transferEncoding %q. Expecting []", r.TransferEncoding)
+		}
+		if r.Host != expectedHost {
+			t.Fatalf("unexpected host %q. Expecting %q", r.Host, expectedHost)
+		}
+		if r.RemoteAddr != expectedRemoteAddr {
+			t.Fatalf("unexpected remoteAddr %q. Expecting %q", r.RemoteAddr, expectedRemoteAddr)
+		}
+		body, rErr := io.ReadAll(r.Body)
+		r.Body.Close()
+		if rErr != nil {
+			t.Fatalf("unexpected error when reading request body: %v", rErr)
+		}
+		if string(body) != expectedBody {
+			t.Fatalf("unexpected body %q. Expecting %q", body, expectedBody)
+		}
+		if !reflect.DeepEqual(r.URL, expectedURL) {
+			t.Fatalf("unexpected URL: %#v. Expecting %#v", r.URL, expectedURL)
+		}
+		if r.Context().Value(expectedContextKey) != expectedContextValue {
+			t.Fatalf("unexpected context value for key %q. Expecting %q", expectedContextKey, expectedContextValue)
+		}
+
+		for k, expectedV := range expectedHeader {
+			v := r.Header.Get(k)
+			if v != expectedV {
+				t.Fatalf("unexpected header value %q for key %q. Expecting %q", v, k, expectedV)
+			}
+		}
+
+		w.Header().Set("Header1", "value1")
+		w.Header().Set("Header2", "value2")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(body) //nolint:errcheck
+	}
+	fasthttpH := NewFastHTTPHandler(http.HandlerFunc(nethttpH))
+	fasthttpH = setContextValueMiddleware(fasthttpH, expectedContextKey, expectedContextValue)
+
+	var ctx fasthttp.RequestCtx
+	var req fasthttp.Request
+
+	req.Header.SetMethod(expectedMethod)
+	req.SetRequestURI(expectedRequestURI)
+	req.Header.SetHost(expectedHost)
+	req.BodyWriter().Write([]byte(expectedBody)) //nolint:errcheck
+	for k, v := range expectedHeader {
+		req.Header.Set(k, v)
+	}
+
+	remoteAddr, err := net.ResolveTCPAddr("tcp", expectedRemoteAddr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ctx.Init(&req, remoteAddr, nil)
+
+	fasthttpH(&ctx)
+
+	if callsCount != 1 {
+		t.Fatalf("unexpected callsCount: %d. Expecting 1", callsCount)
+	}
+
+	resp := &ctx.Response
+	if resp.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatalf("unexpected statusCode: %d. Expecting %d", resp.StatusCode(), fasthttp.StatusBadRequest)
+	}
+	if string(resp.Header.Peek("Header1")) != "value1" {
+		t.Fatalf("unexpected header value: %q. Expecting %q", resp.Header.Peek("Header1"), "value1")
+	}
+	if string(resp.Header.Peek("Header2")) != "value2" {
+		t.Fatalf("unexpected header value: %q. Expecting %q", resp.Header.Peek("Header2"), "value2")
+	}
+	if string(resp.Body()) != expectedBody {
+		t.Fatalf("unexpected response body %q. Expecting %q", resp.Body(), expectedBody)
+	}
+	if string(resp.Header.Peek("Content-Type")) != expectedContentType {
+		t.Fatalf("unexpected response content-type %q. Expecting %q", string(resp.Header.Peek("Content-Type")), expectedBody)
+	}
+}
+
+func setContextValueMiddleware(next fasthttp.RequestHandler, key string, value interface{}) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		ctx.SetUserValue(key, value)
+		next(ctx)
+	}
+}

--- a/utils/fasthttpadaptor/request.go
+++ b/utils/fasthttpadaptor/request.go
@@ -1,0 +1,68 @@
+package fasthttpadaptor
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"unsafe"
+
+	"github.com/valyala/fasthttp"
+)
+
+// ConvertRequest convert a fasthttp.Request to an http.Request
+// forServer should be set to true when the http.Request is going to passed to a http.Handler.
+//
+// The http.Request must not be used after the fasthttp handler has returned!
+// Memory in use by the http.Request will be reused after your handler has returned!
+func ConvertRequest(ctx *fasthttp.RequestCtx, r *http.Request, forServer bool) error {
+	body := ctx.PostBody()
+	strRequestURI := b2s(ctx.RequestURI())
+
+	rURL, err := url.ParseRequestURI(strRequestURI)
+	if err != nil {
+		return err
+	}
+
+	r.Method = b2s(ctx.Method())
+	r.Proto = "HTTP/1.1"
+	r.ProtoMajor = 1
+	r.ProtoMinor = 1
+	r.ContentLength = int64(len(body))
+	r.RemoteAddr = ctx.RemoteAddr().String()
+	r.Host = b2s(ctx.Host())
+	r.TLS = ctx.TLSConnectionState()
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.URL = rURL
+
+	if forServer {
+		r.RequestURI = strRequestURI
+	}
+
+	if r.Header == nil {
+		r.Header = make(http.Header)
+	} else if len(r.Header) > 0 {
+		for k := range r.Header {
+			delete(r.Header, k)
+		}
+	}
+
+	ctx.Request.Header.VisitAll(func(k, v []byte) {
+		sk := b2s(k)
+		sv := b2s(v)
+
+		switch sk {
+		case "Transfer-Encoding":
+			r.TransferEncoding = append(r.TransferEncoding, sv)
+		default:
+			r.Header.Set(sk, sv)
+		}
+	})
+
+	return nil
+}
+
+func b2s(b []byte) string {
+	/* #nosec G103 */
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/utils/fasthttpadaptor/request_test.go
+++ b/utils/fasthttpadaptor/request_test.go
@@ -1,0 +1,29 @@
+package fasthttpadaptor
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+func BenchmarkConvertRequest(b *testing.B) {
+	var httpReq http.Request
+
+	ctx := &fasthttp.RequestCtx{
+		Request: fasthttp.Request{
+			Header:        fasthttp.RequestHeader{},
+			UseHostHeader: false,
+		},
+	}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.Header.Set("x", "test")
+	ctx.Request.Header.Set("y", "test")
+	ctx.Request.SetRequestURI("/test")
+	ctx.Request.SetHost("test")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = ConvertRequest(ctx, &httpReq, true)
+	}
+}


### PR DESCRIPTION
This PR fixes a regression reported by @artursouza that was caught thanks the E2E tests in the Java SDK repos.

The regression was introduced by #5316 . When we converted the HTTP middlewares from fasthttp to net/http, we used two "adapters" to convert between the frameworks. As part of that, user values set in the HTTP context were not passed correctly from the router to the tracing middleware, and they were lost in the conversion. These user values are used by the router to store the values from the URLs (e.g. the method name and target ID app).

This PR fixes the issue by forking the [fasthttpadaptor](https://github.com/valyala/fasthttp/tree/master/fasthttpadaptor) and adding an extension to preserve changes to user values across the adaptors. I opted for a hard fork given that the upstream package seems to be mostly stable and this change is pretty much Dapr-specific. It's also meant to be temporary, until #4979 is addressed.