### PR TITLE
Update deprecated GitHub actions

### DIFF
--- a/.github/workflows/dapr-3rdparty-images.yaml
+++ b/.github/workflows/dapr-3rdparty-images.yaml
@@ -14,14 +14,14 @@ jobs:
         uses: actions/checkout@v3
       - # ghcr logins for pushing image after testing
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Login to DockerHub
-        uses: docker/login-action@v12
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_REGISTRY_ID }}
           password: ${{ secrets.DOCKER_REGISTRY_PASS }}

--- a/.github/workflows/dapr-base-containers.yaml
+++ b/.github/workflows/dapr-base-containers.yaml
@@ -49,7 +49,7 @@ jobs:
             }
       - name: Check out dapr
         if: env.CHECKOUT_REPO != ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}

--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -37,13 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Prune Stale
-      uses: actions/stale@v3.0.14
+      uses: actions/stale@v7.0.0
       with:
         repo-token: ${{ secrets.DAPR_BOT_TOKEN }}
-        # Different amounts of days for issues/PRs are not currently supported but there is a PR
-        # open for it: https://github.com/actions/stale/issues/214
-        days-before-stale: 60
-        days-before-close: 7
+        days-before-pr-stale: 60
+        days-before-pr-close: 7
+        days-before-issue-stale: 60
+        days-before-issue-close: 7
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had activity in the
           last 60 days. It will be closed in the next 7 days unless it is tagged (pinned, good first issue, help wanted or triaged/resolved) or other activity

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -99,7 +99,7 @@ jobs:
             Commit ref: ${{ env.CHECKOUT_REF }}
       - name: Check out code
         if: env.CHECKOUT_REPO != ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -446,7 +446,7 @@ jobs:
           name: dapr_helm_charts_package
           path: ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
       - name: Checkout Helm Charts Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         env:
               DAPR_HELM_REPO: dapr/helm-charts
               DAPR_HELM_REPO_CODE_PATH: helm-charts

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -34,7 +34,7 @@ jobs:
       FOSSA_API_KEY: b88e1f4287c3108c8751bf106fb46db6 # This is a push-only token that is safe to be exposed.
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Run FOSSA Scan"
         uses: fossas/fossa-action@v1.1.0 # Use a specific version if locking is preferred


### PR DESCRIPTION
These Actions are showing a warning and will stop working soon.

Also fixes a typo introduced in my last PR which broke the mirror image action: https://github.com/dapr/dapr/actions/runs/4298680482