### PR TITLE
Fix: Helm dapr upgrade

### DIFF
--- a/charts/dapr/charts/dapr_rbac/templates/operator.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/operator.yaml
@@ -10,7 +10,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: dapr-operator
+  name: dapr-operator-admin
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -41,7 +41,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: dapr-operator
+  name: dapr-operator-admin
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -53,7 +53,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: dapr-operator
+  name: dapr-operator-admin
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Due to how [Helm upgrades](https://github.com/helm/helm/issues/6468), upgrading from v1.9.5 to master is currently broken as `roleRef` in roles cannot be updated in place.

```
Error: UPGRADE FAILED: cannot patch "dapr-operator" with kind ClusterRoleBinding: ClusterRoleBinding.rbac.authorization.k8s.io "dapr-operator" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"ClusterRole", Name:"dapr-operator"}: cannot change roleRef
```

This PR reverts the ClusterRole name back to `dapr-operator-admin` so it doesn't change on an upgrade, and changes the binding name to match.

After a number of future versions, we would be able to remove the `admin` suffix from the role and binding names to be consistent since the upgrade would be deleting the exiting resources with another. There isn't currently a [maximum version upgrade jump](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-upgrade/) though so it's possible a user could always upgrade from pre 1.10 to any future version.

Perhaps we should create a policy for the maximum version jump a user could perform, i.e can only upgrade from target - 2 minor versions? This would allow us to change these resource names, as well as allowing us to handle these kind of problems in future.

Broken from: https://github.com/dapr/dapr/pull/5767

/cc @yaron2 