### PR TITLE
Skip actor id scale test due to flakiness

### DIFF
--- a/tests/perf/actor_id_scale/actor_id_scale_test.go
+++ b/tests/perf/actor_id_scale/actor_id_scale_test.go
@@ -70,6 +70,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorIdStress(t *testing.T) {
+	t.Skip("skipping due to flakiness")
 	// Get the ingress external url of test app
 	testServiceAppURL := tr.Platform.AcquireAppExternalURL(serviceApplicationName)
 	require.NotEmpty(t, testServiceAppURL, "test app external URL must not be empty")


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Actor id perf test has been failing (timeout waiting for pods) for a while. I'm skipping it until its not fixed.

## Issue reference

N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
