### PR TITLE
Skip tracing E2E on Windows due to Zipkin setup.

### DIFF
--- a/tests/e2e/tracing_zipkin/tracing_zipkin_test.go
+++ b/tests/e2e/tracing_zipkin/tracing_zipkin_test.go
@@ -79,6 +79,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestInvoke(t *testing.T) {
+	if utils.TestTargetOS() == "windows" {
+		t.Skip("Skipping tracing test on windows")
+		return
+	}
+
 	t.Run("Simple HTTP invoke with tracing", func(t *testing.T) {
 		// Get the ingress external url of test app
 		externalURL := tr.Platform.AcquireAppExternalURL("tracingapp-a")


### PR DESCRIPTION
Skip tracing E2E on Windows due to Zipkin setup.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
