### PR TITLE
[WIP] Manage reminders and actors in-memory using a priority queue

### DIFF
--- a/pkg/actors/reminders/processor.go
+++ b/pkg/actors/reminders/processor.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	clocklib "github.com/benbjohnson/clock"
+)
+
+var ErrProcessorStopped = errors.New("processor is stopped")
+
+// Processor manages the queue of reminders and processes them at the correct time.
+type Processor struct {
+	executeFn          func(r *Reminder)
+	queue              *Queue
+	clock              clocklib.Clock
+	lock               sync.Mutex
+	processorRunningCh chan struct{}
+	stopCh             chan struct{}
+	stopped            atomic.Bool
+}
+
+// NewProcessor returns a new Processor object.
+// executeFn is the callback invoked when the reminder is to be executed; this will be invoked in a background goroutine.
+func NewProcessor(executeFn func(r *Reminder), clock clocklib.Clock) *Processor {
+	queue := NewQueue()
+
+	return &Processor{
+		executeFn:          executeFn,
+		queue:              &queue,
+		processorRunningCh: make(chan struct{}, 1),
+		stopCh:             make(chan struct{}),
+		clock:              clock,
+	}
+}
+
+// Enqueue adds a new reminder to the queue.
+// If a reminder with the same ID already exists, it'll be replaced.
+func (p *Processor) Enqueue(r *Reminder) error {
+	if p.stopped.Load() {
+		return ErrProcessorStopped
+	}
+
+	// Insert or replace the reminder in the queue
+	// If the reminder added or replaced is the first one in the queue, we need to know that
+	p.lock.Lock()
+	peek := p.queue.Peek()
+	isFirst := (peek != nil && peek.Key() == r.Key()) // This is going to be true if the reminder being replaced is the first one in the queue
+	p.queue.Insert(r, true)
+	isFirst = isFirst || (p.queue.Peek() == r) // This is also going to be true if the reminder just added landed at the front of the queue
+	p.process(isFirst)
+	p.lock.Unlock()
+
+	return nil
+}
+
+// Dequeue removes a reminder from the queue
+func (p *Processor) Dequeue(r *Reminder) error {
+	if p.stopped.Load() {
+		return ErrProcessorStopped
+	}
+
+	// We need to check if this is the next reminder in the queue, as that requires stopping the processor
+	p.lock.Lock()
+	peek := p.queue.Peek()
+	p.queue.Remove(r)
+	if peek != nil && peek.Key() == r.Key() {
+		// If the reminder was the first one in the queue, restart the processor
+		p.process(true)
+	}
+	p.lock.Unlock()
+
+	return nil
+}
+
+// Stop the processor.
+func (p *Processor) Stop() {
+	if !p.stopped.CompareAndSwap(false, true) {
+		// Already stopped
+		return
+	}
+
+	// We need a lock because we're closing stopCh
+	p.lock.Lock()
+	close(p.stopCh)
+	p.lock.Unlock()
+}
+
+// Start the processing loop if it's not already running.
+// This must be invoked while the caller has a lock.
+func (p *Processor) process(isNext bool) {
+	if isNext {
+		// If this is the next reminder, stop the processor if it's running, then restart it
+		p.stopLoop()
+
+		// This will block until the processor is available
+		p.processorRunningCh <- struct{}{}
+		go p.processLoop()
+		return
+	}
+
+	// Do not start a loop if it's already running
+	select {
+	case p.processorRunningCh <- struct{}{}:
+		// nop - fallthrough
+	default:
+		return
+	}
+
+	go p.processLoop()
+}
+
+// Sends a signal that stops the processor loop.
+// This must be invoked while the caller has a lock.
+func (p *Processor) stopLoop() {
+	close(p.stopCh)
+	p.stopCh = make(chan struct{})
+}
+
+// Processing loop.
+func (p *Processor) processLoop() {
+	var (
+		r      *Reminder
+		t      *clocklib.Timer
+		stopCh chan struct{}
+	)
+
+loop:
+	for {
+		// Continue processing reminders until the queue is empty
+		p.lock.Lock()
+		stopCh = p.stopCh
+		r = p.queue.Peek()
+		p.lock.Unlock()
+		if r == nil {
+			break loop
+		}
+
+		t = p.clock.Timer(p.clock.Until(r.NextTick()))
+
+		select {
+		// Wait for when it's time to execute the reminder
+		case <-t.C:
+			// Pop the reminder now that we're ready to process it
+			// There's a small chance this is a different reminder than the one we peeked before
+			p.lock.Lock()
+			// For safety, let's peek at the first reminder before popping it and make sure it's the same object
+			// It's unlikely, but if it's a different object then restart the loop
+			if p.queue.Peek() != r {
+				p.lock.Unlock()
+				continue
+			}
+			r = p.queue.Pop()
+			p.lock.Unlock()
+			if r == nil {
+				break loop
+			}
+
+			go p.executeFn(r)
+
+		// If we receive a stop signal, exit
+		case <-stopCh:
+			// Stop the timer and exit the loop
+			t.Stop()
+			break loop
+		}
+	}
+
+	<-p.processorRunningCh
+	return
+}

--- a/pkg/actors/reminders/processor_test.go
+++ b/pkg/actors/reminders/processor_test.go
@@ -19,14 +19,14 @@ import (
 	"testing"
 	"time"
 
-	clocklib "github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
 func TestProcessor(t *testing.T) {
 	// Create the processor
-	clock := clocklib.NewMock()
+	clock := clocktesting.NewFakeClock(time.Now())
 	executeCh := make(chan *Reminder)
 	processor := NewProcessor(func(r *Reminder) {
 		executeCh <- r
@@ -63,12 +63,12 @@ func TestProcessor(t *testing.T) {
 	// Makes tickers advance
 	// Note that step must be > 500ms
 	advanceTickers := func(step time.Duration, count int) {
-		clock.Add(50 * time.Millisecond)
+		clock.Step(50 * time.Millisecond)
 		// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
 		runtime.Gosched()
 		time.Sleep(50 * time.Millisecond)
 		for i := 0; i < count; i++ {
-			clock.Add(step)
+			clock.Step(step)
 			// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
 			runtime.Gosched()
 			time.Sleep(50 * time.Millisecond)

--- a/pkg/actors/reminders/processor_test.go
+++ b/pkg/actors/reminders/processor_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	clocklib "github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessor(t *testing.T) {
+	// Create the processor
+	clock := clocklib.NewMock()
+	executeCh := make(chan *Reminder)
+	processor := NewProcessor(func(r *Reminder) {
+		executeCh <- r
+	}, clock)
+
+	assertExecutedReminder := func(t *testing.T) *Reminder {
+		t.Helper()
+
+		// The signal is sent in a background goroutine, so we need to use a wall clock here
+		runtime.Gosched()
+		select {
+		case r := <-executeCh:
+			return r
+		case <-time.After(700 * time.Millisecond):
+			t.Fatal("did not receive signal in 700ms")
+		}
+
+		return nil
+	}
+
+	assertNoExecutedReminder := func(t *testing.T) {
+		t.Helper()
+
+		// The signal is sent in a background goroutine, so we need to use a wall clock here
+		runtime.Gosched()
+		select {
+		case r := <-executeCh:
+			t.Fatalf("received unexpected reminder: %s", r.Name)
+		case <-time.After(500 * time.Millisecond):
+			// all good
+		}
+	}
+
+	// Makes tickers advance
+	// Note that step must be > 500ms
+	advanceTickers := func(step time.Duration, count int) {
+		clock.Add(50 * time.Millisecond)
+		// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
+		runtime.Gosched()
+		time.Sleep(50 * time.Millisecond)
+		for i := 0; i < count; i++ {
+			clock.Add(step)
+			// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
+			runtime.Gosched()
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	t.Run("enqueue reminders", func(t *testing.T) {
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by 500ms to start
+		advanceTickers(500*time.Millisecond, 1)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 5; i++ {
+			t.Logf("Waiting for signal %d", i)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(i), received.Name)
+		}
+	})
+
+	t.Run("enqueue reminder to be executed right away", func(t *testing.T) {
+		r := newTestReminder(1, clock.Now())
+		err := processor.Enqueue(r)
+		require.NoError(t, err)
+
+		advanceTickers(500*time.Millisecond, 1)
+
+		received := assertExecutedReminder(t)
+		assert.Equal(t, "1", received.Name)
+	})
+
+	t.Run("enqueue reminder at the front of the queue", func(t *testing.T) {
+		// Enqueue 4 reminders
+		for i := 1; i <= 4; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by 1500ms to trigger the first reminder
+		t.Log("Waiting for signal 1")
+		advanceTickers(500*time.Millisecond, 3)
+
+		received := assertExecutedReminder(t)
+		assert.Equal(t, "1", received.Name)
+
+		// Add a new reminder at the front of the queue
+		err := processor.Enqueue(
+			newTestReminder(99, clock.Now()),
+		)
+		require.NoError(t, err)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 4; i++ {
+			// First reminder should be 99
+			expect := strconv.Itoa(i)
+			if i == 1 {
+				expect = "99"
+			}
+			t.Logf("Waiting for signal %s", expect)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, expect, received.Name)
+		}
+	})
+
+	t.Run("dequeue reminder", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Dequeue reminders 2 and 4
+		err := processor.Dequeue(newTestReminder(2, 0)) // Time is irrelevant
+		require.NoError(t, err)
+		err = processor.Dequeue(newTestReminder(4, 0)) // Time is irrelevant
+		require.NoError(t, err)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 5; i++ {
+			if i == 2 || i == 4 {
+				// Skip reminders that have been removed
+				t.Logf("Should not receive signal %d", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+			t.Logf("Waiting for signal %d", i)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(i), received.Name)
+		}
+	})
+
+	t.Run("dequeue reminder from the front of the queue", func(t *testing.T) {
+		// Enqueue 6 reminders
+		for i := 1; i <= 6; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 6; i++ {
+			// On messages 2 and 5, dequeue the reminder when it's at the front of the queue
+			if i == 2 || i == 5 {
+				// Dequeue the reminder at the front of the queue
+				err := processor.Dequeue(newTestReminder(i, 0)) // Time is irrelevant
+				require.NoError(t, err)
+
+				// Skip reminders that have been removed
+				t.Logf("Should not receive signal %d", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+			t.Logf("Waiting for signal %d", i)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(i), received.Name)
+		}
+	})
+
+	t.Run("replace reminder", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Replace reminder 4, bumping its priority down
+		err := processor.Enqueue(newTestReminder(4, clock.Now().Add(6*time.Second)))
+		require.NoError(t, err)
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 6; i++ {
+			if i == 4 {
+				// This reminder has been pushed down
+				t.Logf("Should not receive signal %d now", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+
+			expect := i
+			if i == 6 {
+				// Reminder 4 should come now
+				expect = 4
+			}
+			t.Logf("Waiting for signal %d", expect)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(expect), received.Name)
+		}
+	})
+
+	t.Run("replace reminder at the front of the queue", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 6; i++ {
+			if i == 2 {
+				// Replace reminder 2, bumping its priority down, while it's at the front of the queue
+				err := processor.Enqueue(newTestReminder(2, clock.Now().Add(5*time.Second)))
+				require.NoError(t, err)
+
+				// This reminder has been pushed down
+				t.Logf("Should not receive signal %d now", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+
+			expect := i
+			if i == 6 {
+				// Reminder 2 should come now
+				expect = 2
+			}
+			t.Logf("Waiting for signal %d", expect)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(expect), received.Name)
+		}
+	})
+
+	t.Run("stop processor", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Stop the processor
+		processor.Stop()
+
+		// Queue should not be processed
+		advanceTickers(time.Second, 2)
+		assertNoExecutedReminder(t)
+
+		// Enqueuing and dequeueing should fail
+		err := processor.Enqueue(newTestReminder(99, clock.Now()))
+		require.ErrorIs(t, err, ErrProcessorStopped)
+		err = processor.Dequeue(newTestReminder(99, clock.Now()))
+		require.ErrorIs(t, err, ErrProcessorStopped)
+
+		// Stopping again is a nop (should not crash)
+		processor.Stop()
+	})
+}

--- a/pkg/actors/reminders/queue.go
+++ b/pkg/actors/reminders/queue.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"container/heap"
+)
+
+// Queue implements a queue for Reminder objects.
+// It acts as a "priority queue", in which reminders are added in order of when they're scheduled.
+// Internally, it uses a heap (from container/heap) that allows Insert and Pop operations to be completed in O(log N) time (where N is the queue's length).
+// Note: methods in this struct are not safe for concurrent use. Callers should use locks to ensure consistency.
+type Queue struct {
+	heap  *queueHeap
+	items map[string]*queueItem
+}
+
+// NewQueue creates a new Reminder queue.
+func NewQueue() Queue {
+	return Queue{
+		heap:  &queueHeap{},
+		items: make(map[string]*queueItem),
+	}
+}
+
+// Len returns the number of reminders in the queue.
+func (p *Queue) Len() int {
+	return p.heap.Len()
+}
+
+// Insert inserts a new reminder into the queue.
+// If replace is true, existing reminders are replaced
+func (p *Queue) Insert(r *Reminder, replace bool) {
+	key := r.Key()
+
+	// Check if the reminder already exists
+	item, ok := p.items[key]
+	if ok {
+		if replace {
+			item.value = r
+			heap.Fix(p.heap, item.index)
+		}
+		return
+	}
+
+	item = &queueItem{
+		value: r,
+	}
+	heap.Push(p.heap, item)
+	p.items[key] = item
+}
+
+// Pop removes the next reminder in the queue and returns it, or nil if the queue is empty.
+func (p *Queue) Pop() *Reminder {
+	if p.Len() == 0 {
+		return nil
+	}
+
+	item, ok := heap.Pop(p.heap).(*queueItem)
+	if !ok || item == nil {
+		return nil
+	}
+
+	delete(p.items, item.value.Key())
+	return item.value
+}
+
+// Peek returns the next reminder in the queue, without removing it, or nil if the queue is empty.
+func (p *Queue) Peek() *Reminder {
+	if p.Len() == 0 {
+		return nil
+	}
+
+	return (*p.heap)[0].value
+}
+
+// Remove a reminder from the queue.
+func (p *Queue) Remove(r *Reminder) {
+	key := r.Key()
+
+	// If the item is not in the queue, this is a nop
+	item, ok := p.items[key]
+	if !ok {
+		return
+	}
+
+	heap.Remove(p.heap, item.index)
+	delete(p.items, key)
+}
+
+// Update a reminder in the queue.
+func (p *Queue) Update(r *Reminder) {
+	// If the item is not in the queue, this is a nop
+	item, ok := p.items[r.Key()]
+	if !ok {
+		return
+	}
+
+	item.value = r
+	heap.Fix(p.heap, item.index)
+}
+
+type queueItem struct {
+	value *Reminder
+
+	// The index of the item in the heap. This is maintained by the heap.Interface methods.
+	index int
+}
+
+type queueHeap []*queueItem
+
+func (pq queueHeap) Len() int {
+	return len(pq)
+}
+
+func (pq queueHeap) Less(i, j int) bool {
+	return pq[i].value.RegisteredTime.UnixNano() < pq[j].value.RegisteredTime.UnixNano()
+}
+
+func (pq queueHeap) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *queueHeap) Push(x any) {
+	n := len(*pq)
+	item := x.(*queueItem)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *queueHeap) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // Avoid memory leak
+	item.index = -1 // For safety
+	*pq = old[0 : n-1]
+	return item
+}

--- a/pkg/actors/reminders/queue_test.go
+++ b/pkg/actors/reminders/queue_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+	queue := NewQueue()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	i := 0
+	for {
+		// Pop an element from the queue
+		r := queue.Pop()
+
+		if i < 5 {
+			require.NotNil(t, r)
+		} else {
+			require.Nil(t, r)
+			break
+		}
+		i++
+
+		// Results should be in order
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+}
+
+func TestQueueSkipDuplicates(t *testing.T) {
+	queue := NewQueue()
+
+	// Add 2 reminders
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Add a duplicate reminder (same actor type, actor ID, name), but different time
+	queue.Insert(newTestReminder(2, "2029-09-09T09:09:09Z"), false)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Pop the items and check only the 2 original ones were in the queue
+	popAndCompare(t, &queue, 1, "2021-01-01T01:01:01Z")
+	popAndCompare(t, &queue, 2, "2022-02-02T02:02:02Z")
+
+	r := queue.Pop()
+	require.Nil(t, r)
+}
+
+func TestQueueReplaceDuplicates(t *testing.T) {
+	queue := NewQueue()
+
+	// Add 2 reminders
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Replace a reminder
+	queue.Insert(newTestReminder(1, "2029-09-09T09:09:09Z"), true)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Pop the items and validate the new order
+	popAndCompare(t, &queue, 2, "2022-02-02T02:02:02Z")
+	popAndCompare(t, &queue, 1, "2029-09-09T09:09:09Z")
+
+	r := queue.Pop()
+	require.Nil(t, r)
+}
+
+func TestAddToQueue(t *testing.T) {
+	queue := NewQueue()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(5, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(8, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(7, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	// Pop 2 elements from the queue
+	for i := 1; i <= 2; i++ {
+		r := queue.Pop()
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	// Add 4 more elements
+	// Two are at the very beginning (including one that had the same time as one popped before)
+	// One is in the middle
+	// One is at the end
+	queue.Insert(newTestReminder(3, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(4, "2021-01-11T11:11:11Z"), false)
+	queue.Insert(newTestReminder(6, "2023-03-13T13:13:13Z"), false)
+	queue.Insert(newTestReminder(9, "2030-10-30T10:10:10Z"), false)
+
+	require.Equal(t, 7, queue.Len())
+
+	// Pop all the remaining elements and make sure they're in order
+	for i := 3; i <= 9; i++ {
+		r := queue.Pop()
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	// Queue should be empty now
+	r := queue.Pop()
+	require.Nil(t, r)
+	require.Equal(t, 0, queue.Len())
+}
+
+func TestRemoveFromQueue(t *testing.T) {
+	queue := NewQueue()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	// Pop 2 elements from the queue
+	for i := 1; i <= 2; i++ {
+		r := queue.Pop()
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	require.Equal(t, 3, queue.Len())
+
+	// Remove the reminder with number "4"
+	queue.Remove(newTestReminder(4, 0)) // DueTime is irrelevant here
+
+	// Removing non-existing reminders is a nop
+	queue.Remove(newTestReminder(10, 0)) // DueTime is irrelevant here
+
+	require.Equal(t, 2, queue.Len())
+
+	// Pop all the remaining elements and make sure they're in order
+	popAndCompare(t, &queue, 3, "2023-03-03T03:03:03Z")
+	popAndCompare(t, &queue, 5, "2029-09-09T09:09:09Z")
+
+	r := queue.Pop()
+	require.Nil(t, r)
+}
+
+func TestUpdateInQueue(t *testing.T) {
+	queue := NewQueue()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	// Pop 2 elements from the queue
+	for i := 1; i <= 2; i++ {
+		r := queue.Pop()
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	require.Equal(t, 3, queue.Len())
+
+	// Update the reminder with number "4" but maintain priority
+	queue.Update(newTestReminder(4, "2024-04-04T14:14:14Z"))
+
+	// Update the reminder with number "5" and increase the priority
+	queue.Update(newTestReminder(5, "2021-01-01T01:01:01Z"))
+
+	// Updating non-existing reminders is a nop
+	queue.Update(newTestReminder(10, "2021-01-01T01:01:01Z"))
+
+	require.Equal(t, 3, queue.Len())
+
+	// Pop all the remaining elements and make sure they're in order
+	popAndCompare(t, &queue, 5, "2021-01-01T01:01:01Z") // 5 comes before 3 now
+	popAndCompare(t, &queue, 3, "2023-03-03T03:03:03Z")
+	popAndCompare(t, &queue, 4, "2024-04-04T14:14:14Z")
+
+	r := queue.Pop()
+	require.Nil(t, r)
+}
+
+func TestQueuePeek(t *testing.T) {
+	queue := NewQueue()
+
+	// Peeking an empty queue returns nil
+	r := queue.Peek()
+	require.Nil(t, r)
+
+	// Add 6 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	peekAndCompare(t, &queue, 2, "2022-02-02T02:02:02Z")
+
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	peekAndCompare(t, &queue, 2, "2022-02-02T02:02:02Z")
+
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	peekAndCompare(t, &queue, 1, "2021-01-01T01:01:01Z")
+
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	peekAndCompare(t, &queue, 1, "2021-01-01T01:01:01Z")
+
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+	peekAndCompare(t, &queue, 1, "2021-01-01T01:01:01Z")
+
+	queue.Insert(newTestReminder(6, "2019-01-19T01:01:01Z"), false)
+	peekAndCompare(t, &queue, 6, "2019-01-19T01:01:01Z")
+
+	// Pop from the queue
+	popAndCompare(t, &queue, 6, "2019-01-19T01:01:01Z")
+	peekAndCompare(t, &queue, 1, "2021-01-01T01:01:01Z")
+
+	// Update a reminder to bring it to first
+	queue.Update(newTestReminder(2, "2019-01-19T01:01:01Z"))
+	peekAndCompare(t, &queue, 2, "2019-01-19T01:01:01Z")
+
+	// Replace the first reminder to push it back
+	queue.Insert(newTestReminder(2, "2039-01-19T01:01:01Z"), true)
+	peekAndCompare(t, &queue, 1, "2021-01-01T01:01:01Z")
+}
+
+func newTestReminder(n int, dueTime any) *Reminder {
+	r := &Reminder{
+		Name:      strconv.Itoa(n),
+		ActorID:   "id",
+		ActorType: "type",
+	}
+
+	switch t := dueTime.(type) {
+	case time.Time:
+		r.RegisteredTime = t
+	case string:
+		r.RegisteredTime, _ = time.Parse(time.RFC3339, t)
+	case int64:
+		r.RegisteredTime = time.Unix(t, 0)
+	}
+
+	return r
+}
+
+func popAndCompare(t *testing.T, queue *Queue, expectN int, expectDueTime string) {
+	t.Helper()
+
+	r := queue.Pop()
+	require.NotNil(t, r)
+	assert.Equal(t, r.Name, strconv.Itoa(expectN))
+	assert.Equal(t, r.RegisteredTime.Format(time.RFC3339), expectDueTime)
+}
+
+func peekAndCompare(t *testing.T, queue *Queue, expectN int, expectDueTime string) {
+	t.Helper()
+
+	r := queue.Peek()
+	require.NotNil(t, r)
+	assert.Equal(t, r.Name, strconv.Itoa(expectN))
+	assert.Equal(t, r.RegisteredTime.Format(time.RFC3339), expectDueTime)
+}


### PR DESCRIPTION
# TODO

- [x] This PR is built on top of #6039  - that needs to be merged first
- [X] Implement the data structure
- [ ] Update the reminders and timers code to use the new data structure

# Description

This is part 2 of the work on improving actor reminders and timers, and changes how the queue of reminders and timers is managed.

Currently, each reminder or timer scheduled in the runtime causes a new goroutine which has multiple timers inside and is blocked until one of the events happens (e.g. the reminder is due to be executed, it's canceled, etc). This means that there's at least 1 goroutine for each timer/reminder that is blocked and waiting, requiring significant amounts of memory (each goroutine comes with a bunch of memory allocated) and more work on the garbage collector.

This PR implements a new data structure that is essentially a priority queue (heap-based). When reminders/timers are scheduled, they are added to the queue in order of their execution time. By maintaining the queue with reminders in order, we can make sure that there's at most one background goroutine blocked, which is waiting on the next reminder/timer only.