### PR TITLE
[release-1.10] Ensure that gRPC interceptors apply to stream-based APIs too

### DIFF
--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -305,13 +305,15 @@ func startDaprAPIServer(port int, testAPIServer *api, token string) *grpc.Server
 	interceptors := []grpc.UnaryServerInterceptor{
 		metadata.SetMetadataInContextUnary,
 	}
+	streamInterceptors := []grpc.StreamServerInterceptor{}
 	if token != "" {
-		interceptors = append(interceptors,
-			setAPIAuthenticationMiddlewareUnary(token, "dapr-api-token"),
-		)
+		unary, stream := getAPIAuthenticationMiddlewares(token, "dapr-api-token")
+		interceptors = append(interceptors, unary)
+		streamInterceptors = append(streamInterceptors, stream)
 	}
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(interceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
 		grpc.InTapHandle(metadata.SetMetadataInTapHandle),
 	}
 
@@ -383,30 +385,50 @@ func TestAPIToken(t *testing.T) {
 		clientConn := createTestClient(port)
 		defer clientConn.Close()
 
-		// act
 		client := runtimev1pb.NewDaprClient(clientConn)
-		req := &runtimev1pb.InvokeServiceRequest{
-			Id: "fakeAppID",
-			Message: &commonv1pb.InvokeRequest{
-				Method: "fakeMethod",
-				Data:   &anypb.Any{Value: []byte("testData")},
-			},
-		}
 		md := grpcMetadata.Pairs("dapr-api-token", token)
 		ctx := grpcMetadata.NewOutgoingContext(context.Background(), md)
-		_, err := client.InvokeService(ctx, req)
 
-		// assert
-		mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 1)
-		s, ok := status.FromError(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.NotFound, s.Code())
-		assert.Equal(t, "Not Found", s.Message())
+		t.Run("unary", func(t *testing.T) {
+			// act
+			req := &runtimev1pb.InvokeServiceRequest{
+				Id: "fakeAppID",
+				Message: &commonv1pb.InvokeRequest{
+					Method: "fakeMethod",
+					Data:   &anypb.Any{Value: []byte("testData")},
+				},
+			}
+			_, err := client.InvokeService(ctx, req)
 
-		errInfo := s.Details()[0].(*epb.ErrorInfo)
-		assert.Equal(t, 1, len(s.Details()))
-		assert.Equal(t, "404", errInfo.Metadata["http.code"])
-		assert.Equal(t, "fakeDirectMessageResponse", errInfo.Metadata["http.error_message"])
+			// assert
+			mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 1)
+			s, ok := status.FromError(err)
+			assert.True(t, ok)
+			assert.Equal(t, codes.NotFound, s.Code())
+			assert.Equal(t, "Not Found", s.Message())
+
+			errInfo := s.Details()[0].(*epb.ErrorInfo)
+			assert.Equal(t, 1, len(s.Details()))
+			assert.Equal(t, "404", errInfo.Metadata["http.code"])
+			assert.Equal(t, "fakeDirectMessageResponse", errInfo.Metadata["http.error_message"])
+		})
+
+		t.Run("stream", func(t *testing.T) {
+			// We use a low-level gRPC method to invoke a method as a stream (even unary methods are streams, internally)
+			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/dapr.proto.runtime.v1.Dapr/InvokeActor")
+			require.NoError(t, err)
+			defer stream.CloseSend()
+
+			// Send a message in the stream since it will be waiting for our input
+			err = stream.SendMsg(&emptypb.Empty{})
+			require.NoError(t, err)
+
+			// The request was invalid so we should get an error about the actor runtime (which means we passed the auth middleware and are hitting the API as expected)
+			var m any
+			err = stream.RecvMsg(&m)
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, "actor runtime")
+		})
 	})
 
 	t.Run("invalid token", func(t *testing.T) {
@@ -433,24 +455,46 @@ func TestAPIToken(t *testing.T) {
 		clientConn := createTestClient(port)
 		defer clientConn.Close()
 
-		// act
 		client := runtimev1pb.NewDaprClient(clientConn)
-		req := &runtimev1pb.InvokeServiceRequest{
-			Id: "fakeAppID",
-			Message: &commonv1pb.InvokeRequest{
-				Method: "fakeMethod",
-				Data:   &anypb.Any{Value: []byte("testData")},
-			},
-		}
-		md := grpcMetadata.Pairs("dapr-api-token", "4567")
+		md := grpcMetadata.Pairs("dapr-api-token", "bad, bad token")
 		ctx := grpcMetadata.NewOutgoingContext(context.Background(), md)
-		_, err := client.InvokeService(ctx, req)
 
-		// assert
-		mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 0)
-		s, ok := status.FromError(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.Unauthenticated, s.Code())
+		t.Run("unary", func(t *testing.T) {
+			// act
+			req := &runtimev1pb.InvokeServiceRequest{
+				Id: "fakeAppID",
+				Message: &commonv1pb.InvokeRequest{
+					Method: "fakeMethod",
+					Data:   &anypb.Any{Value: []byte("testData")},
+				},
+			}
+			_, err := client.InvokeService(ctx, req)
+
+			// assert
+			mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 0)
+			s, ok := status.FromError(err)
+			assert.True(t, ok)
+			assert.Equal(t, codes.Unauthenticated, s.Code())
+		})
+
+		t.Run("stream", func(t *testing.T) {
+			// We use a low-level gRPC method to invoke a method as a stream (even unary methods are streams, internally)
+			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/dapr.proto.runtime.v1.Dapr/InvokeActor")
+			require.NoError(t, err)
+			defer stream.CloseSend()
+
+			// Send a message in the stream since it will be waiting for our input
+			err = stream.SendMsg(&emptypb.Empty{})
+			require.NoError(t, err)
+
+			// We should get an Unauthenticated error
+			var m any
+			err = stream.RecvMsg(&m)
+			assert.Error(t, err)
+			s, ok := status.FromError(err)
+			assert.True(t, ok)
+			assert.Equal(t, codes.Unauthenticated, s.Code())
+		})
 	})
 
 	t.Run("missing token", func(t *testing.T) {
@@ -477,22 +521,45 @@ func TestAPIToken(t *testing.T) {
 		clientConn := createTestClient(port)
 		defer clientConn.Close()
 
-		// act
 		client := runtimev1pb.NewDaprClient(clientConn)
-		req := &runtimev1pb.InvokeServiceRequest{
-			Id: "fakeAppID",
-			Message: &commonv1pb.InvokeRequest{
-				Method: "fakeMethod",
-				Data:   &anypb.Any{Value: []byte("testData")},
-			},
-		}
-		_, err := client.InvokeService(context.Background(), req)
+		ctx := context.Background()
 
-		// assert
-		mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 0)
-		s, ok := status.FromError(err)
-		assert.True(t, ok)
-		assert.Equal(t, codes.Unauthenticated, s.Code())
+		t.Run("unary", func(t *testing.T) {
+			// act
+			req := &runtimev1pb.InvokeServiceRequest{
+				Id: "fakeAppID",
+				Message: &commonv1pb.InvokeRequest{
+					Method: "fakeMethod",
+					Data:   &anypb.Any{Value: []byte("testData")},
+				},
+			}
+			_, err := client.InvokeService(ctx, req)
+
+			// assert
+			mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 0)
+			s, ok := status.FromError(err)
+			assert.True(t, ok)
+			assert.Equal(t, codes.Unauthenticated, s.Code())
+		})
+
+		t.Run("stream", func(t *testing.T) {
+			// We use a low-level gRPC method to invoke a method as a stream (even unary methods are streams, internally)
+			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/dapr.proto.runtime.v1.Dapr/InvokeActor")
+			require.NoError(t, err)
+			defer stream.CloseSend()
+
+			// Send a message in the stream since it will be waiting for our input
+			err = stream.SendMsg(&emptypb.Empty{})
+			require.NoError(t, err)
+
+			// We should get an Unauthenticated error
+			var m any
+			err = stream.RecvMsg(&m)
+			assert.Error(t, err)
+			s, ok := status.FromError(err)
+			assert.True(t, ok)
+			assert.Equal(t, codes.Unauthenticated, s.Code())
+		})
 	})
 }
 

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -415,7 +415,7 @@ func TestAPIToken(t *testing.T) {
 
 		t.Run("stream", func(t *testing.T) {
 			// We use a low-level gRPC method to invoke a method as a stream (even unary methods are streams, internally)
-			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/dapr.proto.runtime.v1.Dapr/InvokeActor")
+			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/"+runtimev1pb.Dapr_ServiceDesc.ServiceName+"/InvokeActor")
 			require.NoError(t, err)
 			defer stream.CloseSend()
 
@@ -479,7 +479,7 @@ func TestAPIToken(t *testing.T) {
 
 		t.Run("stream", func(t *testing.T) {
 			// We use a low-level gRPC method to invoke a method as a stream (even unary methods are streams, internally)
-			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/dapr.proto.runtime.v1.Dapr/InvokeActor")
+			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/"+runtimev1pb.Dapr_ServiceDesc.ServiceName+"/InvokeActor")
 			require.NoError(t, err)
 			defer stream.CloseSend()
 
@@ -544,7 +544,7 @@ func TestAPIToken(t *testing.T) {
 
 		t.Run("stream", func(t *testing.T) {
 			// We use a low-level gRPC method to invoke a method as a stream (even unary methods are streams, internally)
-			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/dapr.proto.runtime.v1.Dapr/InvokeActor")
+			stream, err := clientConn.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true, ClientStreams: true}, "/"+runtimev1pb.Dapr_ServiceDesc.ServiceName+"/InvokeActor")
 			require.NoError(t, err)
 			defer stream.CloseSend()
 

--- a/pkg/grpc/auth.go
+++ b/pkg/grpc/auth.go
@@ -10,26 +10,38 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 )
 
-func setAPIAuthenticationMiddlewareUnary(apiToken, authHeader string) grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		md, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			err := invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing metadata in request")
-			return nil, err
+func getAPIAuthenticationMiddlewares(apiToken, authHeader string) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			err := checkAPITokenInContext(ctx, apiToken, authHeader)
+			if err != nil {
+				return nil, err
+			}
+			return handler(ctx, req)
+		},
+		func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			err := checkAPITokenInContext(stream.Context(), apiToken, authHeader)
+			if err != nil {
+				return err
+			}
+			return handler(srv, stream)
 		}
+}
 
-		token, ok := md[authHeader]
-		if !ok || len(token) == 0 {
-			err := invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing api token in request metadata")
-			return nil, err
-		}
-
-		if token[0] != apiToken {
-			err := invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "authentication error: api token mismatch")
-			return nil, err
-		}
-
-		md.Set(authHeader, "")
-		return handler(ctx, req)
+// Checks if the API token in the gRPC request's context is valid; returns an error otherwise.
+func checkAPITokenInContext(ctx context.Context, apiToken, authHeader string) error {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing metadata in request")
 	}
+
+	if len(md[authHeader]) == 0 {
+		return invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing api token in request metadata")
+	}
+
+	if md[authHeader][0] != apiToken {
+		return invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "authentication error: api token mismatch")
+	}
+
+	md.Set(authHeader, "")
+	return nil
 }

--- a/pkg/grpc/endpoints_test.go
+++ b/pkg/grpc/endpoints_test.go
@@ -51,6 +51,7 @@ func TestEndpointCompleteness(t *testing.T) {
 func hUnary(ctx context.Context, req any) (any, error) {
 	return nil, nil
 }
+
 func hStream(srv any, stream grpc.ServerStream) error {
 	return nil
 }

--- a/pkg/grpc/endpoints_test.go
+++ b/pkg/grpc/endpoints_test.go
@@ -48,11 +48,40 @@ func TestEndpointCompleteness(t *testing.T) {
 	assert.Equal(t, runtimeEndpoints, packageEndpoints, "the list of endpoints defined in this package does not match the endpoints defined in the %s gRPC service", runtimev1pb.Dapr_ServiceDesc.ServiceName)
 }
 
-func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
-	h := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return nil, nil
-	}
+func hUnary(ctx context.Context, req any) (any, error) {
+	return nil, nil
+}
+func hStream(srv any, stream grpc.ServerStream) error {
+	return nil
+}
 
+func testMiddleware(u grpc.UnaryServerInterceptor, s grpc.StreamServerInterceptor) func(t *testing.T, method string, expectErr bool) {
+	return func(t *testing.T, method string, expectErr bool) {
+		t.Helper()
+
+		_, err := u(nil, nil, &grpc.UnaryServerInfo{
+			FullMethod: method,
+		}, hUnary)
+		if expectErr {
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, "Unimplemented")
+		} else {
+			assert.NoError(t, err)
+		}
+
+		err = s(nil, nil, &grpc.StreamServerInfo{
+			FullMethod: method,
+		}, hStream)
+		if expectErr {
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, "Unimplemented")
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestSetAPIEndpointsMiddleware(t *testing.T) {
 	t.Run("state.v1 endpoints allowed", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
@@ -62,22 +91,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["state.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "state.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -92,22 +115,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["state.v1alpha1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "state.v1alpha1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -122,22 +139,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["publish.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "publish.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -152,22 +163,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["actors.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "actors.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -182,22 +187,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["bindings.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "bindings.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -212,22 +211,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["secrets.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "secrets.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -242,22 +235,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["metadata.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "metadata.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -272,22 +259,16 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["shutdown.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "shutdown.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
@@ -302,48 +283,28 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
+		tm := testMiddleware(setAPIEndpointsMiddlewares(a))
 
 		for _, e := range endpoints["invoke.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
+			tm(t, e, false)
 		}
 
 		for k, v := range endpoints {
 			if k != "invoke.v1" {
 				for _, e := range v {
-					_, err := f(nil, nil, &grpc.UnaryServerInfo{
-						FullMethod: e,
-					}, h)
-					assert.Error(t, err)
+					tm(t, e, true)
 				}
 			}
 		}
 	})
 
-	t.Run("no rules, all endpoints are allowed", func(t *testing.T) {
-		f := setAPIEndpointsMiddlewareUnary(nil)
-
-		for _, e := range endpoints["invoke.v1"] {
-			_, err := f(nil, nil, &grpc.UnaryServerInfo{
-				FullMethod: e,
-			}, h)
-			assert.NoError(t, err)
-		}
-
-		for _, v := range endpoints {
-			for _, e := range v {
-				_, err := f(nil, nil, &grpc.UnaryServerInfo{
-					FullMethod: e,
-				}, h)
-				assert.NoError(t, err)
-			}
-		}
+	t.Run("no rules, middlewares are nil", func(t *testing.T) {
+		u, s := setAPIEndpointsMiddlewares(nil)
+		assert.Nil(t, u)
+		assert.Nil(t, s)
 	})
 
-	t.Run("protocol mismatch, rule not applied", func(t *testing.T) {
+	t.Run("protocol mismatch, middlewares are nil", func(t *testing.T) {
 		a := []config.APIAccessRule{
 			{
 				Name:     "state",
@@ -352,15 +313,8 @@ func TestSetAPIEndpointsMiddlewareUnary(t *testing.T) {
 			},
 		}
 
-		f := setAPIEndpointsMiddlewareUnary(a)
-
-		for _, v := range endpoints {
-			for _, e := range v {
-				_, err := f(nil, nil, &grpc.UnaryServerInfo{
-					FullMethod: e,
-				}, h)
-				assert.NoError(t, err)
-			}
-		}
+		u, s := setAPIEndpointsMiddlewares(a)
+		assert.Nil(t, u)
+		assert.Nil(t, s)
 	})
 }

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -213,7 +213,7 @@ func (s *server) generateWorkloadCert() error {
 
 func (s *server) getMiddlewareOptions() []grpcGo.ServerOption {
 	intr := make([]grpcGo.UnaryServerInterceptor, 0, 6)
-	intrStream := make([]grpcGo.StreamServerInterceptor, 0, 4)
+	intrStream := make([]grpcGo.StreamServerInterceptor, 0, 5)
 
 	intr = append(intr, metadata.SetMetadataInContextUnary)
 
@@ -228,7 +228,9 @@ func (s *server) getMiddlewareOptions() []grpcGo.ServerOption {
 
 	if s.authToken != "" {
 		s.logger.Info("Enabled token authentication on gRPC server")
-		intr = append(intr, setAPIAuthenticationMiddlewareUnary(s.authToken, authConsts.APITokenHeader))
+		unary, stream := getAPIAuthenticationMiddlewares(s.authToken, authConsts.APITokenHeader)
+		intr = append(intr, unary)
+		intrStream = append(intrStream, stream)
 	}
 
 	if diagUtils.IsTracingEnabled(s.tracingSpec.SamplingRate) {

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -141,7 +141,7 @@ func TestClose(t *testing.T) {
 	})
 }
 
-func Test_server_getGRPCAPILoggingInfo(t *testing.T) {
+func Test_server_getGRPCAPILoggingMiddlewares(t *testing.T) {
 	logDest := &bytes.Buffer{}
 	infoLog := logger.NewLogger("test-api-logging")
 	infoLog.EnableJSONOutput(true)
@@ -158,7 +158,7 @@ func Test_server_getGRPCAPILoggingInfo(t *testing.T) {
 		return nil, nil
 	}
 
-	logInterceptor := s.getGRPCAPILoggingInfo()
+	logInterceptor, _ := s.getGRPCAPILoggingMiddlewares()
 
 	runTest := func(userAgent string) func(t *testing.T) {
 		md := grpcMetadata.MD{}

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -83,8 +83,9 @@ func TestGetMiddlewareOptions(t *testing.T) {
 			apiSpec: config.APISpec{
 				Allowed: []config.APIAccessRule{
 					{
-						Name:    "state",
-						Version: "v1",
+						Name:     "state",
+						Version:  "v1",
+						Protocol: "grpc",
 					},
 				},
 			},


### PR DESCRIPTION
Three middlewares in the gRPC API server were only applied to unary RPCs and did not have a variant for stream-based RPCs (currently, that involves `SubscribeConfigurationAlpha1` since Dapr 1.9):

- API token authentication
- API allowlisting
- API logging

This means that invoking `SubscribeConfigurationAlpha1` (and any other stream-based RPC in the future) bypassed API token authentication, allowlists, and those calls were not logged.