### PR TITLE
Improve perf test output format

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -462,6 +462,11 @@ jobs:
           #TODO: .json suffix can be removed from artifact name after test analytics scripts are updated
           name: test_perf.json
           path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_perf*.*
+      - name: Show test summary
+        if: always()
+        uses: test-summary/action@v2
+        with:
+          paths: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_perf*.xml
       - name: Update PR comment for success
         if: success() && env.PR_NUMBER != ''
         uses: artursouza/sticky-pull-request-comment@v2.2.0

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -349,6 +349,7 @@ ifeq ($(DAPR_PERF_TEST),)
 		gotestsum \
 		--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_perf.json \
 		--junitfile $(TEST_OUTPUT_FILE_PREFIX)_perf.xml \
+		--hide-summary=output \
 		--format standard-quiet \
 		-- \
 			-timeout 1h -p 1 -count=1 -v -tags=perf ./tests/perf/...

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -349,7 +349,6 @@ ifeq ($(DAPR_PERF_TEST),)
 		gotestsum \
 		--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_perf.json \
 		--junitfile $(TEST_OUTPUT_FILE_PREFIX)_perf.xml \
-		--hide-summary=output \
 		--format standard-quiet \
 		-- \
 			-timeout 1h -p 1 -count=1 -v -tags=perf ./tests/perf/...


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Previously the performance test were shown individually at github actions because they are a github action step each. Now, a single step is responsible for running the whole test binary, so the output might be compromised, making difficult to track which test has failed and for what reason.
 
This PR aims to improve the perf tests output format as well as allowing users to run performance test in newly added tests as we are proposing to.
## Issue reference

N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
