### PR TITLE
fix debug dockerfile

### DIFF
--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -4,5 +4,6 @@ FROM golang:1.20
 
 ARG PKG_FILES
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN mv /go/bin/dlv /
 WORKDIR /
 COPY /$PKG_FILES /


### PR DESCRIPTION
# Description

go install installs dlv to `/go/bin/dlv`, but using `/dlv` in the starting command.[for example daprd debug command](https://github.com/dapr/dapr/blob/master/pkg/injector/sidecar/container.go#L180)

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
