### PR TITLE
Fix/placement close stream

### DIFF
--- a/pkg/actors/internal/client.go
+++ b/pkg/actors/internal/client.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"sync"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+
+	"google.golang.org/grpc"
+)
+
+type placementClient struct {
+	// getGrpcOpts are the options that should be used to connect to the placement service
+	getGrpcOpts func() ([]grpc.DialOption, error)
+
+	streamMu *sync.RWMutex
+	closeMu  *sync.RWMutex
+
+	// clientStream is the client side stream.
+	clientStream v1pb.Placement_ReportDaprStatusClient
+	// clientConn is the gRPC client connection.
+	clientConn *grpc.ClientConn
+	// streamConnAlive is the status of stream connection alive.
+	streamConnAlive bool
+	// streamConnectedCond is the condition variable for goroutines waiting for or announcing
+	// that the stream between runtime and placement is connected.
+	streamConnectedCond *sync.Cond
+
+	// ctx is the stream context
+	ctx context.Context
+	// cancel is the cancel func for context
+	cancel context.CancelFunc
+}
+
+// connectToServer initializes a new connection to the target server and if it succeeds replace the current
+// stream with the connected stream.
+func (c *placementClient) connectToServer(serverAddr string) error {
+	opts, err := c.getGrpcOpts()
+	if err != nil {
+		return err
+	}
+
+	conn, err := grpc.Dial(serverAddr, opts...)
+	if err != nil {
+		if conn != nil {
+			conn.Close()
+		}
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := v1pb.NewPlacementClient(conn)
+	stream, err := client.ReportDaprStatus(ctx)
+	if err != nil {
+		cancel()
+		return err
+	}
+
+	c.streamConnectedCond.L.Lock()
+	c.streamMu.Lock()
+	c.closeMu.Lock()
+	c.ctx, c.cancel, c.clientStream, c.clientConn = ctx, cancel, stream, conn
+	c.closeMu.Unlock()
+	c.streamMu.Unlock()
+	c.streamConnAlive = true
+	c.streamConnectedCond.Broadcast()
+	c.streamConnectedCond.L.Unlock()
+	return nil
+}
+
+// drain the grpc stream as described in the documentation
+// https://github.com/grpc/grpc-go/blob/be1fb4f27549f736b9b4ec26104c7c6b29845ad0/stream.go#L109
+func (c *placementClient) drain(stream grpc.ClientStream, cancelFunc context.CancelFunc) {
+	stream.CloseSend()
+	cancelFunc()
+
+	for {
+		if err := stream.RecvMsg(struct{}{}); err != nil {
+			break
+		}
+	}
+}
+
+func (c *placementClient) disconnect() {
+	c.closeMu.RLock()
+	c.clientConn.Close()
+	c.closeMu.RUnlock()
+
+	c.streamConnectedCond.L.Lock()
+	defer c.streamConnectedCond.L.Unlock()
+	if !c.streamConnAlive {
+		return
+	}
+
+	c.drain(c.clientStream, c.cancel)
+
+	c.streamConnAlive = false
+	c.streamConnectedCond.Broadcast()
+}
+
+func (c *placementClient) isConnected() bool {
+	c.streamConnectedCond.L.Lock()
+	defer c.streamConnectedCond.L.Unlock()
+	return c.streamConnAlive
+}
+
+func (c *placementClient) waitWhile(predicate func(streamConnAlive bool) bool) {
+	c.streamConnectedCond.L.Lock()
+	for !predicate(c.streamConnAlive) {
+		c.streamConnectedCond.Wait()
+	}
+	c.streamConnectedCond.L.Unlock()
+}
+
+func (c *placementClient) recv() (*v1pb.PlacementOrder, error) {
+	c.streamConnectedCond.L.Lock()
+	defer c.streamConnectedCond.L.Unlock()
+	return c.clientStream.Recv() // cannot recv in parallel
+}
+
+func (c *placementClient) send(host *v1pb.Host) error {
+	c.streamConnectedCond.L.Lock()
+	defer c.streamConnectedCond.L.Unlock()
+	return c.clientStream.Send(host) // cannot close send and send in parallel
+}
+
+func newPlacementClient(optionGetter func() ([]grpc.DialOption, error)) *placementClient {
+	return &placementClient{
+		getGrpcOpts:         optionGetter,
+		streamConnAlive:     false,
+		streamConnectedCond: sync.NewCond(&sync.Mutex{}),
+		closeMu:             &sync.RWMutex{},
+		streamMu:            &sync.RWMutex{},
+	}
+}

--- a/pkg/actors/internal/client_test.go
+++ b/pkg/actors/internal/client_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+func TestConnectToServer(t *testing.T) {
+	t.Run("when grpc get opts return an error connectToServer should return an error", func(t *testing.T) {
+		client := newPlacementClient(func() ([]grpc.DialOption, error) {
+			return nil, errEstablishingTLSConn
+		})
+		assert.Equal(t, client.connectToServer(""), errEstablishingTLSConn)
+	})
+	t.Run("when grpc dial returns an error connectToServer should return an error", func(t *testing.T) {
+		client := newPlacementClient(func() ([]grpc.DialOption, error) {
+			return []grpc.DialOption{}, nil
+		})
+
+		assert.NotNil(t, client.connectToServer(""))
+	})
+	t.Run("when new placement stream returns an error connectToServer should return an error", func(t *testing.T) {
+		client := newPlacementClient(func() ([]grpc.DialOption, error) {
+			return []grpc.DialOption{}, nil
+		})
+		conn, cleanup := newTestServerWithOpts() // do not register the placement stream server
+		defer cleanup()
+		assert.NotNil(t, client.connectToServer(conn))
+	})
+	t.Run("when connectToServer succeeds it should broadcast that a new connection is alive", func(t *testing.T) {
+		conn, _, cleanup := newTestServer() // do not register the placement stream server
+		defer cleanup()
+
+		client := newPlacementClient(getGrpcOptsGetter([]string{conn}, nil))
+
+		var ready sync.WaitGroup
+		ready.Add(1)
+		go func() {
+			client.waitUntil(func(streamConnAlive bool) bool {
+				return streamConnAlive
+			})
+			ready.Done()
+		}()
+
+		assert.Nil(t, client.connectToServer(conn))
+		ready.Wait() // should not timeout
+		assert.True(t, client.streamConnAlive)
+	})
+}
+
+func TestDisconnect(t *testing.T) {
+	t.Run("disconnectFn should return and broadcast when connection is not alive", func(t *testing.T) {
+		client := newPlacementClient(func() ([]grpc.DialOption, error) {
+			return nil, nil
+		})
+		client.streamConnAlive = true
+
+		called := false
+		shouldNotBeCalled := func() {
+			called = true
+		}
+		var ready sync.WaitGroup
+		ready.Add(1)
+
+		go func() {
+			client.waitUntil(func(streamConnAlive bool) bool {
+				return !streamConnAlive
+			})
+			ready.Done()
+		}()
+		client.streamConnAlive = false
+		client.disconnectFn(shouldNotBeCalled)
+		ready.Wait()
+		assert.False(t, called)
+	})
+	t.Run("disconnectFn should broadcast not connected when disconnected and should drain and execute func inside lock", func(t *testing.T) {
+		conn, _, cleanup := newTestServer() // do not register the placement stream server
+		defer cleanup()
+
+		client := newPlacementClient(getGrpcOptsGetter([]string{conn}, nil))
+		assert.Nil(t, client.connectToServer(conn))
+
+		called := false
+		shouldBeCalled := func() {
+			called = true
+		}
+
+		var ready sync.WaitGroup
+		ready.Add(1)
+
+		go func() {
+			client.waitUntil(func(streamConnAlive bool) bool {
+				return !streamConnAlive
+			})
+			ready.Done()
+		}()
+		client.disconnectFn(shouldBeCalled)
+		ready.Wait()
+		assert.Equal(t, client.clientConn.GetState(), connectivity.Shutdown)
+		assert.True(t, called)
+	})
+}

--- a/pkg/actors/internal/grpc_opts.go
+++ b/pkg/actors/internal/grpc_opts.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"errors"
+	"strings"
+	"sync"
+
+	daprCredentials "github.com/dapr/dapr/pkg/credentials"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/dapr/pkg/runtime/security"
+
+	"google.golang.org/grpc"
+)
+
+var errEstablishingTLSConn = errors.New("failed to establish TLS credentials for actor placement service")
+
+// getGrpcOptsGetter returns a function that provides the grpc options and once defined, a cached version will be returned.
+func getGrpcOptsGetter(servers []string, clientCert *daprCredentials.CertChain) func() ([]grpc.DialOption, error) {
+	mu := sync.RWMutex{}
+	var cached []grpc.DialOption
+	return func() ([]grpc.DialOption, error) {
+		mu.RLock()
+		if cached != nil {
+			mu.RUnlock()
+			return cached, nil
+		}
+		mu.RUnlock()
+		mu.Lock()
+		defer mu.Unlock()
+
+		if cached != nil { // double check lock
+			return cached, nil
+		}
+
+		opts, err := daprCredentials.GetClientOptions(clientCert, security.TLSServerName)
+		if err != nil {
+			log.Errorf("%s: %s", errEstablishingTLSConn, err)
+			return nil, errEstablishingTLSConn
+		}
+
+		if diag.DefaultGRPCMonitoring.IsEnabled() {
+			opts = append(
+				opts,
+				grpc.WithUnaryInterceptor(diag.DefaultGRPCMonitoring.UnaryClientInterceptor()))
+		}
+
+		if len(servers) == 1 && strings.HasPrefix(servers[0], "dns:///") {
+			// In Kubernetes environment, dapr-placement headless service resolves multiple IP addresses.
+			// With round robin load balancer, Dapr can find the leader automatically.
+			opts = append(opts, grpc.WithDefaultServiceConfig(grpcServiceConfig))
+		}
+		cached = opts
+		return cached, nil
+	}
+}

--- a/pkg/actors/internal/placement_test.go
+++ b/pkg/actors/internal/placement_test.go
@@ -18,12 +18,12 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -337,7 +337,7 @@ func (s *testServer) ReportDaprStatus(srv placementv1pb.Placement_ReportDaprStat
 			s.recvError = err
 			return err
 		}
-		s.recvCount.Inc()
+		s.recvCount.Add(1)
 		s.lastHost = req
 		s.lastTimestamp = time.Now()
 	}


### PR DESCRIPTION
# Description

I've created a new placement client which is responsible for providing best practices when dealing with grpc streams.
It provides thread-safe guarantees and stream draining well implemented avoiding memory leaks and concurrent access to it.

Now, instead of two loops (Recv and Send) I've added a new one which is responsible for connecting to a new server if necessary, therefore none of the previous used loops (recv and send) are responsible for connecting to a new stream, all they need is to close the current connection and the connection loop will take care of either, find a new server or wait for the app to be healthy again, once a new connection is made, the recv and send loop starts to run again.

## Issue reference

Please reference the issue this PR will close: #5587 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
