### PR TITLE
Add component field to logs from components

### DIFF
--- a/pkg/apis/components/v1alpha1/types.go
+++ b/pkg/apis/components/v1alpha1/types.go
@@ -16,6 +16,7 @@ package v1alpha1
 import (
 	"strconv"
 
+	"github.com/dapr/dapr/utils"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -40,6 +41,11 @@ type Component struct {
 // Kind returns the component kind.
 func (Component) Kind() string {
 	return "Component"
+}
+
+// LogName returns the name of the component that can be used in logging.
+func (c Component) LogName() string {
+	return utils.ComponentLogName(c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 }
 
 // ComponentSpec is the spec for a component.

--- a/pkg/apis/components/v1alpha1/types.go
+++ b/pkg/apis/components/v1alpha1/types.go
@@ -16,9 +16,10 @@ package v1alpha1
 import (
 	"strconv"
 
-	"github.com/dapr/dapr/utils"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/dapr/utils"
 )
 
 //+genclient

--- a/pkg/components/bindings/registry.go
+++ b/pkg/components/bindings/registry.go
@@ -119,7 +119,7 @@ func (b *Registry) getOutputBinding(name, version, logName string) (func() bindi
 func (b *Registry) wrapInputBindingFn(componentFactory func(logger.Logger) bindings.InputBinding, logName string) func() bindings.InputBinding {
 	return func() bindings.InputBinding {
 		l := b.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})
@@ -131,7 +131,7 @@ func (b *Registry) wrapInputBindingFn(componentFactory func(logger.Logger) bindi
 func (b *Registry) wrapOutputBindingFn(componentFactory func(logger.Logger) bindings.OutputBinding, logName string) func() bindings.OutputBinding {
 	return func() bindings.OutputBinding {
 		l := b.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/components/bindings/registry_test.go
+++ b/pkg/components/bindings/registry_test.go
@@ -59,21 +59,21 @@ func TestRegistry(t *testing.T) {
 
 		// assert v0 and v1
 		assert.True(t, testRegistry.HasInputBinding(componentName, "v0"))
-		p, e := testRegistry.CreateInputBinding(componentName, "v0")
+		p, e := testRegistry.CreateInputBinding(componentName, "v0", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockInput, p)
-		p, e = testRegistry.CreateInputBinding(componentName, "v1")
+		p, e = testRegistry.CreateInputBinding(componentName, "v1", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockInput, p)
 
 		// assert v2
 		assert.True(t, testRegistry.HasInputBinding(componentName, "v2"))
-		pV2, e := testRegistry.CreateInputBinding(componentName, "v2")
+		pV2, e := testRegistry.CreateInputBinding(componentName, "v2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockInputV2, pV2)
 
 		// check case-insensitivity
-		pV2, e = testRegistry.CreateInputBinding(strings.ToUpper(componentName), "V2")
+		pV2, e = testRegistry.CreateInputBinding(strings.ToUpper(componentName), "V2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockInputV2, pV2)
 	})
@@ -88,7 +88,7 @@ func TestRegistry(t *testing.T) {
 		assert.False(t, testRegistry.HasInputBinding(componentName, "v0"))
 		assert.False(t, testRegistry.HasInputBinding(componentName, "v1"))
 		assert.False(t, testRegistry.HasInputBinding(componentName, "v2"))
-		p, actualError := testRegistry.CreateInputBinding(componentName, "v1")
+		p, actualError := testRegistry.CreateInputBinding(componentName, "v1", "")
 		expectedError := fmt.Errorf("couldn't find input binding %s/v1", componentName)
 
 		// assert
@@ -117,17 +117,17 @@ func TestRegistry(t *testing.T) {
 
 		// assert v0 and v1
 		assert.True(t, testRegistry.HasOutputBinding(componentName, "v0"))
-		p, e := testRegistry.CreateOutputBinding(componentName, "v0")
+		p, e := testRegistry.CreateOutputBinding(componentName, "v0", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockOutput, p)
 		assert.True(t, testRegistry.HasOutputBinding(componentName, "v1"))
-		p, e = testRegistry.CreateOutputBinding(componentName, "v1")
+		p, e = testRegistry.CreateOutputBinding(componentName, "v1", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockOutput, p)
 
 		// assert v2
 		assert.True(t, testRegistry.HasOutputBinding(componentName, "v2"))
-		pV2, e := testRegistry.CreateOutputBinding(componentName, "v2")
+		pV2, e := testRegistry.CreateOutputBinding(componentName, "v2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockOutputV2, pV2)
 	})
@@ -142,7 +142,7 @@ func TestRegistry(t *testing.T) {
 		assert.False(t, testRegistry.HasOutputBinding(componentName, "v0"))
 		assert.False(t, testRegistry.HasOutputBinding(componentName, "v1"))
 		assert.False(t, testRegistry.HasOutputBinding(componentName, "v2"))
-		p, actualError := testRegistry.CreateOutputBinding(componentName, "v1")
+		p, actualError := testRegistry.CreateOutputBinding(componentName, "v1", "")
 		expectedError := fmt.Errorf("couldn't find output binding %s/v1", componentName)
 
 		// assert

--- a/pkg/components/configuration/registry.go
+++ b/pkg/components/configuration/registry.go
@@ -74,7 +74,7 @@ func (s *Registry) getConfigurationStore(name, version, logName string) (func() 
 func (s *Registry) wrapFn(componentFactory func(logger.Logger) configuration.Store, logName string) func() configuration.Store {
 	return func() configuration.Store {
 		l := s.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/components/configuration/registry_test.go
+++ b/pkg/components/configuration/registry_test.go
@@ -52,20 +52,20 @@ func TestRegistry(t *testing.T) {
 		}, stateNameV2)
 
 		// assert v0 and v1
-		p, e := testRegistry.Create(componentName, "v0")
+		p, e := testRegistry.Create(componentName, "v0", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
-		p, e = testRegistry.Create(componentName, "v1")
+		p, e = testRegistry.Create(componentName, "v1", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
 
 		// assert v2
-		pV2, e := testRegistry.Create(componentName, "v2")
+		pV2, e := testRegistry.Create(componentName, "v2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 
 		// check case-insensitivity
-		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2")
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 	})
@@ -77,7 +77,7 @@ func TestRegistry(t *testing.T) {
 		)
 
 		// act
-		p, actualError := testRegistry.Create(componentName, "v1")
+		p, actualError := testRegistry.Create(componentName, "v1", "")
 		expectedError := fmt.Errorf("couldn't find configuration store %s/v1", componentName)
 
 		// assert

--- a/pkg/components/lock/registry.go
+++ b/pkg/components/lock/registry.go
@@ -59,7 +59,7 @@ func (r *Registry) getStore(name, version, logName string) (func() lock.Store, b
 func (r *Registry) wrapFn(componentFactory func(logger.Logger) lock.Store, logName string) func() lock.Store {
 	return func() lock.Store {
 		l := r.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/components/lock/registry_test.go
+++ b/pkg/components/lock/registry_test.go
@@ -24,13 +24,13 @@ func TestNewRegistry(t *testing.T) {
 	r.RegisterComponent(func(_ logger.Logger) lock.Store {
 		return nil
 	}, compNameV2)
-	if _, err := r.Create(fullName, "v1"); err != nil {
+	if _, err := r.Create(fullName, "v1", ""); err != nil {
 		t.Fatalf("create mock store failed: %v", err)
 	}
-	if _, err := r.Create(fullName, "v2"); err != nil {
+	if _, err := r.Create(fullName, "v2", ""); err != nil {
 		t.Fatalf("create mock store failed: %v", err)
 	}
-	if _, err := r.Create("not exists", "v1"); !strings.Contains(err.Error(), "couldn't find lock store") {
+	if _, err := r.Create("not exists", "v1", ""); !strings.Contains(err.Error(), "couldn't find lock store") {
 		t.Fatalf("create mock store failed: %v", err)
 	}
 }
@@ -41,6 +41,6 @@ func TestAliasing(t *testing.T) {
 	r.RegisterComponent(func(_ logger.Logger) lock.Store {
 		return nil
 	}, "", alias)
-	_, err := r.Create("lock."+alias, "")
+	_, err := r.Create("lock."+alias, "", "")
 	assert.Nil(t, err)
 }

--- a/pkg/components/middleware/http/registry.go
+++ b/pkg/components/middleware/http/registry.go
@@ -56,8 +56,8 @@ func (p *Registry) RegisterComponent(componentFactory func(logger.Logger) Factor
 }
 
 // Create instantiates a HTTP middleware based on `name`.
-func (p *Registry) Create(name, version string, metadata middleware.Metadata) (httpMiddleware.Middleware, error) {
-	if method, ok := p.getMiddleware(name, version); ok {
+func (p *Registry) Create(name, version string, metadata middleware.Metadata, logName string) (httpMiddleware.Middleware, error) {
+	if method, ok := p.getMiddleware(name, version, logName); ok {
 		mid, err := method(metadata)
 		if err != nil {
 			return nil, fmt.Errorf("error creating HTTP middleware %s/%s: %w", name, version, err)
@@ -67,24 +67,30 @@ func (p *Registry) Create(name, version string, metadata middleware.Metadata) (h
 	return nil, fmt.Errorf("HTTP middleware %s/%s has not been registered", name, version)
 }
 
-func (p *Registry) getMiddleware(name, version string) (FactoryMethod, bool) {
+func (p *Registry) getMiddleware(name, version, logName string) (FactoryMethod, bool) {
 	nameLower := strings.ToLower(name)
 	versionLower := strings.ToLower(version)
 	middlewareFn, ok := p.middleware[nameLower+"/"+versionLower]
 	if ok {
-		return p.applyLogger(middlewareFn), true
+		return p.applyLogger(middlewareFn, logName), true
 	}
 	if components.IsInitialVersion(versionLower) {
 		middlewareFn, ok = p.middleware[nameLower]
 		if ok {
-			return p.applyLogger(middlewareFn), true
+			return p.applyLogger(middlewareFn, logName), true
 		}
 	}
 	return nil, false
 }
 
-func (p *Registry) applyLogger(componentFactory func(logger.Logger) FactoryMethod) FactoryMethod {
-	return componentFactory(p.Logger)
+func (p *Registry) applyLogger(componentFactory func(logger.Logger) FactoryMethod, logName string) FactoryMethod {
+	l := p.Logger
+	if logName != "" {
+		l = l.WithFields(map[string]any{
+			"component": logName,
+		})
+	}
+	return componentFactory(l)
 }
 
 func createFullName(name string) string {

--- a/pkg/components/middleware/http/registry.go
+++ b/pkg/components/middleware/http/registry.go
@@ -85,7 +85,7 @@ func (p *Registry) getMiddleware(name, version, logName string) (FactoryMethod, 
 
 func (p *Registry) applyLogger(componentFactory func(logger.Logger) FactoryMethod, logName string) FactoryMethod {
 	l := p.Logger
-	if logName != "" {
+	if logName != "" && l != nil {
 		l = l.WithFields(map[string]any{
 			"component": logName,
 		})

--- a/pkg/components/middleware/http/registry_test.go
+++ b/pkg/components/middleware/http/registry_test.go
@@ -65,20 +65,20 @@ func TestRegistry(t *testing.T) {
 		// to get the address of a function value.
 
 		// assert v0 and v1
-		p, e := testRegistry.Create(componentName, "v0", metadata)
+		p, e := testRegistry.Create(componentName, "v0", metadata, "")
 		assert.NoError(t, e)
 		assert.True(t, reflect.ValueOf(mock) == reflect.ValueOf(p))
-		p, e = testRegistry.Create(componentName, "v1", metadata)
+		p, e = testRegistry.Create(componentName, "v1", metadata, "")
 		assert.NoError(t, e)
 		assert.True(t, reflect.ValueOf(mock) == reflect.ValueOf(p))
 
 		// assert v2
-		pV2, e := testRegistry.Create(componentName, "v2", metadata)
+		pV2, e := testRegistry.Create(componentName, "v2", metadata, "")
 		assert.NoError(t, e)
 		assert.True(t, reflect.ValueOf(mockV2) == reflect.ValueOf(pV2))
 
 		// check case-insensitivity
-		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2", metadata)
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2", metadata, "")
 		assert.NoError(t, e)
 		assert.True(t, reflect.ValueOf(mockV2) == reflect.ValueOf(pV2))
 	})
@@ -92,7 +92,7 @@ func TestRegistry(t *testing.T) {
 		metadata := h.Metadata{}
 
 		// act
-		p, actualError := testRegistry.Create(componentName, "v1", metadata)
+		p, actualError := testRegistry.Create(componentName, "v1", metadata, "")
 		expectedError := fmt.Errorf("HTTP middleware %s/v1 has not been registered", componentName)
 
 		// assert

--- a/pkg/components/nameresolution/registry.go
+++ b/pkg/components/nameresolution/registry.go
@@ -83,7 +83,7 @@ func (s *Registry) getResolver(name, version, logName string) (func() nr.Resolve
 func (s *Registry) wrapFn(componentFactory FactoryMethod, logName string) func() nr.Resolver {
 	return func() nr.Resolver {
 		l := s.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/components/nameresolution/registry_test.go
+++ b/pkg/components/nameresolution/registry_test.go
@@ -51,20 +51,20 @@ func TestRegistry(t *testing.T) {
 		}, resolverNameV2)
 
 		// assert v0 and v1
-		p, e := testRegistry.Create(resolverName, "v0")
+		p, e := testRegistry.Create(resolverName, "v0", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
-		p, e = testRegistry.Create(resolverName, "v1")
+		p, e = testRegistry.Create(resolverName, "v1", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
 
 		// assert v2
-		pV2, e := testRegistry.Create(resolverName, "v2")
+		pV2, e := testRegistry.Create(resolverName, "v2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 
 		// check case-insensitivity
-		pV2, e = testRegistry.Create(strings.ToUpper(resolverName), "V2")
+		pV2, e = testRegistry.Create(strings.ToUpper(resolverName), "V2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 	})
@@ -75,7 +75,7 @@ func TestRegistry(t *testing.T) {
 		)
 
 		// act
-		p, actualError := testRegistry.Create(resolverName, "v1")
+		p, actualError := testRegistry.Create(resolverName, "v1", "")
 		expectedError := fmt.Errorf("couldn't find name resolver %s/v1", resolverName)
 
 		// assert

--- a/pkg/components/pubsub/registry.go
+++ b/pkg/components/pubsub/registry.go
@@ -45,33 +45,39 @@ func (p *Registry) RegisterComponent(componentFactory func(logger.Logger) pubsub
 }
 
 // Create instantiates a pub/sub based on `name`.
-func (p *Registry) Create(name, version string) (pubsub.PubSub, error) {
-	if method, ok := p.getPubSub(name, version); ok {
+func (p *Registry) Create(name, version, logName string) (pubsub.PubSub, error) {
+	if method, ok := p.getPubSub(name, version, logName); ok {
 		return method(), nil
 	}
 	return nil, fmt.Errorf("couldn't find message bus %s/%s", name, version)
 }
 
-func (p *Registry) getPubSub(name, version string) (func() pubsub.PubSub, bool) {
+func (p *Registry) getPubSub(name, version, logName string) (func() pubsub.PubSub, bool) {
 	nameLower := strings.ToLower(name)
 	versionLower := strings.ToLower(version)
 	pubSubFn, ok := p.messageBuses[nameLower+"/"+versionLower]
 	if ok {
-		return p.wrapFn(pubSubFn), true
+		return p.wrapFn(pubSubFn, logName), true
 	}
 	if components.IsInitialVersion(versionLower) {
 		pubSubFn, ok = p.messageBuses[nameLower]
 		if ok {
-			return p.wrapFn(pubSubFn), true
+			return p.wrapFn(pubSubFn, logName), true
 		}
 	}
 
 	return nil, false
 }
 
-func (p *Registry) wrapFn(componentFactory func(logger.Logger) pubsub.PubSub) func() pubsub.PubSub {
+func (p *Registry) wrapFn(componentFactory func(logger.Logger) pubsub.PubSub, logName string) func() pubsub.PubSub {
 	return func() pubsub.PubSub {
-		return componentFactory(p.Logger)
+		l := p.Logger
+		if logName != "" {
+			l = l.WithFields(map[string]any{
+				"component": logName,
+			})
+		}
+		return componentFactory(l)
 	}
 }
 

--- a/pkg/components/pubsub/registry.go
+++ b/pkg/components/pubsub/registry.go
@@ -72,7 +72,7 @@ func (p *Registry) getPubSub(name, version, logName string) (func() pubsub.PubSu
 func (p *Registry) wrapFn(componentFactory func(logger.Logger) pubsub.PubSub, logName string) func() pubsub.PubSub {
 	return func() pubsub.PubSub {
 		l := p.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/components/pubsub/registry_test.go
+++ b/pkg/components/pubsub/registry_test.go
@@ -66,21 +66,21 @@ func TestCreatePubSub(t *testing.T) {
 		}, pubSubNameV2)
 
 		// assert v0 and v1
-		p, e := testRegistry.Create(componentName, "v0")
+		p, e := testRegistry.Create(componentName, "v0", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockPubSub, p)
 
-		p, e = testRegistry.Create(componentName, "v1")
+		p, e = testRegistry.Create(componentName, "v1", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockPubSub, p)
 
 		// assert v2
-		pV2, e := testRegistry.Create(componentName, "v2")
+		pV2, e := testRegistry.Create(componentName, "v2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockPubSubV2, pV2)
 
 		// check case-insensitivity
-		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2")
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockPubSubV2, pV2)
 	})
@@ -89,7 +89,7 @@ func TestCreatePubSub(t *testing.T) {
 		const PubSubName = "fakePubSub"
 
 		// act
-		p, actualError := testRegistry.Create(createFullName(PubSubName), "v1")
+		p, actualError := testRegistry.Create(createFullName(PubSubName), "v1", "")
 		expectedError := fmt.Errorf("couldn't find message bus %s/v1", createFullName(PubSubName))
 		// assert
 		assert.Nil(t, p)

--- a/pkg/components/secretstores/registry.go
+++ b/pkg/components/secretstores/registry.go
@@ -53,33 +53,39 @@ func (s *Registry) RegisterComponent(componentFactory func(logger.Logger) secret
 }
 
 // Create instantiates a secret store based on `name`.
-func (s *Registry) Create(name, version string) (secretstores.SecretStore, error) {
-	if method, ok := s.getSecretStore(name, version); ok {
+func (s *Registry) Create(name, version, logName string) (secretstores.SecretStore, error) {
+	if method, ok := s.getSecretStore(name, version, logName); ok {
 		return method(), nil
 	}
 
 	return nil, fmt.Errorf("couldn't find secret store %s/%s", name, version)
 }
 
-func (s *Registry) getSecretStore(name, version string) (func() secretstores.SecretStore, bool) {
+func (s *Registry) getSecretStore(name, version, logName string) (func() secretstores.SecretStore, bool) {
 	nameLower := strings.ToLower(name)
 	versionLower := strings.ToLower(version)
 	secretStoreFn, ok := s.secretStores[nameLower+"/"+versionLower]
 	if ok {
-		return s.wrapFn(secretStoreFn), true
+		return s.wrapFn(secretStoreFn, logName), true
 	}
 	if components.IsInitialVersion(versionLower) {
 		secretStoreFn, ok = s.secretStores[nameLower]
 		if ok {
-			return s.wrapFn(secretStoreFn), true
+			return s.wrapFn(secretStoreFn, logName), true
 		}
 	}
 	return nil, false
 }
 
-func (s *Registry) wrapFn(componentFactory func(logger.Logger) secretstores.SecretStore) func() secretstores.SecretStore {
+func (s *Registry) wrapFn(componentFactory func(logger.Logger) secretstores.SecretStore, logName string) func() secretstores.SecretStore {
 	return func() secretstores.SecretStore {
-		return componentFactory(s.Logger)
+		l := s.Logger
+		if logName != "" {
+			l = l.WithFields(map[string]any{
+				"component": logName,
+			})
+		}
+		return componentFactory(l)
 	}
 }
 

--- a/pkg/components/secretstores/registry.go
+++ b/pkg/components/secretstores/registry.go
@@ -80,7 +80,7 @@ func (s *Registry) getSecretStore(name, version, logName string) (func() secrets
 func (s *Registry) wrapFn(componentFactory func(logger.Logger) secretstores.SecretStore, logName string) func() secretstores.SecretStore {
 	return func() secretstores.SecretStore {
 		l := s.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/components/secretstores/registry_test.go
+++ b/pkg/components/secretstores/registry_test.go
@@ -52,20 +52,20 @@ func TestRegistry(t *testing.T) {
 		}, secretStoreNameV2)
 
 		// assert v0 and v1
-		p, e := testRegistry.Create(componentName, "v0")
+		p, e := testRegistry.Create(componentName, "v0", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
-		p, e = testRegistry.Create(componentName, "v1")
+		p, e = testRegistry.Create(componentName, "v1", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
 
 		// assert v2
-		pV2, e := testRegistry.Create(componentName, "v2")
+		pV2, e := testRegistry.Create(componentName, "v2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 
 		// check case-insensitivity
-		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2")
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 	})
@@ -77,7 +77,7 @@ func TestRegistry(t *testing.T) {
 		)
 
 		// act
-		p, actualError := testRegistry.Create(componentName, "v1")
+		p, actualError := testRegistry.Create(componentName, "v1", "")
 		expectedError := fmt.Errorf("couldn't find secret store %s/v1", componentName)
 
 		// assert

--- a/pkg/components/state/registry.go
+++ b/pkg/components/state/registry.go
@@ -72,7 +72,7 @@ func (s *Registry) getStateStore(name, version, logName string) (func() state.St
 func (s *Registry) wrapFn(componentFactory func(logger.Logger) state.Store, logName string) func() state.Store {
 	return func() state.Store {
 		l := s.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/components/state/registry.go
+++ b/pkg/components/state/registry.go
@@ -45,33 +45,39 @@ func (s *Registry) RegisterComponent(componentFactory func(logger.Logger) state.
 	}
 }
 
-func (s *Registry) Create(name, version string) (state.Store, error) {
-	if method, ok := s.getStateStore(name, version); ok {
+func (s *Registry) Create(name, version, logName string) (state.Store, error) {
+	if method, ok := s.getStateStore(name, version, logName); ok {
 		return method(), nil
 	}
 	return nil, fmt.Errorf("couldn't find state store %s/%s", name, version)
 }
 
-func (s *Registry) getStateStore(name, version string) (func() state.Store, bool) {
+func (s *Registry) getStateStore(name, version, logName string) (func() state.Store, bool) {
 	nameLower := strings.ToLower(name)
 	versionLower := strings.ToLower(version)
 	stateStoreFn, ok := s.stateStores[nameLower+"/"+versionLower]
 	if ok {
-		return s.wrapFn(stateStoreFn), true
+		return s.wrapFn(stateStoreFn, logName), true
 	}
 	if components.IsInitialVersion(versionLower) {
 		stateStoreFn, ok = s.stateStores[nameLower]
 		if ok {
-			return s.wrapFn(stateStoreFn), true
+			return s.wrapFn(stateStoreFn, logName), true
 		}
 	}
 
 	return nil, false
 }
 
-func (s *Registry) wrapFn(componentFactory func(logger.Logger) state.Store) func() state.Store {
+func (s *Registry) wrapFn(componentFactory func(logger.Logger) state.Store, logName string) func() state.Store {
 	return func() state.Store {
-		return componentFactory(s.Logger)
+		l := s.Logger
+		if logName != "" {
+			l = l.WithFields(map[string]any{
+				"component": logName,
+			})
+		}
+		return componentFactory(l)
 	}
 }
 

--- a/pkg/components/state/registry_test.go
+++ b/pkg/components/state/registry_test.go
@@ -52,20 +52,20 @@ func TestRegistry(t *testing.T) {
 		}, stateNameV2)
 
 		// assert v0 and v1
-		p, e := testRegistry.Create(componentName, "v0")
+		p, e := testRegistry.Create(componentName, "v0", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
-		p, e = testRegistry.Create(componentName, "v1")
+		p, e = testRegistry.Create(componentName, "v1", "")
 		assert.NoError(t, e)
 		assert.Same(t, mock, p)
 
 		// assert v2
-		pV2, e := testRegistry.Create(componentName, "v2")
+		pV2, e := testRegistry.Create(componentName, "v2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 
 		// check case-insensitivity
-		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2")
+		pV2, e = testRegistry.Create(strings.ToUpper(componentName), "V2", "")
 		assert.NoError(t, e)
 		assert.Same(t, mockV2, pV2)
 	})
@@ -77,7 +77,7 @@ func TestRegistry(t *testing.T) {
 		)
 
 		// act
-		p, actualError := testRegistry.Create(componentName, "v1")
+		p, actualError := testRegistry.Create(componentName, "v1", "")
 		expectedError := fmt.Errorf("couldn't find state store %s/v1", componentName)
 
 		// assert

--- a/pkg/components/workflows/registry.go
+++ b/pkg/components/workflows/registry.go
@@ -71,7 +71,7 @@ func (s *Registry) getWorkflowComponent(name, version, logName string) (func() w
 func (s *Registry) wrapFn(componentFactory func(logger.Logger) wfs.Workflow, logName string) func() wfs.Workflow {
 	return func() wfs.Workflow {
 		l := s.Logger
-		if logName != "" {
+		if logName != "" && l != nil {
 			l = l.WithFields(map[string]any{
 				"component": logName,
 			})

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -142,11 +142,6 @@ type HandlerSpec struct {
 	SelectorSpec SelectorSpec `json:"selector,omitempty" yaml:"selector,omitempty"`
 }
 
-const (
-	logNameFmt        = "%s (%s)"
-	logNameVersionFmt = "%s (%s/%s)"
-)
-
 // LogName returns the name of the handler that can be used in logging.
 func (h HandlerSpec) LogName() string {
 	return utils.ComponentLogName(h.Name, h.Type, h.Version)

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/buildinfo"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/utils"
 )
 
 // Feature Flags section
@@ -139,6 +140,16 @@ type HandlerSpec struct {
 	Type         string       `json:"type" yaml:"type"`
 	Version      string       `json:"version" yaml:"version"`
 	SelectorSpec SelectorSpec `json:"selector,omitempty" yaml:"selector,omitempty"`
+}
+
+const (
+	logNameFmt        = "%s (%s)"
+	logNameVersionFmt = "%s (%s/%s)"
+)
+
+// LogName returns the name of the handler that can be used in logging.
+func (h HandlerSpec) LogName() string {
+	return utils.ComponentLogName(h.Name, h.Type, h.Version)
 }
 
 type SelectorSpec struct {

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -2906,7 +2906,7 @@ func buildHTTPPineline(spec config.PipelineSpec) httpMiddleware.Pipeline {
 	}, "uppercase")
 	var handlers []httpMiddleware.Middleware
 	for i := 0; i < len(spec.Handlers); i++ {
-		handler, err := registry.Create(spec.Handlers[i].Type, spec.Handlers[i].Version, middleware.Metadata{})
+		handler, err := registry.Create(spec.Handlers[i].Type, spec.Handlers[i].Version, middleware.Metadata{}, "")
 		if err != nil {
 			return httpMiddleware.Pipeline{}
 		}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -661,13 +661,15 @@ func (a *DaprRuntime) buildHTTPPipelineForSpec(spec config.PipelineSpec, targetP
 			middlewareSpec := spec.Handlers[i]
 			component, exists := a.getComponent(middlewareSpec.Type, middlewareSpec.Name)
 			if !exists {
-				return httpMiddleware.Pipeline{}, fmt.Errorf("couldn't find middleware component with name %s and type %s/%s",
-					middlewareSpec.Name,
-					middlewareSpec.Type,
-					middlewareSpec.Version)
+				err := fmt.Errorf(
+					"couldn't find middleware component with name %s and type %s/%s",
+					middlewareSpec.Name, middlewareSpec.Type, middlewareSpec.Version,
+				)
+				return httpMiddleware.Pipeline{}, err
 			}
-			handler, err := a.httpMiddlewareRegistry.Create(middlewareSpec.Type, middlewareSpec.Version,
-				middleware.Metadata{Base: a.toBaseMetadata(component)})
+			md := middleware.Metadata{Base: a.toBaseMetadata(component)}
+			fName := fmt.Sprintf(componentFormat, middlewareSpec.Name, middlewareSpec.Type, middlewareSpec.Version)
+			handler, err := a.httpMiddlewareRegistry.Create(middlewareSpec.Type, middlewareSpec.Version, md, fName)
 			if err != nil {
 				return httpMiddleware.Pipeline{}, err
 			}
@@ -1564,16 +1566,15 @@ func (a *DaprRuntime) isAppSubscribedToBinding(binding string) (bool, error) {
 }
 
 func (a *DaprRuntime) initInputBinding(c componentsV1alpha1.Component) error {
-	binding, err := a.bindingsRegistry.CreateInputBinding(c.Spec.Type, c.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
+	binding, err := a.bindingsRegistry.CreateInputBinding(c.Spec.Type, c.Spec.Version, fName)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation", c.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 	err = binding.Init(bindings.Metadata{Base: a.toBaseMetadata(c)})
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init", c.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		return NewInitError(InitComponentFailure, fName, err)
 	}
 
@@ -1590,10 +1591,10 @@ func (a *DaprRuntime) initInputBinding(c componentsV1alpha1.Component) error {
 }
 
 func (a *DaprRuntime) initOutputBinding(c componentsV1alpha1.Component) error {
-	binding, err := a.bindingsRegistry.CreateOutputBinding(c.Spec.Type, c.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
+	binding, err := a.bindingsRegistry.CreateOutputBinding(c.Spec.Type, c.Spec.Version, fName)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation", c.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 
@@ -1601,7 +1602,6 @@ func (a *DaprRuntime) initOutputBinding(c componentsV1alpha1.Component) error {
 		err := binding.Init(bindings.Metadata{Base: a.toBaseMetadata(c)})
 		if err != nil {
 			diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init", c.ObjectMeta.Name)
-			fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 			return NewInitError(InitComponentFailure, fName, err)
 		}
 		log.Infof("successful init for output binding %s (%s/%s)", c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
@@ -1612,17 +1612,16 @@ func (a *DaprRuntime) initOutputBinding(c componentsV1alpha1.Component) error {
 }
 
 func (a *DaprRuntime) initConfiguration(s componentsV1alpha1.Component) error {
-	store, err := a.configurationStoreRegistry.Create(s.Spec.Type, s.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
+	store, err := a.configurationStoreRegistry.Create(s.Spec.Type, s.Spec.Version, fName)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "creation", s.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 	if store != nil {
 		err := store.Init(configuration.Metadata{Base: a.toBaseMetadata(s)})
 		if err != nil {
 			diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init", s.ObjectMeta.Name)
-			fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 			return NewInitError(InitComponentFailure, fName, err)
 		}
 
@@ -1635,10 +1634,10 @@ func (a *DaprRuntime) initConfiguration(s componentsV1alpha1.Component) error {
 
 func (a *DaprRuntime) initLock(s componentsV1alpha1.Component) error {
 	// create the component
-	store, err := a.lockStoreRegistry.Create(s.Spec.Type, s.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
+	store, err := a.lockStoreRegistry.Create(s.Spec.Type, s.Spec.Version, fName)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "creation", s.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 	if store == nil {
@@ -1650,7 +1649,6 @@ func (a *DaprRuntime) initLock(s componentsV1alpha1.Component) error {
 	err = store.InitLockStore(lock.Metadata{Base: baseMetadata})
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init", s.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 		return NewInitError(InitComponentFailure, fName, err)
 	}
 	// save lock related configuration
@@ -1659,7 +1657,6 @@ func (a *DaprRuntime) initLock(s componentsV1alpha1.Component) error {
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init", s.ObjectMeta.Name)
 		wrapError := fmt.Errorf("failed to save lock keyprefix: %s", err.Error())
-		fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 		return NewInitError(InitComponentFailure, fName, wrapError)
 	}
 	diag.DefaultMonitoring.ComponentInitialized(s.Spec.Type)
@@ -1669,7 +1666,8 @@ func (a *DaprRuntime) initLock(s componentsV1alpha1.Component) error {
 
 func (a *DaprRuntime) initWorkflowComponent(s componentsV1alpha1.Component) error {
 	// create the component
-	workflowComp, err := a.workflowComponentRegistry.Create(s.Spec.Type, s.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
+	workflowComp, err := a.workflowComponentRegistry.Create(s.Spec.Type, s.Spec.Version, fName)
 	if err != nil {
 		log.Warnf("error creating workflow component %s (%s/%s): %s", s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version, err)
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init", s.ObjectMeta.Name)
@@ -1685,7 +1683,6 @@ func (a *DaprRuntime) initWorkflowComponent(s componentsV1alpha1.Component) erro
 	err = workflowComp.Init(wfs.Metadata{Base: baseMetadata})
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init", s.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 		return NewInitError(InitComponentFailure, fName, err)
 	}
 	// save workflow related configuration
@@ -1697,10 +1694,10 @@ func (a *DaprRuntime) initWorkflowComponent(s componentsV1alpha1.Component) erro
 
 // Refer for state store api decision  https://github.com/dapr/dapr/blob/master/docs/decision_records/api/API-008-multi-state-store-api-design.md
 func (a *DaprRuntime) initState(s componentsV1alpha1.Component) error {
-	store, err := a.stateStoreRegistry.Create(s.Spec.Type, s.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
+	store, err := a.stateStoreRegistry.Create(s.Spec.Type, s.Spec.Version, fName)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "creation", s.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 	if store != nil {
@@ -1710,7 +1707,6 @@ func (a *DaprRuntime) initState(s componentsV1alpha1.Component) error {
 		encKeys, encErr := encryption.ComponentEncryptionKey(s, secretStore)
 		if encErr != nil {
 			diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "creation", s.ObjectMeta.Name)
-			fName := fmt.Sprintf(componentFormat+" encyption", s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 			return NewInitError(CreateComponentFailure, fName, err)
 		}
 
@@ -1726,7 +1722,6 @@ func (a *DaprRuntime) initState(s componentsV1alpha1.Component) error {
 		err = store.Init(state.Metadata{Base: baseMetadata})
 		if err != nil {
 			diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init", s.ObjectMeta.Name)
-			fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 			return NewInitError(InitComponentFailure, fName, err)
 		}
 
@@ -1735,7 +1730,6 @@ func (a *DaprRuntime) initState(s componentsV1alpha1.Component) error {
 		if err != nil {
 			diag.DefaultMonitoring.ComponentInitFailed(s.Spec.Type, "init", s.ObjectMeta.Name)
 			wrapError := fmt.Errorf("failed to save lock keyprefix: %s", err.Error())
-			fName := fmt.Sprintf(componentFormat, s.ObjectMeta.Name, s.Spec.Type, s.Spec.Version)
 			return NewInitError(InitComponentFailure, fName, wrapError)
 		}
 
@@ -1896,10 +1890,10 @@ func (a *DaprRuntime) getTopicRoutes() (map[string]TopicRoutes, error) {
 }
 
 func (a *DaprRuntime) initPubSub(c componentsV1alpha1.Component) error {
-	pubSub, err := a.pubSubRegistry.Create(c.Spec.Type, c.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
+	pubSub, err := a.pubSubRegistry.Create(c.Spec.Type, c.Spec.Version, fName)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation", c.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 
@@ -1914,7 +1908,6 @@ func (a *DaprRuntime) initPubSub(c componentsV1alpha1.Component) error {
 	err = pubSub.Init(pubsub.Metadata{Base: baseMetadata})
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init", c.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		return NewInitError(InitComponentFailure, fName, err)
 	}
 
@@ -2071,7 +2064,8 @@ func (a *DaprRuntime) initNameResolution() error {
 		resolverVersion = components.FirstStableVersion
 	}
 
-	resolver, err = a.nameResolutionRegistry.Create(resolverName, resolverVersion)
+	fName := fmt.Sprintf(componentFormat, resolverName, "nameResolution", resolverVersion)
+	resolver, err = a.nameResolutionRegistry.Create(resolverName, resolverVersion, fName)
 	resolverMetadata.Name = resolverName
 	resolverMetadata.Configuration = a.globalConfig.Spec.NameResolutionSpec.Configuration
 	resolverMetadata.Properties = map[string]string{
@@ -2088,13 +2082,11 @@ func (a *DaprRuntime) initNameResolution() error {
 
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed("nameResolution", "creation", resolverName)
-		fName := fmt.Sprintf(componentFormat, resolverName, "nameResolution", resolverVersion)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 
 	if err = resolver.Init(resolverMetadata); err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed("nameResolution", "init", resolverName)
-		fName := fmt.Sprintf(componentFormat, resolverName, "nameResolution", resolverVersion)
 		return NewInitError(InitComponentFailure, fName, err)
 	}
 
@@ -2919,17 +2911,16 @@ func (a *DaprRuntime) appendBuiltinSecretStore() {
 }
 
 func (a *DaprRuntime) initSecretStore(c componentsV1alpha1.Component) error {
-	secretStore, err := a.secretStoresRegistry.Create(c.Spec.Type, c.Spec.Version)
+	fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
+	secretStore, err := a.secretStoresRegistry.Create(c.Spec.Type, c.Spec.Version, fName)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "creation", c.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		return NewInitError(CreateComponentFailure, fName, err)
 	}
 
 	err = secretStore.Init(secretstores.Metadata{Base: a.toBaseMetadata(c)})
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(c.Spec.Type, "init", c.ObjectMeta.Name)
-		fName := fmt.Sprintf(componentFormat, c.ObjectMeta.Name, c.Spec.Type, c.Spec.Version)
 		return NewInitError(InitComponentFailure, fName, err)
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,6 +14,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -168,4 +169,18 @@ func Filter[T any](items []T, test func(item T) bool) []T {
 		}
 	}
 	return slices.Clip(filteredItems)
+}
+
+const (
+	logNameFmt        = "%s (%s)"
+	logNameVersionFmt = "%s (%s/%s)"
+)
+
+// ComponentLogName returns the name of a component that can be used in logging.
+func ComponentLogName(name, typ, version string) string {
+	if version == "" {
+		return fmt.Sprintf(logNameFmt, name, typ)
+	}
+
+	return fmt.Sprintf(logNameVersionFmt, name, typ, version)
 }


### PR DESCRIPTION
This PR updates the loggers used by components to include the name of the component that emitted the log. For example:

```
DEBU[0004] Receiving messages for subscription checkout to topic topic1  app_id=checkout component="order-pub-sub (pubsub.azure.servicebus/v1)" instance=asegala-mbp.local scope=dapr.contrib type=log ver=dev
```

(in JSON, it would be another field like `"component": "order-pub-sub (pubsub.azure.servicebus/v1)"`)

This is particularly useful when having multiple components and trying to identify which one is emitting the log.