### PR TITLE
Fix e2e test by updating global.tag when deploying dapr via Makefile (take 2)

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -396,11 +396,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target_os: [linux, windows]
+        target_os: [linux]
         target_arch: [amd64, arm64]
-        exclude:
+        include:
           - target_os: windows
-            target_arch: arm64
+            target_arch: amd64
+            windows_version: ltsc2022
     steps:
       - name: Set up log paths
         run: |


### PR DESCRIPTION
# Description

Continuation of #6051, missed setting windows_version again in test-e2e matrix.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #NA

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
