### PR TITLE
Backporting 1.9.5 hotfixes into 1.8

### DIFF
--- a/docs/release_notes/v1.8.7.md
+++ b/docs/release_notes/v1.8.7.md
@@ -1,0 +1,45 @@
+# Dapr 1.8.7
+
+- Fixes component initialization failure when the built-in Kubernetes secret store is disabled
+- Fixes nil dereference crash in placement membership heartbeat loop in sidecar
+
+## Fixes component initialization failure when the built-in Kubernetes secret store is disabled
+
+### Problem
+
+When running on Kubernetes, Dapr automatically initializes a Kubernetes secret store in each sidecar. Starting with Dapr 1.8, this behavior can be [turned off](https://docs.dapr.io/reference/arguments-annotations-overview/) using the `dapr.io/disable-builtin-k8s-secret-store`.
+
+However, with the built-in Kubernetes secret store disabled, an error prevented components from being able to retrieve secrets [stored as Kubernetes secrets](https://docs.dapr.io/operations/components/component-secrets/#referencing-a-kubernetes-secret) during initialization. This caused components to fail to initialize due to not being able to read secrets, for example connection strings or passwords.
+
+### Impact
+
+The issue impacts users on Dapr 1.8.0-1.9.4 who want to disable the built-in Kubernetes secret store.
+
+### Root cause
+
+In Dapr, components that use secrets stored as Kubernetes secrets should not need the built-in Kubernetes secret store to be loaded to work. This is because the Dapr Operator service populates the secrets from the Kubernetes secret store and passes them to the sidecar automatically.
+
+However, during initialization of a component that references a secret stored in Kubernetes, a bug caused Dapr to return an error if the built-in Kubernetes secret store was disabled, and the value of the secret as included by the Dapr Operator was ignored.
+
+### Solution
+
+We have implemented a fix in the component initialization sequence. Now, components that reference secrets from the Kubernetes secret store do not need the built-in Kubernetes secret store to be enabled anymore.
+
+
+## Fixes panic in actor placement membership in Dapr sidecar
+
+### Problem
+
+When recovering from a failure in the connection to the Dapr placement service, the Dapr sidecar could have encountered a panic in some cases.
+
+### Impact
+
+The issue can impact all Dapr users on Dapr 1.7.0-1.9.4 using actors.
+
+### Root cause
+
+We identified a race condition in the actor placement service client that could have caused the Dapr to panic after recovering from a failure.
+
+### Solution
+
+We updated actor placement service to address the race condition and remove the cause for the panic.

--- a/pkg/actors/internal/placement.go
+++ b/pkg/actors/internal/placement.go
@@ -304,12 +304,10 @@ func (p *ActorPlacement) closeStream() {
 
 		if p.clientStream != nil {
 			p.clientStream.CloseSend()
-			p.clientStream = nil
 		}
 
 		if p.clientConn != nil {
 			p.clientConn.Close()
-			p.clientConn = nil
 		}
 	}()
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2220,11 +2220,6 @@ func (a *DaprRuntime) processComponentSecrets(component components_v1alpha1.Comp
 		}
 
 		secretStoreName := a.authSecretStoreOrDefault(component)
-		secretStore := a.getSecretStore(secretStoreName)
-		if secretStore == nil {
-			log.Warnf("component %s references a secret store that isn't loaded: %s", component.Name, secretStoreName)
-			return component, secretStoreName
-		}
 
 		// If running in Kubernetes, do not fetch secrets from the Kubernetes secret store as they will be populated by the operator.
 		// Instead, base64 decode the secret values into their real self.
@@ -2252,6 +2247,12 @@ func (a *DaprRuntime) processComponentSecrets(component components_v1alpha1.Comp
 
 			component.Spec.Metadata[i] = m
 			continue
+		}
+
+		secretStore := a.getSecretStore(secretStoreName)
+		if secretStore == nil {
+			log.Warnf("component %s references a secret store that isn't loaded: %s", component.Name, secretStoreName)
+			return component, secretStoreName
 		}
 
 		resp, ok := cache[m.SecretKeyRef.Name]

--- a/tests/config/redis_override.yaml
+++ b/tests/config/redis_override.yaml
@@ -16,7 +16,7 @@ auth:
 
 image:
   repository: redislabs/rejson
-  tag: latest
+  tag: 2.0.11
 
 architecture: standalone
 


### PR DESCRIPTION
# Description

Pulled in the fixes from the following PR's:
Fix placement nil dereference when reading stream #5582 (https://github.com/dapr/dapr/pull/5582)
Fixed: components that reference secrets cannot be initialized when --disable-builtin-k8s-secret-store=true #5584 (https://github.com/dapr/dapr/pull/5584)

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
