### PR TITLE
Normalize URI Path in in nethttpadaptor

### DIFF
--- a/utils/nethttpadaptor/nethttpadaptor.go
+++ b/utils/nethttpadaptor/nethttpadaptor.go
@@ -46,7 +46,8 @@ func NewNetHTTPHandlerFunc(h fasthttp.RequestHandler) http.HandlerFunc {
 			}
 			c.Request.SetBody(reqBody)
 		}
-		c.Request.SetRequestURI(r.URL.RequestURI())
+		c.Request.URI().SetQueryString(r.URL.RawQuery)
+		c.Request.URI().SetPath(r.URL.Path)
 		c.Request.URI().SetScheme(r.URL.Scheme)
 		c.Request.SetHost(r.Host)
 		c.Request.Header.SetMethod(r.Method)

--- a/utils/nethttpadaptor/nethttpadaptor_test.go
+++ b/utils/nethttpadaptor/nethttpadaptor_test.go
@@ -344,6 +344,22 @@ func TestNewNetHTTPHandlerFuncRequests(t *testing.T) {
 				}
 			},
 		},
+		{
+			"http request path is normalized",
+			func() *http.Request {
+				req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://localhost:8080//foo//bar/123/?hello=world", nil)
+				return req
+			},
+			func(t *testing.T) func(ctx *fasthttp.RequestCtx) {
+				return func(ctx *fasthttp.RequestCtx) {
+					assert.Equal(t, "/foo/bar/123/", string(ctx.Request.URI().Path()))
+					assert.Equal(t, "localhost:8080", string(ctx.Request.URI().Host()))
+					assert.Equal(t, "https", string(ctx.Request.URI().Scheme()))
+					assert.Equal(t, "hello=world", string(ctx.Request.URI().QueryString()))
+					assert.Equal(t, "https://localhost:8080/foo/bar/123/?hello=world", string(ctx.Request.URI().FullURI()))
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fixes #6324 

In the base nethttpadapter, we are currently using `SetRequestURI` for incoming requests. This results in fasthttp _not_ normalizing the HTTP request path which eventually leads to requests not being routed to their intended handler (see issue).

PR changes the adapter to use `SetQueryString`, and importantly, `SetPath` which _does_ normalize the path. This results in fixing downstream problems like the one in the issue.


/assign @artursouza 