### PR TITLE
Disallow app-id containing dots

### DIFF
--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -127,6 +127,9 @@ func FromFlags() (*DaprRuntime, error) {
 	if *appID == "" {
 		return nil, errors.New("app-id parameter cannot be empty")
 	}
+	if strings.IndexRune(*appID, '.') != -1 {
+		return nil, errors.New("app-id parameter cannot contain dots")
+	}
 
 	// Apply options to all loggers
 	loggerOptions.SetAppID(*appID)

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -40,6 +40,7 @@ import (
 	operatorV1 "github.com/dapr/dapr/pkg/proto/operator/v1"
 	resiliencyConfig "github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/security"
+	"github.com/dapr/dapr/pkg/validation"
 	"github.com/dapr/dapr/pkg/version"
 	"github.com/dapr/dapr/utils"
 )
@@ -124,11 +125,8 @@ func FromFlags() (*DaprRuntime, error) {
 		os.Exit(0)
 	}
 
-	if *appID == "" {
-		return nil, errors.New("app-id parameter cannot be empty")
-	}
-	if strings.IndexRune(*appID, '.') != -1 {
-		return nil, errors.New("app-id parameter cannot contain dots")
+	if err := validation.ValidateSelfHostedAppID(*appID); err != nil {
+		return nil, err
 	}
 
 	// Apply options to all loggers

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -30,7 +30,7 @@ const (
 
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
 
-// ValidateKubernetesAppID returns a bool that indicates whether a dapr app id is valid for the Kubernetes platform.
+// ValidateKubernetesAppID returns an error if the Dapr app id is not valid for the Kubernetes platform.
 func ValidateKubernetesAppID(appID string) error {
 	if appID == "" {
 		return errors.New("value for the dapr.io/app-id annotation is empty")
@@ -39,8 +39,19 @@ func ValidateKubernetesAppID(appID string) error {
 	if len(r) == 0 {
 		return nil
 	}
-	s := fmt.Sprintf("invalid app id(input: %s, service: %s): %s", appID, serviceName(appID), strings.Join(r, ","))
-	return errors.New(s)
+	return fmt.Errorf("invalid app id (input: %s, service: %s): %s", appID, serviceName(appID), strings.Join(r, ", "))
+}
+
+// ValidateSelfHostedAppID returns an error if the Dapr app id is not valid for self-hosted.
+func ValidateSelfHostedAppID(appID string) error {
+	if appID == "" {
+		return errors.New("parameter app-id cannot be empty")
+	}
+	r := isDNS1123Label(serviceName(appID))
+	if len(r) == 0 {
+		return nil
+	}
+	return fmt.Errorf("parameter app-id is invalid: %s", strings.Join(r, ", "))
 }
 
 func serviceName(appID string) string {

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidationForKubernetes(t *testing.T) {
+func TestValidateKubernetesAppID(t *testing.T) {
 	t.Run("invalid length", func(t *testing.T) {
 		id := ""
 		for i := 0; i < 64; i++ {
@@ -58,6 +58,41 @@ func TestValidationForKubernetes(t *testing.T) {
 	t.Run("invalid empty", func(t *testing.T) {
 		id := ""
 		err := ValidateKubernetesAppID(id)
-		assert.Regexp(t, "value for the dapr.io/app-id annotation is empty", err.Error())
+		assert.Contains(t, "value for the dapr.io/app-id annotation is empty", err.Error())
+	})
+}
+
+func TestValidateSelfHostedAppID(t *testing.T) {
+	t.Run("invalid length", func(t *testing.T) {
+		id := ""
+		for i := 0; i < 64; i++ {
+			id += "a"
+		}
+		err := ValidateSelfHostedAppID(id)
+		assert.Error(t, err)
+	})
+
+	t.Run("valid id", func(t *testing.T) {
+		id := "my-app-id"
+		err := ValidateSelfHostedAppID(id)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid char: .", func(t *testing.T) {
+		id := "my-app-id.app"
+		err := ValidateSelfHostedAppID(id)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid chars space", func(t *testing.T) {
+		id := "my-app-id app"
+		err := ValidateSelfHostedAppID(id)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid empty", func(t *testing.T) {
+		id := ""
+		err := ValidateSelfHostedAppID(id)
+		assert.Contains(t, "parameter app-id cannot be empty", err.Error())
 	})
 }


### PR DESCRIPTION
The daprd binary now shows a fatal error if `--app-id` contains a dot, which is not allowed.

Fixes #5552