### PR TITLE
Pin contrib 1.10.6 and update release notes

### DIFF
--- a/docs/release_notes/v1.10.6.md
+++ b/docs/release_notes/v1.10.6.md
@@ -1,6 +1,6 @@
 # Dapr 1.10.6
 
-This patch release contains fixes for 2 bugs.
+This patch release contains fixes for 3 bugs.
 
 ## Fixed Actor Timers/Reminders not being unmarshaled correctly
 
@@ -37,3 +37,21 @@ Accidental regression on refactor of reminders code.
 ### Solution
 
 Fixed the runtime code to support more null-equivalent values.
+
+## Fixed an issue in Kafka components with SASL authentication
+
+### Problem
+
+When attempting to connect to Kafka compatible services like Azure Event Hubs using SALS authentication the connection fails with the message "client has run out of available brokers to talk to."
+
+### Impact
+
+The issue impacts users on Dapr 1.10.x who use Kafka components to connect to Azure Event Hubs. Other Kafka compatible services may be impacted too.
+
+### Root cause
+
+The latest versions (1.38.X) of the shopify/sarama kafka library introduced this problem.
+
+### Solution
+
+Downgrading the shopify/sarama library to release 1.37.2 resolves this problem. An issue with the maintainers of the sarama library has been created for further investigation.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/PuerkitoBio/purell v1.2.0
 	github.com/cenkalti/backoff/v4 v4.2.0
-	github.com/dapr/components-contrib v1.10.5
+	github.com/dapr/components-contrib v1.10.6
 	github.com/dapr/kit v0.0.5-0.20230307192505-b5bafe889a81
 	github.com/fasthttp/router v1.4.15
 	github.com/ghodss/yaml v1.0.0
@@ -319,7 +319,7 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -716,8 +716,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.10.5 h1:3hg+xsXlHL9bUVj6o2Ccx/DwSYKLat8Bmo+GUgib4/g=
-github.com/dapr/components-contrib v1.10.5/go.mod h1:21BqAjEn5hOjg2Y8/mu3nf/hD+9TSpQ45HdjesN24mQ=
+github.com/dapr/components-contrib v1.10.6 h1:H+UIGaCoSawlzqL6vBMQF/QUBwd6Vy1PhtUTcXwmLfA=
+github.com/dapr/components-contrib v1.10.6/go.mod h1:t8p+Sp/aEN90SqdeHoYqhYrZeEGNd3ic1+NNeCIUTjc=
 github.com/dapr/kit v0.0.5-0.20230307192505-b5bafe889a81 h1:8vCcvFXpCH4xvbG4JuG0g9bFk0T3cgY0infitTxG7oA=
 github.com/dapr/kit v0.0.5-0.20230307192505-b5bafe889a81/go.mod h1:JXPc/7O0s0ieBe+GpOUuYiyxRcgip1MQwSwCmQPYSVE=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1575,8 +1575,9 @@ github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
+github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
 github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=


### PR DESCRIPTION
# Description

Pins contrib 1.10.6 and updates release notes.

Fixes https://github.com/dapr/components-contrib/issues/2755
