### PR TITLE
Setting MinTLS for CA server

### DIFF
--- a/pkg/sentry/server/server.go
+++ b/pkg/sentry/server/server.go
@@ -70,7 +70,6 @@ func (s *server) Run(port int, trustBundler ca.TrustRootBundler) error {
 func (s *server) tlsServerOption(trustBundler ca.TrustRootBundler) grpc.ServerOption {
 	cp := trustBundler.GetTrustAnchors()
 
-	//nolint:gosec
 	config := &tls.Config{
 		ClientCAs: cp,
 		// Require cert verification

--- a/pkg/sentry/server/server.go
+++ b/pkg/sentry/server/server.go
@@ -87,6 +87,7 @@ func (s *server) tlsServerOption(trustBundler ca.TrustRootBundler) grpc.ServerOp
 			}
 			return s.certificate, nil
 		},
+		MinVersion: tls.VersionTLS12,
 	}
 	return grpc.Creds(credentials.NewTLS(config))
 }


### PR DESCRIPTION
# Description

This change sets MinTLS version as tls1.2 for Sentry CA Server.

## Issue reference

Please reference the issue this PR is linked to: #6031 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
