### PR TITLE
Issue 5321 - Broken trace when timeout resiliency policy is enabled

### DIFF
--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -80,6 +80,11 @@ func SpanFromContext(ctx context.Context) trace.Span {
 		if val != nil {
 			return val.(trace.Span)
 		}
+	} else {
+		val := ctx.Value(daprFastHTTPContextKey)
+		if val != nil {
+			return val.(trace.Span)
+		}
 	}
 
 	span := trace.SpanFromContext(ctx)


### PR DESCRIPTION
Signed-off-by: Akhila Chetlapalle <akhila@Akhilas-MacBook-Pro.local>

# Description
When timeout resiliency policy is enabled, the traceID does not propagate with the request and a broken trace is shown with a Span of 1, separately for client and server. To replicate the issue run the service invocation Quickstart and check the traces in zipkin. connected traces for order processor and checkout will be shown. 
Now enable resiliency [ since it is a preview feature ] and apply timeout policy to both the services. You will see individual traces for order processor and checkout app 

With this fix, you will be able to see a connected trace in both the scenarios.

<!--
Please explain the changes you've made.
-->
Retrieving the span using the utility function fails as the function checks for the context object to be of type fast http context. When resiliency policy for timeout is enabled, the context object passed is of type timeout Context. So the span is retrieved as <nil>.

Fixed the utility function to directly look for value in the context if the context is not of type fasthttp. Retained default behaviour if the span value is not found based on the key "daprSpanContextKey"

## Issue reference


<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #5321 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
