### PR TITLE
[release-1.10] Fix Helm chart for Injector options

### DIFF
--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -144,14 +144,10 @@ spec:
         - name: IGNORE_ENTRYPOINT_TOLERATIONS
           value: "{{ .Values.ignoreEntrypointTolerations }}"
 {{- end }}
-{{- if .Values.sidecarRunAsNonRoot }}
         - name: SIDECAR_RUN_AS_NON_ROOT
           value: "{{ .Values.sidecarRunAsNonRoot }}"
-{{- end }}
-{{- if .Values.sidecarReadOnlyRootFilesystem }}
         - name: SIDECAR_READ_ONLY_ROOT_FILESYSTEM
           value: "{{ .Values.sidecarReadOnlyRootFilesystem }}"
-{{- end }}
 {{- if .Values.allowedServiceAccounts }}
         - name: ALLOWED_SERVICE_ACCOUNTS
           value: "{{ .Values.allowedServiceAccounts }}"


### PR DESCRIPTION
Because SIDECAR_RUN_AS_NON_ROOT and SIDECAR_READ_ONLY_ROOT_FILESYSTEM default to true if unset, to have a value of false we need to specify them explicitly.

Without this PR, the options `dapr_sidecar_injector.sidecarRunAsNonRoot` and `dapr_sidecar_injector.sidecarReadOnlyRootFilesystem` are not effective when set to `false`: the env vars were not set in the container, which meant the injector assumed the default value to the "true"

This makes it impossible, for example, to use Dapr debug containers