### PR TITLE
Using <namespace:name> format for allowed service accounts

### DIFF
--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -28,7 +28,7 @@ func TestGetInjectorConfig(t *testing.T) {
 		t.Setenv("SIDECAR_IMAGE_PULL_POLICY", "Always")
 		t.Setenv("NAMESPACE", "test-namespace")
 		t.Setenv("KUBE_CLUSTER_DOMAIN", "cluster.local")
-		t.Setenv("ALLOWED_SERVICE_ACCOUNTS", "test-service-account1:test1,test-service-account2:test2")
+		t.Setenv("ALLOWED_SERVICE_ACCOUNTS", "test1:test-service-account1,test2:test-service-account2")
 
 		cfg, err := GetConfig()
 		assert.NoError(t, err)
@@ -38,7 +38,7 @@ func TestGetInjectorConfig(t *testing.T) {
 		assert.Equal(t, "Always", cfg.SidecarImagePullPolicy)
 		assert.Equal(t, "test-namespace", cfg.Namespace)
 		assert.Equal(t, "cluster.local", cfg.KubeClusterDomain)
-		assert.Equal(t, "test-service-account1:test1,test-service-account2:test2", cfg.AllowedServiceAccounts)
+		assert.Equal(t, "test1:test-service-account1,test2:test-service-account2", cfg.AllowedServiceAccounts)
 	})
 
 	t.Run("not set kube cluster domain env", func(t *testing.T) {

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -46,13 +46,13 @@ const (
 var log = logger.NewLogger("dapr.injector")
 
 var AllowedServiceAccountInfos = []string{
-	"replicaset-controller:kube-system",
-	"deployment-controller:kube-system",
-	"cronjob-controller:kube-system",
-	"job-controller:kube-system",
-	"statefulset-controller:kube-system",
-	"daemon-set-controller:kube-system",
-	"tekton-pipelines-controller:tekton-pipelines",
+	"kube-system:replicaset-controller",
+	"kube-system:deployment-controller",
+	"kube-system:cronjob-controller",
+	"kube-system:job-controller",
+	"kube-system:statefulset-controller",
+	"kube-system:daemon-set-controller",
+	"tekton-pipelines:tekton-pipelines-controller",
 }
 
 // Injector is the interface for the Dapr runtime sidecar injection component.
@@ -148,7 +148,7 @@ func getServiceAccount(ctx context.Context, kubeClient kubernetes.Interface, all
 		serviceAccountInfo := strings.Split(allowedServiceInfo, ":")
 		found := false
 		for _, sa := range serviceaccounts.Items {
-			if sa.Name == serviceAccountInfo[0] && sa.Namespace == serviceAccountInfo[1] {
+			if sa.Namespace == serviceAccountInfo[0] && sa.Name == serviceAccountInfo[1] {
 				allowedUids = append(allowedUids, string(sa.ObjectMeta.UID))
 				found = true
 				break

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -576,8 +576,8 @@ func TestAllowedControllersServiceAccountUID(t *testing.T) {
 	client := kubernetesfake.NewSimpleClientset()
 
 	testCases := []struct {
-		name      string
 		namespace string
+		name      string
 	}{
 		{metav1.NamespaceSystem, "replicaset-controller"},
 		{"tekton-pipelines", "tekton-pipelines-controller"},

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -579,8 +579,8 @@ func TestAllowedControllersServiceAccountUID(t *testing.T) {
 		name      string
 		namespace string
 	}{
-		{"replicaset-controller", metav1.NamespaceSystem},
-		{"tekton-pipelines-controller", "tekton-pipelines"},
+		{metav1.NamespaceSystem, "replicaset-controller"},
+		{"tekton-pipelines", "tekton-pipelines-controller"},
 		{"test", "test"},
 	}
 


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Use `<namespace:sa-name>` to specify allowed service accounts into the sidecar injector by specifying the Environment Variable: `ALLOWED_SERVICE_ACCOUNTS`

## Issue reference


Fixes #5890 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
