### PR TITLE
Passing gRPC max msg size to proxy client stream

### DIFF
--- a/pkg/grpc/proxy/handler_test.go
+++ b/pkg/grpc/proxy/handler_test.go
@@ -687,6 +687,7 @@ func (s *proxyTestSuite) SetupSuite() {
 		func(ctx context.Context, address, id, namespace string, customOpts ...grpc.DialOption) (*grpc.ClientConn, func(destroy bool), error) {
 			return s.getServerClientConn()
 		},
+		4,
 	)
 	s.proxy = grpc.NewServer(
 		grpc.UnknownServiceHandler(th),

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -41,34 +41,34 @@ type Proxy interface {
 }
 
 type proxy struct {
-	appID             string
-	appClientFn       func() (grpc.ClientConnInterface, error)
-	connectionFactory messageClientConnection
-	remoteAppFn       func(appID string) (remoteApp, error)
-	telemetryFn       func(context.Context) context.Context
-	acl               *config.AccessControlList
-	resiliency        resiliency.Provider
+	appID              string
+	appClientFn        func() (grpc.ClientConnInterface, error)
+	connectionFactory  messageClientConnection
+	remoteAppFn        func(appID string) (remoteApp, error)
+	telemetryFn        func(context.Context) context.Context
+	acl                *config.AccessControlList
+	resiliency         resiliency.Provider
 	maxRequestBodySize int
 }
 
 // ProxyOpts is the struct with options for NewProxy.
 type ProxyOpts struct {
-	AppClientFn       func() (grpc.ClientConnInterface, error)
-	ConnectionFactory messageClientConnection
-	AppID             string
-	ACL               *config.AccessControlList
-	Resiliency        resiliency.Provider
+	AppClientFn        func() (grpc.ClientConnInterface, error)
+	ConnectionFactory  messageClientConnection
+	AppID              string
+	ACL                *config.AccessControlList
+	Resiliency         resiliency.Provider
 	MaxRequestBodySize int
 }
 
 // NewProxy returns a new proxy.
 func NewProxy(opts ProxyOpts) Proxy {
 	return &proxy{
-		appClientFn:       opts.AppClientFn,
-		appID:             opts.AppID,
-		connectionFactory: opts.ConnectionFactory,
-		acl:               opts.ACL,
-		resiliency:        opts.Resiliency,
+		appClientFn:        opts.AppClientFn,
+		appID:              opts.AppID,
+		connectionFactory:  opts.ConnectionFactory,
+		acl:                opts.ACL,
+		resiliency:         opts.Resiliency,
 		maxRequestBodySize: opts.MaxRequestBodySize,
 	}
 }

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -48,6 +48,7 @@ type proxy struct {
 	telemetryFn       func(context.Context) context.Context
 	acl               *config.AccessControlList
 	resiliency        resiliency.Provider
+	maxRequestBodySize int
 }
 
 // ProxyOpts is the struct with options for NewProxy.
@@ -57,6 +58,7 @@ type ProxyOpts struct {
 	AppID             string
 	ACL               *config.AccessControlList
 	Resiliency        resiliency.Provider
+	MaxRequestBodySize int
 }
 
 // NewProxy returns a new proxy.
@@ -67,6 +69,7 @@ func NewProxy(opts ProxyOpts) Proxy {
 		connectionFactory: opts.ConnectionFactory,
 		acl:               opts.ACL,
 		resiliency:        opts.Resiliency,
+		maxRequestBodySize: opts.MaxRequestBodySize,
 	}
 }
 
@@ -82,6 +85,7 @@ func (p *proxy) Handler() grpc.StreamHandler {
 			return resiliency.NoOp{}.EndpointPolicy("", "")
 		},
 		grpcProxy.DirectorConnectionFactory(p.connectionFactory),
+		p.maxRequestBodySize,
 	)
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1029,11 +1029,11 @@ func (a *DaprRuntime) initDirectMessaging(resolver nr.Resolver) {
 
 func (a *DaprRuntime) initProxy() {
 	a.proxy = messaging.NewProxy(messaging.ProxyOpts{
-		AppClientFn:       a.grpc.GetAppClient,
-		ConnectionFactory: a.grpc.GetGRPCConnection,
-		AppID:             a.runtimeConfig.ID,
-		ACL:               a.accessControlList,
-		Resiliency:        a.resiliency,
+		AppClientFn:        a.grpc.GetAppClient,
+		ConnectionFactory:  a.grpc.GetGRPCConnection,
+		AppID:              a.runtimeConfig.ID,
+		ACL:                a.accessControlList,
+		Resiliency:         a.resiliency,
 		MaxRequestBodySize: a.runtimeConfig.MaxRequestBodySize,
 	})
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1034,6 +1034,7 @@ func (a *DaprRuntime) initProxy() {
 		AppID:             a.runtimeConfig.ID,
 		ACL:               a.accessControlList,
 		Resiliency:        a.resiliency,
+		MaxRequestBodySize: a.runtimeConfig.MaxRequestBodySize,
 	})
 
 	log.Info("gRPC proxy enabled")

--- a/tests/apps/service_invocation_grpc_proxy_client/app.go
+++ b/tests/apps/service_invocation_grpc_proxy_client/app.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/dapr/dapr/tests/apps/utils"
@@ -33,8 +34,25 @@ type appResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
+type testCommandRequest struct {
+	RemoteApp        string  `json:"remoteApp,omitempty"`
+	Method           string  `json:"method,omitempty"`
+	RemoteAppTracing string  `json:"remoteAppTracing"`
+	Message          *string `json:"message"`
+}
+
 func run(w http.ResponseWriter, r *http.Request) {
-	conn, err := grpc.Dial("localhost:50001", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	var request testCommandRequest
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		log.Fatalf("could not decode request body: %v", err)
+	}
+
+	conn, err := grpc.Dial("localhost:50001",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(6*1024*1024), grpc.MaxCallSendMsgSize(6*1024*1024)),
+	)
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
@@ -45,7 +63,15 @@ func run(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-app-id", "grpcproxyserver")
-	resp, err := c.SayHello(ctx, &pb.HelloRequest{Name: "Darth Tyranus"})
+
+	var name string
+	if request.Method == "maxsize" {
+		name = strings.Repeat("d", 5*1024*1024)
+	} else {
+		name = "Darth Tyranus"
+	}
+
+	resp, err := c.SayHello(ctx, &pb.HelloRequest{Name: name})
 	if err != nil {
 		log.Printf("could not greet: %v\n", err)
 		w.WriteHeader(500)
@@ -53,7 +79,11 @@ func run(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("Greeting: %s", resp.GetMessage())
+	if request.Method == "maxsize" {
+		log.Printf("Message bytes exchanged: %d", len(resp.GetMessage()))
+	} else {
+		log.Printf("Greeting: %s", resp.GetMessage())
+	}
 
 	appResp := appResponse{
 		Message: "success",

--- a/tests/apps/service_invocation_grpc_proxy_client/service.yaml
+++ b/tests/apps/service_invocation_grpc_proxy_client/service.yaml
@@ -35,6 +35,7 @@ spec:
       annotations:
         dapr.io/enabled: "true"
         dapr.io/app-id: "grpcproxyclient"
+        dapr.io/http-max-request-size: "6"
     spec:
       containers:
       - name: service-invocation-grpc-proxy-client

--- a/tests/apps/service_invocation_grpc_proxy_server/app.go
+++ b/tests/apps/service_invocation_grpc_proxy_server/app.go
@@ -42,7 +42,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	s := grpc.NewServer()
+	s := grpc.NewServer(grpc.MaxRecvMsgSize(6<<20), grpc.MaxSendMsgSize(6<<20))
 	pb.RegisterGreeterServer(s, &server{})
 	log.Printf("server listening at %v", lis.Addr())
 	if err := s.Serve(lis); err != nil {

--- a/tests/apps/service_invocation_grpc_proxy_server/service.yaml
+++ b/tests/apps/service_invocation_grpc_proxy_server/service.yaml
@@ -20,6 +20,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "grpcproxyserver"
         dapr.io/app-port: "50051"
+        dapr.io/http-max-request-size: "6"
     spec:
       containers:
       - name: service-invocation-grpc-proxy-server

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -370,6 +370,12 @@ var grpcProxyTests = []struct {
 		"",
 		"success",
 	},
+	{
+		"Test grpc proxy",
+		"grpcproxyclient",
+		"maxsize",
+		"success",
+	},
 }
 
 func TestServiceInvocation(t *testing.T) {

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -146,12 +146,13 @@ func TestMain(m *testing.M) {
 			AppProtocol:    "grpc",
 		},
 		{
-			AppName:        "grpcproxyclient",
-			DaprEnabled:    true,
-			ImageName:      "e2e-service_invocation_grpc_proxy_client",
-			Replicas:       1,
-			IngressEnabled: true,
-			MetricsEnabled: true,
+			AppName:          "grpcproxyclient",
+			DaprEnabled:      true,
+			ImageName:        "e2e-service_invocation_grpc_proxy_client",
+			Replicas:         1,
+			IngressEnabled:   true,
+			MetricsEnabled:   true,
+			MaxRequestSizeMB: 6,
 		},
 		{
 			AppName:        "grpcproxyserverexternal",
@@ -171,6 +172,7 @@ func TestMain(m *testing.M) {
 			AppProtocol:       "grpc",
 			AppPort:           50051,
 			AppChannelAddress: "grpcproxyserver-app",
+			MaxRequestSizeMB:  6,
 		},
 		{
 			AppName:        "serviceinvocation-callee-external",

--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -74,6 +74,7 @@ type AppDescription struct {
 	AppHealthProbeTimeout     int                             `json:",omitempty"` // In milliseconds
 	AppHealthThreshold        int                             `json:",omitempty"`
 	AppChannelAddress         string                          `json:",omitempty"`
+	MaxRequestSizeMB          int                             `json:",omitempty"`
 }
 
 func (a AppDescription) String() string {

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -155,6 +155,10 @@ func buildDaprAnnotations(appDesc AppDescription) map[string]string {
 		annotationObject["dapr.io/sidecar-image"] = appDesc.SidecarImage
 	}
 
+	if appDesc.MaxRequestSizeMB != 0 {
+		annotationObject["dapr.io/http-max-request-size"] = strconv.Itoa(appDesc.MaxRequestSizeMB)
+	}
+
 	return annotationObject
 }
 


### PR DESCRIPTION
# Description

Updated the `handler.go` file to use a passed-in argument of `maxMessageBodySizeMB` that is provided from the `runtime.go` instantiation of the proxy down through the `TransparentHandler` by using the configuration item `--dapr-http-max-request-size` parameter.  If there is no parameter configured, a zero value is propagated, so any value of zero (or less) is ignored and defaults are used.

## Issue reference

https://github.com/dapr/dapr/issues/6349

Please reference the issue this PR will close: #_6349_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
