### PR TITLE
Fix injector to handle empty app-channel-address.

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -50,6 +50,11 @@ jobs:
       DAPR_REGISTRY: localhost:5000/dapr
       DAPR_TAG: dev
       DAPR_NAMESPACE: dapr-tests
+      # Useful for upgrade/downgrade/compatibility tests
+      # 1.9.6 does not work on newest Windows version for E2E tests
+      # Add this env var to Windows runs too once we have an old version that works with latest win version
+      # TODO: Make this auto-populated based on GitHub's releases.
+      DAPR_TEST_N_MINUS_2_IMAGE: "ghcr.io/dapr/daprd:1.9.6"
       # Container registry where to cache e2e test images
       DAPR_CACHE_REGISTRY: "dapre2eacr.azurecr.io"
       PULL_POLICY: IfNotPresent

--- a/pkg/injector/sidecar/container.go
+++ b/pkg/injector/sidecar/container.go
@@ -148,7 +148,10 @@ func GetSidecarContainer(cfg ContainerConfig) (*corev1.Container, error) {
 		"--dapr-http-read-buffer-size", strconv.Itoa(int(readBufferSize)),
 		"--dapr-graceful-shutdown-seconds", strconv.Itoa(int(gracefulShutdownSeconds)),
 		"--disable-builtin-k8s-secret-store=" + strconv.FormatBool(disableBuiltinK8sSecretStore),
-		"--app-channel-address", cfg.Annotations.GetString(annotations.KeyAppChannel),
+	}
+
+	if v, ok := cfg.Annotations[annotations.KeyAppChannel]; ok && v != "" {
+		args = append(args, "--app-channel-address", v)
 	}
 
 	// --enable-api-logging is set only if there's an explicit annotation (true or false) for that

--- a/pkg/injector/sidecar/container_test.go
+++ b/pkg/injector/sidecar/container_test.go
@@ -172,7 +172,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--log-as-json",
 			"--enable-mtls",
 		}
@@ -247,7 +246,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--log-as-json",
 			"--enable-mtls",
 		}
@@ -322,7 +320,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--log-as-json",
 			"--enable-mtls",
 		}
@@ -395,7 +392,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--log-as-json",
 			"--enable-mtls",
 		}
@@ -469,7 +465,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--log-as-json",
 			"--enable-mtls",
 		}
@@ -525,7 +520,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--enable-mtls",
 		}
 
@@ -569,7 +563,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--enable-mtls",
 		}
 
@@ -613,7 +606,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "5",
 			"--disable-builtin-k8s-secret-store=false",
-			"--app-channel-address", "",
 			"--enable-mtls",
 		}
 
@@ -701,7 +693,6 @@ func TestGetSidecarContainer(t *testing.T) {
 			"--dapr-http-read-buffer-size", "-1",
 			"--dapr-graceful-shutdown-seconds", "-1",
 			"--disable-builtin-k8s-secret-store=true",
-			"--app-channel-address", "",
 			"--enable-mtls",
 		}
 
@@ -748,7 +739,6 @@ func TestGetSidecarContainer(t *testing.T) {
 				"--dapr-http-read-buffer-size", "-1",
 				"--dapr-graceful-shutdown-seconds", "-1",
 				"--disable-builtin-k8s-secret-store=true",
-				"--app-channel-address", "",
 				"--enable-mtls",
 			}
 
@@ -783,7 +773,6 @@ func TestGetSidecarContainer(t *testing.T) {
 				"--dapr-http-read-buffer-size", "-1",
 				"--dapr-graceful-shutdown-seconds", "-1",
 				"--disable-builtin-k8s-secret-store=true",
-				"--app-channel-address", "",
 				"--enable-api-logging=true",
 				"--enable-mtls",
 			}
@@ -819,7 +808,6 @@ func TestGetSidecarContainer(t *testing.T) {
 				"--dapr-http-read-buffer-size", "-1",
 				"--dapr-graceful-shutdown-seconds", "-1",
 				"--disable-builtin-k8s-secret-store=true",
-				"--app-channel-address", "",
 				"--enable-api-logging=false",
 				"--enable-mtls",
 			}

--- a/tests/e2e/hellodapr/hellodapr_test.go
+++ b/tests/e2e/hellodapr/hellodapr_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dapr/dapr/tests/e2e/utils"
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 	"github.com/dapr/dapr/tests/runner"
+	runtime_utils "github.com/dapr/dapr/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +57,7 @@ func TestMain(m *testing.M) {
 			AppName:           "hellobluedapr",
 			DaprEnabled:       true,
 			ImageName:         "e2e-hellodapr",
+			SidecarImage:      runtime_utils.GetEnvOrElse("DAPR_TEST_N_MINUS_2_IMAGE", ""), // old image to avoid regression in injector.
 			Replicas:          1,
 			IngressEnabled:    true,
 			MetricsEnabled:    true,

--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -37,6 +37,7 @@ type AppDescription struct {
 	DaprEnabled               bool                            `json:",omitempty"`
 	ImageName                 string                          `json:",omitempty"`
 	ImageSecret               string                          `json:",omitempty"`
+	SidecarImage              string                          `json:",omitempty"`
 	RegistryName              string                          `json:",omitempty"`
 	Replicas                  int32                           `json:",omitempty"`
 	IngressEnabled            bool                            `json:",omitempty"`

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -151,6 +151,9 @@ func buildDaprAnnotations(appDesc AppDescription) map[string]string {
 	if appDesc.InjectPluggableComponents {
 		annotationObject["dapr.io/inject-pluggable-components"] = "true"
 	}
+	if appDesc.SidecarImage != "" {
+		annotationObject["dapr.io/sidecar-image"] = appDesc.SidecarImage
+	}
 
 	return annotationObject
 }


### PR DESCRIPTION
Fix injector to handle empty app-channel-address.
Allow sidecar image override on E2E tests.

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: endgame

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
