### PR TITLE
Actor reminder perf test: reduce wait time

### DIFF
--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -29,6 +29,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
 	"github.com/dapr/dapr/tests/runner/summary"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,7 +125,7 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 	// Perform dapr test
 	endpoint := fmt.Sprintf("http://127.0.0.1:3500/v1.0/actors/%v/{uuid}/reminders/myreminder", actorType)
 	p.TargetEndpoint = endpoint
-	p.Payload = "{\"dueTime\":\"24h\",\"period\":\"24h\"}"
+	p.Payload = `{"dueTime":"24h","period":"24h"}`
 	body, err := json.Marshal(&p)
 	require.NoError(t, err)
 
@@ -136,8 +137,8 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 	// fast fail if daprResp starts with error
 	require.False(t, strings.HasPrefix(string(daprResp), "error"))
 
-	// Let test run for 10 minutes triggering the timers and collect metrics.
-	time.Sleep(10 * time.Minute)
+	// Let test run for 90s triggering the timers and collect metrics.
+	time.Sleep(90 * time.Second)
 
 	appUsage, err := tr.Platform.GetAppUsage(serviceApplicationName)
 	require.NoError(t, err)
@@ -190,8 +191,8 @@ func TestActorReminderRegistrationPerformance(t *testing.T) {
 		OutputFortio(daprResult).
 		Flush()
 
-	require.Equal(t, 0, daprResult.RetCodes.Num400)
-	require.Equal(t, 0, daprResult.RetCodes.Num500)
-	require.Equal(t, 0, restarts)
-	require.True(t, daprResult.ActualQPS > 55)
+	assert.Equal(t, 0, daprResult.RetCodes.Num400)
+	assert.Equal(t, 0, daprResult.RetCodes.Num500)
+	assert.Equal(t, 0, restarts)
+	assert.True(t, daprResult.ActualQPS > 55)
 }


### PR DESCRIPTION
The current actor_reminder perf test has a `time.Sleep(10 * time.Minute)` which is meant to let reminders be executed and capture errors.

That is a very long wait time that makes the tests take a lot of time, but has no impact on perf. In fact, perf is measured only while reminders are being created or updated before that.

Its purpose seems only to make sure that reminders execute without error, and that's something that should be done in an E2E test and not perf.

So, this PR reduces the wait time from 10m to 90s, to make the tests quicker to run.