### PR TITLE
Ignore context canceled errors in proxy test

### DIFF
--- a/pkg/grpc/proxy/handler_test.go
+++ b/pkg/grpc/proxy/handler_test.go
@@ -145,7 +145,10 @@ func (s *assertingService) PingStream(stream pb.TestService_PingStreamServer) er
 			if s.expectPingStreamError.Load() {
 				require.Error(s.t, err, "should have failed reading stream - test name: "+testName)
 			} else {
-				require.NoError(s.t, err, "can't fail reading stream - test name: "+testName)
+				// Ignore the case where error is context.Canceled which signifies the end of a test
+				if !errors.Is(err, context.Canceled) {
+					require.NoError(s.t, err, "can't fail reading stream - test name: "+testName)
+				}
 			}
 			return err
 		}

--- a/pkg/grpc/proxy/handler_test.go
+++ b/pkg/grpc/proxy/handler_test.go
@@ -144,11 +144,9 @@ func (s *assertingService) PingStream(stream pb.TestService_PingStreamServer) er
 		} else if err != nil {
 			if s.expectPingStreamError.Load() {
 				require.Error(s.t, err, "should have failed reading stream - test name: "+testName)
-			} else {
+			} else if !errors.Is(err, context.Canceled) {
 				// Ignore the case where error is context.Canceled which signifies the end of a test
-				if !errors.Is(err, context.Canceled) {
-					require.NoError(s.t, err, "can't fail reading stream - test name: "+testName)
-				}
+				require.NoError(s.t, err, "can't fail reading stream - test name: "+testName)
 			}
 			return err
 		}


### PR DESCRIPTION
The stream can receive a context canceled error if it's the end of the test. It should not be considered a test failure.

Fixes some flakiness in the gRPC proxy test