### PR TITLE
[release-1.10] Fix invoke 2xx

### DIFF
--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -25,9 +25,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-
-	"github.com/dapr/components-contrib/lock"
-
 	grpcMiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +43,7 @@ import (
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/components-contrib/configuration"
+	"github.com/dapr/components-contrib/lock"
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/components-contrib/state"

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -1707,8 +1707,10 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 			} else {
 				resStatus.Code = statusCode
 			}
-		} else if resStatus.Code != fasthttp.StatusOK {
-			return rResp, fmt.Errorf("Received non-successful status code: %d", resStatus.Code) //nolint:stylecheck
+		} else if resStatus.Code < 200 || resStatus.Code > 299 {
+			// We are not returning an `invokeError` here on purpose.
+			// Returning an error that is not an `invokeError` will cause Resiliency to retry the request (if retries are enabled), but if the request continues to fail, the response is sent to the user with whatever status code the app returned so the "received non-successful status code" is "swallowed" (will appear in logs but won't be returned to the app).
+			return rResp, fmt.Errorf("received non-successful status code: %d", resStatus.Code)
 		}
 		return rResp, nil
 	})

--- a/pkg/testing/directmessaging_mock.go
+++ b/pkg/testing/directmessaging_mock.go
@@ -15,6 +15,7 @@ package testing
 
 import (
 	"context"
+	"net/http"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -57,7 +58,8 @@ func (_m *MockDirectMessaging) Close() error {
 }
 
 type FailingDirectMessaging struct {
-	Failure Failure
+	Failure           Failure
+	SuccessStatusCode int
 }
 
 func (f *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
@@ -69,7 +71,12 @@ func (f *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string,
 	if err != nil {
 		return &invokev1.InvokeMethodResponse{}, err
 	}
-	resp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
+	statusCode := f.SuccessStatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	resp := invokev1.
+		NewInvokeMethodResponse(int32(statusCode), http.StatusText(statusCode), nil).
 		WithRawDataBytes(r.Message.Data.Value)
 	return resp, nil
 }


### PR DESCRIPTION
When performing HTTP service invocation, only responses with a 200 status code were considered successful, and other 2xx were treated as failures. Because of that, even thought he user would ultimately get the response with a 2xx status code as if "nothing happened", the request would be retried if the resiliency policy had retries on.

This only applied to HTTP APIs; gRPC ones were already working as expected (when calling HTTP endpoints)