### PR TITLE
Fix perf tests currently broken

### DIFF
--- a/tests/perf/utils/helpers.go
+++ b/tests/perf/utils/helpers.go
@@ -93,7 +93,7 @@ func UploadAzureBlob(report *perf.TestReport) error {
 	l := logger.NewLogger("dapr-perf-test")
 	azblob := blobstorage.NewAzureBlobStorage(l)
 
-	err = azblob.Init(bindings.Metadata{
+	err = azblob.Init(context.Background(), bindings.Metadata{
 		Base: metadata.Base{
 			Properties: map[string]string{
 				"storageAccount":    accountName,


### PR DESCRIPTION
The interface for the Init method of state stores changed and that broke our perf tests

See: https://github.com/dapr/dapr/actions/workflows/dapr-perf.yml