### PR TITLE
Fix summary tests for windows

### DIFF
--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -24,8 +24,17 @@ import (
 	"github.com/labstack/gommon/log"
 )
 
+const (
+	// testNameSeparator is the default character used by go test to separate between suitecases under the same test func.
+	testNameSeparator = "/"
+)
+
+func sanitizeTestName(testName string) string {
+	return strings.ReplaceAll(testName, testNameSeparator, "_")
+}
+
 func filePath(prefix, testName string) string {
-	return fmt.Sprintf("%s_summary_table_%s.json", prefix, strings.ReplaceAll(testName, string(os.PathSeparator), "_"))
+	return fmt.Sprintf("%s_summary_table_%s.json", prefix, sanitizeTestName(testName))
 }
 
 // Table is primarily used as a source of arbitrary test output. Tests can send output to the summary table and later flush them.


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

The test is failing on windows due to wrong use of os.PathSeparator since it is always "/".

## Issue reference

N/A
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
