### PR TITLE
Fixed workflow APIs not working in master branch

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -90,7 +90,6 @@ type api struct {
 	appChannel                 channel.AppChannel
 	resiliency                 resiliency.Provider
 	stateStores                map[string]state.Store
-	workflowComponents         map[string]workflows.Workflow
 	transactionalStateStores   map[string]state.TransactionalStore
 	configurationStores        map[string]configuration.Store
 	configurationSubscribe     map[string]chan struct{} // store map[storeName||key1,key2] -> stopChan
@@ -277,6 +276,7 @@ func NewAPI(opts APIOpts) API {
 			Resiliency:           opts.Resiliency,
 			SecretStores:         opts.SecretStores,
 			SecretsConfiguration: opts.SecretsConfiguration,
+			WorkflowComponents:   opts.WorkflowComponents,
 		},
 		directMessaging:            opts.DirectMessaging,
 		actor:                      opts.Actor,
@@ -286,7 +286,6 @@ func NewAPI(opts APIOpts) API {
 		pubsubAdapter:              opts.PubsubAdapter,
 		stateStores:                opts.StateStores,
 		transactionalStateStores:   transactionalStateStores,
-		workflowComponents:         opts.WorkflowComponents,
 		configurationStores:        opts.ConfigurationStores,
 		configurationSubscribe:     make(map[string]chan struct{}),
 		lockStores:                 opts.LockStores,

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -85,7 +85,6 @@ type api struct {
 	getSubscriptionsFn         func() []runtimePubsub.Subscription
 	resiliency                 resiliency.Provider
 	stateStores                map[string]state.Store
-	workflowComponents         map[string]wfs.Workflow
 	lockStores                 map[string]lock.Store
 	configurationStores        map[string]configuration.Store
 	configurationSubscribe     map[string]chan struct{}
@@ -203,7 +202,6 @@ func NewAPI(opts APIOpts) API {
 		getSubscriptionsFn:         opts.GetSubscriptionsFn,
 		resiliency:                 opts.Resiliency,
 		stateStores:                opts.StateStores,
-		workflowComponents:         opts.WorkflowsComponents,
 		lockStores:                 opts.LockStores,
 		secretStores:               opts.SecretStores,
 		secretsConfiguration:       opts.SecretsConfiguration,
@@ -224,6 +222,7 @@ func NewAPI(opts APIOpts) API {
 			Resiliency:           opts.Resiliency,
 			SecretStores:         opts.SecretStores,
 			SecretsConfiguration: opts.SecretsConfiguration,
+			WorkflowComponents:   opts.WorkflowsComponents,
 		},
 	}
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -3005,14 +3005,14 @@ func TestV1Alpha1Workflow(t *testing.T) {
 	workflowComponents := map[string]workflowContrib.Workflow{
 		componentName: fakeWorkflowComponent,
 	}
+	resiliencyConfig := resiliency.FromConfigurations(logger.NewLogger("workflow.test"), testResiliency)
 	testAPI := &api{
-		resiliency:         resiliency.FromConfigurations(logger.NewLogger("workflow.test"), testResiliency),
-		workflowComponents: workflowComponents,
-	}
-	testAPI.universal = &universalapi.UniversalAPI{
-		Logger:             logger.NewLogger("fakeLogger"),
-		WorkflowComponents: workflowComponents,
-		Resiliency:         testAPI.resiliency,
+		resiliency: resiliencyConfig,
+		universal: &universalapi.UniversalAPI{
+			Logger:             logger.NewLogger("fakeLogger"),
+			WorkflowComponents: workflowComponents,
+			Resiliency:         resiliencyConfig,
+		},
 	}
 
 	fakeServer.StartServer(testAPI.constructWorkflowEndpoints())


### PR DESCRIPTION
Fixes a regression introduced in a recent PR that converted the workflows APIs to universal. The map of workflow components was not set, so HTTP and gRPC APIs would not work.