### PR TITLE
Add option to Operator to disable the reconciler for Services

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -126,6 +126,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_operator.runAsNonRoot`              | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
 | `dapr_operator.resources`                 | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_operator.debug.enabled`             | Boolean value for enabling debug mode | `{}` |
+| `dapr_operator.serviceReconciler`         | Boolean value for enabling the reconciler that creates Services for Dapr-enabled Deployments and StatefulSets | `true` |
 | `dapr_operator.watchNamespace`            | The namespace to watch for annoated Dapr resources in | `""` |
 
 ### Dapr Placement options:

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -133,7 +133,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_operator.runAsNonRoot`              | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
 | `dapr_operator.resources`                 | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_operator.debug.enabled`             | Boolean value for enabling debug mode | `{}` |
-| `dapr_operator.serviceReconciler.disabled`| Boolean value for disabling the reconciler that creates Services for Dapr-enabled Deployments and StatefulSets.<br>Note: disabling this reconciler could prevent Dapr service invocation from working. | `false` |
+| `dapr_operator.serviceReconciler.enabled`| If false, disables the reconciler that creates Services for Dapr-enabled Deployments and StatefulSets.<br>Note: disabling this reconciler could prevent Dapr service invocation from working. | `true` |
 | `dapr_operator.watchNamespace`            | The namespace to watch for annoated Dapr resources in | `""` |
 
 ### Dapr Placement options:

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -126,7 +126,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_operator.runAsNonRoot`              | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
 | `dapr_operator.resources`                 | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_operator.debug.enabled`             | Boolean value for enabling debug mode | `{}` |
-| `dapr_operator.serviceReconciler`         | Boolean value for enabling the reconciler that creates Services for Dapr-enabled Deployments and StatefulSets.<br>Note: disabling this could prevent Dapr service invocation from working. | `true` |
+| `dapr_operator.serviceReconciler.disabled`| Boolean value for disabling the reconciler that creates Services for Dapr-enabled Deployments and StatefulSets.<br>Note: disabling this reconciler could prevent Dapr service invocation from working. | `false` |
 | `dapr_operator.watchNamespace`            | The namespace to watch for annoated Dapr resources in | `""` |
 
 ### Dapr Placement options:

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -126,7 +126,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_operator.runAsNonRoot`              | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
 | `dapr_operator.resources`                 | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
 | `dapr_operator.debug.enabled`             | Boolean value for enabling debug mode | `{}` |
-| `dapr_operator.serviceReconciler`         | Boolean value for enabling the reconciler that creates Services for Dapr-enabled Deployments and StatefulSets | `true` |
+| `dapr_operator.serviceReconciler`         | Boolean value for enabling the reconciler that creates Services for Dapr-enabled Deployments and StatefulSets.<br>Note: disabling this could prevent Dapr service invocation from working. | `true` |
 | `dapr_operator.watchNamespace`            | The namespace to watch for annoated Dapr resources in | `""` |
 
 ### Dapr Placement options:

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -188,7 +188,7 @@ spec:
         - "--watch-namespace"
         - "{{ .Values.watchNamespace }}"
 {{- end }}
-{{- if not .Values.serviceReconciler }}
+{{- if .Values.serviceReconciler.disabled }}
         - "--disable-service-reconciler"
 {{- end }}
       serviceAccountName: dapr-operator

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -188,6 +188,9 @@ spec:
         - "--watch-namespace"
         - "{{ .Values.watchNamespace }}"
 {{- end }}
+{{- if not .Values.serviceReconciler }}
+        - "--disable-service-reconciler"
+{{- end }}
       serviceAccountName: dapr-operator
       volumes:
         - name: credentials

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -188,7 +188,7 @@ spec:
         - "--watch-namespace"
         - "{{ .Values.watchNamespace }}"
 {{- end }}
-{{- if .Values.serviceReconciler.disabled }}
+{{- if not .Values.serviceReconciler.enabled }}
         - "--disable-service-reconciler"
 {{- end }}
       serviceAccountName: dapr-operator

--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 runAsNonRoot: true
 
 serviceReconciler:
-  disabled: false
+  enabled: true
 
 ports:
   protocol: TCP

--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -16,7 +16,8 @@ fullnameOverride: ""
 
 runAsNonRoot: true
 
-serviceReconciler: true
+serviceReconciler:
+  disabled: false
 
 ports:
   protocol: TCP

--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -16,6 +16,8 @@ fullnameOverride: ""
 
 runAsNonRoot: true
 
+serviceReconciler: true
+
 ports:
   protocol: TCP
   port: 80

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -20,24 +20,24 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/dapr/kit/logger"
-
 	"github.com/dapr/dapr/pkg/buildinfo"
 	"github.com/dapr/dapr/pkg/credentials"
 	"github.com/dapr/dapr/pkg/metrics"
 	"github.com/dapr/dapr/pkg/operator"
 	"github.com/dapr/dapr/pkg/operator/monitoring"
 	"github.com/dapr/dapr/pkg/signals"
+	"github.com/dapr/kit/logger"
 )
 
 var (
-	log                     = logger.NewLogger("dapr.operator")
-	config                  string
-	certChainPath           string
-	watchInterval           string
-	maxPodRestartsPerMinute int
-	disableLeaderElection   bool
-	watchNamespace          string
+	log                      = logger.NewLogger("dapr.operator")
+	config                   string
+	certChainPath            string
+	watchInterval            string
+	maxPodRestartsPerMinute  int
+	disableLeaderElection    bool
+	disableServiceReconciler bool
+	watchNamespace           string
 )
 
 //nolint:gosec
@@ -66,6 +66,7 @@ func main() {
 		WatchdogInterval:          0,
 		WatchdogMaxRestartsPerMin: maxPodRestartsPerMinute,
 		WatchNamespace:            watchNamespace,
+		ServiceReconcilerEnabled:  !disableServiceReconciler,
 	}
 
 	switch strings.ToLower(watchInterval) {
@@ -114,8 +115,9 @@ func init() {
 
 	flag.StringVar(&watchInterval, "watch-interval", defaultWatchInterval, "Interval for polling pods' state, e.g. '2m'. Set to '0' to disable, or 'once' to only run once when the operator starts")
 	flag.IntVar(&maxPodRestartsPerMinute, "max-pod-restarts-per-minute", defaultMaxPodRestartsPerMinute, "Maximum number of pods in an invalid state that can be restarted per minute")
-	flag.BoolVar(&disableLeaderElection, "disable-leader-election", false, "Disable leader election for operator")
 
+	flag.BoolVar(&disableLeaderElection, "disable-leader-election", false, "Disable leader election for operator")
+	flag.BoolVar(&disableServiceReconciler, "disable-service-reconciler", false, "Disable the Service reconciler for Dapr-enabled Deployments and StatefulSets")
 	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to watch Dapr annotated resources in")
 
 	flag.Parse()

--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -34,6 +34,10 @@ const (
 	defaultMetricsPort              = 9090
 	clusterIPNone                   = "None"
 	daprServiceOwnerField           = ".metadata.controller"
+	annotationPrometheusProbe       = "prometheus.io/probe"
+	annotationPrometheusScrape      = "prometheus.io/scrape"
+	annotationPrometheusPort        = "prometheus.io/port"
+	annotationPrometheusPath        = "prometheus.io/path"
 )
 
 var log = logger.NewLogger("dapr.operator.handlers")
@@ -231,10 +235,10 @@ func (h *DaprHandler) createDaprServiceValues(ctx context.Context, expectedServi
 	}
 
 	if enableMetrics {
-		annotationsMap["prometheus.io/probe"] = "true"
-		annotationsMap["prometheus.io/scrape"] = "true" // WARN: deprecated as of v1.7 please use prometheus.io/probe instead.
-		annotationsMap["prometheus.io/port"] = strconv.Itoa(metricsPort)
-		annotationsMap["prometheus.io/path"] = "/"
+		annotationsMap[annotationPrometheusProbe] = "true"
+		annotationsMap[annotationPrometheusScrape] = "true" // WARN: deprecated as of v1.7 please use prometheus.io/probe instead.
+		annotationsMap[annotationPrometheusPort] = strconv.Itoa(metricsPort)
+		annotationsMap[annotationPrometheusPath] = "/"
 	}
 
 	return &corev1.Service{

--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	"github.com/dapr/dapr/pkg/injector/annotations"
 	"github.com/dapr/dapr/pkg/operator/monitoring"
 	"github.com/dapr/dapr/pkg/validation"
 	"github.com/dapr/dapr/utils"
@@ -23,10 +23,6 @@ import (
 )
 
 const (
-	daprEnabledAnnotationKey        = "dapr.io/enabled"
-	appIDAnnotationKey              = "dapr.io/app-id"
-	daprEnableMetricsKey            = "dapr.io/enable-metrics"
-	daprMetricsPortKey              = "dapr.io/metrics-port"
 	daprSidecarHTTPPortName         = "dapr-http"
 	daprSidecarAPIGRPCPortName      = "dapr-grpc"
 	daprSidecarInternalGRPCPortName = "dapr-internal"
@@ -56,6 +52,7 @@ type Reconciler struct {
 }
 
 // NewDaprHandler returns a new Dapr handler.
+// This is a reconciler that watches all Deployment and StatefulSet resources and ensures that a matching Service resource is deployed to allow Dapr sidecar-to-sidecar communication and access to other ports.
 func NewDaprHandler(mgr ctrl.Manager) *DaprHandler {
 	return &DaprHandler{
 		mgr: mgr,
@@ -67,7 +64,7 @@ func NewDaprHandler(mgr ctrl.Manager) *DaprHandler {
 
 // Init allows for various startup tasks.
 func (h *DaprHandler) Init() error {
-	if err := h.mgr.GetFieldIndexer().IndexField(
+	err := h.mgr.GetFieldIndexer().IndexField(
 		context.TODO(),
 		&corev1.Service{},
 		daprServiceOwnerField,
@@ -78,11 +75,13 @@ func (h *DaprHandler) Init() error {
 				return nil
 			}
 			return []string{owner.Name}
-		}); err != nil {
+		},
+	)
+	if err != nil {
 		return err
 	}
 
-	if err := ctrl.NewControllerManagedBy(h.mgr).
+	err = ctrl.NewControllerManagedBy(h.mgr).
 		For(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(controller.Options{
@@ -93,10 +92,12 @@ func (h *DaprHandler) Init() error {
 			newWrapper: func() ObjectWrapper {
 				return &DeploymentWrapper{}
 			},
-		}); err != nil {
+		})
+	if err != nil {
 		return err
 	}
-	return ctrl.NewControllerManagedBy(h.mgr).
+
+	err = ctrl.NewControllerManagedBy(h.mgr).
 		For(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		WithOptions(controller.Options{
@@ -108,19 +109,25 @@ func (h *DaprHandler) Init() error {
 				return &StatefulSetWrapper{}
 			},
 		})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (h *DaprHandler) daprServiceName(appID string) string {
-	return fmt.Sprintf("%s-dapr", appID)
+	return appID + "-dapr"
 }
 
-// Reconcile the expected services for deployments | statefulset annotated for Dapr.
+// Reconcile the expected services for Deployment and StatefulSet resources annotated for Dapr.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// var wrapper appsv1.Deployment | appsv1.StatefulSet
 	wrapper := r.newWrapper()
 
 	expectedService := false
-	if err := r.Get(ctx, req.NamespacedName, wrapper.GetObject()); err != nil {
+	err := r.Get(ctx, req.NamespacedName, wrapper.GetObject())
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Debugf("deployment has be deleted, %s", req.NamespacedName)
 		} else {
@@ -136,7 +143,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if expectedService {
-		if err := r.ensureDaprServicePresent(ctx, req.Namespace, wrapper); err != nil {
+		err := r.ensureDaprServicePresent(ctx, req.Namespace, wrapper)
+		if err != nil {
 			return ctrl.Result{Requeue: true}, err
 		}
 	}
@@ -156,7 +164,8 @@ func (h *DaprHandler) ensureDaprServicePresent(ctx context.Context, namespace st
 		Name:      h.daprServiceName(appID),
 	}
 	var daprSvc corev1.Service
-	if err := h.Get(ctx, daprSvcName, &daprSvc); err != nil {
+	err = h.Get(ctx, daprSvcName, &daprSvc)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Debugf("no service for wrapper found, wrapper: %s/%s", namespace, daprSvcName.Name)
 			return h.createDaprService(ctx, daprSvcName, wrapper)
@@ -165,7 +174,8 @@ func (h *DaprHandler) ensureDaprServicePresent(ctx context.Context, namespace st
 		return err
 	}
 
-	if err := h.patchDaprService(ctx, daprSvcName, wrapper, daprSvc); err != nil {
+	err = h.patchDaprService(ctx, daprSvcName, wrapper, daprSvc)
+	if err != nil {
 		log.Errorf("unable to update service, %s, err: %s", daprSvcName, err)
 		return err
 	}
@@ -177,13 +187,15 @@ func (h *DaprHandler) patchDaprService(ctx context.Context, expectedService type
 	appID := h.getAppID(wrapper)
 	service := h.createDaprServiceValues(ctx, expectedService, wrapper, appID)
 
-	if err := ctrl.SetControllerReference(wrapper.GetObject(), service, h.Scheme); err != nil {
+	err := ctrl.SetControllerReference(wrapper.GetObject(), service, h.Scheme)
+	if err != nil {
 		return err
 	}
 
 	service.ObjectMeta.ResourceVersion = daprSvc.ObjectMeta.ResourceVersion
 
-	if err := h.Update(ctx, service); err != nil {
+	err = h.Update(ctx, service)
+	if err != nil {
 		return err
 	}
 
@@ -195,10 +207,12 @@ func (h *DaprHandler) createDaprService(ctx context.Context, expectedService typ
 	appID := h.getAppID(wrapper)
 	service := h.createDaprServiceValues(ctx, expectedService, wrapper, appID)
 
-	if err := ctrl.SetControllerReference(wrapper.GetObject(), service, h.Scheme); err != nil {
+	err := ctrl.SetControllerReference(wrapper.GetObject(), service, h.Scheme)
+	if err != nil {
 		return err
 	}
-	if err := h.Create(ctx, service); err != nil {
+	err = h.Create(ctx, service)
+	if err != nil {
 		log.Errorf("unable to create Dapr service for wrapper, service: %s, err: %s", expectedService, err)
 		return err
 	}
@@ -212,23 +226,23 @@ func (h *DaprHandler) createDaprServiceValues(ctx context.Context, expectedServi
 	metricsPort := h.getMetricsPort(wrapper)
 	log.Debugf("enableMetrics: %v", enableMetrics)
 
-	annotations := map[string]string{
-		appIDAnnotationKey: appID,
+	annotationsMap := map[string]string{
+		annotations.KeyAppID: appID,
 	}
 
 	if enableMetrics {
-		annotations["prometheus.io/probe"] = "true"
-		annotations["prometheus.io/scrape"] = "true" // WARN: deprecated as of v1.7 please use prometheus.io/probe instead.
-		annotations["prometheus.io/port"] = strconv.Itoa(metricsPort)
-		annotations["prometheus.io/path"] = "/"
+		annotationsMap["prometheus.io/probe"] = "true"
+		annotationsMap["prometheus.io/scrape"] = "true" // WARN: deprecated as of v1.7 please use prometheus.io/probe instead.
+		annotationsMap["prometheus.io/port"] = strconv.Itoa(metricsPort)
+		annotationsMap["prometheus.io/path"] = "/"
 	}
 
 	return &corev1.Service{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:        expectedService.Name,
 			Namespace:   expectedService.Namespace,
-			Labels:      map[string]string{daprEnabledAnnotationKey: "true"},
-			Annotations: annotations,
+			Labels:      map[string]string{annotations.KeyEnabled: "true"},
+			Annotations: annotationsMap,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector:  wrapper.GetMatchLabels(),
@@ -264,37 +278,32 @@ func (h *DaprHandler) createDaprServiceValues(ctx context.Context, expectedServi
 }
 
 func (h *DaprHandler) getAppID(wrapper ObjectWrapper) string {
-	annotations := wrapper.GetTemplateAnnotations()
-	if val, ok := annotations[appIDAnnotationKey]; ok && val != "" {
-		return val
-	}
-	return ""
+	annotationsMap := wrapper.GetTemplateAnnotations()
+	return annotationsMap[annotations.KeyAppID]
 }
 
 func (h *DaprHandler) isAnnotatedForDapr(wrapper ObjectWrapper) bool {
-	annotations := wrapper.GetTemplateAnnotations()
-	enabled, ok := annotations[daprEnabledAnnotationKey]
-	if !ok {
+	annotationsMap := wrapper.GetTemplateAnnotations()
+	val := annotationsMap[annotations.KeyEnabled]
+	if val == "" {
 		return false
 	}
-	return utils.IsTruthy(enabled)
+	return utils.IsTruthy(val)
 }
 
 func (h *DaprHandler) getEnableMetrics(wrapper ObjectWrapper) bool {
-	annotations := wrapper.GetTemplateAnnotations()
+	annotationsMap := wrapper.GetTemplateAnnotations()
 	enableMetrics := defaultMetricsEnabled
-	if val, ok := annotations[daprEnableMetricsKey]; ok {
-		if v, err := strconv.ParseBool(val); err == nil {
-			enableMetrics = v
-		}
+	if val := annotationsMap[annotations.KeyEnableMetrics]; val != "" {
+		enableMetrics = utils.IsTruthy(val)
 	}
 	return enableMetrics
 }
 
 func (h *DaprHandler) getMetricsPort(wrapper ObjectWrapper) int {
-	annotations := wrapper.GetTemplateAnnotations()
+	annotationsMap := wrapper.GetTemplateAnnotations()
 	metricsPort := defaultMetricsPort
-	if val, ok := annotations[daprMetricsPortKey]; ok {
+	if val := annotationsMap[annotations.KeyMetricsPort]; val != "" {
 		if v, err := strconv.Atoi(val); err == nil {
 			metricsPort = v
 		}

--- a/pkg/operator/handlers/dapr_handler_test.go
+++ b/pkg/operator/handlers/dapr_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/dapr/dapr/pkg/injector/annotations"
 	dapr_testing "github.com/dapr/dapr/pkg/testing"
 )
 
@@ -112,20 +113,20 @@ func TestCreateDaprServiceAppIDAndMetricsSettings(t *testing.T) {
 		Name:      "test",
 	}
 	deployment := getDeployment("test", "true")
-	deployment.GetTemplateAnnotations()[daprMetricsPortKey] = "12345"
+	deployment.GetTemplateAnnotations()[annotations.KeyMetricsPort] = "12345"
 
 	service := testDaprHandler.createDaprServiceValues(ctx, myDaprService, deployment, "test")
 	require.NotNil(t, service)
-	assert.Equal(t, "test", service.ObjectMeta.Annotations[appIDAnnotationKey])
+	assert.Equal(t, "test", service.ObjectMeta.Annotations[annotations.KeyAppID])
 	assert.Equal(t, "true", service.ObjectMeta.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "12345", service.ObjectMeta.Annotations["prometheus.io/port"])
 	assert.Equal(t, "/", service.ObjectMeta.Annotations["prometheus.io/path"])
 
-	deployment.GetTemplateAnnotations()[daprEnableMetricsKey] = "false"
+	deployment.GetTemplateAnnotations()[annotations.KeyEnableMetrics] = "false"
 
 	service = testDaprHandler.createDaprServiceValues(ctx, myDaprService, deployment, "test")
 	require.NotNil(t, service)
-	assert.Equal(t, "test", service.ObjectMeta.Annotations[appIDAnnotationKey])
+	assert.Equal(t, "test", service.ObjectMeta.Annotations[annotations.KeyAppID])
 	assert.Equal(t, "", service.ObjectMeta.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "", service.ObjectMeta.Annotations["prometheus.io/port"])
 	assert.Equal(t, "", service.ObjectMeta.Annotations["prometheus.io/path"])
@@ -154,7 +155,7 @@ func TestPatchDaprService(t *testing.T) {
 	var actualService corev1.Service
 	err = cli.Get(ctx, myDaprService, &actualService)
 	assert.NoError(t, err)
-	assert.Equal(t, "test", actualService.ObjectMeta.Annotations[appIDAnnotationKey])
+	assert.Equal(t, "test", actualService.ObjectMeta.Annotations[annotations.KeyAppID])
 	assert.Equal(t, "true", actualService.ObjectMeta.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "/", actualService.ObjectMeta.Annotations["prometheus.io/path"])
 	assert.Len(t, actualService.OwnerReferences, 1)
@@ -165,7 +166,7 @@ func TestPatchDaprService(t *testing.T) {
 	assert.NoError(t, err)
 	err = cli.Get(ctx, myDaprService, &actualService)
 	assert.NoError(t, err)
-	assert.Equal(t, "test", actualService.ObjectMeta.Annotations[appIDAnnotationKey])
+	assert.Equal(t, "test", actualService.ObjectMeta.Annotations[annotations.KeyAppID])
 	assert.Equal(t, "true", actualService.ObjectMeta.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "/", actualService.ObjectMeta.Annotations["prometheus.io/path"])
 	assert.Len(t, actualService.OwnerReferences, 1)
@@ -217,8 +218,8 @@ func TestWrapper(t *testing.T) {
 	})
 
 	t.Run("get annotations from wrapper", func(t *testing.T) {
-		assert.Equal(t, "test_id", deploymentWrapper.GetTemplateAnnotations()[appIDAnnotationKey])
-		assert.Equal(t, "test_id", statefulsetWrapper.GetTemplateAnnotations()[appIDAnnotationKey])
+		assert.Equal(t, "test_id", deploymentWrapper.GetTemplateAnnotations()[annotations.KeyAppID])
+		assert.Equal(t, "test_id", statefulsetWrapper.GetTemplateAnnotations()[annotations.KeyAppID])
 	})
 
 	t.Run("get object from wrapper", func(t *testing.T) {
@@ -292,7 +293,7 @@ func TestInit(t *testing.T) {
 
 func getDeploymentWithMetricsPortAnnotation(daprID string, daprEnabled string, metricsPort string) ObjectWrapper {
 	d := getDeployment(daprID, daprEnabled)
-	d.GetTemplateAnnotations()[daprMetricsPortKey] = metricsPort
+	d.GetTemplateAnnotations()[annotations.KeyMetricsPort] = metricsPort
 	return d
 }
 
@@ -302,9 +303,9 @@ func getDeployment(appID string, daprEnabled string) ObjectWrapper {
 		Name:   "app",
 		Labels: map[string]string{"app": "test_app"},
 		Annotations: map[string]string{
-			appIDAnnotationKey:       appID,
-			daprEnabledAnnotationKey: daprEnabled,
-			daprEnableMetricsKey:     "true",
+			annotations.KeyAppID:         appID,
+			annotations.KeyEnabled:       daprEnabled,
+			annotations.KeyEnableMetrics: "true",
 		},
 	}
 
@@ -336,9 +337,9 @@ func getStatefulSet(appID string, daprEnabled string) ObjectWrapper {
 		Name:   "app",
 		Labels: map[string]string{"app": "test_app"},
 		Annotations: map[string]string{
-			appIDAnnotationKey:       appID,
-			daprEnabledAnnotationKey: daprEnabled,
-			daprEnableMetricsKey:     "true",
+			annotations.KeyAppID:         appID,
+			annotations.KeyEnabled:       daprEnabled,
+			annotations.KeyEnableMetrics: "true",
 		},
 	}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -58,11 +58,11 @@ type Options struct {
 	WatchdogInterval          time.Duration
 	WatchdogMaxRestartsPerMin int
 	WatchNamespace            string
+	ServiceReconcilerEnabled  bool
 }
 
 type operator struct {
-	daprHandler *handlers.DaprHandler
-	apiServer   api.Server
+	apiServer api.Server
 
 	configName    string
 	certChainPath string
@@ -119,14 +119,15 @@ func NewOperator(opts Options) Operator {
 		log.Infof("Dapr Watchdog is not enabled")
 	}
 
-	daprHandler := handlers.NewDaprHandler(mgr)
-	err = daprHandler.Init()
-	if err != nil {
-		log.Fatalf("Unable to initialize handler, err: %s", err)
+	if opts.ServiceReconcilerEnabled {
+		daprHandler := handlers.NewDaprHandler(mgr)
+		err = daprHandler.Init()
+		if err != nil {
+			log.Fatalf("Unable to initialize handler, err: %s", err)
+		}
 	}
 
 	o := &operator{
-		daprHandler:   daprHandler,
 		mgr:           mgr,
 		client:        mgrClient,
 		configName:    opts.Config,
@@ -139,14 +140,14 @@ func NewOperator(opts Options) Operator {
 	cancel()
 	if err != nil {
 		log.Fatalf("Unable to get setup components informer, err: %s", err)
-	} else {
-		componentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc: o.syncComponent,
-			UpdateFunc: func(_, newObj interface{}) {
-				o.syncComponent(newObj)
-			},
-		})
 	}
+
+	componentInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: o.syncComponent,
+		UpdateFunc: func(_, newObj any) {
+			o.syncComponent(newObj)
+		},
+	})
 
 	return o
 }
@@ -160,7 +161,7 @@ func (o *operator) prepareConfig() {
 	o.config.Credentials = credentials.NewTLSCredentials(o.certChainPath)
 }
 
-func (o *operator) syncComponent(obj interface{}) {
+func (o *operator) syncComponent(obj any) {
 	c, ok := obj.(*componentsapi.Component)
 	if ok {
 		log.Debugf("Observed component to be synced, %s/%s", c.Namespace, c.Name)


### PR DESCRIPTION
# Description

Adds a new CLI flag to the Dapr Operator service `--disable-service-reconciler` to disable the built-in reconciler (default=false - i.e. the reconciler is enabled)

The Operator has multiple roles in Dapr, and one of them is having a reconciler that creates Services for each Dapr-enabled Deployment and StatefulSet. In some cases, this reconciler may conflict with other reconcilers that are running on the cluster. Additionally, it uses a lot of memory, even in clusters that do not need it.

Also added an option to the Helm chart to control this flag.