### PR TITLE
Remove dapr local replacement for pluggable apps

### DIFF
--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -2,8 +2,6 @@ module github.com/dapr/dapr/tests/apps/kafka-bindings
 
 go 1.19
 
-replace github.com/dapr/dapr => ../../../
-
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff
 	github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514

--- a/tests/apps/pluggable_kafka-bindings/go.sum
+++ b/tests/apps/pluggable_kafka-bindings/go.sum
@@ -7,6 +7,8 @@ github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff h1:
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff/go.mod h1:gK31Fk/lEYg0sCaoxFhPyBL54N5AOeeWfeZFl36P2Ko=
 github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514 h1:2HaeVAj6ePRjxwEXJVeUV209VVAiurQ+eS7xB1k7t7g=
 github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514/go.mod h1:o92XRraeBOkmrZKZCUaEGuxAN0OdOH4CGwdqwi8pYMQ=
+github.com/dapr/dapr v1.9.4-0.20221212235750-ac9256f214e0 h1:Y3WZ1lgR7vBXowF6xbBo1lSEsW2aiXN7U9gRhz8rQcM=
+github.com/dapr/dapr v1.9.4-0.20221212235750-ac9256f214e0/go.mod h1:chJw8EsdwW+Z0E2e0XJN2JzVO5FgUkMkYCYrRKTIqGc=
 github.com/dapr/kit v0.0.4-0.20221211173611-bcf6ee09314e h1:/1VuHsZJOeOLZ1KkW+484RDVZ1FqHTunUSCagEtP8bw=
 github.com/dapr/kit v0.0.4-0.20221211173611-bcf6ee09314e/go.mod h1:+vh2UIRT0KzFm5YJWfj7az4XVSdodys1OCz1WzNe1Eo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/apps/pluggable_redis-pubsub/go.mod
+++ b/tests/apps/pluggable_redis-pubsub/go.mod
@@ -2,8 +2,6 @@ module github.com/dapr/dapr/tests/apps/pluggable_redis-pubsub
 
 go 1.19
 
-replace github.com/dapr/dapr => ../../../
-
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff
 	github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514

--- a/tests/apps/pluggable_redis-pubsub/go.sum
+++ b/tests/apps/pluggable_redis-pubsub/go.sum
@@ -4,6 +4,8 @@ github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff h1:
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff/go.mod h1:gK31Fk/lEYg0sCaoxFhPyBL54N5AOeeWfeZFl36P2Ko=
 github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514 h1:2HaeVAj6ePRjxwEXJVeUV209VVAiurQ+eS7xB1k7t7g=
 github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514/go.mod h1:o92XRraeBOkmrZKZCUaEGuxAN0OdOH4CGwdqwi8pYMQ=
+github.com/dapr/dapr v1.9.4-0.20221212235750-ac9256f214e0 h1:Y3WZ1lgR7vBXowF6xbBo1lSEsW2aiXN7U9gRhz8rQcM=
+github.com/dapr/dapr v1.9.4-0.20221212235750-ac9256f214e0/go.mod h1:chJw8EsdwW+Z0E2e0XJN2JzVO5FgUkMkYCYrRKTIqGc=
 github.com/dapr/kit v0.0.4-0.20221211173611-bcf6ee09314e h1:/1VuHsZJOeOLZ1KkW+484RDVZ1FqHTunUSCagEtP8bw=
 github.com/dapr/kit v0.0.4-0.20221211173611-bcf6ee09314e/go.mod h1:+vh2UIRT0KzFm5YJWfj7az4XVSdodys1OCz1WzNe1Eo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/apps/pluggable_redis-statestore/go.mod
+++ b/tests/apps/pluggable_redis-statestore/go.mod
@@ -2,8 +2,6 @@ module github.com/dapr/dapr/tests/apps/pluggable_redis-statestore
 
 go 1.19
 
-replace github.com/dapr/dapr => ../../../
-
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff
 	github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514

--- a/tests/apps/pluggable_redis-statestore/go.sum
+++ b/tests/apps/pluggable_redis-statestore/go.sum
@@ -6,6 +6,8 @@ github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff h1:
 github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff/go.mod h1:gK31Fk/lEYg0sCaoxFhPyBL54N5AOeeWfeZFl36P2Ko=
 github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514 h1:2HaeVAj6ePRjxwEXJVeUV209VVAiurQ+eS7xB1k7t7g=
 github.com/dapr/components-contrib v1.9.1-0.20221213185150-c5c985a68514/go.mod h1:o92XRraeBOkmrZKZCUaEGuxAN0OdOH4CGwdqwi8pYMQ=
+github.com/dapr/dapr v1.9.4-0.20221212235750-ac9256f214e0 h1:Y3WZ1lgR7vBXowF6xbBo1lSEsW2aiXN7U9gRhz8rQcM=
+github.com/dapr/dapr v1.9.4-0.20221212235750-ac9256f214e0/go.mod h1:chJw8EsdwW+Z0E2e0XJN2JzVO5FgUkMkYCYrRKTIqGc=
 github.com/dapr/kit v0.0.4-0.20221211173611-bcf6ee09314e h1:/1VuHsZJOeOLZ1KkW+484RDVZ1FqHTunUSCagEtP8bw=
 github.com/dapr/kit v0.0.4-0.20221211173611-bcf6ee09314e/go.mod h1:+vh2UIRT0KzFm5YJWfj7az4XVSdodys1OCz1WzNe1Eo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -391,7 +391,7 @@ endif
 
 # install k6 loadtesting to the cluster
 setup-test-env-k6:
-	rm -rf /tmp/.k6-operator >/dev/null && git clone https://github.com/grafana/k6-operator /tmp/.k6-operator && cd /tmp/.k6-operator && make deploy && cd - && rm -rf /tmp/.k6-operator
+	export IMG=ghcr.io/grafana/operator:controller-v0.0.8 && rm -rf /tmp/.k6-operator >/dev/null && git clone --depth 1 --branch v0.0.8 https://github.com/grafana/k6-operator /tmp/.k6-operator && cd /tmp/.k6-operator && make deploy && cd - && rm -rf /tmp/.k6-operator
 delete-test-env-k6:
 	rm -rf /tmp/.k6-operator >/dev/null && git clone https://github.com/grafana/k6-operator /tmp/.k6-operator && cd /tmp/.k6-operator && make delete && cd - && rm -rf /tmp/.k6-operator
 


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Removed the dapr/dapr replacement on pluggable apps. This will

1) Avoid errors when updating the transitive dependency on components-contrib
2) Will continue to track breaking changes on the *.proto for pluggable components (which is desirable)

Breaking changes on components-contrib will continue to affect the sandbox repository but this should be tracked on sandbox repo.

also: Fixed k6 controller version to use 0.0.8 due to a upcoming breaking change.

## Issue reference

N/A

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
