### PR TITLE
provide more information on where we are listening when starting up

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -131,14 +131,16 @@ func (s *server) StartNonBlocking() error {
 		if err != nil {
 			return err
 		}
+		s.logger.Infof("gRPC listening on UNIX socket at %s", socket)
 		listeners = append(listeners, l)
 	} else {
 		for _, apiListenAddress := range s.config.APIListenAddresses {
 			addr := apiListenAddress + ":" + strconv.Itoa(s.config.Port)
 			l, err := net.Listen("tcp", addr)
 			if err != nil {
-				s.logger.Debugf("Failed to listen on %s with error: %v", addr, err)
+				s.logger.Debugf("Failed to listen gRPC on TCP at %s with error: %v", addr, err)
 			} else {
+				s.logger.Infof("gRPC listening on TCP socket at %s", addr)
 				listeners = append(listeners, l)
 			}
 		}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -104,14 +104,16 @@ func (s *server) StartNonBlocking() error {
 		if err != nil {
 			return err
 		}
+		log.Infof("HTTP server Listening on UNIX socket at %s", socket)
 		listeners = append(listeners, l)
 	} else {
 		for _, apiListenAddress := range s.config.APIListenAddresses {
 			addr := apiListenAddress + ":" + strconv.Itoa(s.config.Port)
 			l, err := net.Listen("tcp", addr)
 			if err != nil {
-				log.Debugf("Failed to listen on %s with error: %v", addr, err)
+				log.Debugf("Failed to listen HTTP on TCP at %s with error: %v", addr, err)
 			} else {
+				log.Infof("HTTP server Listening on TCP at %s", addr)
 				listeners = append(listeners, l)
 			}
 		}
@@ -160,11 +162,11 @@ func (s *server) StartNonBlocking() error {
 	if s.config.EnableProfiling {
 		for _, apiListenAddress := range s.config.APIListenAddresses {
 			addr := apiListenAddress + ":" + strconv.Itoa(s.config.ProfilePort)
-			log.Infof("starting profiling server on %s", addr)
 			pl, err := net.Listen("tcp", addr)
 			if err != nil {
-				log.Debugf("Failed to listen on %s with error: %v", addr, err)
+				log.Debugf("Failed to listen HTTP for Profiling at %s with error: %v", addr, err)
 			} else {
+				log.Infof("Starting listening HTTP for Profiling at %s", addr)
 				profilingListeners = append(profilingListeners, pl)
 			}
 		}


### PR DESCRIPTION
# Description

Add Info log messages when we bind to a UNIX/TCP socket

## Issue reference


Please reference the issue this PR will close: #5830 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
