### PR TITLE
Return a "stable" port for internal gRPC server if unset (for better local DX)

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -63,7 +63,7 @@ type server struct {
 	metricSpec         config.MetricSpec
 	authenticator      auth.Authenticator
 	servers            []*grpcGo.Server
-	renewMutex         *sync.Mutex
+	renewMutex         sync.Mutex
 	signedCert         *auth.SignedCertificate
 	tlsCert            tls.Certificate
 	signedCertDuration time.Duration
@@ -109,7 +109,6 @@ func NewInternalServer(api API, config ServerConfig, tracingSpec config.TracingS
 		tracingSpec:      tracingSpec,
 		metricSpec:       metricSpec,
 		authenticator:    authenticator,
-		renewMutex:       &sync.Mutex{},
 		kind:             internalServer,
 		logger:           internalServerLogger,
 		maxConnectionAge: getDefaultMaxAgeDuration(),

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -48,8 +47,7 @@ func TestGetMiddlewareOptions(t *testing.T) {
 			tracingSpec: config.TracingSpec{
 				SamplingRate: "1",
 			},
-			renewMutex: &sync.Mutex{},
-			logger:     logger.NewLogger("dapr.runtime.grpc.test"),
+			logger: logger.NewLogger("dapr.runtime.grpc.test"),
 		}
 
 		serverOption := fakeServer.getMiddlewareOptions()
@@ -63,8 +61,7 @@ func TestGetMiddlewareOptions(t *testing.T) {
 			tracingSpec: config.TracingSpec{
 				SamplingRate: "0",
 			},
-			renewMutex: &sync.Mutex{},
-			logger:     logger.NewLogger("dapr.runtime.grpc.test"),
+			logger: logger.NewLogger("dapr.runtime.grpc.test"),
 		}
 
 		serverOption := fakeServer.getMiddlewareOptions()
@@ -78,8 +75,7 @@ func TestGetMiddlewareOptions(t *testing.T) {
 			tracingSpec: config.TracingSpec{
 				SamplingRate: "0",
 			},
-			renewMutex: &sync.Mutex{},
-			logger:     logger.NewLogger("dapr.runtime.grpc.test"),
+			logger: logger.NewLogger("dapr.runtime.grpc.test"),
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{

--- a/pkg/runtime/cli.go
+++ b/pkg/runtime/cli.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/phayes/freeport"
-
 	"github.com/dapr/dapr/pkg/acl"
 	resiliencyV1alpha "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
 	"github.com/dapr/dapr/pkg/apphealth"
@@ -167,7 +165,9 @@ func FromFlags() (*DaprRuntime, error) {
 			return nil, fmt.Errorf("error parsing dapr-internal-grpc-port: %w", err)
 		}
 	} else {
-		daprInternalGRPC, err = freeport.GetFreePort()
+		// Get a "stable random" port in the range 47300-49,347 if it can be acquired using a deterministic algorithm that returns the same value if the same app is restarted
+		// Otherwise, the port will be random.
+		daprInternalGRPC, err = utils.GetStablePort(47300, *appID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get free port for internal grpc server: %w", err)
 		}

--- a/utils/ports.go
+++ b/utils/ports.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/sha256"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/phayes/freeport"
+)
+
+// GetStablePort returns an available TCP port.
+// It first attempts to get a free port that is between start and start+2047, which is calculated in a deterministic way based on the current process' environment.
+// If no available port can be found, it returns a random port (which could be outside of the range defined above).
+func GetStablePort(start int, appID string) (int, error) {
+	// Try determining a "stable" port
+	// The algorithm considers the following elements to generate a "random-looking", but stable, port number:
+	// - app-id: app-id values should be unique within a solution
+	// - Current working directory: allows separating different projects a developer is working on
+	// - ID of the current user: allows separating different users
+	// - Hostname: this is also different within each container
+	parts := make([]string, 4)
+	parts[0] = appID
+	parts[1], _ = os.Getwd()
+	parts[2] = strconv.Itoa(os.Getuid())
+	parts[3], _ = os.Hostname()
+	base := []byte(strings.Join(parts, "|"))
+
+	// Compute the SHA-256 hash to generate a "random", but stable, sequence of binary values
+	h := sha256.Sum256(base)
+
+	// Get the first 11 bits (0-2047) as "random number"
+	rnd := int(h[0]) + int(h[1]>>5)<<8
+	port := start + rnd
+
+	// Check if the port is available
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:"+strconv.Itoa(port))
+	if err != nil {
+		// Consider these as hard errors, as it should never happen that a port can't be resolved
+		return 0, err
+	}
+
+	// Try listening on that port; if it works, assume the port is available
+	l, err := net.ListenTCP("tcp", addr)
+	if err == nil {
+		l.Close()
+		return port, nil
+	}
+
+	// Fall back to returning a random port
+	return freeport.GetFreePort()
+}

--- a/utils/ports_test.go
+++ b/utils/ports_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStablePort(t *testing.T) {
+	// Try twice; if there's an error, use a different starting port to avoid conflicts
+	getPort := func(t *testing.T, appID string) int {
+		t.Helper()
+
+		startPort := 10233
+	getport:
+		port, err := GetStablePort(startPort, appID)
+		if err != nil && startPort == 10233 {
+			startPort = 22444
+			goto getport
+		}
+
+		require.NoError(t, err)
+
+		return port
+	}
+
+	t.Run("invoking twice should return the same port", func(t *testing.T) {
+		port1 := getPort(t, "myapp")
+		assert.True(t, (port1 >= 10233 && port1 <= 12280) || (port1 >= 22444 && port1 <= 24491))
+
+		port2 := getPort(t, "myapp")
+		assert.Equal(t, port1, port2)
+	})
+
+	t.Run("Invoking with a different appID returns a different port", func(t *testing.T) {
+		port1 := getPort(t, "myapp1")
+		assert.True(t, (port1 >= 10233 && port1 <= 12280) || (port1 >= 22444 && port1 <= 24491))
+
+		port2 := getPort(t, "myapp2")
+		assert.True(t, (port2 >= 10233 && port2 <= 12280) || (port2 >= 22444 && port2 <= 24491))
+		assert.NotEqual(t, port1, port2)
+	})
+
+	t.Run("returns a random port if the stable one is busy", func(t *testing.T) {
+		port1 := getPort(t, "myapp1")
+		assert.True(t, (port1 >= 10233 && port1 <= 12280) || (port1 >= 22444 && port1 <= 24491))
+
+		addr, err := net.ResolveTCPAddr("tcp", "localhost:"+strconv.Itoa(port1))
+		require.NoError(t, err)
+		l, err := net.ListenTCP("tcp", addr)
+		require.NoError(t, err)
+		defer l.Close()
+
+		port2 := getPort(t, "myapp1")
+		assert.NotEqual(t, port1, port2)
+	})
+}


### PR DESCRIPTION
Fixes dapr/components-contrib#2413

# Description

When Dapr is running as self-hosted, the internal gRPC server (used for service invocation) is started on a random port every time, unless `--dapr-internal-grpc-port` is set explicitly. (In K8s mode, the injector adds that flag with a stable port automatically).

During local development, this can cause issues such as dapr/components-contrib#2413 and dapr/components-contrib#2489 . For example:

- App A calls App B. Both use mDNS (or Consul) as nameresolver. They do not have an explicit `--dapr-internal-grpc-port`
- App A invokes App B, which works.
- App B is restarted. When it comes back, the internal gRPC server listens on a different port.
- App A invokes App B. It looks up the address and port from the nameresolver, which uses the cache
- If the cache hasn't expired, App A receives the old port for App B, and service invocation fails until the cache is cleared

The above is a bad DX. It can be fixed by passing `--dapr-internal-grpc-port`, but then developers need to manually set non-conflicting ports and that's not great DX either.

This PR changes the way the "random" port is selected by first attempting to use a "stable random" port, which is computed by looking at 4 variables which should be stable when the app is restarted:

- app-id: app-id values should be unique within a solution
- Current working directory: allows separating different projects a developer is working on
- ID of the current user: allows separating different users
- Hostname: this is also different within each container

If the port computed that way is not available, only then Dapr uses a random port as fallback.

This improves the DX by making it so if the same app is restarted, its internal server will (likely) listen on the same port, so it doesn't break service invocation.