### PR TITLE
Updating pause resume methods for built-in workflow component

### DIFF
--- a/pkg/runtime/wfengine/component.go
+++ b/pkg/runtime/wfengine/component.go
@@ -65,7 +65,6 @@ func BuiltinWorkflowFactory(engine *WorkflowEngine) func(logger.Logger) workflow
 }
 
 type workflowEngineComponent struct {
-	workflows.Workflow
 	logger logger.Logger
 	client backend.TaskHubClient
 }
@@ -199,7 +198,7 @@ func (c *workflowEngineComponent) Get(ctx context.Context, req *workflows.GetReq
 	}
 }
 
-func (c *workflowEngineComponent) PauseWorkflow(ctx context.Context, req *workflows.PauseRequest) error {
+func (c *workflowEngineComponent) Pause(ctx context.Context, req *workflows.PauseRequest) error {
 	if req.InstanceID == "" {
 		return errors.New("a workflow instance ID is required")
 	}
@@ -212,7 +211,7 @@ func (c *workflowEngineComponent) PauseWorkflow(ctx context.Context, req *workfl
 	return nil
 }
 
-func (c *workflowEngineComponent) ResumeWorkflow(ctx context.Context, req *workflows.ResumeRequest) error {
+func (c *workflowEngineComponent) Resume(ctx context.Context, req *workflows.ResumeRequest) error {
 	if req.InstanceID == "" {
 		return errors.New("a workflow instance ID is required")
 	}
@@ -235,6 +234,10 @@ func (c *workflowEngineComponent) PurgeWorkflow(ctx context.Context, req *workfl
 	}
 
 	c.logger.Infof("purging workflow instance '%s'", req.InstanceID)
+	return nil
+}
+
+func (c *workflowEngineComponent) GetComponentMetadata() map[string]string {
 	return nil
 }
 


### PR DESCRIPTION
# Description

Pause and Resume for the built-in workflow engine component were misnamed and non reachable. This PR changes the functions to be correctly named.

The changes in this PR are being tested here: https://github.com/dapr/dotnet-sdk/pull/1080

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
