### PR TITLE
Standardize postgres/postgresql component names

### DIFF
--- a/cmd/daprd/components/binding_postgres.go
+++ b/cmd/daprd/components/binding_postgres.go
@@ -19,5 +19,5 @@ import (
 )
 
 func init() {
-	bindingsLoader.DefaultRegistry.RegisterOutputBinding(postgres.NewPostgres, "postgres")
+	bindingsLoader.DefaultRegistry.RegisterOutputBinding(postgres.NewPostgres, "postgres", "postgresql")
 }

--- a/cmd/daprd/components/configuration_postgres.go
+++ b/cmd/daprd/components/configuration_postgres.go
@@ -19,5 +19,5 @@ import (
 )
 
 func init() {
-	configurationLoader.DefaultRegistry.RegisterComponent(configPostgres.NewPostgresConfigurationStore, "postgres")
+	configurationLoader.DefaultRegistry.RegisterComponent(configPostgres.NewPostgresConfigurationStore, "postgres", "postgresql")
 }

--- a/cmd/daprd/components/state_postgres.go
+++ b/cmd/daprd/components/state_postgres.go
@@ -19,5 +19,5 @@ import (
 )
 
 func init() {
-	stateLoader.DefaultRegistry.RegisterComponent(postgresql.NewPostgreSQLStateStore, "postgresql")
+	stateLoader.DefaultRegistry.RegisterComponent(postgresql.NewPostgreSQLStateStore, "postgres", "postgresql")
 }


### PR DESCRIPTION
We currently have 3 components for postgres, and they do not use the same nomenclature:

- `state.postgresql`
- `bindings.postgres`
- `configuration.postgres`

This PR changes all 3 to accept both "postgres" and "postgresql" (and we should probably change the docs to use "postgres" everywhere)