### PR TITLE
Fix ping method invoked before Init method for pluggable components

### DIFF
--- a/pkg/components/pluggable/discovery.go
+++ b/pkg/components/pluggable/discovery.go
@@ -123,7 +123,7 @@ func serviceDiscovery(reflectClientFactory func(string) (reflectServiceClient, f
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to list services")
 		}
-		dialer := socketDialer(socket)
+		dialer := socketDialer(socket, grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
 
 		componentName := removeExt(f.Name())
 		for _, svc := range serviceList {

--- a/pkg/components/pluggable/grpc.go
+++ b/pkg/components/pluggable/grpc.go
@@ -100,7 +100,7 @@ func (g *GRPCConnector[TClient]) Dial(name string) error {
 
 	g.Client = g.clientFactory(grpcConn)
 
-	return g.Ping()
+	return nil
 }
 
 // Ping pings the grpc component.

--- a/pkg/components/pluggable/grpc_test.go
+++ b/pkg/components/pluggable/grpc_test.go
@@ -45,7 +45,7 @@ func TestGRPCConnector(t *testing.T) {
 		return
 	}
 
-	t.Run("grpc connection should be idle or transient-failure when the process is listening to the socket", func(t *testing.T) {
+	t.Run("grpc connection should be idle or ready when the process is listening to the socket due to withblock usage", func(t *testing.T) {
 		fakeFactoryCalled := 0
 		clientFake := &fakeClient{}
 		fakeFactory := func(grpc.ClientConnInterface) *fakeClient {
@@ -55,13 +55,13 @@ func TestGRPCConnector(t *testing.T) {
 		connector := NewGRPCConnector("/tmp/socket.sock", fakeFactory)
 		require.NoError(t, connector.Dial(""))
 		acceptedStatus := []connectivity.State{
-			connectivity.TransientFailure,
+			connectivity.Ready,
 			connectivity.Idle,
 		}
 
 		assert.Contains(t, acceptedStatus, connector.conn.GetState())
 		assert.Equal(t, 1, fakeFactoryCalled)
-		assert.Equal(t, int64(1), clientFake.pingCalled.Load())
+		assert.Equal(t, int64(0), clientFake.pingCalled.Load())
 		connector.Close()
 	})
 


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Using `WithBlock` grpc option to block connection until it is ready to be used rather than relying on `WaitForReady` for `Ping` method call when initializing pluggable components gRPC connection.

See the related issue for the detailed explanation.
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #5658 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
