### PR TITLE
#5674 check replicaCount value for Sidecar Injector Helm Chart deploy…

### DIFF
--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
 {{- if eq .Values.global.ha.enabled true }}
   replicas: {{ .Values.global.ha.replicaCount }}
+{{- else }}
+  replicas: {{ .Values.replicaCount }}  
 {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
# Description

Added setting of `replicas` from `.Values.replicaCount` in `./charts/dapr/charts/dapr_sidecar_injector/Chart.yaml` when `.Values.global.ha.enabled` is not set - so that implementation matches documentation.

## Issue reference

Please reference the issue this PR will close: #5674 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
