### PR TITLE
Fix panic in bulk publish while unmarshalling incorrect cloudevent

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -2119,7 +2119,7 @@ func (a *api) onBulkPublish(reqCtx *fasthttp.RequestCtx) {
 			}, entries[i].Metadata)
 			if envelopeErr != nil {
 				msg := NewErrorResponse("ERR_PUBSUB_CLOUD_EVENTS_SER",
-					fmt.Sprintf(messages.ErrPubsubCloudEventCreation, err.Error()))
+					fmt.Sprintf(messages.ErrPubsubCloudEventCreation, envelopeErr.Error()))
 				respond(reqCtx, withError(fasthttp.StatusInternalServerError, msg), closeChildSpans)
 				log.Debug(msg)
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -604,11 +604,8 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 				ContentType: "application/json",
 			},
 			{
-				EntryId: "2",
-				Event: map[string]string{
-					"key":   "second",
-					"value": "second value",
-				},
+				EntryId:     "2",
+				Event:       "this is not a cloudevent!",
 				ContentType: "application/cloudevents+json",
 				Metadata: map[string]string{
 					"md1": "mdVal1",

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -620,7 +620,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 			// act
 			resp := fakeServer.DoRequest(method, apiPath, rBytes, nil)
 			// assert
-			assert.Equal(t, 400, resp.StatusCode, "unexpected success publishing with %s", method)
+			assert.Equal(t, 500, resp.StatusCode, "unexpected success publishing with %s", method)
 			assert.Equal(t, "ERR_PUBSUB_CLOUD_EVENTS_SER", resp.ErrorBody["errorCode"])
 			assert.Contains(t, resp.ErrorBody["message"], "cannot create cloudevent")
 		}

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -609,7 +609,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 					"key":   "second",
 					"value": "second value",
 				},
-				ContentType: "text/xml",
+				ContentType: "application/cloudevents+json",
 				Metadata: map[string]string{
 					"md1": "mdVal1",
 					"md2": "mdVal2",


### PR DESCRIPTION
# Description

Incorrect error variable was used, which was causing a panic when making this request -

POST http://localhost:3500/v1.0-alpha1/publish/bulk/pubsub/bulk-examples
Content-Type: application/json

```json
[
    {
        "entryId": "ae6bf7c6-4af2-11ed-b878-0242ac120002",
        "event":  "first text message",
        "contentType": "text/plain"
    },
    {
        "entryId": "b1f40bd6-4af2-11ed-b878-0242ac120002",
        "event":  "second message", // invalid cloudevent!
        "contentType": "application/cloudevents+json"
    }
]
```

Daprd logs
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x10853af68]

goroutine 96 [running]:
github.com/dapr/dapr/pkg/http.(*api).onBulkPublish(0x14000884b60, 0x14001409200)
        /Users/runner/work/dapr/dapr/pkg/http/api.go:2459 +0xb18
github.com/dapr/dapr/pkg/http.(*server).unescapeRequestParametersHandler.func1(0x14001409200)
        /Users/runner/work/dapr/dapr/pkg/http/server.go:330 +0x68
github.com/fasthttp/router.(*Router).Handler(0x140004325b0, 0x14001409200)
        /Users/runner/go/pkg/mod/github.com/fasthttp/router@v1.4.15/router.go:414 +0x3f0
github.com/dapr/dapr/utils/nethttpadaptor.NewNetHTTPHandlerFunc.func1({0x10a5a0550, 0x140014341b0}, 0x140009c6a00)
        /Users/runner/work/dapr/dapr/utils/nethttpadaptor/nethttpadaptor.go:79 +0x858
net/http.HandlerFunc.ServeHTTP(0x14001408c00?, {0x10a5a0550?, 0x140014341b0?}, 0x1?)
        /Users/runner/hostedtoolcache/go/1.20.1/x64/src/net/http/server.go:2122 +0x38
github.com/dapr/dapr/utils/fasthttpadaptor.NewFastHTTPHandler.func1(0x14001408c00)
        /Users/runner/work/dapr/dapr/utils/fasthttpadaptor/adaptor.go:58 +0x1a4
github.com/dapr/dapr/pkg/diagnostics.(*httpMetrics).FastHTTPMiddleware.func1(0x14001408c00)
        /Users/runner/work/dapr/dapr/pkg/diagnostics/http_monitoring.go:227 +0xfc
github.com/dapr/dapr/pkg/diagnostics.HTTPTraceMiddleware.func1(0x14001408c00)
        /Users/runner/work/dapr/dapr/pkg/diagnostics/http_tracing.go:55 +0x13c
github.com/valyala/fasthttp.(*Server).serveConn(0x14000132c00, {0x10a5cc200?, 0x14000a01208})
        /Users/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.44.0/server.go:2372 +0xd88
github.com/valyala/fasthttp.(*workerPool).workerFunc(0x14000424640, 0x140002ad320)
        /Users/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.44.0/workerpool.go:224 +0x70
github.com/valyala/fasthttp.(*workerPool).getCh.func1()
        /Users/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.44.0/workerpool.go:196 +0x38
created by github.com/valyala/fasthttp.(*workerPool).getCh
        /Users/runner/go/pkg/mod/github.com/valyala/fasthttp@v1.44.0/workerpool.go:195 +0x218
```

Response after fix
```
HTTP/1.1 500 Internal Server Error
Date: Thu, 13 Apr 2023 05:17:25 GMT
Content-Type: application/json
Content-Length: 157
Traceparent: 00-75cfae0c7f391867aa8d3304710a4878-c38d5ae3167e8985-01
Connection: close

{
  "errorCode": "ERR_PUBSUB_CLOUD_EVENTS_SER",
  "message": "cannot create cloudevent: json: cannot unmarshal string into Go value of type map[string]interface {}"
}
```

## Issue reference

Please reference the issue this PR will close: #NA

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
