### PR TITLE
Fix flakiness in service_invocation E2E test

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -377,16 +377,16 @@ func (a *api) CallLocal(ctx context.Context, in *internalv1pb.InternalInvokeRequ
 		diag.DefaultMonitoring.ServiceInvocationResponseSent(callerAppID, req.Message().Method, statusCode)
 	}()
 
+	// stausCode will be read by the deferred method above
 	resp, err := a.appChannel.InvokeMethod(ctx, req)
 	if err != nil {
 		statusCode = int32(codes.Internal)
-		err = status.Errorf(codes.Internal, messages.ErrChannelInvoke, err)
-		return nil, err
+		return nil, status.Errorf(codes.Internal, messages.ErrChannelInvoke, err)
 	} else {
 		statusCode = resp.Status().Code
 	}
 
-	return resp.Proto(), err
+	return resp.Proto(), nil
 }
 
 // CallActor invokes a virtual actor.

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -1047,8 +1047,8 @@ func TestNegativeCases(t *testing.T) {
 		// Valid errors are:
 		// - `rpc error: code = Internal desc = fail to invoke, id: serviceinvocation-callee-0, err: rpc error: code = Internal desc = error invoking app channel: Post \"http://127.0.0.1:3000/timeouterror\": context deadline exceeded``
 		// - `rpc error: code = DeadlineExceeded desc = context deadline exceeded`
-		assert.Contains(t, testResults.RawError, "rpc error")
-		assert.Contains(t, testResults.RawError, "desc = context deadline exceeded")
+		assert.Contains(t, testResults.RawError, "rpc error:")
+		assert.Contains(t, testResults.RawError, "context deadline exceeded")
 		assert.NotContains(t, testResults.RawError, "Client waited longer than it should have.")
 	})
 

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -1043,8 +1043,13 @@ func TestNegativeCases(t *testing.T) {
 
 		require.False(t, testResults.MainCallSuccessful)
 		require.Equal(t, 500, status)
-		require.Contains(t, testResults.RawError, "rpc error: code = DeadlineExceeded desc = context deadline exceeded")
-		require.NotContains(t, testResults.RawError, "Client waited longer than it should have.")
+		// This error could have code either DeadlineExceeded or Internal, depending on where the context timeout was caught
+		// Valid errors are:
+		// - `rpc error: code = Internal desc = fail to invoke, id: serviceinvocation-callee-0, err: rpc error: code = Internal desc = error invoking app channel: Post \"http://127.0.0.1:3000/timeouterror\": context deadline exceeded``
+		// - `rpc error: code = DeadlineExceeded desc = context deadline exceeded`
+		assert.Contains(t, testResults.RawError, "rpc error")
+		assert.Contains(t, testResults.RawError, "desc = context deadline exceeded")
+		assert.NotContains(t, testResults.RawError, "Client waited longer than it should have.")
 	})
 
 	t.Run("service_parse_error_http", func(t *testing.T) {


### PR DESCRIPTION
Depending on where the context cancelation is caught, the error could have a slightly different code, but same description. Seems to be failing frequently lately, perhaps due to having enabled resiliency.

Examples of test failure:
- https://github.com/dapr/dapr/actions/runs/3642837826/jobs/6150405698
- https://github.com/dapr/dapr/actions/runs/3642837826/jobs/6150405833
