### PR TITLE
[WIP] Filter by pod label

### DIFF
--- a/pkg/operator/handlers/dapr_handler_test.go
+++ b/pkg/operator/handlers/dapr_handler_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/dapr/dapr/pkg/injector/annotations"
+	"github.com/dapr/dapr/pkg/injector/sidecar"
 	dapr_testing "github.com/dapr/dapr/pkg/testing"
 )
 
@@ -280,6 +281,7 @@ func TestInit(t *testing.T) {
 		assert.NotNil(t, wrapper)
 
 		assert.Equal(t, reflect.TypeOf(&appsv1.Deployment{}), reflect.TypeOf(wrapper.GetObject()))
+		assert.Equal(t, wrapper.GetMatchLabels(), map[string]string{sidecar.SidecarInjectedLabel: "true"})
 
 		reconciler = reflect.Indirect(reflect.ValueOf(statefulsetCtl)).FieldByName("Do").Interface().(*Reconciler)
 
@@ -288,6 +290,7 @@ func TestInit(t *testing.T) {
 		assert.NotNil(t, wrapper)
 
 		assert.Equal(t, reflect.TypeOf(&appsv1.StatefulSet{}), reflect.TypeOf(wrapper.GetObject()))
+		assert.Equal(t, wrapper.GetMatchLabels(), map[string]string{sidecar.SidecarInjectedLabel: "true"})
 	})
 }
 


### PR DESCRIPTION
# Description

After the addition of #5937, now there exists an label in the sidecar pod that can be used to filter only for pods that have dapr enabled. With this, instead of going through the annotations, we can directly get the containers with dapr enabled and ensure the container is running. 

## Issue reference

Please reference the issue this PR will close: #5693 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [WIP] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
