### PR TITLE
Improvments to placement tests

### DIFF
--- a/pkg/placement/ha_test.go
+++ b/pkg/placement/ha_test.go
@@ -114,11 +114,11 @@ func TestPlacementHA(t *testing.T) {
 		// There should be no leader
 		assert.Eventually(t, func() bool {
 			for _, srv := range raftServers {
-				if srv != nil {
-					return !srv.IsLeader()
+				if srv != nil && srv.IsLeader() {
+					return false
 				}
 			}
-			return false
+			return true
 		}, time.Second*5, time.Millisecond*100, "leader did not step down")
 	})
 	t.Run("leader elected when second node comes up", func(t *testing.T) {

--- a/pkg/placement/ha_test.go
+++ b/pkg/placement/ha_test.go
@@ -264,5 +264,6 @@ func retrieveValidState(t *testing.T, srv *raft.Server, expect *raft.DaprHostMem
 		return found && expect.Name == actual.Name &&
 			expect.AppID == actual.AppID
 	}, 5*time.Second, 100*time.Millisecond, "%v != %v", expect, actual)
+	require.NotNil(t, actual)
 	assert.EqualValues(t, expect.Entities, actual.Entities)
 }

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -233,7 +233,7 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 				return nil
 			}
 
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 				log.Debugf("Stream connection is disconnected gracefully: %s", registeredMemberID)
 				if isActorRuntime {
 					p.membershipCh <- hostMemberChange{

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -40,7 +40,8 @@ func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Ser
 	serverStoped := make(chan struct{})
 	testServer := NewPlacementService(raftServer)
 
-	port, _ := freeport.GetFreePort()
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
 	go func() {
 		defer close(serverStoped)
 		assert.NoError(t, testServer.Run(ctx, strconv.Itoa(port), nil))

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -81,7 +81,7 @@ func TestMemberRegistration_NoLeadership(t *testing.T) {
 
 	// arrange
 	conn, stream, err := newTestClient(serverAddress)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	host := &v1pb.Host{
 		Name:     "127.0.0.1:50102",
@@ -92,7 +92,7 @@ func TestMemberRegistration_NoLeadership(t *testing.T) {
 	}
 
 	// act
-	stream.Send(host)
+	stream.Send(ost)
 	_, err = stream.Recv()
 	s, ok := status.FromError(err)
 
@@ -113,7 +113,7 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 	t.Run("Connect server and disconnect it gracefully", func(t *testing.T) {
 		// arrange
 		conn, stream, err := newTestClient(serverAddress)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		host := &v1pb.Host{
 			Name:     "127.0.0.1:50102",
@@ -160,7 +160,7 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 	t.Run("Connect server and disconnect it forcefully", func(t *testing.T) {
 		// arrange
 		conn, stream, err := newTestClient(serverAddress)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// act
 		host := &v1pb.Host{
@@ -209,7 +209,7 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 	t.Run("non actor host", func(t *testing.T) {
 		// arrange
 		conn, stream, err := newTestClient(serverAddress)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// act
 		host := &v1pb.Host{

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -92,7 +92,7 @@ func TestMemberRegistration_NoLeadership(t *testing.T) {
 	}
 
 	// act
-	stream.Send(ost)
+	stream.Send(host)
 	_, err = stream.Recv()
 	s, ok := status.FromError(err)
 


### PR DESCRIPTION
Broke in https://github.com/dapr/dapr/pull/5850/files#diff-ef2719861c9d881554d04132e16b205f2af186b32ceb40aa260fa008b7598d2c

Test every server for leader election loss.

Gracefully exit stream when context is cancelled.

Use `require`s on failed `newTestClient`.

Maybe fixes #6020