### PR TITLE
add an output modifier for get bulk secret api

### DIFF
--- a/pkg/http/api_secrets.go
+++ b/pkg/http/api_secrets.go
@@ -76,7 +76,8 @@ func (a *api) onBulkGetSecretHandler() fasthttp.RequestHandler {
 					return nil, nil
 				}
 
-				secrets := map[string]map[string]string{}
+				var secrets map[string]map[string]string
+				secrets = make(map[string]map[string]string, len(out.Data))
 				// Return just the secrets as map
 				for secretKey, secret := range out.Data {
 					secrets[secretKey] = secret.Secrets

--- a/pkg/http/api_secrets.go
+++ b/pkg/http/api_secrets.go
@@ -70,6 +70,20 @@ func (a *api) onBulkGetSecretHandler() fasthttp.RequestHandler {
 				in.Metadata = getMetadataFromRequest(reqCtx)
 				return in, nil
 			},
+			OutModifier: func(out *runtimev1pb.GetBulkSecretResponse) (any, error) {
+				// If the data is nil, return nil
+				if out == nil || out.Data == nil {
+					return nil, nil
+				}
+
+				secrets := map[string]map[string]string{}
+				// Return just the secrets as map
+				for secretKey, secret := range out.Data {
+					secrets[secretKey] = secret.Secrets
+				}
+
+				return secrets, nil
+			},
 		},
 	)
 }

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -5190,11 +5190,17 @@ func TestV1SecretEndpoints(t *testing.T) {
 	})
 
 	t.Run("Get Bulk secret - Good Key default allow", func(t *testing.T) {
+		// The interface{} use here is due to JSONBody usage
+		expectedOutput := map[string]interface{}{
+			"good-key": map[string]interface{}{"good-key": "life is good"},
+		}
 		apiPath := fmt.Sprintf("v1.0/secrets/%s/bulk", storeName)
 		// act
 		resp := fakeServer.DoRequest("GET", apiPath, nil, nil)
 		// assert
 		assert.Equal(t, 200, resp.StatusCode, "reading secrets should succeed")
+		body := resp.JSONBody
+		assert.Equal(t, expectedOutput, body, "bulk secret response should be same as expected")
 	})
 
 	t.Run("Get secret - retries on initial failure with resiliency", func(t *testing.T) {

--- a/tests/apps/secretapp/app.go
+++ b/tests/apps/secretapp/app.go
@@ -66,7 +66,7 @@ func get(key, store string) (*map[string]string, int, error) {
 		return nil, http.StatusInternalServerError, err
 	}
 
-	log.Printf("Fetching state from %s", url)
+	log.Printf("Fetching secret from %s", url)
 	// url is created from user input, it is OK since this is a test app only and will not run in prod.
 	/* #nosec */
 	res, err := httpClient.Get(url)
@@ -87,23 +87,23 @@ func get(key, store string) (*map[string]string, int, error) {
 
 	log.Printf("Found secret for key %s: %s", key, body)
 
-	state := map[string]string{}
+	secret := map[string]string{}
 	if len(body) == 0 {
 		return nil, http.StatusOK, nil
 	}
 
 	// a key not found in Dapr will return 200 but an empty response.
-	err = json.Unmarshal(body, &state)
+	err = json.Unmarshal(body, &secret)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("could not parse value for key %s from Dapr: %s", key, err.Error())
 	}
 
-	return &state, http.StatusOK, nil
+	return &secret, http.StatusOK, nil
 }
 
 func getAll(secrets []daprSecret) ([]daprSecret, int, error) {
 	statusCode := http.StatusOK
-	log.Printf("Processing get request for %d states.", len(secrets))
+	log.Printf("Processing get request for %d secrets.", len(secrets))
 
 	output := make([]daprSecret, 0, len(secrets))
 	for _, secret := range secrets {
@@ -124,6 +124,60 @@ func getAll(secrets []daprSecret) ([]daprSecret, int, error) {
 	log.Printf("Result for get request for %d secrets: %v", len(secrets), output)
 
 	return output, statusCode, nil
+}
+
+func getBulk(secrets []daprSecret) ([]daprSecret, int, error) {
+	if len(secrets) == 0 {
+		return nil, http.StatusBadRequest, fmt.Errorf("no secret store specified")
+	}
+	store := secrets[0].Store
+	log.Println("Processing get bulk request for secrerts.")
+
+	output := []daprSecret{}
+	url, err := createSecretURL("bulk", store)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
+	log.Printf("Fetching secret from %s", url)
+	// url is created from user input, it is OK since this is a test app only and will not run in prod.
+	/* #nosec */
+	res, err := httpClient.Get(url)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("bulk get secret request faild %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("reading body of bulk get secret response failed %w", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		log.Printf("Non 200 StatusCode: %d\n", res.StatusCode)
+
+		return nil, res.StatusCode, fmt.Errorf("got non-200 response for bulk get secret request from Dapr: %s", body)
+	}
+
+	resMap := map[string]map[string]string{}
+	if len(body) == 0 {
+		return nil, http.StatusOK, nil
+	}
+
+	// a key not found in Dapr will return 200 but an empty response.
+	err = json.Unmarshal(body, &resMap)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("could not parse response for bulk get secret request from Dapr: %w", err)
+	}
+
+	for key, value := range resMap {
+		value := value
+		output = append(output, daprSecret{
+			Key:   key,
+			Value: &value,
+			Store: store,
+		})
+	}
+	return output, http.StatusOK, nil
 }
 
 // handles all APIs
@@ -151,6 +205,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	cmd := mux.Vars(r)["command"]
 	switch cmd {
+	case "bulk":
+		// Only use req.Secrets for store name for bulk get
+		// Only req.Secrets[0] is used for key
+		secrets, statusCode, err = getBulk(req.Secrets)
+		res.Secrets = secrets
+		if statusCode != http.StatusOK {
+			res.Message = err.Error()
+		}
 	case "get":
 		secrets, statusCode, err = getAll(req.Secrets)
 		res.Secrets = secrets

--- a/tests/config/dapr_tests_cluster_role_binding.yaml
+++ b/tests/config/dapr_tests_cluster_role_binding.yaml
@@ -21,5 +21,5 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get"]
-  
+  verbs: ["get", "list"]
+

--- a/tests/e2e/secretapp/secretapp_test.go
+++ b/tests/e2e/secretapp/secretapp_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/e2e/secretapp/secretapp_test.go
+++ b/tests/e2e/secretapp/secretapp_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,6 +39,12 @@ const (
 	nonExistentSecret = "nonexistentsecret"
 	emptySecret       = "emptysecret"
 	testCase1Value    = "admin"
+	redisSecret       = "redissecret"
+)
+
+var (
+	redisSecretValue = map[string]string{"host": "dapr-redis-master:6379"}
+	daprSecretValue  = map[string]string{"username": "admin"}
 )
 
 // daprSecret represents a secret in Dapr.
@@ -49,6 +52,18 @@ type daprSecret struct {
 	Key   string             `json:"key,omitempty"`
 	Value *map[string]string `json:"value,omitempty"`
 	Store string             `json:"store,omitempty"`
+}
+
+// Stringer interface impl for test logging.
+func (d daprSecret) String() string {
+	s := "key: " + d.Key + ", store: " + d.Store + ", value: {"
+	if d.Value != nil {
+		for k, v := range *d.Value {
+			s += k + ": " + v + ", "
+		}
+	}
+	s += "}"
+	return s
 }
 
 // requestResponse represents a request or response for the APIs in the app.
@@ -64,6 +79,7 @@ type testCase struct {
 	errorExpected    bool
 	statusCode       int
 	errorString      string
+	isBulk           bool
 }
 
 func generateDaprSecret(kv utils.SimpleKeyValue, store string) daprSecret {
@@ -76,10 +92,17 @@ func generateDaprSecret(kv utils.SimpleKeyValue, store string) daprSecret {
 		return daprSecret{key, nil, ""}
 	}
 
-	secret := fmt.Sprintf("%v", kv.Value)
 	value := map[string]string{}
-	if secret != "" {
-		value["username"] = secret
+	switch val := kv.Value.(type) {
+	case map[string]string:
+		value = val
+	case string:
+		if val != "" {
+			value["username"] = val
+		}
+	default:
+		// This should not happen in tests
+		panic(fmt.Sprintf("unexpected type %v", reflect.TypeOf(val)))
 	}
 	return daprSecret{key, &value, store}
 }
@@ -122,54 +145,74 @@ func generateTestCases() []testCase {
 			false,
 			200,
 			"", // no error
+			false,
 		},
 		{
 			"empty secret",
-			newRequest(secretStore, utils.SimpleKeyValue{emptySecret, ""}),
-			newResponse(secretStore, utils.SimpleKeyValue{emptySecret, ""}),
+			newRequest(secretStore, utils.SimpleKeyValue{Key: emptySecret, Value: ""}),
+			newResponse(secretStore, utils.SimpleKeyValue{Key: emptySecret, Value: ""}),
 			false,
 			200,
 			"", // no error
+			false,
 		},
 		{
 			"allowed secret",
-			newRequest(secretStore, utils.SimpleKeyValue{allowedSecret, testCase1Value}),
-			newResponse(secretStore, utils.SimpleKeyValue{allowedSecret, testCase1Value}),
+			newRequest(secretStore, utils.SimpleKeyValue{Key: allowedSecret, Value: testCase1Value}),
+			newResponse(secretStore, utils.SimpleKeyValue{Key: allowedSecret, Value: testCase1Value}),
 			false,
 			200,
 			"", // no error
+			false,
 		},
 		{
 			"unallowed secret",
-			newRequest(secretStore, utils.SimpleKeyValue{unallowedSecret, ""}),
-			newResponse("", utils.SimpleKeyValue{unallowedSecret, ""}),
+			newRequest(secretStore, utils.SimpleKeyValue{Key: unallowedSecret, Value: ""}),
+			newResponse("", utils.SimpleKeyValue{Key: unallowedSecret, Value: ""}),
 			true,
 			403,
 			"ERR_PERMISSION_DENIED",
+			false,
 		},
 		{
 			"nonexistent secret",
-			newRequest(secretStore, utils.SimpleKeyValue{nonExistentSecret, ""}),
-			newResponse("", utils.SimpleKeyValue{nonExistentSecret, ""}),
+			newRequest(secretStore, utils.SimpleKeyValue{Key: nonExistentSecret, Value: ""}),
+			newResponse("", utils.SimpleKeyValue{Key: nonExistentSecret, Value: ""}),
 			true,
 			500,
 			"ERR_SECRET_GET",
+			false,
 		},
 		{
 			"secret from nonexistent secret store",
-			newRequest(nonexistentStore, utils.SimpleKeyValue{allowedSecret, ""}),
-			newResponse("", utils.SimpleKeyValue{allowedSecret, ""}),
+			newRequest(nonexistentStore, utils.SimpleKeyValue{Key: allowedSecret, Value: ""}),
+			newResponse("", utils.SimpleKeyValue{Key: allowedSecret, Value: ""}),
 			true,
 			401,
 			"ERR_SECRET_STORE_NOT_FOUND",
+			false,
 		},
 		{
 			"secret from the disabled secret store",
-			newRequest(badSecretStore, utils.SimpleKeyValue{allowedSecret, ""}),
-			newResponse("", utils.SimpleKeyValue{allowedSecret, ""}),
+			newRequest(badSecretStore, utils.SimpleKeyValue{Key: allowedSecret, Value: ""}),
+			newResponse("", utils.SimpleKeyValue{Key: allowedSecret, Value: ""}),
 			true,
 			401,
 			"ERR_SECRET_STORE_NOT_FOUND",
+			false,
+		},
+		{
+			"bulk get secret",
+			// Request does not matter, only the secretStore from request matters.
+			newRequest(secretStore, utils.SimpleKeyValue{Key: allowedSecret, Value: testCase1Value}),
+			newResponse(secretStore,
+				utils.SimpleKeyValue{Key: allowedSecret, Value: daprSecretValue},
+				utils.SimpleKeyValue{Key: emptySecret, Value: ""},
+				utils.SimpleKeyValue{Key: redisSecret, Value: redisSecretValue}),
+			false,
+			200,
+			"",   // no error
+			true, // bulk get
 		},
 	}
 }
@@ -183,6 +226,7 @@ func generateTestCasesForDisabledSecretStore() []testCase {
 			true,
 			500,
 			"ERR_SECRET_STORES_NOT_CONFIGURED",
+			false,
 		},
 	}
 }
@@ -253,7 +297,14 @@ func TestSecretApp(t *testing.T) {
 				// setup
 				body, err := json.Marshal(tc.request)
 				require.NoError(t, err)
-				url := fmt.Sprintf("%s/test/get", externalURL)
+				var url string
+				if !tc.isBulk {
+					t.Log("Single test")
+					url = fmt.Sprintf("%s/test/get", externalURL)
+				} else {
+					t.Log("Bulk test")
+					url = fmt.Sprintf("%s/test/bulk", externalURL)
+				}
 
 				// act
 				resp, statusCode, err := utils.HTTPPostWithStatus(url, body)
@@ -266,7 +317,10 @@ func TestSecretApp(t *testing.T) {
 					err = json.Unmarshal(resp, &appResp)
 					require.NoError(t, err, "Failed to unmarshal. Response (%d) was: %s", statusCode, string(resp))
 
-					require.True(t, reflect.DeepEqual(tc.expectedResponse, appResp))
+					t.Log("App Response", appResp)
+					t.Log("Expected Response", tc.expectedResponse)
+					// For bulk get order does not matter
+					require.ElementsMatch(t, tc.expectedResponse.Secrets, appResp.Secrets, "Expected response to match")
 					require.Equal(t, tc.statusCode, statusCode, "Expected statusCode to be equal")
 				} else {
 					require.Contains(t, string(resp), tc.errorString, "Expected error string to match")


### PR DESCRIPTION
# Description

For the HTTP Get Bulk Secret API, the output in master has changed from 
```
{
    "randomKey": {
        "randomKey": "value"
    },
    "redisPassword": {
        "redisPassword": "root123"
    }
}
```
to
```
{
    "data": {
        "randomKey": {
            "secrets": {
                "randomKey": "value"
            }
        },
        "redisPassword": {
            "secrets": {
                "redisPassword": "root123"
            }
        }
    }
}
```

This PR fixes this issue. Adds a unit test for the same. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Related to #6301 
Related to #6207 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
