### PR TITLE
Fix placement nil dereference when reading stream

### DIFF
--- a/pkg/actors/internal/placement.go
+++ b/pkg/actors/internal/placement.go
@@ -181,12 +181,11 @@ func (p *ActorPlacement) Start() {
 			p.clientLock.RLock()
 			clientStream := p.clientStream
 			p.clientLock.RUnlock()
-
+			resp, err := clientStream.Recv()
 			if p.shutdown.Load() {
 				break
 			}
 
-			resp, err := clientStream.Recv()
 			// TODO: we may need to handle specific errors later.
 			if err != nil {
 				p.closeStream()

--- a/pkg/actors/internal/placement.go
+++ b/pkg/actors/internal/placement.go
@@ -181,11 +181,12 @@ func (p *ActorPlacement) Start() {
 			p.clientLock.RLock()
 			clientStream := p.clientStream
 			p.clientLock.RUnlock()
-			resp, err := clientStream.Recv()
+
 			if p.shutdown.Load() {
 				break
 			}
 
+			resp, err := clientStream.Recv()
 			// TODO: we may need to handle specific errors later.
 			if err != nil {
 				p.closeStream()
@@ -304,15 +305,8 @@ func (p *ActorPlacement) closeStream() {
 		p.clientLock.Lock()
 		defer p.clientLock.Unlock()
 
-		if p.clientStream != nil {
-			p.clientStream.CloseSend()
-			p.clientStream = nil
-		}
-
-		if p.clientConn != nil {
-			p.clientConn.Close()
-			p.clientConn = nil
-		}
+		p.clientStream.CloseSend()
+		p.clientConn.Close()
 	}()
 
 	func() {

--- a/pkg/actors/internal/placement.go
+++ b/pkg/actors/internal/placement.go
@@ -305,8 +305,13 @@ func (p *ActorPlacement) closeStream() {
 		p.clientLock.Lock()
 		defer p.clientLock.Unlock()
 
-		p.clientStream.CloseSend()
-		p.clientConn.Close()
+		if p.clientStream != nil {
+			p.clientStream.CloseSend()
+		}
+
+		if p.clientConn != nil {
+			p.clientConn.Close()
+		}
 	}()
 
 	func() {

--- a/pkg/actors/internal/placement_test.go
+++ b/pkg/actors/internal/placement_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/dapr/dapr/pkg/placement/hashing"
 	placementv1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
-	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 )
 
 func TestAddDNSResolverPrefix(t *testing.T) {
@@ -146,17 +145,17 @@ func TestAppHealthyStatus(t *testing.T) {
 
 type fakeStream struct {
 	//nolint:nosnakecase
-	v1pb.Placement_ReportDaprStatusClient
-	send            func(host *v1pb.Host) error
-	recv            func() (*v1pb.PlacementOrder, error)
+	placementv1pb.Placement_ReportDaprStatusClient
+	send            func(host *placementv1pb.Host) error
+	recv            func() (*placementv1pb.PlacementOrder, error)
 	closeSendCalled atomic.Int64
 }
 
-func (f *fakeStream) Send(host *v1pb.Host) error {
+func (f *fakeStream) Send(host *placementv1pb.Host) error {
 	return f.send(host)
 }
 
-func (f *fakeStream) Recv() (*v1pb.PlacementOrder, error) {
+func (f *fakeStream) Recv() (*placementv1pb.PlacementOrder, error) {
 	return f.recv()
 }
 
@@ -195,14 +194,14 @@ func TestCloseOnRecv(t *testing.T) {
 
 		testPlacement.clientLock.Lock()
 		fs := &fakeStream{
-			recv: func() (*v1pb.PlacementOrder, error) {
+			recv: func() (*placementv1pb.PlacementOrder, error) {
 				defer func() {
 					called++
 				}()
 				if called == 0 { // first call should close stream and wait
 					recvGroup.Done()
 					closeGroup.Wait()
-					return &v1pb.PlacementOrder{
+					return &placementv1pb.PlacementOrder{
 						Operation: unlockOperation,
 					}, nil
 				}
@@ -211,11 +210,11 @@ func TestCloseOnRecv(t *testing.T) {
 					return nil, errors.New("force reconnect")
 				}
 
-				return &v1pb.PlacementOrder{
+				return &placementv1pb.PlacementOrder{
 					Operation: unlockOperation,
 				}, nil
 			},
-			send: func(host *v1pb.Host) error {
+			send: func(host *placementv1pb.Host) error {
 				return nil
 			},
 		}

--- a/pkg/actors/internal/placement_test.go
+++ b/pkg/actors/internal/placement_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/placement/hashing"
 	placementv1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 )
 
 func TestAddDNSResolverPrefix(t *testing.T) {
@@ -140,6 +142,106 @@ func TestAppHealthyStatus(t *testing.T) {
 	// clean up
 	testPlacement.Stop()
 	cleanup()
+}
+
+type fakeStream struct {
+	//nolint:nosnakecase
+	v1pb.Placement_ReportDaprStatusClient
+	send            func(host *v1pb.Host) error
+	recv            func() (*v1pb.PlacementOrder, error)
+	closeSendCalled atomic.Int64
+}
+
+func (f *fakeStream) Send(host *v1pb.Host) error {
+	return f.send(host)
+}
+
+func (f *fakeStream) Recv() (*v1pb.PlacementOrder, error) {
+	return f.recv()
+}
+
+func (f *fakeStream) CloseSend() error {
+	f.closeSendCalled.Add(1)
+	return nil
+}
+
+func TestCloseOnRecv(t *testing.T) {
+	t.Run("should not panic", func(t *testing.T) {
+		address, testSrv, cleanup := newTestServer()
+
+		// set leader
+		testSrv.setLeader(true)
+
+		appHealth := atomic.Bool{}
+		appHealth.Store(true)
+
+		appHealthFunc := appHealth.Load
+		noopTableUpdateFunc := func() {}
+		testPlacement := NewActorPlacement(
+			[]string{address}, nil, "testAppID", "127.0.0.1:1000", []string{"actorOne", "actorTwo"},
+			appHealthFunc, noopTableUpdateFunc)
+
+		// act
+		testPlacement.Start()
+
+		assert.NotNil(t, testPlacement.clientStream)
+
+		var called int
+		recvGroup := sync.WaitGroup{}
+		recvGroup.Add(1)
+
+		closeGroup := sync.WaitGroup{}
+		closeGroup.Add(1)
+
+		testPlacement.clientLock.Lock()
+		fs := &fakeStream{
+			recv: func() (*v1pb.PlacementOrder, error) {
+				defer func() {
+					called++
+				}()
+				if called == 0 { // first call should close stream and wait
+					recvGroup.Done()
+					closeGroup.Wait()
+					return &v1pb.PlacementOrder{
+						Operation: unlockOperation,
+					}, nil
+				}
+
+				if called == 1 { // force reconnect
+					return nil, errors.New("force reconnect")
+				}
+
+				return &v1pb.PlacementOrder{
+					Operation: unlockOperation,
+				}, nil
+			},
+			send: func(host *v1pb.Host) error {
+				return nil
+			},
+		}
+		testPlacement.clientStream = fs
+		testPlacement.clientLock.Unlock()
+
+		go func() {
+			recvGroup.Wait()
+			testPlacement.closeStream()
+			closeGroup.Done()
+		}()
+		// should not panic
+		closeGroup.Wait()
+		testPlacement.streamConnectedCond.L.Lock()
+		for !testPlacement.streamConnAlive {
+			testPlacement.streamConnectedCond.Wait()
+		}
+		testPlacement.streamConnectedCond.L.Unlock()
+
+		assert.Equal(t, called, 2)
+		assert.GreaterOrEqual(t, fs.closeSendCalled.Load(), int64(2))
+		assert.NotEqual(t, testPlacement.clientStream, fs)
+		// clean up
+		testPlacement.Stop()
+		cleanup()
+	})
 }
 
 func TestOnPlacementOrder(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

I've removed the nil assignment for the clientStream when closing the stream that was causing a nil dereference. This should not be a problem in terms of garbage collection, given the `closeStream` calling frequency. Also, calling CloseSend and Close twice does not panic, so it will not be a problema as well.

## Issue reference


Please reference the issue this PR will close: #5575

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
