### PR TITLE
[Hotfix 1.10.3] Update pinned components-contrib and release notes

### DIFF
--- a/docs/release_notes/v1.10.3.md
+++ b/docs/release_notes/v1.10.3.md
@@ -1,9 +1,12 @@
 # Dapr 1.10.3
 
-This hotfix release contains two bug fixes.
+This hotfix release contains five bug fixes.
 
 - [Fixes Dapr starting without middlewares when one component in the pipeline fails to init](#fixes-dapr-starting-without-middlewares-when-one-component-in-the-pipeline-fails-to-init)
 - [Fixes handling of "continue-as-new" for Dapr Workflows](#fixes-handling-of-continue-as-new-for-dapr-workflows)
+- [Fixes issues with Azure Service Bus components not recovering after failures](#fixes-issues-with-azure-service-bus-components-not-recovering-after-failures)
+- [Restores support for certificate authentication without password or mTLS in Kafka](#restores-support-for-certificate-authentication-without-password-or-mtls-in-kafka)
+- [Fixed issues with NATS JetStream when no subscription name is specified](#fixed-issues-with-nats-jetstream-when-no-subscription-name-is-specified)
 
 ## Fixes Dapr starting without middlewares when one component in the pipeline fails to init
 
@@ -43,3 +46,57 @@ An error in the implementation of Dapr Workflows prevented caused the "continue-
 ### Solution
 
 We addressed the underlying issue in Dapr 1.10.3 and added more tests to prevent future regressions.
+
+## Fixes issues with Azure Service Bus components not recovering after failures
+
+### Problem
+
+In certain cases, the connection with Azure Service Bus could not be recovered automatically after a failure. Users reported seeing error messages containing `$cbs node has already been opened`, requiring a restart of the Dapr sidecar.
+
+### Impact
+
+This issue impacts users on Dapr 1.10.0-1.10.2 that use Azure Service Bus components.
+
+### Root cause
+
+The issue was traced to a bug in an upstream SDK.
+
+### Solution
+
+We worked with the vendors of the upstream SDK to address the issue and include a new version of the SDK in Dapr 1.10.3.
+
+## Restores support for certificate authentication without password or mTLS in Kafka
+
+### Problem
+
+A regression introduced in Dapr 1.8.0 accidentally removed support for authenticating with Kafka components using a certificate, without password or mTLS.
+
+### Impact
+
+The issue impacts users on Dapr 1.8.0-1.10.2 that use Kafka components and want to use a certificate for authentication.
+
+### Root cause
+
+Support for the feature was accidentally removed in Dapr 1.8.0 due to a bug.
+
+### Solution
+
+We restored support for authenticating with Kafka components using a certificate, and we added more tests to prevent future regressions.
+
+## Fixed issues with NATS JetStream when no subscription name is specified
+
+### Problem
+
+NATS JetStream components cannot be initialized when no subscription name is specified. Users would encounter errors with failures to create a subscription for a delivery group that is not a configured queue group.
+
+### Impact
+
+This impact users on Dapr 1.10.0-1.10.2 using NATS JetStream.
+
+### Root cause
+
+The Dapr Runtime injects a default consumer group name when none is specified. A code refactor standardized the use of this value when no consumer group was specified in all PubSub components. This behavior however was incorrect NATS JetStream
+
+### Solution
+
+We reverted the code change for NATS JetStream, so that no default queue group or consumer group value is assigned.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/PuerkitoBio/purell v1.2.0
 	github.com/benbjohnson/clock v1.3.0
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/dapr/components-contrib v1.10.0-rc.9
+	github.com/dapr/components-contrib v1.10.3
 	github.com/dapr/kit v0.0.4
 	github.com/fasthttp/router v1.4.15
 	github.com/ghodss/yaml v1.0.0
@@ -96,7 +96,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs v0.4.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0 h1:Lg6BW0VPmCwcMl
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.0/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs v0.4.0 h1:X/ePaAG8guM7j5WORT5eEIw7cGUxe9Ah1jEQJKLmmSo=
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs v0.4.0/go.mod h1:5dog28UP3dd1BnCPFYvyHfsmA+Phmoezt+KWT5cZnyc=
-github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.2.0 h1:2BE/tjVTT4SNWwI3dWiMqX9mt0cImxYoJIXtFeJ72t4=
-github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.2.0/go.mod h1:R6+0udeRV8iYSTVuT5RT7If4sc46K5Bz3ZKrmvZQF7U=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.2.1 h1:ryVRjO3SrGrSM8PNlLuMbMYFz9vexPzvenNUEBfsgCo=
+github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.2.1/go.mod h1:R6+0udeRV8iYSTVuT5RT7If4sc46K5Bz3ZKrmvZQF7U=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.0.0 h1:PcP4TC+0dC85A3i1p7CbD0FyrjnTvzQ3ipgSkJTIb7Y=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.0.0/go.mod h1:rUn3oBeYkTxIsUzKxtXUPOt1ZO+bVHuZ3m5wauIfUHw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.0.0 h1:BWeAAEzkCnL0ABVJqs+4mYudNch7oFGPtTlSmIWL8ms=
@@ -716,8 +716,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.10.0-rc.9 h1:iHVmtJ1Tc4Y1XaxA+LMLpKEfAanwSudXRAD+/+kgG8Q=
-github.com/dapr/components-contrib v1.10.0-rc.9/go.mod h1:JM3xDSSDVb+ot246VZndZZK1K8Ft/6Ch2FtXW1Jbbhk=
+github.com/dapr/components-contrib v1.10.3 h1:9kNx++EmcOh+LeFqGD5VURBgNn2EFQX4sAsrPGKuywc=
+github.com/dapr/components-contrib v1.10.3/go.mod h1:21BqAjEn5hOjg2Y8/mu3nf/hD+9TSpQ45HdjesN24mQ=
 github.com/dapr/kit v0.0.4 h1:i+7TIN4crC1Mo0JFyWpIkwAE8orlliA0O6/ibvs2AaE=
 github.com/dapr/kit v0.0.4/go.mod h1:RFN6r5pZzhrelB0SUr8Dha44ckRBl7t+B01X5aw8WeE=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
This PR updates the pinned components-contrib for 1.10.3 (with the latest fixes) and adds the remaining fixes in the release notes.

See: #6015