### PR TITLE
Honouring grace period before closing DAPR APIs

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2418,8 +2418,8 @@ func (a *DaprRuntime) Shutdown(duration time.Duration) {
 	// Ensure the Unix socket file is removed if a panic occurs.
 	defer a.cleanSocket()
 
-	log.Info("dapr shutting down.")
-
+	log.Info("Dapr shutting down in %f seconds", duration.Seconds())
+	<-time.After(duration)
 	log.Info("Stopping PubSub subscribers and input bindings")
 	a.stopSubscriptions()
 	a.stopReadingFromBindings()
@@ -2439,8 +2439,6 @@ func (a *DaprRuntime) Shutdown(duration time.Duration) {
 		}
 	}()
 
-	log.Infof("Waiting %s to finish outstanding operations", duration)
-	<-time.After(duration)
 	shutdownCancel()
 	a.shutdownOutputComponents()
 	a.shutdownC <- nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2416,7 +2416,6 @@ func (a *DaprRuntime) cleanSocket() {
 
 func (a *DaprRuntime) Shutdown(duration time.Duration) {
 	// Ensure the Unix socket file is removed if a panic occurs.
-	// time.Sleep(15 * time.Second)
 	defer a.cleanSocket()
 	log.Info("Dapr shutting down")
 	log.Info("Stopping PubSub subscribers and input bindings")

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2416,6 +2416,7 @@ func (a *DaprRuntime) cleanSocket() {
 
 func (a *DaprRuntime) Shutdown(duration time.Duration) {
 	// Ensure the Unix socket file is removed if a panic occurs.
+	// time.Sleep(15 * time.Second)
 	defer a.cleanSocket()
 	log.Info("Dapr shutting down")
 	log.Info("Stopping PubSub subscribers and input bindings")
@@ -2442,7 +2443,7 @@ func (a *DaprRuntime) Shutdown(duration time.Duration) {
 		}
 	}()
 
-	log.Info("Shutting down tracing provider")
+	log.Info("Initiating shut down of tracing provider")
 	shutdownCancel()
 	a.shutdownOutputComponents()
 	a.cancel()

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2417,14 +2417,17 @@ func (a *DaprRuntime) cleanSocket() {
 func (a *DaprRuntime) Shutdown(duration time.Duration) {
 	// Ensure the Unix socket file is removed if a panic occurs.
 	defer a.cleanSocket()
-
-	log.Info("Dapr shutting down in %f seconds", duration.Seconds())
-	<-time.After(duration)
+	log.Info("Dapr shutting down")
 	log.Info("Stopping PubSub subscribers and input bindings")
 	a.stopSubscriptions()
 	a.stopReadingFromBindings()
-	a.cancel()
+
+	log.Info("Initiating actor shutdown")
 	a.stopActor()
+
+	log.Infof("Holding shutdown for %s to allow graceful stop of outstanding operations", duration.String())
+	<-time.After(duration)
+
 	log.Info("Stopping Dapr APIs")
 	for _, closer := range a.apiClosers {
 		if err := closer.Close(); err != nil {
@@ -2439,8 +2442,10 @@ func (a *DaprRuntime) Shutdown(duration time.Duration) {
 		}
 	}()
 
+	log.Info("Shutting down tracing provider")
 	shutdownCancel()
 	a.shutdownOutputComponents()
+	a.cancel()
 	a.shutdownC <- nil
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -5139,7 +5139,7 @@ func TestNamespacedPublisher(t *testing.T) {
 
 func TestGracefulShutdownPubSub(t *testing.T) {
 	rt := NewTestDaprRuntime(modes.StandaloneMode)
-	//setup pubsub
+	// setup pubsub
 	testGracefulRestartPubSub := "shutdownPubsub"
 	pubsubComponent := componentsV1alpha1.Component{
 		ObjectMeta: metaV1.ObjectMeta{
@@ -5186,7 +5186,11 @@ func TestGracefulShutdownPubSub(t *testing.T) {
 		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
 	}()
 
-	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	if p, err := os.FindProcess(os.Getpid()); err != nil {
+		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
+	} else {
+		p.Signal(syscall.SIGTERM)
+	}
 	time.Sleep(1 * time.Second)
 	assert.Nil(t, rt.pubsubCtx)
 	assert.Nil(t, rt.topicCtxCancels)
@@ -5228,8 +5232,11 @@ func TestGracefulShutdownBindings(t *testing.T) {
 		<-sigs
 		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
 	}()
-
-	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	if p, err := os.FindProcess(os.Getpid()); err != nil {
+		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
+	} else {
+		p.Signal(syscall.SIGTERM)
+	}
 	time.Sleep(1 * time.Second)
 	assert.Nil(t, rt.inputBindingsCancel)
 	assert.Nil(t, rt.inputBindingsCtx)
@@ -5290,7 +5297,11 @@ func TestGracefulShutdownActors(t *testing.T) {
 		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
 	}()
 
-	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	if p, err := os.FindProcess(os.Getpid()); err != nil {
+		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
+	} else {
+		p.Signal(syscall.SIGTERM)
+	}
 	time.Sleep(3 * time.Second)
 
 	var activeActCount int

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -5095,46 +5095,6 @@ func matchContextInterface(v any) bool {
 	return ok
 }
 
-func TestMetadataContainsNamespace(t *testing.T) {
-	t.Run("namespace field present", func(t *testing.T) {
-		r := metadataContainsNamespace(
-			[]componentsV1alpha1.MetadataItem{
-				{
-					Value: componentsV1alpha1.DynamicValue{
-						JSON: v1.JSON{Raw: []byte("{namespace}")},
-					},
-				},
-			},
-		)
-
-		assert.True(t, r)
-	})
-
-	t.Run("namespace field not present", func(t *testing.T) {
-		r := metadataContainsNamespace(
-			[]componentsV1alpha1.MetadataItem{
-				{},
-			},
-		)
-
-		assert.False(t, r)
-	})
-}
-
-func TestNamespacedPublisher(t *testing.T) {
-	rt := NewTestDaprRuntime(modes.StandaloneMode)
-	rt.namespace = "ns1"
-	defer stopRuntime(t, rt)
-
-	rt.pubSubs[TestPubsubName] = pubsubItem{component: &mockPublishPubSub{}, namespaceScoped: true}
-	rt.Publish(&pubsub.PublishRequest{
-		PubsubName: TestPubsubName,
-		Topic:      "topic0",
-	})
-
-	assert.Equal(t, "ns1topic0", rt.pubSubs[TestPubsubName].component.(*mockPublishPubSub).PublishedRequest.Topic)
-}
-
 func TestGracefulShutdownPubSub(t *testing.T) {
 	rt := NewTestDaprRuntime(modes.StandaloneMode)
 	mockPubSub := new(daprt.MockPubSub)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -5178,19 +5178,7 @@ func TestGracefulShutdownPubSub(t *testing.T) {
 	assert.NotNil(t, rt.topicCtxCancels)
 	assert.NotNil(t, rt.topicRoutes)
 
-	rt.runtimeConfig.GracefulShutdownDuration = 3 * time.Second
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
-	}()
-
-	if p, err := os.FindProcess(os.Getpid()); err != nil {
-		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
-	} else {
-		p.Signal(syscall.SIGTERM)
-	}
+	sendSigterm(rt)
 	time.Sleep(1 * time.Second)
 	assert.Nil(t, rt.pubsubCtx)
 	assert.Nil(t, rt.topicCtxCancels)
@@ -5225,18 +5213,7 @@ func TestGracefulShutdownBindings(t *testing.T) {
 	assert.Equal(t, len(rt.inputBindings), 1)
 	assert.Equal(t, len(rt.outputBindings), 1)
 
-	rt.runtimeConfig.GracefulShutdownDuration = 3 * time.Second
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
-	}()
-	if p, err := os.FindProcess(os.Getpid()); err != nil {
-		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
-	} else {
-		p.Signal(syscall.SIGTERM)
-	}
+	sendSigterm(rt)
 	time.Sleep(1 * time.Second)
 	assert.Nil(t, rt.inputBindingsCancel)
 	assert.Nil(t, rt.inputBindingsCtx)
@@ -5289,20 +5266,8 @@ func TestGracefulShutdownActors(t *testing.T) {
 	rt.runtimeConfig.mtlsEnabled = true
 	assert.Nil(t, rt.initActors())
 
-	rt.runtimeConfig.GracefulShutdownDuration = 3 * time.Second
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
-	}()
-
-	if p, err := os.FindProcess(os.Getpid()); err != nil {
-		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
-	} else {
-		p.Signal(syscall.SIGTERM)
-	}
-	time.Sleep(3 * time.Second)
+	sendSigterm(rt)
+	time.Sleep(rt.runtimeConfig.GracefulShutdownDuration)
 
 	var activeActCount int
 	activeActors := rt.actor.GetActiveActorsCount(rt.ctx)
@@ -5333,4 +5298,21 @@ func initMockStateStoreForRuntime(rt *DaprRuntime, primaryKey string, e error) *
 	mockStateStore.On("Init", expectedMetadata).Return(e)
 
 	return mockStateStore
+}
+
+func sendSigterm(rt *DaprRuntime) {
+	rt.runtimeConfig.GracefulShutdownDuration = 3 * time.Second
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
+	}()
+	if p, err := os.FindProcess(os.Getpid()); err != nil {
+		rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
+	} else {
+		if err := p.Signal(syscall.SIGTERM); err != nil { // SIGTERM cannot be sent on WINDOWS
+			rt.Shutdown(rt.runtimeConfig.GracefulShutdownDuration)
+		}
+	}
 }


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
Issue https://github.com/dapr/dapr/issues/5481 limits usage of Dapr in GKE for a subset of users, especially during rolling upgrade. The load balancer continues to send requests even after SIGTERM is sent to the Pod. The app being written in spring can support a pre-stop hook and delay shutdown to ensure the requests coming un while load balancer identifies the pod as Terminating and removes it from the list of active pods.

Dapr, however, closes inbound channels and hence will not receive any requests once SIGTERM is received. So many failed requests are noticed in this environment.

This PR moves the closing of inbound channels to after the graceperiod expiry to address the immediate closure and hence dropping of requests.
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #5481 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
