### PR TITLE
Fix flaky unit tests in pkg/messaging

### DIFF
--- a/pkg/grpc/api_daprinternal.go
+++ b/pkg/grpc/api_daprinternal.go
@@ -153,7 +153,7 @@ func (a *api) CallLocalStream(stream internalv1pb.ServiceInvocation_CallLocalStr
 
 			// Read the next chunk
 			readErr = stream.RecvMsg(chunk)
-			if readErr == io.EOF {
+			if errors.Is(readErr, io.EOF) {
 				// Receiving an io.EOF signifies that the client has stopped sending data over the pipe, so we can stop reading
 				break
 			} else if readErr != nil {

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -408,7 +408,7 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 
 			// Read the next chunk
 			readErr = stream.RecvMsg(chunk)
-			if readErr == io.EOF {
+			if errors.Is(readErr, io.EOF) {
 				// Receiving an io.EOF signifies that the client has stopped sending data over the pipe, so we can stop reading
 				break
 			} else if readErr != nil {

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -323,7 +323,11 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 		// Send the chunk if there's anything to send
 		if proto.Request != nil || proto.Payload != nil {
 			err = stream.SendMsg(proto)
-			if err != nil {
+			if errors.Is(err, io.EOF) {
+				// If SendMsg returns an io.EOF error, it usually means that there's a transport-level error
+				// The exact error can only be determined by RecvMsg, so if we encounter an EOF error here, just consider the stream done and let RecvMsg handle the error
+				done = true
+			} else if err != nil {
 				return nil, fmt.Errorf("error sending message: %w", err)
 			}
 		}


### PR DESCRIPTION
The unit tests in pkg/messaging have been particularly flaky lately. I am not able to reproduce the issue ever locally, which seems to be happening only on CI agents (maybe due to their lower perf? totally unclear), but I've attempted to make some improvements to hopefully improve the stability.

1. Errors were happening on the send side on SendMsg. Per the documentation, when SendMsg returns an EOF error (what we are seeing), it means that there was some sort of transport-level failure, but the exact error is only returned by RecvMsg. I've changed the code so when SendMsg encounters an EOF, it doesn't return the error right away, but falls through and lets SendMsg return the actual error. This is unlikely to improve the flakiness, but hopefully helps getting better errors.
1. The test gRPC server now listens on a unix socket rather than a TCP port. Flakiness due to using TCP is not new in our unit tests, it's been going on for months, and using a UDS should hopefully improve the situation.