### PR TITLE
Fix makefile perf tests exit code

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -355,6 +355,7 @@ ifeq ($(DAPR_PERF_TEST),)
 			-timeout 1h -p 1 -count=1 -v -tags=perf ./tests/perf/...
 	jq -r .Output $(TEST_OUTPUT_FILE_PREFIX)_perf.json | strings
 else
+	exit_code=0
 	for app in $(DAPR_PERF_TEST); do \
 		DAPR_CONTAINER_LOG_PATH=$(DAPR_CONTAINER_LOG_PATH) \
 		DAPR_TEST_LOG_PATH=$(DAPR_TEST_LOG_PATH) \
@@ -370,8 +371,10 @@ else
 			--format standard-quiet \
 			-- \
 				-p 1 -count=1 -v -tags=perf ./tests/perf/$$app... ; \
+		[[ $$? != 0 ]] && exit_code=1; \
 		jq -r .Output $(TEST_OUTPUT_FILE_PREFIX)_perf.json | strings ; \
 	done
+	exit $(exit_code);
 endif
 
 # add required helm repo


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

When the env var `DAPR_PERF_TEST` is specified the `test-perf-all` make target uses a for loop to run each specified test individually. The problem is that the exit code is ignored since it is inside a for loop and the for loop exit code will be returned which is always 0.

## Issue reference

N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
