### PR TITLE
Fixed typo in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
         // "BIND_LOCALHOST_DOCKER": "true",
 
         // Necessary for components-contrib's certification tests
-        "GOLANG_PROTOBUF_REGISTRATION_CONFLICT": "true"
+        "GOLANG_PROTOBUF_REGISTRATION_CONFLICT": "ignore"
     },
     "extensions": [
         "davidanson.vscode-markdownlint",


### PR DESCRIPTION
Fixed a small typo in the env vars set in devcontainer.json