### PR TITLE
[release-1.10] Cherry-pick #5976 to reduce unit test flakiness

### DIFF
--- a/pkg/grpc/api_daprinternal.go
+++ b/pkg/grpc/api_daprinternal.go
@@ -153,7 +153,7 @@ func (a *api) CallLocalStream(stream internalv1pb.ServiceInvocation_CallLocalStr
 
 			// Read the next chunk
 			readErr = stream.RecvMsg(chunk)
-			if readErr == io.EOF {
+			if errors.Is(readErr, io.EOF) {
 				// Receiving an io.EOF signifies that the client has stopped sending data over the pipe, so we can stop reading
 				break
 			} else if readErr != nil {


### PR DESCRIPTION
**Because this is a cherry-pick, please DO NOT SQUASH**

Cherry-picks a commit into release-1.10 as this should reduce a lot of flakiness in the unit tests and greatly reduce our build failures for 1.10 hotfixes.

The changes in the commit were primarily in unit tests, with a small code change in something that's gated behind a feature flag, so risk should be small.