### PR TITLE
Fix profile port

### DIFF
--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -157,7 +157,7 @@ func (s *server) StartNonBlocking() error {
 
 	if s.config.EnableProfiling {
 		for _, apiListenAddress := range s.config.APIListenAddresses {
-			addr := apiListenAddress + ":" + strconv.Itoa(s.config.Port)
+			addr := apiListenAddress + ":" + strconv.Itoa(s.config.ProfilePort)
 			log.Infof("starting profiling server on %s", addr)
 			pl, err := net.Listen("tcp", addr)
 			if err != nil {


### PR DESCRIPTION
Fixes a regression (typo) introduced in #5648 . This is the reason for the test failures in components-contrib (see dapr/components-contrib#2405 )