### PR TITLE
Fix pluggable component withblock usage on tests

### DIFF
--- a/pkg/components/pluggable/grpc_test.go
+++ b/pkg/components/pluggable/grpc_test.go
@@ -16,6 +16,7 @@ package pluggable
 import (
 	"context"
 	"net"
+	"os"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -52,7 +53,22 @@ func TestGRPCConnector(t *testing.T) {
 			fakeFactoryCalled++
 			return clientFake
 		}
-		connector := NewGRPCConnectorWithDialer(socketDialer("/tmp/socket.sock", grpc.WithBlock()), fakeFactory)
+		const fakeSocketPath = "/tmp/socket.sock"
+		os.RemoveAll(fakeSocketPath) // guarantee that is not being used.
+		defer os.RemoveAll(fakeSocketPath)
+		listener, err := net.Listen("unix", fakeSocketPath)
+		require.NoError(t, err)
+		defer listener.Close()
+
+		connector := NewGRPCConnectorWithDialer(socketDialer(fakeSocketPath, grpc.WithBlock(), grpc.FailOnNonTempDialError(true)), fakeFactory)
+		defer connector.Close()
+
+		go func() {
+			s := grpc.NewServer()
+			s.Serve(listener)
+			s.Stop()
+		}()
+
 		require.NoError(t, connector.Dial(""))
 		acceptedStatus := []connectivity.State{
 			connectivity.Ready,
@@ -62,7 +78,6 @@ func TestGRPCConnector(t *testing.T) {
 		assert.Contains(t, acceptedStatus, connector.conn.GetState())
 		assert.Equal(t, 1, fakeFactoryCalled)
 		assert.Equal(t, int64(0), clientFake.pingCalled.Load())
-		connector.Close()
 	})
 
 	t.Run("grpc connection should be ready when socket is listening", func(t *testing.T) {
@@ -74,6 +89,8 @@ func TestGRPCConnector(t *testing.T) {
 		}
 
 		const fakeSocketPath = "/tmp/socket.sock"
+		os.RemoveAll(fakeSocketPath) // guarantee that is not being used.
+		defer os.RemoveAll(fakeSocketPath)
 		connector := NewGRPCConnector(fakeSocketPath, fakeFactory)
 
 		listener, err := net.Listen("unix", fakeSocketPath)

--- a/pkg/components/pluggable/grpc_test.go
+++ b/pkg/components/pluggable/grpc_test.go
@@ -52,7 +52,7 @@ func TestGRPCConnector(t *testing.T) {
 			fakeFactoryCalled++
 			return clientFake
 		}
-		connector := NewGRPCConnector("/tmp/socket.sock", fakeFactory)
+		connector := NewGRPCConnectorWithDialer(socketDialer("/tmp/socket.sock", grpc.WithBlock()), fakeFactory)
 		require.NoError(t, connector.Dial(""))
 		acceptedStatus := []connectivity.State{
 			connectivity.Ready,
@@ -80,7 +80,7 @@ func TestGRPCConnector(t *testing.T) {
 		require.NoError(t, err)
 		defer listener.Close()
 
-		require.NoError(t, connector.Dial(""), grpc.WithBlock())
+		require.NoError(t, connector.Dial(""))
 		defer connector.Close()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Fix flaky test due to the missing `WithBlock` grpc param

## Issue reference

N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
