### PR TITLE
Replace `go.uber.org/atomic` and `github.com/pkg/errors` with standard library packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -126,6 +126,8 @@ linters-settings:
     packages-with-error-message:
       - "github.com/Sirupsen/logrus": "must use github.com/dapr/kit/logger"
       - "github.com/agrea/ptr": "must use github.com/dapr/kit/ptr"
+      - "go.uber.org/atomic": "must use sync/atomic"
+      - "github.com/pkg/errors": "must use standard library (errors package and/or fmt.Errorf)"
       - "github.com/cenkalti/backoff": "must use github.com/cenkalti/backoff/v4"
       - "github.com/cenkalti/backoff/v2": "must use github.com/cenkalti/backoff/v4"
       - "github.com/cenkalti/backoff/v3": "must use github.com/cenkalti/backoff/v4"

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/common v0.37.0
@@ -51,7 +50,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.11.1
 	go.temporal.io/api v1.13.0
 	go.temporal.io/sdk v1.19.0
-	go.uber.org/atomic v1.10.0
 	go.uber.org/automaxprocs v1.5.1
 	go.uber.org/ratelimit v0.2.0
 	golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f
@@ -320,6 +318,7 @@ require (
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
@@ -372,6 +371,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.11.1 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect

--- a/pkg/actors/actor_lock.go
+++ b/pkg/actors/actor_lock.go
@@ -14,13 +14,12 @@ limitations under the License.
 package actors
 
 import (
+	"errors"
 	"sync"
-
-	"github.com/pkg/errors"
-	"go.uber.org/atomic"
+	"sync/atomic"
 )
 
-var ErrMaxStackDepthExceeded = errors.New("Maximum stack depth exceeded")
+var ErrMaxStackDepthExceeded = errors.New("maximum stack depth exceeded")
 
 type ActorLock struct {
 	methodLock    *sync.Mutex
@@ -35,7 +34,7 @@ func NewActorLock(maxStackDepth int32) ActorLock {
 		methodLock:    &sync.Mutex{},
 		requestLock:   &sync.Mutex{},
 		activeRequest: nil,
-		stackDepth:    atomic.NewInt32(int32(0)),
+		stackDepth:    &atomic.Int32{},
 		maxStackDepth: maxStackDepth,
 	}
 }
@@ -50,16 +49,16 @@ func (a *ActorLock) Lock(requestID *string) error {
 	if currentRequest == nil || *currentRequest != *requestID {
 		a.methodLock.Lock()
 		a.setCurrentID(requestID)
-		a.stackDepth.Inc()
+		a.stackDepth.Add(1)
 	} else {
-		a.stackDepth.Inc()
+		a.stackDepth.Add(1)
 	}
 
 	return nil
 }
 
 func (a *ActorLock) Unlock() {
-	a.stackDepth.Dec()
+	a.stackDepth.Add(-1)
 	if a.stackDepth.Load() == 0 {
 		a.clearCurrentID()
 		a.methodLock.Unlock()

--- a/pkg/actors/actor_lock_test.go
+++ b/pkg/actors/actor_lock_test.go
@@ -92,7 +92,7 @@ func TestStackDepthLimit(t *testing.T) {
 	err = lock.Lock(requestID)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "Maximum stack depth exceeded", err.Error())
+	assert.Equal(t, "maximum stack depth exceeded", err.Error())
 }
 
 func TestLockBlocksForNonMatchingID(t *testing.T) {

--- a/pkg/actors/actor_test.go
+++ b/pkg/actors/actor_test.go
@@ -14,11 +14,11 @@ limitations under the License.
 package actors
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 var reentrancyStackDepth = 32
@@ -117,7 +117,7 @@ func TestPendingActorCalls(t *testing.T) {
 		testActor := newActor("testType", "testID", &reentrancyStackDepth)
 		testActor.lock(nil)
 
-		channelClosed := atomic.NewBool(false)
+		channelClosed := atomic.Bool{}
 		go func() {
 			select {
 			case <-time.After(200 * time.Millisecond):

--- a/pkg/apphealth/health.go
+++ b/pkg/apphealth/health.go
@@ -16,9 +16,8 @@ package apphealth
 import (
 	"context"
 	"strconv"
+	"sync/atomic"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/dapr/kit/logger"
 )
@@ -55,12 +54,16 @@ type ChangeCallback func(status uint8)
 
 // NewAppHealth creates a new AppHealth object.
 func NewAppHealth(config *Config, probeFn ProbeFunction) *AppHealth {
+	// Initial state is unhealthy until we validate it
+	failureCount := &atomic.Int32{}
+	failureCount.Store(config.Threshold)
+
 	return &AppHealth{
 		config:            config,
 		probeFn:           probeFn,
 		report:            make(chan uint8, 1),
-		failureCount:      atomic.NewInt32(config.Threshold), // Initial state is unhealthy until we validate it
-		lastReport:        atomic.NewInt64(0),
+		failureCount:      failureCount,
+		lastReport:        &atomic.Int64{},
 		reportMinInterval: 1e6,
 		queue:             make(chan struct{}, 1),
 	}
@@ -209,7 +212,7 @@ func (h *AppHealth) setResult(successful bool) {
 	}
 
 	// Count the failure
-	failures := h.failureCount.Inc()
+	failures := h.failureCount.Add(1)
 
 	// First, check if we've overflown
 	if failures < 0 {

--- a/pkg/components/bindings/input_pluggable.go
+++ b/pkg/components/bindings/input_pluggable.go
@@ -15,17 +15,14 @@ package bindings
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
+	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/components/pluggable"
 	proto "github.com/dapr/dapr/pkg/proto/components/v1"
-
-	"github.com/dapr/components-contrib/bindings"
-
 	"github.com/dapr/kit/logger"
-
-	"github.com/pkg/errors"
 )
 
 // grpcInputBinding is a implementation of a inputbinding over a gRPC Protocol.
@@ -101,7 +98,7 @@ func (b *grpcInputBinding) adaptHandler(ctx context.Context, streamingPull proto
 func (b *grpcInputBinding) Read(ctx context.Context, handler bindings.Handler) error {
 	readStream, err := b.Client.Read(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "unable to read from binding")
+		return fmt.Errorf("unable to read from binding: %w", err)
 	}
 
 	streamCtx, cancel := context.WithCancel(readStream.Context())

--- a/pkg/components/bindings/registry.go
+++ b/pkg/components/bindings/registry.go
@@ -14,9 +14,8 @@ limitations under the License.
 package bindings
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/components"
@@ -60,7 +59,7 @@ func (b *Registry) CreateInputBinding(name, version string) (bindings.InputBindi
 	if method, ok := b.getInputBinding(name, version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find input binding %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find input binding %s/%s", name, version)
 }
 
 // CreateOutputBinding Create instantiates an output binding based on `name`.
@@ -68,7 +67,7 @@ func (b *Registry) CreateOutputBinding(name, version string) (bindings.OutputBin
 	if method, ok := b.getOutputBinding(name, version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find output binding %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find output binding %s/%s", name, version)
 }
 
 // HasInputBinding checks if an input binding based on `name` exists in the registry.

--- a/pkg/components/bindings/registry_test.go
+++ b/pkg/components/bindings/registry_test.go
@@ -14,16 +14,15 @@ limitations under the License.
 package bindings_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	b "github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/components/bindings"
+	"github.com/dapr/kit/logger"
 )
 
 type (
@@ -90,7 +89,7 @@ func TestRegistry(t *testing.T) {
 		assert.False(t, testRegistry.HasInputBinding(componentName, "v1"))
 		assert.False(t, testRegistry.HasInputBinding(componentName, "v2"))
 		p, actualError := testRegistry.CreateInputBinding(componentName, "v1")
-		expectedError := errors.Errorf("couldn't find input binding %s/v1", componentName)
+		expectedError := fmt.Errorf("couldn't find input binding %s/v1", componentName)
 
 		// assert
 		assert.Nil(t, p)
@@ -144,7 +143,7 @@ func TestRegistry(t *testing.T) {
 		assert.False(t, testRegistry.HasOutputBinding(componentName, "v1"))
 		assert.False(t, testRegistry.HasOutputBinding(componentName, "v2"))
 		p, actualError := testRegistry.CreateOutputBinding(componentName, "v1")
-		expectedError := errors.Errorf("couldn't find output binding %s/v1", componentName)
+		expectedError := fmt.Errorf("couldn't find output binding %s/v1", componentName)
 
 		// assert
 		assert.Nil(t, p)

--- a/pkg/components/configuration/registry.go
+++ b/pkg/components/configuration/registry.go
@@ -14,9 +14,8 @@ limitations under the License.
 package configuration
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/configuration"
 	"github.com/dapr/dapr/pkg/components"
@@ -53,7 +52,7 @@ func (s *Registry) Create(name, version string) (configuration.Store, error) {
 	if method, ok := s.getConfigurationStore(name, version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find configuration store %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find configuration store %s/%s", name, version)
 }
 
 func (s *Registry) getConfigurationStore(name, version string) (func() configuration.Store, bool) {

--- a/pkg/components/configuration/registry_test.go
+++ b/pkg/components/configuration/registry_test.go
@@ -14,16 +14,15 @@ limitations under the License.
 package configuration_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	c "github.com/dapr/components-contrib/configuration"
 	"github.com/dapr/dapr/pkg/components/configuration"
 	"github.com/dapr/kit/logger"
-
-	c "github.com/dapr/components-contrib/configuration"
 )
 
 type mockState struct {
@@ -79,7 +78,7 @@ func TestRegistry(t *testing.T) {
 
 		// act
 		p, actualError := testRegistry.Create(componentName, "v1")
-		expectedError := errors.Errorf("couldn't find configuration store %s/v1", componentName)
+		expectedError := fmt.Errorf("couldn't find configuration store %s/v1", componentName)
 
 		// assert
 		assert.Nil(t, p)

--- a/pkg/components/lock/lock_config.go
+++ b/pkg/components/lock/lock_config.go
@@ -3,8 +3,6 @@ package lock
 import (
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -76,7 +74,7 @@ func getConfiguration(storeName string) *StoreConfiguration {
 
 func checkKeyIllegal(key string) error {
 	if strings.Contains(key, separator) {
-		return errors.Errorf("input key/keyPrefix '%s' can't contain '%s'", key, separator)
+		return fmt.Errorf("input key/keyPrefix '%s' can't contain '%s'", key, separator)
 	}
 	return nil
 }

--- a/pkg/components/lock/registry.go
+++ b/pkg/components/lock/registry.go
@@ -1,9 +1,8 @@
 package lock
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/lock"
 	"github.com/dapr/dapr/pkg/components"
@@ -38,7 +37,7 @@ func (r *Registry) Create(name, version string) (lock.Store, error) {
 	if method, ok := r.getStore(name, version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find lock store %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find lock store %s/%s", name, version)
 }
 
 func (r *Registry) getStore(name, version string) (func() lock.Store, bool) {

--- a/pkg/components/middleware/http/registry.go
+++ b/pkg/components/middleware/http/registry.go
@@ -14,15 +14,13 @@ limitations under the License.
 package http
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	middleware "github.com/dapr/components-contrib/middleware"
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/components"
 	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
+	"github.com/dapr/kit/logger"
 )
 
 type (
@@ -62,11 +60,11 @@ func (p *Registry) Create(name, version string, metadata middleware.Metadata) (h
 	if method, ok := p.getMiddleware(name, version); ok {
 		mid, err := method(metadata)
 		if err != nil {
-			return nil, errors.Errorf("error creating HTTP middleware %s/%s: %s", name, version, err)
+			return nil, fmt.Errorf("error creating HTTP middleware %s/%s: %w", name, version, err)
 		}
 		return mid, nil
 	}
-	return nil, errors.Errorf("HTTP middleware %s/%s has not been registered", name, version)
+	return nil, fmt.Errorf("HTTP middleware %s/%s has not been registered", name, version)
 }
 
 func (p *Registry) getMiddleware(name, version string) (FactoryMethod, bool) {

--- a/pkg/components/middleware/http/registry_test.go
+++ b/pkg/components/middleware/http/registry_test.go
@@ -14,19 +14,18 @@ limitations under the License.
 package http_test
 
 import (
+	"fmt"
 	nethttp "net/http"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	h "github.com/dapr/components-contrib/middleware"
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/components/middleware/http"
 	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
+	"github.com/dapr/kit/logger"
 )
 
 func TestRegistry(t *testing.T) {
@@ -94,7 +93,7 @@ func TestRegistry(t *testing.T) {
 
 		// act
 		p, actualError := testRegistry.Create(componentName, "v1", metadata)
-		expectedError := errors.Errorf("HTTP middleware %s/v1 has not been registered", componentName)
+		expectedError := fmt.Errorf("HTTP middleware %s/v1 has not been registered", componentName)
 
 		// assert
 		assert.Nil(t, p)

--- a/pkg/components/nameresolution/registry.go
+++ b/pkg/components/nameresolution/registry.go
@@ -14,14 +14,12 @@ limitations under the License.
 package nameresolution
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	nr "github.com/dapr/components-contrib/nameresolution"
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/components"
+	"github.com/dapr/kit/logger"
 )
 
 type (
@@ -60,7 +58,7 @@ func (s *Registry) Create(name, version string) (nr.Resolver, error) {
 	if method, ok := s.getResolver(createFullName(name), version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find name resolver %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find name resolver %s/%s", name, version)
 }
 
 func (s *Registry) getResolver(name, version string) (func() nr.Resolver, bool) {

--- a/pkg/components/nameresolution/registry_test.go
+++ b/pkg/components/nameresolution/registry_test.go
@@ -14,16 +14,15 @@ limitations under the License.
 package nameresolution_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	nr "github.com/dapr/components-contrib/nameresolution"
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/components/nameresolution"
+	"github.com/dapr/kit/logger"
 )
 
 type mockResolver struct {
@@ -77,7 +76,7 @@ func TestRegistry(t *testing.T) {
 
 		// act
 		p, actualError := testRegistry.Create(resolverName, "v1")
-		expectedError := errors.Errorf("couldn't find name resolver %s/v1", resolverName)
+		expectedError := fmt.Errorf("couldn't find name resolver %s/v1", resolverName)
 
 		// assert
 		assert.Nil(t, p)

--- a/pkg/components/pluggable/discovery.go
+++ b/pkg/components/pluggable/discovery.go
@@ -15,18 +15,16 @@ package pluggable
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/dapr/dapr/utils"
-	"github.com/dapr/kit/logger"
-
-	"github.com/pkg/errors"
-
 	"github.com/jhump/protoreflect/grpcreflect"
-
 	"google.golang.org/grpc"
 	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+
+	"github.com/dapr/dapr/utils"
+	"github.com/dapr/kit/logger"
 )
 
 var (
@@ -94,7 +92,7 @@ func serviceDiscovery(reflectClientFactory func(string) (reflectServiceClient, f
 
 	files, err := os.ReadDir(componentsSocketPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list pluggable components unix sockets")
+		return nil, fmt.Errorf("could not list pluggable components unix sockets: %w", err)
 	}
 
 	for _, dirEntry := range files {
@@ -121,7 +119,7 @@ func serviceDiscovery(reflectClientFactory func(string) (reflectServiceClient, f
 
 		serviceList, err := refctClient.ListServices()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to list services")
+			return nil, fmt.Errorf("unable to list services: %w", err)
 		}
 		dialer := socketDialer(socket, grpc.WithBlock(), grpc.FailOnNonTempDialError(true))
 

--- a/pkg/components/pluggable/grpc.go
+++ b/pkg/components/pluggable/grpc.go
@@ -15,10 +15,9 @@ package pluggable
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dapr/kit/logger"
-
-	"github.com/pkg/errors"
 
 	proto "github.com/dapr/dapr/pkg/proto/components/v1"
 
@@ -85,7 +84,7 @@ func SocketDial(ctx context.Context, socket string, additionalOpts ...grpc.DialO
 
 	grpcConn, err := grpc.DialContext(ctx, udsSocket, additionalOpts...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to open GRPC connection using socket '%s'", udsSocket)
+		return nil, fmt.Errorf("unable to open GRPC connection using socket '%s': %w", udsSocket, err)
 	}
 	return grpcConn, nil
 }
@@ -94,7 +93,7 @@ func SocketDial(ctx context.Context, socket string, additionalOpts ...grpc.DialO
 func (g *GRPCConnector[TClient]) Dial(name string) error {
 	grpcConn, err := g.dialer(g.Context, name)
 	if err != nil {
-		return errors.Wrapf(err, "unable to open GRPC connection using the dialer")
+		return fmt.Errorf("unable to open GRPC connection using the dialer: %w", err)
 	}
 	g.conn = grpcConn
 

--- a/pkg/components/pubsub/pluggable.go
+++ b/pkg/components/pubsub/pluggable.go
@@ -15,17 +15,14 @@ package pubsub
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
 	"github.com/dapr/components-contrib/pubsub"
-
 	"github.com/dapr/dapr/pkg/components/pluggable"
 	proto "github.com/dapr/dapr/pkg/proto/components/v1"
-
 	"github.com/dapr/kit/logger"
-
-	"github.com/pkg/errors"
 )
 
 // grpcPubSub is a implementation of a pubsub over a gRPC Protocol.
@@ -131,7 +128,7 @@ func (p *grpcPubSub) pullMessages(ctx context.Context, topic *proto.Topic, handl
 	// first pull should be sync and subsequent connections can be made in background if necessary
 	pull, err := p.Client.PullMessages(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "unable to subscribe")
+		return fmt.Errorf("unable to subscribe: %w", err)
 	}
 
 	streamCtx, cancel := context.WithCancel(pull.Context())
@@ -149,7 +146,7 @@ func (p *grpcPubSub) pullMessages(ctx context.Context, topic *proto.Topic, handl
 
 	if err != nil {
 		cleanup()
-		return errors.Wrapf(err, "unable to subscribe")
+		return fmt.Errorf("unable to subscribe: %w", err)
 	}
 
 	handle := p.adaptHandler(streamCtx, pull, handler)

--- a/pkg/components/pubsub/pluggable_test.go
+++ b/pkg/components/pubsub/pluggable_test.go
@@ -21,25 +21,20 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	guuid "github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	contribMetadata "github.com/dapr/components-contrib/metadata"
 	"github.com/dapr/components-contrib/pubsub"
-
-	"go.uber.org/atomic"
-
 	"github.com/dapr/dapr/pkg/components/pluggable"
 	proto "github.com/dapr/dapr/pkg/proto/components/v1"
 	testingGrpc "github.com/dapr/dapr/pkg/testing/grpc"
-
 	"github.com/dapr/kit/logger"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"google.golang.org/grpc"
 )
 
 var testLogger = logger.NewLogger("pubsub-pluggable-test")

--- a/pkg/components/pubsub/registry.go
+++ b/pkg/components/pubsub/registry.go
@@ -14,9 +14,8 @@ limitations under the License.
 package pubsub
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/components"
@@ -50,7 +49,7 @@ func (p *Registry) Create(name, version string) (pubsub.PubSub, error) {
 	if method, ok := p.getPubSub(name, version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find message bus %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find message bus %s/%s", name, version)
 }
 
 func (p *Registry) getPubSub(name, version string) (func() pubsub.PubSub, bool) {

--- a/pkg/components/pubsub/registry_test.go
+++ b/pkg/components/pubsub/registry_test.go
@@ -14,10 +14,10 @@ limitations under the License.
 package pubsub
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dapr/components-contrib/pubsub"
@@ -90,7 +90,7 @@ func TestCreatePubSub(t *testing.T) {
 
 		// act
 		p, actualError := testRegistry.Create(createFullName(PubSubName), "v1")
-		expectedError := errors.Errorf("couldn't find message bus %s/v1", createFullName(PubSubName))
+		expectedError := fmt.Errorf("couldn't find message bus %s/v1", createFullName(PubSubName))
 		// assert
 		assert.Nil(t, p)
 		assert.Equal(t, expectedError.Error(), actualError.Error())

--- a/pkg/components/secretstores/registry.go
+++ b/pkg/components/secretstores/registry.go
@@ -14,9 +14,8 @@ limitations under the License.
 package secretstores
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/dapr/pkg/components"
@@ -59,7 +58,7 @@ func (s *Registry) Create(name, version string) (secretstores.SecretStore, error
 		return method(), nil
 	}
 
-	return nil, errors.Errorf("couldn't find secret store %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find secret store %s/%s", name, version)
 }
 
 func (s *Registry) getSecretStore(name, version string) (func() secretstores.SecretStore, bool) {

--- a/pkg/components/secretstores/registry_test.go
+++ b/pkg/components/secretstores/registry_test.go
@@ -14,16 +14,15 @@ limitations under the License.
 package secretstores_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	ss "github.com/dapr/components-contrib/secretstores"
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/components/secretstores"
+	"github.com/dapr/kit/logger"
 )
 
 type mockSecretStore struct {
@@ -79,7 +78,7 @@ func TestRegistry(t *testing.T) {
 
 		// act
 		p, actualError := testRegistry.Create(componentName, "v1")
-		expectedError := errors.Errorf("couldn't find secret store %s/v1", componentName)
+		expectedError := fmt.Errorf("couldn't find secret store %s/v1", componentName)
 
 		// assert
 		assert.Nil(t, p)

--- a/pkg/components/state/registry.go
+++ b/pkg/components/state/registry.go
@@ -14,9 +14,8 @@ limitations under the License.
 package state
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/components"
@@ -50,7 +49,7 @@ func (s *Registry) Create(name, version string) (state.Store, error) {
 	if method, ok := s.getStateStore(name, version); ok {
 		return method(), nil
 	}
-	return nil, errors.Errorf("couldn't find state store %s/%s", name, version)
+	return nil, fmt.Errorf("couldn't find state store %s/%s", name, version)
 }
 
 func (s *Registry) getStateStore(name, version string) (func() state.Store, bool) {

--- a/pkg/components/state/registry_test.go
+++ b/pkg/components/state/registry_test.go
@@ -14,16 +14,15 @@ limitations under the License.
 package state_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	s "github.com/dapr/components-contrib/state"
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/components/state"
+	"github.com/dapr/kit/logger"
 )
 
 type mockState struct {
@@ -79,7 +78,7 @@ func TestRegistry(t *testing.T) {
 
 		// act
 		p, actualError := testRegistry.Create(componentName, "v1")
-		expectedError := errors.Errorf("couldn't find state store %s/v1", componentName)
+		expectedError := fmt.Errorf("couldn't find state store %s/v1", componentName)
 
 		// assert
 		assert.Nil(t, p)

--- a/pkg/components/state/state_config.go
+++ b/pkg/components/state/state_config.go
@@ -18,8 +18,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -113,7 +111,7 @@ func getStateConfiguration(storeName string) *StoreConfiguration {
 
 func checkKeyIllegal(key string) error {
 	if strings.Contains(key, daprSeparator) {
-		return errors.Errorf("input key/keyPrefix '%s' can't contain '%s'", key, daprSeparator)
+		return fmt.Errorf("input key/keyPrefix '%s' can't contain '%s'", key, daprSeparator)
 	}
 	return nil
 }

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -16,13 +16,13 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
-	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -302,7 +302,7 @@ func LoadKubernetesConfiguration(config, namespace string, podName string, opera
 		return nil, err
 	}
 	if resp.GetConfiguration() == nil {
-		return nil, errors.Errorf("configuration %s not found", config)
+		return nil, fmt.Errorf("configuration %s not found", config)
 	}
 	conf := LoadDefaultConfiguration()
 	err = json.Unmarshal(resp.GetConfiguration(), conf)
@@ -325,12 +325,12 @@ func sortAndValidateSecretsConfiguration(conf *Configuration) error {
 	for _, scope := range scopes {
 		// validate scope
 		if set.Has(scope.StoreName) {
-			return errors.Errorf("%q storeName is repeated in secrets configuration", scope.StoreName)
+			return fmt.Errorf("%q storeName is repeated in secrets configuration", scope.StoreName)
 		}
 		if scope.DefaultAccess != "" &&
 			!strings.EqualFold(scope.DefaultAccess, AllowAccess) &&
 			!strings.EqualFold(scope.DefaultAccess, DenyAccess) {
-			return errors.Errorf("defaultAccess %q can be either allow or deny", scope.DefaultAccess)
+			return fmt.Errorf("defaultAccess %q can be either allow or deny", scope.DefaultAccess)
 		}
 		set.Insert(scope.StoreName)
 

--- a/pkg/credentials/grpc.go
+++ b/pkg/credentials/grpc.go
@@ -3,8 +3,9 @@ package credentials
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -46,7 +47,7 @@ func GetClientOptions(certChain *CertChain, serverName string) ([]grpc.DialOptio
 		}
 		config, err := TLSConfigFromCertAndKey(certChain.Cert, certChain.Key, serverName, cp)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create tls config from cert and key")
+			return nil, fmt.Errorf("failed to create tls config from cert and key: %w", err)
 		}
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(config)))
 	} else {

--- a/pkg/encryption/encryption.go
+++ b/pkg/encryption/encryption.go
@@ -20,9 +20,9 @@ import (
 	"crypto/rand"
 	b64 "encoding/base64"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/dapr/pkg/apis/components/v1alpha1"
@@ -93,7 +93,7 @@ func ComponentEncryptionKey(component v1alpha1.Component, secretStore secretstor
 
 		key, err := tryGetEncryptionKeyFromMetadataItem(component.Namespace, m, secretStore)
 		if err != nil {
-			return ComponentEncryptionKeys{}, errors.Wrap(err, errPrefix)
+			return ComponentEncryptionKeys{}, fmt.Errorf("%s: %w", errPrefix, err)
 		}
 
 		if m.Name == primaryEncryptionKey {
@@ -125,7 +125,7 @@ func ComponentEncryptionKey(component v1alpha1.Component, secretStore secretstor
 
 func tryGetEncryptionKeyFromMetadataItem(namespace string, item v1alpha1.MetadataItem, secretStore secretstores.SecretStore) (Key, error) {
 	if item.SecretKeyRef.Name == "" {
-		return Key{}, errors.Errorf("%s: secretKeyRef cannot be empty", errPrefix)
+		return Key{}, fmt.Errorf("%s: secretKeyRef cannot be empty", errPrefix)
 	}
 
 	// TODO: cascade context.
@@ -136,7 +136,7 @@ func tryGetEncryptionKeyFromMetadataItem(namespace string, item v1alpha1.Metadat
 		},
 	})
 	if err != nil {
-		return Key{}, errors.Wrap(err, errPrefix)
+		return Key{}, fmt.Errorf("%s: %w", errPrefix, err)
 	}
 
 	key := item.SecretKeyRef.Key
@@ -146,7 +146,7 @@ func tryGetEncryptionKeyFromMetadataItem(namespace string, item v1alpha1.Metadat
 
 	if val, ok := r.Data[key]; ok {
 		if val == "" {
-			return Key{}, errors.Errorf("%s: encryption key cannot be empty", errPrefix)
+			return Key{}, fmt.Errorf("%s: encryption key cannot be empty", errPrefix)
 		}
 
 		return Key{

--- a/pkg/encryption/state.go
+++ b/pkg/encryption/state.go
@@ -16,8 +16,7 @@ package encryption
 import (
 	"bytes"
 	b64 "encoding/base64"
-
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 var encryptedStateStores = map[string]ComponentEncryptionKeys{}
@@ -65,7 +64,7 @@ func TryDecryptValue(storeName string, value []byte) ([]byte, error) {
 	keyName := string(value[ind+len(separator):])
 
 	if len(keyName) == 0 {
-		return value, errors.Errorf("could not decrypt data for state store %s: encryption key name not found on record", storeName)
+		return value, fmt.Errorf("could not decrypt data for state store %s: encryption key name not found on record", storeName)
 	}
 
 	var key Key

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -191,7 +190,7 @@ func (g *Manager) connectRemote(
 		var cert tls.Certificate
 		cert, err = tls.X509KeyPair(signedCert.WorkloadCert, signedCert.PrivateKeyPem)
 		if err != nil {
-			return nil, errors.Errorf("error loading x509 Key Pair: %s", err)
+			return nil, fmt.Errorf("error loading x509 Key Pair: %w", err)
 		}
 
 		var serverName string

--- a/pkg/grpc/proxy/codec/codec.go
+++ b/pkg/grpc/proxy/codec/codec.go
@@ -7,10 +7,9 @@ package codec
 import (
 	"fmt"
 
+	protoV1 "github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/protobuf/proto"
-
-	protoV1 "github.com/golang/protobuf/proto"
 )
 
 // Name is the name by which the proxy codec is registered in the encoding codec registry

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -16,6 +16,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	grpcMiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/pkg/errors"
 	grpcGo "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -140,7 +140,7 @@ func (s *server) StartNonBlocking() error {
 	}
 
 	if len(listeners) == 0 {
-		return errors.Errorf("could not listen on any endpoint")
+		return errors.New("could not listen on any endpoint")
 	}
 
 	for _, listener := range listeners {
@@ -186,13 +186,13 @@ func (s *server) generateWorkloadCert() error {
 	s.logger.Info("sending workload csr request to sentry")
 	signedCert, err := s.authenticator.CreateSignedWorkloadCert(s.config.AppID, s.config.NameSpace, s.config.TrustDomain)
 	if err != nil {
-		return errors.Wrap(err, "error from authenticator CreateSignedWorkloadCert")
+		return fmt.Errorf("error from authenticator CreateSignedWorkloadCert: %w", err)
 	}
 	s.logger.Info("certificate signed successfully")
 
 	tlsCert, err := tls.X509KeyPair(signedCert.WorkloadCert, signedCert.PrivateKeyPem)
 	if err != nil {
-		return errors.Wrap(err, "error creating x509 Key Pair")
+		return fmt.Errorf("error creating x509 Key Pair: %w", err)
 	}
 
 	s.signedCert = signedCert

--- a/pkg/injector/pod_containers.go
+++ b/pkg/injector/pod_containers.go
@@ -14,6 +14,9 @@ limitations under the License.
 package injector
 
 import (
+	"fmt"
+
+	"golang.org/x/sync/singleflight"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -21,10 +24,6 @@ import (
 	"github.com/dapr/dapr/pkg/injector/annotations"
 	"github.com/dapr/dapr/pkg/injector/components"
 	"github.com/dapr/dapr/pkg/injector/sidecar"
-
-	"github.com/pkg/errors"
-
-	"golang.org/x/sync/singleflight"
 )
 
 // namespaceFlight deduplicates requests for the same namespace
@@ -47,7 +46,7 @@ func (i *injector) splitContainers(pod corev1.Pod) (appContainers map[int]corev1
 			return i.daprClient.ComponentsV1alpha1().Components(pod.Namespace).List(metav1.ListOptions{})
 		})
 		if err != nil {
-			return nil, nil, nil, errors.Wrap(err, "error reading components")
+			return nil, nil, nil, fmt.Errorf("error reading components: %w", err)
 		}
 		injectedComponentContainers = components.Injectable(an.GetString(annotations.KeyAppID), componentsList.(*v1alpha1.ComponentList).Items)
 	}

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -16,8 +16,8 @@ package injector
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,8 +42,7 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 	var pod corev1.Pod
 	err = json.Unmarshal(req.Object.Raw, &pod)
 	if err != nil {
-		errors.Wrap(err, "could not unmarshal raw object")
-		return nil, err
+		return nil, fmt.Errorf("could not unmarshal raw object: %w", err)
 	}
 
 	log.Infof(

--- a/pkg/injector/sidecar/annotations_map.go
+++ b/pkg/injector/sidecar/annotations_map.go
@@ -14,9 +14,8 @@ limitations under the License.
 package sidecar
 
 import (
+	"fmt"
 	"strconv"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/dapr/utils"
 )
@@ -67,7 +66,7 @@ func (a Annotations) GetInt32(key string) (int32, error) {
 	}
 	value, err := strconv.ParseInt(s, 10, 32)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error parsing %s int value %s ", key, s)
+		return -1, fmt.Errorf("error parsing %s int value %s: %w", key, s, err)
 	}
 	return int32(value), nil
 }

--- a/pkg/injector/sidecar/container.go
+++ b/pkg/injector/sidecar/container.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -400,7 +399,7 @@ func getResourceRequirements(an Annotations) (*corev1.ResourceRequirements, erro
 	if ok {
 		list, err := appendQuantityToResourceList(cpuLimit, corev1.ResourceCPU, r.Limits)
 		if err != nil {
-			return nil, errors.Wrap(err, "error parsing sidecar cpu limit")
+			return nil, fmt.Errorf("error parsing sidecar cpu limit: %w", err)
 		}
 		r.Limits = *list
 	}
@@ -408,7 +407,7 @@ func getResourceRequirements(an Annotations) (*corev1.ResourceRequirements, erro
 	if ok {
 		list, err := appendQuantityToResourceList(memLimit, corev1.ResourceMemory, r.Limits)
 		if err != nil {
-			return nil, errors.Wrap(err, "error parsing sidecar memory limit")
+			return nil, fmt.Errorf("error parsing sidecar memory limit: %w", err)
 		}
 		r.Limits = *list
 	}
@@ -416,7 +415,7 @@ func getResourceRequirements(an Annotations) (*corev1.ResourceRequirements, erro
 	if ok {
 		list, err := appendQuantityToResourceList(cpuRequest, corev1.ResourceCPU, r.Requests)
 		if err != nil {
-			return nil, errors.Wrap(err, "error parsing sidecar cpu request")
+			return nil, fmt.Errorf("error parsing sidecar cpu request: %w", err)
 		}
 		r.Requests = *list
 	}
@@ -424,7 +423,7 @@ func getResourceRequirements(an Annotations) (*corev1.ResourceRequirements, erro
 	if ok {
 		list, err := appendQuantityToResourceList(memRequest, corev1.ResourceMemory, r.Requests)
 		if err != nil {
-			return nil, errors.Wrap(err, "error parsing sidecar memory request")
+			return nil, fmt.Errorf("error parsing sidecar memory request: %w", err)
 		}
 		r.Requests = *list
 	}

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -1,11 +1,11 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/pkg/errors"
 	prom "github.com/prometheus/client_golang/prometheus"
 
 	"github.com/dapr/kit/logger"
@@ -67,7 +67,7 @@ func (m *promMetricsExporter) Init() error {
 		Namespace: m.namespace,
 		Registry:  prom.DefaultRegisterer.(*prom.Registry),
 	}); err != nil {
-		return errors.Errorf("failed to create Prometheus exporter: %v", err)
+		return fmt.Errorf("failed to create Prometheus exporter: %w", err)
 	}
 
 	// start metrics server

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"sync"
 	"time"
 
@@ -85,7 +84,7 @@ func (a *apiServer) Run(ctx context.Context, certChain *daprCredentials.CertChai
 	s := grpc.NewServer(opts...)
 	operatorv1pb.RegisterOperatorServer(s, a)
 
-	lis, err := net.Listen("tcp", strconv.Itoa(serverPort))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", serverPort))
 	if err != nil {
 		log.Fatalf("error starting tcp listener: %v", err)
 	}

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -3,11 +3,12 @@ package client
 import (
 	"context"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"time"
 
 	grpcMiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
@@ -46,7 +47,7 @@ func GetOperatorClient(address, serverName string, certChain *daprCredentials.Ce
 
 	config, err := daprCredentials.TLSConfigFromCertAndKey(certChain.Cert, certChain.Key, serverName, cp)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create tls config from cert and key")
+		return nil, nil, fmt.Errorf("failed to create tls config from cert and key: %w", err)
 	}
 	// block for connection
 	opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(config)), grpc.WithBlock())

--- a/pkg/placement/hashing/consistent_hash.go
+++ b/pkg/placement/hashing/consistent_hash.go
@@ -23,6 +23,7 @@ package hashing
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -30,7 +31,6 @@ import (
 	"sync/atomic"
 
 	blake2b "github.com/minio/blake2b-simd"
-	"github.com/pkg/errors"
 )
 
 var replicationFactor int

--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -254,7 +254,7 @@ func (p *Service) processRaftStateCommand(stopCh chan struct{}) {
 
 						// ApplyCommand returns true only if the command changes hashing table.
 						if updated {
-							p.memberUpdateCount.Inc()
+							p.memberUpdateCount.Add(1)
 							// disseminateNextTime will be updated whenever apply is done, so that
 							// it will keep moving the time to disseminate the table, which will
 							// reduce the unnecessary table dissemination.

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -17,10 +17,9 @@ package placement
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"

--- a/pkg/placement/raft/fsm.go
+++ b/pkg/placement/raft/fsm.go
@@ -14,12 +14,12 @@ limitations under the License.
 package raft
 
 import (
+	"errors"
 	"io"
 	"strconv"
 	"sync"
 
 	"github.com/hashicorp/raft"
-	"github.com/pkg/errors"
 
 	"github.com/dapr/dapr/pkg/placement/hashing"
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"

--- a/pkg/placement/raft/server.go
+++ b/pkg/placement/raft/server.go
@@ -14,13 +14,14 @@ limitations under the License.
 package raft
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"path/filepath"
 	"time"
 
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -131,7 +132,7 @@ func (s *Server) StartRaft(config *raft.Config) error {
 		s.snapStore = raft.NewInmemSnapshotStore()
 	} else {
 		if err = ensureDir(s.raftStorePath()); err != nil {
-			return errors.Wrap(err, "failed to create log store directory")
+			return fmt.Errorf("failed to create log store directory: %w", err)
 		}
 
 		// Create the backend raft store for logs and stable storage.

--- a/pkg/placement/raft/util.go
+++ b/pkg/placement/raft/util.go
@@ -15,10 +15,10 @@ package raft
 
 import (
 	"bytes"
+	"errors"
 	"os"
 
 	"github.com/hashicorp/go-msgpack/codec"
-	"github.com/pkg/errors"
 )
 
 const defaultDirPermission = 0o755

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -15,6 +15,7 @@ limitations under the License.
 package runtime
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -23,10 +24,6 @@ import (
 	"time"
 
 	"github.com/phayes/freeport"
-	"github.com/pkg/errors"
-
-	"github.com/dapr/kit/logger"
-	"github.com/dapr/kit/ptr"
 
 	"github.com/dapr/dapr/pkg/acl"
 	resiliencyV1alpha "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
@@ -43,6 +40,8 @@ import (
 	"github.com/dapr/dapr/pkg/validation"
 	"github.com/dapr/dapr/pkg/version"
 	"github.com/dapr/dapr/utils"
+	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/ptr"
 )
 
 // FromFlags parses command flags and returns DaprRuntime instance.
@@ -147,29 +146,29 @@ func FromFlags() (*DaprRuntime, error) {
 
 	daprHTTP, err := strconv.Atoi(*daprHTTPPort)
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing dapr-http-port flag")
+		return nil, fmt.Errorf("error parsing dapr-http-port flag: %w", err)
 	}
 
 	daprAPIGRPC, err := strconv.Atoi(*daprAPIGRPCPort)
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing dapr-grpc-port flag")
+		return nil, fmt.Errorf("error parsing dapr-grpc-port flag: %w", err)
 	}
 
 	profPort, err := strconv.Atoi(*profilePort)
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing profile-port flag")
+		return nil, fmt.Errorf("error parsing profile-port flag: %w", err)
 	}
 
 	var daprInternalGRPC int
 	if *daprInternalGRPCPort != "" && *daprInternalGRPCPort != "0" {
 		daprInternalGRPC, err = strconv.Atoi(*daprInternalGRPCPort)
 		if err != nil {
-			return nil, errors.Wrap(err, "error parsing dapr-internal-grpc-port")
+			return nil, fmt.Errorf("error parsing dapr-internal-grpc-port: %w", err)
 		}
 	} else {
 		daprInternalGRPC, err = freeport.GetFreePort()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get free port for internal grpc server")
+			return nil, fmt.Errorf("failed to get free port for internal grpc server: %w", err)
 		}
 	}
 
@@ -177,7 +176,7 @@ func FromFlags() (*DaprRuntime, error) {
 	if *daprPublicPort != "" {
 		port, cerr := strconv.Atoi(*daprPublicPort)
 		if cerr != nil {
-			return nil, errors.Wrap(cerr, "error parsing dapr-public-port")
+			return nil, fmt.Errorf("error parsing dapr-public-port: %w", cerr)
 		}
 		publicPort = &port
 	}
@@ -186,7 +185,7 @@ func FromFlags() (*DaprRuntime, error) {
 	if *appPort != "" {
 		applicationPort, err = strconv.Atoi(*appPort)
 		if err != nil {
-			return nil, errors.Wrap(err, "error parsing app-port")
+			return nil, fmt.Errorf("error parsing app-port: %w", err)
 		}
 	}
 

--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -4,23 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/dapr/dapr/utils"
-
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/dapr/kit/retry"
 
 	subscriptionsapiV1alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	subscriptionsapiV2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
@@ -30,7 +26,9 @@ import (
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/utils"
 	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/retry"
 )
 
 const (
@@ -105,7 +103,7 @@ func GetSubscriptionsHTTP(channel channel.AppChannel, log logger.Logger, r resil
 		_, body := resp.RawData()
 		if err := json.Unmarshal(body, &subscriptionItems); err != nil {
 			log.Errorf(deserializeTopicsError, err)
-			return nil, errors.Errorf(deserializeTopicsError, err)
+			return nil, fmt.Errorf(deserializeTopicsError, err)
 		}
 		subscriptions = make([]Subscription, len(subscriptionItems))
 		for i, si := range subscriptionItems {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -32,7 +33,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	otlptracegrpc "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otlptracehttp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -344,7 +344,7 @@ func (a *DaprRuntime) getOperatorClient() (operatorv1pb.OperatorClient, error) {
 	if a.runtimeConfig.Mode == modes.KubernetesMode {
 		client, _, err := client.GetOperatorClient(a.runtimeConfig.Kubernetes.ControlPlaneAddress, security.TLSServerName, a.runtimeConfig.CertChain)
 		if err != nil {
-			return nil, errors.Wrap(err, "error creating operator client")
+			return nil, fmt.Errorf("error creating operator client: %w", err)
 		}
 		return client, nil
 	}
@@ -439,10 +439,10 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 	}
 
 	if a.hostAddress, err = utils.GetHostAddress(); err != nil {
-		return errors.Wrap(err, "failed to determine host address")
+		return fmt.Errorf("failed to determine host address: %w", err)
 	}
 	if err = a.setupTracing(a.hostAddress, newOpentelemetryTracerProviderStore()); err != nil {
-		return errors.Wrap(err, "failed to setup tracing")
+		return fmt.Errorf("failed to setup tracing: %w", err)
 	}
 	// Register and initialize name resolution for service discovery.
 	a.nameResolutionRegistry = opts.nameResolutionRegistry
@@ -652,7 +652,7 @@ func (a *DaprRuntime) buildHTTPPipelineForSpec(spec config.PipelineSpec, targetP
 			middlewareSpec := spec.Handlers[i]
 			component, exists := a.getComponent(middlewareSpec.Type, middlewareSpec.Name)
 			if !exists {
-				return httpMiddleware.Pipeline{}, errors.Errorf("couldn't find middleware component with name %s and type %s/%s",
+				return httpMiddleware.Pipeline{}, fmt.Errorf("couldn't find middleware component with name %s and type %s/%s",
 					middlewareSpec.Name,
 					middlewareSpec.Type,
 					middlewareSpec.Version)
@@ -955,7 +955,7 @@ func matchRoutingRule(rules []*runtimePubsub.Rule, data map[string]interface{}) 
 		}
 		result, ok := iResult.(bool)
 		if !ok {
-			return nil, errors.Errorf("the result of match expression %s was not a boolean", rule.Match)
+			return nil, fmt.Errorf("the result of match expression %s was not a boolean", rule.Match)
 		}
 
 		if result {
@@ -1138,9 +1138,9 @@ func (a *DaprRuntime) sendToOutputBinding(name string, req *bindings.InvokeReque
 		for _, o := range ops {
 			supported = append(supported, string(o))
 		}
-		return nil, errors.Errorf("binding %s does not support operation %s. supported operations:%s", name, req.Operation, strings.Join(supported, " "))
+		return nil, fmt.Errorf("binding %s does not support operation %s. supported operations:%s", name, req.Operation, strings.Join(supported, " "))
 	}
-	return nil, errors.Errorf("couldn't find output binding %s", name)
+	return nil, fmt.Errorf("couldn't find output binding %s", name)
 }
 
 func (a *DaprRuntime) onAppResponse(response *bindings.AppResponse) error {
@@ -2042,7 +2042,7 @@ func (a *DaprRuntime) initNameResolution() error {
 			resolverName = "mdns"
 		default:
 			fullName := fmt.Sprintf(componentFormat, resolverName, "nameResolution", resolverVersion)
-			return NewInitError(InitComponentFailure, fullName, errors.Errorf("unable to determine name resolver for %s mode", string(a.runtimeConfig.Mode)))
+			return NewInitError(InitComponentFailure, fullName, fmt.Errorf("unable to determine name resolver for %s mode", string(a.runtimeConfig.Mode)))
 		}
 	}
 
@@ -2106,7 +2106,7 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 
 	if err != nil {
 		diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
-		return errors.Wrap(err, "error from app channel while sending pub/sub event to app")
+		return fmt.Errorf("error from app channel while sending pub/sub event to app: %w", err)
 	}
 
 	statusCode := int(resp.Status().Code)
@@ -2139,7 +2139,7 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 			return nil
 		case pubsub.Retry:
 			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
-			return errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField])
+			return fmt.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField])
 		case pubsub.Drop:
 			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Drop)), msg.topic, elapsed)
 			log.Warnf("DROP status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField])
@@ -2147,7 +2147,7 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 		}
 		// Consider unknown status field as error and retry
 		diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
-		return errors.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent[pubsub.IDField], appResponse.Status)
+		return fmt.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent[pubsub.IDField], appResponse.Status)
 	}
 
 	if statusCode == nethttp.StatusNotFound {
@@ -2163,7 +2163,7 @@ func (a *DaprRuntime) publishMessageHTTP(ctx context.Context, msg *pubsubSubscri
 	errMsg := fmt.Sprintf("retriable error returned from app while processing pub/sub event %v, topic: %v, body: %s. status code returned: %v", cloudEvent[pubsub.IDField], cloudEvent[pubsub.TopicField], body, statusCode)
 	log.Warnf(errMsg)
 	diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
-	return errors.Errorf(errMsg)
+	return errors.New(errMsg)
 }
 
 func (a *DaprRuntime) publishMessageGRPC(ctx context.Context, msg *pubsubSubscribedMessage) error {
@@ -2266,7 +2266,7 @@ func (a *DaprRuntime) publishMessageGRPC(ctx context.Context, msg *pubsubSubscri
 			return nil
 		}
 
-		err = errors.Errorf("error returned from app while processing pub/sub event %v: %s", cloudEvent[pubsub.IDField], err)
+		err = fmt.Errorf("error returned from app while processing pub/sub event %v: %w", cloudEvent[pubsub.IDField], err)
 		log.Debug(err)
 		diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
 
@@ -2282,7 +2282,7 @@ func (a *DaprRuntime) publishMessageGRPC(ctx context.Context, msg *pubsubSubscri
 		return nil
 	case runtimev1pb.TopicEventResponse_RETRY: //nolint:nosnakecase
 		diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
-		return errors.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField])
+		return fmt.Errorf("RETRY status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField])
 	case runtimev1pb.TopicEventResponse_DROP: //nolint:nosnakecase
 		log.Warnf("DROP status returned from app while processing pub/sub event %v", cloudEvent[pubsub.IDField])
 		diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Drop)), msg.topic, elapsed)
@@ -2292,7 +2292,7 @@ func (a *DaprRuntime) publishMessageGRPC(ctx context.Context, msg *pubsubSubscri
 
 	// Consider unknown status field as error and retry
 	diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.pubsub, strings.ToLower(string(pubsub.Retry)), msg.topic, elapsed)
-	return errors.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent[pubsub.IDField], res.GetStatus())
+	return fmt.Errorf("unknown status returned from app while processing pub/sub event %v: %v", cloudEvent[pubsub.IDField], res.GetStatus())
 }
 
 func extractCloudEventExtensions(cloudEvent map[string]interface{}) (*structpb.Struct, error) {
@@ -2417,7 +2417,7 @@ func (a *DaprRuntime) loadComponents(opts *runtimeOpts) error {
 	case modes.StandaloneMode:
 		loader = components.NewStandaloneComponents(a.runtimeConfig.Standalone)
 	default:
-		return errors.Errorf("components loader for mode %s not found", a.runtimeConfig.Mode)
+		return fmt.Errorf("components loader for mode %s not found", a.runtimeConfig.Mode)
 	}
 
 	log.Info("loading components")
@@ -2507,7 +2507,7 @@ func (a *DaprRuntime) processComponentAndDependents(comp componentsV1alpha1.Comp
 	compCategory := a.extractComponentCategory(comp)
 	if compCategory == "" {
 		// the category entered is incorrect, return error
-		return errors.Errorf("incorrect type %s", comp.Spec.Type)
+		return fmt.Errorf("incorrect type %s", comp.Spec.Type)
 	}
 
 	ch := make(chan error, 1)
@@ -2836,7 +2836,7 @@ func (a *DaprRuntime) createAppChannel() (err error) {
 		}
 		ch.(*httpChannel.Channel).SetAppHealthCheckPath(a.runtimeConfig.AppHealthCheckHTTPPath)
 	default:
-		return errors.Errorf("cannot create app channel for protocol %s", string(a.runtimeConfig.ApplicationProtocol))
+		return fmt.Errorf("cannot create app channel for protocol %s", a.runtimeConfig.ApplicationProtocol)
 	}
 
 	if a.runtimeConfig.MaxConcurrency > 0 {

--- a/pkg/sentry/ca/certificate_authority.go
+++ b/pkg/sentry/ca/certificate_authority.go
@@ -5,19 +5,18 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
-
-	"github.com/dapr/kit/logger"
 
 	"github.com/dapr/dapr/pkg/credentials"
 	"github.com/dapr/dapr/pkg/sentry/certs"
 	"github.com/dapr/dapr/pkg/sentry/config"
 	"github.com/dapr/dapr/pkg/sentry/csr"
 	"github.com/dapr/dapr/pkg/sentry/identity"
+	"github.com/dapr/kit/logger"
 )
 
 const (
@@ -99,17 +98,17 @@ func (c *defaultCA) SignCSR(csrPem []byte, subject string, identity *identity.Bu
 
 	cert, err := certs.ParsePemCSR(csrPem)
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing csr pem")
+		return nil, fmt.Errorf("error parsing csr pem: %w", err)
 	}
 
 	crtb, err := csr.GenerateCSRCertificate(cert, subject, identity, signingCert, cert.PublicKey, signingKey, certLifetime, c.config.AllowedClockSkew, isCA)
 	if err != nil {
-		return nil, errors.Wrap(err, "error signing csr")
+		return nil, fmt.Errorf("error signing csr: %w", err)
 	}
 
 	csrCert, err := x509.ParseCertificate(crtb)
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing cert")
+		return nil, fmt.Errorf("error parsing cert: %w", err)
 	}
 
 	certPem := pem.EncodeToMemory(&pem.Block{
@@ -183,12 +182,12 @@ func (c *defaultCA) validateAndBuildTrustBundle() (*trustRootBundle, error) {
 
 		certChain, err := credentials.LoadFromDisk(c.config.RootCertPath, c.config.IssuerCertPath, c.config.IssuerKeyPath)
 		if err != nil {
-			return nil, errors.Wrap(err, "error loading cert chain from disk")
+			return nil, fmt.Errorf("error loading cert chain from disk: %w", err)
 		}
 
 		issuerCreds, err = certs.PEMCredentialsFromFiles(certChain.Cert, certChain.Key)
 		if err != nil {
-			return nil, errors.Wrap(err, "error reading PEM credentials")
+			return nil, fmt.Errorf("error reading PEM credentials: %w", err)
 		}
 
 		rootCertBytes = certChain.RootCA
@@ -199,7 +198,7 @@ func (c *defaultCA) validateAndBuildTrustBundle() (*trustRootBundle, error) {
 		var err error
 		issuerCreds, rootCertBytes, issuerCertBytes, err = c.generateRootAndIssuerCerts()
 		if err != nil {
-			return nil, errors.Wrap(err, "error generating trust root bundle")
+			return nil, fmt.Errorf("error generating trust root bundle: %w", err)
 		}
 
 		log.Info("self signed certs generated and persisted successfully")
@@ -208,7 +207,7 @@ func (c *defaultCA) validateAndBuildTrustBundle() (*trustRootBundle, error) {
 	// load trust anchors
 	trustAnchors, err := certs.CertPoolFromPEM(rootCertBytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "error parsing cert pool for trust anchors")
+		return nil, fmt.Errorf("error parsing cert pool for trust anchors: %w", err)
 	}
 
 	return &trustRootBundle{

--- a/pkg/sentry/certs/certs.go
+++ b/pkg/sentry/certs/certs.go
@@ -8,8 +8,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 )
 
 const (
@@ -40,7 +40,7 @@ func DecodePEMKey(key []byte) (interface{}, error) {
 	case BlockTypePKCS8PrivateKey:
 		return x509.ParsePKCS8PrivateKey(block.Bytes)
 	default:
-		return nil, errors.Errorf("unsupported block type %s", block.Type)
+		return nil, fmt.Errorf("unsupported block type %s", block.Type)
 	}
 }
 
@@ -160,7 +160,7 @@ func ParsePemCSR(csrPem []byte) (*x509.CertificateRequest, error) {
 	}
 	csr, err := x509.ParseCertificateRequest(block.Bytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse X.509 certificate signing request")
+		return nil, fmt.Errorf("failed to parse X.509 certificate signing request: %w", err)
 	}
 	return csr, nil
 }

--- a/pkg/sentry/certs/store.go
+++ b/pkg/sentry/certs/store.go
@@ -2,9 +2,9 @@ package certs
 
 import (
 	"context"
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -49,7 +49,7 @@ func storeKubernetes(rootCertPem, issuerCertPem, issuerCertKey []byte) error {
 	// We update and not create because sentry expects a secret to already exist
 	_, err = kubeClient.CoreV1().Secrets(namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 	if err != nil {
-		return errors.Wrap(err, "failed saving secret to kubernetes")
+		return fmt.Errorf("failed saving secret to kubernetes: %w", err)
 	}
 	return nil
 }
@@ -84,17 +84,17 @@ func CredentialsExist(conf config.SentryConfig) (bool, error) {
 func storeSelfhosted(rootCertPem, issuerCertPem, issuerKeyPem []byte, rootCertPath, issuerCertPath, issuerKeyPath string) error {
 	err := os.WriteFile(rootCertPath, rootCertPem, 0o644)
 	if err != nil {
-		return errors.Wrapf(err, "failed saving file to %s", rootCertPath)
+		return fmt.Errorf("failed saving file to %s: %w", rootCertPath, err)
 	}
 
 	err = os.WriteFile(issuerCertPath, issuerCertPem, 0o644)
 	if err != nil {
-		return errors.Wrapf(err, "failed saving file to %s", issuerCertPath)
+		return fmt.Errorf("failed saving file to %s: %w", issuerCertPath, err)
 	}
 
 	err = os.WriteFile(issuerKeyPath, issuerKeyPem, 0o644)
 	if err != nil {
-		return errors.Wrapf(err, "failed saving file to %s", issuerKeyPath)
+		return fmt.Errorf("failed saving file to %s: %w", issuerKeyPath, err)
 	}
 	return nil
 }

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -2,11 +2,12 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
@@ -68,7 +69,7 @@ func FromConfigName(configName string) (SentryConfig, error) {
 
 	conf, err := confGetterFn(configName)
 	if err != nil {
-		err = errors.Wrapf(err, "loading default config. couldn't find config name: %s", configName)
+		err = fmt.Errorf("loading default config. couldn't find config name '%s': %w", configName, err)
 		conf = getDefaultConfig()
 	}
 
@@ -149,7 +150,7 @@ func parseConfiguration(conf SentryConfig, daprConfig *daprGlobalConfig.Configur
 	if daprConfig.Spec.MTLSSpec.WorkloadCertTTL != "" {
 		d, err := time.ParseDuration(daprConfig.Spec.MTLSSpec.WorkloadCertTTL)
 		if err != nil {
-			return conf, errors.Wrap(err, "error parsing WorkloadCertTTL duration")
+			return conf, fmt.Errorf("error parsing WorkloadCertTTL duration: %w", err)
 		}
 
 		conf.WorkloadCertTTL = d
@@ -158,7 +159,7 @@ func parseConfiguration(conf SentryConfig, daprConfig *daprGlobalConfig.Configur
 	if daprConfig.Spec.MTLSSpec.AllowedClockSkew != "" {
 		d, err := time.ParseDuration(daprConfig.Spec.MTLSSpec.AllowedClockSkew)
 		if err != nil {
-			return conf, errors.Wrap(err, "error parsing AllowedClockSkew duration")
+			return conf, fmt.Errorf("error parsing AllowedClockSkew duration: %w", err)
 		}
 
 		conf.AllowedClockSkew = d

--- a/pkg/sentry/csr/csr.go
+++ b/pkg/sentry/csr/csr.go
@@ -12,8 +12,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/dapr/dapr/pkg/sentry/certs"
 	"github.com/dapr/dapr/pkg/sentry/identity"
 )
@@ -32,17 +30,17 @@ var oidSubjectAlternativeName = asn1.ObjectIdentifier{2, 5, 29, 17}
 func GenerateCSR(org string, pkcs8 bool) ([]byte, []byte, error) {
 	key, err := certs.GenerateECPrivateKey()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "unable to generate private keys")
+		return nil, nil, fmt.Errorf("unable to generate private keys: %w", err)
 	}
 
 	templ, err := genCSRTemplate(org)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error generating csr template")
+		return nil, nil, fmt.Errorf("error generating csr template: %w", err)
 	}
 
 	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, templ, key)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create CSR")
+		return nil, nil, fmt.Errorf("failed to create CSR: %w", err)
 	}
 
 	crtPem, keyPem, err := encode(true, csrBytes, key, pkcs8)
@@ -121,7 +119,7 @@ func GenerateCSRCertificate(csr *x509.CertificateRequest, subject string, identi
 ) ([]byte, error) {
 	cert, err := generateBaseCert(ttl, skew, publicKey)
 	if err != nil {
-		return nil, errors.Wrap(err, "error generating csr certificate")
+		return nil, fmt.Errorf("error generating csr certificate: %w", err)
 	}
 	if isCA {
 		cert.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
@@ -147,7 +145,7 @@ func GenerateCSRCertificate(csr *x509.CertificateRequest, subject string, identi
 	if identityBundle != nil {
 		spiffeID, err := identity.CreateSPIFFEID(identityBundle.TrustDomain, identityBundle.Namespace, identityBundle.ID)
 		if err != nil {
-			return nil, errors.Wrap(err, "error generating spiffe id")
+			return nil, fmt.Errorf("error generating spiffe id: %w", err)
 		}
 
 		rv := []asn1.RawValue{
@@ -165,7 +163,7 @@ func GenerateCSRCertificate(csr *x509.CertificateRequest, subject string, identi
 
 		b, err := asn1.Marshal(rv)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal asn1 raw value for spiffe id")
+			return nil, fmt.Errorf("failed to marshal asn1 raw value for spiffe id: %w", err)
 		}
 
 		cert.ExtraExtensions = append(cert.ExtraExtensions, pkix.Extension{
@@ -207,7 +205,7 @@ func newSerialNumber() (*big.Int, error) {
 	serialNumLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNum, err := rand.Int(rand.Reader, serialNumLimit)
 	if err != nil {
-		return nil, errors.Wrap(err, "error generating serial number")
+		return nil, fmt.Errorf("error generating serial number: %w", err)
 	}
 	return serialNum, nil
 }

--- a/pkg/sentry/identity/kubernetes/validator.go
+++ b/pkg/sentry/identity/kubernetes/validator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	kauthapi "k8s.io/api/authentication/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
@@ -40,10 +39,10 @@ type validator struct {
 
 func (v *validator) Validate(id, token, namespace string) error {
 	if id == "" {
-		return errors.Errorf("%s: id field in request must not be empty", errPrefix)
+		return fmt.Errorf("%s: id field in request must not be empty", errPrefix)
 	}
 	if token == "" {
-		return errors.Errorf("%s: token field in request must not be empty", errPrefix)
+		return fmt.Errorf("%s: token field in request must not be empty", errPrefix)
 	}
 
 	// TODO: Remove once the NoDefaultTokenAudience feature is finalized

--- a/pkg/sentry/identity/kubernetes/validator_test.go
+++ b/pkg/sentry/identity/kubernetes/validator_test.go
@@ -1,9 +1,9 @@
 package kubernetes
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	kauthapi "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,7 +27,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		err := v.Validate("a1:ns1", "a2:ns2", "ns2")
-		assert.Equal(t, errors.Errorf("%s: invalid token: bad token", errPrefix).Error(), err.Error())
+		assert.Equal(t, fmt.Errorf("%s: invalid token: bad token", errPrefix).Error(), err.Error())
 	})
 
 	t.Run("unauthenticated", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		err := v.Validate("a1:ns1", "a2:ns2", "ns")
-		expectedErr := errors.Errorf("%s: authentication failed", errPrefix)
+		expectedErr := fmt.Errorf("%s: authentication failed", errPrefix)
 		assert.Equal(t, expectedErr.Error(), err.Error())
 	})
 
@@ -64,7 +64,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		err := v.Validate("a1:ns1", "a2:ns2", "ns2")
-		expectedErr := errors.Errorf("%s: provided token is not a properly structured service account token", errPrefix)
+		expectedErr := fmt.Errorf("%s: provided token is not a properly structured service account token", errPrefix)
 		assert.Equal(t, expectedErr.Error(), err.Error())
 	})
 
@@ -83,7 +83,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		err := v.Validate("ns2:a1", "ns2:a2", "ns1")
-		expectedErr := errors.Errorf("%s: token/id mismatch. received id: ns2:a1", errPrefix)
+		expectedErr := fmt.Errorf("%s: token/id mismatch. received id: ns2:a1", errPrefix)
 		assert.Equal(t, expectedErr.Error(), err.Error())
 	})
 
@@ -95,7 +95,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		err := v.Validate("a1:ns1", "", "ns")
-		expectedErr := errors.Errorf("%s: token field in request must not be empty", errPrefix)
+		expectedErr := fmt.Errorf("%s: token field in request must not be empty", errPrefix)
 		assert.Equal(t, expectedErr.Error(), err.Error())
 	})
 
@@ -107,7 +107,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		err := v.Validate("", "a1:ns1", "ns")
-		expectedErr := errors.Errorf("%s: id field in request must not be empty", errPrefix)
+		expectedErr := fmt.Errorf("%s: id field in request must not be empty", errPrefix)
 		assert.Equal(t, expectedErr.Error(), err.Error())
 	})
 

--- a/pkg/sentry/identity/spiffe.go
+++ b/pkg/sentry/identity/spiffe.go
@@ -1,10 +1,9 @@
 package identity
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // CreateSPIFFEID returns a SPIFFE standard unique id for the given trust domain, namespace and appID.

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/dapr/dapr/pkg/sentry/ca"
 	"github.com/dapr/dapr/pkg/sentry/config"
@@ -178,7 +178,7 @@ func (s *sentry) createValidator() (identity.Validator, error) {
 		// we're in Kubernetes, create client and init a new serviceaccount token validator
 		kubeClient, err := k8s.GetClient()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create kubernetes client")
+			return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
 		}
 
 		// TODO: Remove once the NoDefaultTokenAudience feature is finalized

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -14,11 +14,10 @@ limitations under the License.
 package validation
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // The consts and vars beginning with dns* were taken from: https://github.com/kubernetes/apimachinery/blob/fc49b38c19f02a58ebc476347e622142f19820b9/pkg/util/validation/validation.go

--- a/tests/docs/running-e2e-test.md
+++ b/tests/docs/running-e2e-test.md
@@ -183,8 +183,13 @@ To completely remove Dapr, test dependencies, and any lingering e2e test apps:
 *Make sure you have DAPR_NAMESPACE set properly before you do this!*
 
 ```bash
-# Uninstall dapr, dapr-kafka, dapr-redis, dapr-mongodb, dapr-temporal services
-helm uninstall dapr dapr-kafka dapr-redis dapr-mongodb dapr-temporal -n $DAPR_NAMESPACE
+# Uninstall dapr, dapr-kafka, dapr-redis, dapr-mongodb, dapr-temporal services, then remove dapr-zipkin
+helm uninstall dapr -n $DAPR_NAMESPACE || true
+helm uninstall dapr-kafka  -n $DAPR_NAMESPACE || true
+helm uninstall dapr-redis  -n $DAPR_NAMESPACE || true
+helm uninstall dapr-mongodb  -n $DAPR_NAMESPACE || true
+helm uninstall dapr-temporal -n $DAPR_NAMESPACE || true
+kubectl delete deployment dapr-zipkin -n $DAPR_NAMESPACE || true
 
 # Remove the test namespace
 make delete-test-namespace

--- a/tests/runner/loadtest/k6.go
+++ b/tests/runner/loadtest/k6.go
@@ -28,7 +28,6 @@ import (
 	"github.com/dapr/dapr/tests/runner"
 
 	k6api "github.com/grafana/k6-operator/api/v1alpha1"
-	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -173,7 +172,7 @@ func collectResult[T any](k6 *K6, podName string) (*T, error) {
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogs)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to copy logs from the pod")
+		return nil, fmt.Errorf("unable to copy logs from the pod: %w", err)
 	}
 
 	bts := buf.Bytes()
@@ -185,7 +184,7 @@ func collectResult[T any](k6 *K6, podName string) (*T, error) {
 	var k6Result K6RunnerSummary[T]
 	if err := json.Unmarshal(bts, &k6Result); err != nil {
 		// this shouldn't normally happen but if it does, let's log output by default
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to marshal: `%s`", string(bts)))
+		return nil, fmt.Errorf("unable to marshal `%s`: %w", string(bts), err)
 	}
 
 	return &k6Result.Metrics, nil

--- a/utils/host.go
+++ b/utils/host.go
@@ -14,10 +14,10 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -38,7 +38,7 @@ func GetHostAddress() (string, error) {
 		// Could not find one via a  UDP connection, so we fallback to the "old" way: try first non-loopback IPv4:
 		addrs, err := net.InterfaceAddrs()
 		if err != nil {
-			return "", errors.Wrap(err, "error getting interface IP addresses")
+			return "", fmt.Errorf("error getting interface IP addresses: %w", err)
 		}
 
 		for _, addr := range addrs {


### PR DESCRIPTION
No functionality changes. The packages are now forbidden by a linter rule.