### PR TITLE
Add table metrics for all perf tests

### DIFF
--- a/tests/perf/actor_activation/actor_activation_test.go
+++ b/tests/perf/actor_activation/actor_activation_test.go
@@ -93,9 +93,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorActivate(t *testing.T) {
-	table := summary.ForTest(t)
-	defer table.Flush()
-
 	p := perf.Params(
 		perf.WithQPS(500),
 		perf.WithConnections(8),
@@ -178,15 +175,17 @@ func TestActorActivate(t *testing.T) {
 		t.Error(err)
 	}
 
-	table.Output("Service", serviceApplicationName).
-		Output("Client", clientApplicationName).
-		Outputf("CPU", "%vm", appUsage.CPUm).
-		Outputf("Memory", "%vMb", appUsage.MemoryMb).
-		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
-		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
-		OutputInt("Restarts", restarts).
-		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
-		OutputInt("QPS", p.QPS)
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		Client(clientApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_activation/actor_activation_test.go
+++ b/tests/perf/actor_activation/actor_activation_test.go
@@ -185,6 +185,7 @@ func TestActorActivate(t *testing.T) {
 		Restarts(restarts).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)

--- a/tests/perf/actor_double_activation/actor_double_activation_test.go
+++ b/tests/perf/actor_double_activation/actor_double_activation_test.go
@@ -26,6 +26,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/dapr/dapr/tests/runner/loadtest"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,11 +85,31 @@ func TestActorDoubleActivation(t *testing.T) {
 	defer k6Test.Dispose()
 	t.Log("running the k6 load test...")
 	require.NoError(t, tr.Platform.LoadTest(k6Test))
-	summary, err := loadtest.K6Result[json.RawMessage](k6Test)
+	sm, err := loadtest.K6ResultDefault(k6Test)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	bts, err := json.MarshalIndent(summary, "", " ")
+	require.NotNil(t, sm)
+	bts, err := json.MarshalIndent(sm, "", " ")
 	require.NoError(t, err)
-	require.True(t, summary.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
+	appUsage, err := tr.Platform.GetAppUsage(serviceApplicationName)
+	require.NoError(t, err)
+
+	sidecarUsage, err := tr.Platform.GetSidecarUsage(serviceApplicationName)
+	require.NoError(t, err)
+
+	restarts, err := tr.Platform.GetTotalRestarts(serviceApplicationName)
+	require.NoError(t, err)
+
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		OutputK6(sm.RunnersResults).
+		Flush()
+
+	require.True(t, sm.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
 	t.Logf("test summary `%s`", string(bts))
+
 }

--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -187,6 +187,7 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 		Restarts(restarts).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)

--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -96,9 +96,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorReminderRegistrationPerformance(t *testing.T) {
-	table := summary.ForTest(t)
-	defer table.Flush()
-
 	p := perf.Params(
 		perf.WithQPS(500),
 		perf.WithConnections(8),
@@ -180,15 +177,17 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 		t.Error(err)
 	}
 
-	table.Output("Service", serviceApplicationName).
-		Output("Client", clientApplicationName).
-		Outputf("CPU", "%vm", appUsage.CPUm).
-		Outputf("Memory", "%vMb", appUsage.MemoryMb).
-		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
-		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
-		OutputInt("Restarts", restarts).
-		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
-		OutputInt("QPS", p.QPS)
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		Client(clientApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_timer/actor_timer_test.go
+++ b/tests/perf/actor_timer/actor_timer_test.go
@@ -183,6 +183,7 @@ func TestActorTimerWithStatePerformance(t *testing.T) {
 		Restarts(restarts).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)

--- a/tests/perf/actor_timer/actor_timer_test.go
+++ b/tests/perf/actor_timer/actor_timer_test.go
@@ -93,8 +93,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorTimerWithStatePerformance(t *testing.T) {
-	table := summary.ForTest(t)
-	defer table.Flush()
 	p := perf.Params(
 		perf.WithQPS(220),
 		perf.WithConnections(10),
@@ -175,15 +173,17 @@ func TestActorTimerWithStatePerformance(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	table.Output("Service", serviceApplicationName).
-		Output("Client", clientApplicationName).
-		Outputf("CPU", "%vm", appUsage.CPUm).
-		Outputf("Memory", "%vMb", appUsage.MemoryMb).
-		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
-		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
-		OutputInt("Restarts", restarts).
-		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
-		OutputInt("QPS", p.QPS)
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		Client(clientApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_type_scale/actor_type_scale_test.go
+++ b/tests/perf/actor_type_scale/actor_type_scale_test.go
@@ -26,6 +26,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/dapr/dapr/tests/runner/loadtest"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,13 +90,11 @@ func TestActorIdStress(t *testing.T) {
 	// defer k6Test.Dispose()
 	t.Log("running the k6 load test...")
 	require.NoError(t, tr.Platform.LoadTest(k6Test))
-	summary, err := loadtest.K6ResultDefault(k6Test)
+	sm, err := loadtest.K6ResultDefault(k6Test)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	bts, err := json.MarshalIndent(summary, "", " ")
+	require.NotNil(t, sm)
+	bts, err := json.MarshalIndent(sm, "", " ")
 	require.NoError(t, err)
-	require.True(t, summary.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
-	t.Logf("test summary `%s`", string(bts))
 
 	appUsage, err := tr.Platform.GetAppUsage(serviceApplicationName)
 	require.NoError(t, err)
@@ -106,8 +105,21 @@ func TestActorIdStress(t *testing.T) {
 	restarts, err := tr.Platform.GetTotalRestarts(serviceApplicationName)
 	require.NoError(t, err)
 
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		OutputK6(sm.RunnersResults).
+		Flush()
+
 	t.Logf("target dapr app consumed %vm CPU and %vMb of Memory", appUsage.CPUm, appUsage.MemoryMb)
 	t.Logf("target dapr sidecar consumed %vm CPU and %vMb of Memory", sidecarUsage.CPUm, sidecarUsage.MemoryMb)
 	t.Logf("target dapr app or sidecar restarted %v times", restarts)
+
+	require.True(t, sm.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
 	require.Equal(t, 0, restarts)
+	t.Logf("test summary `%s`", string(bts))
 }

--- a/tests/perf/pubsub_bulk_publish_grpc/pubsub_bulk_publish_grpc_test.go
+++ b/tests/perf/pubsub_bulk_publish_grpc/pubsub_bulk_publish_grpc_test.go
@@ -201,6 +201,7 @@ func TestBulkPubsubPublishGrpcPerformance(t *testing.T) {
 				OutputFloat64("Increase in QPS", increaseQPS).
 				ActualQPS(bulkResult.ActualQPS).
 				Params(p).
+				OutputFortio(bulkResult).
 				Flush()
 
 			report := perf.NewTestReport(

--- a/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
+++ b/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -144,9 +145,25 @@ func TestPubsubPublishGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("tester").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
+++ b/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
@@ -163,6 +163,7 @@ func TestPubsubPublishGrpcPerformance(t *testing.T) {
 		AddedLatency(avg).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	report := perf.NewTestReport(

--- a/tests/perf/pubsub_publish_http/pubsub_publish_http_test.go
+++ b/tests/perf/pubsub_publish_http/pubsub_publish_http_test.go
@@ -27,6 +27,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/dapr/dapr/tests/runner/loadtest"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,11 +77,14 @@ func TestPubsubPublishHttpPerformance(t *testing.T) {
 	defer k6Test.Dispose()
 	t.Log("running the k6 load test...")
 	require.NoError(t, tr.Platform.LoadTest(k6Test))
-	summary, err := loadtest.K6Result[json.RawMessage](k6Test)
+	sm, err := loadtest.K6ResultDefault(k6Test)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	bts, err := json.MarshalIndent(summary, "", " ")
+	require.NotNil(t, sm)
+	summary.ForTest(t).
+		OutputK6(sm.RunnersResults).
+		Flush()
+	bts, err := json.MarshalIndent(sm, "", " ")
 	require.NoError(t, err)
-	require.True(t, summary.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
+	require.True(t, sm.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
 	t.Logf("test summary `%s`", string(bts))
 }

--- a/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
+++ b/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -180,9 +181,25 @@ func TestServiceInvocationGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("testapp").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
+++ b/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
@@ -199,6 +199,7 @@ func TestServiceInvocationGrpcPerformance(t *testing.T) {
 		AddedLatency(avg).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	report := perf.NewTestReport(

--- a/tests/perf/service_invocation_http/service_invocation_http_test.go
+++ b/tests/perf/service_invocation_http/service_invocation_http_test.go
@@ -195,6 +195,7 @@ func TestServiceInvocationHTTPPerformance(t *testing.T) {
 		AddedLatency(avg).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	report := perf.NewTestReport(

--- a/tests/perf/state_get_grpc/state_get_grpc_test.go
+++ b/tests/perf/state_get_grpc/state_get_grpc_test.go
@@ -163,6 +163,7 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 		AddedLatency(avg).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	report := perf.NewTestReport(

--- a/tests/perf/state_get_grpc/state_get_grpc_test.go
+++ b/tests/perf/state_get_grpc/state_get_grpc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -144,9 +145,25 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("tester").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/state_get_http/state_get_http_test.go
+++ b/tests/perf/state_get_http/state_get_http_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -145,9 +146,25 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("tester").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/state_get_http/state_get_http_test.go
+++ b/tests/perf/state_get_http/state_get_http_test.go
@@ -164,6 +164,7 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 		AddedLatency(avg).
 		ActualQPS(daprResult.ActualQPS).
 		Params(p).
+		OutputFortio(daprResult).
 		Flush()
 
 	report := perf.NewTestReport(

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -130,6 +130,16 @@ func (t *Table) QPS(qps int) *Table {
 	return t.OutputInt("QPS", qps)
 }
 
+// P90 is a short for .Outputf("P90", "%2.fms")
+func (t *Table) P90(p90 float64) *Table {
+	return t.Outputf("P90", "%.2fms", p90)
+}
+
+// P90 is a short for .Outputf("P90", "%2.fms")
+func (t *Table) P99(p99 float64) *Table {
+	return t.Outputf("P99", "%.2fms", p99)
+}
+
 // QPS is a short for .OutputInt("QPS")
 func (t *Table) Params(p perf.TestParameters) *Table {
 	return t.QPS(p.QPS).
@@ -148,6 +158,21 @@ func (t *Table) OutputK6Trend(prefix string, unit string, trend loadtest.K6Trend
 	t.Outputf(fmt.Sprintf("%s P90", prefix), "%f%s", trend.Values.P90, unit)
 	t.Outputf(fmt.Sprintf("%s P95", prefix), "%f%s", trend.Values.P95, unit)
 	return t
+}
+
+const (
+	p90Index = 2
+	p99Index = 3
+)
+
+// OutputFortio summarize the fortio results.
+func (t *Table) OutputFortio(result perf.TestResult) *Table {
+	return t.
+		P90(result.DurationHistogram.Percentiles[p90Index].Value).
+		P99(result.DurationHistogram.Percentiles[p99Index].Value).
+		OutputInt("2xx", result.RetCodes.Num200).
+		OutputInt("4xx", result.RetCodes.Num400).
+		OutputInt("5xx", result.RetCodes.Num500)
 }
 
 // OutputK6 summarize the K6 results for each runner.

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -140,13 +140,13 @@ func (t *Table) Params(p perf.TestParameters) *Table {
 }
 
 // OutputK6Trend outputs the given k6trend using the given prefix.
-func (t *Table) OutputK6Trend(prefix string, trend loadtest.K6TrendMetric) *Table {
-	t.OutputFloat64(fmt.Sprintf("%s MAX", prefix), trend.Values.Max)
-	t.OutputFloat64(fmt.Sprintf("%s MIN", prefix), trend.Values.Min)
-	t.OutputFloat64(fmt.Sprintf("%s AVG", prefix), trend.Values.Avg)
-	t.OutputFloat64(fmt.Sprintf("%s MED", prefix), trend.Values.Med)
-	t.OutputFloat64(fmt.Sprintf("%s P90", prefix), trend.Values.P90)
-	t.OutputFloat64(fmt.Sprintf("%s P95", prefix), trend.Values.P95)
+func (t *Table) OutputK6Trend(prefix string, unit string, trend loadtest.K6TrendMetric) *Table {
+	t.Outputf(fmt.Sprintf("%s MAX", prefix), "%f%s", trend.Values.Max, unit)
+	t.Outputf(fmt.Sprintf("%s MIN", prefix), "%f%s", trend.Values.Min, unit)
+	t.Outputf(fmt.Sprintf("%s AVG", prefix), "%f%s", trend.Values.Avg, unit)
+	t.Outputf(fmt.Sprintf("%s MED", prefix), "%f%s", trend.Values.Med, unit)
+	t.Outputf(fmt.Sprintf("%s P90", prefix), "%f%s", trend.Values.P90, unit)
+	t.Outputf(fmt.Sprintf("%s P95", prefix), "%f%s", trend.Values.P95, unit)
 	return t
 }
 
@@ -155,8 +155,8 @@ func (t *Table) OutputK6(k6results []*loadtest.K6RunnerMetricsSummary) *Table {
 	for i, result := range k6results {
 		t.OutputInt(fmt.Sprintf("[Runner %d]: VUs Max", i), result.Vus.Values.Max)
 		t.OutputFloat64(fmt.Sprintf("[Runner %d]: Iterations Count", i), result.Iterations.Values.Count)
-		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req duration", i), result.HTTPReqDuration)
-		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req Waiting", i), result.HTTPReqWaiting)
+		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req duration", i), "ms", result.HTTPReqDuration)
+		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req Waiting", i), "ms", result.HTTPReqWaiting)
 	}
 	return t
 }

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -165,11 +165,15 @@ const (
 	p99Index = 3
 )
 
+const (
+	secondToMillisecond = 1000
+)
+
 // OutputFortio summarize the fortio results.
 func (t *Table) OutputFortio(result perf.TestResult) *Table {
 	return t.
-		P90(result.DurationHistogram.Percentiles[p90Index].Value).
-		P99(result.DurationHistogram.Percentiles[p99Index].Value).
+		P90(result.DurationHistogram.Percentiles[p90Index].Value*secondToMillisecond).
+		P99(result.DurationHistogram.Percentiles[p99Index].Value*secondToMillisecond).
 		OutputInt("2xx", result.RetCodes.Num200).
 		OutputInt("4xx", result.RetCodes.Num400).
 		OutputInt("5xx", result.RetCodes.Num500)

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dapr/dapr/tests/perf"
 	"github.com/dapr/dapr/tests/runner/loadtest"
+
 	"github.com/labstack/gommon/log"
 )
 

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -149,14 +149,24 @@ func (t *Table) Params(p perf.TestParameters) *Table {
 		OutputInt("PayloadSizeKB", p.PayloadSizeKB)
 }
 
+type unit string
+
+const (
+	millisecond unit = "ms"
+)
+
+var unitFormats = map[unit]string{
+	millisecond: "%.2fms",
+}
+
 // OutputK6Trend outputs the given k6trend using the given prefix.
-func (t *Table) OutputK6Trend(prefix string, unit string, trend loadtest.K6TrendMetric) *Table {
-	t.Outputf(fmt.Sprintf("%s MAX", prefix), "%f%s", trend.Values.Max, unit)
-	t.Outputf(fmt.Sprintf("%s MIN", prefix), "%f%s", trend.Values.Min, unit)
-	t.Outputf(fmt.Sprintf("%s AVG", prefix), "%f%s", trend.Values.Avg, unit)
-	t.Outputf(fmt.Sprintf("%s MED", prefix), "%f%s", trend.Values.Med, unit)
-	t.Outputf(fmt.Sprintf("%s P90", prefix), "%f%s", trend.Values.P90, unit)
-	t.Outputf(fmt.Sprintf("%s P95", prefix), "%f%s", trend.Values.P95, unit)
+func (t *Table) OutputK6Trend(prefix string, unit unit, trend loadtest.K6TrendMetric) *Table {
+	t.Outputf(fmt.Sprintf("%s MAX", prefix), unitFormats[unit], trend.Values.Max)
+	t.Outputf(fmt.Sprintf("%s MIN", prefix), unitFormats[unit], trend.Values.Min)
+	t.Outputf(fmt.Sprintf("%s AVG", prefix), unitFormats[unit], trend.Values.Avg)
+	t.Outputf(fmt.Sprintf("%s MED", prefix), unitFormats[unit], trend.Values.Med)
+	t.Outputf(fmt.Sprintf("%s P90", prefix), unitFormats[unit], trend.Values.P90)
+	t.Outputf(fmt.Sprintf("%s P95", prefix), unitFormats[unit], trend.Values.P95)
 	return t
 }
 
@@ -184,8 +194,8 @@ func (t *Table) OutputK6(k6results []*loadtest.K6RunnerMetricsSummary) *Table {
 	for i, result := range k6results {
 		t.OutputInt(fmt.Sprintf("[Runner %d]: VUs Max", i), result.Vus.Values.Max)
 		t.OutputFloat64(fmt.Sprintf("[Runner %d]: Iterations Count", i), result.Iterations.Values.Count)
-		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req duration", i), "ms", result.HTTPReqDuration)
-		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req Waiting", i), "ms", result.HTTPReqWaiting)
+		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req duration", i), millisecond, result.HTTPReqDuration)
+		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req Waiting", i), millisecond, result.HTTPReqWaiting)
 	}
 	return t
 }


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

This is a continuation of https://github.com/dapr/dapr/pull/5856. Now we should be able to see metrics of k6 perf tests as well.

## Issue reference

Please reference the issue this PR will close: #5800 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
