### PR TITLE
Replaces `github.com/benbjohnson/clock` with `k8s.io/utils/clock`.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,7 @@ linters-settings:
       - "github.com/cenkalti/backoff": "must use github.com/cenkalti/backoff/v4"
       - "github.com/cenkalti/backoff/v2": "must use github.com/cenkalti/backoff/v4"
       - "github.com/cenkalti/backoff/v3": "must use github.com/cenkalti/backoff/v4"
+      - "github.com/benbjohnson/clock": "must use k8s.io/utils/clock"
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/PuerkitoBio/purell v1.2.0
-	github.com/benbjohnson/clock v1.3.0
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/dapr/components-contrib v1.10.0-rc.9.0.20230303212325-d6f35401af8a
 	github.com/dapr/kit v0.0.4
@@ -137,6 +136,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.202 // indirect
 	github.com/awslabs/kinesis-aggregation/go v0.0.0-20210630091500-54e17340d32f // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
@@ -389,7 +389,7 @@ require (
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/utils v0.0.0-20230115233650-391b47cb4029 // indirect
+	k8s.io/utils v0.0.0-20230115233650-391b47cb4029
 	lukechampine.com/uint128 v1.2.0 // indirect
 	modernc.org/cc/v3 v3.40.0 // indirect
 	modernc.org/ccgo/v3 v3.16.13 // indirect

--- a/pkg/actors/actor.go
+++ b/pkg/actors/actor.go
@@ -19,7 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	clocklib "github.com/benbjohnson/clock"
+	"k8s.io/utils/clock"
 
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 )
@@ -54,12 +54,12 @@ type actor struct {
 	disposeCh chan struct{}
 
 	once  sync.Once
-	clock clocklib.Clock
+	clock clock.Clock
 }
 
-func newActor(actorType, actorID string, maxReentrancyDepth *int, clock clocklib.Clock) *actor {
-	if clock == nil {
-		clock = clocklib.New()
+func newActor(actorType, actorID string, maxReentrancyDepth *int, cl clock.Clock) *actor {
+	if cl == nil {
+		cl = &clock.RealClock{}
 	}
 	return &actor{
 		actorType:         actorType,
@@ -69,8 +69,8 @@ func newActor(actorType, actorID string, maxReentrancyDepth *int, clock clocklib
 		disposeLock:       &sync.RWMutex{},
 		disposeCh:         nil,
 		disposed:          false,
-		clock:             clock,
-		lastUsedTime:      clock.Now(),
+		clock:             cl,
+		lastUsedTime:      cl.Now().UTC(),
 	}
 }
 

--- a/pkg/actors/actor_test.go
+++ b/pkg/actors/actor_test.go
@@ -26,8 +26,6 @@ import (
 var reentrancyStackDepth = 32
 
 func TestIsBusy(t *testing.T) {
-	t.Parallel()
-
 	testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 	testActor.lock(nil)
@@ -36,8 +34,6 @@ func TestIsBusy(t *testing.T) {
 }
 
 func TestTurnBasedConcurrencyLocks(t *testing.T) {
-	t.Parallel()
-
 	testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 	// first lock
@@ -78,8 +74,6 @@ func TestTurnBasedConcurrencyLocks(t *testing.T) {
 }
 
 func TestDisposedActor(t *testing.T) {
-	t.Parallel()
-
 	t.Run("not disposed", func(t *testing.T) {
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
@@ -107,8 +101,6 @@ func TestDisposedActor(t *testing.T) {
 }
 
 func TestPendingActorCalls(t *testing.T) {
-	t.Parallel()
-
 	t.Run("no pending actor call with new actor object", func(t *testing.T) {
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 		channelClosed := false

--- a/pkg/actors/actor_test.go
+++ b/pkg/actors/actor_test.go
@@ -81,8 +81,6 @@ func TestDisposedActor(t *testing.T) {
 	t.Parallel()
 
 	t.Run("not disposed", func(t *testing.T) {
-		t.Parallel()
-
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 		testActor.lock(nil)
@@ -94,8 +92,6 @@ func TestDisposedActor(t *testing.T) {
 	})
 
 	t.Run("disposed", func(t *testing.T) {
-		t.Parallel()
-
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 		testActor.lock(nil)
@@ -114,8 +110,6 @@ func TestPendingActorCalls(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no pending actor call with new actor object", func(t *testing.T) {
-		t.Parallel()
-
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 		channelClosed := false
 
@@ -131,8 +125,6 @@ func TestPendingActorCalls(t *testing.T) {
 	})
 
 	t.Run("close channel before timeout", func(t *testing.T) {
-		t.Parallel()
-
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 		testActor.lock(nil)
 
@@ -154,8 +146,6 @@ func TestPendingActorCalls(t *testing.T) {
 	})
 
 	t.Run("multiple listeners", func(t *testing.T) {
-		t.Parallel()
-
 		clock := clocktesting.NewFakeClock(time.Now())
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, clock)
 		testActor.lock(nil)

--- a/pkg/actors/actor_test.go
+++ b/pkg/actors/actor_test.go
@@ -150,9 +150,7 @@ func TestPendingActorCalls(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		testActor.unlock()
 
-		assert.Eventually(t, func() bool {
-			return channelClosed.Load()
-		}, time.Second, 10*time.Microsecond)
+		assert.Eventually(t, channelClosed.Load, time.Second, 10*time.Microsecond)
 	})
 
 	t.Run("multiple listeners", func(t *testing.T) {

--- a/pkg/actors/actor_test.go
+++ b/pkg/actors/actor_test.go
@@ -19,11 +19,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
 var reentrancyStackDepth = 32
 
 func TestIsBusy(t *testing.T) {
+	t.Parallel()
+
 	testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 	testActor.lock(nil)
@@ -32,6 +36,8 @@ func TestIsBusy(t *testing.T) {
 }
 
 func TestTurnBasedConcurrencyLocks(t *testing.T) {
+	t.Parallel()
+
 	testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 	// first lock
@@ -45,7 +51,7 @@ func TestTurnBasedConcurrencyLocks(t *testing.T) {
 	go func() {
 		waitCh <- false
 		testActor.lock(nil)
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		testActor.unlock()
 		waitCh <- false
 	}()
@@ -65,13 +71,18 @@ func TestTurnBasedConcurrencyLocks(t *testing.T) {
 
 	// unlock the second lock
 	<-waitCh
+
 	assert.Equal(t, int32(0), testActor.pendingActorCalls.Load())
 	assert.False(t, testActor.isBusy())
 	assert.True(t, testActor.lastUsedTime.Sub(firstLockTime) >= 10*time.Millisecond)
 }
 
 func TestDisposedActor(t *testing.T) {
+	t.Parallel()
+
 	t.Run("not disposed", func(t *testing.T) {
+		t.Parallel()
+
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 		testActor.lock(nil)
@@ -83,6 +94,8 @@ func TestDisposedActor(t *testing.T) {
 	})
 
 	t.Run("disposed", func(t *testing.T) {
+		t.Parallel()
+
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 
 		testActor.lock(nil)
@@ -98,7 +111,11 @@ func TestDisposedActor(t *testing.T) {
 }
 
 func TestPendingActorCalls(t *testing.T) {
+	t.Parallel()
+
 	t.Run("no pending actor call with new actor object", func(t *testing.T) {
+		t.Parallel()
+
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 		channelClosed := false
 
@@ -114,6 +131,8 @@ func TestPendingActorCalls(t *testing.T) {
 	})
 
 	t.Run("close channel before timeout", func(t *testing.T) {
+		t.Parallel()
+
 		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
 		testActor.lock(nil)
 
@@ -121,21 +140,26 @@ func TestPendingActorCalls(t *testing.T) {
 		go func() {
 			select {
 			case <-time.After(200 * time.Millisecond):
-				break
+				require.Fail(t, "channel should be closed before timeout")
 			case <-testActor.channel():
 				channelClosed.Store(true)
 				break
 			}
 		}()
 
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		testActor.unlock()
-		time.Sleep(100 * time.Millisecond)
-		assert.True(t, channelClosed.Load())
+
+		assert.Eventually(t, func() bool {
+			return channelClosed.Load()
+		}, time.Second, 10*time.Microsecond)
 	})
 
 	t.Run("multiple listeners", func(t *testing.T) {
-		testActor := newActor("testType", "testID", &reentrancyStackDepth, nil)
+		t.Parallel()
+
+		clock := clocktesting.NewFakeClock(time.Now())
+		testActor := newActor("testType", "testID", &reentrancyStackDepth, clock)
 		testActor.lock(nil)
 
 		nListeners := 10
@@ -154,10 +178,15 @@ func TestPendingActorCalls(t *testing.T) {
 			}(i)
 		}
 		testActor.unlock()
-		time.Sleep(100 * time.Millisecond)
 
-		for i := 0; i < nListeners; i++ {
-			assert.True(t, releaseSignaled[i].Load())
-		}
+		assert.Eventually(t, func() bool {
+			clock.Step(100 * time.Millisecond)
+			for i := 0; i < nListeners; i++ {
+				if !releaseSignaled[i].Load() {
+					return false
+				}
+			}
+			return true
+		}, time.Second, time.Microsecond)
 	})
 }

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -17,20 +17,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	clocklib "github.com/benbjohnson/clock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	kclock "k8s.io/utils/clock"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
@@ -293,7 +293,7 @@ type runtimeBuilder struct {
 	config         *Config
 	actorStore     state.Store
 	actorStoreName string
-	clock          clocklib.Clock
+	clock          kclock.WithTicker
 }
 
 func (b *runtimeBuilder) buildActorRuntime() *actorsRuntime {
@@ -323,8 +323,7 @@ func (b *runtimeBuilder) buildActorRuntime() *actorsRuntime {
 
 	clock := b.clock
 	if clock == nil {
-		mc := clocklib.NewMock()
-		mc.Set(startOfTime)
+		mc := clocktesting.NewFakeClock(startOfTime)
 		clock = mc
 	}
 
@@ -349,8 +348,7 @@ func newTestActorsRuntimeWithMock(appChannel channel.AppChannel) *actorsRuntime 
 		AppConfig:          config.ApplicationConfig{},
 	})
 
-	clock := clocklib.NewMock()
-	clock.Set(startOfTime)
+	clock := clocktesting.NewFakeClock(startOfTime)
 
 	a := newActorsWithClock(ActorsOpts{
 		StateStore:     store,
@@ -372,8 +370,7 @@ func newTestActorsRuntimeWithMockWithoutPlacement(appChannel channel.AppChannel)
 		AppConfig:          config.ApplicationConfig{},
 	})
 
-	clock := clocklib.NewMock()
-	clock.Set(startOfTime)
+	clock := clocktesting.NewFakeClock(startOfTime)
 
 	a := newActorsWithClock(ActorsOpts{
 		AppChannel:     appChannel,
@@ -395,8 +392,7 @@ func newTestActorsRuntimeWithMockAndNoStore(appChannel channel.AppChannel) *acto
 		AppConfig:          config.ApplicationConfig{},
 	})
 
-	clock := clocklib.NewMock()
-	clock.Set(startOfTime)
+	clock := clocktesting.NewFakeClock(startOfTime)
 
 	a := newActorsWithClock(ActorsOpts{
 		StateStore:     store,
@@ -429,8 +425,7 @@ func newTestActorsRuntimeWithMockAndActorMetadataPartition(appChannel channel.Ap
 		AppConfig:          appConfig,
 	})
 
-	clock := clocklib.NewMock()
-	clock.Set(startOfTime)
+	clock := clocktesting.NewFakeClock(startOfTime)
 
 	a := newActorsWithClock(ActorsOpts{
 		StateStore:     store,
@@ -473,7 +468,7 @@ func fakeStore() state.Store {
 	}
 }
 
-func fakeCallAndActivateActor(actors *actorsRuntime, actorType, actorID string, clock clocklib.Clock) {
+func fakeCallAndActivateActor(actors *actorsRuntime, actorType, actorID string, clock kclock.WithTicker) {
 	actorKey := constructCompositeKey(actorType, actorID)
 	actors.actorsTable.LoadOrStore(actorKey, newActor(actorType, actorID, &reentrancyStackDepth, clock))
 }
@@ -482,9 +477,11 @@ func deactivateActorWithDuration(testActorsRuntime *actorsRuntime, actorType, ac
 	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
 
 	ch := make(chan struct{}, 1)
-	go testActorsRuntime.deactivationTicker(testActorsRuntime.config, func(actorType, actorID string) error {
-		testActorsRuntime.removeActorFromTable(actorType, actorID)
-		ch <- struct{}{}
+	go testActorsRuntime.deactivationTicker(testActorsRuntime.config, func(at, aid string) error {
+		if actorType == at {
+			testActorsRuntime.removeActorFromTable(at, aid)
+			ch <- struct{}{}
+		}
 		return nil
 	})
 	return ch
@@ -515,16 +512,27 @@ func createTimerData(actorID, actorType, name, period, dueTime, ttl, callback, d
 	}
 }
 
-func assertTestSignal(t *testing.T, ch <-chan struct{}) {
+func assertTestSignal(t *testing.T, clock *clocktesting.FakeClock, ch <-chan struct{}) {
 	t.Helper()
 
-	// The signal is sent in a background goroutine, so we need to use a wall clock here
-	runtime.Gosched()
-	select {
-	case <-ch:
-		// all good
-	case <-time.After(700 * time.Millisecond):
-		t.Fatal("did not receive signal in 700ms")
+	end := clock.Now().Add(700 * time.Millisecond)
+
+	for {
+		select {
+		case <-ch:
+			// all good
+			return
+		default:
+		}
+
+		if clock.Now().After(end) {
+			require.Fail(t, "did not receive signal in 700ms")
+		}
+
+		// The signal is sent in a background goroutine, so we need to use a wall
+		// clock here
+		time.Sleep(time.Millisecond * 5)
+		advanceTickers(t, clock, time.Millisecond*10)
 	}
 }
 
@@ -532,35 +540,35 @@ func assertNoTestSignal(t *testing.T, ch <-chan struct{}) {
 	t.Helper()
 
 	// The signal is sent in a background goroutine, so we need to use a wall clock here
-	runtime.Gosched()
 	select {
 	case <-ch:
-		t.Fatal("received unexpected signal")
+		t.Fatalf("received unexpected signal")
 	case <-time.After(500 * time.Millisecond):
 		// all good
 	}
 }
 
 // Makes tickers advance
-// Note that step must be > 500ms
-func advanceTickers(rt *actorsRuntime, step time.Duration, count int) {
-	clock := rt.clock.(*clocklib.Mock)
-	clock.Add(100 * time.Millisecond)
-	// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
-	runtime.Gosched()
-	time.Sleep(100 * time.Millisecond)
-	for i := 0; i < count; i++ {
-		clock.Add(step)
-		// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
-		runtime.Gosched()
-		time.Sleep(100 * time.Millisecond)
-	}
+func advanceTickers(t *testing.T, clock *clocktesting.FakeClock, step time.Duration) {
+	t.Helper()
+
+	// Wait for the clock to have tickers before stepping, since they are likely
+	// being created in another go routine to this test.
+	require.Eventually(t, func() bool {
+		return clock.HasWaiters()
+	}, time.Second, time.Millisecond, "ticker in program not created in time")
+	clock.Step(step)
 }
 
 func TestDeactivationTicker(t *testing.T) {
+	t.Parallel()
+
 	t.Run("actor is deactivated", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 		actorType, actorID := getTestActorTypeAndID()
 		actorKey := constructCompositeKey(actorType, actorID)
@@ -573,16 +581,20 @@ func TestDeactivationTicker(t *testing.T) {
 		_, exists := testActorsRuntime.actorsTable.Load(actorKey)
 		assert.True(t, exists)
 
-		advanceTickers(testActorsRuntime, time.Second, 3)
-		assertTestSignal(t, ch)
+		advanceTickers(t, clock, time.Second*3)
+
+		assertTestSignal(t, clock, ch)
 
 		_, exists = testActorsRuntime.actorsTable.Load(actorKey)
 		assert.False(t, exists)
 	})
 
 	t.Run("actor is not deactivated", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 		actorType, actorID := getTestActorTypeAndID()
 		actorKey := constructCompositeKey(actorType, actorID)
@@ -595,7 +607,7 @@ func TestDeactivationTicker(t *testing.T) {
 		_, exists := testActorsRuntime.actorsTable.Load(actorKey)
 		assert.True(t, exists)
 
-		advanceTickers(testActorsRuntime, time.Second, 3)
+		advanceTickers(t, clock, time.Second*3)
 		assertNoTestSignal(t, ch)
 
 		_, exists = testActorsRuntime.actorsTable.Load(actorKey)
@@ -603,8 +615,11 @@ func TestDeactivationTicker(t *testing.T) {
 	})
 
 	t.Run("per-actor timeout", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 		firstType := "a"
 		secondType := "b"
@@ -617,8 +632,8 @@ func TestDeactivationTicker(t *testing.T) {
 		ch1 := deactivateActorWithDuration(testActorsRuntime, firstType, actorID)
 		ch2 := deactivateActorWithDuration(testActorsRuntime, secondType, actorID)
 
-		advanceTickers(testActorsRuntime, time.Second, 3)
-		assertTestSignal(t, ch1)
+		advanceTickers(t, clock, time.Second*2)
+		assertTestSignal(t, clock, ch1)
 		assertNoTestSignal(t, ch2)
 
 		_, exists := testActorsRuntime.actorsTable.Load(constructCompositeKey(firstType, actorID))
@@ -630,6 +645,8 @@ func TestDeactivationTicker(t *testing.T) {
 }
 
 func TestStoreIsNotInitialized(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 	testActorsRuntime.store = nil
@@ -669,6 +686,8 @@ func TestStoreIsNotInitialized(t *testing.T) {
 }
 
 func TestTimerExecution(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -680,6 +699,8 @@ func TestTimerExecution(t *testing.T) {
 }
 
 func TestTimerExecutionZeroDuration(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -691,6 +712,8 @@ func TestTimerExecutionZeroDuration(t *testing.T) {
 }
 
 func TestReminderExecution(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -709,6 +732,8 @@ func TestReminderExecution(t *testing.T) {
 }
 
 func TestReminderExecutionZeroDuration(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -727,6 +752,8 @@ func TestReminderExecutionZeroDuration(t *testing.T) {
 }
 
 func TestSetReminderTrack(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -737,7 +764,11 @@ func TestSetReminderTrack(t *testing.T) {
 }
 
 func TestGetReminderTrack(t *testing.T) {
+	t.Parallel()
+
 	t.Run("reminder doesn't exist", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -747,6 +778,8 @@ func TestGetReminderTrack(t *testing.T) {
 	})
 
 	t.Run("reminder exists", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -762,6 +795,8 @@ func TestGetReminderTrack(t *testing.T) {
 }
 
 func TestCreateReminder(t *testing.T) {
+	t.Parallel()
+
 	numReminders := 100
 	appChannel := new(mockAppChannel)
 	testActorsRuntime := newTestActorsRuntimeWithMock(appChannel)
@@ -863,6 +898,8 @@ func TestCreateReminder(t *testing.T) {
 }
 
 func TestRenameReminder(t *testing.T) {
+	t.Parallel()
+
 	appChannel := new(mockAppChannel)
 	testActorsRuntime := newTestActorsRuntimeWithMock(appChannel)
 	defer testActorsRuntime.Stop()
@@ -914,8 +951,12 @@ func TestRenameReminder(t *testing.T) {
 }
 
 func TestOverrideReminder(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -932,6 +973,8 @@ func TestOverrideReminder(t *testing.T) {
 	})
 
 	t.Run("override dueTime", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -948,6 +991,8 @@ func TestOverrideReminder(t *testing.T) {
 	})
 
 	t.Run("override period", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -964,6 +1009,8 @@ func TestOverrideReminder(t *testing.T) {
 	})
 
 	t.Run("override TTL", func(t *testing.T) {
+		t.Parallel()
+
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -987,14 +1034,19 @@ func TestOverrideReminder(t *testing.T) {
 }
 
 func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
+		t.Parallel()
+
 		requestC := make(chan testRequest, 10)
 		appChannel := mockAppChannel{
 			requestC: requestC,
 		}
 		testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
 		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 		actorType, actorID := getTestActorTypeAndID()
 		reminderName := "reminder1"
@@ -1022,7 +1074,7 @@ func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
 		assert.Equal(t, "c", reminders[0].reminder.Data)
 
 		// due time for reminder3 is 2s
-		advanceTickers(testActorsRuntime, time.Second, 2)
+		advanceTickers(t, clock, time.Second*2)
 
 		// The reminder update fires in a goroutine so we need to use the wall clock here
 		select {
@@ -1036,14 +1088,19 @@ func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
 }
 
 func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
+		t.Parallel()
+
 		requestC := make(chan testRequest, 10)
 		appChannel := mockAppChannel{
 			requestC: requestC,
 		}
 		testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
 		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 		actorType, actorID := getTestActorTypeAndID()
 		reminderName := "reminder1"
@@ -1054,15 +1111,11 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 
 		reminder2 := createReminderData(actorID, actorType, reminderName, "8s", "4s", "", "b")
 		reminder3 := createReminderData(actorID, actorType, reminderName, "8s", "4s", "", "c")
-		go testActorsRuntime.CreateReminder(ctx, &reminder2)
-		go testActorsRuntime.CreateReminder(ctx, &reminder3)
-
-		// Sleep on the wall clock because we used a background goroutine
-		runtime.Gosched()
-		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, testActorsRuntime.CreateReminder(ctx, &reminder2))
+		require.NoError(t, testActorsRuntime.CreateReminder(ctx, &reminder3))
 
 		// due time for reminders is 4s, advance less
-		advanceTickers(testActorsRuntime, time.Second, 2)
+		advanceTickers(t, clock, time.Second*2)
 
 		// Check reminder is updated
 		reminders, _, err := testActorsRuntime.getRemindersForActorType(actorType, false)
@@ -1072,17 +1125,14 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 		assert.Equal(t, "8s", reminders[0].reminder.Period)
 		assert.Equal(t, "4s", reminders[0].reminder.DueTime)
 
-		// Sleep on the wall clock because we used a background goroutine
-		runtime.Gosched()
-		time.Sleep(100 * time.Millisecond)
-
 		reminder4 := createReminderData(actorID, actorType, reminderName, "7s", "2s", "", "d")
 		testActorsRuntime.CreateReminder(ctx, &reminder4)
 		reminders, _, err = testActorsRuntime.getRemindersForActorType(actorType, false)
 		assert.NoError(t, err)
 
 		// due time for reminder is 2s
-		advanceTickers(testActorsRuntime, time.Second, 2)
+		advanceTickers(t, clock, time.Second)
+		advanceTickers(t, clock, time.Second)
 
 		// The reminder update fires in a goroutine so we need to use the wall clock here
 		select {
@@ -1101,6 +1151,8 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 }
 
 func TestDeleteReminder(t *testing.T) {
+	t.Parallel()
+
 	appChannel := new(mockAppChannel)
 	testActorsRuntime := newTestActorsRuntimeWithMockAndActorMetadataPartition(appChannel)
 	defer testActorsRuntime.Stop()
@@ -1120,6 +1172,8 @@ func TestDeleteReminder(t *testing.T) {
 }
 
 func TestDeleteReminderWithPartitions(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1137,178 +1191,334 @@ func TestDeleteReminderWithPartitions(t *testing.T) {
 	assert.Equal(t, 0, len(testActorsRuntime.reminders[actorType]))
 }
 
-func reminderRepeats(ctx context.Context, t *testing.T, dueTimeAny any, period string, ttlAny any, repeats int, timeoutSeconds int, delAfterSeconds int) {
-	requestC := make(chan testRequest, 10)
-	appChannel := mockAppChannel{
-		requestC: requestC,
+func Test_ReminderRepeats(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		dueTimeAny      any
+		period          string
+		ttlAny          any
+		delAfterSeconds float64
+		expRepeats      int
+	}{
+		"reminder with dueTime is ignored": {
+			dueTimeAny:      "2s",
+			period:          "R0/PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 0,
+			expRepeats:      0,
+		},
+		"reminder without dueTime is ignored": {
+			dueTimeAny:      "",
+			period:          "R0/PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 0,
+			expRepeats:      0,
+		},
+		"reminder with dueTime repeats once": {
+			dueTimeAny:      "2s",
+			period:          "R1/PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 6,
+			expRepeats:      1,
+		},
+		"reminder without dueTime repeats once": {
+			dueTimeAny:      "",
+			period:          "R1/PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 4,
+			expRepeats:      1,
+		},
+		"reminder with dueTime repeats no set": {
+			dueTimeAny:      "2s",
+			period:          "",
+			ttlAny:          "",
+			delAfterSeconds: 0,
+			expRepeats:      1,
+		},
+		"reminder with dueTime repeats not set": {
+			dueTimeAny:      "2s",
+			period:          "",
+			ttlAny:          "",
+			delAfterSeconds: 0,
+			expRepeats:      1,
+		},
+		"reminder without dueTime repeats not set": {
+			dueTimeAny:      "",
+			period:          "",
+			ttlAny:          "",
+			delAfterSeconds: 0,
+			expRepeats:      1,
+		},
+		"reminder with dueTime repeats 3 times": {
+			dueTimeAny:      "2s",
+			period:          "R3/PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 0,
+			expRepeats:      3,
+		},
+		"reminder without dueTime repeats 3 times": {
+			dueTimeAny:      "",
+			period:          "R3/PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 0,
+			expRepeats:      3,
+		},
+		"reminder with dueTime deleted after 1 sec": {
+			dueTimeAny:      2,
+			period:          "PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 3,
+			expRepeats:      1,
+		},
+		"reminder without dueTime deleted after 1 sec": {
+			dueTimeAny:      "",
+			period:          "PT2S",
+			ttlAny:          "",
+			delAfterSeconds: 1,
+			expRepeats:      1,
+		},
+		"reminder with dueTime ttl": {
+			dueTimeAny:      2,
+			period:          "PT2S",
+			ttlAny:          "3s",
+			delAfterSeconds: 0,
+			expRepeats:      2,
+		},
+		"reminder without dueTime ttl": {
+			dueTimeAny:      "",
+			period:          "2s",
+			ttlAny:          3,
+			delAfterSeconds: 0,
+			expRepeats:      2,
+		},
 	}
-	testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
-	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
 
-	actorType, actorID := getTestActorTypeAndID()
-	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, clock)
+	for name, testT := range tests {
+		test := testT
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	var dueTime string
-	switch x := dueTimeAny.(type) {
-	case string:
-		dueTime = x
-	case int:
-		dueTime = clock.Now().Add(time.Duration(x) * time.Second).Format(time.RFC3339)
-	}
-
-	var ttl string
-	switch x := ttlAny.(type) {
-	case string:
-		ttl = x
-	case int:
-		ttl = clock.Now().Add(time.Duration(x) * time.Second).Format(time.RFC3339)
-	}
-
-	reminder := createReminderData(actorID, actorType, "reminder1", period, dueTime, ttl, "data")
-	err := testActorsRuntime.CreateReminder(ctx, &reminder)
-	if repeats == 0 {
-		assert.EqualError(t, err, "reminder reminder1 has zero repetitions")
-		return
-	}
-	assert.NoError(t, err)
-	testActorsRuntime.remindersLock.RLock()
-	assert.Equal(t, 1, len(testActorsRuntime.reminders[actorType]))
-	testActorsRuntime.remindersLock.RUnlock()
-
-	count := 0
-	clock.Add(100 * time.Millisecond)
-L:
-	for i := 0; i < timeoutSeconds; i++ {
-		clock.Add(time.Second)
-
-		if delAfterSeconds > 0 && i == delAfterSeconds-1 {
-			testActorsRuntime.DeleteReminder(ctx, &DeleteReminderRequest{
-				Name:      reminder.Name,
-				ActorID:   reminder.ActorID,
-				ActorType: reminder.ActorType,
-			})
-		}
-
-		select {
-		case request := <-requestC:
-			assert.Equal(t, reminder.Data, request.Data)
-			count++
-			if count > repeats {
-				break L
+			requestC := make(chan testRequest, 10)
+			appChannel := mockAppChannel{
+				requestC: requestC,
 			}
-		// Use a wall clock here because we have background goroutines
-		case <-time.After(100 * time.Millisecond):
-			// nop
-		}
-	}
-	assert.Equal(t, repeats, count)
-}
+			testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
+			t.Cleanup(testActorsRuntime.Stop)
+			clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
-func TestReminderRepeats(t *testing.T) {
-	ctx := context.Background()
-	t.Run("reminder with dueTime is ignored", func(t *testing.T) {
-		reminderRepeats(ctx, t, "2s", "R0/PT2S", "", 0, 0, 0)
-	})
-	t.Run("reminder without dueTime is ignored", func(t *testing.T) {
-		reminderRepeats(ctx, t, "", "R0/PT2S", "", 0, 0, 0)
-	})
-	t.Run("reminder with dueTime repeats once", func(t *testing.T) {
-		reminderRepeats(ctx, t, "2s", "R1/PT2S", "", 1, 6, 0)
-	})
-	t.Run("reminder without dueTime repeats once", func(t *testing.T) {
-		reminderRepeats(ctx, t, "", "R1/PT2S", "", 1, 4, 0)
-	})
-	t.Run("reminder with dueTime repeats not set", func(t *testing.T) {
-		reminderRepeats(ctx, t, "2s", "", "", 1, 6, 0)
-	})
-	t.Run("reminder without dueTime repeats not set", func(t *testing.T) {
-		reminderRepeats(ctx, t, "", "", "", 1, 4, 0)
-	})
-	t.Run("reminder with dueTime repeats 3 times", func(t *testing.T) {
-		reminderRepeats(ctx, t, "2s", "R3/PT2S", "", 3, 10, 0)
-	})
-	t.Run("reminder without dueTime repeats 3 times", func(t *testing.T) {
-		reminderRepeats(ctx, t, "", "R3/PT2S", "", 3, 8, 0)
-	})
-	t.Run("reminder with dueTime deleted after 1 sec", func(t *testing.T) {
-		reminderRepeats(ctx, t, 2, "PT2S", "", 1, 6, 3)
-	})
-	t.Run("reminder without dueTime deleted after 1 sec", func(t *testing.T) {
-		reminderRepeats(ctx, t, "", "PT2S", "", 1, 4, 1)
-	})
-	t.Run("reminder with dueTime ttl", func(t *testing.T) {
-		reminderRepeats(ctx, t, 2, "PT2S", "3s", 2, 8, 0)
-	})
-	t.Run("reminder without dueTime ttl", func(t *testing.T) {
-		reminderRepeats(ctx, t, "", "2s", 3, 2, 6, 0)
-	})
-}
+			actorType, actorID := getTestActorTypeAndID()
+			fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, clock)
 
-func reminderTTL(ctx context.Context, t *testing.T, dueTime string, period string, ttlAny any, repeats int, timeoutSeconds int) {
-	requestC := make(chan testRequest, 10)
-	appChannel := mockAppChannel{
-		requestC: requestC,
-	}
-	testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
-	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
-
-	actorType, actorID := getTestActorTypeAndID()
-	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, clock)
-
-	var ttl string
-	switch x := ttlAny.(type) {
-	case string:
-		ttl = x
-	case int:
-		ttl = clock.Now().Add(time.Duration(x) * time.Second).Format(time.RFC3339)
-	}
-
-	reminder := createReminderData(actorID, actorType, "reminder1", period, dueTime, ttl, "data")
-	err := testActorsRuntime.CreateReminder(ctx, &reminder)
-	assert.NoError(t, err)
-
-	count := 0
-	clock.Add(100 * time.Millisecond)
-L:
-	for i := 0; i < timeoutSeconds; i++ {
-		clock.Add(time.Second)
-		select {
-		case request := <-requestC:
-			assert.Equal(t, reminder.Data, request.Data)
-			count++
-			if count > repeats {
-				break L
+			var dueTime string
+			switch x := test.dueTimeAny.(type) {
+			case string:
+				dueTime = x
+			case int:
+				dueTime = clock.Now().Add(time.Duration(x) * time.Second).Format(time.RFC3339)
 			}
-			// Use a wall clock here because we have background goroutines
-		case <-time.After(100 * time.Millisecond):
-			// nop
-		}
+
+			var ttl string
+			switch x := test.ttlAny.(type) {
+			case string:
+				ttl = x
+			case int:
+				ttl = clock.Now().Add(time.Duration(x) * time.Second).Format(time.RFC3339)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			t.Cleanup(cancel)
+
+			reminder := CreateReminderRequest{
+				ActorID:   actorID,
+				ActorType: actorType,
+				Name:      "reminder1",
+				Period:    test.period,
+				DueTime:   dueTime,
+				TTL:       ttl,
+				Data:      "data",
+			}
+
+			err := testActorsRuntime.CreateReminder(ctx, &reminder)
+			if test.expRepeats == 0 {
+				assert.EqualError(t, err, "reminder reminder1 has zero repetitions")
+				return
+			}
+			assert.NoError(t, err)
+
+			testActorsRuntime.remindersLock.RLock()
+			assert.Equal(t, 1, len(testActorsRuntime.reminders[actorType]))
+			testActorsRuntime.remindersLock.RUnlock()
+
+			count := 0
+
+			// Ensure ticker is setup.
+			advanceTickers(t, clock, 0)
+
+			var wg sync.WaitGroup
+			t.Cleanup(wg.Wait)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer cancel()
+
+				start := clock.Now()
+
+				ticker := clock.NewTicker(time.Second)
+				defer ticker.Stop()
+
+				for i := 0; i < 10; i++ {
+					if test.delAfterSeconds > 0 && clock.Now().Sub(start).Seconds() >= test.delAfterSeconds {
+						require.NoError(t, testActorsRuntime.DeleteReminder(ctx, &DeleteReminderRequest{
+							Name:      reminder.Name,
+							ActorID:   reminder.ActorID,
+							ActorType: reminder.ActorType,
+						}))
+					}
+					select {
+					case request := <-requestC:
+						// Decrease i since time hasn't increased.
+						i--
+						assert.Equal(t, reminder.Data, request.Data)
+						count++
+					case <-ticker.C():
+					}
+				}
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
+					require.Equal(t, test.expRepeats, count)
+					return
+				case <-time.After(time.Millisecond):
+					advanceTickers(t, clock, time.Millisecond*500)
+				}
+			}
+		})
 	}
-	assert.Equal(t, repeats, count)
 }
 
-func TestReminderTTL(t *testing.T) {
-	ctx := context.Background()
-	t.Run("reminder ttl with dueTime", func(t *testing.T) {
-		reminderTTL(ctx, t, "2s", "R5/PT2S", "5s", 3, 10)
-	})
-	t.Run("reminder ttl without dueTime", func(t *testing.T) {
-		reminderTTL(ctx, t, "", "R5/PT2S", "5s", 3, 8)
-	})
-	t.Run("reminder ttl in ISO 8601 with dueTime", func(t *testing.T) {
-		reminderTTL(ctx, t, "2s", "R5/PT2S", "PT5S", 3, 10)
-	})
-	t.Run("reminder ttl in RFC3339 without dueTime", func(t *testing.T) {
-		reminderTTL(ctx, t, "", "R5/PT2S", 5, 3, 8)
-	})
-	t.Run("reminder ttl expired with dueTime", func(t *testing.T) {
-		reminderTTL(ctx, t, "2s", "R5/PT2S", "1s", 1, 4)
-	})
+func Test_ReminderTTL(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		dueTime    string
+		period     string
+		ttlAny     any
+		expRepeats int
+	}{
+		"reminder ttl with dueTime": {
+			dueTime:    "2s",
+			period:     "R5/PT2S",
+			ttlAny:     "5s",
+			expRepeats: 3,
+		},
+		"reminder ttl without dueTime": {
+			dueTime:    "",
+			period:     "R5/PT2S",
+			ttlAny:     "5s",
+			expRepeats: 3,
+		},
+		"reminder ttl in ISO 8601 with dueTime": {
+			dueTime:    "2s",
+			period:     "R5/PT2S",
+			ttlAny:     "PT5S",
+			expRepeats: 3,
+		},
+		"reminder ttl in RFC3339 without dueTime": {
+			dueTime:    "",
+			period:     "R5/PT2S",
+			ttlAny:     5,
+			expRepeats: 3,
+		},
+		"reminder ttl expired with dueTime": {
+			dueTime:    "2s",
+			period:     "R5/PT2S",
+			ttlAny:     "1s",
+			expRepeats: 1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			requestC := make(chan testRequest)
+			appChannel := mockAppChannel{
+				requestC: requestC,
+			}
+			testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
+			t.Cleanup(testActorsRuntime.Stop)
+			clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
+
+			actorType, actorID := getTestActorTypeAndID()
+			fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, clock)
+
+			var ttl string
+			switch x := test.ttlAny.(type) {
+			case string:
+				ttl = x
+			case int:
+				ttl = clock.Now().Add(time.Duration(x) * time.Second).Format(time.RFC3339)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			t.Cleanup(cancel)
+
+			reminder := CreateReminderRequest{
+				ActorID:   actorID,
+				ActorType: actorType,
+				Name:      "reminder1",
+				Period:    test.period,
+				DueTime:   test.dueTime,
+				TTL:       ttl,
+				Data:      "data",
+			}
+			err := testActorsRuntime.CreateReminder(ctx, &reminder)
+			assert.NoError(t, err)
+
+			count := 0
+
+			var wg sync.WaitGroup
+			t.Cleanup(wg.Wait)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer cancel()
+
+				ticker := clock.NewTicker(time.Second)
+				defer ticker.Stop()
+
+				for i := 0; i < 10; i++ {
+					select {
+					case request := <-requestC:
+						// Decrease i since time hasn't increased.
+						i--
+						assert.Equal(t, reminder.Data, request.Data)
+						count++
+					case <-ctx.Done():
+					case <-ticker.C():
+					}
+				}
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
+					require.Equal(t, test.expRepeats, count)
+					return
+				case <-time.After(time.Millisecond):
+					advanceTickers(t, clock, time.Millisecond*500)
+				}
+			}
+		})
+	}
 }
 
 func reminderValidation(ctx context.Context, t *testing.T, dueTime, period, ttl, msg string) {
+	t.Parallel()
+
 	requestC := make(chan testRequest, 10)
 	appChannel := mockAppChannel{
 		requestC: requestC,
@@ -1329,6 +1539,8 @@ func reminderValidation(ctx context.Context, t *testing.T, dueTime, period, ttl,
 }
 
 func TestReminderValidation(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("reminder dueTime invalid (1)", func(t *testing.T) {
 		reminderValidation(ctx, t, "invalid", "R5/PT2S", "1h", "error parsing reminder due time: unsupported time/duration format \"invalid\"")
@@ -1363,6 +1575,8 @@ func TestReminderValidation(t *testing.T) {
 }
 
 func TestGetReminder(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1383,24 +1597,42 @@ func TestGetReminder(t *testing.T) {
 }
 
 func TestCreateTimerDueTimes(t *testing.T) {
-	testActorsRuntime := newTestActorsRuntime()
-	defer testActorsRuntime.Stop()
+	t.Parallel()
 
-	actorType, actorID := getTestActorTypeAndID()
-	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
 	t.Run("test create timer with positive DueTime", func(t *testing.T) {
+		t.Parallel()
+
+		testActorsRuntime := newTestActorsRuntime()
+		defer testActorsRuntime.Stop()
+		actorType, actorID := getTestActorTypeAndID()
+		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
+
 		timer := createTimerData(actorID, actorType, "positiveTimer", "1s", "2s", "", "callback", "testTimer")
 		err := testActorsRuntime.CreateTimer(context.Background(), &timer)
 		assert.NoError(t, err)
 	})
 
 	t.Run("test create timer with 0 DueTime", func(t *testing.T) {
+		t.Parallel()
+
+		testActorsRuntime := newTestActorsRuntime()
+		defer testActorsRuntime.Stop()
+		actorType, actorID := getTestActorTypeAndID()
+		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
+
 		timer := createTimerData(actorID, actorType, "positiveTimer", "1s", "0s", "", "callback", "testTimer")
 		err := testActorsRuntime.CreateTimer(context.Background(), &timer)
 		assert.NoError(t, err)
 	})
 
 	t.Run("test create timer with no DueTime", func(t *testing.T) {
+		t.Parallel()
+
+		testActorsRuntime := newTestActorsRuntime()
+		defer testActorsRuntime.Stop()
+		actorType, actorID := getTestActorTypeAndID()
+		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
+
 		timer := createTimerData(actorID, actorType, "positiveTimer", "1s", "", "", "callback", "testTimer")
 		err := testActorsRuntime.CreateTimer(context.Background(), &timer)
 		assert.NoError(t, err)
@@ -1408,6 +1640,8 @@ func TestCreateTimerDueTimes(t *testing.T) {
 }
 
 func TestDeleteTimer(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1437,6 +1671,8 @@ func TestDeleteTimer(t *testing.T) {
 }
 
 func TestOverrideTimerCancelsActiveTimers(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		requestC := make(chan testRequest, 10)
@@ -1445,6 +1681,7 @@ func TestOverrideTimerCancelsActiveTimers(t *testing.T) {
 		}
 		testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
 		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 		actorType, actorID := getTestActorTypeAndID()
 		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
@@ -1461,7 +1698,8 @@ func TestOverrideTimerCancelsActiveTimers(t *testing.T) {
 		testActorsRuntime.CreateTimer(ctx, &timer3)
 
 		// due time for timer3 is 2s
-		advanceTickers(testActorsRuntime, time.Second, 2)
+		advanceTickers(t, clock, time.Second)
+		advanceTickers(t, clock, time.Second)
 
 		// The timer update fires in a goroutine so we need to use the wall clock here
 		select {
@@ -1475,6 +1713,8 @@ func TestOverrideTimerCancelsActiveTimers(t *testing.T) {
 }
 
 func TestOverrideTimerCancelsMultipleActiveTimers(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		requestC := make(chan testRequest, 10)
@@ -1483,6 +1723,7 @@ func TestOverrideTimerCancelsMultipleActiveTimers(t *testing.T) {
 		}
 		testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
 		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 		actorType, actorID := getTestActorTypeAndID()
 		timerName := "timer1"
@@ -1494,21 +1735,18 @@ func TestOverrideTimerCancelsMultipleActiveTimers(t *testing.T) {
 
 		timer2 := createTimerData(actorID, actorType, timerName, "8s", "4s", "", "callback2", "b")
 		timer3 := createTimerData(actorID, actorType, timerName, "8s", "4s", "", "callback3", "c")
-		go testActorsRuntime.CreateTimer(ctx, &timer2)
-		go testActorsRuntime.CreateTimer(ctx, &timer3)
-
-		// Sleep on the wall clock due to background goroutines
-		runtime.Gosched()
-		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, testActorsRuntime.CreateTimer(ctx, &timer2))
+		require.NoError(t, testActorsRuntime.CreateTimer(ctx, &timer3))
 
 		// due time for timer2/timer3 is 4s, advance less
-		advanceTickers(testActorsRuntime, time.Second, 2)
+		advanceTickers(t, clock, time.Second)
+		advanceTickers(t, clock, time.Second)
 
 		timer4 := createTimerData(actorID, actorType, timerName, "7s", "2s", "", "callback4", "d")
 		testActorsRuntime.CreateTimer(ctx, &timer4)
 
 		// due time for timer4 is 2s
-		advanceTickers(testActorsRuntime, time.Second, 2)
+		advanceTickers(t, clock, time.Second*2)
 
 		// The timer update fires in a goroutine so we need to use the wall clock here
 		select {
@@ -1521,146 +1759,269 @@ func TestOverrideTimerCancelsMultipleActiveTimers(t *testing.T) {
 	})
 }
 
-func timerRepeats(ctx context.Context, t *testing.T, dueTime, period, ttl string, repeats int, timeoutSeconds int, delAfterSeconds int) {
-	requestC := make(chan testRequest, 10)
-	appChannel := mockAppChannel{
-		requestC: requestC,
+func Test_TimerRepeats(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		dueTime         string
+		period          string
+		ttl             string
+		expRepeats      int
+		delAfterSeconds float64
+	}{
+		"timer with dueTime is ignored": {
+			dueTime:         "2s",
+			period:          "R0/PT2S",
+			ttl:             "",
+			expRepeats:      0,
+			delAfterSeconds: 0,
+		},
+		"timer without dueTime is ignored": {
+			dueTime:         "",
+			period:          "R0/PT2S",
+			ttl:             "",
+			expRepeats:      0,
+			delAfterSeconds: 0,
+		},
+		"timer with dueTime repeats once": {
+			dueTime:         "2s",
+			period:          "R1/PT2S",
+			ttl:             "",
+			expRepeats:      1,
+			delAfterSeconds: 0,
+		},
+		"timer without dueTime repeats once": {
+			dueTime:         "",
+			period:          "R1/PT2S",
+			ttl:             "",
+			expRepeats:      1,
+			delAfterSeconds: 0,
+		},
+		"timer with dueTime period not set": {
+			dueTime:         "2s",
+			period:          "",
+			ttl:             "",
+			expRepeats:      1,
+			delAfterSeconds: 0,
+		},
+		"timer without dueTime period not set": {
+			dueTime:         "",
+			period:          "",
+			ttl:             "",
+			expRepeats:      1,
+			delAfterSeconds: 0,
+		},
+		"timer with dueTime repeats 3 times": {
+			dueTime:         "2s",
+			period:          "R3/PT2S",
+			ttl:             "",
+			expRepeats:      3,
+			delAfterSeconds: 0,
+		},
+		"timer without dueTime repeats 3 times": {
+			dueTime:         "",
+			period:          "R3/PT2S",
+			ttl:             "",
+			expRepeats:      3,
+			delAfterSeconds: 0,
+		},
+		"timer with dueTime deleted after 1 sec": {
+			dueTime:         startOfTime.Add(2 * time.Second).Format(time.RFC3339),
+			period:          "PT4S",
+			ttl:             "",
+			expRepeats:      1,
+			delAfterSeconds: 3,
+		},
+		"timer without dueTime deleted after 1 sec": {
+			dueTime:         "",
+			period:          "PT2S",
+			ttl:             "",
+			expRepeats:      1,
+			delAfterSeconds: 1,
+		},
+		"timer with dueTime ttl": {
+			dueTime:         startOfTime.Add(2 * time.Second).Format(time.RFC3339),
+			period:          "PT2S",
+			ttl:             "3s",
+			expRepeats:      2,
+			delAfterSeconds: 0,
+		},
+		"timer without dueTime ttl": {
+			dueTime:         "",
+			period:          "4s",
+			ttl:             startOfTime.Add(6 * time.Second).Format(time.RFC3339),
+			expRepeats:      2,
+			delAfterSeconds: 0,
+		},
 	}
-	testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
-	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
 
-	actorType, actorID := getTestActorTypeAndID()
-	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
+	for name, testT := range tests {
+		test := testT
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	timer := createTimerData(actorID, actorType, "timer", period, dueTime, ttl, "callback", "data")
-	err := testActorsRuntime.CreateTimer(ctx, &timer)
-	if repeats == 0 {
-		assert.EqualError(t, err, "timer cat||e485d5de-de48-45ab-816e-6cc700d18ace||timer has zero repetitions")
-		return
-	}
-	assert.NoError(t, err)
-
-	count := 0
-	clock.Add(100 * time.Millisecond)
-L:
-	for i := 0; i < timeoutSeconds; i++ {
-		clock.Add(time.Second)
-
-		if delAfterSeconds > 0 && i == delAfterSeconds-1 {
-			testActorsRuntime.DeleteTimer(ctx, &DeleteTimerRequest{
-				Name:      timer.Name,
-				ActorID:   timer.ActorID,
-				ActorType: timer.ActorType,
-			})
-		}
-
-		select {
-		case request := <-requestC:
-			assert.Equal(t, timer.Data, request.Data)
-			count++
-			if count > repeats {
-				break L
+			requestC := make(chan testRequest, 10)
+			appChannel := mockAppChannel{
+				requestC: requestC,
 			}
-		// Use a wall clock here because we have background goroutines
-		case <-time.After(100 * time.Millisecond):
-			// nop
-		}
-	}
-	assert.Equal(t, repeats, count)
-}
+			testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
+			defer testActorsRuntime.Stop()
+			clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
-func TestTimerRepeats(t *testing.T) {
-	ctx := context.Background()
-	t.Run("timer with dueTime is ignored", func(t *testing.T) {
-		timerRepeats(ctx, t, "2s", "R0/PT2S", "", 0, 0, 0)
-	})
-	t.Run("timer without dueTime is ignored", func(t *testing.T) {
-		timerRepeats(ctx, t, "", "R0/PT2S", "", 0, 0, 0)
-	})
-	t.Run("timer with dueTime repeats once", func(t *testing.T) {
-		timerRepeats(ctx, t, "2s", "R1/PT2S", "", 1, 6, 0)
-	})
-	t.Run("timer without dueTime repeats once", func(t *testing.T) {
-		timerRepeats(ctx, t, "", "R1/PT2S", "", 1, 4, 0)
-	})
-	t.Run("timer with dueTime period not set", func(t *testing.T) {
-		timerRepeats(ctx, t, "2s", "", "", 1, 6, 0)
-	})
-	t.Run("timer without dueTime period not set", func(t *testing.T) {
-		timerRepeats(ctx, t, "", "", "", 1, 4, 0)
-	})
-	t.Run("timer with dueTime repeats 3 times", func(t *testing.T) {
-		timerRepeats(ctx, t, "2s", "R3/PT2S", "", 3, 10, 0)
-	})
-	t.Run("timer without dueTime repeats 3 times", func(t *testing.T) {
-		timerRepeats(ctx, t, "", "R3/PT2S", "", 3, 8, 0)
-	})
-	t.Run("timer with dueTime deleted after 1 sec", func(t *testing.T) {
-		timerRepeats(ctx, t, startOfTime.Add(2*time.Second).Format(time.RFC3339), "PT4S", "", 1, 8, 3)
-	})
-	t.Run("timer without dueTime deleted after 1 sec", func(t *testing.T) {
-		timerRepeats(ctx, t, "", "PT2S", "", 1, 4, 1)
-	})
-	t.Run("timer with dueTime ttl", func(t *testing.T) {
-		timerRepeats(ctx, t, startOfTime.Add(2*time.Second).Format(time.RFC3339), "PT2S", "3s", 2, 8, 0)
-	})
-	t.Run("timer without dueTime ttl", func(t *testing.T) {
-		timerRepeats(ctx, t, "", "4s", startOfTime.Add(6*time.Second).Format(time.RFC3339), 2, 10, 0)
-	})
-}
+			actorType, actorID := getTestActorTypeAndID()
+			fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
 
-func timerTTL(ctx context.Context, t *testing.T, iso bool) {
-	requestC := make(chan testRequest, 10)
-	appChannel := mockAppChannel{
-		requestC: requestC,
-	}
-	testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
-	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
-
-	actorType, actorID := getTestActorTypeAndID()
-	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
-
-	ttl := "7s"
-	if iso {
-		ttl = "PT7S"
-	}
-	timer := createTimerData(actorID, actorType, "timer", "R5/PT2S", "2s", ttl, "callback", "data")
-	err := testActorsRuntime.CreateTimer(ctx, &timer)
-	assert.NoError(t, err)
-
-	count := 0
-	clock.Add(100 * time.Millisecond)
-L:
-	for i := 0; i < 10; i++ {
-		clock.Add(time.Second)
-		select {
-		case request := <-requestC:
-			assert.Equal(t, timer.Data, request.Data)
-			count++
-			if count > 4 {
-				break L
+			timer := CreateTimerRequest{
+				ActorID:   actorID,
+				ActorType: actorType,
+				Name:      "timer",
+				Period:    test.period,
+				DueTime:   test.dueTime,
+				TTL:       test.ttl,
+				Data:      "data",
+				Callback:  "callback",
 			}
-			// Use a wall clock here because we have background goroutines
-		case <-time.After(100 * time.Millisecond):
-			// nop
-		}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			t.Cleanup(cancel)
+
+			err := testActorsRuntime.CreateTimer(ctx, &timer)
+			if test.expRepeats == 0 {
+				assert.EqualError(t, err, "timer cat||e485d5de-de48-45ab-816e-6cc700d18ace||timer has zero repetitions")
+				return
+			}
+			assert.NoError(t, err)
+
+			count := 0
+
+			var wg sync.WaitGroup
+			t.Cleanup(wg.Wait)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer cancel()
+
+				start := clock.Now()
+				ticker := clock.NewTicker(time.Second)
+				defer ticker.Stop()
+
+				for i := 0; i < 10; i++ {
+					if test.delAfterSeconds > 0 && clock.Now().Sub(start).Seconds() >= test.delAfterSeconds {
+						require.NoError(t, testActorsRuntime.DeleteTimer(ctx, &DeleteTimerRequest{
+							Name:      timer.Name,
+							ActorID:   timer.ActorID,
+							ActorType: timer.ActorType,
+						}))
+					}
+
+					select {
+					case request := <-requestC:
+						// Decrease i since time hasn't increased.
+						i--
+						assert.Equal(t, timer.Data, request.Data)
+						count++
+					case <-ctx.Done():
+					case <-ticker.C():
+					}
+				}
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
+					require.Equal(t, test.expRepeats, count)
+					return
+				case <-time.After(time.Millisecond):
+					advanceTickers(t, clock, time.Millisecond*500)
+				}
+			}
+		})
 	}
-	assert.Equal(t, 4, count)
 }
 
-func TestTimerTTL(t *testing.T) {
-	ctx := context.Background()
-	t.Run("timer ttl", func(t *testing.T) {
-		timerTTL(ctx, t, false)
-	})
-	t.Run("timer ttl with ISO 8601", func(t *testing.T) {
-		timerTTL(ctx, t, true)
-	})
+func Test_TimerTTL(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		iso bool
+	}{
+		"timer ttl": {
+			iso: false,
+		},
+		"timer ttl with ISO 8601": {
+			iso: true,
+		},
+	}
+
+	for name, testT := range tests {
+		test := testT
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			requestC := make(chan testRequest, 10)
+			appChannel := mockAppChannel{
+				requestC: requestC,
+			}
+			testActorsRuntime := newTestActorsRuntimeWithMock(&appChannel)
+			defer testActorsRuntime.Stop()
+			clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
+
+			actorType, actorID := getTestActorTypeAndID()
+			fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
+
+			ttl := "7s"
+			if test.iso {
+				ttl = "PT7S"
+			}
+			timer := createTimerData(actorID, actorType, "timer", "R5/PT2S", "2s", ttl, "callback", "data")
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			t.Cleanup(cancel)
+			assert.NoError(t, testActorsRuntime.CreateTimer(ctx, &timer))
+
+			count := 0
+
+			ticker := clock.NewTicker(time.Second)
+			defer ticker.Stop()
+
+			advanceTickers(t, clock, 0)
+
+			var wg sync.WaitGroup
+			t.Cleanup(wg.Wait)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer cancel()
+
+				for i := 0; i < 10; i++ {
+					select {
+					case request := <-requestC:
+						// Decrease i since time hasn't increased.
+						i--
+						assert.Equal(t, timer.Data, request.Data)
+						count++
+					case <-ticker.C():
+						//nop
+					}
+				}
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
+					assert.Equal(t, 4, count)
+					return
+				case <-time.After(time.Millisecond):
+					advanceTickers(t, clock, time.Millisecond*500)
+				}
+			}
+		})
+	}
 }
 
 func timerValidation(ctx context.Context, t *testing.T, dueTime, period, ttl, msg string) {
+	t.Parallel()
+
 	requestC := make(chan testRequest, 10)
 	appChannel := mockAppChannel{
 		requestC: requestC,
@@ -1677,6 +2038,8 @@ func timerValidation(ctx context.Context, t *testing.T, dueTime, period, ttl, ms
 }
 
 func TestTimerValidation(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("timer dueTime invalid (1)", func(t *testing.T) {
 		timerValidation(ctx, t, "invalid", "R5/PT2S", "1h", "error parsing timer due time: unsupported time/duration format \"invalid\"")
@@ -1711,9 +2074,11 @@ func TestTimerValidation(t *testing.T) {
 }
 
 func TestReminderFires(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
+	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 	actorType, actorID := getTestActorTypeAndID()
 	ctx := context.Background()
@@ -1721,25 +2086,23 @@ func TestReminderFires(t *testing.T) {
 	err := testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.NoError(t, err)
 
-	// Need to advance the clock twice in two steps here due to how the clock library works
-	clock.Add(time.Millisecond)
-	clock.Add(100 * time.Millisecond)
-
-	// Sleep on the wall clock to allow background goroutines to complete
-	runtime.Gosched()
-	time.Sleep(100 * time.Millisecond)
+	advanceTickers(t, clock, time.Millisecond*101)
 
 	actorKey := constructCompositeKey(actorType, actorID)
-	track, err := testActorsRuntime.getReminderTrack(actorKey, "reminder1")
-	assert.NoError(t, err)
-	assert.NotNil(t, track)
-	assert.NotEmpty(t, track.LastFiredTime)
+	assert.Eventually(t, func() bool {
+		track, err := testActorsRuntime.getReminderTrack(actorKey, "reminder1")
+		require.NoError(t, err)
+		require.NotNil(t, track)
+		return len(track.LastFiredTime) > 0
+	}, time.Second, time.Millisecond)
 }
 
 func TestReminderDueDate(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
+	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 	actorType, actorID := getTestActorTypeAndID()
 	ctx := context.Background()
@@ -1752,59 +2115,66 @@ func TestReminderDueDate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, track.LastFiredTime)
 
-	// Need to advance the clock twice in two steps here due to how the clock library works
-	clock.Add(time.Millisecond)
-	clock.Add(500 * time.Millisecond)
+	advanceTickers(t, clock, time.Millisecond*500)
 
-	// Sleep on the wall clock to allow background goroutines to complete
-	runtime.Gosched()
-	time.Sleep(100 * time.Millisecond)
-
-	track, err = testActorsRuntime.getReminderTrack(actorKey, "reminder1")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, track.LastFiredTime)
+	assert.Eventually(t, func() bool {
+		track, err := testActorsRuntime.getReminderTrack(actorKey, "reminder1")
+		require.NoError(t, err)
+		require.NotNil(t, track)
+		return len(track.LastFiredTime) > 0
+	}, time.Second, time.Millisecond)
 }
 
 func TestReminderPeriod(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
+	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 	actorType, actorID := getTestActorTypeAndID()
 	ctx := context.Background()
 	actorKey := constructCompositeKey(actorType, actorID)
-	reminder := createReminderData(actorID, actorType, "reminder1", "100ms", "100ms", "", "a")
-	err := testActorsRuntime.CreateReminder(ctx, &reminder)
-	assert.NoError(t, err)
+	require.NoError(t, testActorsRuntime.CreateReminder(ctx, &CreateReminderRequest{
+		ActorID:   actorID,
+		ActorType: actorType,
+		Name:      "reminder1",
+		Period:    "100ms",
+		DueTime:   "100ms",
+		TTL:       "",
+		Data:      "a",
+	}))
 
-	// Need to advance the clock twice in two steps here due to how the clock library works
-	clock.Add(time.Millisecond)
-	clock.Add(250 * time.Millisecond)
+	advanceTickers(t, clock, 0)
 
-	// Sleep on the wall clock to allow background goroutines to complete
-	runtime.Gosched()
-	time.Sleep(100 * time.Millisecond)
+	var (
+		track  *ReminderTrack
+		track2 *ReminderTrack
+		err    error
+	)
 
-	track, _ := testActorsRuntime.getReminderTrack(actorKey, "reminder1")
-	assert.NotEmpty(t, track.LastFiredTime)
+	assert.Eventually(t, func() bool {
+		track, err = testActorsRuntime.getReminderTrack(actorKey, "reminder1")
+		require.NoError(t, err)
+		require.NotNil(t, track)
+		return len(track.LastFiredTime) > 0
+	}, time.Second, time.Millisecond)
 
-	clock.Add(3 * time.Second)
-
-	// Sleep on the wall clock to allow background goroutines to complete
-	runtime.Gosched()
-	time.Sleep(100 * time.Millisecond)
-
-	track2, err := testActorsRuntime.getReminderTrack(actorKey, "reminder1")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, track2.LastFiredTime)
-
-	assert.NotEqual(t, track.LastFiredTime, track2.LastFiredTime)
+	assert.Eventually(t, func() bool {
+		advanceTickers(t, clock, time.Millisecond*100)
+		track2, err = testActorsRuntime.getReminderTrack(actorKey, "reminder1")
+		require.NoError(t, err)
+		require.NotNil(t, track2)
+		return len(track2.LastFiredTime) > 0 && track.LastFiredTime != track2.LastFiredTime
+	}, time.Second, time.Millisecond)
 }
 
 func TestReminderFiresOnceWithEmptyPeriod(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
+	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 	actorType, actorID := getTestActorTypeAndID()
 	ctx := context.Background()
@@ -1813,19 +2183,15 @@ func TestReminderFiresOnceWithEmptyPeriod(t *testing.T) {
 	err := testActorsRuntime.CreateReminder(ctx, &reminder)
 	assert.NoError(t, err)
 
-	// Need to advance the clock twice in two steps here due to how the clock library works
-	clock.Add(time.Millisecond)
-	clock.Add(100 * time.Millisecond)
-
-	// Sleep on the wall clock to allow background goroutines to complete
-	runtime.Gosched()
-	time.Sleep(100 * time.Millisecond)
+	clock.Step(100 * time.Millisecond)
 
 	track, _ := testActorsRuntime.getReminderTrack(actorKey, "reminder1")
 	assert.Empty(t, track.LastFiredTime)
 }
 
 func TestConstructActorStateKey(t *testing.T) {
+	t.Parallel()
+
 	delim := "||"
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
@@ -1849,6 +2215,8 @@ func TestConstructActorStateKey(t *testing.T) {
 }
 
 func TestGetState(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1888,6 +2256,8 @@ func TestGetState(t *testing.T) {
 }
 
 func TestDeleteState(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1953,6 +2323,8 @@ func TestDeleteState(t *testing.T) {
 }
 
 func TestCallLocalActor(t *testing.T) {
+	t.Parallel()
+
 	const (
 		testActorType = "pet"
 		testActorID   = "dog"
@@ -2003,6 +2375,8 @@ func TestCallLocalActor(t *testing.T) {
 }
 
 func TestTransactionalState(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("Single set request succeeds", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
@@ -2100,6 +2474,8 @@ func TestTransactionalState(t *testing.T) {
 }
 
 func TestGetOrCreateActor(t *testing.T) {
+	t.Parallel()
+
 	const testActorType = "fakeActor"
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
@@ -2118,6 +2494,8 @@ func TestGetOrCreateActor(t *testing.T) {
 }
 
 func TestActiveActorsCount(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	t.Run("Actors Count", func(t *testing.T) {
 		expectedCounts := []ActiveActorsCount{{Type: "cat", Count: 2}, {Type: "dog", Count: 1}}
@@ -2145,9 +2523,11 @@ func TestActiveActorsCount(t *testing.T) {
 }
 
 func TestActorsAppHealthCheck(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
+	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 	testActorsRuntime.config.HostedActorTypes = []string{"actor1"}
 	go testActorsRuntime.startAppHealthCheck(
@@ -2157,22 +2537,18 @@ func TestActorsAppHealthCheck(t *testing.T) {
 		health.WithRequestTimeout(100*time.Millisecond),
 	)
 
-	// Sleep on the wall clock to allow the background goroutines to get in sync
-	runtime.Gosched()
-	time.Sleep(200 * time.Millisecond)
-
-	clock.Add(2 * time.Second)
-
-	// Sleep on the wall clock to allow the background goroutines to get in sync
-	runtime.Gosched()
-	time.Sleep(200 * time.Millisecond)
-	assert.False(t, testActorsRuntime.appHealthy.Load())
+	assert.Eventually(t, func() bool {
+		advanceTickers(t, clock, time.Second)
+		return !testActorsRuntime.appHealthy.Load()
+	}, time.Second, time.Microsecond*10, testActorsRuntime.appHealthy.Load())
 }
 
 func TestHostedActorsWithoutStateStore(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntimeWithoutStore()
 	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
+	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 	testActorsRuntime.config.HostedActorTypes = []string{"actor1"}
 	go testActorsRuntime.startAppHealthCheck(
@@ -2182,22 +2558,18 @@ func TestHostedActorsWithoutStateStore(t *testing.T) {
 		health.WithRequestTimeout(100*time.Millisecond),
 	)
 
-	// Sleep on the wall clock to allow the background goroutines to get in sync
-	runtime.Gosched()
-	time.Sleep(200 * time.Millisecond)
-
-	clock.Add(2 * time.Second)
-
-	// Sleep on the wall clock to allow the background goroutines to get in sync
-	runtime.Gosched()
-	time.Sleep(200 * time.Millisecond)
-	assert.False(t, testActorsRuntime.appHealthy.Load())
+	assert.Eventually(t, func() bool {
+		advanceTickers(t, clock, time.Second)
+		return !testActorsRuntime.appHealthy.Load()
+	}, time.Second, time.Microsecond*10, testActorsRuntime.appHealthy.Load())
 }
 
 func TestNoHostedActorsWithoutStateStore(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntimeWithoutStore()
 	defer testActorsRuntime.Stop()
-	clock := testActorsRuntime.clock.(*clocklib.Mock)
+	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
 	testActorsRuntime.config.HostedActorTypes = []string{}
 	go testActorsRuntime.startAppHealthCheck(
@@ -2207,19 +2579,16 @@ func TestNoHostedActorsWithoutStateStore(t *testing.T) {
 		health.WithRequestTimeout(100*time.Millisecond),
 	)
 
-	// Sleep on the wall clock to allow the background goroutines to get in sync
-	runtime.Gosched()
-	time.Sleep(200 * time.Millisecond)
+	clock.Step(2 * time.Second)
 
-	clock.Add(2 * time.Second)
-
-	// Sleep on the wall clock to allow the background goroutines to get in sync
-	runtime.Gosched()
-	time.Sleep(200 * time.Millisecond)
-	assert.True(t, testActorsRuntime.appHealthy.Load())
+	assert.Eventually(t, func() bool {
+		return testActorsRuntime.appHealthy.Load()
+	}, time.Second, time.Microsecond*10)
 }
 
 func TestShutdown(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntime()
 
 	t.Run("no panic when placement is nil", func(t *testing.T) {
@@ -2230,6 +2599,8 @@ func TestShutdown(t *testing.T) {
 }
 
 func TestConstructCompositeKeyWithThreeArgs(t *testing.T) {
+	t.Parallel()
+
 	appID := "myapp"
 	actorType := "TestActor"
 	actorID := "abc123"
@@ -2240,6 +2611,8 @@ func TestConstructCompositeKeyWithThreeArgs(t *testing.T) {
 }
 
 func TestConfig(t *testing.T) {
+	t.Parallel()
+
 	appConfig := config.ApplicationConfig{
 		Entities:                   []string{"1"},
 		ActorScanInterval:          "1s",
@@ -2270,8 +2643,12 @@ func TestConfig(t *testing.T) {
 }
 
 func TestReentrancyConfig(t *testing.T) {
-	appConfig := DefaultAppConfig
+	t.Parallel()
+
 	t.Run("Test empty reentrancy values", func(t *testing.T) {
+		t.Parallel()
+
+		appConfig := DefaultAppConfig
 		c := NewConfig(ConfigOpts{
 			HostAddress:        "localhost:5050",
 			AppID:              "app1",
@@ -2286,6 +2663,9 @@ func TestReentrancyConfig(t *testing.T) {
 	})
 
 	t.Run("Test per type reentrancy", func(t *testing.T) {
+		t.Parallel()
+
+		appConfig := DefaultAppConfig
 		appConfig.EntityConfigs = []config.EntityConfig{
 			{
 				Entities: []string{"reentrantActor"},
@@ -2309,6 +2689,9 @@ func TestReentrancyConfig(t *testing.T) {
 	})
 
 	t.Run("Test minimum reentrancy values", func(t *testing.T) {
+		t.Parallel()
+
+		appConfig := DefaultAppConfig
 		appConfig.Reentrancy = config.ReentrancyConfig{Enabled: true}
 		c := NewConfig(ConfigOpts{
 			HostAddress:        "localhost:5050",
@@ -2324,6 +2707,9 @@ func TestReentrancyConfig(t *testing.T) {
 	})
 
 	t.Run("Test full reentrancy values", func(t *testing.T) {
+		t.Parallel()
+
+		appConfig := DefaultAppConfig
 		reentrancyLimit := 64
 		appConfig.Reentrancy = config.ReentrancyConfig{Enabled: true, MaxStackDepth: &reentrancyLimit}
 		c := NewConfig(ConfigOpts{
@@ -2341,33 +2727,47 @@ func TestReentrancyConfig(t *testing.T) {
 }
 
 func TestHostValidation(t *testing.T) {
+	t.Parallel()
+
 	t.Run("kubernetes mode with mTLS, missing namespace", func(t *testing.T) {
+		t.Parallel()
+
 		err := ValidateHostEnvironment(true, modes.KubernetesMode, "")
 		assert.Error(t, err)
 	})
 
 	t.Run("kubernetes mode without mTLS, missing namespace", func(t *testing.T) {
+		t.Parallel()
+
 		err := ValidateHostEnvironment(false, modes.KubernetesMode, "")
 		assert.NoError(t, err)
 	})
 
 	t.Run("kubernetes mode with mTLS and namespace", func(t *testing.T) {
+		t.Parallel()
+
 		err := ValidateHostEnvironment(true, modes.KubernetesMode, "default")
 		assert.NoError(t, err)
 	})
 
 	t.Run("self hosted mode with mTLS, missing namespace", func(t *testing.T) {
+		t.Parallel()
+
 		err := ValidateHostEnvironment(true, modes.StandaloneMode, "")
 		assert.NoError(t, err)
 	})
 
 	t.Run("self hosted mode without mTLS, missing namespace", func(t *testing.T) {
+		t.Parallel()
+
 		err := ValidateHostEnvironment(false, modes.StandaloneMode, "")
 		assert.NoError(t, err)
 	})
 }
 
 func TestBasicReentrantActorLocking(t *testing.T) {
+	t.Parallel()
+
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrant", "1")
 	defer req.Close()
 	req2 := invokev1.NewInvokeMethodRequest("second").WithActor("reentrant", "1")
@@ -2401,6 +2801,8 @@ func TestBasicReentrantActorLocking(t *testing.T) {
 }
 
 func TestReentrantActorLockingOverMultipleActors(t *testing.T) {
+	t.Parallel()
+
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrant", "1")
 	defer req.Close()
 	req2 := invokev1.NewInvokeMethodRequest("second").WithActor("other", "1")
@@ -2437,6 +2839,8 @@ func TestReentrantActorLockingOverMultipleActors(t *testing.T) {
 }
 
 func TestReentrancyStackLimit(t *testing.T) {
+	t.Parallel()
+
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrant", "1")
 	defer req.Close()
 
@@ -2464,6 +2868,8 @@ func TestReentrancyStackLimit(t *testing.T) {
 }
 
 func TestReentrancyPerActor(t *testing.T) {
+	t.Parallel()
+
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrantActor", "1")
 	defer req.Close()
 	req2 := invokev1.NewInvokeMethodRequest("second").WithActor("reentrantActor", "1")
@@ -2505,6 +2911,8 @@ func TestReentrancyPerActor(t *testing.T) {
 }
 
 func TestReentrancyStackLimitPerActor(t *testing.T) {
+	t.Parallel()
+
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrantActor", "1")
 	defer req.Close()
 
@@ -2541,6 +2949,8 @@ func TestReentrancyStackLimitPerActor(t *testing.T) {
 }
 
 func TestActorsRuntimeResiliency(t *testing.T) {
+	t.Parallel()
+
 	actorType := "failingActor"
 	actorID := "failingId"
 	failingState := &daprt.FailingStatestore{
@@ -2576,7 +2986,7 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 		actorStore:     failingState,
 		actorStoreName: "failStore",
 		// This test is using a real wall clock
-		clock: clocklib.New(),
+		clock: &kclock.RealClock{},
 	}
 	runtime := builder.buildActorRuntime()
 
@@ -2695,6 +3105,8 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 }
 
 func TestPlacementSwitchIsNotTurnedOn(t *testing.T) {
+	t.Parallel()
+
 	testActorsRuntime := newTestActorsRuntimeWithoutPlacement()
 	defer testActorsRuntime.Stop()
 

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -564,8 +564,6 @@ func TestDeactivationTicker(t *testing.T) {
 	t.Parallel()
 
 	t.Run("actor is deactivated", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -590,8 +588,6 @@ func TestDeactivationTicker(t *testing.T) {
 	})
 
 	t.Run("actor is not deactivated", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -615,8 +611,6 @@ func TestDeactivationTicker(t *testing.T) {
 	})
 
 	t.Run("per-actor timeout", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -767,8 +761,6 @@ func TestGetReminderTrack(t *testing.T) {
 	t.Parallel()
 
 	t.Run("reminder doesn't exist", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -778,8 +770,6 @@ func TestGetReminderTrack(t *testing.T) {
 	})
 
 	t.Run("reminder exists", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -955,8 +945,6 @@ func TestOverrideReminder(t *testing.T) {
 
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -973,8 +961,6 @@ func TestOverrideReminder(t *testing.T) {
 	})
 
 	t.Run("override dueTime", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -991,8 +977,6 @@ func TestOverrideReminder(t *testing.T) {
 	})
 
 	t.Run("override period", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -1009,8 +993,6 @@ func TestOverrideReminder(t *testing.T) {
 	})
 
 	t.Run("override TTL", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 
@@ -1038,8 +1020,6 @@ func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
 
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
-		t.Parallel()
-
 		requestC := make(chan testRequest, 10)
 		appChannel := mockAppChannel{
 			requestC: requestC,
@@ -1092,8 +1072,6 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
-		t.Parallel()
-
 		requestC := make(chan testRequest, 10)
 		appChannel := mockAppChannel{
 			requestC: requestC,
@@ -1294,11 +1272,8 @@ func Test_ReminderRepeats(t *testing.T) {
 		},
 	}
 
-	for name, testT := range tests {
-		test := testT
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			requestC := make(chan testRequest, 10)
 			appChannel := mockAppChannel{
 				requestC: requestC,
@@ -1440,11 +1415,8 @@ func Test_ReminderTTL(t *testing.T) {
 		},
 	}
 
-	for name, testT := range tests {
-		test := testT
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			requestC := make(chan testRequest)
 			appChannel := mockAppChannel{
 				requestC: requestC,
@@ -1601,8 +1573,6 @@ func TestCreateTimerDueTimes(t *testing.T) {
 	t.Parallel()
 
 	t.Run("test create timer with positive DueTime", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 		actorType, actorID := getTestActorTypeAndID()
@@ -1614,8 +1584,6 @@ func TestCreateTimerDueTimes(t *testing.T) {
 	})
 
 	t.Run("test create timer with 0 DueTime", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 		actorType, actorID := getTestActorTypeAndID()
@@ -1627,8 +1595,6 @@ func TestCreateTimerDueTimes(t *testing.T) {
 	})
 
 	t.Run("test create timer with no DueTime", func(t *testing.T) {
-		t.Parallel()
-
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
 		actorType, actorID := getTestActorTypeAndID()
@@ -1856,11 +1822,8 @@ func Test_TimerRepeats(t *testing.T) {
 		},
 	}
 
-	for name, testT := range tests {
-		test := testT
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			requestC := make(chan testRequest, 10)
 			appChannel := mockAppChannel{
 				requestC: requestC,
@@ -1954,11 +1917,8 @@ func Test_TimerTTL(t *testing.T) {
 		},
 	}
 
-	for name, testT := range tests {
-		test := testT
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			requestC := make(chan testRequest, 10)
 			appChannel := mockAppChannel{
 				requestC: requestC,

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -1440,7 +1440,8 @@ func Test_ReminderTTL(t *testing.T) {
 		},
 	}
 
-	for name, test := range tests {
+	for name, testT := range tests {
+		test := testT
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2001,7 +2002,7 @@ func Test_TimerTTL(t *testing.T) {
 						assert.Equal(t, timer.Data, request.Data)
 						count++
 					case <-ticker.C():
-						//nop
+						// nop
 					}
 				}
 			}()

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -561,8 +561,6 @@ func advanceTickers(t *testing.T, clock *clocktesting.FakeClock, step time.Durat
 }
 
 func TestDeactivationTicker(t *testing.T) {
-	t.Parallel()
-
 	t.Run("actor is deactivated", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
@@ -639,8 +637,6 @@ func TestDeactivationTicker(t *testing.T) {
 }
 
 func TestStoreIsNotInitialized(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 	testActorsRuntime.store = nil
@@ -680,8 +676,6 @@ func TestStoreIsNotInitialized(t *testing.T) {
 }
 
 func TestTimerExecution(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -693,8 +687,6 @@ func TestTimerExecution(t *testing.T) {
 }
 
 func TestTimerExecutionZeroDuration(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -706,8 +698,6 @@ func TestTimerExecutionZeroDuration(t *testing.T) {
 }
 
 func TestReminderExecution(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -726,8 +716,6 @@ func TestReminderExecution(t *testing.T) {
 }
 
 func TestReminderExecutionZeroDuration(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -746,8 +734,6 @@ func TestReminderExecutionZeroDuration(t *testing.T) {
 }
 
 func TestSetReminderTrack(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -758,8 +744,6 @@ func TestSetReminderTrack(t *testing.T) {
 }
 
 func TestGetReminderTrack(t *testing.T) {
-	t.Parallel()
-
 	t.Run("reminder doesn't exist", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
@@ -785,8 +769,6 @@ func TestGetReminderTrack(t *testing.T) {
 }
 
 func TestCreateReminder(t *testing.T) {
-	t.Parallel()
-
 	numReminders := 100
 	appChannel := new(mockAppChannel)
 	testActorsRuntime := newTestActorsRuntimeWithMock(appChannel)
@@ -888,8 +870,6 @@ func TestCreateReminder(t *testing.T) {
 }
 
 func TestRenameReminder(t *testing.T) {
-	t.Parallel()
-
 	appChannel := new(mockAppChannel)
 	testActorsRuntime := newTestActorsRuntimeWithMock(appChannel)
 	defer testActorsRuntime.Stop()
@@ -941,8 +921,6 @@ func TestRenameReminder(t *testing.T) {
 }
 
 func TestOverrideReminder(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
@@ -1016,8 +994,6 @@ func TestOverrideReminder(t *testing.T) {
 }
 
 func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		requestC := make(chan testRequest, 10)
@@ -1068,8 +1044,6 @@ func TestOverrideReminderCancelsActiveReminders(t *testing.T) {
 }
 
 func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		requestC := make(chan testRequest, 10)
@@ -1129,8 +1103,6 @@ func TestOverrideReminderCancelsMultipleActiveReminders(t *testing.T) {
 }
 
 func TestDeleteReminder(t *testing.T) {
-	t.Parallel()
-
 	appChannel := new(mockAppChannel)
 	testActorsRuntime := newTestActorsRuntimeWithMockAndActorMetadataPartition(appChannel)
 	defer testActorsRuntime.Stop()
@@ -1150,8 +1122,6 @@ func TestDeleteReminder(t *testing.T) {
 }
 
 func TestDeleteReminderWithPartitions(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1170,8 +1140,6 @@ func TestDeleteReminderWithPartitions(t *testing.T) {
 }
 
 func Test_ReminderRepeats(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		dueTimeAny      any
 		period          string
@@ -1375,8 +1343,6 @@ func Test_ReminderRepeats(t *testing.T) {
 }
 
 func Test_ReminderTTL(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		dueTime    string
 		period     string
@@ -1490,8 +1456,6 @@ func Test_ReminderTTL(t *testing.T) {
 }
 
 func reminderValidation(ctx context.Context, t *testing.T, dueTime, period, ttl, msg string) {
-	t.Parallel()
-
 	requestC := make(chan testRequest, 10)
 	appChannel := mockAppChannel{
 		requestC: requestC,
@@ -1512,8 +1476,6 @@ func reminderValidation(ctx context.Context, t *testing.T, dueTime, period, ttl,
 }
 
 func TestReminderValidation(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("reminder dueTime invalid (1)", func(t *testing.T) {
 		reminderValidation(ctx, t, "invalid", "R5/PT2S", "1h", "error parsing reminder due time: unsupported time/duration format \"invalid\"")
@@ -1548,8 +1510,6 @@ func TestReminderValidation(t *testing.T) {
 }
 
 func TestGetReminder(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1570,8 +1530,6 @@ func TestGetReminder(t *testing.T) {
 }
 
 func TestCreateTimerDueTimes(t *testing.T) {
-	t.Parallel()
-
 	t.Run("test create timer with positive DueTime", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
 		defer testActorsRuntime.Stop()
@@ -1607,8 +1565,6 @@ func TestCreateTimerDueTimes(t *testing.T) {
 }
 
 func TestDeleteTimer(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -1638,8 +1594,6 @@ func TestDeleteTimer(t *testing.T) {
 }
 
 func TestOverrideTimerCancelsActiveTimers(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		requestC := make(chan testRequest, 10)
@@ -1680,8 +1634,6 @@ func TestOverrideTimerCancelsActiveTimers(t *testing.T) {
 }
 
 func TestOverrideTimerCancelsMultipleActiveTimers(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("override data", func(t *testing.T) {
 		requestC := make(chan testRequest, 10)
@@ -1727,8 +1679,6 @@ func TestOverrideTimerCancelsMultipleActiveTimers(t *testing.T) {
 }
 
 func Test_TimerRepeats(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		dueTime         string
 		period          string
@@ -1904,8 +1854,6 @@ func Test_TimerRepeats(t *testing.T) {
 }
 
 func Test_TimerTTL(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]struct {
 		iso bool
 	}{
@@ -1981,8 +1929,6 @@ func Test_TimerTTL(t *testing.T) {
 }
 
 func timerValidation(ctx context.Context, t *testing.T, dueTime, period, ttl, msg string) {
-	t.Parallel()
-
 	requestC := make(chan testRequest, 10)
 	appChannel := mockAppChannel{
 		requestC: requestC,
@@ -1999,8 +1945,6 @@ func timerValidation(ctx context.Context, t *testing.T, dueTime, period, ttl, ms
 }
 
 func TestTimerValidation(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("timer dueTime invalid (1)", func(t *testing.T) {
 		timerValidation(ctx, t, "invalid", "R5/PT2S", "1h", "error parsing timer due time: unsupported time/duration format \"invalid\"")
@@ -2035,8 +1979,6 @@ func TestTimerValidation(t *testing.T) {
 }
 
 func TestReminderFires(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -2059,8 +2001,6 @@ func TestReminderFires(t *testing.T) {
 }
 
 func TestReminderDueDate(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -2087,8 +2027,6 @@ func TestReminderDueDate(t *testing.T) {
 }
 
 func TestReminderPeriod(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -2131,8 +2069,6 @@ func TestReminderPeriod(t *testing.T) {
 }
 
 func TestReminderFiresOnceWithEmptyPeriod(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -2151,8 +2087,6 @@ func TestReminderFiresOnceWithEmptyPeriod(t *testing.T) {
 }
 
 func TestConstructActorStateKey(t *testing.T) {
-	t.Parallel()
-
 	delim := "||"
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
@@ -2176,8 +2110,6 @@ func TestConstructActorStateKey(t *testing.T) {
 }
 
 func TestGetState(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -2217,8 +2149,6 @@ func TestGetState(t *testing.T) {
 }
 
 func TestDeleteState(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 
@@ -2284,8 +2214,6 @@ func TestDeleteState(t *testing.T) {
 }
 
 func TestCallLocalActor(t *testing.T) {
-	t.Parallel()
-
 	const (
 		testActorType = "pet"
 		testActorID   = "dog"
@@ -2336,8 +2264,6 @@ func TestCallLocalActor(t *testing.T) {
 }
 
 func TestTransactionalState(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("Single set request succeeds", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
@@ -2435,8 +2361,6 @@ func TestTransactionalState(t *testing.T) {
 }
 
 func TestGetOrCreateActor(t *testing.T) {
-	t.Parallel()
-
 	const testActorType = "fakeActor"
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
@@ -2455,8 +2379,6 @@ func TestGetOrCreateActor(t *testing.T) {
 }
 
 func TestActiveActorsCount(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	t.Run("Actors Count", func(t *testing.T) {
 		expectedCounts := []ActiveActorsCount{{Type: "cat", Count: 2}, {Type: "dog", Count: 1}}
@@ -2484,8 +2406,6 @@ func TestActiveActorsCount(t *testing.T) {
 }
 
 func TestActorsAppHealthCheck(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 	defer testActorsRuntime.Stop()
 	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -2505,8 +2425,6 @@ func TestActorsAppHealthCheck(t *testing.T) {
 }
 
 func TestHostedActorsWithoutStateStore(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntimeWithoutStore()
 	defer testActorsRuntime.Stop()
 	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -2526,8 +2444,6 @@ func TestHostedActorsWithoutStateStore(t *testing.T) {
 }
 
 func TestNoHostedActorsWithoutStateStore(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntimeWithoutStore()
 	defer testActorsRuntime.Stop()
 	clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
@@ -2548,8 +2464,6 @@ func TestNoHostedActorsWithoutStateStore(t *testing.T) {
 }
 
 func TestShutdown(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntime()
 
 	t.Run("no panic when placement is nil", func(t *testing.T) {
@@ -2560,8 +2474,6 @@ func TestShutdown(t *testing.T) {
 }
 
 func TestConstructCompositeKeyWithThreeArgs(t *testing.T) {
-	t.Parallel()
-
 	appID := "myapp"
 	actorType := "TestActor"
 	actorID := "abc123"
@@ -2572,8 +2484,6 @@ func TestConstructCompositeKeyWithThreeArgs(t *testing.T) {
 }
 
 func TestConfig(t *testing.T) {
-	t.Parallel()
-
 	appConfig := config.ApplicationConfig{
 		Entities:                   []string{"1"},
 		ActorScanInterval:          "1s",
@@ -2604,11 +2514,7 @@ func TestConfig(t *testing.T) {
 }
 
 func TestReentrancyConfig(t *testing.T) {
-	t.Parallel()
-
 	t.Run("Test empty reentrancy values", func(t *testing.T) {
-		t.Parallel()
-
 		appConfig := DefaultAppConfig
 		c := NewConfig(ConfigOpts{
 			HostAddress:        "localhost:5050",
@@ -2624,8 +2530,6 @@ func TestReentrancyConfig(t *testing.T) {
 	})
 
 	t.Run("Test per type reentrancy", func(t *testing.T) {
-		t.Parallel()
-
 		appConfig := DefaultAppConfig
 		appConfig.EntityConfigs = []config.EntityConfig{
 			{
@@ -2650,8 +2554,6 @@ func TestReentrancyConfig(t *testing.T) {
 	})
 
 	t.Run("Test minimum reentrancy values", func(t *testing.T) {
-		t.Parallel()
-
 		appConfig := DefaultAppConfig
 		appConfig.Reentrancy = config.ReentrancyConfig{Enabled: true}
 		c := NewConfig(ConfigOpts{
@@ -2668,8 +2570,6 @@ func TestReentrancyConfig(t *testing.T) {
 	})
 
 	t.Run("Test full reentrancy values", func(t *testing.T) {
-		t.Parallel()
-
 		appConfig := DefaultAppConfig
 		reentrancyLimit := 64
 		appConfig.Reentrancy = config.ReentrancyConfig{Enabled: true, MaxStackDepth: &reentrancyLimit}
@@ -2688,47 +2588,33 @@ func TestReentrancyConfig(t *testing.T) {
 }
 
 func TestHostValidation(t *testing.T) {
-	t.Parallel()
-
 	t.Run("kubernetes mode with mTLS, missing namespace", func(t *testing.T) {
-		t.Parallel()
-
 		err := ValidateHostEnvironment(true, modes.KubernetesMode, "")
 		assert.Error(t, err)
 	})
 
 	t.Run("kubernetes mode without mTLS, missing namespace", func(t *testing.T) {
-		t.Parallel()
-
 		err := ValidateHostEnvironment(false, modes.KubernetesMode, "")
 		assert.NoError(t, err)
 	})
 
 	t.Run("kubernetes mode with mTLS and namespace", func(t *testing.T) {
-		t.Parallel()
-
 		err := ValidateHostEnvironment(true, modes.KubernetesMode, "default")
 		assert.NoError(t, err)
 	})
 
 	t.Run("self hosted mode with mTLS, missing namespace", func(t *testing.T) {
-		t.Parallel()
-
 		err := ValidateHostEnvironment(true, modes.StandaloneMode, "")
 		assert.NoError(t, err)
 	})
 
 	t.Run("self hosted mode without mTLS, missing namespace", func(t *testing.T) {
-		t.Parallel()
-
 		err := ValidateHostEnvironment(false, modes.StandaloneMode, "")
 		assert.NoError(t, err)
 	})
 }
 
 func TestBasicReentrantActorLocking(t *testing.T) {
-	t.Parallel()
-
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrant", "1")
 	defer req.Close()
 	req2 := invokev1.NewInvokeMethodRequest("second").WithActor("reentrant", "1")
@@ -2762,8 +2648,6 @@ func TestBasicReentrantActorLocking(t *testing.T) {
 }
 
 func TestReentrantActorLockingOverMultipleActors(t *testing.T) {
-	t.Parallel()
-
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrant", "1")
 	defer req.Close()
 	req2 := invokev1.NewInvokeMethodRequest("second").WithActor("other", "1")
@@ -2800,8 +2684,6 @@ func TestReentrantActorLockingOverMultipleActors(t *testing.T) {
 }
 
 func TestReentrancyStackLimit(t *testing.T) {
-	t.Parallel()
-
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrant", "1")
 	defer req.Close()
 
@@ -2829,8 +2711,6 @@ func TestReentrancyStackLimit(t *testing.T) {
 }
 
 func TestReentrancyPerActor(t *testing.T) {
-	t.Parallel()
-
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrantActor", "1")
 	defer req.Close()
 	req2 := invokev1.NewInvokeMethodRequest("second").WithActor("reentrantActor", "1")
@@ -2872,8 +2752,6 @@ func TestReentrancyPerActor(t *testing.T) {
 }
 
 func TestReentrancyStackLimitPerActor(t *testing.T) {
-	t.Parallel()
-
 	req := invokev1.NewInvokeMethodRequest("first").WithActor("reentrantActor", "1")
 	defer req.Close()
 
@@ -2910,8 +2788,6 @@ func TestReentrancyStackLimitPerActor(t *testing.T) {
 }
 
 func TestActorsRuntimeResiliency(t *testing.T) {
-	t.Parallel()
-
 	actorType := "failingActor"
 	actorID := "failingId"
 	failingState := &daprt.FailingStatestore{
@@ -3066,8 +2942,6 @@ func TestActorsRuntimeResiliency(t *testing.T) {
 }
 
 func TestPlacementSwitchIsNotTurnedOn(t *testing.T) {
-	t.Parallel()
-
 	testActorsRuntime := newTestActorsRuntimeWithoutPlacement()
 	defer testActorsRuntime.Stop()
 

--- a/pkg/grpc/pool.go
+++ b/pkg/grpc/pool.go
@@ -18,14 +18,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	clocklib "github.com/benbjohnson/clock"
 	"google.golang.org/grpc"
+	kclock "k8s.io/utils/clock"
 
 	"github.com/dapr/kit/ptr"
 )
 
 // Real-time clock (wrapper around time.Time) to allow mocking
-var clock = clocklib.New()
+var clock kclock.Clock = &kclock.RealClock{}
 
 // Maximum number of concurrent streams in a single gRPC connection
 // This is the default value used by gRPC servers and clients

--- a/pkg/testing/failure_mock.go
+++ b/pkg/testing/failure_mock.go
@@ -18,11 +18,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"k8s.io/utils/clock"
 )
 
 func NewFailure(fails map[string]int, timeouts map[string]time.Duration, callCount map[string]int) Failure {
-	return newFailureWithClock(fails, timeouts, callCount, clock.New())
+	return newFailureWithClock(fails, timeouts, callCount, &clock.RealClock{})
 }
 
 func newFailureWithClock(fails map[string]int, timeouts map[string]time.Duration, callCount map[string]int, clock clock.Clock) Failure {


### PR DESCRIPTION
This PR does 2 things: replacing the use of `github.com/benbjohnson/clock` with `k8s.io/utils/clock`, and de-flaking the `pkgs/actors` unit tests.

When working on the actors unit tests, I found the k8s clock implementation to be more reliable. We can also assume that the k8s implementation to be maintained and exist on GH longer into the future given it's under the k8s project and used extensively there.

---

The actor tests now rely significantly less on wall time, and instead use the fake clock as much as possible. This means "eventually" style checks and assertions are more deterministic and reliable. We also get a big speed up, with the new tests taking about 10% of the time (when the tests actually pass!)

```
go test --race -v --count 1 ./pkg/actors  5.06s user 0.76s system 24% cpu 23.470 total
```

```
go test --race -v --count 1 ./pkg/actors  3.65s user 0.73s system 217% cpu 2.018 total
```

~Tests are now labelled for parallelism.~

Have removed the test `Parallel()`s since the Windows runners were having trouble with them.

/cc @ItalyPaleAle 