### PR TITLE
Revert "Fixes metric grouping for CPU usage graphs."

### DIFF
--- a/grafana/grafana-system-services-dashboard.json
+++ b/grafana/grafana-system-services-dashboard.json
@@ -154,9 +154,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(label_replace(rate(container_cpu_usage_seconds_total{pod=~\"(feed-generator|hashtag-actor|hashtag-counter|pubsub-workflow|validation-worker|message-analyzer).*\", namespace=\"longhaul-test\"}[5m]), \"app_name\", \"$1\", \"pod\", \"(.*-app)-.*\")) by (app_name)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"(dapr-sentry|dapr-sidecar-injector|dapr-placement-server|dapr-operator).*\"}[5m])) by (pod)",
           "interval": "",
-          "legendFormat": "{{app_name}}",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
# Description

This reverts commit 86cb534aab1928f4201708d4294446052440ef26, done as part of dapr/dapr#5525, which did not modify the appropriate place (dapr workloads).

Signed-off-by: Tiago Alves Macambira <tmacam@burocrata.org>

## Issue reference

Please reference the issue this PR will close: #5524

Reverts PR dapr/dapr#5525

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
