### PR TITLE
[release-1.10] Backport changes to test infra

### DIFF
--- a/.github/scripts/dapr_tests_summary.js
+++ b/.github/scripts/dapr_tests_summary.js
@@ -1,0 +1,12 @@
+const fs = require('fs')
+
+module.exports = async ({ glob, core }) => {
+    const globber = await glob.create(process.env["TEST_OUTPUT_FILE_PREFIX"] + "_summary_table_*.json")
+    for await (const file of globber.globGenerator()) {
+        const testSummary = JSON.parse(fs.readFileSync(file, 'utf8'))
+        await core.summary
+            .addHeading(testSummary.test)
+            .addTable(testSummary.data)
+            .write()
+    }
+}

--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -462,11 +462,18 @@ jobs:
           #TODO: .json suffix can be removed from artifact name after test analytics scripts are updated
           name: test_perf.json
           path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_perf*.*
-      - name: Show test summary
+      - name: Add job test summary
         if: always()
         uses: test-summary/action@v2
         with:
           paths: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_perf*.xml
+      - name: Add job test outputs
+        if: always()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/dapr_tests_summary.js')
+            await script({core, glob})
       - name: Update PR comment for success
         if: success() && env.PR_NUMBER != ''
         uses: artursouza/sticky-pull-request-comment@v2.2.0

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -26,7 +26,7 @@ name: dapr-test
 on:
   # Run every 2 hours
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: "0 */2 * * *"
   # Manual trigger
   workflow_dispatch:
   # Dispatch on external events
@@ -530,11 +530,18 @@ jobs:
       - name: Run E2E tests
         if: env.TEST_PREFIX != '' && env.SKIP_E2E != 'true'
         run: make test-e2e-all
-      - name: Show test summary
+      - name: Add job test summary
         if: always()
         uses: test-summary/action@v2
         with:
           paths: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_e2e*.xml
+      - name: Add job test outputs
+        if: always()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/dapr_tests_summary.js')
+            await script({core, glob})
       - name: Save control plane K8s resources
         if: always() && env.TEST_PREFIX != ''
         run: |

--- a/go.mod
+++ b/go.mod
@@ -273,7 +273,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labd/commercetools-go-sdk v1.2.0 // indirect
 	github.com/labstack/echo/v4 v4.9.0 // indirect
-	github.com/labstack/gommon v0.3.1 // indirect
+	github.com/labstack/gommon v0.3.1
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -369,7 +369,7 @@ else
 			--junitfile $(TEST_OUTPUT_FILE_PREFIX)_perf.xml \
 			--format standard-quiet \
 			-- \
-				-p 1 -count=1 -v -tags=perf ./tests/perf/$$app... ; \
+				-timeout 1h -p 1 -count=1 -v -tags=perf ./tests/perf/$$app... || exit -1 ; \
 		jq -r .Output $(TEST_OUTPUT_FILE_PREFIX)_perf.json | strings ; \
 	done
 endif

--- a/tests/perf/actor_activation/actor_activation_test.go
+++ b/tests/perf/actor_activation/actor_activation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,6 +93,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorActivate(t *testing.T) {
+	table := summary.ForTest(t)
+	defer table.Flush()
+
 	p := perf.Params(
 		perf.WithQPS(500),
 		perf.WithConnections(8),
@@ -173,6 +177,16 @@ func TestActorActivate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	table.Output("Service", serviceApplicationName).
+		Output("Client", clientApplicationName).
+		Outputf("CPU", "%vm", appUsage.CPUm).
+		Outputf("Memory", "%vMb", appUsage.MemoryMb).
+		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
+		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
+		OutputInt("Restarts", restarts).
+		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
+		OutputInt("QPS", p.QPS)
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_activation/actor_activation_test.go
+++ b/tests/perf/actor_activation/actor_activation_test.go
@@ -93,9 +93,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorActivate(t *testing.T) {
-	table := summary.ForTest(t)
-	defer table.Flush()
-
 	p := perf.Params(
 		perf.WithQPS(500),
 		perf.WithConnections(8),
@@ -178,15 +175,18 @@ func TestActorActivate(t *testing.T) {
 		t.Error(err)
 	}
 
-	table.Output("Service", serviceApplicationName).
-		Output("Client", clientApplicationName).
-		Outputf("CPU", "%vm", appUsage.CPUm).
-		Outputf("Memory", "%vMb", appUsage.MemoryMb).
-		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
-		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
-		OutputInt("Restarts", restarts).
-		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
-		OutputInt("QPS", p.QPS)
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		Client(clientApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_double_activation/actor_double_activation_test.go
+++ b/tests/perf/actor_double_activation/actor_double_activation_test.go
@@ -26,6 +26,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/dapr/dapr/tests/runner/loadtest"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,11 +85,31 @@ func TestActorDoubleActivation(t *testing.T) {
 	defer k6Test.Dispose()
 	t.Log("running the k6 load test...")
 	require.NoError(t, tr.Platform.LoadTest(k6Test))
-	summary, err := loadtest.K6Result[json.RawMessage](k6Test)
+	sm, err := loadtest.K6ResultDefault(k6Test)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	bts, err := json.MarshalIndent(summary, "", " ")
+	require.NotNil(t, sm)
+	bts, err := json.MarshalIndent(sm, "", " ")
 	require.NoError(t, err)
-	require.True(t, summary.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
+	appUsage, err := tr.Platform.GetAppUsage(serviceApplicationName)
+	require.NoError(t, err)
+
+	sidecarUsage, err := tr.Platform.GetSidecarUsage(serviceApplicationName)
+	require.NoError(t, err)
+
+	restarts, err := tr.Platform.GetTotalRestarts(serviceApplicationName)
+	require.NoError(t, err)
+
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		OutputK6(sm.RunnersResults).
+		Flush()
+
+	require.True(t, sm.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
 	t.Logf("test summary `%s`", string(bts))
+
 }

--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,6 +96,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorReminderRegistrationPerformance(t *testing.T) {
+	table := summary.ForTest(t)
+	defer table.Flush()
+
 	p := perf.Params(
 		perf.WithQPS(500),
 		perf.WithConnections(8),
@@ -175,6 +179,16 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	table.Output("Service", serviceApplicationName).
+		Output("Client", clientApplicationName).
+		Outputf("CPU", "%vm", appUsage.CPUm).
+		Outputf("Memory", "%vMb", appUsage.MemoryMb).
+		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
+		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
+		OutputInt("Restarts", restarts).
+		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
+		OutputInt("QPS", p.QPS)
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -96,9 +96,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorReminderRegistrationPerformance(t *testing.T) {
-	table := summary.ForTest(t)
-	defer table.Flush()
-
 	p := perf.Params(
 		perf.WithQPS(500),
 		perf.WithConnections(8),
@@ -180,15 +177,18 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 		t.Error(err)
 	}
 
-	table.Output("Service", serviceApplicationName).
-		Output("Client", clientApplicationName).
-		Outputf("CPU", "%vm", appUsage.CPUm).
-		Outputf("Memory", "%vMb", appUsage.MemoryMb).
-		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
-		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
-		OutputInt("Restarts", restarts).
-		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
-		OutputInt("QPS", p.QPS)
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		Client(clientApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_timer/actor_timer_test.go
+++ b/tests/perf/actor_timer/actor_timer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,6 +93,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorTimerWithStatePerformance(t *testing.T) {
+	table := summary.ForTest(t)
+	defer table.Flush()
 	p := perf.Params(
 		perf.WithQPS(220),
 		perf.WithConnections(10),
@@ -172,6 +175,15 @@ func TestActorTimerWithStatePerformance(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	table.Output("Service", serviceApplicationName).
+		Output("Client", clientApplicationName).
+		Outputf("CPU", "%vm", appUsage.CPUm).
+		Outputf("Memory", "%vMb", appUsage.MemoryMb).
+		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
+		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
+		OutputInt("Restarts", restarts).
+		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
+		OutputInt("QPS", p.QPS)
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_timer/actor_timer_test.go
+++ b/tests/perf/actor_timer/actor_timer_test.go
@@ -93,8 +93,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestActorTimerWithStatePerformance(t *testing.T) {
-	table := summary.ForTest(t)
-	defer table.Flush()
 	p := perf.Params(
 		perf.WithQPS(220),
 		perf.WithConnections(10),
@@ -175,15 +173,18 @@ func TestActorTimerWithStatePerformance(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	table.Output("Service", serviceApplicationName).
-		Output("Client", clientApplicationName).
-		Outputf("CPU", "%vm", appUsage.CPUm).
-		Outputf("Memory", "%vMb", appUsage.MemoryMb).
-		Outputf("Sidecar CPU", "%vm", sidecarUsage.CPUm).
-		Outputf("Sidecar Memory", "%vMb", sidecarUsage.MemoryMb).
-		OutputInt("Restarts", restarts).
-		Outputf("Actual QPS", "%.2f", daprResult.ActualQPS).
-		OutputInt("QPS", p.QPS)
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		Client(clientApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	require.Equal(t, 0, daprResult.RetCodes.Num400)
 	require.Equal(t, 0, daprResult.RetCodes.Num500)

--- a/tests/perf/actor_type_scale/actor_type_scale_test.go
+++ b/tests/perf/actor_type_scale/actor_type_scale_test.go
@@ -26,6 +26,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/dapr/dapr/tests/runner/loadtest"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,13 +90,11 @@ func TestActorIdStress(t *testing.T) {
 	// defer k6Test.Dispose()
 	t.Log("running the k6 load test...")
 	require.NoError(t, tr.Platform.LoadTest(k6Test))
-	summary, err := loadtest.K6ResultDefault(k6Test)
+	sm, err := loadtest.K6ResultDefault(k6Test)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	bts, err := json.MarshalIndent(summary, "", " ")
+	require.NotNil(t, sm)
+	bts, err := json.MarshalIndent(sm, "", " ")
 	require.NoError(t, err)
-	require.True(t, summary.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
-	t.Logf("test summary `%s`", string(bts))
 
 	appUsage, err := tr.Platform.GetAppUsage(serviceApplicationName)
 	require.NoError(t, err)
@@ -106,8 +105,21 @@ func TestActorIdStress(t *testing.T) {
 	restarts, err := tr.Platform.GetTotalRestarts(serviceApplicationName)
 	require.NoError(t, err)
 
+	summary.ForTest(t).
+		Service(serviceApplicationName).
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		OutputK6(sm.RunnersResults).
+		Flush()
+
 	t.Logf("target dapr app consumed %vm CPU and %vMb of Memory", appUsage.CPUm, appUsage.MemoryMb)
 	t.Logf("target dapr sidecar consumed %vm CPU and %vMb of Memory", sidecarUsage.CPUm, sidecarUsage.MemoryMb)
 	t.Logf("target dapr app or sidecar restarted %v times", restarts)
+
+	require.True(t, sm.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
 	require.Equal(t, 0, restarts)
+	t.Logf("test summary `%s`", string(bts))
 }

--- a/tests/perf/pubsub_bulk_publish_grpc/pubsub_bulk_publish_grpc_test.go
+++ b/tests/perf/pubsub_bulk_publish_grpc/pubsub_bulk_publish_grpc_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -174,13 +175,34 @@ func TestBulkPubsubPublishGrpcPerformance(t *testing.T) {
 				t.Logf("reduced latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 			}
 			avg := (baselineResult.DurationHistogram.Avg - bulkResult.DurationHistogram.Avg) * 1000
-			t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-			t.Logf("bulk latency avg: %sms", fmt.Sprintf("%.2f", bulkResult.DurationHistogram.Avg*1000))
-			t.Logf("reduced latency avg: %sms", fmt.Sprintf("%.2f", avg))
+			baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+			bulkLatencyMS := fmt.Sprintf("%.2f", bulkResult.DurationHistogram.Avg*1000)
+			reducedLatencyMS := fmt.Sprintf("%.2f", avg)
+			t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+			t.Logf("bulk latency avg: %sms", bulkLatencyMS)
+			t.Logf("reduced latency avg: %sms", reducedLatencyMS)
 
 			t.Logf("baseline QPS: %v", baselineResult.ActualQPS)
 			t.Logf("bulk QPS: %v", bulkResult.ActualQPS)
-			t.Logf("increase in QPS: %v", (bulkResult.ActualQPS-baselineResult.ActualQPS)/baselineResult.ActualQPS*100)
+			increaseQPS := (bulkResult.ActualQPS - baselineResult.ActualQPS) / baselineResult.ActualQPS * 100
+			t.Logf("increase in QPS: %v", increaseQPS)
+
+			summary.ForTest(t).
+				Service("tester").
+				CPU(appUsage.CPUm).
+				Memory(appUsage.MemoryMb).
+				SidecarCPU(sidecarUsage.CPUm).
+				SidecarMemory(sidecarUsage.MemoryMb).
+				Restarts(restarts).
+				BaselineLatency(baselineLatency).
+				Outputf("Bulk latency avg", "%sms", bulkLatencyMS).
+				Outputf("Reduced latency avg", "%sms", reducedLatencyMS).
+				OutputFloat64("Baseline QPS", baselineResult.ActualQPS).
+				OutputFloat64("Increase in QPS", increaseQPS).
+				ActualQPS(bulkResult.ActualQPS).
+				Params(p).
+				OutputFortio(bulkResult).
+				Flush()
 
 			report := perf.NewTestReport(
 				[]perf.TestResult{baselineResult, bulkResult},

--- a/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
+++ b/tests/perf/pubsub_publish_grpc/pubsub_publish_grpc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -144,9 +145,26 @@ func TestPubsubPublishGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("tester").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/pubsub_publish_http/pubsub_publish_http_test.go
+++ b/tests/perf/pubsub_publish_http/pubsub_publish_http_test.go
@@ -27,6 +27,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/dapr/dapr/tests/runner/loadtest"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,11 +77,14 @@ func TestPubsubPublishHttpPerformance(t *testing.T) {
 	defer k6Test.Dispose()
 	t.Log("running the k6 load test...")
 	require.NoError(t, tr.Platform.LoadTest(k6Test))
-	summary, err := loadtest.K6Result[json.RawMessage](k6Test)
+	sm, err := loadtest.K6ResultDefault(k6Test)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	bts, err := json.MarshalIndent(summary, "", " ")
+	require.NotNil(t, sm)
+	summary.ForTest(t).
+		OutputK6(sm.RunnersResults).
+		Flush()
+	bts, err := json.MarshalIndent(sm, "", " ")
 	require.NoError(t, err)
-	require.True(t, summary.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
+	require.True(t, sm.Pass, fmt.Sprintf("test has not passed, results %s", string(bts)))
 	t.Logf("test summary `%s`", string(bts))
 }

--- a/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
+++ b/tests/perf/service_invocation_grpc/service_invocation_grpc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -180,9 +181,26 @@ func TestServiceInvocationGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("testapp").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/service_invocation_http/service_invocation_http_test.go
+++ b/tests/perf/service_invocation_http/service_invocation_http_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 )
 
@@ -176,9 +177,26 @@ func TestServiceInvocationHTTPPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("testapp").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/state_get_grpc/state_get_grpc_test.go
+++ b/tests/perf/state_get_grpc/state_get_grpc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -144,9 +145,26 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("tester").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/perf/state_get_http/state_get_http_test.go
+++ b/tests/perf/state_get_http/state_get_http_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/perf/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	"github.com/dapr/dapr/tests/runner/summary"
 )
 
 const numHealthChecks = 60 // Number of times to check for endpoint health per app.
@@ -145,9 +146,26 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 		t.Logf("added latency for %s percentile: %sms", v, fmt.Sprintf("%.2f", latency))
 	}
 	avg := (daprResult.DurationHistogram.Avg - baselineResult.DurationHistogram.Avg) * 1000
-	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineResult.DurationHistogram.Avg*1000))
-	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprResult.DurationHistogram.Avg*1000))
+	baselineLatency := baselineResult.DurationHistogram.Avg * 1000
+	daprLatency := daprResult.DurationHistogram.Avg * 1000
+	t.Logf("baseline latency avg: %sms", fmt.Sprintf("%.2f", baselineLatency))
+	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
+
+	summary.ForTest(t).
+		Service("tester").
+		CPU(appUsage.CPUm).
+		Memory(appUsage.MemoryMb).
+		SidecarCPU(sidecarUsage.CPUm).
+		SidecarMemory(sidecarUsage.MemoryMb).
+		Restarts(restarts).
+		BaselineLatency(baselineLatency).
+		DaprLatency(daprLatency).
+		AddedLatency(avg).
+		ActualQPS(daprResult.ActualQPS).
+		Params(p).
+		OutputFortio(daprResult).
+		Flush()
 
 	report := perf.NewTestReport(
 		[]perf.TestResult{baselineResult, daprResult},

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package summary
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/labstack/gommon/log"
+)
+
+func filePath(prefix, testName string) string {
+	return fmt.Sprintf("%s_summary_table_%s.json", prefix, strings.ReplaceAll(testName, string(os.PathSeparator), "_"))
+}
+
+// Table is primarily used as a source of arbitrary test output. Tests can send output to the summary table and later flush them.
+// when flush is called so the table is serialized into a file that contains the test name on it, so you should use one table per test.
+// the table output is typically used as a github enhanced job summary.
+// see more: https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/
+type Table struct {
+	Test string      `json:"test"`
+	Data [][2]string `json:"data"`
+}
+
+// Output adds a pair to the table data pairs.
+func (t *Table) Output(header, value string) *Table {
+	t.Data = append(t.Data, [2]string{header, value})
+	return t
+}
+
+// OutputInt same as output but converts from int to string.
+func (t *Table) OutputInt(header string, value int) *Table {
+	return t.Output(header, strconv.Itoa(value))
+}
+
+// Outputf same as output but uses a formatter.
+func (t *Table) Outputf(header, format string, params ...any) *Table {
+	return t.Output(header, fmt.Sprintf(format, params...))
+}
+
+// Flush saves the summary into the disk using the desired format.
+func (t *Table) Flush() error {
+	bts, err := json.Marshal(t)
+	if err != nil {
+		log.Errorf("error when marshalling table %s %v", t.Test, err)
+		return err
+	}
+
+	filePrefixOutput, ok := os.LookupEnv("TEST_OUTPUT_FILE_PREFIX")
+	if !ok {
+		filePrefixOutput = "./test_report"
+	}
+
+	err = os.WriteFile(filePath(filePrefixOutput, t.Test), bts, os.ModePerm)
+	if err != nil {
+		log.Errorf("error when saving table %s %v", t.Test, err)
+		return err
+	}
+	return nil
+}
+
+// ForTest returns a table ready to be written for the given test.
+func ForTest(tst *testing.T) *Table {
+	return &Table{
+		Test: tst.Name(),
+		Data: [][2]string{},
+	}
+}

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -27,8 +27,17 @@ import (
 	"github.com/labstack/gommon/log"
 )
 
+const (
+	// testNameSeparator is the default character used by go test to separate between suitecases under the same test func.
+	testNameSeparator = "/"
+)
+
+func sanitizeTestName(testName string) string {
+	return strings.ReplaceAll(testName, testNameSeparator, "_")
+}
+
 func filePath(prefix, testName string) string {
-	return fmt.Sprintf("%s_summary_table_%s.json", prefix, strings.ReplaceAll(testName, string(os.PathSeparator), "_"))
+	return fmt.Sprintf("%s_summary_table_%s.json", prefix, sanitizeTestName(testName))
 }
 
 // Table is primarily used as a source of arbitrary test output. Tests can send output to the summary table and later flush them.

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dapr/dapr/tests/perf"
+	"github.com/dapr/dapr/tests/runner/loadtest"
+
 	"github.com/labstack/gommon/log"
 )
 
@@ -48,9 +51,144 @@ func (t *Table) OutputInt(header string, value int) *Table {
 	return t.Output(header, strconv.Itoa(value))
 }
 
+// OutputFloat64 same as output but converts from float64 to string.
+func (t *Table) OutputFloat64(header string, value float64) *Table {
+	return t.Outputf(header, "%f", value)
+}
+
 // Outputf same as output but uses a formatter.
 func (t *Table) Outputf(header, format string, params ...any) *Table {
 	return t.Output(header, fmt.Sprintf(format, params...))
+}
+
+// Service is a shortcut for .Output("Service")
+func (t *Table) Service(serviceName string) *Table {
+	return t.Output("Service", serviceName)
+}
+
+// Service is a shortcut for .Output("Client")
+func (t *Table) Client(clientName string) *Table {
+	return t.Output("Client", clientName)
+}
+
+// CPU is a shortcut for .Outputf("CPU", "%vm")
+func (t *Table) CPU(cpu int64) *Table {
+	return t.Outputf("CPU", "%vm", cpu)
+}
+
+// Memory is a shortcut for .Outputf("Memory", "%vm")
+func (t *Table) Memory(cpu float64) *Table {
+	return t.Outputf("Memory", "%vMb", cpu)
+}
+
+// SidecarCPU is a shortcut for .Outputf("Sidecar CPU", "%vm")
+func (t *Table) SidecarCPU(cpu int64) *Table {
+	return t.Outputf("Sidecar CPU", "%vm", cpu)
+}
+
+// BaselineLatency is a shortcut for Outputf("Baseline latency avg", "%2.fms")
+func (t *Table) BaselineLatency(latency float64) *Table {
+	return t.Outputf("Baseline latency avg", "%.2fms", latency)
+}
+
+// DaprLatency is a shortcut for Outputf("Dapr latency avg", "%2.fms")
+func (t *Table) DaprLatency(latency float64) *Table {
+	return t.Outputf("Dapr latency avg", "%.2fms", latency)
+}
+
+// AddedLatency is a shortcut for Outputf("Added latency avg", "%2.fms")
+func (t *Table) AddedLatency(latency float64) *Table {
+	return t.Outputf("Dapr latency avg", "%.2fms", latency)
+}
+
+// SidecarMemory is a shortcut for .Outputf("Sidecar Memory", "%vm")
+func (t *Table) SidecarMemory(cpu float64) *Table {
+	return t.Outputf("Sidecar Memory", "%vMb", cpu)
+}
+
+// Restarts is a shortcut for .OutputInt("Restarts")
+func (t *Table) Restarts(restarts int) *Table {
+	return t.OutputInt("Restarts", restarts)
+}
+
+// ActualQPS is a short for .Outputf("QPS", ".2f")
+func (t *Table) ActualQPS(qps float64) *Table {
+	return t.Outputf("Actual QPS", "%.2f", qps)
+}
+
+// QPS is a short for .OutputInt("QPS")
+func (t *Table) QPS(qps int) *Table {
+	return t.OutputInt("QPS", qps)
+}
+
+// P90 is a short for .Outputf("P90", "%2.fms")
+func (t *Table) P90(p90 float64) *Table {
+	return t.Outputf("P90", "%.2fms", p90)
+}
+
+// P90 is a short for .Outputf("P90", "%2.fms")
+func (t *Table) P99(p99 float64) *Table {
+	return t.Outputf("P99", "%.2fms", p99)
+}
+
+// QPS is a short for .OutputInt("QPS")
+func (t *Table) Params(p perf.TestParameters) *Table {
+	return t.QPS(p.QPS).
+		OutputInt("Client connections", p.ClientConnections).
+		Output("Target endpoint", p.TargetEndpoint).
+		Output("Test duration", p.TestDuration).
+		OutputInt("PayloadSizeKB", p.PayloadSizeKB)
+}
+
+type unit string
+
+const (
+	millisecond unit = "ms"
+)
+
+var unitFormats = map[unit]string{
+	millisecond: "%.2fms",
+}
+
+// OutputK6Trend outputs the given k6trend using the given prefix.
+func (t *Table) OutputK6Trend(prefix string, unit unit, trend loadtest.K6TrendMetric) *Table {
+	t.Outputf(fmt.Sprintf("%s MAX", prefix), unitFormats[unit], trend.Values.Max)
+	t.Outputf(fmt.Sprintf("%s MIN", prefix), unitFormats[unit], trend.Values.Min)
+	t.Outputf(fmt.Sprintf("%s AVG", prefix), unitFormats[unit], trend.Values.Avg)
+	t.Outputf(fmt.Sprintf("%s MED", prefix), unitFormats[unit], trend.Values.Med)
+	t.Outputf(fmt.Sprintf("%s P90", prefix), unitFormats[unit], trend.Values.P90)
+	t.Outputf(fmt.Sprintf("%s P95", prefix), unitFormats[unit], trend.Values.P95)
+	return t
+}
+
+const (
+	p90Index = 2
+	p99Index = 3
+)
+
+const (
+	secondToMillisecond = 1000
+)
+
+// OutputFortio summarize the fortio results.
+func (t *Table) OutputFortio(result perf.TestResult) *Table {
+	return t.
+		P90(result.DurationHistogram.Percentiles[p90Index].Value*secondToMillisecond).
+		P99(result.DurationHistogram.Percentiles[p99Index].Value*secondToMillisecond).
+		OutputInt("2xx", result.RetCodes.Num200).
+		OutputInt("4xx", result.RetCodes.Num400).
+		OutputInt("5xx", result.RetCodes.Num500)
+}
+
+// OutputK6 summarize the K6 results for each runner.
+func (t *Table) OutputK6(k6results []*loadtest.K6RunnerMetricsSummary) *Table {
+	for i, result := range k6results {
+		t.OutputInt(fmt.Sprintf("[Runner %d]: VUs Max", i), result.Vus.Values.Max)
+		t.OutputFloat64(fmt.Sprintf("[Runner %d]: Iterations Count", i), result.Iterations.Values.Count)
+		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req duration", i), millisecond, result.HTTPReqDuration)
+		t.OutputK6Trend(fmt.Sprintf("[Runner %d]: Req Waiting", i), millisecond, result.HTTPReqWaiting)
+	}
+	return t
 }
 
 // Flush saves the summary into the disk using the desired format.

--- a/tests/runner/summary/summary_test.go
+++ b/tests/runner/summary/summary_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package summary
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummary(t *testing.T) {
+	t.Run("flush should save file", func(t *testing.T) {
+		dir := t.TempDir()
+		prefix := path.Join(dir, "test_report")
+		t.Setenv("TEST_OUTPUT_FILE_PREFIX", prefix)
+		summary := ForTest(t)
+		summary.Output("test", "test").OutputInt("test", 2).Outputf("test", "%s", "1")
+		require.NoError(t, summary.Flush())
+		f, err := os.ReadFile(filePath(prefix, t.Name()))
+		require.NoError(t, err)
+		tab := &Table{}
+		require.NoError(t, json.Unmarshal(f, &tab))
+		assert.Len(t, tab.Data, 3)
+		assert.Equal(t, tab.Test, t.Name())
+	})
+}

--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -43,7 +43,7 @@ param diagStorageResourceId string = ''
 var osDiskSizeGB = 0
 
 // Version of Kubernetes
-var kubernetesVersion = '1.24.6'
+var kubernetesVersion = '1.25.5'
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
   name: '${namePrefix}acr'

--- a/tests/test-infra/azure-servicebus.bicep
+++ b/tests/test-infra/azure-servicebus.bicep
@@ -154,7 +154,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-11-01' = {
   sku: {
     name: 'Premium'
     tier: 'Premium'
-    capacity: 4
+    capacity: 1
   }
   properties: {
     disableLocalAuth: false


### PR DESCRIPTION
The pipelines that run tests, especially perf ones, have changed in master, so AKS tests in the release-1.10 branch are failing.

Example: https://github.com/dapr/dapr/actions/runs/4621492216

This contains cherry-picked commits that should restore our ability to run perf tests in the release-1.10 branch. Does not include any change that would alter the code of Dapr when built.

> Since this contains cherry-picked commits, DCO will fail