### PR TITLE
Update durabletask-go dependency to v0.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20220329195025-15018e9b97e0
 	github.com/jhump/protoreflect v1.14.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/microsoft/durabletask-go v0.1.3
+	github.com/microsoft/durabletask-go v0.1.4
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5

--- a/go.sum
+++ b/go.sum
@@ -1422,8 +1422,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
-github.com/microsoft/durabletask-go v0.1.3 h1:7SJ4U7MUn64xdKzRr/8CDtK4WtZmc7WC5lEQYWFEo6c=
-github.com/microsoft/durabletask-go v0.1.3/go.mod h1:UOgcE09cx6SzBS31p4darJ7ve9P5pSVIStPShxDnvPo=
+github.com/microsoft/durabletask-go v0.1.4 h1:sHVFysoJQvG2Sp4wh2tblZBd4DDJmXrBdYCyUlo38MM=
+github.com/microsoft/durabletask-go v0.1.4/go.mod h1:UOgcE09cx6SzBS31p4darJ7ve9P5pSVIStPShxDnvPo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -634,6 +634,43 @@ func TestRetryActivityOnTimeout(t *testing.T) {
 	}
 }
 
+func TestConcurrentTimerExecution(t *testing.T) {
+	r := task.NewTaskRegistry()
+	r.AddOrchestratorN("TimerFanOut", func(ctx *task.OrchestrationContext) (any, error) {
+		tasks := []task.Task{}
+		for i := 0; i < 2; i++ {
+			tasks = append(tasks, ctx.CreateTimer(1*time.Second))
+		}
+		for _, t := range tasks {
+			if err := t.Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+
+	ctx := context.Background()
+	client, engine := startEngine(ctx, r)
+	for _, opt := range GetTestOptions() {
+		t.Run(opt(engine), func(t *testing.T) {
+			id, err := client.ScheduleNewOrchestration(ctx, "TimerFanOut")
+			if assert.NoError(t, err) {
+				// Add a 5 second timeout so that the test doesn't take forever if something isn't working
+				timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+
+				metadata, err := client.WaitForOrchestrationCompletion(timeoutCtx, id)
+				if assert.NoError(t, err) {
+					assert.True(t, metadata.IsComplete())
+
+					// Because all the timers run in parallel, they should complete very quickly
+					assert.Less(t, metadata.LastUpdatedAt.Sub(metadata.CreatedAt), 3*time.Second)
+				}
+			}
+		})
+	}
+}
+
 func startEngine(ctx context.Context, r *task.TaskRegistry) (backend.TaskHubClient, *wfengine.WorkflowEngine) {
 	var client backend.TaskHubClient
 	engine := getEngine()


### PR DESCRIPTION
# Description

This PR updates the `durabletask-go` dependency used by the workflow engine to v0.1.4. There are two important changes included in this update:

- Internal suspend/resume workflow implementation (https://github.com/microsoft/durabletask-go/pull/8)
- Fix for user-reported issue about concurrent workflow timers not getting scheduled (https://github.com/microsoft/durabletask-go/pull/10)

The reason for making this a standalone PR is because it will automatically fix #5978 (listed below). A regression test has also been added which verifies the fix (this new test would have failed previously).

There will be a separate PR for lighting up the suspend/resume functionality, which we hope to get done for Dapr v1.11.

## Issue reference

Fixes #5978

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
