### PR TITLE
Fix e2e test by updating global.tag when deploying dapr via Makefile 

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -256,7 +256,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: Cache Go modules (Linux)
         if: env.CHECKOUT_REPO != '' && runner.os == 'Linux'
         uses: actions/cache@v3
@@ -439,7 +439,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: Cache Go modules (test)
         if: env.CHECKOUT_REPO != '' && runner.os == 'Linux'
         uses: actions/cache@v3
@@ -483,6 +483,7 @@ jobs:
           echo "DAPR_TAG=${TEST_PREFIX}" >> $GITHUB_ENV
           echo "DAPR_TEST_TAG=${TEST_PREFIX}" >> $GITHUB_ENV
           echo "TEST_RESOURCE_GROUP=Dapr-E2E-${TEST_PREFIX}" >> $GITHUB_ENV
+          echo "WINDOWS_VERSION=${{ matrix.windows_version }}" >> $GITHUB_ENV
         shell: bash
       - name: Enable tcpdump
         if: env.TCP_DUMPS == 'true'

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ docker-deploy-k8s: check-docker-env check-arch
 	$(info Deploying ${DAPR_REGISTRY}/${RELEASE_NAME}:${DAPR_TAG} to the current K8S context...)
 	$(HELM) upgrade --install \
 		$(RELEASE_NAME) --namespace=$(DAPR_NAMESPACE) --wait --timeout 5m0s \
-		--set global.ha.enabled=$(HA_MODE) --set-string global.tag=$(DAPR_TAG)-$(TARGET_OS)-$(TARGET_ARCH) \
+		--set global.ha.enabled=$(HA_MODE) --set-string global.tag=$(BUILD_TAG) \
 		--set-string global.registry=$(DAPR_REGISTRY) --set global.logAsJson=true \
 		--set global.daprControlPlaneOs=$(TARGET_OS) --set global.daprControlPlaneArch=$(TARGET_ARCH) \
 		--set dapr_placement.logLevel=debug --set dapr_sidecar_injector.sidecarImagePullPolicy=$(PULL_POLICY) \


### PR DESCRIPTION
# Description

This PR updates the Makefile to use the correct tag while deploying dapr on k8s. Due to the linked PR, the `<dapr-tag>-windows-amd64` is now a manifest that points to 1809 and ltsc2022 Windows images. In e2e pipeline, the manifests are not created, so the pipeline tries to look for `<test-prefix>-windows-amd64` and fails. This PR updates the deploy step to look for the actual image `<test-prefix>-windows-lts2022-amd64` instead of manifest.

Example broken run: https://github.com/dapr/dapr/actions/runs/4372310169/jobs/7649326519

## Issue reference

Related to https://github.com/dapr/dapr/pull/5999

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
