### PR TITLE
Update AKS version due to EOL for 1.22.x

### DIFF
--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -43,7 +43,7 @@ param diagStorageResourceId string = ''
 var osDiskSizeGB = 0
 
 // Version of Kubernetes
-var kubernetesVersion = '1.22.11'
+var kubernetesVersion = '1.24.6'
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
   name: '${namePrefix}acr'


### PR DESCRIPTION
Per an email from the AKS team, AKS running on Kubernetes 1.22 will be deprecated on December 4. Because we create AKS clusters on-demand, our E2E tests will fail starting that date.

This PR changes the version of AKS we use to 1.25.

Note: We have been postponing this for a while due to an issue with AKS 1.23+ on Windows: they switched the container runtime from Docker to containerd, and that causes an increase in failures in our tests due to pods failing to deploy. I've been working with the AKS team on identifying this issue in parallel, but in the meanwhile we can't postpone upgrading AKS anymore.