### PR TITLE
[release-1.10] Use a single HTTP client for all connections to the app, which supports TLS [Fixes actors not working with app-ssl enabled]

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -123,8 +123,6 @@ type actorsRuntime struct {
 	clock                  clock.WithTicker
 	internalActors         map[string]InternalActor
 	internalActorChannel   *internalActorChannel
-	healthHTTPClient       *nethttp.Client
-	healthEndpoint         string
 }
 
 // ActiveActorsCount contain actorType and count of actors each type has.
@@ -271,7 +269,7 @@ func (a *actorsRuntime) Init() error {
 		health.WithFailureThreshold(4),
 		health.WithInterval(5*time.Second),
 		health.WithRequestTimeout(2*time.Second),
-		health.WithHTTPClient(a.healthHTTPClient),
+		health.WithHTTPClient(a.config.HealthHTTPClient),
 	)
 
 	return nil
@@ -282,7 +280,7 @@ func (a *actorsRuntime) startAppHealthCheck(opts ...health.Option) {
 		return
 	}
 
-	ch := health.StartEndpointHealthCheck(a.ctx, a.healthEndpoint+"/healthz", opts...)
+	ch := health.StartEndpointHealthCheck(a.ctx, a.config.HealthEndpoint+"/healthz", opts...)
 	for {
 		select {
 		case <-a.ctx.Done():

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -105,10 +105,6 @@ var testResiliency = &v1alpha1.Resiliency{
 	},
 }
 
-func (m *mockAppChannel) GetBaseAddress() string {
-	return "http://127.0.0.1"
-}
-
 func (m *mockAppChannel) InvokeMethod(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
 	if m.requestC != nil {
 		var request testRequest
@@ -126,10 +122,6 @@ type reentrantAppChannel struct {
 	nextCall []*invokev1.InvokeMethodRequest
 	callLog  []string
 	a        *actorsRuntime
-}
-
-func (r *reentrantAppChannel) GetBaseAddress() string {
-	return "http://127.0.0.1"
 }
 
 func (r *reentrantAppChannel) InvokeMethod(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {

--- a/pkg/actors/config.go
+++ b/pkg/actors/config.go
@@ -14,6 +14,7 @@ limitations under the License.
 package actors
 
 import (
+	"net/http"
 	"time"
 
 	daprAppConfig "github.com/dapr/dapr/pkg/config"
@@ -35,6 +36,8 @@ type Config struct {
 	Reentrancy                    daprAppConfig.ReentrancyConfig
 	RemindersStoragePartitions    int
 	EntityConfigs                 map[string]EntityConfig
+	HealthHTTPClient              *http.Client
+	HealthEndpoint                string
 }
 
 // Remap of daprAppConfig.EntityConfig but with more useful types for actors.go.
@@ -63,6 +66,8 @@ type ConfigOpts struct {
 	Port               int
 	Namespace          string
 	AppConfig          daprAppConfig.ApplicationConfig
+	HealthHTTPClient   *http.Client
+	HealthEndpoint     string
 }
 
 // NewConfig returns the actor runtime configuration.
@@ -77,6 +82,8 @@ func NewConfig(opts ConfigOpts) Config {
 		HostedActorTypes:              opts.AppConfig.Entities,
 		Reentrancy:                    opts.AppConfig.Reentrancy,
 		RemindersStoragePartitions:    opts.AppConfig.RemindersStoragePartitions,
+		HealthHTTPClient:              opts.HealthHTTPClient,
+		HealthEndpoint:                opts.HealthEndpoint,
 		HeartbeatInterval:             defaultHeartbeatInterval,
 		ActorDeactivationScanInterval: defaultActorScanInterval,
 		ActorIdleTimeout:              defaultActorIdleTimeout,

--- a/pkg/actors/internal_actor.go
+++ b/pkg/actors/internal_actor.go
@@ -82,11 +82,6 @@ func (c *internalActorChannel) GetAppConfig() (*config.ApplicationConfig, error)
 	return config, nil
 }
 
-// GetBaseAddress implements channel.AppChannel
-func (internalActorChannel) GetBaseAddress() string {
-	return ""
-}
-
 // HealthProbe implements channel.AppChannel
 func (internalActorChannel) HealthProbe(ctx context.Context) (bool, error) {
 	return true, nil

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -28,7 +28,6 @@ const (
 
 // AppChannel is an abstraction over communications with user code.
 type AppChannel interface {
-	GetBaseAddress() string
 	GetAppConfig() (*config.ApplicationConfig, error)
 	InvokeMethod(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error)
 	HealthProbe(ctx context.Context) (bool, error)

--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -66,11 +66,6 @@ func CreateLocalChannel(port, maxConcurrency int, conn *grpc.ClientConn, spec co
 	return c
 }
 
-// GetBaseAddress returns the application base address.
-func (g *Channel) GetBaseAddress() string {
-	return g.baseAddress
-}
-
 // GetAppConfig gets application config from user application.
 func (g *Channel) GetAppConfig() (*config.ApplicationConfig, error) {
 	return nil, nil

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -642,24 +642,6 @@ func TestAppToken(t *testing.T) {
 	})
 }
 
-func TestCreateChannel(t *testing.T) {
-	t.Run("ssl scheme", func(t *testing.T) {
-		ch, err := CreateLocalChannel(3000, 0, httpMiddleware.Pipeline{}, config.TracingSpec{}, true, 4, 4)
-		assert.NoError(t, err)
-
-		b := ch.GetBaseAddress()
-		assert.Equal(t, b, "https://127.0.0.1:3000")
-	})
-
-	t.Run("non-ssl scheme", func(t *testing.T) {
-		ch, err := CreateLocalChannel(3000, 0, httpMiddleware.Pipeline{}, config.TracingSpec{}, false, 4, 4)
-		assert.NoError(t, err)
-
-		b := ch.GetBaseAddress()
-		assert.Equal(t, b, "http://127.0.0.1:3000")
-	})
-}
-
 func TestHealthProbe(t *testing.T) {
 	ctx := context.Background()
 	h := &testStatusCodeHandler{}

--- a/pkg/channel/testing/channel_mock.go
+++ b/pkg/channel/testing/channel_mock.go
@@ -43,20 +43,6 @@ func (_m *MockAppChannel) GetAppConfig() (*config.ApplicationConfig, error) {
 	return r0, r1
 }
 
-// GetBaseAddress provides a mock function with given fields:
-func (_m *MockAppChannel) GetBaseAddress() string {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
 // HealthProbe provides a mock function with given fields: ctx
 func (_m *MockAppChannel) HealthProbe(ctx context.Context) (bool, error) {
 	ret := _m.Called(ctx)

--- a/pkg/testing/app_channel_mock.go
+++ b/pkg/testing/app_channel_mock.go
@@ -28,10 +28,6 @@ type FailingAppChannel struct {
 	KeyFunc func(req *invokev1.InvokeMethodRequest) string
 }
 
-func (f *FailingAppChannel) GetBaseAddress() string {
-	return ""
-}
-
 func (f *FailingAppChannel) GetAppConfig() (*config.ApplicationConfig, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Fixes #6141

This was implemented in a way that:

- Makes health checks work when `app-ssl` is enabled (#6141)
- Switches the health package's client to net/http rather than fasthttp. This allows taking advantage of HTTP/2 and multiplexing, among other things.
- Uses a single http.Client for health checks and app channel. This allows re-using TCP sockets and multiplexing when HTTP/2 is enabled, possibly offering much better efficienty