### PR TITLE
Changes to the resiliency.NewRunner

### DIFF
--- a/pkg/resiliency/policy.go
+++ b/pkg/resiliency/policy.go
@@ -16,6 +16,8 @@ package resiliency
 import (
 	"context"
 	"errors"
+	"reflect"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -47,12 +49,31 @@ type PolicyDefinition struct {
 	cb   *breaker.CircuitBreaker
 }
 
+type RunnerOpts[T any] struct {
+	// The disposer is a function which is invoked when the operation fails, including due to timing out in a background goroutine. It receives the value returned by the operation function as long as it's non-zero (e.g. non-nil for pointer types).
+	// The disposer can be used to perform cleanup tasks on values returned by the operation function that would otherwise leak (because they're not returned by the result of the runner).
+	Disposer func(T)
+
+	// The accumulator is a function that is invoked synchronously when an operation completes without timing out, whether successfully or not. It receives the value returned by the operation function as long as it's non-zero (e.g. non-nil for pointer types).
+	// The accumulator can be used to collect intermediate results and not just the final ones, for example in case of working with batched operations.
+	Accumulator func(T)
+}
+
 // NewRunner returns a policy runner that encapsulates the configured resiliency policies in a simple execution wrapper.
 // We can't implement this as a method of the Resiliency struct because we can't yet use generic methods in structs.
 func NewRunner[T any](ctx context.Context, def *PolicyDefinition) Runner[T] {
+	return NewRunnerWithOptions(ctx, def, RunnerOpts[T]{})
+}
+
+// NewRunnerWithOptions is like NewRunner but allows setting additional options
+func NewRunnerWithOptions[T any](ctx context.Context, def *PolicyDefinition, opts RunnerOpts[T]) Runner[T] {
 	if def == nil {
 		return func(oper Operation[T]) (T, error) {
-			return oper(ctx)
+			rRes, rErr := oper(ctx)
+			if opts.Accumulator != nil && !isZero(rRes) {
+				opts.Accumulator(rRes)
+			}
+			return rRes, rErr
 		}
 	}
 
@@ -61,24 +82,42 @@ func NewRunner[T any](ctx context.Context, def *PolicyDefinition) Runner[T] {
 		operation := oper
 		if def.t > 0 {
 			// Handle timeout
-			// TODO: This should ideally be handled by the underlying service/component. Revisit once those understand contexts
 			operCopy := operation
 			operation = func(ctx context.Context) (T, error) {
 				ctx, cancel := context.WithTimeout(ctx, def.t)
 				defer cancel()
 
 				done := make(chan doneCh[T])
+				timedOut := atomic.Bool{}
 				go func() {
 					rRes, rErr := operCopy(ctx)
-					done <- doneCh[T]{rRes, rErr}
+					if !timedOut.Load() {
+						done <- doneCh[T]{rRes, rErr}
+					} else if opts.Disposer != nil && !isZero(rRes) {
+						// Invoke the disposer if we have a non-zero return value
+						// Note that in case of timeouts we do not invoke the accumulator
+						opts.Disposer(rRes)
+					}
 				}()
 
 				select {
 				case v := <-done:
 					return v.res, v.err
 				case <-ctx.Done():
+					timedOut.Store(true)
 					return zero, ctx.Err()
 				}
+			}
+		}
+
+		if opts.Accumulator != nil {
+			operCopy := operation
+			operation = func(ctx context.Context) (T, error) {
+				rRes, rErr := operCopy(ctx)
+				if !isZero(rRes) {
+					opts.Accumulator(rRes)
+				}
+				return rRes, rErr
 			}
 		}
 
@@ -112,7 +151,13 @@ func NewRunner[T any](ctx context.Context, def *PolicyDefinition) Runner[T] {
 		b := def.r.NewBackOffWithContext(ctx)
 		return retry.NotifyRecoverWithData(
 			func() (T, error) {
-				return operation(ctx)
+				rRes, rErr := operation(ctx)
+				// In case of an error, if we have a disposer we invoke it with the return value, then reset the return value
+				if rErr != nil && opts.Disposer != nil && !isZero(rRes) {
+					opts.Disposer(rRes)
+					rRes = zero
+				}
+				return rRes, rErr
 			},
 			b,
 			func(opErr error, _ time.Duration) {
@@ -124,4 +169,8 @@ func NewRunner[T any](ctx context.Context, def *PolicyDefinition) Runner[T] {
 			},
 		)
 	}
+}
+
+func isZero(val any) bool {
+	return reflect.ValueOf(val).IsZero()
 }

--- a/pkg/resiliency/policy_test.go
+++ b/pkg/resiliency/policy_test.go
@@ -15,12 +15,14 @@ package resiliency
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/slices"
 
 	"github.com/dapr/dapr/pkg/resiliency/breaker"
 	"github.com/dapr/kit/logger"
@@ -28,6 +30,98 @@ import (
 )
 
 var testLog = logger.NewLogger("dapr.resiliency.test")
+
+// Example of using NewRunnerWithOptions with an Accumulator function
+func ExampleNewRunnerWithOptions_accumulator() {
+	// Example polocy definition
+	policyDef := &PolicyDefinition{
+		log:  testLog,
+		name: "retry",
+		t:    10 * time.Millisecond,
+		r:    &retry.Config{MaxRetries: 6},
+	}
+
+	// Handler function
+	val := atomic.Int32{}
+	fn := func(ctx context.Context) (int32, error) {
+		v := val.Add(1)
+		// When the value is "2", we add a sleep that will trip the timeout
+		// As a consequence, the accumulator is not called, so the value "2" should not be included in the result
+		if v == 2 {
+			time.Sleep(50 * time.Millisecond)
+		}
+		// Make this method be executed 4 times in total
+		if v <= 3 {
+			return v, errors.New("continue")
+		}
+		return v, nil
+	}
+
+	// Invoke the policy and collect all received values
+	received := []int32{}
+	policy := NewRunnerWithOptions(context.Background(), policyDef, RunnerOpts[int32]{
+		Accumulator: func(i int32) {
+			// Safe to use non-atomic operations in the next line because "received" is not used in the operation function ("fn")
+			received = append(received, i)
+		},
+	})
+
+	// When using accumulators, the result only contains the last value and is normally ignored
+	res, err := policy(fn)
+
+	fmt.Println(res, err, received)
+	// Output: 4 <nil> [1 3 4]
+}
+
+// Example of using NewRunnerWithOptions with a Disposer function
+func ExampleNewRunnerWithOptions_disposer() {
+	// Example polocy definition
+	policyDef := &PolicyDefinition{
+		log:  testLog,
+		name: "retry",
+		t:    10 * time.Millisecond,
+		r:    &retry.Config{MaxRetries: 6},
+	}
+
+	// Handler function
+	counter := atomic.Int32{}
+	fn := func(ctx context.Context) (int32, error) {
+		v := counter.Add(1)
+		// When the value is "2", we add a sleep that will trip the timeout
+		if v == 2 {
+			time.Sleep(50 * time.Millisecond)
+		}
+		if v <= 3 {
+			return v, errors.New("continue")
+		}
+		return v, nil
+	}
+
+	// Invoke the policy and collect all disposed values
+	disposerCalled := make(chan int32, 5)
+	policy := NewRunnerWithOptions(context.Background(), policyDef, RunnerOpts[int32]{
+		Disposer: func(val int32) {
+			// Dispose the object as needed, for example calling things like:
+			// val.Close()
+
+			// Use a buffered channel here because the disposer method should not block
+			disposerCalled <- val
+		},
+	})
+
+	// Execute the policy
+	res, err := policy(fn)
+
+	// The disposer should be 3 times called with values 1, 2, 3
+	disposed := []int32{}
+	for i := 0; i < 3; i++ {
+		disposed = append(disposed, <-disposerCalled)
+	}
+	slices.Sort(disposed)
+
+	fmt.Println(res, err, disposed)
+	// Output: 4 <nil> [1 2 3]
+}
 
 func TestPolicy(t *testing.T) {
 	retryValue := retry.DefaultConfig()
@@ -162,4 +256,103 @@ func TestPolicyRetry(t *testing.T) {
 			assert.Equal(t, test.expected, called.Load())
 		})
 	}
+}
+
+func TestPolicyAccumulator(t *testing.T) {
+	val := atomic.Int32{}
+	fnCalled := atomic.Int32{}
+	fn := func(ctx context.Context) (int32, error) {
+		fnCalled.Add(1)
+		v := val.Load()
+		if v == 0 || v == 2 {
+			// Because the accumulator isn't called when "val" is 0 or 2, we need to increment "val" here
+			val.Add(1)
+		}
+		// When the value is "2", we add a sleep that will trip the timeout
+		// As a consequence, the accumulator is not called, so the value "2" should not be included in the result
+		if v == 2 {
+			time.Sleep(50 * time.Millisecond)
+		}
+		if v <= 3 {
+			return v, errors.New("continue")
+		}
+		return v, nil
+	}
+
+	received := []int32{}
+	policyDef := &PolicyDefinition{
+		log:  testLog,
+		name: "retry",
+		t:    10 * time.Millisecond,
+		r:    &retry.Config{MaxRetries: 6},
+	}
+	var accumulatorCalled int
+	policy := NewRunnerWithOptions(context.Background(), policyDef, RunnerOpts[int32]{
+		Accumulator: func(i int32) {
+			// Only reason for incrementing "val" here is to have something to check for race conditions with "go test -race"
+			val.Add(1)
+			// Safe to use non-atomic operations in the next line because "received" is not used in the operation function ("fn")
+			received = append(received, i)
+			accumulatorCalled++
+		},
+	})
+	res, err := policy(fn)
+
+	// Sleep a bit to ensure that things in the background aren't continuing
+	time.Sleep(100 * time.Millisecond)
+
+	assert.NoError(t, err)
+	// res should contain only the last result, i.e. 4
+	assert.Equal(t, res, int32(4))
+	assert.Equal(t, 3, accumulatorCalled)
+	assert.Equal(t, int32(5), fnCalled.Load())
+	assert.Equal(t, []int32{1, 3, 4}, received)
+}
+
+func TestPolicyDisposer(t *testing.T) {
+	counter := atomic.Int32{}
+	fn := func(ctx context.Context) (int32, error) {
+		v := counter.Add(1)
+		// When the value is "2", we add a sleep that will trip the timeout
+		if v == 2 {
+			time.Sleep(50 * time.Millisecond)
+		}
+		if v <= 3 {
+			return v, errors.New("continue")
+		}
+		return v, nil
+	}
+
+	disposerCalled := make(chan int32, 5)
+	policyDef := &PolicyDefinition{
+		log:  testLog,
+		name: "retry",
+		t:    10 * time.Millisecond,
+		r:    &retry.Config{MaxRetries: 5},
+	}
+	policy := NewRunnerWithOptions(context.Background(), policyDef, RunnerOpts[int32]{
+		Disposer: func(i int32) {
+			disposerCalled <- i
+		},
+	})
+	res, err := policy(fn)
+
+	assert.NoError(t, err)
+	// res should contain only the last result, i.e. 4
+	assert.Equal(t, res, int32(4))
+
+	// The disposer should be 3 times called with values 1, 2, 3
+	disposed := []int32{}
+	for i := 0; i < 3; i++ {
+		disposed = append(disposed, <-disposerCalled)
+	}
+	// Shouldn't have more messages coming in
+	select {
+	case <-time.After(100 * time.Millisecond):
+		// all good
+	case <-disposerCalled:
+		t.Error("received an extra message we were not expecting")
+	}
+	slices.Sort(disposed)
+	assert.Equal(t, []int32{1, 2, 3}, disposed)
 }


### PR DESCRIPTION
Three main changes:

## Fixes a goroutine leak when a timeout happens

Previously, when a timeout happened, there was likely going to be a goroutine leak because the runner was storing the return value in an unbuffered channel which was never read. The background goroutine would then leak "forever".

## Add accumulator functions

(Co-authored by @mukundansundar )

Runners can now accept an optional "Accumulator" which is a function that receives all non-zero values returned by the operation functions, even when there's an error, except when there's a timeout (because in case of timeouts, the policy should move on to the next retry and not wait for results).

The use case is for PRs such as #5603 where we need to be able to do operations in bulk and not retry things in the batch that have been successful already.

## Add disposer functions

Runners can also now accept an optional "Disposer" which is a function that receives all non-zero values returned by the operation functions when there's an error (including timeouts).

Use case is being able to dispose objects that are otherwise going to "leak" (until the GC picks them up). Example is if the operation function returns a `*http.Response` object, in which case we need to be able to call `res.Body.Close()` in the returned value _even when_ there's an error such as a timeout (otherwise, those returned values would be lost).

This will be needed in another PR I'm working on.