### PR TITLE
raft: fix index out of range

### DIFF
--- a/pkg/placement/raft/fsm.go
+++ b/pkg/placement/raft/fsm.go
@@ -154,7 +154,7 @@ func (c *FSM) Apply(log *raft.Log) interface{} {
 	}
 
 	if len(log.Data) < 2 {
-		logging.Infof("too short log data")
+		logging.Warnf("too short log data in raft logs")
 		return false
 	}
 

--- a/pkg/placement/raft/fsm.go
+++ b/pkg/placement/raft/fsm.go
@@ -153,6 +153,11 @@ func (c *FSM) Apply(log *raft.Log) interface{} {
 		return false
 	}
 
+	if len(log.Data) < 2 {
+		logging.Infof("too short log data")
+		return false
+	}
+
 	switch CommandType(log.Data[0]) {
 	case MemberUpsert:
 		updated, err = c.upsertMember(log.Data[1:])

--- a/pkg/placement/raft/fsm.go
+++ b/pkg/placement/raft/fsm.go
@@ -154,7 +154,7 @@ func (c *FSM) Apply(log *raft.Log) interface{} {
 	}
 
 	if len(log.Data) < 2 {
-		logging.Warnf("too short log data in raft logs")
+		logging.Warnf("too short log data in raft logs: %v", log.Data)
 		return false
 	}
 


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
Fix index out of range in case log.Data has too little data.

If log.Data has less than 2 entries, then several IoR can happen on these lines:

https://github.com/dapr/dapr/blob/770d4e51604f1264d8bb25cedf16ea9f77539394/pkg/placement/raft/fsm.go#L156C35-L163

Found by OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58799

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
