### PR TITLE
Add constant for activityId delimiter

### DIFF
--- a/pkg/runtime/wfengine/activity.go
+++ b/pkg/runtime/wfengine/activity.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/actors"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"github.com/dapr/dapr/utils"
 )
 
 var ErrDuplicateInvocation = errors.New("duplicate invocation")
@@ -146,7 +147,7 @@ func (a *activityActor) executeActivity(ctx context.Context, actorID string, nam
 		return err
 	}
 
-	endIndex := strings.LastIndex(actorID, "::")
+	endIndex := strings.LastIndex(actorID, utils.WFActivityIdDelimiter)
 	if endIndex < 0 {
 		return fmt.Errorf("invalid activity actor ID: %s", actorID)
 	}

--- a/pkg/runtime/wfengine/activity.go
+++ b/pkg/runtime/wfengine/activity.go
@@ -147,7 +147,7 @@ func (a *activityActor) executeActivity(ctx context.Context, actorID string, nam
 		return err
 	}
 
-	endIndex := strings.LastIndex(actorID, utils.WFActivityIdDelimiter)
+	endIndex := strings.LastIndex(actorID, utils.WFActivityIDDelimiter)
 	if endIndex < 0 {
 		return fmt.Errorf("invalid activity actor ID: %s", actorID)
 	}

--- a/pkg/runtime/wfengine/backend.go
+++ b/pkg/runtime/wfengine/backend.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/actors"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"github.com/dapr/dapr/utils"
 )
 
 // workflowScheduler is an interface for pushing work items into the backend
@@ -146,7 +147,7 @@ func (be *actorBackend) GetOrchestrationMetadata(ctx context.Context, id api.Ins
 // AbandonActivityWorkItem implements backend.Backend. It gets called by durabletask-go when there is
 // an unexpected failure in the workflow activity execution pipeline.
 func (*actorBackend) AbandonActivityWorkItem(ctx context.Context, wi *backend.ActivityWorkItem) error {
-	wfLogger.Warnf("%s: aborting activity execution (::%d)", wi.InstanceID, wi.NewEvent.EventId)
+	wfLogger.Warnf("%s: aborting activity execution (%s%d)", wi.InstanceID, utils.WFActivityIdDelimiter, wi.NewEvent.EventId)
 
 	// Sending false signals the waiting activity actor to abort the activity execution.
 	if channel, ok := wi.Properties[CallbackChannelProperty]; ok {

--- a/pkg/runtime/wfengine/backend.go
+++ b/pkg/runtime/wfengine/backend.go
@@ -147,7 +147,7 @@ func (be *actorBackend) GetOrchestrationMetadata(ctx context.Context, id api.Ins
 // AbandonActivityWorkItem implements backend.Backend. It gets called by durabletask-go when there is
 // an unexpected failure in the workflow activity execution pipeline.
 func (*actorBackend) AbandonActivityWorkItem(ctx context.Context, wi *backend.ActivityWorkItem) error {
-	wfLogger.Warnf("%s: aborting activity execution (%s%d)", wi.InstanceID, utils.WFActivityIdDelimiter, wi.NewEvent.EventId)
+	wfLogger.Warnf("%s: aborting activity execution (%s%d)", wi.InstanceID, utils.WFActivityIDDelimiter, wi.NewEvent.EventId)
 
 	// Sending false signals the waiting activity actor to abort the activity execution.
 	if channel, ok := wi.Properties[CallbackChannelProperty]; ok {

--- a/pkg/runtime/wfengine/workflow.go
+++ b/pkg/runtime/wfengine/workflow.go
@@ -430,7 +430,7 @@ func (wf *workflowActor) runWorkflow(ctx context.Context, actorID string, remind
 			resp, err := wf.actors.Call(ctx, req)
 			if err != nil {
 				if errors.Is(err, ErrDuplicateInvocation) {
-					wfLogger.Warnf("%s: activity invocation %s%s%d was flagged as a duplicate and will be skipped", actorID, ts.Name, utils.WFActivityIdDelimiter, e.EventId)
+					wfLogger.Warnf("%s: activity invocation %s%s%d was flagged as a duplicate and will be skipped", actorID, ts.Name, utils.WFActivityIDDelimiter, e.EventId)
 					continue
 				}
 				return newRecoverableError(fmt.Errorf("failed to invoke activity actor '%s' to execute '%s': %v", targetActorID, ts.Name, err))
@@ -537,7 +537,7 @@ func getRuntimeState(actorID string, state workflowState) *backend.Orchestration
 
 func getActivityActorID(workflowActorID string, taskID int32) string {
 	// An activity can be identified by it's name followed by it's task ID. Example: SayHello::0, SayHello::1, etc.
-	return fmt.Sprintf("%s%s%d", workflowActorID, utils.WFActivityIdDelimiter, taskID)
+	return fmt.Sprintf("%s%s%d", workflowActorID, utils.WFActivityIDDelimiter, taskID)
 }
 
 func (wf *workflowActor) removeCompletedStateData(ctx context.Context, state workflowState, actorID string) error {

--- a/pkg/runtime/wfengine/workflow.go
+++ b/pkg/runtime/wfengine/workflow.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/actors"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"github.com/dapr/dapr/utils"
 )
 
 const (
@@ -429,7 +430,7 @@ func (wf *workflowActor) runWorkflow(ctx context.Context, actorID string, remind
 			resp, err := wf.actors.Call(ctx, req)
 			if err != nil {
 				if errors.Is(err, ErrDuplicateInvocation) {
-					wfLogger.Warnf("%s: activity invocation %s::%d was flagged as a duplicate and will be skipped", actorID, ts.Name, e.EventId)
+					wfLogger.Warnf("%s: activity invocation %s%s%d was flagged as a duplicate and will be skipped", actorID, ts.Name, utils.WFActivityIdDelimiter, e.EventId)
 					continue
 				}
 				return newRecoverableError(fmt.Errorf("failed to invoke activity actor '%s' to execute '%s': %v", targetActorID, ts.Name, err))
@@ -536,7 +537,7 @@ func getRuntimeState(actorID string, state workflowState) *backend.Orchestration
 
 func getActivityActorID(workflowActorID string, taskID int32) string {
 	// An activity can be identified by it's name followed by it's task ID. Example: SayHello::0, SayHello::1, etc.
-	return fmt.Sprintf("%s::%d", workflowActorID, taskID)
+	return fmt.Sprintf("%s%s%d", workflowActorID, utils.WFActivityIdDelimiter, taskID)
 }
 
 func (wf *workflowActor) removeCompletedStateData(ctx context.Context, state workflowState, actorID string) error {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	DotDelimiter          = "."
-	WFActivityIdDelimiter = "::" // Delimiter between workflow id and activity id
+	WFActivityIDDelimiter = "::" // Delimiter between workflow id and activity id
 )
 
 var (

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	DotDelimiter = "."
+	DotDelimiter          = "."
+	WFActivityIdDelimiter = "::" // Delimiter between workflow id and activity id
 )
 
 var (


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
It simply adds a constant for Activity Id Deliemiter (`::`).

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #6313 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
