### PR TITLE
Hotfix 1.9.5 and release notes

### DIFF
--- a/docs/release_notes/v1.9.5.md
+++ b/docs/release_notes/v1.9.5.md
@@ -1,0 +1,45 @@
+# Dapr 1.9.5
+
+- Fixes an issue in the CosmosDB state store component when performing transaction request with ETags
+- Fixes component initialization failure when the built-in Kubernetes secret store is disabled
+
+## Fixes an issue in the CosmosDB state store component when performing transaction request with ETags
+
+### Problem
+
+When setting any ETag in a transaction request inside CosmosDB, dapr exits due to a nil pointer dereference.
+
+### Impact
+
+This issue impacts all users of CosmosDB state store.
+
+### Root cause
+
+When setting an ETag on a transaction request in CosmosDB state store, a nil pointer was being dereferenced. 
+
+### Solution
+
+We fixed a bug that caused Dapr to panic
+
+
+## Fixes component initialization failure when the built-in Kubernetes secret store is disabled
+ 
+### Problem
+
+When running on Kubernetes, Dapr automatically initializes a Kubernetes secret store in each sidecar. Starting with Dapr 1.8, this behavior can be [turned off](https://docs.dapr.io/reference/arguments-annotations-overview/) using the `dapr.io/disable-builtin-k8s-secret-store`.
+
+However, with the built-in Kubernetes secret store disabled, an error prevented components from being able to retrieve secrets [stored as Kubernetes secrets](https://docs.dapr.io/operations/components/component-secrets/#referencing-a-kubernetes-secret) during initialization. This caused components to fail to initialize due to not being able to read secrets, for example connection strings or passwords.
+ 
+### Impact
+
+The issue impacts users on Dapr 1.8.0-1.9.4 who want to disable the built-in Kubernetes secret store.
+ 
+### Root cause
+
+In Dapr, components that use secrets stored as Kubernetes secrets should not need the built-in Kubernetes secret store to be loaded to work. This is because the Dapr Operator service populates the secrets from the Kubernetes secret store and passes them to the sidecar automatically.
+
+However, during initialization of a component that references a secret stored in Kubernetes, a bug caused Dapr to return an error if the built-in Kubernetes secret store was disabled, and the value of the secret as included by the Dapr Operator was ignored.
+
+### Solution
+ 
+We have implemented a fix in the component initialization sequence. Now, components that reference secrets from the Kubernetes secret store do not need the built-in Kubernetes secret store to be enabled anymore.

--- a/docs/release_notes/v1.9.5.md
+++ b/docs/release_notes/v1.9.5.md
@@ -1,25 +1,25 @@
 # Dapr 1.9.5
 
-- Fixes an issue in the CosmosDB state store component when performing transaction request with ETags
+- Fixes a panic in the Azure Cosmos DB state store component when performing transaction request with ETags
 - Fixes component initialization failure when the built-in Kubernetes secret store is disabled
 
-## Fixes an issue in the CosmosDB state store component when performing transaction request with ETags
+## Fixes a panic in the Azure Cosmos DB state store component when performing transaction request with ETags
 
 ### Problem
 
-When setting any ETag in a transaction request inside CosmosDB, dapr exits due to a nil pointer dereference.
+When setting any ETag in a transaction request with the Azure Cosmos DB state store, Dapr panics with a nil pointer dereference.
 
 ### Impact
 
-This issue impacts all users of CosmosDB state store.
+This issue impacts all users of the Azure Cosmos DB state store on Dapr 1.9.0-1.9.4.
 
 ### Root cause
 
-When setting an ETag on a transaction request in CosmosDB state store, a nil pointer was being dereferenced. 
+When setting an ETag on a transaction request in the Azure Cosmos DB state store, a bug causes Dapr to panic.
 
 ### Solution
 
-We fixed a bug that caused Dapr to panic
+We fixed a bug that caused Dapr to panic.
 
 
 ## Fixes component initialization failure when the built-in Kubernetes secret store is disabled

--- a/docs/release_notes/v1.9.5.md
+++ b/docs/release_notes/v1.9.5.md
@@ -3,6 +3,7 @@
 - Fixes a panic in the Azure Cosmos DB state store component when performing transaction request with ETags
 - Fixes component initialization failure when the built-in Kubernetes secret store is disabled
 - Fixes nil dereference crash in placement membership heartbeat loop in sidecar
+- Fixes MQTT message acknowledgement for retained messages
 
 ## Fixes a panic in the Azure Cosmos DB state store component when performing transaction request with ETags
 
@@ -63,3 +64,22 @@ We identified a race condition in the actor placement service client that could 
 ### Solution
 
 We updated actor placement service to address the race condition and remove the cause for the panic.
+
+
+## Fixes MQTT message acknowledgement for retained messages
+
+### Problem
+
+Retained mqtt messages should be only processed once, however, they were not being acknowledged and thus were resent indefinitely.
+
+### Impact
+
+This issue impacts all users of MQTT on Dapr 1.9.0-1.9.4.
+
+### Root cause
+
+MQTT retained messages were never being acknowledged and were therefore being resent indefinitely. 
+
+### Solution
+
+We updated Dapr to acknowledge a retained message.

--- a/docs/release_notes/v1.9.5.md
+++ b/docs/release_notes/v1.9.5.md
@@ -74,7 +74,7 @@ Retained MQTT messages should be only processed once, however, they were not bei
 
 ### Impact
 
-This issue impacts all users of the MQTT PubSub component on Dapr 1.9.0-1.9.4, who have enabled `retain` in the component's metadata.
+This issue impacts all users of the MQTT PubSub component on Dapr 1.9.0-1.9.4, where-in a subscriber using MQTT component receives a `retained` message.
 
 ### Root cause
 

--- a/docs/release_notes/v1.9.5.md
+++ b/docs/release_notes/v1.9.5.md
@@ -2,6 +2,7 @@
 
 - Fixes a panic in the Azure Cosmos DB state store component when performing transaction request with ETags
 - Fixes component initialization failure when the built-in Kubernetes secret store is disabled
+- Fixes nil dereference crash in placement membership heartbeat loop in sidecar
 
 ## Fixes a panic in the Azure Cosmos DB state store component when performing transaction request with ETags
 
@@ -43,3 +44,22 @@ However, during initialization of a component that references a secret stored in
 ### Solution
  
 We have implemented a fix in the component initialization sequence. Now, components that reference secrets from the Kubernetes secret store do not need the built-in Kubernetes secret store to be enabled anymore.
+
+
+## Fixes nil dereference crash in placement membership heartbeat loop in sidecar
+
+### Problem
+
+Dapr sidecar panics due to a nil dereference in the actor placement service.
+
+### Impact
+
+This issue impacts all users who are using actors.
+
+### Root cause
+
+After closing the client stream in the actor placement service, the stream was being set to nil.
+
+### Solution
+
+We updated actor placement service to properly close the client stream and no longer set it to nil.

--- a/docs/release_notes/v1.9.5.md
+++ b/docs/release_notes/v1.9.5.md
@@ -46,20 +46,20 @@ However, during initialization of a component that references a secret stored in
 We have implemented a fix in the component initialization sequence. Now, components that reference secrets from the Kubernetes secret store do not need the built-in Kubernetes secret store to be enabled anymore.
 
 
-## Fixes nil dereference crash in placement membership heartbeat loop in sidecar
+## Fixes panic in actor placement membership in Dapr sidecar
 
 ### Problem
 
-Dapr sidecar panics due to a nil dereference in the actor placement service.
+When recovering from a failure in the connection to the Dapr placement service, the Dapr sidecar could have encountered a panic in some cases.
 
 ### Impact
 
-This issue impacts all users who are using actors.
+The issue can impact all Dapr users on Dapr 1.7.0-1.9.4 using actors.
 
 ### Root cause
 
-After closing the client stream in the actor placement service, the stream was being set to nil.
+We identified a race condition in the actor placement service client that could have caused the Dapr to panic after recovering from a failure.
 
 ### Solution
 
-We updated actor placement service to properly close the client stream and no longer set it to nil.
+We updated actor placement service to address the race condition and remove the cause for the panic.

--- a/docs/release_notes/v1.9.5.md
+++ b/docs/release_notes/v1.9.5.md
@@ -70,11 +70,11 @@ We updated actor placement service to address the race condition and remove the 
 
 ### Problem
 
-Retained mqtt messages should be only processed once, however, they were not being acknowledged and thus were resent indefinitely.
+Retained MQTT messages should be only processed once, however, they were not being acknowledged and thus were resent indefinitely.
 
 ### Impact
 
-This issue impacts all users of MQTT on Dapr 1.9.0-1.9.4.
+This issue impacts all users of the MQTT PubSub component on Dapr 1.9.0-1.9.4, who have enabled `retain` in the component's metadata.
 
 ### Root cause
 
@@ -82,4 +82,4 @@ MQTT retained messages were never being acknowledged and were therefore being re
 
 ### Solution
 
-We updated Dapr to acknowledge a retained message.
+We updated Dapr to acknowledge a retained message in the MQTT PubSub component.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1
 	github.com/agrea/ptr v0.0.0-20180711073057-77a518d99b7b
 	github.com/cenkalti/backoff/v4 v4.1.3
-	github.com/dapr/components-contrib v1.9.4
+	github.com/dapr/components-contrib v1.9.6
 	github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7
 	github.com/fasthttp/router v1.4.12
 	github.com/fsnotify/fsnotify v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -593,8 +593,8 @@ github.com/danieljoos/wincred v1.0.2/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3E
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.9.4 h1:9Jkbq03YVQcZ4Ai28q6sCWGTPZGVlbRZD7g65XZpOdU=
-github.com/dapr/components-contrib v1.9.4/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
+github.com/dapr/components-contrib v1.9.6 h1:C12fnZhNim8AsOzTCsWZDZ0MXqsaG161fStVuVAQgN4=
+github.com/dapr/components-contrib v1.9.6/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7 h1:XDb+PwAOxbVNvLxkmwPgKlH5ltYlDdz/GcEDMe8RJxE=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7/go.mod h1:FR+yc0R0szlKnJooVqJvl7FhWf21wzY4/EzmyFQrESw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -6,7 +6,7 @@ replace github.com/dapr/dapr => ../../../
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb
-	github.com/dapr/components-contrib v1.9.4
+	github.com/dapr/components-contrib v1.9.6
 	github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7
 )
 

--- a/tests/apps/pluggable_kafka-bindings/go.sum
+++ b/tests/apps/pluggable_kafka-bindings/go.sum
@@ -56,8 +56,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb h1:N35TA4ra10ZTCk66IiP2jCUcH8HKnN78MGyuO/64Gn0=
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb/go.mod h1:ybLpIBlVHbHt17ovO+19PyC4iIHGbuSstX1XPvHRYLo=
-github.com/dapr/components-contrib v1.9.4 h1:9Jkbq03YVQcZ4Ai28q6sCWGTPZGVlbRZD7g65XZpOdU=
-github.com/dapr/components-contrib v1.9.4/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
+github.com/dapr/components-contrib v1.9.6 h1:C12fnZhNim8AsOzTCsWZDZ0MXqsaG161fStVuVAQgN4=
+github.com/dapr/components-contrib v1.9.6/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7 h1:XDb+PwAOxbVNvLxkmwPgKlH5ltYlDdz/GcEDMe8RJxE=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7/go.mod h1:FR+yc0R0szlKnJooVqJvl7FhWf21wzY4/EzmyFQrESw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/apps/pluggable_redis-pubsub/go.mod
+++ b/tests/apps/pluggable_redis-pubsub/go.mod
@@ -6,7 +6,7 @@ replace github.com/dapr/dapr => ../../../
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb
-	github.com/dapr/components-contrib v1.9.4
+	github.com/dapr/components-contrib v1.9.6
 	github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7
 )
 

--- a/tests/apps/pluggable_redis-pubsub/go.sum
+++ b/tests/apps/pluggable_redis-pubsub/go.sum
@@ -15,8 +15,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb h1:N35TA4ra10ZTCk66IiP2jCUcH8HKnN78MGyuO/64Gn0=
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb/go.mod h1:ybLpIBlVHbHt17ovO+19PyC4iIHGbuSstX1XPvHRYLo=
-github.com/dapr/components-contrib v1.9.4 h1:9Jkbq03YVQcZ4Ai28q6sCWGTPZGVlbRZD7g65XZpOdU=
-github.com/dapr/components-contrib v1.9.4/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
+github.com/dapr/components-contrib v1.9.6 h1:C12fnZhNim8AsOzTCsWZDZ0MXqsaG161fStVuVAQgN4=
+github.com/dapr/components-contrib v1.9.6/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7 h1:XDb+PwAOxbVNvLxkmwPgKlH5ltYlDdz/GcEDMe8RJxE=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7/go.mod h1:FR+yc0R0szlKnJooVqJvl7FhWf21wzY4/EzmyFQrESw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/apps/pluggable_redis-statestore/go.mod
+++ b/tests/apps/pluggable_redis-statestore/go.mod
@@ -6,7 +6,7 @@ replace github.com/dapr/dapr => ../../../
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb
-	github.com/dapr/components-contrib v1.9.4
+	github.com/dapr/components-contrib v1.9.6
 	github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7
 )
 

--- a/tests/apps/pluggable_redis-statestore/go.sum
+++ b/tests/apps/pluggable_redis-statestore/go.sum
@@ -19,8 +19,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb h1:N35TA4ra10ZTCk66IiP2jCUcH8HKnN78MGyuO/64Gn0=
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20220928114348-32097c6273eb/go.mod h1:ybLpIBlVHbHt17ovO+19PyC4iIHGbuSstX1XPvHRYLo=
-github.com/dapr/components-contrib v1.9.4 h1:9Jkbq03YVQcZ4Ai28q6sCWGTPZGVlbRZD7g65XZpOdU=
-github.com/dapr/components-contrib v1.9.4/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
+github.com/dapr/components-contrib v1.9.6 h1:C12fnZhNim8AsOzTCsWZDZ0MXqsaG161fStVuVAQgN4=
+github.com/dapr/components-contrib v1.9.6/go.mod h1:U0cjxEEbZR7sNN9i1ZdWnkIOZP8iRSvoyF2gRhBaHfc=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7 h1:XDb+PwAOxbVNvLxkmwPgKlH5ltYlDdz/GcEDMe8RJxE=
 github.com/dapr/kit v0.0.3-0.20220930182601-272e358ba6a7/go.mod h1:FR+yc0R0szlKnJooVqJvl7FhWf21wzY4/EzmyFQrESw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Signed-off-by: Ryan Lettieri <ryanLettieri@microsoft.com>

# Description

Release hotfix for 1.9.5 which covers the fix for cosmosDB etag crash, 
Release hotfix for 1.9.5 which covers the fix for init failure due to kubernetes built in secret store being disabled
Release hotfix for 1.9.5 which covers fix placement nil dereference when reading stream
Release hotfix for 1.9.5 which covers fix for Mqtt/Pub-sub: Ack Retained Messages
## Issue reference

See [#5576 ](https://github.com/dapr/dapr/issues/5576)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
