### PR TITLE
Draft: More Placment test improvments

### DIFF
--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -91,7 +91,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 	}
 
 	t.Run("successful dissemination", func(t *testing.T) {
-		teardown := setupEach(t)
+		t.Cleanup(setupEach(t))
 		// arrange
 		testServer.faultyHostDetectDuration.Store(int64(faultyHostDetectInitialDuration))
 
@@ -145,21 +145,17 @@ func TestMembershipChangeWorker(t *testing.T) {
 			"flushed all member updates and faultyHostDetectDuration must be faultyHostDetectDuration")
 
 		conn.Close()
-
-		teardown()
 	})
 
 	t.Run("faulty host detector", func(t *testing.T) {
 		// arrange
-		teardown := setupEach(t)
+		t.Cleanup(setupEach(t))
 		arrangeFakeMembers(t)
 
 		// faulty host detector removes all members if heartbeat does not happen
 		assert.Eventually(t, func() bool {
 			return len(testServer.raftNode.FSM().State().Members()) == 0
 		}, faultyHostDetectInitialDuration+100*time.Millisecond, 10*time.Millisecond)
-
-		teardown()
 	})
 }
 

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -162,6 +162,7 @@ func (p *Service) Run(ctx context.Context, port string, certChain *daprCredentia
 	case err = <-stopErr:
 		// nop
 	}
+	log.Info("placement service stopped")
 	return err
 }
 

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -61,7 +61,9 @@ func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Ser
 }
 
 func newTestClient(serverAddress string) (*grpc.ClientConn, v1pb.Placement_ReportDaprStatusClient, error) { //nolint:nosnakecase
-	conn, err := grpc.Dial(serverAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, serverAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -44,7 +44,7 @@ func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Ser
 	require.NoError(t, err)
 	go func() {
 		defer close(serverStoped)
-		assert.NoError(t, testServer.Run(ctx, strconv.Itoa(port), nil))
+		require.NoError(t, testServer.Run(ctx, strconv.Itoa(port), nil))
 	}()
 
 	cleanUpFn := func() {
@@ -80,6 +80,7 @@ func newTestClient(serverAddress string) (*grpc.ClientConn, v1pb.Placement_Repor
 func TestMemberRegistration_NoLeadership(t *testing.T) {
 	// set up
 	serverAddress, testServer, cleanup := newTestPlacementServer(t, testRaftServer)
+	t.Cleanup(cleanup)
 	testServer.hasLeadership.Store(false)
 
 	// arrange
@@ -106,11 +107,11 @@ func TestMemberRegistration_NoLeadership(t *testing.T) {
 
 	// tear down
 	conn.Close()
-	cleanup()
 }
 
 func TestMemberRegistration_Leadership(t *testing.T) {
 	serverAddress, testServer, cleanup := newTestPlacementServer(t, testRaftServer)
+	t.Cleanup(cleanup)
 	testServer.hasLeadership.Store(true)
 
 	t.Run("Connect server and disconnect it gracefully", func(t *testing.T) {
@@ -238,6 +239,4 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 		// where dapr runtime disconnects the connection from placement service unexpectedly.
 		conn.Close()
 	})
-
-	cleanup()
 }


### PR DESCRIPTION
- Adds context and block to placement `newTestClient`
- Always cleanup servers in tests
- Log when placement service stopped