### PR TITLE
Set actor stress tests thresholds based on previous run

### DIFF
--- a/tests/perf/actor_id_scale/test.js
+++ b/tests/perf/actor_id_scale/test.js
@@ -22,7 +22,7 @@ export const options = {
   discardResponseBodies: true,
   thresholds: {
     checks: ['rate==1'],
-    http_req_duration: ['p(95)<200'], // 95% of requests should be below 200ms
+    http_req_duration: ['p(95)<70'], // 95% of requests should be below 70ms
   },
   scenarios: {
     idStress: {

--- a/tests/perf/actor_type_scale/test.js
+++ b/tests/perf/actor_type_scale/test.js
@@ -27,7 +27,7 @@ export const options = {
   discardResponseBodies: true,
   thresholds: {
     checks: ['rate==1'],
-    http_req_duration: ['p(95)<200'], // 95% of requests should be below 200ms
+    http_req_duration: ['p(95)<70'], // 95% of requests should be below 70ms
   },
   scenarios: {
     idStress: {


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Set tests thresholds based on previous perf tests run. Previously, there's no magic number to use given that the first run has occurred only after the test was merged.

## Issue reference

N/A

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
