### PR TITLE
Add `time.Sleep`s to placement tests to improve flakes

### DIFF
--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -61,6 +61,8 @@ func TestMembershipChangeWorker(t *testing.T) {
 			testServer.membershipChangeWorker(ctx)
 		}()
 
+		time.Sleep(time.Second * 2)
+
 		return func() {
 			cancel()
 			cancelServer()
@@ -87,7 +89,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 		// wait until all host member change requests are flushed
 		assert.Eventually(t, func() bool {
 			return len(testServer.raftNode.FSM().State().Members()) == 3
-		}, disseminateTimerInterval+500*time.Millisecond, time.Millisecond)
+		}, disseminateTimerInterval+time.Second*3, time.Millisecond)
 	}
 
 	t.Run("successful dissemination", func(t *testing.T) {
@@ -122,7 +124,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		select {
 		case <-done:
-		case <-time.After(disseminateTimerInterval + 500*time.Millisecond):
+		case <-time.After(disseminateTimerInterval + time.Second*3):
 			t.Error("dissemination did not happen in time")
 		}
 
@@ -146,6 +148,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 			"flushed all member updates and faultyHostDetectDuration must be faultyHostDetectDuration")
 
 		conn.Close()
+		time.Sleep(time.Second * 3)
 	})
 
 	t.Run("faulty host detector", func(t *testing.T) {

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -153,7 +153,7 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 			default:
 				return false
 			}
-		}, testStreamSendLatency, time.Millisecond, "no membership change")
+		}, testStreamSendLatency+3*time.Second, time.Millisecond, "no membership change")
 
 		// act
 		// Runtime needs to close stream gracefully which will let placement remove runtime host from hashing ring
@@ -204,7 +204,7 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 			default:
 				return false
 			}
-		}, testStreamSendLatency, time.Millisecond, "no membership change")
+		}, testStreamSendLatency+3*time.Second, time.Millisecond, "no membership change")
 
 		// act
 		// Close tcp connection before closing stream, which simulates the scenario
@@ -298,7 +298,7 @@ func TestGetPlacementTables(t *testing.T) {
 		// wait until host member change requests are flushed
 		assert.Eventually(t, func() bool {
 			return len(testServer.raftNode.FSM().State().Members()) == 1
-		}, disseminateTimerInterval+500*time.Millisecond, 50*time.Millisecond,
+		}, time.Second*10, 50*time.Millisecond,
 			"placement failed apply host registration")
 
 		// get placement tables

--- a/pkg/placement/testmain_test.go
+++ b/pkg/placement/testmain_test.go
@@ -56,6 +56,14 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	// It is painful that we have to include a `time.Sleep` here, but due to the
+	// non-deterministic behaviour of the raft library we are using we will fail
+	// later fail on slower test runner machines. A clock timer wait means we
+	// have a _better_ chance of being in the right spot in the state machine and
+	// the network has died down. Ideally we should move to a different raft
+	// library that is more deterministic and reliable for our use case.
+	time.Sleep(time.Second * 3)
+
 	retVal := m.Run()
 
 	cancel()


### PR DESCRIPTION
Part of the [`v1.11` Endgame](https://github.com/dapr/dapr/issues/6301).

Although painful to do so, because of the nature of the raft library we are using being nondeterministic in its state machine and being reliant on wall clock time, I have added `time.Sleep`s to the placement tests to improve the reliability of the placement tests on slower test runners (windows & mac). This obviously increases the run time of the tests, but when testing on this PR, has greatly reduced the runs being flaky.

We can revisit these tests if we still find them to be flaky, but this should at least improve things somewhat.

Improves (not fix): https://github.com/dapr/dapr/issues/6265