### PR TITLE
Add CI step to detect disallowed changes to go.mod

### DIFF
--- a/.github/scripts/check_go_mod.mjs
+++ b/.github/scripts/check_go_mod.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import {readFile} from 'node:fs/promises'
+
+const match = `// Uncomment for local development for testing with changes in the components-contrib repository.
+// Don't commit with this uncommented!
+//
+// replace github.com/dapr/components-contrib => ../components-contrib
+//
+// Then, run \`make modtidy\` in this repository.
+// This ensures that go.mod and go.sum are up-to-date.`
+
+const read = await readFile('go.mod', {encoding: 'utf8'})
+if (!read.includes(match)) {
+    console.log('File go.mod was committed with a change in the block around "replace github.com/dapr/components-contrib"')
+    process.exit(1)
+}
+console.log('go.mod is ok')

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -135,6 +135,9 @@ jobs:
           key: ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-build-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ matrix.target_os }}-${{ matrix.target_arch }}-go-${{ env.GOVER }}-build-
+      - name: Check for disallowed changes in go.mod
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
+        run: node ./.github/scripts/check_go_mod.mjs
       - name: golangci-lint
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
         uses: golangci/golangci-lint-action@v3.2.0

--- a/go.mod
+++ b/go.mod
@@ -422,7 +422,6 @@ replace (
 // Don't commit with this uncommented!
 //
 // replace github.com/dapr/components-contrib => ../components-contrib
-
 //
 // Then, run `make modtidy` in this repository.
 // This ensures that go.mod and go.sum are up-to-date.


### PR DESCRIPTION
Makes sure that people don't accidentally make commits with changes in the go.mod around the code to replace components-contrib

Catches issues such as #5809 too