### PR TITLE
Reduce size of Azure Service Bus in Azure tests

### DIFF
--- a/tests/test-infra/azure-servicebus.bicep
+++ b/tests/test-infra/azure-servicebus.bicep
@@ -154,7 +154,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-11-01' = {
   sku: {
     name: 'Premium'
     tier: 'Premium'
-    capacity: 4
+    capacity: 1
   }
   properties: {
     disableLocalAuth: false


### PR DESCRIPTION
Our Azure tests are running with a very high capacity for Azure Service Bus, which we just verified is consuming a very large amount of Azure credits. In fact, that alone is taking up almost 75% of our monthly Azure credit utilization.

In the past we needed a very large capacity due to how the ASB components were implemented (pre-1.8). Since then, our components are much more efficient and we should be able to use ASB with 1 scale unit rather than 4 (I suspect we don't even need the premium tier, really, but this is a start).