### PR TITLE
Enforce minimum TLS ver 1.2 for the internal gRPC server

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -282,6 +282,12 @@ func (s *server) getGRPCServer() (*grpcGo.Server, error) {
 				return &s.tlsCert, nil
 			},
 		}
+
+		// In the internal server, enforce minimum version TLS 1.2
+		if s.kind == internalServer {
+			tlsConfig.MinVersion = tls.VersionTLS12
+		}
+
 		ta := credentials.NewTLS(&tlsConfig)
 
 		opts = append(opts, grpcGo.Creds(ta))


### PR DESCRIPTION
# Description

As discussed in the call this morning w.r.t #6031, this PR changes the **internal** gRPC server to require TLS >= 1.2.

This is mostly done for compliance reasons, as nothing changes in practice. The Go client was already using TLS >= 1.2, so nothing should change in practice.

## Issue reference

Related to #6031 