### PR TITLE
Add `enabled` option to sidecar-injector to gate whether the sidecar injector chart is installed

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -174,7 +174,7 @@ The Helm chart has the follow configuration options that can be supplied:
 ### Dapr Sidecar Injector options:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
-| `dapr_sidecar_injector.enable`            | Enable the sidecar injector                                             | `enable`                |
+| `dapr_sidecar_injector.enabled`           | Enable the sidecar injector                                             | `enable`                |
 | `dapr_sidecar_injector.sidecarImagePullPolicy`      | Dapr sidecar image pull policy                                | `IfNotPresent`                     |
 | `dapr_sidecar_injector.replicaCount`      | Number of replicas                                                      | `1`                     |
 | `dapr_sidecar_injector.logLevel`          | Log level                                                               | `info`                  |

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -174,6 +174,7 @@ The Helm chart has the follow configuration options that can be supplied:
 ### Dapr Sidecar Injector options:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
+| `dapr_sidecar_injector.enable`            | Enable the sidecar injector                                             | `enable`                |
 | `dapr_sidecar_injector.sidecarImagePullPolicy`      | Dapr sidecar image pull policy                                | `IfNotPresent`                     |
 | `dapr_sidecar_injector.replicaCount`      | Number of replicas                                                      | `1`                     |
 | `dapr_sidecar_injector.logLevel`          | Log level                                                               | `info`                  |

--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -174,7 +174,7 @@ The Helm chart has the follow configuration options that can be supplied:
 ### Dapr Sidecar Injector options:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
-| `dapr_sidecar_injector.enabled`           | Enable the sidecar injector                                             | `enable`                |
+| `dapr_sidecar_injector.enabled`           | Enable the sidecar injector                                             | `true`                |
 | `dapr_sidecar_injector.sidecarImagePullPolicy`      | Dapr sidecar image pull policy                                | `IfNotPresent`                     |
 | `dapr_sidecar_injector.replicaCount`      | Number of replicas                                                      | `1`                     |
 | `dapr_sidecar_injector.logLevel`          | Log level                                                               | `info`                  |

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.enabled true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -219,4 +220,5 @@ spec:
 {{- if .Values.global.tolerations }}
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_poddisruptionbudget.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.enabled true }}
 {{- if eq .Values.global.ha.enabled true }}
 {{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
@@ -28,4 +29,5 @@ spec:
       {{- with .Values.global.labels }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
     name: https
   selector:
     app: dapr-sidecar-injector
+{{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.enabled true }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "dapr-sidecar-injector-cert"}}
 {{- $existingWebHookConfig := lookup "admissionregistration.k8s.io/v1" "MutatingWebhookConfiguration" .Release.Namespace "dapr-sidecar-injector"}}
 {{- $ca := genCA "dapr-sidecar-injector-ca" 3650 }}
@@ -54,3 +55,4 @@ webhooks:
   failurePolicy: {{ .Values.webhookFailurePolicy}}
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
+{{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -1,3 +1,4 @@
+enabled: true
 replicaCount: 1
 logLevel: info
 component: sidecar-injector


### PR DESCRIPTION
# Description

For some use cases of dapr, users would like to manage their own daprd instances so installing the injector is a waste of bytes and cpu cycles in the cluster.

This PR adds a `dapr_sidecar_injector.enabled` helm option which gates whether the sidecar injector is installed. This value defaults to `true`.

/cc @famarting 