### PR TITLE
Fix build breaks & get tests passing again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0
 	github.com/jhump/protoreflect v1.13.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/microsoft/durabletask-go v0.1.1-0.20221208003005-2805efd98b8b
+	github.com/microsoft/durabletask-go v0.1.1-0.20230107193448-0758fec7267d
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5

--- a/go.sum
+++ b/go.sum
@@ -1312,8 +1312,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
-github.com/microsoft/durabletask-go v0.1.1-0.20221208003005-2805efd98b8b h1:4OIQSoSwtQTkReZeyPjz3/7GfKiZ0iuaygbZp+kXe1Y=
-github.com/microsoft/durabletask-go v0.1.1-0.20221208003005-2805efd98b8b/go.mod h1:YGIEYZAoKqwOHZBfXTs3RrKaKxp++B3SMhkqRWlwNR4=
+github.com/microsoft/durabletask-go v0.1.1-0.20230107193448-0758fec7267d h1:BDk0hHaC+eo745uneyrF9LoQyr/YOuqTxpor1VjVubU=
+github.com/microsoft/durabletask-go v0.1.1-0.20230107193448-0758fec7267d/go.mod h1:UOgcE09cx6SzBS31p4darJ7ve9P5pSVIStPShxDnvPo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=

--- a/pkg/actors/internal_actor.go
+++ b/pkg/actors/internal_actor.go
@@ -117,7 +117,11 @@ func (c *internalActorChannel) InvokeMethod(ctx context.Context, req *invokev1.I
 		}
 		methodName := methodURL[methodStartIndex+len("/method/"):]
 
-		requestData := req.Message().GetData().GetValue()
+		var requestData []byte
+		requestData, err = req.RawDataFull()
+		if err != nil {
+			return nil, err
+		}
 
 		// Check for well-known method names; otherwise, just call InvokeMethod on the internal actor.
 		if strings.HasPrefix(methodName, "remind/") {

--- a/pkg/runtime/wfengine/README.md
+++ b/pkg/runtime/wfengine/README.md
@@ -11,7 +11,7 @@ The workflow engine is entirely encapsulated within the [dapr sidecar (a.k.a. da
 Internally, this engine depends on the [Durable Task Framework for Go](https://github.com/microsoft/durabletask-go), an MIT-licensed open-source project for authoring workflows as code. Use the following command to get the latest build of this dependency:
 
 ```bash
-go get github.com/microsoft/durabletask-go@dapr
+go get github.com/microsoft/durabletask-go
 ```
 
 The following command can be used to build a version of Daprd that supports the workflow engine.
@@ -49,7 +49,7 @@ DEBU[0000] activity-processor: waiting for new work items...       app_id=foo in
 
 ## Running tests
 
-There are no tests that directly target Dapr Workflows yet. However, this engine is fully compatible with .NET and Java Durable Task SDKs.
+There are no end-to-end tests that directly target the Dapr Workflows engine yet. However, this engine is fully compatible with .NET and Java Durable Task SDKs.
 
 | Language/Stack | Package | Project Home | Samples |
 | - | - | - | - |

--- a/pkg/runtime/wfengine/activity.go
+++ b/pkg/runtime/wfengine/activity.go
@@ -196,9 +196,13 @@ loop:
 		WithActor(WorkflowActorType, workflowID).
 		WithRawDataBytes(resultData).
 		WithContentType(invokev1.OctetStreamContentType)
-	if _, err := a.actorRuntime.Call(ctx, req); err != nil {
+	defer req.Close()
+
+	resp, err := a.actorRuntime.Call(ctx, req)
+	if err != nil {
 		return newRecoverableError(fmt.Errorf("failed to invoke '%s' method on workflow actor: %w", AddWorkflowEventMethod, err))
 	}
+	defer resp.Close()
 	return nil
 }
 

--- a/pkg/runtime/wfengine/backend.go
+++ b/pkg/runtime/wfengine/backend.go
@@ -100,9 +100,13 @@ func (be *actorBackend) CreateOrchestrationInstance(ctx context.Context, e *back
 		WithActor(WorkflowActorType, workflowInstanceID).
 		WithRawDataBytes(eventData).
 		WithContentType(invokev1.OctetStreamContentType)
-	if _, err := be.actors.Call(ctx, req); err != nil {
+	defer req.Close()
+
+	resp, err := be.actors.Call(ctx, req)
+	if err != nil {
 		return err
 	}
+	defer resp.Close()
 	return nil
 }
 
@@ -113,9 +117,12 @@ func (be *actorBackend) GetOrchestrationMetadata(ctx context.Context, id api.Ins
 		NewInvokeMethodRequest(GetWorkflowMetadataMethod).
 		WithActor(WorkflowActorType, string(id)).
 		WithContentType(invokev1.OctetStreamContentType)
+	defer req.Close()
+
 	if res, err := be.actors.Call(ctx, req); err != nil {
 		return nil, err
 	} else {
+		defer res.Close()
 		data, err := res.RawDataFull()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read the internal actor response: %w", err)
@@ -168,9 +175,13 @@ func (be *actorBackend) AddNewOrchestrationEvent(ctx context.Context, id api.Ins
 		WithActor(WorkflowActorType, string(id)).
 		WithRawDataBytes(data).
 		WithContentType(invokev1.OctetStreamContentType)
-	if _, err := be.actors.Call(ctx, req); err != nil {
+	defer req.Close()
+
+	resp, err := be.actors.Call(ctx, req)
+	if err != nil {
 		return err
 	}
+	defer resp.Close()
 	return nil
 }
 

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -84,7 +84,7 @@ func (f *fakeStateStore) Features() []state.Feature {
 	return []state.Feature{state.FeatureETag, state.FeatureTransactional}
 }
 
-func (f *fakeStateStore) Delete(req *state.DeleteRequest) error {
+func (f *fakeStateStore) Delete(ctx context.Context, req *state.DeleteRequest) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	delete(f.items, req.Key)
@@ -92,11 +92,11 @@ func (f *fakeStateStore) Delete(req *state.DeleteRequest) error {
 	return nil
 }
 
-func (f *fakeStateStore) BulkDelete(req []state.DeleteRequest) error {
+func (f *fakeStateStore) BulkDelete(ctx context.Context, req []state.DeleteRequest) error {
 	return nil
 }
 
-func (f *fakeStateStore) Get(req *state.GetRequest) (*state.GetResponse, error) {
+func (f *fakeStateStore) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	item := f.items[req.Key]
@@ -108,10 +108,10 @@ func (f *fakeStateStore) Get(req *state.GetRequest) (*state.GetResponse, error) 
 	return &state.GetResponse{Data: item.data, ETag: item.etag}, nil
 }
 
-func (f *fakeStateStore) BulkGet(req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
+func (f *fakeStateStore) BulkGet(ctx context.Context, req []state.GetRequest) (bool, []state.BulkGetResponse, error) {
 	res := []state.BulkGetResponse{}
 	for _, oneRequest := range req {
-		oneResponse, err := f.Get(&state.GetRequest{
+		oneResponse, err := f.Get(ctx, &state.GetRequest{
 			Key:      oneRequest.Key,
 			Metadata: oneRequest.Metadata,
 			Options:  oneRequest.Options,
@@ -130,7 +130,7 @@ func (f *fakeStateStore) BulkGet(req []state.GetRequest) (bool, []state.BulkGetR
 	return true, res, nil
 }
 
-func (f *fakeStateStore) Set(req *state.SetRequest) error {
+func (f *fakeStateStore) Set(ctx context.Context, req *state.SetRequest) error {
 	b, _ := marshal(&req.Value, json.Marshal)
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -143,11 +143,11 @@ func (f *fakeStateStore) GetComponentMetadata() map[string]string {
 	return map[string]string{}
 }
 
-func (f *fakeStateStore) BulkSet(req []state.SetRequest) error {
+func (f *fakeStateStore) BulkSet(ctx context.Context, req []state.SetRequest) error {
 	return nil
 }
 
-func (f *fakeStateStore) Multi(request *state.TransactionalStateRequest) error {
+func (f *fakeStateStore) Multi(ctx context.Context, request *state.TransactionalStateRequest) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	// First we check all eTags


### PR DESCRIPTION
# Description

This PR fixes build breaks in test code and makes necessary changes to get the tests passing again.

The build break was caused by a change to the state store interface, breaking the wfengine mock/test state store.

The test failures were caused by changes to the invoke method request/response objects, which have been updated for streaming support back in December.

I also updated the durabletask-go reference to include a minor bug fix that sometimes caused an incorrect error message to get logged during shutdown.

## Issue reference

N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing

FYI @johnewart @artursouza 