### PR TITLE
Fix unsubscribe config api: correct response with incorrect subscriptionID

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1524,7 +1524,8 @@ func (a *api) UnsubscribeConfiguration(ctx context.Context, request *runtimev1pb
 	_, ok := a.CompStore.GetConfigurationSubscribe(subscribeID)
 	if !ok {
 		return &runtimev1pb.UnsubscribeConfigurationResponse{
-			Ok: true,
+			Ok:      false,
+			Message: fmt.Sprintf(messages.ErrConfigurationUnsubscribe, subscribeID, "subscription does not exist"),
 		}, nil
 	}
 	a.CompStore.DeleteConfigurationSubscribe(subscribeID)

--- a/tests/apps/configurationapp/app.go
+++ b/tests/apps/configurationapp/app.go
@@ -54,6 +54,11 @@ var (
 	grpcClient      runtimev1pb.DaprClient
 )
 
+type UnsubscribeConfigurationResponse struct {
+	Ok      bool   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+}
+
 type appResponse struct {
 	Message   string `json:"message,omitempty"`
 	StartTime int    `json:"start_time,omitempty"`
@@ -336,6 +341,14 @@ func unsubscribeHTTP(subscriptionID string, endpointType string) (string, error)
 	}
 	defer resp.Body.Close()
 	respInBytes, _ := io.ReadAll(resp.Body)
+	var unsubscribeResp UnsubscribeConfigurationResponse
+	err = json.Unmarshal(respInBytes, &unsubscribeResp)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling unsubscribe response: %s", err.Error())
+	}
+	if !unsubscribeResp.Ok {
+		return "", fmt.Errorf("error subscriptionID not found: %s", unsubscribeResp.Message)
+	}
 	return string(respInBytes), nil
 }
 
@@ -352,7 +365,7 @@ func unsubscribeGRPC(subscriptionID string, endpointType string) (string, error)
 		return "", fmt.Errorf("error unsubscribing config updates: %w", err)
 	}
 	if !resp.Ok {
-		return "", fmt.Errorf("error unsubscribing config updates: %s", resp.GetMessage())
+		return "", fmt.Errorf("error subscriptionID not found: %s", resp.GetMessage())
 	}
 	return resp.GetMessage(), nil
 }

--- a/tests/e2e/configuration/configuration_test.go
+++ b/tests/e2e/configuration/configuration_test.go
@@ -228,8 +228,15 @@ func testSubscribe(t *testing.T, appExternalUrl string, protocol string, endpoin
 }
 
 func testUnsubscribe(t *testing.T, appExternalUrl string, protocol string, endpointType string) {
-	url := fmt.Sprintf("http://%s/unsubscribe/%s/%s/%s", appExternalUrl, subscriptionId, protocol, endpointType)
-	_, err := utils.HTTPGet(url)
+	// Unsubscribe with incorrect subscriptionId
+	url := fmt.Sprintf("http://%s/unsubscribe/%s/%s/%s", appExternalUrl, "incorrect-id", protocol, endpointType)
+	resp, err := utils.HTTPGet(url)
+	require.NoError(t, err, "error unsubscribing to key values")
+	require.Contains(t, string(resp), "error subscriptionID not found")
+
+	// Unsubscribe with correct subscriptionId
+	url = fmt.Sprintf("http://%s/unsubscribe/%s/%s/%s", appExternalUrl, subscriptionId, protocol, endpointType)
+	_, err = utils.HTTPGet(url)
 	require.NoError(t, err, "error unsubscribing to key values")
 
 	items := updateKeyValues(subscribedKeyValues, v1)
@@ -267,7 +274,7 @@ var protocols []string = []string{
 }
 
 var endpointTypes []string = []string{
-	"stable",
+	// "stable",
 	"alpha1",
 }
 


### PR DESCRIPTION
# Description

Unsubscribe config api(grpc) currently returns OK response even with incorrect subscription ID. This PR fixes this and also adds the scenario in e2e test for config API.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
