### PR TITLE
Add option to annotate application pods

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -175,6 +175,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sidecar_injector.debug.enabled`     | Boolean value for enabling debug mode | `{}` |
 | `dapr_sidecar_injector.kubeClusterDomain` | Domain for this kubernetes cluster. If not set, will auto-detect the cluster domain through the `/etc/resolv.conf` file `search domains` content. | `cluster.local` |
 | `dapr_sidecar_injector.ignoreEntrypointTolerations` | JSON array of Kubernetes tolerations. If pod contains any of these tolerations, it will ignore the Docker image ENTRYPOINT for Dapr sidecar. | `[{\"effect\":\"NoSchedule\",\"key\":\"alibabacloud.com/eci\"},{\"effect\":\"NoSchedule\",\"key\":\"azure.com/aci\"},{\"effect\":\"NoSchedule\",\"key\":\"aws\"},{\"effect\":\"NoSchedule\",\"key\":\"huawei.com/cci\"}]` |
+| `dapr_sidecar_injector.appPodAnnotations` | JSON object of Kubernetes annotations to add to the application pod, e.g., `{\"foo\": \"bar\"}` | `{}` |
 | `dapr_sidecar_injector.hostNetwork` | Enable hostNetwork mode. This is helpful when working with overlay networks such as Calico CNI and admission webhooks fail | `false` |
 | `dapr_sidecar_injector.healthzPort` | The port used for health checks. Helpful in combination with hostNetwork to avoid port collisions | `8080` |
 

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -175,7 +175,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sidecar_injector.debug.enabled`     | Boolean value for enabling debug mode | `{}` |
 | `dapr_sidecar_injector.kubeClusterDomain` | Domain for this kubernetes cluster. If not set, will auto-detect the cluster domain through the `/etc/resolv.conf` file `search domains` content. | `cluster.local` |
 | `dapr_sidecar_injector.ignoreEntrypointTolerations` | JSON array of Kubernetes tolerations. If pod contains any of these tolerations, it will ignore the Docker image ENTRYPOINT for Dapr sidecar. | `[{\"effect\":\"NoSchedule\",\"key\":\"alibabacloud.com/eci\"},{\"effect\":\"NoSchedule\",\"key\":\"azure.com/aci\"},{\"effect\":\"NoSchedule\",\"key\":\"aws\"},{\"effect\":\"NoSchedule\",\"key\":\"huawei.com/cci\"}]` |
-| `dapr_sidecar_injector.appPodAnnotations` | JSON object of Kubernetes annotations to add to the application pod, e.g., `{\"foo\": \"bar\"}` | `{}` |
+| `dapr_sidecar_injector.appPodAnnotations` | JSON object of Kubernetes annotations to add to the application pod, e.g., `{\"foo\": \"bar\"}` | `""` |
 | `dapr_sidecar_injector.hostNetwork` | Enable hostNetwork mode. This is helpful when working with overlay networks such as Calico CNI and admission webhooks fail | `false` |
 | `dapr_sidecar_injector.healthzPort` | The port used for health checks. Helpful in combination with hostNetwork to avoid port collisions | `8080` |
 

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -144,6 +144,10 @@ spec:
         - name: SIDECAR_READ_ONLY_ROOT_FILESYSTEM
           value: "{{ .Values.sidecarReadOnlyRootFilesystem }}"
 {{- end }}
+{{ if .Values.appPodAnnotations }}
+        - name: APP_POD_ANNOTATIONS
+          value: "{{ .Values.appPodAnnotations }}"
+{{- end }}
         ports:
         - name: https
           containerPort: 4000

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -144,7 +144,7 @@ spec:
         - name: SIDECAR_READ_ONLY_ROOT_FILESYSTEM
           value: "{{ .Values.sidecarReadOnlyRootFilesystem }}"
 {{- end }}
-{{ if .Values.appPodAnnotations }}
+{{- if .Values.appPodAnnotations }}
         - name: APP_POD_ANNOTATIONS
           value: "{{ .Values.appPodAnnotations }}"
 {{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -26,6 +26,7 @@ kubeClusterDomain: cluster.local
 ignoreEntrypointTolerations: "[{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"alibabacloud.com/eci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"azure.com/aci\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"aws\\\"},{\\\"effect\\\":\\\"NoSchedule\\\",\\\"key\\\":\\\"huawei.com/cci\\\"}]"
 hostNetwork: false
 healthzPort: 8080
+appPodAnnotations: ""
 
 livenessProbe:
   initialDelaySeconds: 3
@@ -40,5 +41,3 @@ debug:
   enabled: false
   port: 40000
   initialDelaySeconds: 30000
-
-appPodAnnotations: {}

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -40,3 +40,5 @@ debug:
   enabled: false
   port: 40000
   initialDelaySeconds: 30000
+
+appPodAnnotations: {}

--- a/pkg/injector/common/pod_patch.go
+++ b/pkg/injector/common/pod_patch.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+// PatchOperation represents a discreet change to be applied to a Kubernetes resource.
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}

--- a/pkg/injector/components/components_test.go
+++ b/pkg/injector/components/components_test.go
@@ -18,6 +18,7 @@ import (
 
 	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/injector/annotations"
+	"github.com/dapr/dapr/pkg/injector/common"
 	"github.com/dapr/dapr/pkg/injector/sidecar"
 
 	"github.com/stretchr/testify/assert"
@@ -37,7 +38,7 @@ func TestComponentsPatch(t *testing.T) {
 		appID          string
 		componentsList []componentsapi.Component
 		pod            *corev1.Pod
-		expPatch       []sidecar.PatchOperation
+		expPatch       []common.PatchOperation
 		expMount       *corev1.VolumeMount
 	}{
 		{
@@ -52,7 +53,7 @@ func TestComponentsPatch(t *testing.T) {
 					Containers: []corev1.Container{appContainer},
 				},
 			},
-			[]sidecar.PatchOperation{},
+			[]common.PatchOperation{},
 			nil,
 		},
 		{
@@ -71,7 +72,7 @@ func TestComponentsPatch(t *testing.T) {
 					}},
 				},
 			},
-			[]sidecar.PatchOperation{
+			[]common.PatchOperation{
 				{
 					Op:    "add",
 					Path:  sidecar.PatchPathVolumes,
@@ -111,7 +112,7 @@ func TestComponentsPatch(t *testing.T) {
 					}},
 				},
 			},
-			[]sidecar.PatchOperation{
+			[]common.PatchOperation{
 				{
 					Op:    "add",
 					Path:  sidecar.PatchPathVolumes,
@@ -160,7 +161,7 @@ func TestComponentsPatch(t *testing.T) {
 					}},
 				},
 			},
-			[]sidecar.PatchOperation{
+			[]common.PatchOperation{
 				{
 					Op:    "add",
 					Path:  sidecar.PatchPathVolumes,
@@ -250,7 +251,7 @@ func TestComponentsPatch(t *testing.T) {
 					}},
 				},
 			},
-			[]sidecar.PatchOperation{
+			[]common.PatchOperation{
 				{
 					Op:    "add",
 					Path:  sidecar.PatchPathVolumes + "/-",

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -93,6 +93,9 @@ func (c *Config) GetIgnoreEntrypointTolerations() []corev1.Toleration {
 }
 
 func (c *Config) GetAppPodAnnotations() map[string]string {
+	if c.parsedAppPodAnnotations == nil {
+		return map[string]string{}
+	}
 	return c.parsedAppPodAnnotations
 }
 

--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -188,3 +188,51 @@ func TestTolerationsParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAppPodAnnotations(t *testing.T) {
+	testCases := []struct {
+		name   string
+		expect map[string]string
+		input  string
+	}{
+		{
+			"empty annotations",
+			map[string]string{},
+			"",
+		},
+		{
+			"single annotation",
+			map[string]string{
+				"foo.com/bar": "baz",
+			},
+			`{"foo.com/bar":"baz"}`,
+		},
+		{
+			"multiple annotations",
+			map[string]string{
+				"foo.com/bar": "baz",
+				"foo.com/baz": "bar",
+			},
+			`{"foo.com/bar":"baz","foo.com/baz":"bar"}`,
+		},
+		{
+			"invalid JSON",
+			map[string]string{},
+			`hi`,
+		},
+		{
+			"invalid JSON structure",
+			map[string]string{},
+			`{}`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{
+				AppPodAnnotations: tc.input,
+			}
+			c.parseAppPodAnnotations()
+			assert.EqualValues(t, tc.expect, c.GetAppPodAnnotations())
+		})
+	}
+}

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
+	"github.com/dapr/dapr/pkg/injector/common"
 	"github.com/dapr/dapr/pkg/injector/monitoring"
 	"github.com/dapr/dapr/pkg/injector/sidecar"
 	"github.com/dapr/dapr/utils"
@@ -226,7 +227,7 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var patchOps []sidecar.PatchOperation
+	var patchOps []common.PatchOperation
 	patchedSuccessfully := false
 
 	ar := v1.AdmissionReview{}

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -101,15 +101,6 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 	// Projected volume with the token
 	tokenVolume := sidecar.GetTokenVolume()
 
-	// Pod annotations
-	podPatchOps := []common.PatchOperation{
-		{
-			Op:    "add",
-			Path:  patchPathAnnotations,
-			Value: i.config.GetAppPodAnnotations(),
-		},
-	}
-
 	// Get the sidecar container
 	sidecarContainer, err := sidecar.GetSidecarContainer(sidecar.ContainerConfig{
 		AppID:                        appID,
@@ -146,6 +137,16 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 		})
 	}
 
+	// Pod annotations
+	podAnnotations := i.config.GetAppPodAnnotations()
+	if len(podAnnotations) > 0 {
+		patchOps = append(patchOps, common.PatchOperation{
+			Op:    "add",
+			Path:  patchPathAnnotations,
+			Value: podAnnotations,
+		})
+	}
+
 	patchOps = append(patchOps, common.PatchOperation{
 		Op:    "add",
 		Path:  sidecar.PatchPathContainers + "/-",
@@ -162,7 +163,6 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 	)
 	patchOps = append(patchOps, volumePatchOps...)
 	patchOps = append(patchOps, componentPatchOps...)
-	patchOps = append(patchOps, podPatchOps...)
 
 	return patchOps, nil
 }

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -98,6 +98,15 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 	// Projected volume with the token
 	tokenVolume := sidecar.GetTokenVolume()
 
+	// Pod annotations
+	podPatchOps := []sidecar.PatchOperation{
+		{
+			Op:    "add",
+			Path:  sidecar.PatchPathAnnotations,
+			Value: i.config.GetAppPodAnnotations(),
+		},
+	}
+
 	// Get the sidecar container
 	sidecarContainer, err := sidecar.GetSidecarContainer(sidecar.ContainerConfig{
 		AppID:                        appID,
@@ -150,6 +159,7 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 	)
 	patchOps = append(patchOps, volumePatchOps...)
 	patchOps = append(patchOps, componentPatchOps...)
+	patchOps = append(patchOps, podPatchOps...)
 
 	return patchOps, nil
 }

--- a/pkg/injector/sidecar/consts.go
+++ b/pkg/injector/sidecar/consts.go
@@ -32,7 +32,6 @@ const (
 	UserContainerDaprGRPCPortName  = "DAPR_GRPC_PORT"          // Name of the variable exposed to the app containing the Dapr gRPC port.
 	PatchPathContainers            = "/spec/containers"
 	PatchPathVolumes               = "/spec/volumes"
-	PatchPathAnnotations           = "/metadata/annotations"
 	TokenVolumeKubernetesMountPath = "/var/run/secrets/dapr.io/sentrytoken" /* #nosec */ // Mount path for the Kubernetes service account volume with the sentry token.
 	TokenVolumeName                = "dapr-identity-token"                  /* #nosec */ // Name of the volume with the service account token for daprd.
 )

--- a/pkg/injector/sidecar/consts.go
+++ b/pkg/injector/sidecar/consts.go
@@ -32,6 +32,7 @@ const (
 	UserContainerDaprGRPCPortName  = "DAPR_GRPC_PORT"          // Name of the variable exposed to the app containing the Dapr gRPC port.
 	PatchPathContainers            = "/spec/containers"
 	PatchPathVolumes               = "/spec/volumes"
+	PatchPathAnnotations           = "/metadata/annotations"
 	TokenVolumeKubernetesMountPath = "/var/run/secrets/dapr.io/sentrytoken" /* #nosec */ // Mount path for the Kubernetes service account volume with the sentry token.
 	TokenVolumeName                = "dapr-identity-token"                  /* #nosec */ // Name of the volume with the service account token for daprd.
 )

--- a/pkg/injector/sidecar/pod_patch_test.go
+++ b/pkg/injector/sidecar/pod_patch_test.go
@@ -21,6 +21,7 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 
 	"github.com/dapr/dapr/pkg/injector/annotations"
+	"github.com/dapr/dapr/pkg/injector/common"
 )
 
 func TestAddDaprEnvVarsToContainers(t *testing.T) {
@@ -28,7 +29,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 		testName      string
 		mockContainer coreV1.Container
 		expOpsLen     int
-		expOps        []PatchOperation
+		expOps        []common.PatchOperation
 	}{
 		{
 			testName: "empty environment vars",
@@ -36,7 +37,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 				Name: "MockContainer",
 			},
 			expOpsLen: 1,
-			expOps: []PatchOperation{
+			expOps: []common.PatchOperation{
 				{
 					Op:   "add",
 					Path: "/spec/containers/0/env",
@@ -65,7 +66,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 				},
 			},
 			expOpsLen: 2,
-			expOps: []PatchOperation{
+			expOps: []common.PatchOperation{
 				{
 					Op:   "add",
 					Path: "/spec/containers/0/env/-",
@@ -100,7 +101,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 				},
 			},
 			expOpsLen: 1,
-			expOps: []PatchOperation{
+			expOps: []common.PatchOperation{
 				{
 					Op:   "add",
 					Path: "/spec/containers/0/env/-",
@@ -127,7 +128,7 @@ func TestAddDaprEnvVarsToContainers(t *testing.T) {
 				},
 			},
 			expOpsLen: 0,
-			expOps:    []PatchOperation{},
+			expOps:    []common.PatchOperation{},
 		},
 	}
 
@@ -147,7 +148,7 @@ func TestAddSocketVolumeToContainers(t *testing.T) {
 		mockContainer coreV1.Container
 		socketMount   *coreV1.VolumeMount
 		expOpsLen     int
-		expOps        []PatchOperation
+		expOps        []common.PatchOperation
 	}{
 		{
 			testName: "empty var, empty volume",
@@ -156,7 +157,7 @@ func TestAddSocketVolumeToContainers(t *testing.T) {
 			},
 			socketMount: nil,
 			expOpsLen:   0,
-			expOps:      []PatchOperation{},
+			expOps:      []common.PatchOperation{},
 		},
 		{
 			testName: "existing var, empty volume",
@@ -168,7 +169,7 @@ func TestAddSocketVolumeToContainers(t *testing.T) {
 				MountPath: "/tmp",
 			},
 			expOpsLen: 1,
-			expOps: []PatchOperation{
+			expOps: []common.PatchOperation{
 				{
 					Op:   "add",
 					Path: "/spec/containers/0/volumeMounts",
@@ -192,7 +193,7 @@ func TestAddSocketVolumeToContainers(t *testing.T) {
 				MountPath: "/tmp",
 			},
 			expOpsLen: 1,
-			expOps: []PatchOperation{
+			expOps: []common.PatchOperation{
 				{
 					Op:   "add",
 					Path: "/spec/containers/0/volumeMounts/-",
@@ -217,7 +218,7 @@ func TestAddSocketVolumeToContainers(t *testing.T) {
 				MountPath: "/tmp",
 			},
 			expOpsLen: 1,
-			expOps: []PatchOperation{
+			expOps: []common.PatchOperation{
 				{
 					Op:   "add",
 					Path: "/spec/containers/0/volumeMounts/-",
@@ -241,7 +242,7 @@ func TestAddSocketVolumeToContainers(t *testing.T) {
 				MountPath: "/tmp",
 			},
 			expOpsLen: 0,
-			expOps:    []PatchOperation{},
+			expOps:    []common.PatchOperation{},
 		},
 		{
 			testName: "existing var, conflict volume mount path",
@@ -256,7 +257,7 @@ func TestAddSocketVolumeToContainers(t *testing.T) {
 				MountPath: "/tmp",
 			},
 			expOpsLen: 0,
-			expOps:    []PatchOperation{},
+			expOps:    []common.PatchOperation{},
 		},
 	}
 


### PR DESCRIPTION
# Description

This PR adds an option to the sidecar injector helm charts to annotate the application pods. Users can specify `dapr_sidecar_injector.appPodAnnotations` via helm and configure application pods running Dapr to contain custom annotations.

## Issue reference

NA

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
