### PR TITLE
Workflow: Fix generation handling for continue-as-new

### DIFF
--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -447,9 +447,20 @@ func TestContinueAsNewWorkflow(t *testing.T) {
 			if err := ctx.CreateTimer(0).Await(nil); err != nil {
 				return nil, err
 			}
-			ctx.ContinueAsNew(input + 1)
+			var nextInput int32
+			if err := ctx.CallActivity("PlusOne", input).Await(&nextInput); err != nil {
+				return nil, err
+			}
+			ctx.ContinueAsNew(nextInput)
 		}
 		return input, nil
+	})
+	r.AddActivityN("PlusOne", func(ctx task.ActivityContext) (any, error) {
+		var input int32
+		if err := ctx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		return input + 1, nil
 	})
 
 	ctx := context.Background()

--- a/pkg/runtime/wfengine/workflow.go
+++ b/pkg/runtime/wfengine/workflow.go
@@ -365,13 +365,11 @@ func (wf *workflowActor) runWorkflow(ctx context.Context, actorID string, remind
 			if err != nil {
 				if errors.Is(err, ErrDuplicateInvocation) {
 					wfLogger.Warnf("%s: activity invocation %s#%d was flagged as a duplicate and will be skipped", actorID, ts.Name, e.EventId)
-				} else {
-					return newRecoverableError(fmt.Errorf("failed to invoke activity actor '%s' to execute '%s': %v", targetActorID, ts.Name, err))
+					continue
 				}
+				return newRecoverableError(fmt.Errorf("failed to invoke activity actor '%s' to execute '%s': %v", targetActorID, ts.Name, err))
 			}
-			if resp != nil {
-				resp.Close()
-			}
+			resp.Close()
 		} else {
 			wfLogger.Warn("don't know how to process task %v", e)
 		}


### PR DESCRIPTION
# Description

This PR fixes a bug in the Dapr Workflow engine that breaks basic scenarios involving the [continue-as-new workflow feature](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-features-concepts/#infinite-loops-and-eternal-workflows).

Prior to this fix, workflow activity invocations would fail with a "duplicate invocation" error. This would cause the workflow to stall indefinitely. This PR does two things to improve this:

1. It fixes the root bug, which is that we forgot to increment the workflow "generation" counter when a continue-as-new is encountered (this counter is needed for detecting duplicate invocations).
2. It fixes the handling of duplicate invocations so that they aren't considered retriable. Instead, the correct behavior is to log a warning and skip that invocation (assuming it truly is a duplicate).

The existing functional test for continue-as-new missed this issue because it uses durable timers inside the workflow instead of activity invocations. The PR also improves the test to cover both timers and activity invocations.

The problem is easy to run into and it might be worth including as part of a planned hotfix, if possible (though this may go against normal policy for alpha features).

## Issue reference

Fixes #5986 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
