### PR TITLE
Reflactor actor internal placment client. Use clock to keep time.

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -86,7 +86,7 @@ type Actors interface {
 // PlacementService allows for interacting with the actor placement service.
 type PlacementService interface {
 	Start(context.Context) error
-	Close()
+	Close() error
 	WaitUntilPlacementTableIsReady(ctx context.Context) error
 	LookupActor(actorType, actorID string) (host string, appID string)
 	AddHostedActorType(actorType string) error

--- a/pkg/actors/internal/client.go
+++ b/pkg/actors/internal/client.go
@@ -15,168 +15,108 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 
 	"google.golang.org/grpc"
 )
 
+type client interface {
+	Send(*v1pb.Host) error
+	Recv() (*v1pb.PlacementOrder, error)
+	Close()
+}
+
+type grpcOptionsFn func() ([]grpc.DialOption, error)
+
 // placementClient implements the best practices when handling grpc streams
 // using exclusion locks to prevent concurrent Recv and Send from channels.
-// properly handle stream closing by draining the renamining events until receives an error.
-// and broadcasts connection results based on new connections and disconnects.
+// properly handle stream closing by draining the renamining events until
+// receives an error.
 type placementClient struct {
-	// getGrpcOpts are the options that should be used to connect to the placement service
-	getGrpcOpts func() ([]grpc.DialOption, error)
-
 	// recvLock prevents concurrent access to the Recv() method.
-	recvLock *sync.Mutex
+	recvLock sync.Mutex
+
 	// sendLock prevents CloseSend and Send being used concurrently.
-	sendLock *sync.Mutex
+	// Sends use the read lock. CloseSend uses the write lock.
+	sendLock sync.RWMutex
 
-	// clientStream is the client side stream.
-	clientStream v1pb.Placement_ReportDaprStatusClient
-	// clientConn is the gRPC client connection.
-	clientConn *grpc.ClientConn
-	// streamConnAlive is the status of stream connection alive.
-	streamConnAlive bool
-	// streamConnectedCond is the condition variable for goroutines waiting for or announcing
-	// that the stream between runtime and placement is connected.
-	streamConnectedCond *sync.Cond
+	// stream is the client side stream.
+	stream v1pb.Placement_ReportDaprStatusClient
 
-	// ctx is the stream context
-	ctx context.Context
-	// cancel is the cancel func for context
-	cancel context.CancelFunc
+	// conn is the gRPC client connection.
+	conn *grpc.ClientConn
+
+	closed atomic.Bool
 }
 
-// connectToServer initializes a new connection to the target server and if it succeeds replace the current
-// stream with the connected stream.
-func (c *placementClient) connectToServer(serverAddr string) error {
-	opts, err := c.getGrpcOpts()
+func newPlacementClient(ctx context.Context, addr string, getGrpcOpts grpcOptionsFn) (client, error) {
+	opts, err := getGrpcOpts()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	conn, err := grpc.Dial(serverAddr, opts...)
+	conn, err := grpc.DialContext(ctx, addr, opts...)
 	if err != nil {
 		if conn != nil {
 			conn.Close()
 		}
-		return err
+		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	client := v1pb.NewPlacementClient(conn)
-	stream, err := client.ReportDaprStatus(ctx)
+	stream, err := v1pb.NewPlacementClient(conn).ReportDaprStatus(ctx)
 	if err != nil {
-		if conn != nil {
-			conn.Close()
-		}
-		cancel()
-		return err
+		return nil, err
 	}
 
-	c.streamConnectedCond.L.Lock()
-	c.ctx = ctx
-	c.cancel = cancel
-	c.clientStream = stream
-	c.clientConn = conn
-	c.streamConnAlive = true
-	c.streamConnectedCond.Broadcast()
-	c.streamConnectedCond.L.Unlock()
-	return nil
+	return &placementClient{
+		conn:   conn,
+		stream: stream,
+	}, nil
 }
 
-// drain the grpc stream as described in the documentation
-// https://github.com/grpc/grpc-go/blob/be1fb4f27549f736b9b4ec26104c7c6b29845ad0/stream.go#L109
-func (c *placementClient) drain(stream grpc.ClientStream, conn *grpc.ClientConn, cancelFunc context.CancelFunc) {
-	c.sendLock.Lock()
-	stream.CloseSend() // CloseSend cannot be invoked concurrently with Send()
-	c.sendLock.Unlock()
-	conn.Close()
-	cancelFunc()
-
+// Recv is a convenient way to call recv providing thread-safe guarantees with
+// disconnections and draining operations.
+func (c *placementClient) Recv() (*v1pb.PlacementOrder, error) {
 	c.recvLock.Lock()
 	defer c.recvLock.Unlock()
+	if c.closed.Load() {
+		return nil, errors.New("placement client is closed")
+	}
+	// cannot recv in parallel
+	return c.stream.Recv()
+}
+
+// Send is a convenient way of invoking send providing thread-safe guarantees
+// with `CloseSend` operations.
+func (c *placementClient) Send(host *v1pb.Host) error {
+	if c.closed.Load() {
+		return errors.New("placement client is closed")
+	}
+	c.sendLock.RLock()
+	defer c.sendLock.RUnlock()
+	return c.stream.Send(host)
+}
+
+func (c *placementClient) Close() {
+	c.closed.Store(true)
+
+	// drain the grpc stream as described in the documentation
+	// https://github.com/grpc/grpc-go/blob/be1fb4f27549f736b9b4ec26104c7c6b29845ad0/stream.go#L109
+	c.sendLock.Lock()
+	c.recvLock.Lock()
+	defer c.sendLock.Unlock()
+	defer c.recvLock.Unlock()
+
+	c.stream.CloseSend() // CloseSend cannot be invoked concurrently with Send()
+	c.conn.Close()
+
 	for {
-		if err := stream.RecvMsg(struct{}{}); err != nil { // recv cannot be invoked concurrently with other Recv.
+		if err := c.stream.RecvMsg(struct{}{}); err != nil { // recv cannot be invoked concurrently with other Recv.
 			break
 		}
-	}
-}
-
-var noop = func() {}
-
-// disconnect from the current server without any additional operation.
-func (c *placementClient) disconnect() {
-	c.disconnectFn(noop)
-}
-
-// disonnectFn disconnects from the current server providing a way to run a function inside the lock in case of new disconnection occurs.
-// the function will not be executed in case of the stream is already disconnected.
-func (c *placementClient) disconnectFn(insideLockFn func()) {
-	c.streamConnectedCond.L.Lock()
-	if !c.streamConnAlive {
-		c.streamConnectedCond.Broadcast()
-		c.streamConnectedCond.L.Unlock()
-		return
-	}
-
-	c.drain(c.clientStream, c.clientConn, c.cancel)
-
-	c.streamConnAlive = false
-	c.streamConnectedCond.Broadcast()
-
-	insideLockFn()
-
-	c.streamConnectedCond.L.Unlock()
-}
-
-// isConnected returns if the current instance is connected to any placement server.
-func (c *placementClient) isConnected() bool {
-	c.streamConnectedCond.L.Lock()
-	defer c.streamConnectedCond.L.Unlock()
-	return c.streamConnAlive
-}
-
-// waitUntil receives a predicate that given a current stream status returns a boolean that indicates if the stream reached the desired state.
-func (c *placementClient) waitUntil(predicate func(streamConnAlive bool) bool) {
-	c.streamConnectedCond.L.Lock()
-	for !predicate(c.streamConnAlive) {
-		c.streamConnectedCond.Wait()
-	}
-	c.streamConnectedCond.L.Unlock()
-}
-
-// recv is a convenient way to call recv providing thread-safe guarantees with disconnections and draining operations.
-func (c *placementClient) recv() (*v1pb.PlacementOrder, error) {
-	c.streamConnectedCond.L.Lock()
-	stream := c.clientStream
-	c.streamConnectedCond.L.Unlock()
-	c.recvLock.Lock()
-	defer c.recvLock.Unlock()
-	return stream.Recv() // cannot recv in parallel
-}
-
-// sned is a convenient way of invoking send providing thread-safe guarantees with `CloseSend` operations.
-func (c *placementClient) send(host *v1pb.Host) error {
-	c.streamConnectedCond.L.Lock()
-	stream := c.clientStream
-	c.streamConnectedCond.L.Unlock()
-	c.sendLock.Lock()
-	defer c.sendLock.Unlock()
-	return stream.Send(host) // cannot close send and send in parallel
-}
-
-// newPlacementClient creates a new placement client for the given dial opts.
-func newPlacementClient(optionGetter func() ([]grpc.DialOption, error)) *placementClient {
-	return &placementClient{
-		getGrpcOpts:         optionGetter,
-		streamConnAlive:     false,
-		streamConnectedCond: sync.NewCond(&sync.Mutex{}),
-		recvLock:            &sync.Mutex{},
-		sendLock:            &sync.Mutex{},
 	}
 }

--- a/pkg/actors/internal/client.go
+++ b/pkg/actors/internal/client.go
@@ -21,9 +21,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
-
 	"google.golang.org/grpc"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 )
 
 type client interface {

--- a/pkg/actors/internal/grpc_opts.go
+++ b/pkg/actors/internal/grpc_opts.go
@@ -18,11 +18,11 @@ import (
 	"strings"
 	"sync"
 
+	"google.golang.org/grpc"
+
 	daprCredentials "github.com/dapr/dapr/pkg/credentials"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/runtime/security"
-
-	"google.golang.org/grpc"
 )
 
 var errEstablishingTLSConn = errors.New("failed to establish TLS credentials for actor placement service")
@@ -56,6 +56,8 @@ func getGrpcOptsGetter(servers []string, clientCert *daprCredentials.CertChain) 
 				opts,
 				grpc.WithUnaryInterceptor(diag.DefaultGRPCMonitoring.UnaryClientInterceptor()))
 		}
+
+		opts = append(opts, grpc.WithBlock())
 
 		if len(servers) == 1 && strings.HasPrefix(servers[0], "dns:///") {
 			// In Kubernetes environment, dapr-placement headless service resolves multiple IP addresses.

--- a/pkg/actors/internal/placement.go
+++ b/pkg/actors/internal/placement.go
@@ -281,12 +281,13 @@ func (p *ActorPlacement) manageConnectionLoop(ctx context.Context, firstAttempt 
 }
 
 // Close shuts down server stream gracefully.
-func (p *ActorPlacement) Close() {
+func (p *ActorPlacement) Close() error {
 	// CAS to avoid stop more than once.
 	if p.shutdown.CompareAndSwap(false, true) {
 		close(p.closedCh)
 	}
 	p.wg.Wait()
+	return nil
 }
 
 // WaitUntilPlacementTableIsReady waits until placement table is until table lock is unlocked.

--- a/pkg/actors/internal/placement_test.go
+++ b/pkg/actors/internal/placement_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,6 +79,7 @@ func TestPlacementStream_RoundRobin(t *testing.T) {
 	})
 	clock := clocktesting.NewFakeClock(time.Now())
 	testPlacement.clock = clock
+	testPlacement.backoff.(*backoff.ExponentialBackOff).Clock = clock
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -249,7 +249,7 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 				return nil
 			}
 
-			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+			if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled || errors.Is(err, context.Canceled) {
 				log.Debugf("Stream connection is disconnected gracefully: %s", registeredMemberID)
 				if isActorRuntime {
 					p.membershipCh <- hostMemberChange{

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -214,13 +214,15 @@ func (*mockPlacement) LookupActor(actorType string, actorID string) (name string
 }
 
 // Start implements internal.PlacementService
-func (*mockPlacement) Start() {
+func (*mockPlacement) Start(context.Context) error {
 	// no-op
+	return nil
 }
 
-// Stop implements internal.PlacementService
-func (*mockPlacement) Stop() {
+// Close implements internal.PlacementService
+func (*mockPlacement) Close() error {
 	// no-op
+	return nil
 }
 
 // WaitUntilPlacementTableIsReady implements internal.PlacementService


### PR DESCRIPTION
Part of https://github.com/dapr/dapr/issues/2478

Refactors the actor placement client to hopefully be a bit more simple, and ensures all go routines have returned on `Close()`.

Uses clock for time keeping so tests run quicker and are more reliable.

I found the tests to be slightly flaky before- this should fix that.