### PR TITLE
Deploy (& dispose) E2E test apps in parallel

### DIFF
--- a/docker/Dockerfile-mariner
+++ b/docker/Dockerfile-mariner
@@ -3,8 +3,5 @@
 ARG MARINER_VERSION=2.0
 FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:${MARINER_VERSION}-nonroot
 ARG PKG_FILES
-# The base image specifies the user with its name ("nonroot").
-# This is the equivalent UID: Kubernetes requires a numeric ID for "runAsRoot: false" support
-USER 65532
 WORKDIR /
 COPY /$PKG_FILES /

--- a/tests/config/tailscale_subnet_router.yaml
+++ b/tests/config/tailscale_subnet_router.yaml
@@ -66,5 +66,8 @@ spec:
             runAsGroup: 1000
           resources:
             limits:
-              cpu: "800m"
+              cpu: "1000m"
+              memory: "256Mi"
+            requests:
+              cpu: "700m"
               memory: "128Mi"

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -229,9 +229,11 @@ endef
 
 create-test-namespace:
 	kubectl create namespace $(DAPR_TEST_NAMESPACE)
+	kubectl create namespace $(DAPR_TEST_NAMESPACE)-2
 
 delete-test-namespace:
 	kubectl delete namespace $(DAPR_TEST_NAMESPACE)
+	kubectl delete namespace $(DAPR_TEST_NAMESPACE)-2
 
 setup-3rd-party: setup-helm-init setup-test-env-redis setup-test-env-kafka setup-test-env-mongodb setup-test-env-zipkin setup-test-env-temporal
 

--- a/tests/platforms/kubernetes/client.go
+++ b/tests/platforms/kubernetes/client.go
@@ -76,9 +76,17 @@ func clientConfig(kubeConfigPath string, clusterName string) (*rest.Config, erro
 		overrides.Context.Cluster = clusterName
 	}
 
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
 		&overrides).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Reduce the QPS to avoid rate-limiting
+	config.QPS = 3
+	config.Burst = 5
+	return config, nil
 }
 
 // GetClientConfig returns client configuration.

--- a/tests/runner/testresource.go
+++ b/tests/runner/testresource.go
@@ -44,7 +44,7 @@ func (r *TestResources) Add(dr Disposable) {
 	r.resources = append(r.resources, dr)
 }
 
-// dequeueResource dequeus Disposable resource from resources queue.
+// dequeueResource dequeues Disposable resource from resources queue.
 func (r *TestResources) dequeueResource() Disposable {
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
@@ -90,26 +90,60 @@ func (r *TestResources) FindActiveResource(name string) Disposable {
 func (r *TestResources) setup() error {
 	r.ctx, r.cancel = context.WithCancel(context.Background())
 
-	for dr := r.dequeueResource(); dr != nil; dr = r.dequeueResource() {
-		err := dr.Init(r.ctx)
-		r.pushActiveResource(dr)
+	resourceCount := 0
+	errs := make(chan error)
+	for {
+		dr := r.dequeueResource()
+		if dr == nil {
+			break
+		}
+
+		resourceCount++
+		go func() {
+			err := dr.Init(r.ctx)
+			r.pushActiveResource(dr)
+			errs <- err
+		}()
+	}
+
+	for i := 0; i < resourceCount; i++ {
+		err := <-errs
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
 // TearDown initializes the resources by calling Dispose.
 func (r *TestResources) tearDown() (retErr error) {
-	retErr = nil
-	for dr := r.popActiveResource(); dr != nil; dr = r.popActiveResource() {
-		err := dr.Dispose(false)
+	resourceCount := 0
+	errs := make(chan error)
+	for {
+		dr := r.popActiveResource()
+		if dr == nil {
+			break
+		}
+
+		resourceCount++
+		go func() {
+			err := dr.Dispose(false)
+			if err != nil {
+				err = fmt.Errorf("failed to tear down %s. got: %w", dr.Name(), err)
+			}
+			errs <- err
+		}()
+	}
+
+	for i := 0; i < resourceCount; i++ {
+		err := <-errs
 		if err != nil {
+			os.Stderr.WriteString(err.Error() + "\n")
 			retErr = err
-			fmt.Fprintf(os.Stderr, "Failed to tear down %s. got: %q", dr.Name(), err)
 		}
 	}
+
 	if r.cancel != nil {
 		r.cancel()
 		r.cancel = nil

--- a/tests/runner/testresource_test.go
+++ b/tests/runner/testresource_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/exp/slices"
 )
 
 // MockDisposable is the mock of Disposable interface.
@@ -58,46 +59,62 @@ func TestAdd(t *testing.T) {
 
 func TestSetup(t *testing.T) {
 	t.Run("active all resources", func(t *testing.T) {
+		expect := []string{}
 		resource := new(TestResources)
 		for i := 0; i < 3; i++ {
+			name := fmt.Sprintf("resource - %d", i)
 			r := new(MockDisposable)
-			r.On("Name").Return(fmt.Sprintf("resource - %d", i))
+			r.On("Name").Return(name)
 			r.On("Init").Return(nil)
 			resource.Add(r)
+			expect = append(expect, name)
 		}
 
 		err := resource.setup()
 		assert.NoError(t, err)
 
+		found := []string{}
 		for i := 2; i >= 0; i-- {
 			r := resource.popActiveResource()
-			assert.Equal(t, fmt.Sprintf("resource - %d", i), r.Name())
+			found = append(found, r.Name())
 		}
+
+		slices.Sort(expect)
+		slices.Sort(found)
+		assert.Equal(t, expect, found)
 	})
 
 	t.Run("fails to setup resources and stops the process", func(t *testing.T) {
+		expect := []string{}
 		resource := new(TestResources)
 		for i := 0; i < 3; i++ {
+			name := fmt.Sprintf("resource - %d", i)
 			r := new(MockDisposable)
-			r.On("Name").Return(fmt.Sprintf("resource - %d", i))
+			r.On("Name").Return(name)
 			if i != 1 {
 				r.On("Init").Return(nil)
 			} else {
-				r.On("Init").Return(fmt.Errorf("setup error"))
+				r.On("Init").Return(fmt.Errorf("setup error %d", i))
 			}
+			expect = append(expect, name)
 			resource.Add(r)
 		}
 
 		err := resource.setup()
 		assert.Error(t, err)
 
-		for i := 1; i >= 0; i-- {
+		found := []string{}
+		for i := 2; i >= 0; i-- {
 			r := resource.popActiveResource()
-			assert.Equal(t, fmt.Sprintf("resource - %d", i), r.Name())
+			found = append(found, r.Name())
 		}
 
 		r := resource.popActiveResource()
 		assert.Nil(t, r)
+
+		slices.Sort(expect)
+		slices.Sort(found)
+		assert.Equal(t, expect, found)
 	})
 }
 


### PR DESCRIPTION
Should help making E2E tests complete a few mins quicker by deploying (and disposing) E2E test apps in parallel. This should be especially useful in AKS (because of having to pull from a container registry through the network and because of the need to wait for a load balancer), and especially for tests like "service_invocation" that requires deploying half a dozen apps.