### PR TITLE
Load secret stores before other kinds of components

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2476,12 +2476,12 @@ func (a *DaprRuntime) loadComponents(opts *runtimeOpts) error {
 	// First, we look for secret stores and load those, then all other components
 	// Sure, we could sort the list of authorizedComps... but this is simpler and most certainly faster
 	for _, comp := range authorizedComps {
-		if strings.HasPrefix(comp.Spec.Type, "secretstores.") {
+		if strings.HasPrefix(comp.Spec.Type, string(components.CategorySecretStore)+".") {
 			a.pendingComponents <- comp
 		}
 	}
 	for _, comp := range authorizedComps {
-		if !strings.HasPrefix(comp.Spec.Type, "secretstores.") {
+		if !strings.HasPrefix(comp.Spec.Type, string(components.CategorySecretStore)+".") {
 			a.pendingComponents <- comp
 		}
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2472,8 +2472,18 @@ func (a *DaprRuntime) loadComponents(opts *runtimeOpts) error {
 	a.components = authorizedComps
 	a.componentsLock.Unlock()
 
+	// Iterate through the list twice
+	// First, we look for secret stores and load those, then all other components
+	// Sure, we could sort the list of authorizedComps... but this is simpler and most certainly faster
 	for _, comp := range authorizedComps {
-		a.pendingComponents <- comp
+		if strings.HasPrefix(comp.Spec.Type, "secretstores.") {
+			a.pendingComponents <- comp
+		}
+	}
+	for _, comp := range authorizedComps {
+		if !strings.HasPrefix(comp.Spec.Type, "secretstores.") {
+			a.pendingComponents <- comp
+		}
 	}
 
 	return nil
@@ -2748,6 +2758,8 @@ func (a *DaprRuntime) WaitUntilShutdown() error {
 	return <-a.shutdownC
 }
 
+// Returns the component updated with the secrets applied.
+// If the component references a secret store that hasn't been loaded yet, it returns the name of the secret store component as second returned value.
 func (a *DaprRuntime) processComponentSecrets(component componentsV1alpha1.Component) (componentsV1alpha1.Component, string) {
 	cache := map[string]secretstores.GetSecretResponse{}
 


### PR DESCRIPTION
This makes it so users won't see a warning like `component X references a secret store that isn't loaded` if the component was just loaded later 

> Note: users could still see the warning in case a secret store references secrets from another secret store that is loaded after. For example, if secret store A references a secret in store B (it will still work, but there'll be a warning). This doesn't apply to secrets that are loaded from the built-in K8s secret store, which is always loaded as the very first thing.

Fixes #5727