### PR TITLE
Renamed mqtt components to mqtt3

### DIFF
--- a/cmd/daprd/components/binding_mqtt3.go
+++ b/cmd/daprd/components/binding_mqtt3.go
@@ -14,10 +14,17 @@ limitations under the License.
 package components
 
 import (
-	"github.com/dapr/components-contrib/pubsub/mqtt"
-	pubsubLoader "github.com/dapr/dapr/pkg/components/pubsub"
+	"github.com/dapr/components-contrib/bindings"
+	mqtt3 "github.com/dapr/components-contrib/bindings/mqtt3"
+	bindingsLoader "github.com/dapr/dapr/pkg/components/bindings"
+	"github.com/dapr/kit/logger"
 )
 
 func init() {
-	pubsubLoader.DefaultRegistry.RegisterComponent(mqtt.NewMQTTPubSub, "mqtt")
+	bindingsLoader.DefaultRegistry.RegisterInputBinding(func(l logger.Logger) bindings.InputBinding {
+		return mqtt3.NewMQTT(l)
+	}, "mqtt3", "mqtt")
+	bindingsLoader.DefaultRegistry.RegisterOutputBinding(func(l logger.Logger) bindings.OutputBinding {
+		return mqtt3.NewMQTT(l)
+	}, "mqtt3", "mqtt")
 }

--- a/cmd/daprd/components/pubsub_mqtt3.go
+++ b/cmd/daprd/components/pubsub_mqtt3.go
@@ -14,17 +14,10 @@ limitations under the License.
 package components
 
 import (
-	"github.com/dapr/components-contrib/bindings"
-	"github.com/dapr/components-contrib/bindings/mqtt"
-	bindingsLoader "github.com/dapr/dapr/pkg/components/bindings"
-	"github.com/dapr/kit/logger"
+	mqtt3 "github.com/dapr/components-contrib/pubsub/mqtt3"
+	pubsubLoader "github.com/dapr/dapr/pkg/components/pubsub"
 )
 
 func init() {
-	bindingsLoader.DefaultRegistry.RegisterInputBinding(func(l logger.Logger) bindings.InputBinding {
-		return mqtt.NewMQTT(l)
-	}, "mqtt")
-	bindingsLoader.DefaultRegistry.RegisterOutputBinding(func(l logger.Logger) bindings.OutputBinding {
-		return mqtt.NewMQTT(l)
-	}, "mqtt")
+	pubsubLoader.DefaultRegistry.RegisterComponent(mqtt3.NewMQTTPubSub, "mqtt3", "mqtt")
 }


### PR DESCRIPTION
**In draft until dapr/components-contrib#2437 - will need to update pinned components-contrib after**

See: dapr/components-contrib#2437
Fixes: dapr/components-contrib#2359

Renames these components:

- `pubsub.mqtt` -> `pubsub.mqtt3`
- `bindings.mqtt` -> `bindings.mqtt3`

The old names remain available as aliases for backwards-compatibility.

Docs PR: https://github.com/dapr/docs/pull/3059