### PR TITLE
Fixed: components that reference secrets cannot be initialized when `--disable-builtin-k8s-secret-store=true`

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2459,11 +2459,6 @@ func (a *DaprRuntime) processComponentSecrets(component componentsV1alpha1.Compo
 		}
 
 		secretStoreName := a.authSecretStoreOrDefault(component)
-		secretStore := a.getSecretStore(secretStoreName)
-		if secretStore == nil {
-			log.Warnf("component %s references a secret store that isn't loaded: %s", component.Name, secretStoreName)
-			return component, secretStoreName
-		}
 
 		// If running in Kubernetes, do not fetch secrets from the Kubernetes secret store as they will be populated by the operator.
 		// Instead, base64 decode the secret values into their real self.
@@ -2489,6 +2484,12 @@ func (a *DaprRuntime) processComponentSecrets(component componentsV1alpha1.Compo
 
 			component.Spec.Metadata[i] = m
 			continue
+		}
+
+		secretStore := a.getSecretStore(secretStoreName)
+		if secretStore == nil {
+			log.Warnf("component %s references a secret store that isn't loaded: %s", component.Name, secretStoreName)
+			return component, secretStoreName
 		}
 
 		resp, ok := cache[m.SecretKeyRef.Name]


### PR DESCRIPTION
When the flag `--disable-builtin-k8s-secret-store` is set to true, an issue is preventing components that reference secrets from being initialized. Those components fail with a message saying that the secret store `"kubernetes"` doesn't exist - even though the secrets should be fetched from the Dapr Operator and not the secret store itself.