### PR TITLE
Add `dapr_http_server_response_count` metric

### DIFF
--- a/docs/development/dapr-metrics.md
+++ b/docs/development/dapr-metrics.md
@@ -128,9 +128,11 @@ We support only server side metrics.
 * [server metrics](../../pkg/diagnostics/http_monitoring.go)
 
 #### Server metrics
+> Note: Server metrics are prefixed by a forward slash character `/`
 
 * dapr_http_server_request_count: Number of HTTP requests started in server
 * dapr_http_server_request_bytes: HTTP request body size if set as ContentLength (uncompressed) in server
+* dapr_http_server_response_count: Number of HTTP responses in server
 * dapr_http_server_response_bytes: HTTP response body size (uncompressed) in server.
 * dapr_http_server_latency: HTTP request end to end latency in server.
 


### PR DESCRIPTION
# Description

Add `dapr_http_server_response_count` server metric as it was missing. Also a note to say that all server metrics are prefixed with a forward slash character.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
