### PR TITLE
Adds scheduled, and manual test runner, for the Dapr Java + Python SDK test validation.

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -399,7 +399,7 @@ async function cmdTestSDK(github, issue, isFromPulls, command, args) {
         const testSDKPayload = {
             pull_head_ref: pull.data.head.sha,
             pull_head_repo: pull.data.head.repo.full_name,
-            command: command.replace(/\/$/, ''),
+            command: command.substring(1),
             args,
             issue: issue,
         }
@@ -408,7 +408,7 @@ async function cmdTestSDK(github, issue, isFromPulls, command, args) {
         await github.repos.createDispatchEvent({
             owner: issue.owner,
             repo: issue.repo,
-            event_type: command.replace(/\/$/, ''),
+            event_type: command.substring(1),
             client_payload: testSDKPayload,
         })
 

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -119,6 +119,17 @@ async function handleIssueCommentCreate({ github, context }) {
                 commandParts.join(' ')
             )
             break
+        case '/test-sdk-all':
+        case '/test-sdk-java':
+        case '/test-sdk-python':
+            await cmdTestSDK(
+                github,
+                issue,
+                isFromPulls,
+                command,
+                commandParts.join(' ')
+            )
+            break
         default:
             console.log(
                 `[handleIssueCommentCreate] command ${command} not found, exiting.`
@@ -356,6 +367,54 @@ async function cmdOkToPerfComponents(github, issue, isFromPulls, args) {
         console.log(
             `[cmdOkToPerfComponents] triggered perf test for ${JSON.stringify(
                 perfPayload
+            )}`
+        )
+    }
+}
+
+/**
+ * Trigger SDK test(s) for the pull request.
+ * @param {*} github GitHub object reference
+ * @param {*} issue GitHub issue object
+ * @param {boolean} isFromPulls is the workflow triggered by a pull request?
+ * @param {string} command which was used
+ */
+async function cmdTestSDK(github, issue, isFromPulls, command, args) {
+    if (!isFromPulls) {
+        console.log(
+            '[cmdTestSDK] only pull requests supported, skipping command execution.'
+        )
+        return
+    }
+
+    // Get pull request
+    const pull = await github.pulls.get({
+        owner: issue.owner,
+        repo: issue.repo,
+        pull_number: issue.number,
+    })
+
+    if (pull && pull.data) {
+        // Get commit id and repo from pull head
+        const testSDKPayload = {
+            pull_head_ref: pull.data.head.sha,
+            pull_head_repo: pull.data.head.repo.full_name,
+            command: command.replace(/\/$/, ''),
+            args,
+            issue: issue,
+        }
+
+        // Fire repository_dispatch event to trigger e2e test
+        await github.repos.createDispatchEvent({
+            owner: issue.owner,
+            repo: issue.repo,
+            event_type: command.replace(/\/$/, ''),
+            client_payload: testSDKPayload,
+        })
+
+        console.log(
+            `[cmdTestSDK] triggered SDK test for ${JSON.stringify(
+                testSDKPayload
             )}`
         )
     }

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -69,7 +69,7 @@ module.exports = async ({ github, context }) => {
 async function handleIssueCommentCreate({ github, context }) {
     const payload = context.payload
     const issue = context.issue
-    const username = context.actor
+    const username = context.actor.toLowerCase()
     const isFromPulls = !!payload.issue.pull_request
     const commentBody = payload.comment.body
 

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -19,16 +19,31 @@ on:
     - cron: "0 */12 * * 1-5"
     - cron: "30 0 * * 0,6"
   issue_comment:
-    types: [created, edited]
+    types: [created]
 env:
   GOOS: linux
   GOARCH: amd64
   GOPROXY: https://proxy.golang.org
-  DAPR_CLI_VER: 1.10.0
 
+# Job(s) can be triggered with the following commands:
+  # /test-sdk-all
+  # /test-sdk-python
+  # /test-sdk-java
+# Because of the way the GitHub handles string litterals, we need to use
+# `fromJSON` so that we only match on commands which are on their own line
+# with no space text.
+# Janky, but this is produces better UX for maintainers and prevents accidental
+# runs.
 jobs:
   python-sdk:
-    if: ${{ github.event_name == 'schedule' }} || contains(github.event.comment.body, '/test-sdk-python') || contains(github.event.comment.body, '/test-sdk-all')
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issue_comment' &&
+        (
+          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-all\r\n"')) ||
+          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-python\r\n"'))
+        )
+      )
     name: "Python SDK verification tests"
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +63,7 @@ jobs:
           repository: dapr/python-sdk
           path: python-sdk
       - name: Set up Dapr CLI
-        run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+        run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
       - name: Initialize Dapr runtime
         run: |
           dapr init
@@ -61,14 +76,6 @@ jobs:
         run: |
           docker stop dapr_placement
           ./dist/linux_amd64/release/placement --healthz-port 9091 &
-      - name: Install python-sdk kafka using docker-compose
-        run: |
-          docker-compose -f python-sdk/sdk-tests/deploy/local-test-kafka.yml up -d
-          docker ps
-      - name: Install Local mongo database using docker-compose
-        run: |
-          docker-compose -f python-sdk/sdk-tests/deploy/local-test-mongo.yml up -d
-          docker ps
       - name: Install dependencies
         run: |
           cd python-sdk
@@ -79,17 +86,19 @@ jobs:
           cd python-sdk || true
           tox -e examples
   java-sdk:
-    if: ${{ github.event_name == 'schedule' }} || contains(github.event.comment.body, '/test-sdk-java') || contains(github.event.comment.body, '/test-sdk-all')
-    name: "Java SDK verification tests jdk:${{ matrix.java }} sb:${{ matrix.spring-boot-version }} exp:${{ matrix.experimental }}"
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'issue_comment' &&
+        (
+          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-all\r\n"')) ||
+          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-java\r\n"'))
+        )
+      )
+    name: "Java SDK verification tests"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        java: [ 16 ]
-        spring-boot-version: [ 2.7.8 ]
-        experimental: [ false ]
     env:
-      JDK_VER: ${{ matrix.java }}
+      JDK_VER: 16
+      JAVA_SPRING_BOOT_VERSION: 2.7.8
     steps:
       - uses: actions/checkout@v3
       - name: Set up OpenJDK ${{ env.JDK_VER }}
@@ -108,7 +117,7 @@ jobs:
           repository: dapr/java-sdk
           path: java-sdk
       - name: Set up Dapr CLI
-        run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+        run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
       - name: Initialize Dapr runtime
         run: |
           dapr init
@@ -139,9 +148,9 @@ jobs:
         uses: codecov/codecov-action@v3.1.1
       - name: Install jars
         run: cd java-sdk && mvn install -q -B -DskipTests
-      - name: Integration tests using spring boot version ${{ matrix.spring-boot-version }}
+      - name: Integration tests using spring boot version ${{ env.JAVA_SPRING_BOOT_VERSION }}
         id: integration_tests
-        run: cd java-sdk && PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} mvn -B -f sdk-tests/pom.xml verify
+        run: cd java-sdk && PRODUCT_SPRING_BOOT_VERSION=${{ env.JAVA_SPRING_BOOT_VERSION }} mvn -B -f sdk-tests/pom.xml verify
       - name: Upload test report for sdk
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -11,6 +11,9 @@
 # limitations under the License.
 #
 
+## Required secrets:
+# - DAPR_BOT_TOKEN: Token for the Dapr bot
+
 name: dapr-test-sdk
 
 on:
@@ -38,7 +41,7 @@ jobs:
   python-sdk:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'issue_comment' &&
+      (github.event.issue.pull_request &&
         (
           contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-all\r\n"')) ||
           contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-python\r\n"'))
@@ -47,6 +50,19 @@ jobs:
     name: "Python SDK verification tests"
     runs-on: ubuntu-latest
     steps:
+      - name: Create PR comment
+        if: ${{ github.event.issue.pull_request }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          hide: true
+          hide_classify: OUTDATED
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            # Dapr SDK Python test
+
+            🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
       - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -85,10 +101,45 @@ jobs:
         run: |
           cd python-sdk || true
           tox -e examples
+      - name: Update PR comment for success
+        if: ${{ success() }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ✅ Python SDK tests passed
+      - name: Update PR comment for failure
+        if: ${{ failure() }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ✅ Python SDK tests failed
+
+            Please check the logs for details on the error.
+      - name: Update PR comment for cancellation
+        if: ${{ cancelled() }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ⚠️ Python SDK tests cancelled
+
+            The Action has been canceled
+
   java-sdk:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'issue_comment' &&
+      (github.event.issue.pull_request &&
         (
           contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-all\r\n"')) ||
           contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-java\r\n"'))
@@ -100,6 +151,19 @@ jobs:
       JDK_VER: 11
       JAVA_SPRING_BOOT_VERSION: 2.7.8
     steps:
+      - name: Create PR comment
+        if: ${{ github.event.issue.pull_request }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          hide: true
+          hide_classify: OUTDATED
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            # Dapr SDK Java test
+
+            🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
       - uses: actions/checkout@v3
       - name: Set up OpenJDK ${{ env.JDK_VER }}
         uses: actions/setup-java@v3
@@ -169,3 +233,37 @@ jobs:
         with:
           name: surefire-report-sdk-tests
           path: java-sdk/sdk-tests/target/surefire-reports
+      - name: Update PR comment for success
+        if: ${{ success() }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ✅ Java SDK tests passed
+      - name: Update PR comment for failure
+        if: ${{ failure() }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ✅ Java SDK tests failed
+
+            Please check the logs for details on the error.
+      - name: Update PR comment for cancellation
+        if: ${{ cancelled() }}
+        uses: artursouza/sticky-pull-request-comment@v2.2.0
+        with:
+          header: ${{ github.run_id }}
+          number: ${{ github.event.issue.number }}
+          append: true
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          message: |
+            ## ⚠️ Java SDK tests cancelled
+
+            The Action has been canceled

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -33,19 +33,14 @@ env:
   # /test-sdk-all
   # /test-sdk-python
   # /test-sdk-java
-# Because of the way the GitHub handles string litterals, we need to use
-# `fromJSON` so that we only match on commands which are on their own line
-# with no space text.
-# Janky, but this is produces better UX for maintainers and prevents accidental
-# runs.
 jobs:
   python-sdk:
     if: |
       github.event_name == 'schedule' ||
       ( github.event_name == 'repository_dispatch' &&
         (
-          github.event_type == 'test-sdk-all' ||
-          github.event_type == 'test-sdk-python'
+          github.event.action == 'test-sdk-all' ||
+          github.event.action == 'test-sdk-python'
         )
       )
     name: "Python SDK verification tests"
@@ -64,7 +59,7 @@ jobs:
           github-token: ${{secrets.DAPR_BOT_TOKEN}}
           script: |
             const testPayload = context.payload.client_payload;
-            if testPayload {
+            if (testPayload) {
               var fs = require('fs');
               // Set environment variables
               fs.appendFileSync(process.env.GITHUB_ENV,
@@ -168,8 +163,8 @@ jobs:
       github.event_name == 'schedule' ||
       ( github.event_name == 'repository_dispatch' &&
         (
-          github.event_type == 'test-sdk-all' ||
-          github.event_type == 'test-sdk-java'
+          github.event.action == 'test-sdk-all' ||
+          github.event.action == 'test-sdk-java'
         )
       )
     name: "Java SDK verification tests"
@@ -191,7 +186,7 @@ jobs:
           github-token: ${{secrets.DAPR_BOT_TOKEN}}
           script: |
             const testPayload = context.payload.client_payload;
-            if testPayload {
+            if (testPayload) {
               var fs = require('fs');
               // Set environment variables
               fs.appendFileSync(process.env.GITHUB_ENV,

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -97,7 +97,7 @@ jobs:
     name: "Java SDK verification tests"
     runs-on: ubuntu-latest
     env:
-      JDK_VER: 16
+      JDK_VER: 11
       JAVA_SPRING_BOOT_VERSION: 2.7.8
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -27,6 +27,57 @@ env:
   DAPR_CLI_VER: 1.10.0
 
 jobs:
+  python-sdk:
+    if: ${{ github.event_name == 'schedule' }} || contains(github.event.comment.body, '/test-sdk-python') || contains(github.event.comment.body, '/test-sdk-all')
+    name: "Python SDK verification tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: "Set up Go"
+        id: setup-go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+      - name: Checkout p repo to run tests.
+        uses: actions/checkout@v3
+        with:
+          repository: dapr/python-sdk
+          path: python-sdk
+      - name: Set up Dapr CLI
+        run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+      - name: Initialize Dapr runtime
+        run: |
+          dapr init
+      - name: Build and override daprd with HEAD.
+        run: |
+          make
+          mkdir -p $HOME/.dapr/bin/
+          cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
+      - name: Override placement service.
+        run: |
+          docker stop dapr_placement
+          ./dist/linux_amd64/release/placement --healthz-port 9091 &
+      - name: Install python-sdk kafka using docker-compose
+        run: |
+          docker-compose -f ./python-sdk/sdk-tests/deploy/local-test-kafka.yml up -d
+          docker ps
+      - name: Install Local mongo database using docker-compose
+        run: |
+          docker-compose -f ./python-sdk/sdk-tests/deploy/local-test-mongo.yml up -d
+          docker ps
+      - name: Install dependencies
+        run: |
+          cd python-sdk
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine tox
+      - name: Check Python Examples
+        run: |
+          cd python-sdk || true
+          tox -e examples
   java-sdk:
     if: ${{ github.event_name == 'schedule' }} || contains(github.event.comment.body, '/test-sdk-java') || contains(github.event.comment.body, '/test-sdk-all')
     name: "Java SDK verification tests jdk:${{ matrix.java }} sb:${{ matrix.spring-boot-version }} exp:${{ matrix.experimental }}"
@@ -34,96 +85,82 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java: [ 11, 13, 15, 16 ]
         java: [ 16 ]
         spring-boot-version: [ 2.7.8 ]
         experimental: [ false ]
-        include:
-        - java: 11
-          spring-boot-version: 2.6.14
-          experimental: false
-        - java: 11
-          spring-boot-version: 2.5.7
-          experimental: false
-        - java: 11
-          spring-boot-version: 2.4.0
-          experimental: false
-        - java: 11
-          spring-boot-version: 2.3.6.RELEASE
-          experimental: false
     env:
       JDK_VER: ${{ matrix.java }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up OpenJDK ${{ env.JDK_VER }}
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'adopt'
-        java-version: ${{ env.JDK_VER }}
-    - name: "Set up Go"
-      id: setup-go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: "go.mod"
-    - name: Checkout java-sdk repo to run tests.
-      uses: actions/checkout@v3
-      with:
-        repository: dapr/java-sdk
-        path: java-sdk
-    - name: Set up Dapr CLI
-      run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
-    - name: Initialize Dapr runtime
-      run: |
-        dapr init
-    - name: Build and override daprd with HEAD.
-      run: |
-        make
-        mkdir -p $HOME/.dapr/bin/
-        cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
-    - name: Override placement service.
-      run: |
-        docker stop dapr_placement
-        ./dist/linux_amd64/release/placement &
-    - name: Install java-sdk kafka using docker-compose
-      run: |
-        docker-compose -f ./java-sdk/sdk-tests/deploy/local-test-kafka.yml up -d
-        docker ps
-    - name: Install Local mongo database using docker-compose
-      run: |
-        docker-compose -f ./java-sdk/sdk-tests/deploy/local-test-mongo.yml up -d
-        docker ps
-    - name: Clean up files
-      run: cd java-sdk && mvn clean -B
-    - name: Build sdk
-      run: cd java-sdk && mvn compile -B -q
-    - name: Unit tests
-      run: cd java-sdk && mvn -B test -q
-    - name: Codecov
-      uses: codecov/codecov-action@v3.1.1
-    - name: Install jars
-      run: cd java-sdk && mvn install -q -B -DskipTests
-    - name: Integration tests using spring boot version ${{ matrix.spring-boot-version }}
-      id: integration_tests
-      run: cd java-sdk && PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} mvn -B -f sdk-tests/pom.xml verify
-    - name: Upload test report for sdk
-      uses: actions/upload-artifact@master
-      with:
-        name: report-dapr-java-sdk
-        path: java-sdk/sdk/target/jacoco-report/
-    - name: Upload test report for sdk-actors
-      uses: actions/upload-artifact@master
-      with:
-        name: report-dapr-java-sdk-actors
-        path: java-sdk/sdk-actors/target/jacoco-report/
-    - name: Upload failsafe test report for sdk-tests on failure
-      if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@master
-      with:
-        name: failsafe-report-sdk-tests
-        path: java-sdk/sdk-tests/target/failsafe-reports
-    - name: Upload surefire test report for sdk-tests on failure
-      if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
-      uses: actions/upload-artifact@master
-      with:
-        name: surefire-report-sdk-tests
-        path: java-sdk/sdk-tests/target/surefire-reports
+      - uses: actions/checkout@v3
+      - name: Set up OpenJDK ${{ env.JDK_VER }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: ${{ env.JDK_VER }}
+      - name: "Set up Go"
+        id: setup-go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+      - name: Checkout java-sdk repo to run tests.
+        uses: actions/checkout@v3
+        with:
+          repository: dapr/java-sdk
+          path: java-sdk
+      - name: Set up Dapr CLI
+        run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+      - name: Initialize Dapr runtime
+        run: |
+          dapr init
+      - name: Build and override daprd with HEAD.
+        run: |
+          make
+          mkdir -p $HOME/.dapr/bin/
+          cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
+      - name: Override placement service.
+        run: |
+          docker stop dapr_placement
+          ./dist/linux_amd64/release/placement &
+      - name: Install java-sdk kafka using docker-compose
+        run: |
+          docker-compose -f ./java-sdk/sdk-tests/deploy/local-test-kafka.yml up -d
+          docker ps
+      - name: Install Local mongo database using docker-compose
+        run: |
+          docker-compose -f ./java-sdk/sdk-tests/deploy/local-test-mongo.yml up -d
+          docker ps
+      - name: Clean up files
+        run: cd java-sdk && mvn clean -B
+      - name: Build sdk
+        run: cd java-sdk && mvn compile -B -q
+      - name: Unit tests
+        run: cd java-sdk && mvn -B test -q
+      - name: Codecov
+        uses: codecov/codecov-action@v3.1.1
+      - name: Install jars
+        run: cd java-sdk && mvn install -q -B -DskipTests
+      - name: Integration tests using spring boot version ${{ matrix.spring-boot-version }}
+        id: integration_tests
+        run: cd java-sdk && PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} mvn -B -f sdk-tests/pom.xml verify
+      - name: Upload test report for sdk
+        uses: actions/upload-artifact@master
+        with:
+          name: report-dapr-java-sdk
+          path: java-sdk/sdk/target/jacoco-report/
+      - name: Upload test report for sdk-actors
+        uses: actions/upload-artifact@master
+        with:
+          name: report-dapr-java-sdk-actors
+          path: java-sdk/sdk-actors/target/jacoco-report/
+      - name: Upload failsafe test report for sdk-tests on failure
+        if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: failsafe-report-sdk-tests
+          path: java-sdk/sdk-tests/target/failsafe-reports
+      - name: Upload surefire test report for sdk-tests on failure
+        if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: surefire-report-sdk-tests
+          path: java-sdk/sdk-tests/target/surefire-reports

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -142,8 +142,6 @@ jobs:
         run: cd java-sdk && mvn clean -B
       - name: Build sdk
         run: cd java-sdk && mvn compile -B -q
-      - name: Unit tests
-        run: cd java-sdk && mvn -B test -q
       - name: Install jars
         run: cd java-sdk && mvn install -q -B -DskipTests
       - name: Integration tests using spring boot version ${{ env.JAVA_SPRING_BOOT_VERSION }}

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -1,0 +1,129 @@
+#
+# Copyright 2023 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: dapr-test-sdk
+
+on:
+  # Run every 12 hours on weekdays, and every 24 hours on weekends.
+  schedule:
+    - cron: "0 */12 * * 1-5"
+    - cron: "30 0 * * 0,6"
+  issue_comment:
+    types: [created, edited]
+env:
+  GOOS: linux
+  GOARCH: amd64
+  GOPROXY: https://proxy.golang.org
+  DAPR_CLI_VER: 1.10.0
+
+jobs:
+  java-sdk:
+    if: ${{ github.event_name == 'schedule' }} || contains(github.event.comment.body, '/test-sdk-java') || contains(github.event.comment.body, '/test-sdk-all')
+    name: "Java SDK verification tests jdk:${{ matrix.java }} sb:${{ matrix.spring-boot-version }} exp:${{ matrix.experimental }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        java: [ 11, 13, 15, 16 ]
+        java: [ 16 ]
+        spring-boot-version: [ 2.7.8 ]
+        experimental: [ false ]
+        include:
+        - java: 11
+          spring-boot-version: 2.6.14
+          experimental: false
+        - java: 11
+          spring-boot-version: 2.5.7
+          experimental: false
+        - java: 11
+          spring-boot-version: 2.4.0
+          experimental: false
+        - java: 11
+          spring-boot-version: 2.3.6.RELEASE
+          experimental: false
+    env:
+      JDK_VER: ${{ matrix.java }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up OpenJDK ${{ env.JDK_VER }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: ${{ env.JDK_VER }}
+    - name: "Set up Go"
+      id: setup-go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: "go.mod"
+    - name: Checkout java-sdk repo to run tests.
+      uses: actions/checkout@v3
+      with:
+        repository: dapr/java-sdk
+        path: java-sdk
+    - name: Set up Dapr CLI
+      run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+    - name: Initialize Dapr runtime
+      run: |
+        dapr init
+    - name: Build and override daprd with HEAD.
+      run: |
+        make
+        mkdir -p $HOME/.dapr/bin/
+        cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
+    - name: Override placement service.
+      run: |
+        docker stop dapr_placement
+        ./dist/linux_amd64/release/placement &
+    - name: Install java-sdk kafka using docker-compose
+      run: |
+        docker-compose -f ./java-sdk/sdk-tests/deploy/local-test-kafka.yml up -d
+        docker ps
+    - name: Install Local mongo database using docker-compose
+      run: |
+        docker-compose -f ./java-sdk/sdk-tests/deploy/local-test-mongo.yml up -d
+        docker ps
+    - name: Clean up files
+      run: cd java-sdk && mvn clean -B
+    - name: Build sdk
+      run: cd java-sdk && mvn compile -B -q
+    - name: Unit tests
+      run: cd java-sdk && mvn -B test -q
+    - name: Codecov
+      uses: codecov/codecov-action@v3.1.1
+    - name: Install jars
+      run: cd java-sdk && mvn install -q -B -DskipTests
+    - name: Integration tests using spring boot version ${{ matrix.spring-boot-version }}
+      id: integration_tests
+      run: cd java-sdk && PRODUCT_SPRING_BOOT_VERSION=${{ matrix.spring-boot-version }} mvn -B -f sdk-tests/pom.xml verify
+    - name: Upload test report for sdk
+      uses: actions/upload-artifact@master
+      with:
+        name: report-dapr-java-sdk
+        path: java-sdk/sdk/target/jacoco-report/
+    - name: Upload test report for sdk-actors
+      uses: actions/upload-artifact@master
+      with:
+        name: report-dapr-java-sdk-actors
+        path: java-sdk/sdk-actors/target/jacoco-report/
+    - name: Upload failsafe test report for sdk-tests on failure
+      if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
+      uses: actions/upload-artifact@master
+      with:
+        name: failsafe-report-sdk-tests
+        path: java-sdk/sdk-tests/target/failsafe-reports
+    - name: Upload surefire test report for sdk-tests on failure
+      if: ${{ failure() && steps.integration_tests.conclusion == 'failure' }}
+      uses: actions/upload-artifact@master
+      with:
+        name: surefire-report-sdk-tests
+        path: java-sdk/sdk-tests/target/surefire-reports

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -63,11 +63,11 @@ jobs:
           ./dist/linux_amd64/release/placement --healthz-port 9091 &
       - name: Install python-sdk kafka using docker-compose
         run: |
-          docker-compose -f ./python-sdk/sdk-tests/deploy/local-test-kafka.yml up -d
+          docker-compose -f python-sdk/sdk-tests/deploy/local-test-kafka.yml up -d
           docker ps
       - name: Install Local mongo database using docker-compose
         run: |
-          docker-compose -f ./python-sdk/sdk-tests/deploy/local-test-mongo.yml up -d
+          docker-compose -f python-sdk/sdk-tests/deploy/local-test-mongo.yml up -d
           docker ps
       - name: Install dependencies
         run: |

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -80,14 +80,15 @@ jobs:
           path: python-sdk
       - name: Set up Dapr CLI
         run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
+      - name: Initialize Dapr runtime
+        run: |
+          dapr unintall --all
+          dapr init
       - name: Build and override daprd with HEAD.
         run: |
           make
           mkdir -p $HOME/.dapr/bin/
           cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
-      - name: Initialize Dapr runtime
-        run: |
-          dapr init
       - name: Override placement service.
         run: |
           docker stop dapr_placement
@@ -182,14 +183,15 @@ jobs:
           path: java-sdk
       - name: Set up Dapr CLI
         run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
+      - name: Initialize Dapr runtime
+        run: |
+          dapr unintall --all
+          dapr init
       - name: Build and override daprd with HEAD.
         run: |
           make
           mkdir -p $HOME/.dapr/bin/
           cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
-      - name: Initialize Dapr runtime
-        run: |
-          dapr init
       - name: Override placement service.
         run: |
           docker stop dapr_placement

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -144,8 +144,6 @@ jobs:
         run: cd java-sdk && mvn compile -B -q
       - name: Unit tests
         run: cd java-sdk && mvn -B test -q
-      - name: Codecov
-        uses: codecov/codecov-action@v3.1.1
       - name: Install jars
         run: cd java-sdk && mvn install -q -B -DskipTests
       - name: Integration tests using spring boot version ${{ env.JAVA_SPRING_BOOT_VERSION }}

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -64,14 +64,14 @@ jobs:
           path: python-sdk
       - name: Set up Dapr CLI
         run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
-      - name: Initialize Dapr runtime
-        run: |
-          dapr init
       - name: Build and override daprd with HEAD.
         run: |
           make
           mkdir -p $HOME/.dapr/bin/
           cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
+      - name: Initialize Dapr runtime
+        run: |
+          dapr init
       - name: Override placement service.
         run: |
           docker stop dapr_placement
@@ -118,14 +118,14 @@ jobs:
           path: java-sdk
       - name: Set up Dapr CLI
         run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
-      - name: Initialize Dapr runtime
-        run: |
-          dapr init
       - name: Build and override daprd with HEAD.
         run: |
           make
           mkdir -p $HOME/.dapr/bin/
           cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
+      - name: Initialize Dapr runtime
+        run: |
+          dapr init
       - name: Override placement service.
         run: |
           docker stop dapr_placement

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -142,7 +142,7 @@ jobs:
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
-            ## ✅ Python SDK tests failed
+            ## ❌ Python SDK tests failed
 
             Please check the logs for details on the error.
       - name: Update PR comment for cancellation
@@ -299,7 +299,7 @@ jobs:
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
-            ## ✅ Java SDK tests failed
+            ## ❌ Java SDK tests failed
 
             Please check the logs for details on the error.
       - name: Update PR comment for cancellation

--- a/.github/workflows/dapr-test-sdk.yml
+++ b/.github/workflows/dapr-test-sdk.yml
@@ -21,8 +21,9 @@ on:
   schedule:
     - cron: "0 */12 * * 1-5"
     - cron: "30 0 * * 0,6"
-  issue_comment:
-    types: [created]
+  # Dispatch on external events
+  repository_dispatch:
+    types: [test-sdk-all, test-sdk-python, test-sdk-java]
 env:
   GOOS: linux
   GOARCH: amd64
@@ -41,21 +42,43 @@ jobs:
   python-sdk:
     if: |
       github.event_name == 'schedule' ||
-      (github.event.issue.pull_request &&
+      ( github.event_name == 'repository_dispatch' &&
         (
-          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-all\r\n"')) ||
-          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-python\r\n"'))
+          github.event_type == 'test-sdk-all' ||
+          github.event_type == 'test-sdk-python'
         )
       )
     name: "Python SDK verification tests"
     runs-on: ubuntu-latest
     steps:
+      - name: Set up for scheduled test
+        if: github.event_name != 'repository_dispatch'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
+        shell: bash
+      - name: Parse test payload
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/github-script@v6.2.0
+        with:
+          github-token: ${{secrets.DAPR_BOT_TOKEN}}
+          script: |
+            const testPayload = context.payload.client_payload;
+            if testPayload {
+              var fs = require('fs');
+              // Set environment variables
+              fs.appendFileSync(process.env.GITHUB_ENV,
+                `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
+                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
+                `PR_NUMBER=${testPayload.issue.number}`
+              );
+            }
       - name: Create PR comment
-        if: ${{ github.event.issue.pull_request }}
+        if: env.PR_NUMBER != ''
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           hide: true
           hide_classify: OUTDATED
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
@@ -63,6 +86,9 @@ jobs:
             # Dapr SDK Python test
 
             🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+
+            Commit ref: ${{ env.CHECKOUT_REF }}
+
       - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -82,7 +108,7 @@ jobs:
         run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
       - name: Initialize Dapr runtime
         run: |
-          dapr unintall --all
+          dapr uninstall --all
           dapr init
       - name: Build and override daprd with HEAD.
         run: |
@@ -107,7 +133,7 @@ jobs:
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
@@ -117,7 +143,7 @@ jobs:
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
@@ -129,7 +155,7 @@ jobs:
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
@@ -140,10 +166,10 @@ jobs:
   java-sdk:
     if: |
       github.event_name == 'schedule' ||
-      (github.event.issue.pull_request &&
+      ( github.event_name == 'repository_dispatch' &&
         (
-          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-all\r\n"')) ||
-          contains(format(fromJSON('"\r\n{0}\r\n"'), github.event.comment.body), fromJSON('"\r\n/test-sdk-java\r\n"'))
+          github.event_type == 'test-sdk-all' ||
+          github.event_type == 'test-sdk-java'
         )
       )
     name: "Java SDK verification tests"
@@ -152,12 +178,34 @@ jobs:
       JDK_VER: 11
       JAVA_SPRING_BOOT_VERSION: 2.7.8
     steps:
+      - name: Set up for scheduled test
+        if: github.event_name != 'repository_dispatch'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
+        shell: bash
+      - name: Parse test payload
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/github-script@v6.2.0
+        with:
+          github-token: ${{secrets.DAPR_BOT_TOKEN}}
+          script: |
+            const testPayload = context.payload.client_payload;
+            if testPayload {
+              var fs = require('fs');
+              // Set environment variables
+              fs.appendFileSync(process.env.GITHUB_ENV,
+                `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
+                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
+                `PR_NUMBER=${testPayload.issue.number}`
+              );
+            }
       - name: Create PR comment
-        if: ${{ github.event.issue.pull_request }}
+        if: env.PR_NUMBER != ''
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           hide: true
           hide_classify: OUTDATED
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
@@ -165,6 +213,8 @@ jobs:
             # Dapr SDK Java test
 
             🔗 **[Link to Action run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+
+            Commit ref: ${{ env.CHECKOUT_REF }}
       - uses: actions/checkout@v3
       - name: Set up OpenJDK ${{ env.JDK_VER }}
         uses: actions/setup-java@v3
@@ -185,7 +235,7 @@ jobs:
         run: wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s
       - name: Initialize Dapr runtime
         run: |
-          dapr unintall --all
+          dapr uninstall --all
           dapr init
       - name: Build and override daprd with HEAD.
         run: |
@@ -240,7 +290,7 @@ jobs:
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
@@ -250,7 +300,7 @@ jobs:
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |
@@ -262,7 +312,7 @@ jobs:
         uses: artursouza/sticky-pull-request-comment@v2.2.0
         with:
           header: ${{ github.run_id }}
-          number: ${{ github.event.issue.number }}
+          number: ${{ env.PR_NUMBER }}
           append: true
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           message: |


### PR DESCRIPTION
Part of #5797.

Adds GitHub action workflow for running SDK tests against Dapr HEAD. These are run on an infrequent schedule, as well as on pull requests when someone comments `/test-sdk-all`.

Tests  the Java SDK, which can also be triggered with `/test-sdk-java`.

Tests  the Python SDK, which can also be triggered with `/test-sdk-python`.

Not fully tested e2e just because of how GH actions work, but hopefully should be close to working.

/cc @artursouza 