### PR TITLE
Misc refactorings and fixes to shutdown sequence

### DIFF
--- a/cmd/daprd/main.go
+++ b/cmd/daprd/main.go
@@ -14,10 +14,6 @@ limitations under the License.
 package main
 
 import (
-	"os"
-	"os/signal"
-	"syscall"
-
 	"go.uber.org/automaxprocs/maxprocs"
 
 	// Register all components
@@ -61,6 +57,8 @@ func main() {
 	workflowsLoader.DefaultRegistry.Logger = logContrib
 	httpMiddlewareLoader.DefaultRegistry.Logger = log // Note this uses log on purpose
 
+	stopCh := runtime.ShutdownSignal()
+
 	err = rt.Run(
 		runtime.WithSecretStores(secretstoresLoader.DefaultRegistry),
 		runtime.WithStates(stateLoader.DefaultRegistry),
@@ -76,8 +74,6 @@ func main() {
 		log.Fatalf("fatal error from runtime: %s", err)
 	}
 
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGTERM, os.Interrupt)
-	<-stop
+	<-stopCh
 	rt.ShutdownWithWait()
 }

--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -39,7 +40,7 @@ import (
 // Channel is a concrete AppChannel implementation for interacting with gRPC based user code.
 type Channel struct {
 	appCallbackClient    runtimev1pb.AppCallbackClient
-	appHealthClient      runtimev1pb.AppCallbackHealthCheckClient
+	conn                 *grpc.ClientConn
 	baseAddress          string
 	ch                   chan struct{}
 	tracingSpec          config.TracingSpec
@@ -53,7 +54,7 @@ func CreateLocalChannel(port, maxConcurrency int, conn *grpc.ClientConn, spec co
 	// readBufferSize is unused
 	c := &Channel{
 		appCallbackClient:    runtimev1pb.NewAppCallbackClient(conn),
-		appHealthClient:      runtimev1pb.NewAppCallbackHealthCheckClient(conn),
+		conn:                 conn,
 		baseAddress:          net.JoinHostPort(channel.DefaultChannelAddress, strconv.Itoa(port)),
 		tracingSpec:          spec,
 		appMetadataToken:     auth.GetAppToken(),
@@ -150,9 +151,20 @@ func (g *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	return rsp, nil
 }
 
+var emptyPbPool = sync.Pool{
+	New: func() any {
+		return &emptypb.Empty{}
+	},
+}
+
 // HealthProbe performs a health probe.
 func (g *Channel) HealthProbe(ctx context.Context) (bool, error) {
-	_, err := g.appHealthClient.HealthCheck(ctx, &emptypb.Empty{})
+	// We use the low-level method here so we can avoid allocating multiple &emptypb.Empty and use the pool
+	in := emptyPbPool.Get()
+	defer emptyPbPool.Put(in)
+	out := emptyPbPool.Get()
+	defer emptyPbPool.Put(out)
+	err := g.conn.Invoke(ctx, "/dapr.proto.runtime.v1.AppCallbackHealthCheck/HealthCheck", in, out)
 
 	// Errors here are network-level errors, so we are not returning them as errors
 	// Instead, we just return a failed probe

--- a/pkg/channel/grpc/grpc_channel_test.go
+++ b/pkg/channel/grpc/grpc_channel_test.go
@@ -94,7 +94,7 @@ func TestInvokeMethod(t *testing.T) {
 	c := Channel{
 		baseAddress:          "localhost:9998",
 		appCallbackClient:    runtimev1pb.NewAppCallbackClient(conn),
-		appHealthClient:      runtimev1pb.NewAppCallbackHealthCheckClient(conn),
+		conn:                 conn,
 		appMetadataToken:     "token1",
 		maxRequestBodySizeMB: 4,
 	}
@@ -140,7 +140,7 @@ func TestHealthProbe(t *testing.T) {
 	c := Channel{
 		baseAddress:          "localhost:9998",
 		appCallbackClient:    runtimev1pb.NewAppCallbackClient(conn),
-		appHealthClient:      runtimev1pb.NewAppCallbackHealthCheckClient(conn),
+		conn:                 conn,
 		appMetadataToken:     "token1",
 		maxRequestBodySizeMB: 4,
 	}

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -68,52 +68,17 @@ const (
 )
 
 // API is the gRPC interface for the Dapr gRPC API. It implements both the internal and external proto definitions.
-//
-//nolint:interfacebloat
 type API interface {
 	// DaprInternal Service methods
-	CallActor(ctx context.Context, in *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error)
-	CallLocal(ctx context.Context, in *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error)
+	internalv1pb.ServiceInvocationServer
 
 	// Dapr Service methods
-	PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequest) (*emptypb.Empty, error)
-	BulkPublishEventAlpha1(ctx context.Context, req *runtimev1pb.BulkPublishRequest) (*runtimev1pb.BulkPublishResponse, error)
-	InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRequest) (*commonv1pb.InvokeResponse, error)
-	InvokeBinding(ctx context.Context, in *runtimev1pb.InvokeBindingRequest) (*runtimev1pb.InvokeBindingResponse, error)
-	GetState(ctx context.Context, in *runtimev1pb.GetStateRequest) (*runtimev1pb.GetStateResponse, error)
-	GetBulkState(ctx context.Context, in *runtimev1pb.GetBulkStateRequest) (*runtimev1pb.GetBulkStateResponse, error)
-	GetSecret(ctx context.Context, in *runtimev1pb.GetSecretRequest) (*runtimev1pb.GetSecretResponse, error)
-	GetBulkSecret(ctx context.Context, in *runtimev1pb.GetBulkSecretRequest) (*runtimev1pb.GetBulkSecretResponse, error)
-	GetConfigurationAlpha1(ctx context.Context, in *runtimev1pb.GetConfigurationRequest) (*runtimev1pb.GetConfigurationResponse, error)
-	SubscribeConfigurationAlpha1(request *runtimev1pb.SubscribeConfigurationRequest, configurationServer runtimev1pb.Dapr_SubscribeConfigurationAlpha1Server) error
-	UnsubscribeConfigurationAlpha1(ctx context.Context, request *runtimev1pb.UnsubscribeConfigurationRequest) (*runtimev1pb.UnsubscribeConfigurationResponse, error)
-	SaveState(ctx context.Context, in *runtimev1pb.SaveStateRequest) (*emptypb.Empty, error)
-	QueryStateAlpha1(ctx context.Context, in *runtimev1pb.QueryStateRequest) (*runtimev1pb.QueryStateResponse, error)
-	DeleteState(ctx context.Context, in *runtimev1pb.DeleteStateRequest) (*emptypb.Empty, error)
-	DeleteBulkState(ctx context.Context, in *runtimev1pb.DeleteBulkStateRequest) (*emptypb.Empty, error)
-	ExecuteStateTransaction(ctx context.Context, in *runtimev1pb.ExecuteStateTransactionRequest) (*emptypb.Empty, error)
+	runtimev1pb.DaprServer
+
+	// Methods internal to the object
 	SetAppChannel(appChannel channel.AppChannel)
 	SetDirectMessaging(directMessaging messaging.DirectMessaging)
 	SetActorRuntime(actor actors.Actors)
-	RegisterActorTimer(ctx context.Context, in *runtimev1pb.RegisterActorTimerRequest) (*emptypb.Empty, error)
-	UnregisterActorTimer(ctx context.Context, in *runtimev1pb.UnregisterActorTimerRequest) (*emptypb.Empty, error)
-	RegisterActorReminder(ctx context.Context, in *runtimev1pb.RegisterActorReminderRequest) (*emptypb.Empty, error)
-	UnregisterActorReminder(ctx context.Context, in *runtimev1pb.UnregisterActorReminderRequest) (*emptypb.Empty, error)
-	RenameActorReminder(ctx context.Context, in *runtimev1pb.RenameActorReminderRequest) (*emptypb.Empty, error)
-	GetActorState(ctx context.Context, in *runtimev1pb.GetActorStateRequest) (*runtimev1pb.GetActorStateResponse, error)
-	ExecuteActorStateTransaction(ctx context.Context, in *runtimev1pb.ExecuteActorStateTransactionRequest) (*emptypb.Empty, error)
-	InvokeActor(ctx context.Context, in *runtimev1pb.InvokeActorRequest) (*runtimev1pb.InvokeActorResponse, error)
-	TryLockAlpha1(ctx context.Context, in *runtimev1pb.TryLockRequest) (*runtimev1pb.TryLockResponse, error)
-	UnlockAlpha1(ctx context.Context, in *runtimev1pb.UnlockRequest) (*runtimev1pb.UnlockResponse, error)
-	// Gets metadata of the sidecar
-	GetMetadata(ctx context.Context, in *emptypb.Empty) (*runtimev1pb.GetMetadataResponse, error)
-	// Sets value in extended metadata of the sidecar
-	SetMetadata(ctx context.Context, in *runtimev1pb.SetMetadataRequest) (*emptypb.Empty, error)
-	GetWorkflowAlpha1(ctx context.Context, in *runtimev1pb.GetWorkflowRequest) (*runtimev1pb.GetWorkflowResponse, error)
-	StartWorkflowAlpha1(ctx context.Context, in *runtimev1pb.StartWorkflowRequest) (*runtimev1pb.WorkflowReference, error)
-	TerminateWorkflowAlpha1(ctx context.Context, in *runtimev1pb.TerminateWorkflowRequest) (*runtimev1pb.TerminateWorkflowResponse, error)
-	// Shutdown the sidecar
-	Shutdown(ctx context.Context, in *emptypb.Empty) (*emptypb.Empty, error)
 }
 
 type api struct {

--- a/pkg/grpc/dial_windows.go
+++ b/pkg/grpc/dial_windows.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 /*
 Copyright 2021 The Dapr Authors
@@ -21,12 +21,7 @@ import (
 )
 
 // GetDialAddressPrefix returns a dial prefix for a gRPC client connections for a given DaprMode.
-// This is used on non-Windows hosts.
+// This is used on Windows hosts.
 func GetDialAddressPrefix(mode modes.DaprMode) string {
-	switch mode {
-	case modes.KubernetesMode:
-		return "dns:///"
-	default:
-		return ""
-	}
+	return ""
 }

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -40,6 +41,9 @@ const (
 	maxConnIdle       = 3 * time.Minute
 )
 
+// ConnCreatorFn is a function that returns a gRPC connection
+type ConnCreatorFn = func() (grpc.ClientConnInterface, error)
+
 // AppChannelConfig contains the configuration for the app channel.
 type AppChannelConfig struct {
 	Port                 int
@@ -57,7 +61,8 @@ type Manager struct {
 	mode              modes.DaprMode
 	channelConfig     *AppChannelConfig
 	localConn         *ConnectionPool
-	localConnCreateFn func() (grpc.ClientConnInterface, error)
+	localConnCreateFn ConnCreatorFn
+	localConnLock     sync.RWMutex
 }
 
 // NewGRPCManager returns a new grpc manager.
@@ -78,6 +83,9 @@ func (g *Manager) SetAuthenticator(auth security.Authenticator) {
 // GetAppChannel returns a connection to the local channel.
 // If there's no active connection to the app, it creates one.
 func (g *Manager) GetAppChannel() (channel.AppChannel, error) {
+	g.localConnLock.RLock()
+	defer g.localConnLock.RUnlock()
+
 	conn, err := g.GetAppClient()
 	if err != nil {
 		return nil, err
@@ -108,10 +116,14 @@ func (g *Manager) CloseAppClient() {
 	g.localConn.DestroyAll()
 }
 
-// SetLocalConnCreateFn sets the function used to create connections.
-// It does not destroy connections that have been established already; use CloseAppClient() after invoking this method if needed.
+// SetLocalConnCreateFn sets the function used to create local connections.
+// It also destroys all existing local channel connections.
 // Set fn to nil to reset to the built-in function.
-func (g *Manager) SetLocalConnCreateFn(fn func() (grpc.ClientConnInterface, error)) {
+func (g *Manager) SetLocalConnCreateFn(fn ConnCreatorFn) {
+	g.localConnLock.Lock()
+	defer g.localConnLock.Unlock()
+
+	g.localConn.DestroyAll()
 	g.localConnCreateFn = fn
 }
 

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -50,6 +50,7 @@ type messageClientConnection func(ctx context.Context, address string, id string
 // DirectMessaging is the API interface for invoking a remote app.
 type DirectMessaging interface {
 	Invoke(ctx context.Context, targetAppID string, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error)
+	SetAppChannel(appChannel channel.AppChannel)
 }
 
 type directMessaging struct {
@@ -132,6 +133,11 @@ func (d *directMessaging) Invoke(ctx context.Context, targetAppID string, req *i
 		return d.invokeLocal(ctx, req)
 	}
 	return d.invokeWithRetry(ctx, retry.DefaultLinearRetryCount, retry.DefaultLinearBackoffInterval, app, d.invokeRemote, req)
+}
+
+// SetAppChannel sets the appChannel property in the object.
+func (d *directMessaging) SetAppChannel(appChannel channel.AppChannel) {
+	d.appChannel = appChannel
 }
 
 // requestAppIDAndNamespace takes an app id and returns the app id, namespace and error.

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -54,7 +54,7 @@ func FromFlags() (*DaprRuntime, error) {
 	daprInternalGRPCPort := flag.String("dapr-internal-grpc-port", "", "gRPC port for the Dapr Internal API to listen on")
 	appPort := flag.String("app-port", "", "The port the application is listening on")
 	profilePort := flag.String("profile-port", strconv.Itoa(DefaultProfilePort), "The port for the profile server")
-	appProtocol := flag.String("app-protocol", string(HTTPProtocol), "Protocol for the application: grpc or http")
+	appProtocolPtr := flag.String("app-protocol", string(HTTPProtocol), "Protocol for the application: grpc or http")
 	componentsPath := flag.String("components-path", "", "Path for components directory. If empty, components will not be loaded. Self-hosted mode only")
 	resourcesPath := flag.String("resources-path", "", "Path for resources directory. If empty, resources will not be loaded. Self-hosted mode only")
 	config := flag.String("config", "", "Path to config file, or name of a configuration object")
@@ -228,9 +228,18 @@ func FromFlags() (*DaprRuntime, error) {
 		concurrency = *appMaxConcurrency
 	}
 
-	appPrtcl := string(HTTPProtocol)
-	if *appProtocol != string(HTTPProtocol) {
-		appPrtcl = *appProtocol
+	var appProtocol string
+	{
+		p := strings.ToLower(*appProtocolPtr)
+		switch p {
+		case string(HTTPProtocol),
+			string(GRPCProtocol):
+			appProtocol = p
+		case "":
+			appProtocol = string(HTTPProtocol)
+		default:
+			return nil, fmt.Errorf("invalid value for 'app-protocol': %v", *appProtocolPtr)
+		}
 	}
 
 	daprAPIListenAddressList := strings.Split(*daprAPIListenAddresses, ",")
@@ -271,7 +280,7 @@ func FromFlags() (*DaprRuntime, error) {
 		AllowedOrigins:               *allowedOrigins,
 		GlobalConfig:                 *config,
 		ComponentsPath:               *componentsPath,
-		AppProtocol:                  appPrtcl,
+		AppProtocol:                  appProtocol,
 		Mode:                         *mode,
 		HTTPPort:                     daprHTTP,
 		InternalGRPCPort:             daprInternalGRPC,

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -23,11 +23,14 @@ import (
 	"net"
 	nethttp "net/http"
 	"os"
+	"os/signal"
 	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -205,6 +208,7 @@ type DaprRuntime struct {
 	subscriptions             []runtimePubsub.Subscription
 	inputBindingRoutes        map[string]string
 	shutdownC                 chan error
+	running                   atomic.Bool
 	apiClosers                []io.Closer
 	componentAuthorizers      []ComponentAuthorizer
 	appHealth                 *apphealth.AppHealth
@@ -322,6 +326,8 @@ func (a *DaprRuntime) Run(opts ...Option) error {
 	if err := a.initRuntime(&o); err != nil {
 		return err
 	}
+
+	a.running.Store(true)
 
 	d := time.Since(start).Milliseconds()
 	log.Infof("dapr initialized. Status: Running. Init Elapsed %vms", d)
@@ -506,6 +512,8 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 		log.Infof("API gRPC server is running on port %v", a.runtimeConfig.APIGRPCPort)
 	}
 
+	a.initDirectMessaging(a.nameResolver)
+
 	// Start HTTP Server
 	err = a.startHTTPServer(a.runtimeConfig.HTTPPort, a.runtimeConfig.PublicPort, a.runtimeConfig.ProfilePort, a.runtimeConfig.AllowedOrigins, pipeline)
 	if err != nil {
@@ -536,17 +544,25 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 	}
 	a.daprHTTPAPI.SetAppChannel(a.appChannel)
 	a.daprGRPCAPI.SetAppChannel(a.appChannel)
+	a.directMessaging.SetAppChannel(a.appChannel)
 
 	a.initDirectMessaging(a.nameResolver)
 
 	a.daprHTTPAPI.SetDirectMessaging(a.directMessaging)
 	a.daprGRPCAPI.SetDirectMessaging(a.directMessaging)
 
+	if a.runtimeConfig.MaxConcurrency > 0 {
+		log.Infof("app max concurrency set to %v", a.runtimeConfig.MaxConcurrency)
+	}
+
 	a.appHealthReady = func() {
 		a.appHealthReadyInit(opts)
 	}
 	if a.runtimeConfig.AppHealthCheck != nil && a.appChannel != nil {
-		a.appHealth = apphealth.NewAppHealth(a.runtimeConfig.AppHealthCheck, a.appChannel.HealthProbe)
+		// We can't just pass "a.appChannel.HealthProbe" because appChannel may be re-created
+		a.appHealth = apphealth.NewAppHealth(a.runtimeConfig.AppHealthCheck, func(ctx context.Context) (bool, error) {
+			return a.appChannel.HealthProbe(ctx)
+		})
 		a.appHealth.OnHealthChange(a.appHealthChanged)
 		a.appHealth.StartProbes(a.ctx)
 
@@ -2654,6 +2670,13 @@ func closeComponent(component any, logmsg string, merr *error) {
 
 // ShutdownWithWait will gracefully stop runtime and wait outstanding operations.
 func (a *DaprRuntime) ShutdownWithWait() {
+	// Another shutdown signal causes an instant shutdown and interrupts the graceful shutdown
+	go func() {
+		<-ShutdownSignal()
+		log.Info("Received another shutdown signal - shutting down right away")
+		os.Exit(0)
+	}()
+
 	a.Shutdown(a.runtimeConfig.GracefulShutdownDuration)
 	os.Exit(0)
 }
@@ -2667,6 +2690,11 @@ func (a *DaprRuntime) cleanSocket() {
 }
 
 func (a *DaprRuntime) Shutdown(duration time.Duration) {
+	// If the shutdown has already been invoked, do nothing
+	if !a.running.CompareAndSwap(true, false) {
+		return
+	}
+
 	// Ensure the Unix socket file is removed if a panic occurs.
 	defer a.cleanSocket()
 	log.Info("Dapr shutting down")
@@ -2797,7 +2825,20 @@ func (a *DaprRuntime) blockUntilAppIsReady() {
 
 	log.Infof("application protocol: %s. waiting on port %v.  This will block until the app is listening on that port.", string(a.runtimeConfig.ApplicationProtocol), a.runtimeConfig.ApplicationPort)
 
+	stopCh := ShutdownSignal()
+	defer signal.Stop(stopCh)
 	for {
+		select {
+		case <-stopCh:
+			// Cause a shutdown
+			a.ShutdownWithWait()
+			return
+		case <-a.ctx.Done():
+			// Return
+			return
+		default:
+			// nop - continue execution
+		}
 		conn, _ := net.DialTimeout("tcp", "127.0.0.1:"+strconv.Itoa(a.runtimeConfig.ApplicationPort), time.Millisecond*500)
 		if conn != nil {
 			conn.Close()
@@ -2851,10 +2892,6 @@ func (a *DaprRuntime) createAppChannel() (err error) {
 		ch.(*httpChannel.Channel).SetAppHealthCheckPath(a.runtimeConfig.AppHealthCheckHTTPPath)
 	default:
 		return fmt.Errorf("cannot create app channel for protocol %s", a.runtimeConfig.ApplicationProtocol)
-	}
-
-	if a.runtimeConfig.MaxConcurrency > 0 {
-		log.Infof("app max concurrency set to %v", a.runtimeConfig.MaxConcurrency)
 	}
 
 	a.appChannel = ch
@@ -3134,4 +3171,11 @@ func (a *DaprRuntime) stopTrace() {
 	} else {
 		a.tracerProvider = nil
 	}
+}
+
+// ShutdownSignal returns a signal that receives a message when the app needs to shut down
+func ShutdownSignal() chan os.Signal {
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, os.Interrupt)
+	return stop
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -5429,6 +5429,7 @@ func TestGracefulShutdownPubSub(t *testing.T) {
 	assert.NotNil(t, rt.pubsubCtx)
 	assert.NotNil(t, rt.topicCtxCancels)
 	assert.NotNil(t, rt.topicRoutes)
+	rt.running.Store(true)
 	go sendSigterm(rt)
 	select {
 	case <-rt.pubsubCtx.Done():
@@ -5469,6 +5470,7 @@ func TestGracefulShutdownBindings(t *testing.T) {
 	assert.Equal(t, len(rt.inputBindings), 1)
 	assert.Equal(t, len(rt.outputBindings), 1)
 
+	rt.running.Store(true)
 	go sendSigterm(rt)
 	<-time.After(rt.runtimeConfig.GracefulShutdownDuration)
 	assert.Nil(t, rt.inputBindingsCancel)
@@ -5523,6 +5525,7 @@ func TestGracefulShutdownActors(t *testing.T) {
 	rt.runtimeConfig.mtlsEnabled = true
 	assert.Nil(t, rt.initActors())
 
+	rt.running.Store(true)
 	go sendSigterm(rt)
 	<-time.After(rt.runtimeConfig.GracefulShutdownDuration + 3*time.Second)
 
@@ -5572,6 +5575,7 @@ func TestTraceShutdown(t *testing.T) {
 	require.NoError(t, rt.setupTracing(rt.hostAddress, tpStore))
 	assert.NotNil(t, rt.tracerProvider)
 
+	rt.running.Store(true)
 	go sendSigterm(rt)
 	<-rt.ctx.Done()
 	assert.Nil(t, rt.tracerProvider)

--- a/pkg/testing/directmessaging_mock.go
+++ b/pkg/testing/directmessaging_mock.go
@@ -18,6 +18,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
+	"github.com/dapr/dapr/pkg/channel"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 )
 
@@ -47,6 +48,10 @@ func (_m *MockDirectMessaging) Invoke(ctx context.Context, targetAppID string, r
 	return r0, r1
 }
 
+func (_m *MockDirectMessaging) SetAppChannel(appChannel channel.AppChannel) {
+	// nop
+}
+
 func (_m *MockDirectMessaging) Close() error {
 	return nil
 }
@@ -67,4 +72,8 @@ func (f *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string,
 	resp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
 		WithRawDataBytes(r.Message.Data.Value)
 	return resp, nil
+}
+
+func (f *FailingDirectMessaging) SetAppChannel(appChannel channel.AppChannel) {
+	// nop
 }


### PR DESCRIPTION
This PR contains misc refactorings extracted from a branch with changes I've been working on (PR coming soon), including some fixes to the shutdown sequence.

Two user-facing changes:

1. Fixed: cannot stop daprd if it's waiting for the app to come online (often happens if the app crashed while using the Dapr CLI)
2. Can force shutdown (aborting any graceful shutdown sequence) by sending a second SIGTERM/SIGINT.