### PR TITLE
Fix typo in metric name

### DIFF
--- a/docs/development/dapr-metrics.md
+++ b/docs/development/dapr-metrics.md
@@ -85,7 +85,7 @@ Dapr uses prometheus process and go collectors by default.
 * dapr_runtime_actor_status_report_total: The number of the successful status reports to placement service.
 * dapr_runtime_actor_status_report_fail_total: The number of the failed status reports to placement service
 * dapr_runtime_actor_table_operation_recv_total: The number of the received actor placement table operations.
-* dapr_runtime_actor_reblanaced_total: The number of the actor rebalance requests.
+* dapr_runtime_actor_rebalanced_total: The number of the actor rebalance requests.
 * dapr_runtime_actor_activated_total: The number of the actor activation.
 * dapr_runtime_actor_activated_failed_total: The number of the actor activation failures.
 * dapr_runtime_actor_deactivated_total: The number of the successful actor deactivation.


### PR DESCRIPTION
Signed-off-by: Stuart Leeks <stuartle@microsoft.com>

# Description

<!--
Please explain the changes you've made.
-->

Fix typo in metric name on docs page ([actual metric name](https://github.com/dapr/dapr/blob/530697d87b042a05ee6e68ec1b255784f4e7e2a2/pkg/diagnostics/service_monitoring.go#L128) is correct, this is purely a docs change)

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Minor change so haven't opened an issue - let me know if you want an issue for this change

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
