### PR TITLE
Allow trace header propagation without trace exporting

### DIFF
--- a/pkg/diagnostics/utils/trace_utils.go
+++ b/pkg/diagnostics/utils/trace_utils.go
@@ -61,6 +61,24 @@ func (e *StdoutExporter) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// NullExporter implements an open telemetry span exporter that discards all telemetry.
+type NullExporter struct{}
+
+// NewNullExporter returns a NullExporter
+func NewNullExporter() *NullExporter {
+	return &NullExporter{}
+}
+
+// ExportSpans implements the open telemetry span exporter interface.
+func (e *NullExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	return nil
+}
+
+// Shutdown implements the open telemetry span exporter interface.
+func (e *NullExporter) Shutdown(ctx context.Context) error {
+	return nil
+}
+
 // GetTraceSamplingRate parses the given rate and returns the parsed rate.
 func GetTraceSamplingRate(rate string) float64 {
 	f, err := strconv.ParseFloat(rate, 64)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -408,6 +408,10 @@ func (a *DaprRuntime) setupTracing(hostAddress string, tpStore tracerProviderSto
 		tpStore.RegisterExporter(otelExporter)
 	}
 
+	if !tpStore.HasExporter() && tracingSpec.SamplingRate != "" {
+		tpStore.RegisterExporter(diagUtils.NewNullExporter())
+	}
+
 	// Register a resource
 	r := resource.NewWithAttributes(
 		semconv.SchemaURL,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -900,6 +900,12 @@ func TestSetupTracing(t *testing.T) {
 		name:          "no trace exporter",
 		tracingConfig: config.TracingSpec{},
 	}, {
+		name: "sampling rate 1 without trace exporter",
+		tracingConfig: config.TracingSpec{
+			SamplingRate: "1",
+		},
+		expectedExporters: []sdktrace.SpanExporter{&diagUtils.NullExporter{}},
+	}, {
 		name: "bad host address, failing zipkin",
 		tracingConfig: config.TracingSpec{
 			Zipkin: config.ZipkinSpec{
@@ -972,6 +978,9 @@ func TestSetupTracing(t *testing.T) {
 				assert.Contains(t, err.Error(), tc.expectedErr)
 			} else {
 				assert.Nil(t, err)
+			}
+			if len(tc.expectedExporters) > 0 {
+				assert.True(t, tpStore.HasExporter())
 			}
 			for i, exporter := range tpStore.exporters {
 				// Exporter types don't expose internals, so we can only validate that

--- a/pkg/runtime/trace.go
+++ b/pkg/runtime/trace.go
@@ -30,6 +30,7 @@ type tracerProviderStore interface {
 	RegisterResource(res *resource.Resource)
 	RegisterSampler(sampler sdktrace.Sampler)
 	RegisterTracerProvider() *sdktrace.TracerProvider
+	HasExporter() bool
 }
 
 // newOpentelemetryTracerProviderStore returns an opentelemetryOptionsStore
@@ -48,6 +49,11 @@ type opentelemetryTracerProviderStore struct {
 // RegisterExporter adds a Span Exporter for registration with open telemetry global trace provider
 func (s *opentelemetryTracerProviderStore) RegisterExporter(exporter sdktrace.SpanExporter) {
 	s.exporters = append(s.exporters, exporter)
+}
+
+// HasExporter returns whether at least one Span Exporter has been registered
+func (s *opentelemetryTracerProviderStore) HasExporter() bool {
+	return len(s.exporters) > 0
 }
 
 // RegisterResource adds a Resource for registration with open telemetry global trace provider
@@ -117,3 +123,8 @@ func (s *fakeTracerProviderStore) RegisterSampler(sampler sdktrace.Sampler) {
 
 // RegisterTraceProvider does nothing
 func (s *fakeTracerProviderStore) RegisterTracerProvider() *sdktrace.TracerProvider { return nil }
+
+// HasExporter returns whether at least one Span Exporter has been registered
+func (s *fakeTracerProviderStore) HasExporter() bool {
+	return len(s.exporters) > 0
+}


### PR DESCRIPTION
This change allows trace ID / traceparent to be propagated or generated by the runtime without exporting full trace logs.

In configuration this can be done via

```
apiVersion: dapr.io/v1alpha1
kind: Configuration
metadata:
  name: daprConfig
spec:
  tracing:
    samplingRate: "1"
```

Previously it was necessary to choose one of the existing exporters like `otel`, `zipkin` or `stdout` (and configure an endpoint for the former two) even if all one was interested in was the forwarding of trace headers through Dapr.

Internally this is accomplished by creating a `NullExporter` which is registered if none of the other trace exporters have been registered.

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
