### PR TITLE
Fix placement shutdown server order

### DIFF
--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -86,7 +86,7 @@ func (s *server) Run(ctx context.Context, port int) error {
 	s.log.Info("Healthz server is shutting down")
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	return errors.Join(<-serveErr, srv.Shutdown(shutdownCtx))
+	return errors.Join(srv.Shutdown(shutdownCtx), <-serveErr)
 }
 
 // healthz is a health endpoint handler.


### PR DESCRIPTION
The placement server currently hangs after receiving a shutdown signal.

Function parameters evaluate in order. This means that `src.Shutdown` will only execute after `<-serveErr` has returned. This is not what we are trying to do here.

PR changes the order so the server is correctly shutdown when the context is cancelled before we wait for `<-serveErr` to return.