### PR TITLE
Deploy (& dispose) E2E test apps in parallel

### DIFF
--- a/tests/runner/testresource.go
+++ b/tests/runner/testresource.go
@@ -97,8 +97,8 @@ func (r *TestResources) setup() error {
 		if dr == nil {
 			break
 		}
-		resourceCount++
 
+		resourceCount++
 		go func() {
 			err := dr.Init(r.ctx)
 			r.pushActiveResource(dr)

--- a/tests/runner/testresource_test.go
+++ b/tests/runner/testresource_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/exp/slices"
 )
 
 // MockDisposable is the mock of Disposable interface.
@@ -58,46 +59,62 @@ func TestAdd(t *testing.T) {
 
 func TestSetup(t *testing.T) {
 	t.Run("active all resources", func(t *testing.T) {
+		expect := []string{}
 		resource := new(TestResources)
 		for i := 0; i < 3; i++ {
+			name := fmt.Sprintf("resource - %d", i)
 			r := new(MockDisposable)
-			r.On("Name").Return(fmt.Sprintf("resource - %d", i))
+			r.On("Name").Return(name)
 			r.On("Init").Return(nil)
 			resource.Add(r)
+			expect = append(expect, name)
 		}
 
 		err := resource.setup()
 		assert.NoError(t, err)
 
+		found := []string{}
 		for i := 2; i >= 0; i-- {
 			r := resource.popActiveResource()
-			assert.Equal(t, fmt.Sprintf("resource - %d", i), r.Name())
+			found = append(found, r.Name())
 		}
+
+		slices.Sort(expect)
+		slices.Sort(found)
+		assert.Equal(t, expect, found)
 	})
 
 	t.Run("fails to setup resources and stops the process", func(t *testing.T) {
+		expect := []string{}
 		resource := new(TestResources)
 		for i := 0; i < 3; i++ {
+			name := fmt.Sprintf("resource - %d", i)
 			r := new(MockDisposable)
-			r.On("Name").Return(fmt.Sprintf("resource - %d", i))
+			r.On("Name").Return(name)
 			if i != 1 {
 				r.On("Init").Return(nil)
 			} else {
-				r.On("Init").Return(fmt.Errorf("setup error"))
+				r.On("Init").Return(fmt.Errorf("setup error %d", i))
 			}
+			expect = append(expect, name)
 			resource.Add(r)
 		}
 
 		err := resource.setup()
 		assert.Error(t, err)
 
-		for i := 1; i >= 0; i-- {
+		found := []string{}
+		for i := 2; i >= 0; i-- {
 			r := resource.popActiveResource()
-			assert.Equal(t, fmt.Sprintf("resource - %d", i), r.Name())
+			found = append(found, r.Name())
 		}
 
 		r := resource.popActiveResource()
 		assert.Nil(t, r)
+
+		slices.Sort(expect)
+		slices.Sort(found)
+		assert.Equal(t, expect, found)
 	})
 }
 


### PR DESCRIPTION
Should help making E2E tests complete a few mins quicker by deploying (and disposing) E2E test apps in parallel. This should be especially useful in AKS (because of having to pull from a container registry through the network and because of the need to wait for a load balancer), and especially for tests like "service_invocation" that requires deploying half a dozen apps.