### PR TITLE
Fix empty value state decryption panic

### DIFF
--- a/pkg/encryption/state.go
+++ b/pkg/encryption/state.go
@@ -58,6 +58,10 @@ func TryEncryptValue(storeName string, value []byte) ([]byte, error) {
 // TryDecryptValue will try to decrypt a byte array if the state store has associated encryption keys.
 // If no encryption keys exist, the function will return the bytes unmodified.
 func TryDecryptValue(storeName string, value []byte) ([]byte, error) {
+	if len(value) == 0 {
+		return []byte(""), nil
+	}
+
 	keys := encryptedStateStores[storeName]
 	// extract the decryption key that should be appended to the value
 	ind := bytes.LastIndex(value, []byte(separator))

--- a/pkg/encryption/state_test.go
+++ b/pkg/encryption/state_test.go
@@ -200,6 +200,34 @@ func TestTryEncryptValue(t *testing.T) {
 	})
 }
 
+func TestTryDecryptValue(t *testing.T) {
+	t.Run("empty value", func(t *testing.T) {
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+
+		bytes := make([]byte, 16)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		pr := Key{
+			Name: "primary",
+			Key:  key,
+		}
+
+		cipherObj, _ := createCipher(pr, AESGCMAlgorithm)
+		pr.cipherObj = cipherObj
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Primary: pr,
+		})
+
+		dr, err := TryDecryptValue("test", nil)
+		assert.NoError(t, err)
+		assert.Empty(t, dr)
+	})
+}
+
 func TestEncryptedStateStore(t *testing.T) {
 	t.Run("store supports encryption", func(t *testing.T) {
 		encryptedStateStores = map[string]ComponentEncryptionKeys{}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -545,8 +545,6 @@ func (a *DaprRuntime) initRuntime(opts *runtimeOpts) error {
 	a.daprHTTPAPI.SetHTTPEndpointsAppChannel(a.httpEndpointsAppChannel)
 	a.directMessaging.SetHTTPEndpointsAppChannel(a.httpEndpointsAppChannel)
 
-	a.initDirectMessaging(a.nameResolver)
-
 	a.daprHTTPAPI.SetDirectMessaging(a.directMessaging)
 	a.daprGRPCAPI.SetDirectMessaging(a.directMessaging)
 


### PR DESCRIPTION
As reported on Discord, trying to decrypt an empty value results in the following panic:

```go
panic: runtime error: slice bounds out of range [1:0]

goroutine 164 [running]:
github.com/dapr/dapr/pkg/encryption.TryDecryptValue({0xc000b8f320, 0xb}, {0x0, 0x0, 0x0})
        D:/a/dapr/dapr/pkg/encryption/state.go:64 +0x2f8
github.com/dapr/dapr/pkg/grpc.(api).GetState(0xc00149a000, {0x6578618, 0xc0013d1230}, 0xc0005fb860)
        D:/a/dapr/dapr/pkg/grpc/api.go:843 +0x4bf
```