### PR TITLE
Revert self-hosted AppID validation and only disallow dots

### DIFF
--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -125,8 +125,16 @@ func FromFlags() (*DaprRuntime, error) {
 		os.Exit(0)
 	}
 
-	if err := validation.ValidateSelfHostedAppID(*appID); err != nil {
-		return nil, err
+	if *mode == string(modes.KubernetesMode) {
+		if err := validation.ValidateKubernetesAppID(*appID); err != nil {
+			return nil, err
+		}
+	} else {
+		// Convert appID to lowercase to be compatible with the validation.
+		*appID = strings.ToLower(*appID)
+		if err := validation.ValidateSelfHostedAppID(*appID); err != nil {
+			return nil, err
+		}
 	}
 
 	// Apply options to all loggers

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -126,11 +126,6 @@ func FromFlags() (*DaprRuntime, error) {
 	}
 
 	if *mode == string(modes.StandaloneMode) {
-		appIDLower := strings.ToLower(*appID)
-		if *appID != appIDLower {
-			log.Warnf("app-id should be lowercase, using %s instead", appIDLower)
-			*appID = appIDLower
-		}
 		if err := validation.ValidateSelfHostedAppID(*appID); err != nil {
 			return nil, err
 		}

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -125,13 +125,12 @@ func FromFlags() (*DaprRuntime, error) {
 		os.Exit(0)
 	}
 
-	if *mode == string(modes.KubernetesMode) {
-		if err := validation.ValidateKubernetesAppID(*appID); err != nil {
-			return nil, err
+	if *mode == string(modes.StandaloneMode) {
+		appIDLower := strings.ToLower(*appID)
+		if *appID != appIDLower {
+			log.Warnf("app-id should be lowercase, using %s instead", appIDLower)
+			*appID = appIDLower
 		}
-	} else {
-		// Convert appID to lowercase to be compatible with the validation.
-		*appID = strings.ToLower(*appID)
 		if err := validation.ValidateSelfHostedAppID(*appID); err != nil {
 			return nil, err
 		}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -47,11 +47,10 @@ func ValidateSelfHostedAppID(appID string) error {
 	if appID == "" {
 		return errors.New("parameter app-id cannot be empty")
 	}
-	r := isDNS1123Label(serviceName(appID))
-	if len(r) == 0 {
-		return nil
+	if strings.Contains(appID, ".") {
+		return errors.New("parameter app-id cannot contain a period (.)")
 	}
-	return fmt.Errorf("parameter app-id is invalid: %s", strings.Join(r, ", "))
+	return nil
 }
 
 func serviceName(appID string) string {

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -63,29 +63,20 @@ func TestValidateKubernetesAppID(t *testing.T) {
 }
 
 func TestValidateSelfHostedAppID(t *testing.T) {
-	t.Run("invalid length", func(t *testing.T) {
-		id := ""
-		for i := 0; i < 64; i++ {
-			id += "a"
-		}
-		err := ValidateSelfHostedAppID(id)
-		assert.Error(t, err)
-	})
-
 	t.Run("valid id", func(t *testing.T) {
 		id := "my-app-id"
 		err := ValidateSelfHostedAppID(id)
 		assert.NoError(t, err)
 	})
 
-	t.Run("invalid char: .", func(t *testing.T) {
+	t.Run("contains a dot", func(t *testing.T) {
 		id := "my-app-id.app"
 		err := ValidateSelfHostedAppID(id)
 		assert.Error(t, err)
 	})
 
-	t.Run("invalid chars space", func(t *testing.T) {
-		id := "my-app-id app"
+	t.Run("contains multiple dots", func(t *testing.T) {
+		id := "foo.bar.baz"
 		err := ValidateSelfHostedAppID(id)
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

This PR reverts the logic introduced in #5556 to validate self-hosted app-ids with RFC-1123. It only throws an error if the app-id contains a period (`.`).

A major reason is that upper-case in app-ids was no longer allowed after #5556, which broke the case-sensitive implementations in state store (app-id is prefixed) and pub/sub (consumer groups use app-id).

~~From #5556, we introduced stricter rules for appID validation in self-hosted mode. This PR relaxes the case restrictions by transforming the appID into a lowercase string. This will prevent breaking existing Dapr integrations where users are using appIDs with uppercase characters.~~

## Issue reference

Please reference the issue this PR will close: #5552

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
