### PR TITLE
Add namespaced rbac mode

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -99,6 +99,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `global.issuerFilenames.ca`               | Custom name of the file containing the root CA certificate inside the container    | `ca.crt`     |
 | `global.issuerFilenames.cert`             | Custom name of the file containing the leaf certificate inside the container       | `issuer.crt` |
 | `global.issuerFilenames.key`              | Custom name of the file containing the leaf certificate's key inside the container | `issuer.key` |
+| `global.rbac.namespaced`                  | Uses roles and roles bindings in all applicable places other than issuing tokens and listing service accounts for identity verification  | `false` |
 
 ### Dapr Dashboard options:
 | Parameter                                 | Description                                                             | Default                 |
@@ -125,6 +126,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_operator.runAsNonRoot`              | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
 | `dapr_operator.resources`                 | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_operator.debug.enabled`             | Boolean value for enabling debug mode | `{}` |
+| `dapr_operator.watchNamespace`            | The namespace to watch for annoated Dapr resources in | `""` |
 
 ### Dapr Placement options:
 | Parameter                                 | Description                                                             | Default                 |

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -99,7 +99,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `global.issuerFilenames.ca`               | Custom name of the file containing the root CA certificate inside the container    | `ca.crt`     |
 | `global.issuerFilenames.cert`             | Custom name of the file containing the leaf certificate inside the container       | `issuer.crt` |
 | `global.issuerFilenames.key`              | Custom name of the file containing the leaf certificate's key inside the container | `issuer.key` |
-| `global.rbac.namespaced`                  | Uses roles and roles bindings in all applicable places other than issuing tokens and listing service accounts for identity verification  | `false` |
+| `global.rbac.namespaced`                  | Removes cluster wide permissions where applicable  | `false` |
 
 ### Dapr Dashboard options:
 | Parameter                                 | Description                                                             | Default                 |

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -184,6 +184,10 @@ spec:
         - "--issuer-key-filename"
         - "{{ .key }}"
 {{- end }}
+{{- if .Values.watchNamespace }}
+        - "--watch-namespace"
+        - "{{ .Values.watchNamespace }}"
+{{- end }}
       serviceAccountName: dapr-operator
       volumes:
         - name: credentials

--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 logLevel: info
 watchInterval: "0"
+watchNamespace: ""
 maxPodRestartsPerMinute: 20
 component: operator
 

--- a/charts/dapr/charts/dapr_rbac/templates/dashboard.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/dashboard.yaml
@@ -7,7 +7,11 @@ metadata:
     {{ $key }}: {{ tpl $value $ }}
     {{- end }}
 ---
+{{- if eq .Values.global.rbac.namespaced true }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-dashboard
@@ -26,7 +30,11 @@ rules:
   resources: ["components", "configurations"]
   verbs: ["get", "list"]
 ---
+{{- if eq .Values.global.rbac.namespaced true }}
+kind: RoleBinding
+{{- else }}
 kind: ClusterRoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-dashboard
@@ -40,5 +48,9 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if eq .Values.global.rbac.namespaced true }}
+  kind: Role
+{{- else }}
   kind: ClusterRole
+{{- end }}
   name: dapr-dashboard

--- a/charts/dapr/charts/dapr_rbac/templates/injector.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/injector.yaml
@@ -19,7 +19,7 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get", "list"]
-{{- if eq .Values.global.rbac.namespaced false }}
+{{- if not .Values.global.rbac.namespaced }}
   - apiGroups: ["dapr.io"]
     resources: ["configurations", "components"]
     verbs: [ "get", "list"]

--- a/charts/dapr/charts/dapr_rbac/templates/injector.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/injector.yaml
@@ -19,9 +19,11 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get", "list"]
+{{- if eq .Values.global.rbac.namespaced false }}
   - apiGroups: ["dapr.io"]
     resources: ["configurations", "components"]
     verbs: [ "get", "list"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,6 +55,11 @@ rules:
     resources: ["secrets"]
     verbs: ["get"]
     resourceNames: ["dapr-trust-bundle"]
+{{- if eq .Values.global.rbac.namespaced true }}
+  - apiGroups: ["dapr.io"]
+    resources: ["configurations", "components"]
+    verbs: [ "get", "list"]
+{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dapr/charts/dapr_rbac/templates/operator.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/operator.yaml
@@ -7,6 +7,7 @@ metadata:
     {{ $key }}: {{ tpl $value $ }}
     {{- end }}
 ---
+{{- if eq .Values.global.rbac.namespaced false }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -37,7 +38,9 @@ rules:
   - apiGroups: ["dapr.io"]
     resources: ["components", "configurations", "subscriptions", "resiliencies"]
     verbs: [ "get", "list", "watch"]
+{{- end }}
 ---
+{{- if eq .Values.global.rbac.namespaced false }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -54,6 +57,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: dapr-operator-admin
+{{- end }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -80,6 +84,29 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps", "events"]
     verbs: ["create"]
+{{- if eq .Values.global.rbac.namespaced true }}
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/finalizers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "statefulsets/finalizers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["services","services/finalizers"]
+    verbs: ["get", "list", "watch", "update", "create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["dapr.io"]
+    resources: ["components", "configurations", "subscriptions", "resiliencies"]
+    verbs: [ "get", "list", "watch"]
+{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dapr/charts/dapr_rbac/templates/operator.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/operator.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ $key }}: {{ tpl $value $ }}
     {{- end }}
 ---
-{{- if eq .Values.global.rbac.namespaced false }}
+{{- if not .Values.global.rbac.namespaced }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -40,7 +40,7 @@ rules:
     verbs: [ "get", "list", "watch"]
 {{- end }}
 ---
-{{- if eq .Values.global.rbac.namespaced false }}
+{{- if not .Values.global.rbac.namespaced }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/dapr/charts/dapr_rbac/templates/placement.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/placement.yaml
@@ -7,7 +7,11 @@ metadata:
     {{ $key }}: {{ tpl $value $ }}
     {{- end }}
 ---
+{{- if eq .Values.global.rbac.namespaced true }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-placement
@@ -17,7 +21,11 @@ metadata:
     {{- end }}
 rules: []
 ---
+{{- if eq .Values.global.rbac.namespaced true }}
+kind: RoleBinding
+{{- else }}
 kind: ClusterRoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-placement
@@ -31,5 +39,9 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if eq .Values.global.rbac.namespaced true }}
+  kind: Role
+{{- else }}
   kind: ClusterRole
+{{- end }}
   name: dapr-placement

--- a/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
@@ -19,9 +19,11 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
+{{- if eq .Values.global.rbac.namespaced false }}
   - apiGroups: ["dapr.io"]
     resources: ["configurations"]
     verbs: ["list"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,6 +55,11 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "update"]
     resourceNames: ["dapr-trust-bundle"]
+{{- if eq .Values.global.rbac.namespaced true }}
+  - apiGroups: ["dapr.io"]
+    resources: ["configurations"]
+    verbs: ["list"]
+{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
@@ -19,7 +19,7 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-{{- if eq .Values.global.rbac.namespaced false }}
+{{- if not .Values.global.rbac.namespaced }}
   - apiGroups: ["dapr.io"]
     resources: ["configurations"]
     verbs: ["list"]

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -7,6 +7,8 @@ global:
   imagePullSecrets: ""
   nodeSelector: {}
   tolerations: []
+  rbac:
+    namespaced: false
   ha:
     enabled: false
     replicaCount: 3

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -37,6 +37,7 @@ var (
 	watchInterval           string
 	maxPodRestartsPerMinute int
 	disableLeaderElection   bool
+	watchNamespace          string
 )
 
 //nolint:gosec
@@ -64,6 +65,7 @@ func main() {
 		WatchdogEnabled:           false,
 		WatchdogInterval:          0,
 		WatchdogMaxRestartsPerMin: maxPodRestartsPerMinute,
+		WatchNamespace:            watchNamespace,
 	}
 
 	switch strings.ToLower(watchInterval) {
@@ -113,6 +115,8 @@ func init() {
 	flag.StringVar(&watchInterval, "watch-interval", defaultWatchInterval, "Interval for polling pods' state, e.g. '2m'. Set to '0' to disable, or 'once' to only run once when the operator starts")
 	flag.IntVar(&maxPodRestartsPerMinute, "max-pod-restarts-per-minute", defaultMaxPodRestartsPerMinute, "Maximum number of pods in an invalid state that can be restarted per minute")
 	flag.BoolVar(&disableLeaderElection, "disable-leader-election", false, "Disable leader election for operator")
+
+	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to watch K8s resources")
 
 	flag.Parse()
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -116,7 +116,7 @@ func init() {
 	flag.IntVar(&maxPodRestartsPerMinute, "max-pod-restarts-per-minute", defaultMaxPodRestartsPerMinute, "Maximum number of pods in an invalid state that can be restarted per minute")
 	flag.BoolVar(&disableLeaderElection, "disable-leader-election", false, "Disable leader election for operator")
 
-	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to watch K8s resources")
+	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to watch Dapr annotated resources in")
 
 	flag.Parse()
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -57,6 +57,7 @@ type Options struct {
 	WatchdogEnabled           bool
 	WatchdogInterval          time.Duration
 	WatchdogMaxRestartsPerMin int
+	WatchNamespace            string
 }
 
 type operator struct {
@@ -94,6 +95,7 @@ func NewOperator(opts Options) Operator {
 		MetricsBindAddress: "0",
 		LeaderElection:     opts.LeaderElection,
 		LeaderElectionID:   "operator.dapr.io",
+		Namespace:          opts.WatchNamespace,
 	})
 	if err != nil {
 		log.Fatalf("Unable to start manager, err: %s", err)

--- a/pkg/operator/watchdog.go
+++ b/pkg/operator/watchdog.go
@@ -196,7 +196,7 @@ func (dw *DaprWatchdog) listPods(ctx context.Context) bool {
 		log.Debugf("Taking a pod restart token")
 		before := time.Now()
 		_ = dw.restartLimiter.Take()
-		log.Debugf("Resumed after pausing for %v", time.Now().Sub(before))
+		log.Debugf("Resumed after pausing for %v", time.Since(before))
 	}
 
 	log.Infof("DaprWatchdog completed checking pods")


### PR DESCRIPTION
Closes https://github.com/dapr/dapr/issues/5787.

This PR enables two settings that both individually and combined allow for stricter RBAC permissions and bring us closer to being able to deploy multiple control plane installations per cluster.