### PR TITLE
Add alias for Azure Service Bus Queues binding

### DIFF
--- a/cmd/daprd/components/binding_azure_servicebus_queues.go
+++ b/cmd/daprd/components/binding_azure_servicebus_queues.go
@@ -23,8 +23,8 @@ import (
 func init() {
 	bindingsLoader.DefaultRegistry.RegisterInputBinding(func(l logger.Logger) bindings.InputBinding {
 		return servicebusqueues.NewAzureServiceBusQueues(l)
-	}, "azure.servicebus.queues", "azure.servicebusqueues")
+	}, "azure.servicebus.queues", "azure.servicebus.queues", "azure.servicebusqueues")
 	bindingsLoader.DefaultRegistry.RegisterOutputBinding(func(l logger.Logger) bindings.OutputBinding {
 		return servicebusqueues.NewAzureServiceBusQueues(l)
-	}, "azure.servicebus.queues", "azure.servicebusqueues")
+	}, "azure.servicebus.queues", "azure.servicebus.queues", "azure.servicebusqueues")
 }


### PR DESCRIPTION
# Description

Add alias for Azure Service Bus Queues binding

Now both `bindings.azure.servicesbusqueues` and `bindings.azure.servicebus.queues` can be used.