### PR TITLE
cloudevent override to use dots instead of dashes

### DIFF
--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -1958,9 +1958,9 @@ func TestPublishTopic(t *testing.T) {
 			PubsubName: "pubsub",
 			Topic:      "topic",
 			Metadata: map[string]string{
-				"cloudevent-source": "unit-test",
-				"cloudevent-topic":  "overridetopic",  // noop -- if this modified the envelope the test would fail
-				"cloudevent-pubsub": "overridepubsub", // noop -- if this modified the envelope the test would fail
+				"cloudevent.source": "unit-test",
+				"cloudevent.topic":  "overridetopic",  // noop -- if this modified the envelope the test would fail
+				"cloudevent.pubsub": "overridepubsub", // noop -- if this modified the envelope the test would fail
 			},
 		})
 		assert.Nil(t, err)
@@ -2150,9 +2150,9 @@ func TestBulkPublish(t *testing.T) {
 			Topic:      "topic",
 			Entries:    sampleEntries,
 			Metadata: map[string]string{
-				"cloudevent-source": "unit-test",
-				"cloudevent-topic":  "overridetopic",  // noop -- if this modified the envelope the test would fail
-				"cloudevent-pubsub": "overridepubsub", // noop -- if this modified the envelope the test would fail
+				"cloudevent.source": "unit-test",
+				"cloudevent.topic":  "overridetopic",  // noop -- if this modified the envelope the test would fail
+				"cloudevent.pubsub": "overridepubsub", // noop -- if this modified the envelope the test would fail
 			},
 		})
 		assert.Nil(t, err)

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -364,9 +364,9 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 			},
 			ContentType: "application/json",
 			Metadata: map[string]string{
-				"cloudevent-source": "unit-test",
-				"cloudevent-topic":  "overridetopic",  // noop -- if this modified the envelope the test would fail
-				"cloudevent-pubsub": "overridepubsub", // noop -- if this modified the envelope the test would fail
+				"cloudevent.source": "unit-test",
+				"cloudevent.topic":  "overridetopic",  // noop -- if this modified the envelope the test would fail
+				"cloudevent.pubsub": "overridepubsub", // noop -- if this modified the envelope the test would fail
 			},
 		},
 	}

--- a/pkg/runtime/pubsub/cloudevents.go
+++ b/pkg/runtime/pubsub/cloudevents.go
@@ -21,18 +21,18 @@ import (
 )
 
 // CloudEvent is a request object to create a Dapr compliant cloudevent.
-// The cloud event properties can manually be overwritten by using metadata beginning with "cloudevent-" as prefix.
+// The cloud event properties can manually be overwritten by using metadata beginning with "cloudevent." as prefix.
 type CloudEvent struct {
-	ID              string `mapstructure:"cloudevent-id"`
+	ID              string `mapstructure:"cloudevent.id"`
 	Data            []byte `mapstructure:"-"` // cannot be overridden
 	Topic           string `mapstructure:"-"` // cannot be overridden
 	Pubsub          string `mapstructure:"-"` // cannot be overridden
 	DataContentType string `mapstructure:"-"` // cannot be overridden
-	TraceID         string `mapstructure:"cloudevent-traceid"`
-	TraceState      string `mapstructure:"cloudevent-tracestate"`
-	Source          string `mapstructure:"cloudevent-source"`
-	Type            string `mapstructure:"cloudevent-type"`
-	TraceParent     string `mapstructure:"cloudevent-traceparent"`
+	TraceID         string `mapstructure:"cloudevent.traceid"`
+	TraceState      string `mapstructure:"cloudevent.tracestate"`
+	Source          string `mapstructure:"cloudevent.source"`
+	Type            string `mapstructure:"cloudevent.type"`
+	TraceParent     string `mapstructure:"cloudevent.traceparent"`
 }
 
 // NewCloudEvent encapsulates the creation of a Dapr cloudevent from an existing cloudevent or a raw payload.
@@ -41,7 +41,7 @@ func NewCloudEvent(req *CloudEvent, metadata map[string]string) (map[string]inte
 		return contribPubsub.FromCloudEvent(req.Data, req.Topic, req.Pubsub, req.TraceID, req.TraceState)
 	}
 
-	// certain metadata beginning with "cloudevent-" are considered overrides to the cloudevent envelope
+	// certain metadata beginning with "cloudevent." are considered overrides to the cloudevent envelope
 	// we ignore any error here as the original cloud event envelope is still valid
 	_ = mapstructure.WeakDecode(metadata, req) // allows ignoring of case
 

--- a/pkg/runtime/pubsub/cloudevents_test.go
+++ b/pkg/runtime/pubsub/cloudevents_test.go
@@ -71,7 +71,7 @@ func TestNewCloudEvent(t *testing.T) {
 		}, map[string]string{
 			// these properties should not actually override anything
 			"cloudevent.topic":           "overridetopic",
-			"cldouevent-pubsub":          "overridepubsub",
+			"cloudevent.pubsub":          "overridepubsub",
 			"cloudevent.data":            "overridedata",
 			"cloudevent.datacontenttype": "overridedatacontenttype",
 			// these properties should override

--- a/pkg/runtime/pubsub/cloudevents_test.go
+++ b/pkg/runtime/pubsub/cloudevents_test.go
@@ -70,16 +70,16 @@ func TestNewCloudEvent(t *testing.T) {
 			Data:            []byte("originaldata"),
 		}, map[string]string{
 			// these properties should not actually override anything
-			"cloudevent-topic":           "overridetopic",
+			"cloudevent.topic":           "overridetopic",
 			"cldouevent-pubsub":          "overridepubsub",
-			"cloudevent-data":            "overridedata",
-			"cloudevent-datacontenttype": "overridedatacontenttype",
+			"cloudevent.data":            "overridedata",
+			"cloudevent.datacontenttype": "overridedatacontenttype",
 			// these properties should override
-			"cloudevent-source":      "overridesource",
-			"cloudevent-id":          "overrideid",
-			"cloudevent-type":        "overridetype",
-			"cloudevent-traceparent": "overridetraceparent",
-			"cloudevent-tracestate":  "overridetracestate",
+			"cloudevent.source":      "overridesource",
+			"cloudevent.id":          "overrideid",
+			"cloudevent.type":        "overridetype",
+			"cloudevent.traceparent": "overridetraceparent",
+			"cloudevent.tracestate":  "overridetracestate",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, "originalpubsub", ce["pubsubname"].(string))


### PR DESCRIPTION
Signed-off-by: Bernd Verst <github@bernd.dev>

# Description

Fixes #5515 

Cloudevent override to use dots instead of dashes
Why no love for dashes? 😢 