### PR TITLE
[release-1.10] Dapr fails to initialize when a middleware component failes to init

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -687,6 +687,8 @@ func (a *DaprRuntime) buildHTTPPipelineForSpec(spec config.PipelineSpec, targetP
 				a.Shutdown(a.runtimeConfig.GracefulShutdownDuration)
 				log.Fatalf("couldn't find middleware component with name %s and type %s/%s",
 					middlewareSpec.Name, middlewareSpec.Type, middlewareSpec.Version)
+				// This error is only caught by tests, since during normal execution we panic
+				return pipeline, errors.New("dapr panicked")
 			}
 			md := middleware.Metadata{Base: a.toBaseMetadata(component)}
 			handler, err := a.httpMiddlewareRegistry.Create(middlewareSpec.Type, middlewareSpec.Version, md, middlewareSpec.LogName())
@@ -696,6 +698,8 @@ func (a *DaprRuntime) buildHTTPPipelineForSpec(spec config.PipelineSpec, targetP
 					log.Warn("error processing middleware component, daprd process will exit gracefully")
 					a.Shutdown(a.runtimeConfig.GracefulShutdownDuration)
 					log.Fatal(e)
+					// This error is only caught by tests, since during normal execution we panic
+					return pipeline, errors.New("dapr panicked")
 				}
 				log.Error(e)
 				continue

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -683,12 +683,10 @@ func (a *DaprRuntime) buildHTTPPipelineForSpec(spec config.PipelineSpec, targetP
 			middlewareSpec := spec.Handlers[i]
 			component, exists := a.getComponent(middlewareSpec.Type, middlewareSpec.Name)
 			if !exists {
-				log.Warn("error processing middleware component, daprd process will exit gracefully")
-				a.Shutdown(a.runtimeConfig.GracefulShutdownDuration)
-				log.Fatalf("couldn't find middleware component with name %s and type %s/%s",
+				// Log the error but continue with initializing the pipeline
+				log.Error("couldn't find middleware component defined in configuration with name %s and type %s/%s",
 					middlewareSpec.Name, middlewareSpec.Type, middlewareSpec.Version)
-				// This error is only caught by tests, since during normal execution we panic
-				return pipeline, errors.New("dapr panicked")
+				continue
 			}
 			md := middleware.Metadata{Base: a.toBaseMetadata(component)}
 			handler, err := a.httpMiddlewareRegistry.Create(middlewareSpec.Type, middlewareSpec.Version, md, middlewareSpec.LogName())

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2079,14 +2079,14 @@ func TestMiddlewareBuildPipeline(t *testing.T) {
 		assert.Empty(t, pipeline.Handlers)
 	})
 
-	t.Run("panic when component does not exists", func(t *testing.T) {
+	t.Run("ignore component that does not exists", func(t *testing.T) {
 		rt := &DaprRuntime{
 			globalConfig:   &config.Configuration{},
 			componentsLock: &sync.RWMutex{},
 			runtimeConfig:  &Config{},
 		}
 
-		_, err := rt.buildHTTPPipelineForSpec(config.PipelineSpec{
+		pipeline, err := rt.buildHTTPPipelineForSpec(config.PipelineSpec{
 			Handlers: []config.HandlerSpec{
 				{
 					Name:         "not_exists",
@@ -2096,12 +2096,8 @@ func TestMiddlewareBuildPipeline(t *testing.T) {
 				},
 			},
 		}, "test")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "dapr panicked")
-		require.Equal(t, 1, lnp.fatalCalled)
-
-		// Reset
-		lnp.fatalCalled = 0
+		require.NoError(t, err)
+		assert.Len(t, pipeline.Handlers, 0)
 	})
 
 	t.Run("all components exists", func(t *testing.T) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2044,7 +2044,33 @@ func TestInitSecretStores(t *testing.T) {
 	})
 }
 
+// Used to override log.Fatal/log.Fatalf so it doesn't cause the app to exit
+type loggerNoPanic struct {
+	logger.Logger
+	fatalCalled int
+}
+
+func (l *loggerNoPanic) Fatal(args ...interface{}) {
+	l.fatalCalled++
+	l.Error(args...)
+}
+
+func (l *loggerNoPanic) Fatalf(format string, args ...interface{}) {
+	l.fatalCalled++
+	l.Errorf(format, args...)
+}
+
 func TestMiddlewareBuildPipeline(t *testing.T) {
+	// Change the logger for these tests so it doesn't panic
+	lnp := &loggerNoPanic{
+		Logger: log,
+	}
+	oldLog := log
+	log = lnp
+	defer func() {
+		log = oldLog
+	}()
+
 	t.Run("build when no global config are set", func(t *testing.T) {
 		rt := &DaprRuntime{}
 
@@ -2052,10 +2078,12 @@ func TestMiddlewareBuildPipeline(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, pipeline.Handlers)
 	})
-	t.Run("build when component does not exists", func(t *testing.T) {
+
+	t.Run("panic when component does not exists", func(t *testing.T) {
 		rt := &DaprRuntime{
 			globalConfig:   &config.Configuration{},
 			componentsLock: &sync.RWMutex{},
+			runtimeConfig:  &Config{},
 		}
 
 		_, err := rt.buildHTTPPipelineForSpec(config.PipelineSpec{
@@ -2068,29 +2096,40 @@ func TestMiddlewareBuildPipeline(t *testing.T) {
 				},
 			},
 		}, "test")
-		require.NotNil(t, err)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "dapr panicked")
+		require.Equal(t, 1, lnp.fatalCalled)
+
+		// Reset
+		lnp.fatalCalled = 0
 	})
-	t.Run("build when component exists", func(t *testing.T) {
-		const name = "fake"
-		typ := fmt.Sprintf("middleware.http.%s", name)
+
+	t.Run("all components exists", func(t *testing.T) {
 		rt := &DaprRuntime{
 			globalConfig:           &config.Configuration{},
 			componentsLock:         &sync.RWMutex{},
 			httpMiddlewareRegistry: httpMiddlewareLoader.NewRegistry(),
 			components: []componentsV1alpha1.Component{
 				{
-					TypeMeta: metaV1.TypeMeta{},
 					ObjectMeta: metaV1.ObjectMeta{
-						Name: name,
+						Name: "mymw1",
 					},
 					Spec: componentsV1alpha1.ComponentSpec{
-						Type:    typ,
+						Type:    "middleware.http.fakemw",
 						Version: "v1",
 					},
-					Auth:   componentsV1alpha1.Auth{},
-					Scopes: []string{},
+				},
+				{
+					ObjectMeta: metaV1.ObjectMeta{
+						Name: "mymw2",
+					},
+					Spec: componentsV1alpha1.ComponentSpec{
+						Type:    "middleware.http.fakemw",
+						Version: "v1",
+					},
 				},
 			},
+			runtimeConfig: &Config{},
 		}
 		called := 0
 		rt.httpMiddlewareRegistry.RegisterComponent(
@@ -2102,22 +2141,110 @@ func TestMiddlewareBuildPipeline(t *testing.T) {
 					}, nil
 				}
 			},
-			name,
+			"fakemw",
 		)
 
 		pipeline, err := rt.buildHTTPPipelineForSpec(config.PipelineSpec{
 			Handlers: []config.HandlerSpec{
 				{
-					Name:         name,
-					Type:         typ,
-					Version:      "v1",
-					SelectorSpec: config.SelectorSpec{},
+					Name:    "mymw1",
+					Type:    "middleware.http.fakemw",
+					Version: "v1",
+				},
+				{
+					Name:    "mymw2",
+					Type:    "middleware.http.fakemw",
+					Version: "v1",
 				},
 			},
 		}, "test")
 		require.NoError(t, err)
-		assert.Len(t, pipeline.Handlers, 1)
+		assert.Len(t, pipeline.Handlers, 2)
+		assert.Equal(t, 2, called)
 	})
+
+	testInitFail := func(ignoreErrors bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			rt := &DaprRuntime{
+				globalConfig:           &config.Configuration{},
+				componentsLock:         &sync.RWMutex{},
+				httpMiddlewareRegistry: httpMiddlewareLoader.NewRegistry(),
+				components: []componentsV1alpha1.Component{
+					{
+						ObjectMeta: metaV1.ObjectMeta{
+							Name: "mymw",
+						},
+						Spec: componentsV1alpha1.ComponentSpec{
+							Type:    "middleware.http.fakemw",
+							Version: "v1",
+						},
+					},
+					{
+						ObjectMeta: metaV1.ObjectMeta{
+							Name: "failmw",
+						},
+						Spec: componentsV1alpha1.ComponentSpec{
+							Type:         "middleware.http.fakemw",
+							Version:      "v1",
+							IgnoreErrors: ignoreErrors,
+							Metadata: []componentsV1alpha1.MetadataItem{
+								{Name: "fail", Value: componentsV1alpha1.DynamicValue{JSON: v1.JSON{Raw: []byte("true")}}},
+							},
+						},
+					},
+				},
+				runtimeConfig: &Config{},
+			}
+			called := 0
+			rt.httpMiddlewareRegistry.RegisterComponent(
+				func(_ logger.Logger) httpMiddlewareLoader.FactoryMethod {
+					called++
+					return func(metadata middleware.Metadata) (httpMiddleware.Middleware, error) {
+						if metadata.Properties["fail"] == "true" {
+							return nil, errors.New("simulated failure")
+						}
+
+						return func(next http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+						}, nil
+					}
+				},
+				"fakemw",
+			)
+
+			pipeline, err := rt.buildHTTPPipelineForSpec(config.PipelineSpec{
+				Handlers: []config.HandlerSpec{
+					{
+						Name:    "mymw",
+						Type:    "middleware.http.fakemw",
+						Version: "v1",
+					},
+					{
+						Name:    "failmw",
+						Type:    "middleware.http.fakemw",
+						Version: "v1",
+					},
+				},
+			}, "test")
+
+			assert.Equal(t, 2, called)
+
+			if ignoreErrors {
+				require.NoError(t, err)
+				assert.Len(t, pipeline.Handlers, 1)
+			} else {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, "dapr panicked")
+				assert.Equal(t, 1, lnp.fatalCalled)
+
+				// Reset
+				lnp.fatalCalled = 0
+			}
+		}
+	}
+
+	t.Run("one components fails to init", testInitFail(false))
+	t.Run("one components fails to init but ignoreErrors is true", testInitFail(true))
 }
 
 func TestMetadataItemsToPropertiesConversion(t *testing.T) {


### PR DESCRIPTION
# Description

When Dapr is configured with middleware components (both app HTTP pipeline and HTTP pipeline) and a component fails to initialize, a warning is shown and then errors are ignored and Dapr continues to start regularly, but without any middleware (not just the one(s) that failed to init).

This behavior can cause unexpected results and in some cases even, potentially, security issues, when the middlewares are used for security purposes (since they'd be totally bypassed if one of the middlewares fails to init).

The same thing happens if the Dapr configuration references a middleware component that has not been defined in a component YAML. In that case, no middleware is loaded (including those that have a matching component YAML)

This PR changes the behavior of the middleware init logic so:

- ~~If the Dapr configuration references a middleware that doesn't have a Component YAML loaded, Dapr fails to init and shuts down right away. This applies to both pipelines ("dapr" and app)~~
   - Per @artursouza 's feedback, in this case Dapr will show an error but will not crash. However, it will continue loading other middleware components (before, an error like this would cause _no_ middleware to be loaded)
- If a middleware component fails to init, we now respect the value of `ignoreErrors` like we do for all other components:
  - If `ignoreErrors: false` (default value if omitted), Dapr fails to start and shuts down right away
  - If `ignoreErrors: true`, Dapr continues to init but without that specific middleware component (other middlewares however can still be used)

Added unit tests to validate the behavior.

## Issue reference

Fixes the runtime part of https://github.com/dapr/components-contrib/issues/2599

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
* [X] End-to-end tests passing
