### PR TITLE
[WIP] Filter daprEnabled label to reduce operator's memory consumption

### DIFF
--- a/pkg/operator/handlers/dapr_handler_test.go
+++ b/pkg/operator/handlers/dapr_handler_test.go
@@ -120,6 +120,7 @@ func TestCreateDaprServiceAppIDAndMetricsSettings(t *testing.T) {
 	assert.Equal(t, "true", service.ObjectMeta.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "12345", service.ObjectMeta.Annotations["prometheus.io/port"])
 	assert.Equal(t, "/", service.ObjectMeta.Annotations["prometheus.io/path"])
+	assert.Equal(t, "true", service.Labels[daprEnabledAnnotationKey])
 
 	deployment.GetTemplateAnnotations()[daprEnableMetricsKey] = "false"
 
@@ -129,6 +130,8 @@ func TestCreateDaprServiceAppIDAndMetricsSettings(t *testing.T) {
 	assert.Equal(t, "", service.ObjectMeta.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "", service.ObjectMeta.Annotations["prometheus.io/port"])
 	assert.Equal(t, "", service.ObjectMeta.Annotations["prometheus.io/path"])
+	assert.Equal(t, "true", service.Labels[daprEnabledAnnotationKey])
+
 }
 
 func TestPatchDaprService(t *testing.T) {
@@ -160,6 +163,7 @@ func TestPatchDaprService(t *testing.T) {
 	assert.Len(t, actualService.OwnerReferences, 1)
 	assert.Equal(t, "Deployment", actualService.OwnerReferences[0].Kind)
 	assert.Equal(t, "app", actualService.OwnerReferences[0].Name)
+	assert.Equal(t, "true", actualService.Labels[daprEnabledAnnotationKey])
 
 	err = testDaprHandler.patchDaprService(ctx, myDaprService, deployment, actualService)
 	assert.NoError(t, err)
@@ -171,6 +175,7 @@ func TestPatchDaprService(t *testing.T) {
 	assert.Len(t, actualService.OwnerReferences, 1)
 	assert.Equal(t, "Deployment", actualService.OwnerReferences[0].Kind)
 	assert.Equal(t, "app", actualService.OwnerReferences[0].Name)
+	assert.Equal(t, "true", actualService.Labels[daprEnabledAnnotationKey])
 }
 
 func TestGetMetricsPort(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Alen Polakof <apolakof@Alens-MacBook-Pro.local>

# Description

Enable label based filtering for operator reconciler. An increase in the number of pods was producing high memory consumption since all the pods in the cluster with StatefulSets and Deployment were being watched for. This changes to only watch the pods that are part of the aforementioned set and also contain the dapr enabled label.   

NOTE: Currently, I'm watching for the daprEnabledAnnotationKey since it was already there and seems like it could do the job from reading the code? But I could also inject another label to it. 

## Issue reference 

Please reference the issue this PR will close: #5693 
