### PR TITLE
Fixed actors tests failures with Cosmos DB

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1554,7 +1554,7 @@ func (a *actorsRuntime) getRemindersForActorType(ctx context.Context, actorType 
 	if resp == nil {
 		resp = &state.GetResponse{}
 	}
-	log.Debugf("read reminders from %s without partition: %s", key, string(resp.Data))
+	log.Debugf("read reminders from %s without partition", key)
 
 	var reminders []reminders.Reminder
 	if len(resp.Data) > 0 {

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1358,6 +1358,9 @@ func (a *actorsRuntime) getActorTypeMetadata(ctx context.Context, actorType stri
 	policyRunner := resiliency.NewRunner[*ActorMetadata](ctx, policyDef)
 	getReq := &state.GetRequest{
 		Key: constructCompositeKey("actors", actorType, "metadata"),
+		Metadata: map[string]string{
+			metadataPartitionKey: constructCompositeKey("actors", actorType),
+		},
 	}
 	return policyRunner(func(ctx context.Context) (*ActorMetadata, error) {
 		rResp, rErr := store.Get(ctx, getReq)


### PR DESCRIPTION
Actor tests are currently failing on master when running against Cosmos DB ([example](https://github.com/dapr/dapr/actions/runs/4744999932))

## TLDR

The issue was caused by a combination of two bugs, including one that was fixed in #6186.

- #6186 brought in a new version of components-contrib which fixed a critical bug in Cosmos DB, where etags (and first-write-wins) were being ignored in transactional operations (possible data loss)
- A separate, prior bug in the runtime caused the actor reminders metadata document to be stored with the incorrect partition key. This was not much of a problem (although could have facilitated race conditions), until the bug above in Cosmos DB was fixed.

## Detailed description

The issue was caused by two bugs that, while both present, "neutralized" each other (but with potential for critical failures).

### First bug

As part of dapr/components-contrib#2427, the companion PR to #6186, a bug was fixed in the Cosmos DB component.

In transactional operations (the `Multi()` method), when adding an upsert operation to the batch, the `options` object which contains options such as the ETag to use and whether to use first-write-wins was not actually added to the batch operation:

https://github.com/dapr/components-contrib/pull/2747/files#diff-72645ea5cedbaa35da8ead1ddfa8dfe4f1a0fb08a7dc3f105975ae77ff965f35R531-R556

It's unclear when this bug was added, but I can find it in the source code for Dapr 1.9 too: https://github.com/dapr/components-contrib/blob/release-1.9/state/azure/cosmosdb/cosmosdb.go#L394

Although the bug was fixed without much thinking, I realize now that was a **critical bug**: it caused upsert operations within a transaction to succeed regardless of etags and first-write-wins. **This has likely been causing data loss.**

### Second bug

The second bug is in the runtime. When retrieving the actor reminders metadata document, the query did not contain the partition key. Tthis is the code from release-1.10:

https://github.com/dapr/dapr/blob/release-1.10/pkg/actors/actors.go#L1358-L1360

The Cosmos DB component behaves so if the partition key is missing, it uses the key name as partition key. In this case, the Get operation was trying to retrieve the document with partition key `actors||actor_type||metadata`.

However, when the reminders metadata document was stored, its partition key was `actors||actor_type`. From release-1.10, `stateMetadata` is the same for both the reminders and metadata documents:

https://github.com/dapr/dapr/blob/release-1.10/pkg/actors/actors.go#L1459

Because the partition key was missing, the reminders metadata document was always returned empty.

### The two together

When storing a reminder, the flow is:

1. Retrieve the metadata and reminders documents
2. Update the state in-memory
3. Save the metadata and reminders documents

The save operations use both an etag and first-write-wins. When both are set, state store components behave this way (as certified by conformance tests):

- if an etag is set and not-empty, they will only save if the etag matches
- if an etag is unset or empty, they will save only if the document doesn't exist (first-write-wins)

This is where the issues popped up for Cosmos DB:

- In step 1, the runtime retrieved the metadata document, but because the Get operation used the wrong partition key (`actors||actor_type||metadata`) (bug 2), it was returned empty. The runtime had thus no etag for the metadata document.
- In step 3, the runtime was saving the metadata document with the empty etag and first-write-wins, using the partition key `actors||actor_type` (and key `actors||actor_type||metadata`).
- Because the etag was empty, a write should have failed due to first-write-wins: a document with that key and partition key `actors||actor_type` already existed.
- However because of Bug 1, Comsos DB was ignoring first-write-wins (as well as etags), so it just overwrote whatever metadata document could find with the key `actors||actor_type||metadata` and partition key `actors||actor_type`.