### PR TITLE
Issue 5778

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -118,7 +118,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_dashboard.ingress.className`      | ingress className of the ingress controller (e.g.nginx)                                                                                                                | ``                 |
 | `dapr_dashboard.ingress.host`           | Fully qualified hostname of the dashboard URL (e.g `dashboard.dapr.local`) | ``  |
 | `dapr_dashboard.ingress.tls.enabled`    | If true, enables TLS on the ingress for the Dashboard                                                                                                                      | `false`            |
-| `dapr_dashboard.ingress.tls.secretName` | Secret name of the kubernetes tls secret (key/certificate)                                                                                                             | ``                 |
+| `dapr_dashboard.ingress.tls.secretName` | Name of the Kubernetes secret containing the TLS certificate (key/certificate) for the Dashboard. Ignored if `dapr_dashboard.ingress.tls.enabled` is `false`. | ``                 |
 
 
 

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -116,7 +116,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_dashboard.resources`              | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty                      | `{}`               |
 | `dapr_dashboard.ingress.enabled`        | Boolean value for enabling the creation of the ingress resource                                                                                                        | `false`            |
 | `dapr_dashboard.ingress.className`      | ingress className of the ingress controller (e.g.nginx)                                                                                                                | ``                 |
-| `dapr_dashboard.ingress.host`           | Fully qualified hostname of the dashboard URL (e.g dapr.127.0.0.1.nip.io)                                                                                              | ``                 |
+| `dapr_dashboard.ingress.host`           | Fully qualified hostname of the dashboard URL (e.g `dashboard.dapr.local`) | ``  |
 | `dapr_dashboard.ingress.tls.enabled`    | Boolean value for enabling the HTTPS/TLS endpoint                                                                                                                      | `false`            |
 | `dapr_dashboard.ingress.tls.secretName` | Secret name of the kubernetes tls secret (key/certificate)                                                                                                             | ``                 |
 

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -110,13 +110,13 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_dashboard.image.registry`         | docker registry                                                                                                                                                        | `docker.io/daprio` |
 | `dapr_dashboard.image.imagePullSecrets` | docker images pull secrets for docker registry                                                                                                                         | `docker.io/daprio` |
 | `dapr_dashboard.image.name`             | docker image name                                                                                                                                                      | `dashboard`        |
-| `dapr_dashboard.image.tag`              | docker image tag                                                                                                                                                       | `"0.6.0"`          |
+| `dapr_dashboard.image.tag`              | docker image tag                                                                                                                                                       | `"0.11.1"`         |
 | `dapr_dashboard.serviceType`            | Type of [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to use for the Dapr Dashboard service | `ClusterIP`        |
 | `dapr_dashboard.runAsNonRoot`           | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube                                                         | `true`             |
 | `dapr_dashboard.resources`              | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty                      | `{}`               |
 | `dapr_dashboard.ingress.enabled`        | Boolean value for enabling the creation of the ingress resource                                                                                                        | `false`            |
 | `dapr_dashboard.ingress.className`      | ingress className of the ingress controller (e.g.nginx)                                                                                                                | ``                 |
-| `dapr_dashboard.ingress.host`           | Fully qualified hostname of the dashboard URL (e.g `dashboard.dapr.local`) | ``  |
+| `dapr_dashboard.ingress.host`           | Fully qualified hostname of the dashboard URL (e.g `dashboard.dapr.local`) | ``                 |
 | `dapr_dashboard.ingress.tls.enabled`    | If true, enables TLS on the ingress for the Dashboard                                                                                                                      | `false`            |
 | `dapr_dashboard.ingress.tls.secretName` | Name of the Kubernetes secret containing the TLS certificate (key/certificate) for the Dashboard. Ignored if `dapr_dashboard.ingress.tls.enabled` is `false`. | ``                 |
 

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -102,18 +102,25 @@ The Helm chart has the follow configuration options that can be supplied:
 | `global.rbac.namespaced`                  | Removes cluster wide permissions where applicable  | `false` |
 
 ### Dapr Dashboard options:
-| Parameter                                 | Description                                                             | Default                 |
-|-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
-| `dapr_dashboard.enabled`                  | Enable the Dapr dashboard                                               | `true`                     |
-| `dapr_dashboard.replicaCount`             | Number of replicas                                                      | `1`                     |
-| `dapr_dashboard.logLevel`                 | service Log level                                                       | `info`                  |
-| `dapr_dashboard.image.registry`           | docker registry                                                         | `docker.io/daprio`      |
-| `dapr_dashboard.image.imagePullSecrets`   | docker images pull secrets for docker registry                          | `docker.io/daprio`      |
-| `dapr_dashboard.image.name`               | docker image name                                                       | `dashboard`             |
-| `dapr_dashboard.image.tag`                | docker image tag                                                        | `"0.6.0"`               |
-| `dapr_dashboard.serviceType`              | Type of [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to use for the Dapr Dashboard service | `ClusterIP` |
-| `dapr_dashboard.runAsNonRoot`             | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube | `true` |
-| `dapr_dashboard.resources`                | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty | `{}` |
+| Parameter                               | Description                                                                                                                                                            | Default            |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| `dapr_dashboard.enabled`                | Enable the Dapr dashboard                                                                                                                                              | `true`             |
+| `dapr_dashboard.replicaCount`           | Number of replicas                                                                                                                                                     | `1`                |
+| `dapr_dashboard.logLevel`               | service Log level                                                                                                                                                      | `info`             |
+| `dapr_dashboard.image.registry`         | docker registry                                                                                                                                                        | `docker.io/daprio` |
+| `dapr_dashboard.image.imagePullSecrets` | docker images pull secrets for docker registry                                                                                                                         | `docker.io/daprio` |
+| `dapr_dashboard.image.name`             | docker image name                                                                                                                                                      | `dashboard`        |
+| `dapr_dashboard.image.tag`              | docker image tag                                                                                                                                                       | `"0.6.0"`          |
+| `dapr_dashboard.serviceType`            | Type of [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to use for the Dapr Dashboard service | `ClusterIP`        |
+| `dapr_dashboard.runAsNonRoot`           | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube                                                         | `true`             |
+| `dapr_dashboard.resources`              | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty                      | `{}`               |
+| `dapr_dashboard.ingress.enabled`        | Boolean value for enabling the creation of the ingress resource                                                                                                        | `false`            |
+| `dapr_dashboard.ingress.className`      | ingress className of the ingress controller (e.g.nginx)                                                                                                                | ``                 |
+| `dapr_dashboard.ingress.host`           | Fully qualified hostname of the dashboard URL (e.g dapr.127.0.0.1.nip.io)                                                                                              | ``                 |
+| `dapr_dashboard.ingress.tls.enabled`    | Boolean value for enabling the HTTPS/TLS endpoint                                                                                                                      | `false`            |
+| `dapr_dashboard.ingress.tls.secretName` | Secret name of the kubernetes tls secret (key/certificate)                                                                                                             | ``                 |
+
+
 
 ### Dapr Operator options:
 | Parameter                                 | Description                                                             | Default                 |

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -117,7 +117,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_dashboard.ingress.enabled`        | Boolean value for enabling the creation of the ingress resource                                                                                                        | `false`            |
 | `dapr_dashboard.ingress.className`      | ingress className of the ingress controller (e.g.nginx)                                                                                                                | ``                 |
 | `dapr_dashboard.ingress.host`           | Fully qualified hostname of the dashboard URL (e.g `dashboard.dapr.local`) | ``  |
-| `dapr_dashboard.ingress.tls.enabled`    | Boolean value for enabling the HTTPS/TLS endpoint                                                                                                                      | `false`            |
+| `dapr_dashboard.ingress.tls.enabled`    | If true, enables TLS on the ingress for the Dashboard                                                                                                                      | `false`            |
 | `dapr_dashboard.ingress.tls.secretName` | Secret name of the kubernetes tls secret (key/certificate)                                                                                                             | ``                 |
 
 

--- a/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_ingress.yaml
+++ b/charts/dapr/charts/dapr_dashboard/templates/dapr_dashboard_ingress.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Values.ingress.enabled true }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dapr-dashboard
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: dapr-dashboard
+    {{- range $key, $value := .Values.global.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if eq .Values.ingress.tls.enabled true }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dapr-dashboard
+                port:
+                  number: {{ .Values.ports.port }}
+{{- end }}

--- a/charts/dapr/charts/dapr_dashboard/values.yaml
+++ b/charts/dapr/charts/dapr_dashboard/values.yaml
@@ -16,7 +16,15 @@ ports:
   protocol: TCP
   port: 8080
   targetPort: 8080
-  
+
+ingress:
+  enabled: false
+  className:
+  host:
+  tls:
+    enabled: false
+    secretName:
+
 runAsNonRoot: true
 serviceType: ClusterIP
 resources: {}


### PR DESCRIPTION
# Description

Add a new ingress template to the dashboard helm chart

## Issue reference

Issue #5778

Please reference the issue this PR will close: #_5778_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

## End to end test

Here is what I did locally to test it

```
- Created a local kind k8s cluster where nginx ingress controller is deployed
- Create a dapr.yml file containing the following values
  dapr_dashboard:
    runAsNonRoot: true
    ingress:
      enabled: true
      className: nginx
      host: dapr.127.0.0.1.nip.io
- helm install dapr -n dapr --create-namespace -f dapr.yml ../dapr-fork/charts/dapr
- Controled successfully if a ingress resource has been created
k get ingress -A
NAMESPACE   NAME             CLASS   HOSTS                   ADDRESS         PORTS   AGE
dapr        dapr-dashboard   nginx   dapr.127.0.0.1.nip.io   10.96.105.166   80      23m
- Accessed the dashboard url from my browser
```
![Screenshot 2023-02-07 at 19 02 14](https://user-images.githubusercontent.com/463790/217328509-f7b944ff-9659-4405-b7c7-e0d47dda4cd3.png)

