### PR TITLE
Update diagnostics to not use global variables.

### DIFF
--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dapr/dapr/pkg/buildinfo"
 	"github.com/dapr/dapr/pkg/concurrency"
 	"github.com/dapr/dapr/pkg/credentials"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/health"
 	"github.com/dapr/dapr/pkg/placement"
 	"github.com/dapr/dapr/pkg/placement/hashing"
@@ -49,7 +50,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = monitoring.InitMetrics()
+	metrics, err := diag.NewMetrics(nil)
+	if err != nil {
+		log.Fatalf("error creating metrics: %s", err)
+	}
+
+	err = monitoring.InitMetrics(metrics)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -79,7 +85,7 @@ func main() {
 
 	// Start Placement gRPC server.
 	hashing.SetReplicationFactor(cfg.replicationFactor)
-	apiServer, err := placement.NewPlacementService(raftServer, certChain)
+	apiServer, err := placement.NewPlacementService(raftServer, certChain, metrics)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/actors/internal/grpc_opts.go
+++ b/pkg/actors/internal/grpc_opts.go
@@ -28,7 +28,7 @@ import (
 var errEstablishingTLSConn = errors.New("failed to establish TLS credentials for actor placement service")
 
 // getGrpcOptsGetter returns a function that provides the grpc options and once defined, a cached version will be returned.
-func getGrpcOptsGetter(servers []string, clientCert *daprCredentials.CertChain) func() ([]grpc.DialOption, error) {
+func getGrpcOptsGetter(servers []string, metrics *diag.Metrics, clientCert *daprCredentials.CertChain) func() ([]grpc.DialOption, error) {
 	mu := sync.RWMutex{}
 	var cached []grpc.DialOption
 	return func() ([]grpc.DialOption, error) {
@@ -51,10 +51,10 @@ func getGrpcOptsGetter(servers []string, clientCert *daprCredentials.CertChain) 
 			return nil, errEstablishingTLSConn
 		}
 
-		if diag.DefaultGRPCMonitoring.IsEnabled() {
+		if metrics.GRPC.IsEnabled() {
 			opts = append(
 				opts,
-				grpc.WithUnaryInterceptor(diag.DefaultGRPCMonitoring.UnaryClientInterceptor()))
+				grpc.WithUnaryInterceptor(metrics.GRPC.UnaryClientInterceptor()))
 		}
 
 		if len(servers) == 1 && strings.HasPrefix(servers[0], "dns:///") {

--- a/pkg/diagnostics/diagtestutils/testutils.go
+++ b/pkg/diagnostics/diagtestutils/testutils.go
@@ -20,7 +20,7 @@ func NewTag(key string, value string) tag.Tag {
 	}
 }
 
-// GetValueForObservationWithTagSet is a helper to find a row out of a slice of rows retrieved when executing view.RetrieveData
+// GetValueForObservationWithTagSet is a helper to find a row out of a slice of rows retrieved when executing meter.RetrieveData
 // This particular row should have the tags present in the tag set.
 func GetValueForObservationWithTagSet(rows []*view.Row, wantedTagSetCount map[tag.Tag]bool) int64 {
 	for _, row := range rows {
@@ -37,7 +37,7 @@ func GetValueForObservationWithTagSet(rows []*view.Row, wantedTagSetCount map[ta
 	return 0
 }
 
-// RequireTagExist tries to find a tag in a slice of rows return from view.RetrieveData
+// RequireTagExist tries to find a tag in a slice of rows return from meter.RetrieveData
 func RequireTagExist(t *testing.T, rows []*view.Row, wantedTag tag.Tag) {
 	t.Helper()
 	var found bool
@@ -53,7 +53,7 @@ outerLoop:
 	require.True(t, found, fmt.Sprintf("did not find tag (%s) in rows:", wantedTag), rows)
 }
 
-// RequireTagNotExist checks a tag in a slice of rows return from view.RetrieveData is not present
+// RequireTagNotExist checks a tag in a slice of rows return from meter.RetrieveData is not present
 func RequireTagNotExist(t *testing.T, rows []*view.Row, wantedTag tag.Tag) {
 	t.Helper()
 	var found bool
@@ -67,15 +67,4 @@ outerLoop:
 		}
 	}
 	require.False(t, found, fmt.Sprintf("found tag (%s) in rows:", wantedTag), rows)
-}
-
-// CleanupRegisteredViews is a safe method to removed registered views to avoid errors when running tests on the same metrics
-func CleanupRegisteredViews(viewNames ...string) {
-	var views []*view.View
-	for _, v := range viewNames {
-		if v := view.Find(v); v != nil {
-			views = append(views, v)
-		}
-	}
-	view.Unregister(views...)
 }

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -64,7 +64,7 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 		}
 
 		ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
-		ctx, span = tracer.Start(ctx, info.FullMethod, spanKind)
+		ctx, span = tracer().Start(ctx, info.FullMethod, spanKind)
 
 		isSampled := span.SpanContext().IsSampled()
 		if isSampled {
@@ -148,7 +148,7 @@ func GRPCTraceStreamServerInterceptor(appID string, spec config.TracingSpec) grp
 		// Overwrite context
 		sc, _ := SpanContextFromIncomingGRPCMetadata(ctx)
 		ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
-		ctx, span = tracer.Start(ctx, info.FullMethod, spanKind)
+		ctx, span = tracer().Start(ctx, info.FullMethod, spanKind)
 		wrapped := grpcMiddleware.WrapServerStream(ss)
 		wrapped.WrappedContext = ctx
 
@@ -215,7 +215,7 @@ func StartGRPCProducerSpanChildFromParent(ct context.Context, parentSpan trace.S
 	netCtx := trace.ContextWithRemoteSpanContext(ct, parentSpan.SpanContext())
 	spanKind := trace.WithSpanKind(trace.SpanKindProducer)
 
-	ctx, span := tracer.Start(netCtx, spanName, spanKind)
+	ctx, span := tracer().Start(netCtx, spanName, spanKind)
 
 	return ctx, span
 }

--- a/pkg/diagnostics/grpc_tracing_test.go
+++ b/pkg/diagnostics/grpc_tracing_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestSpanAttributesMapFromGRPC(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		rpcMethod                    string
 		req                          any
@@ -58,7 +60,9 @@ func TestSpanAttributesMapFromGRPC(t *testing.T) {
 		{"/dapr.proto.internals.v1.ServiceInvocation/CallLocal", &internalv1pb.InternalInvokeRequest{Message: &commonv1pb.InvokeRequest{Method: "mymethod"}}, "ServiceInvocation", "mymethod"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.rpcMethod, func(t *testing.T) {
+			t.Parallel()
 			got := spanAttributesMapFromGRPC("fakeAppID", tt.req, tt.rpcMethod)
 			assert.Equal(t, tt.expectedServiceNameAttribute, got[gRPCServiceSpanAttributeKey], "servicename attribute should be equal")
 		})
@@ -66,6 +70,7 @@ func TestSpanAttributesMapFromGRPC(t *testing.T) {
 }
 
 func TestUserDefinedMetadata(t *testing.T) {
+	t.Parallel()
 	md := grpcMetadata.MD{
 		"dapr-userdefined-1": []string{"value1"},
 		"DAPR-userdefined-2": []string{"value2", "value3"}, // Will be lowercased
@@ -86,7 +91,10 @@ func TestUserDefinedMetadata(t *testing.T) {
 }
 
 func TestSpanContextToGRPCMetadata(t *testing.T) {
+	t.Parallel()
+
 	t.Run("empty span context", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 		newCtx := SpanContextToGRPCMetadata(ctx, trace.SpanContext{})
 
@@ -95,6 +103,8 @@ func TestSpanContextToGRPCMetadata(t *testing.T) {
 }
 
 func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
+	t.Parallel()
+
 	exp := newOtelFakeExporter()
 
 	tp := sdktrace.NewTracerProvider(
@@ -110,6 +120,7 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 	testTraceBinary := diagUtils.BinaryFromSpanContext(testSpanContext)
 
 	t.Run("grpc-trace-bin is given", func(t *testing.T) {
+		t.Parallel()
 		ctx := grpcMetadata.NewIncomingContext(context.Background(), grpcMetadata.Pairs("grpc-trace-bin", string(testTraceBinary)))
 		fakeInfo := &grpc.UnaryServerInfo{
 			FullMethod: "/dapr.proto.runtime.v1.Dapr/GetState",
@@ -137,6 +148,7 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 	})
 
 	t.Run("grpc-trace-bin is not given", func(t *testing.T) {
+		t.Parallel()
 		fakeInfo := &grpc.UnaryServerInfo{
 			FullMethod: "/dapr.proto.runtime.v1.Dapr/GetState",
 		}
@@ -161,6 +173,7 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 	})
 
 	t.Run("InvokeService call", func(t *testing.T) {
+		t.Parallel()
 		fakeInfo := &grpc.UnaryServerInfo{
 			FullMethod: "/dapr.proto.runtime.v1.Dapr/InvokeService",
 		}
@@ -187,6 +200,7 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 	})
 
 	t.Run("InvokeService call with grpc status error", func(t *testing.T) {
+		t.Parallel()
 		// set a new tracer provider with a callback on span completion to check that the span errors out
 		checkErrorStatusOnSpan := func(s sdktrace.ReadOnlySpan) {
 			assert.Equal(t, otelcodes.Error, s.Status().Code, "expected span status to be an error")
@@ -232,6 +246,7 @@ func TestGRPCTraceUnaryServerInterceptor(t *testing.T) {
 }
 
 func TestGRPCTraceStreamServerInterceptor(t *testing.T) {
+	t.Parallel()
 	exp := newOtelFakeExporter()
 
 	tp := sdktrace.NewTracerProvider(
@@ -460,6 +475,8 @@ func (f *fakeStream) RecvMsg(m any) error {
 }
 
 func TestSpanContextSerialization(t *testing.T) {
+	t.Parallel()
+
 	wantScConfig := trace.SpanContextConfig{
 		TraceID:    trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
 		SpanID:     trace.SpanID{0, 240, 103, 170, 11, 169, 2, 183},

--- a/pkg/diagnostics/http_tracing.go
+++ b/pkg/diagnostics/http_tracing.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/valyala/fasthttp"
 
+	"go.opentelemetry.io/otel"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
@@ -97,6 +98,7 @@ func startTracingClientSpanFromHTTPContext(ctx *fasthttp.RequestCtx, spanName st
 	sc, _ := SpanContextFromRequest(&ctx.Request)
 	netCtx := trace.ContextWithRemoteSpanContext(ctx, sc)
 	kindOption := trace.WithSpanKind(trace.SpanKindClient)
+	tracer := otel.Tracer(tracerName)
 	_, span := tracer.Start(netCtx, spanName, kindOption)
 	diagUtils.SpanToFastHTTPContext(ctx, span)
 	return ctx, span
@@ -106,6 +108,7 @@ func StartProducerSpanChildFromParent(ctx *fasthttp.RequestCtx, parentSpan trace
 	path := string(ctx.Request.URI().Path())
 	netCtx := trace.ContextWithRemoteSpanContext(ctx, parentSpan.SpanContext())
 	kindOption := trace.WithSpanKind(trace.SpanKindProducer)
+	tracer := otel.Tracer(tracerName)
 	_, span := tracer.Start(netCtx, path, kindOption)
 	return span
 }

--- a/pkg/diagnostics/http_tracing_test.go
+++ b/pkg/diagnostics/http_tracing_test.go
@@ -20,7 +20,6 @@ import (
 	"net/textproto"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
@@ -35,6 +34,7 @@ import (
 )
 
 func TestSpanContextFromRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		header string
@@ -82,7 +82,9 @@ func TestSpanContextFromRequest(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			req := &fasthttp.Request{}
 			req.Header.Add("traceparent", tt.header)
 
@@ -94,6 +96,7 @@ func TestSpanContextFromRequest(t *testing.T) {
 }
 
 func TestUserDefinedHTTPHeaders(t *testing.T) {
+	t.Parallel()
 	reqCtx := &fasthttp.RequestCtx{}
 	reqCtx.Request.Header.Add("dapr-userdefined-1", "value1")
 	reqCtx.Request.Header.Add("dapr-userdefined-2", "value2")
@@ -107,6 +110,7 @@ func TestUserDefinedHTTPHeaders(t *testing.T) {
 }
 
 func TestSpanContextToHTTPHeaders(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		sc trace.SpanContextConfig
 	}{
@@ -119,7 +123,9 @@ func TestSpanContextToHTTPHeaders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run("SpanContextToHTTPHeaders", func(t *testing.T) {
+			t.Parallel()
 			req := &fasthttp.Request{}
 			wantSc := trace.NewSpanContext(tt.sc)
 			SpanContextToHTTPHeaders(wantSc, req.Header.Set)
@@ -131,6 +137,7 @@ func TestSpanContextToHTTPHeaders(t *testing.T) {
 	}
 
 	t.Run("empty span context", func(t *testing.T) {
+		t.Parallel()
 		req := &fasthttp.Request{}
 		sc := trace.SpanContext{}
 		SpanContextToHTTPHeaders(sc, req.Header.Set)
@@ -140,6 +147,7 @@ func TestSpanContextToHTTPHeaders(t *testing.T) {
 }
 
 func TestGetAPIComponent(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		path    string
 		version string
@@ -157,7 +165,9 @@ func TestGetAPIComponent(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
 			ver, api := getAPIComponent(tt.path)
 			assert.Equal(t, tt.version, ver)
 			assert.Equal(t, tt.api, api)
@@ -166,6 +176,7 @@ func TestGetAPIComponent(t *testing.T) {
 }
 
 func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		path string
 		out  map[string]string
@@ -244,7 +255,9 @@ func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
 			req := getTestHTTPRequest()
 			resp := &fasthttp.Response{}
 			resp.SetStatusCode(200)
@@ -270,6 +283,7 @@ func TestGetSpanAttributesMapFromHTTPContext(t *testing.T) {
 }
 
 func TestSpanContextToResponse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		scConfig trace.SpanContextConfig
 	}{
@@ -282,7 +296,9 @@ func TestSpanContextToResponse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run("SpanContextToResponse", func(t *testing.T) {
+			t.Parallel()
 			resp := &fasthttp.Response{}
 			wantSc := trace.NewSpanContext(tt.scConfig)
 			SpanContextToHTTPHeaders(wantSc, resp.Header.Set)
@@ -323,7 +339,6 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 	responseBody := "fake_responseDaprBody"
 
 	fakeHandler := func(ctx *fasthttp.RequestCtx) {
-		time.Sleep(100 * time.Millisecond)
 		ctx.Response.SetBodyRaw([]byte(responseBody))
 	}
 
@@ -339,6 +354,7 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 	otel.SetTracerProvider(tp)
 
 	t.Run("traceparent is given in request and sampling is enabled", func(t *testing.T) {
+		t.Parallel()
 		testRequestCtx := newTraceFastHTTPRequestCtx(
 			requestBody, "/v1.0/state/statestore",
 			map[string]string{
@@ -356,6 +372,7 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 	})
 
 	t.Run("traceparent is not given in request", func(t *testing.T) {
+		t.Parallel()
 		testRequestCtx := newTraceFastHTTPRequestCtx(
 			requestBody, "/v1.0/state/statestore",
 			map[string]string{
@@ -373,6 +390,7 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 	})
 
 	t.Run("traceparent not given in response", func(t *testing.T) {
+		t.Parallel()
 		testRequestCtx := newTraceFastHTTPRequestCtx(
 			requestBody, "/v1.0/state/statestore",
 			map[string]string{
@@ -387,6 +405,7 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 	})
 
 	t.Run("traceparent given in response", func(t *testing.T) {
+		t.Parallel()
 		testRequestCtx := newTraceFastHTTPRequestCtx(
 			requestBody, "/v1.0/state/statestore",
 			map[string]string{
@@ -404,6 +423,7 @@ func TestHTTPTraceMiddleware(t *testing.T) {
 	})
 
 	t.Run("path is /v1.0/invoke/*", func(t *testing.T) {
+		t.Parallel()
 		testRequestCtx := newTraceFastHTTPRequestCtx(
 			requestBody, "/v1.0/invoke/callee/method/method1",
 			map[string]string{},
@@ -450,7 +470,9 @@ func TestTraceStatusFromHTTPCode(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run("traceStatusFromHTTPCode", func(t *testing.T) {
+			t.Parallel()
 			gotOtelCode, gotOtelCodeDescription := traceStatusFromHTTPCode(tt.httpCode)
 			assert.Equalf(t, gotOtelCode, tt.wantOtelCode, "traceStatusFromHTTPCode(%v) got = %v, want %v", tt.httpCode, gotOtelCode, tt.wantOtelCode)
 			assert.Equalf(t, gotOtelCodeDescription, tt.wantOtelCodeDescription, "traceStatusFromHTTPCode(%v) got = %v, want %v", tt.httpCode, gotOtelCodeDescription, tt.wantOtelCodeDescription)

--- a/pkg/diagnostics/resiliency_monitoring.go
+++ b/pkg/diagnostics/resiliency_monitoring.go
@@ -7,7 +7,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
+	"github.com/dapr/dapr/pkg/diagnostics/utils"
 )
 
 var (
@@ -28,13 +28,16 @@ type resiliencyMetrics struct {
 	executionCount    *stats.Int64Measure
 	activationsCount  *stats.Int64Measure
 
-	appID   string
-	ctx     context.Context
-	enabled bool
+	meter    view.Meter
+	regRules utils.Rules
+	appID    string
+	enabled  bool
 }
 
-func newResiliencyMetrics() *resiliencyMetrics {
+func newResiliencyMetrics(meter view.Meter, regRules utils.Rules) *resiliencyMetrics {
 	return &resiliencyMetrics{ //nolint:exhaustruct
+		meter:    meter,
+		regRules: regRules,
 		policiesLoadCount: stats.Int64(
 			"resiliency/loaded",
 			"Number of resiliency policies loaded.",
@@ -48,64 +51,65 @@ func newResiliencyMetrics() *resiliencyMetrics {
 			"Number of times a resiliency policyKey has been activated in a building block after a failure or after a state change.",
 			stats.UnitDimensionless),
 
-		// TODO: how to use correct context
-		ctx:     context.Background(),
 		enabled: false,
 	}
 }
 
-// Init registers the resiliency metrics views.
-func (m *resiliencyMetrics) Init(id string) error {
+// init registers the resiliency metrics views.
+func (m *resiliencyMetrics) init(id string) error {
 	m.enabled = true
 	m.appID = id
-	return view.Register(
-		diagUtils.NewMeasureView(m.policiesLoadCount, []tag.Key{appIDKey, resiliencyNameKey, namespaceKey}, view.Count()),
-		diagUtils.NewMeasureView(m.executionCount, []tag.Key{appIDKey, resiliencyNameKey, policyKey, namespaceKey, flowDirectionKey, targetKey, statusKey}, view.Count()),
-		diagUtils.NewMeasureView(m.activationsCount, []tag.Key{appIDKey, resiliencyNameKey, policyKey, namespaceKey, flowDirectionKey, targetKey, statusKey}, view.Count()),
+	return m.meter.Register(
+		utils.NewMeasureView(m.policiesLoadCount, []tag.Key{appIDKey, resiliencyNameKey, namespaceKey}, utils.Count()),
+		utils.NewMeasureView(m.executionCount, []tag.Key{appIDKey, resiliencyNameKey, policyKey, namespaceKey, flowDirectionKey, targetKey, statusKey}, utils.Count()),
+		utils.NewMeasureView(m.activationsCount, []tag.Key{appIDKey, resiliencyNameKey, policyKey, namespaceKey, flowDirectionKey, targetKey, statusKey}, utils.Count()),
 	)
 }
 
 // PolicyLoaded records metric when policy is loaded.
-func (m *resiliencyMetrics) PolicyLoaded(resiliencyName, namespace string) {
+func (m *resiliencyMetrics) PolicyLoaded(ctx context.Context, resiliencyName, namespace string) {
 	if m.enabled {
-		_ = stats.RecordWithTags(
-			m.ctx,
-			diagUtils.WithTags(m.policiesLoadCount.Name(), appIDKey, m.appID, resiliencyNameKey, resiliencyName, namespaceKey, namespace),
-			m.policiesLoadCount.M(1),
+		_ = stats.RecordWithOptions(
+			ctx,
+			stats.WithRecorder(m.meter),
+			m.regRules.WithTags(m.policiesLoadCount.Name(), appIDKey, m.appID, resiliencyNameKey, resiliencyName, namespaceKey, namespace),
+			stats.WithMeasurements(m.policiesLoadCount.M(1)),
 		)
 	}
 }
 
 // PolicyWithStatusExecuted records metric when policy is executed with added status information (e.g., circuit breaker open).
-func (m *resiliencyMetrics) PolicyWithStatusExecuted(resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string, status string) {
+func (m *resiliencyMetrics) PolicyWithStatusExecuted(ctx context.Context, resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string, status string) {
 	if m.enabled {
-		_ = stats.RecordWithTags(
-			m.ctx,
-			diagUtils.WithTags(m.executionCount.Name(), appIDKey, m.appID, resiliencyNameKey, resiliencyName, policyKey, string(policy),
+		_ = stats.RecordWithOptions(
+			ctx,
+			stats.WithRecorder(m.meter),
+			m.regRules.WithTags(m.executionCount.Name(), appIDKey, m.appID, resiliencyNameKey, resiliencyName, policyKey, string(policy),
 				namespaceKey, namespace, flowDirectionKey, string(flowDirection), targetKey, target, statusKey, status),
-			m.executionCount.M(1),
+			stats.WithMeasurements(m.executionCount.M(1)),
 		)
 	}
 }
 
 // PolicyExecuted records metric when policy is executed.
-func (m *resiliencyMetrics) PolicyExecuted(resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string) {
-	m.PolicyWithStatusExecuted(resiliencyName, namespace, policy, flowDirection, target, "")
+func (m *resiliencyMetrics) PolicyExecuted(ctx context.Context, resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string) {
+	m.PolicyWithStatusExecuted(ctx, resiliencyName, namespace, policy, flowDirection, target, "")
 }
 
 // PolicyActivated records metric when policy is activated after a failure
-func (m *resiliencyMetrics) PolicyActivated(resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string) {
-	m.PolicyWithStatusActivated(resiliencyName, namespace, policy, flowDirection, target, "")
+func (m *resiliencyMetrics) PolicyActivated(ctx context.Context, resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string) {
+	m.PolicyWithStatusActivated(ctx, resiliencyName, namespace, policy, flowDirection, target, "")
 }
 
 // PolicyWithStatusActivated records metric when policy is activated after a failure or in the case of circuit breaker after a state change. with added state/status (e.g., circuit breaker open).
-func (m *resiliencyMetrics) PolicyWithStatusActivated(resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string, status string) {
+func (m *resiliencyMetrics) PolicyWithStatusActivated(ctx context.Context, resiliencyName, namespace string, policy PolicyType, flowDirection PolicyFlowDirection, target string, status string) {
 	if m.enabled {
-		_ = stats.RecordWithTags(
-			m.ctx,
-			diagUtils.WithTags(m.activationsCount.Name(), appIDKey, m.appID, resiliencyNameKey, resiliencyName, policyKey, string(policy),
+		_ = stats.RecordWithOptions(
+			ctx,
+			stats.WithRecorder(m.meter),
+			m.regRules.WithTags(m.activationsCount.Name(), appIDKey, m.appID, resiliencyNameKey, resiliencyName, policyKey, string(policy),
 				namespaceKey, namespace, flowDirectionKey, string(flowDirection), targetKey, target, statusKey, status),
-			m.activationsCount.M(1),
+			stats.WithMeasurements(m.activationsCount.M(1)),
 		)
 	}
 }

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -31,13 +31,16 @@ import (
 )
 
 func TestSpanContextToW3CString(t *testing.T) {
+	t.Parallel()
 	t.Run("empty SpanContext", func(t *testing.T) {
+		t.Parallel()
 		expected := "00-00000000000000000000000000000000-0000000000000000-00"
 		sc := trace.SpanContext{}
 		got := SpanContextToW3CString(sc)
 		assert.Equal(t, expected, got)
 	})
 	t.Run("valid SpanContext", func(t *testing.T) {
+		t.Parallel()
 		expected := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 		scConfig := trace.SpanContextConfig{
 			TraceID:    trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
@@ -51,12 +54,15 @@ func TestSpanContextToW3CString(t *testing.T) {
 }
 
 func TestTraceStateToW3CString(t *testing.T) {
+	t.Parallel()
 	t.Run("empty Tracestate", func(t *testing.T) {
+		t.Parallel()
 		sc := trace.SpanContext{}
 		got := TraceStateToW3CString(sc)
 		assert.Empty(t, got)
 	})
 	t.Run("valid Tracestate", func(t *testing.T) {
+		t.Parallel()
 		ts := trace.TraceState{}
 		ts, _ = ts.Insert("key", "value")
 		sc := trace.SpanContext{}
@@ -67,13 +73,16 @@ func TestTraceStateToW3CString(t *testing.T) {
 }
 
 func TestSpanContextFromW3CString(t *testing.T) {
+	t.Parallel()
 	t.Run("empty SpanContext", func(t *testing.T) {
+		t.Parallel()
 		sc := "00-00000000000000000000000000000000-0000000000000000-00"
 		expected := trace.SpanContext{}
 		got, _ := SpanContextFromW3CString(sc)
 		assert.Equal(t, expected, got)
 	})
 	t.Run("valid SpanContext", func(t *testing.T) {
+		t.Parallel()
 		sc := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 		scConfig := trace.SpanContextConfig{
 			TraceID:    trace.TraceID{75, 249, 47, 53, 119, 179, 77, 166, 163, 206, 146, 157, 14, 14, 71, 54},
@@ -87,7 +96,9 @@ func TestSpanContextFromW3CString(t *testing.T) {
 }
 
 func TestTraceStateFromW3CString(t *testing.T) {
+	t.Parallel()
 	t.Run("empty Tracestate", func(t *testing.T) {
+		t.Parallel()
 		ts := trace.TraceState{}
 		sc := trace.SpanContext{}
 		sc = sc.WithTraceState(ts)
@@ -96,6 +107,7 @@ func TestTraceStateFromW3CString(t *testing.T) {
 		assert.Equal(t, ts, *got)
 	})
 	t.Run("valid Tracestate", func(t *testing.T) {
+		t.Parallel()
 		ts := trace.TraceState{}
 		ts, _ = ts.Insert("key", "value")
 		sc := trace.SpanContext{}
@@ -105,6 +117,7 @@ func TestTraceStateFromW3CString(t *testing.T) {
 		assert.Equal(t, ts, *got)
 	})
 	t.Run("invalid Tracestate", func(t *testing.T) {
+		t.Parallel()
 		ts := trace.TraceState{}
 		// A non-parsable tracestate should equate back to an empty one.
 		got := TraceStateFromW3CString("bad tracestate")
@@ -113,6 +126,7 @@ func TestTraceStateFromW3CString(t *testing.T) {
 }
 
 func TestStartInternalCallbackSpan(t *testing.T) {
+	t.Parallel()
 	exp := newOtelFakeExporter()
 
 	tp := sdktrace.NewTracerProvider(
@@ -122,6 +136,7 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 	otel.SetTracerProvider(tp)
 
 	t.Run("traceparent is provided and sampling is enabled", func(t *testing.T) {
+		t.Parallel()
 		traceSpec := config.TracingSpec{SamplingRate: "1"}
 
 		scConfig := trace.SpanContextConfig{
@@ -142,6 +157,7 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 	})
 
 	t.Run("traceparent is provided with sampling flag = 1 but sampling is disabled", func(t *testing.T) {
+		t.Parallel()
 		traceSpec := config.TracingSpec{SamplingRate: "0"}
 
 		scConfig := trace.SpanContextConfig{
@@ -159,6 +175,7 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 	})
 
 	t.Run("traceparent is provided with sampling flag = 0 and sampling is enabled (but not P=1.00)", func(t *testing.T) {
+		t.Parallel()
 		// We use a fixed seed for the RNG so we can use an exact number here
 		const expectSampled = 1051
 		const numTraces = 100000
@@ -168,12 +185,14 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 	})
 
 	t.Run("traceparent is provided with sampling flag = 0 and sampling is enabled (and P=1.00)", func(t *testing.T) {
+		t.Parallel()
 		const numTraces = 1000
 		sampledCount := runTraces(t, "test_trace", numTraces, "1.00", 0)
 		require.Equal(t, sampledCount, numTraces, "Expected to sample all traces (%d) but only sampled %d", numTraces, sampledCount)
 	})
 
 	t.Run("traceparent is provided with sampling flag = 1 and sampling is enabled (but not P=1.00)", func(t *testing.T) {
+		t.Parallel()
 		const numTraces = 1000
 		sampledCount := runTraces(t, "test_trace", numTraces, "0.00001", 1)
 		require.Equal(t, sampledCount, numTraces, "Expected to sample all traces (%d) but only sampled %d", numTraces, sampledCount)

--- a/pkg/diagnostics/utils/metrics_utils_test.go
+++ b/pkg/diagnostics/utils/metrics_utils_test.go
@@ -25,14 +25,14 @@ import (
 func TestWithTags(t *testing.T) {
 	t.Run("one tag", func(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
-		mutators := WithTags("", appKey, "test")
+		mutators := Rules{}.tags("", appKey, "test")
 		assert.Equal(t, 1, len(mutators))
 	})
 
 	t.Run("two tags", func(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
 		operationKey := tag.MustNewKey("operation")
-		mutators := WithTags("", appKey, "test", operationKey, "op")
+		mutators := Rules{}.tags("", appKey, "test", operationKey, "op")
 		assert.Equal(t, 2, len(mutators))
 	})
 
@@ -40,14 +40,14 @@ func TestWithTags(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
 		operationKey := tag.MustNewKey("operation")
 		methodKey := tag.MustNewKey("method")
-		mutators := WithTags("", appKey, "test", operationKey, "op", methodKey, "method")
+		mutators := Rules{}.tags("", appKey, "test", operationKey, "op", methodKey, "method")
 		assert.Equal(t, 3, len(mutators))
 	})
 
 	t.Run("two tags with wrong value type", func(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
 		operationKey := tag.MustNewKey("operation")
-		mutators := WithTags("", appKey, "test", operationKey, 1)
+		mutators := Rules{}.tags("", appKey, "test", operationKey, 1)
 		assert.Equal(t, 1, len(mutators))
 	})
 
@@ -55,14 +55,14 @@ func TestWithTags(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
 		operationKey := tag.MustNewKey("operation")
 		methodKey := tag.MustNewKey("method")
-		mutators := WithTags("", appKey, "", operationKey, "op", methodKey, "method")
+		mutators := Rules{}.tags("", appKey, "", operationKey, "op", methodKey, "method")
 		assert.Equal(t, 2, len(mutators))
 	})
 }
 
 func TestCreateRulesMap(t *testing.T) {
 	t.Run("invalid rule", func(t *testing.T) {
-		err := CreateRulesMap([]config.MetricsRule{
+		_, err := CreateRulesMap([]config.MetricsRule{
 			{
 				Name: "test",
 				Labels: []config.MetricLabel{
@@ -79,7 +79,7 @@ func TestCreateRulesMap(t *testing.T) {
 	})
 
 	t.Run("valid rule", func(t *testing.T) {
-		err := CreateRulesMap([]config.MetricsRule{
+		rules, err := CreateRulesMap([]config.MetricsRule{
 			{
 				Name: "test",
 				Labels: []config.MetricLabel{
@@ -94,10 +94,10 @@ func TestCreateRulesMap(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.NotNil(t, metricsRules)
-		assert.Len(t, metricsRules, 1)
-		assert.Len(t, metricsRules["testlabel"], 1)
-		assert.Equal(t, "TEST", metricsRules["testlabel"][0].replace)
-		assert.NotNil(t, metricsRules["testlabel"][0].regex)
+		assert.NotNil(t, rules)
+		assert.Len(t, rules, 1)
+		assert.Len(t, rules["testlabel"], 1)
+		assert.Equal(t, "TEST", rules["testlabel"][0].replace)
+		assert.NotNil(t, rules["testlabel"][0].regex)
 	})
 }

--- a/pkg/grpc/api_actor_test.go
+++ b/pkg/grpc/api_actor_test.go
@@ -18,12 +18,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/dapr/dapr/pkg/actors"
 	"github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	daprt "github.com/dapr/dapr/pkg/testing"
@@ -286,10 +288,13 @@ func TestInvokeActorWithResiliency(t *testing.T) {
 		),
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	server, lis := startDaprAPIServer(&api{
 		id:         "fakeAPI",
 		actor:      &failingActors,
-		resiliency: resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), testActorResiliency),
+		resiliency: resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), metrics, testActorResiliency),
 	}, "")
 	defer server.Stop()
 

--- a/pkg/grpc/api_crypto_test.go
+++ b/pkg/grpc/api_crypto_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/grpc/universalapi"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -37,11 +38,14 @@ import (
 func TestCryptoAlpha1(t *testing.T) {
 	compStore := compstore.New()
 	compStore.AddCryptoProvider("myvault", &daprt.FakeSubtleCrypto{})
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 	fakeAPI := &api{
 		UniversalAPI: &universalapi.UniversalAPI{
 			Logger:     apiServerLogger,
-			Resiliency: resiliency.New(nil),
+			Resiliency: resiliency.New(nil, metrics),
 			CompStore:  compStore,
+			Metrics:    metrics,
 		},
 	}
 

--- a/pkg/grpc/api_daprinternal_test.go
+++ b/pkg/grpc/api_daprinternal_test.go
@@ -24,16 +24,21 @@ import (
 	"google.golang.org/grpc/status"
 
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 )
 
 func TestCallLocal(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	t.Run("appchannel is not ready", func(t *testing.T) {
 		fakeAPI := &api{
 			id:         "fakeAPI",
 			appChannel: nil,
+			metrics:    metrics,
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -53,6 +58,7 @@ func TestCallLocal(t *testing.T) {
 		fakeAPI := &api{
 			id:         "fakeAPI",
 			appChannel: mockAppChannel,
+			metrics:    metrics,
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -77,6 +83,7 @@ func TestCallLocal(t *testing.T) {
 		fakeAPI := &api{
 			id:         "fakeAPI",
 			appChannel: mockAppChannel,
+			metrics:    metrics,
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -93,10 +100,13 @@ func TestCallLocal(t *testing.T) {
 }
 
 func TestCallLocalStream(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 	t.Run("appchannel is not ready", func(t *testing.T) {
 		fakeAPI := &api{
 			id:         "fakeAPI",
 			appChannel: nil,
+			metrics:    metrics,
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -125,6 +135,7 @@ func TestCallLocalStream(t *testing.T) {
 		fakeAPI := &api{
 			id:         "fakeAPI",
 			appChannel: mockAppChannel,
+			metrics:    metrics,
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -160,6 +171,7 @@ func TestCallLocalStream(t *testing.T) {
 		fakeAPI := &api{
 			id:         "fakeAPI",
 			appChannel: mockAppChannel,
+			metrics:    metrics,
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -111,7 +111,7 @@ func TestClose(t *testing.T) {
 			EnableAPILogging:     true,
 		}
 		a := &api{UniversalAPI: &universalapi.UniversalAPI{CompStore: compstore.New()}}
-		server := NewAPIServer(a, serverConfig, config.TracingSpec{}, config.MetricSpec{}, config.APISpec{}, nil, nil)
+		server := NewAPIServer(a, serverConfig, config.TracingSpec{}, config.MetricSpec{}, config.APISpec{}, nil, nil, nil)
 		require.NoError(t, server.StartNonBlocking())
 		dapr_testing.WaitForListeningAddress(t, 5*time.Second, fmt.Sprintf("127.0.0.1:%d", port))
 		assert.NoError(t, server.Close())
@@ -132,7 +132,7 @@ func TestClose(t *testing.T) {
 			EnableAPILogging:     false,
 		}
 		a := &api{UniversalAPI: &universalapi.UniversalAPI{CompStore: compstore.New()}}
-		server := NewAPIServer(a, serverConfig, config.TracingSpec{}, config.MetricSpec{}, config.APISpec{}, nil, nil)
+		server := NewAPIServer(a, serverConfig, config.TracingSpec{}, config.MetricSpec{}, config.APISpec{}, nil, nil, nil)
 		require.NoError(t, server.StartNonBlocking())
 		dapr_testing.WaitForListeningAddress(t, 5*time.Second, fmt.Sprintf("127.0.0.1:%d", port))
 		assert.NoError(t, server.Close())

--- a/pkg/grpc/universalapi/api_crypto.go
+++ b/pkg/grpc/universalapi/api_crypto.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"k8s.io/utils/clock"
 
 	contribCrypto "github.com/dapr/components-contrib/crypto"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -46,9 +47,9 @@ func (a *UniversalAPI) CryptoGetWrapKeyFn(ctx context.Context, componentName str
 			r.wrappedKey, r.tag, rErr = component.WrapKey(ctx, plaintextKey, algorithm, keyName, nonce, nil)
 			return
 		})
-		elapsed := diag.ElapsedSince(start)
+		elapsed := diag.ElapsedSince(clock.RealClock{}, start)
 
-		diag.DefaultComponentMonitoring.CryptoInvoked(ctx, componentName, diag.CryptoOp, err == nil, elapsed)
+		a.Metrics.Component.CryptoInvoked(ctx, componentName, diag.CryptoOp, err == nil, elapsed)
 
 		if err != nil {
 			return nil, nil, err
@@ -66,9 +67,9 @@ func (a *UniversalAPI) CryptoGetUnwrapKeyFn(ctx context.Context, componentName s
 		plaintextKey, err := policyRunner(func(ctx context.Context) (jwk.Key, error) {
 			return component.UnwrapKey(ctx, wrappedKey, algorithm, keyName, nonce, tag, nil)
 		})
-		elapsed := diag.ElapsedSince(start)
+		elapsed := diag.ElapsedSince(clock.RealClock{}, start)
 
-		diag.DefaultComponentMonitoring.CryptoInvoked(ctx, componentName, diag.CryptoOp, err == nil, elapsed)
+		a.Metrics.Component.CryptoInvoked(ctx, componentName, diag.CryptoOp, err == nil, elapsed)
 
 		if err != nil {
 			return nil, err

--- a/pkg/grpc/universalapi/api_secrets.go
+++ b/pkg/grpc/universalapi/api_secrets.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dapr/dapr/pkg/messages"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"k8s.io/utils/clock"
 )
 
 func (a *UniversalAPI) GetSecret(ctx context.Context, in *runtimev1pb.GetSecretRequest) (*runtimev1pb.GetSecretResponse, error) {
@@ -51,9 +52,9 @@ func (a *UniversalAPI) GetSecret(ctx context.Context, in *runtimev1pb.GetSecretR
 		rResp, rErr := component.GetSecret(ctx, req)
 		return &rResp, rErr
 	})
-	elapsed := diag.ElapsedSince(start)
+	elapsed := diag.ElapsedSince(clock.RealClock{}, start)
 
-	diag.DefaultComponentMonitoring.SecretInvoked(ctx, in.StoreName, diag.Get, err == nil, elapsed)
+	a.Metrics.Component.SecretInvoked(ctx, in.StoreName, diag.Get, err == nil, elapsed)
 
 	if err != nil {
 		err = messages.ErrSecretGet.WithFormat(req.Name, in.StoreName, err.Error())
@@ -89,9 +90,9 @@ func (a *UniversalAPI) GetBulkSecret(ctx context.Context, in *runtimev1pb.GetBul
 		rResp, rErr := component.BulkGetSecret(ctx, req)
 		return &rResp, rErr
 	})
-	elapsed := diag.ElapsedSince(start)
+	elapsed := diag.ElapsedSince(clock.RealClock{}, start)
 
-	diag.DefaultComponentMonitoring.SecretInvoked(ctx, in.StoreName, diag.BulkGet, err == nil, elapsed)
+	a.Metrics.Component.SecretInvoked(ctx, in.StoreName, diag.BulkGet, err == nil, elapsed)
 
 	if err != nil {
 		err = messages.ErrBulkSecretGet.WithFormat(in.StoreName, err.Error())

--- a/pkg/grpc/universalapi/api_secrets_test.go
+++ b/pkg/grpc/universalapi/api_secrets_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/dapr/pkg/config"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/messages"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
@@ -33,10 +34,14 @@ import (
 )
 
 func TestSecretStoreNotConfigured(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup Dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:    testLogger,
 		CompStore: compstore.New(),
+		Metrics:   metrics,
 	}
 
 	// act
@@ -161,11 +166,15 @@ func TestGetSecret(t *testing.T) {
 		compStore.AddSecretsConfiguration(name, conf)
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup Dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     testLogger,
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
+		Metrics:    metrics,
 	}
 
 	// act
@@ -226,11 +235,15 @@ func TestGetBulkSecret(t *testing.T) {
 		compStore.AddSecretsConfiguration(name, conf)
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup Dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     testLogger,
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
+		Metrics:    metrics,
 	}
 
 	// act
@@ -264,11 +277,15 @@ func TestSecretAPIWithResiliency(t *testing.T) {
 	compStore := compstore.New()
 	compStore.AddSecretStore("failSecret", failingStore)
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup Dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     testLogger,
-		Resiliency: resiliency.FromConfigurations(testLogger, testResiliency),
+		Resiliency: resiliency.FromConfigurations(testLogger, metrics, testResiliency),
 		CompStore:  compStore,
+		Metrics:    metrics,
 	}
 
 	// act

--- a/pkg/grpc/universalapi/api_state_query.go
+++ b/pkg/grpc/universalapi/api_state_query.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dapr/dapr/pkg/messages"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"k8s.io/utils/clock"
 )
 
 func (a *UniversalAPI) getStateStore(name string) (state.Store, error) {
@@ -80,9 +81,9 @@ func (a *UniversalAPI) QueryStateAlpha1(ctx context.Context, in *runtimev1pb.Que
 	resp, err := policyRunner(func(ctx context.Context) (*state.QueryResponse, error) {
 		return querier.Query(ctx, &req)
 	})
-	elapsed := diag.ElapsedSince(start)
+	elapsed := diag.ElapsedSince(clock.RealClock{}, start)
 
-	diag.DefaultComponentMonitoring.StateInvoked(ctx, in.StoreName, diag.StateQuery, err == nil, elapsed)
+	a.Metrics.Component.StateInvoked(ctx, in.StoreName, diag.StateQuery, err == nil, elapsed)
 
 	if err != nil {
 		err = messages.ErrStateQueryFailed.WithFormat(in.StoreName, err.Error())

--- a/pkg/grpc/universalapi/api_workflow_test.go
+++ b/pkg/grpc/universalapi/api_workflow_test.go
@@ -18,8 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/components-contrib/workflows"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/messages"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
@@ -108,11 +110,13 @@ func TestStartWorkflowAPI(t *testing.T) {
 	for name, wf := range fakeWorkflows {
 		compStore.AddWorkflow(name, wf)
 	}
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 
 	// Setup universal dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     logger.NewLogger("test"),
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
 	}
 
@@ -181,10 +185,13 @@ func TestGetWorkflowAPI(t *testing.T) {
 		compStore.AddWorkflow(name, wf)
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup universal dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     logger.NewLogger("test"),
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
 	}
 
@@ -252,10 +259,13 @@ func TestTerminateWorkflowAPI(t *testing.T) {
 		compStore.AddWorkflow(name, wf)
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup universal dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     logger.NewLogger("test"),
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
 	}
 
@@ -338,10 +348,13 @@ func TestRaiseEventWorkflowApi(t *testing.T) {
 		compStore.AddWorkflow(name, wf)
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup universal dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     logger.NewLogger("test"),
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
 	}
 
@@ -411,10 +424,13 @@ func TestPauseWorkflowApi(t *testing.T) {
 		compStore.AddWorkflow(name, wf)
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup universal dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     logger.NewLogger("test"),
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
 	}
 
@@ -482,10 +498,13 @@ func TestResumeWorkflowApi(t *testing.T) {
 		compStore.AddWorkflow(name, wf)
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	// Setup universal dapr API
 	fakeAPI := &UniversalAPI{
 		Logger:     logger.NewLogger("test"),
-		Resiliency: resiliency.New(nil),
+		Resiliency: resiliency.New(nil, metrics),
 		CompStore:  compStore,
 	}
 

--- a/pkg/grpc/universalapi/universalapi.go
+++ b/pkg/grpc/universalapi/universalapi.go
@@ -16,6 +16,7 @@ limitations under the License.
 package universalapi
 
 import (
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	"github.com/dapr/kit/logger"
@@ -27,4 +28,5 @@ type UniversalAPI struct {
 	Logger     logger.Logger
 	Resiliency resiliency.Provider
 	CompStore  *compstore.ComponentStore
+	Metrics    *diag.Metrics
 }

--- a/pkg/http/api_crypto_test.go
+++ b/pkg/http/api_crypto_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/grpc/universalapi"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
@@ -30,15 +31,19 @@ import (
 
 func TestCryptoEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 
 	compStore := compstore.New()
 	const cryptoComponentName = "myvault"
 	compStore.AddCryptoProvider(cryptoComponentName, &daprt.FakeSubtleCrypto{})
 	testAPI := &api{
+		metrics: metrics,
 		universal: &universalapi.UniversalAPI{
+			Metrics:    metrics,
 			Logger:     log,
 			CompStore:  compStore,
-			Resiliency: resiliency.New(nil),
+			Resiliency: resiliency.New(nil, metrics),
 		},
 	}
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -62,6 +62,7 @@ type server struct {
 	apiSpec            config.APISpec
 	servers            []*fasthttp.Server
 	profilingListeners []net.Listener
+	metrics            *diag.Metrics
 }
 
 // NewServerOpts are the options for NewServer.
@@ -72,6 +73,7 @@ type NewServerOpts struct {
 	MetricSpec  config.MetricSpec
 	Pipeline    httpMiddleware.Pipeline
 	APISpec     config.APISpec
+	Metrics     *diag.Metrics
 }
 
 // NewServer returns a new HTTP server.
@@ -84,6 +86,7 @@ func NewServer(opts NewServerOpts) Server {
 		metricSpec:  opts.MetricSpec,
 		pipeline:    opts.Pipeline,
 		apiSpec:     opts.APISpec,
+		metrics:     opts.Metrics,
 	}
 }
 
@@ -222,7 +225,7 @@ func (s *server) useMetrics(next fasthttp.RequestHandler) fasthttp.RequestHandle
 	if s.metricSpec.Enabled {
 		log.Infof("enabled metrics http middleware")
 
-		return diag.DefaultHTTPMonitoring.FastHTTPMiddleware(next)
+		return s.metrics.HTTP.FastHTTPMiddleware(next)
 	}
 
 	return next

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
@@ -168,7 +169,11 @@ func TestInvokeRemote(t *testing.T) {
 		server := startInternalServer(socket, enableStreaming, chunks)
 		clientConn := createTestClient(socket)
 
+		metrics, err := diag.NewMetrics(nil)
+		require.NoError(t, err)
+
 		messaging := NewDirectMessaging(NewDirectMessagingOpts{
+			Metrics:            metrics,
 			MaxRequestBodySize: 10 << 20,
 			ClientConnFn: func(ctx context.Context, address string, id string, namespace string, customOpts ...grpc.DialOption) (*grpc.ClientConn, func(destroy bool), error) {
 				return clientConn, func(_ bool) {}, nil

--- a/pkg/messaging/grpc_proxy_test.go
+++ b/pkg/messaging/grpc_proxy_test.go
@@ -20,12 +20,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/diagnostics"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 )
@@ -51,12 +53,15 @@ func appClientFn() (grpc.ClientConnInterface, error) {
 }
 
 func TestNewProxy(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 	p := NewProxy(ProxyOpts{
 		ConnectionFactory: connectionFn,
 		AppClientFn:       appClientFn,
 		AppID:             "a",
 		ACL:               nil,
-		Resiliency:        resiliency.New(nil),
+		Resiliency:        resiliency.New(nil, metrics),
+		Metrics:           metrics,
 	})
 	proxy := p.(*proxy)
 
@@ -66,12 +71,15 @@ func TestNewProxy(t *testing.T) {
 }
 
 func TestSetRemoteAppFn(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 	p := NewProxy(ProxyOpts{
 		ConnectionFactory: connectionFn,
 		AppClientFn:       appClientFn,
 		AppID:             "a",
 		ACL:               nil,
-		Resiliency:        resiliency.New(nil),
+		Resiliency:        resiliency.New(nil, metrics),
+		Metrics:           metrics,
 	})
 	p.SetRemoteAppFn(func(s string) (remoteApp, error) {
 		return remoteApp{
@@ -87,12 +95,15 @@ func TestSetRemoteAppFn(t *testing.T) {
 }
 
 func TestSetTelemetryFn(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 	p := NewProxy(ProxyOpts{
 		ConnectionFactory: connectionFn,
 		AppClientFn:       appClientFn,
 		AppID:             "a",
 		ACL:               nil,
-		Resiliency:        resiliency.New(nil),
+		Resiliency:        resiliency.New(nil, metrics),
+		Metrics:           metrics,
 	})
 	p.SetTelemetryFn(func(ctx context.Context) context.Context {
 		return ctx
@@ -107,11 +118,14 @@ func TestSetTelemetryFn(t *testing.T) {
 }
 
 func TestHandler(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 	p := NewProxy(ProxyOpts{
 		ConnectionFactory: connectionFn,
 		AppClientFn:       appClientFn,
 		AppID:             "a",
-		Resiliency:        resiliency.New(nil),
+		Resiliency:        resiliency.New(nil, metrics),
+		Metrics:           metrics,
 	})
 	h := p.Handler()
 
@@ -119,12 +133,15 @@ func TestHandler(t *testing.T) {
 }
 
 func TestIntercept(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
 	t.Run("no app-id in metadata", func(t *testing.T) {
 		p := NewProxy(ProxyOpts{
 			ConnectionFactory: connectionFn,
 			AppClientFn:       appClientFn,
 			AppID:             "a",
-			Resiliency:        resiliency.New(nil),
+			Resiliency:        resiliency.New(nil, metrics),
+			Metrics:           metrics,
 		})
 		p.SetTelemetryFn(func(ctx context.Context) context.Context {
 			return ctx
@@ -150,7 +167,8 @@ func TestIntercept(t *testing.T) {
 			ConnectionFactory: connectionFn,
 			AppClientFn:       appClientFn,
 			AppID:             "a",
-			Resiliency:        resiliency.New(nil),
+			Resiliency:        resiliency.New(nil, metrics),
+			Metrics:           metrics,
 		})
 		p.SetTelemetryFn(func(ctx context.Context) context.Context {
 			return ctx
@@ -174,7 +192,8 @@ func TestIntercept(t *testing.T) {
 			ConnectionFactory: connectionFn,
 			AppClientFn:       appClientFn,
 			AppID:             "a",
-			Resiliency:        resiliency.New(nil),
+			Resiliency:        resiliency.New(nil, metrics),
+			Metrics:           metrics,
 		})
 		p.SetTelemetryFn(func(ctx context.Context) context.Context {
 			return ctx
@@ -201,7 +220,8 @@ func TestIntercept(t *testing.T) {
 			ConnectionFactory: connectionFn,
 			AppClientFn:       appClientFn,
 			AppID:             "a",
-			Resiliency:        resiliency.New(nil),
+			Resiliency:        resiliency.New(nil, metrics),
+			Metrics:           metrics,
 		})
 		p.SetTelemetryFn(func(ctx context.Context) context.Context {
 			ctx = metadata.AppendToOutgoingContext(ctx, "a", "b")
@@ -240,7 +260,8 @@ func TestIntercept(t *testing.T) {
 			AppClientFn:       appClientFn,
 			AppID:             "a",
 			ACL:               acl,
-			Resiliency:        resiliency.New(nil),
+			Resiliency:        resiliency.New(nil, metrics),
+			Metrics:           metrics,
 		})
 		p.SetRemoteAppFn(func(s string) (remoteApp, error) {
 			return remoteApp{
@@ -268,7 +289,8 @@ func TestIntercept(t *testing.T) {
 			ConnectionFactory: connectionFn,
 			AppClientFn:       appClientFn,
 			AppID:             "a",
-			Resiliency:        resiliency.New(nil),
+			Resiliency:        resiliency.New(nil, metrics),
+			Metrics:           metrics,
 		})
 		p.SetTelemetryFn(func(ctx context.Context) context.Context {
 			return ctx

--- a/pkg/operator/client/client.go
+++ b/pkg/operator/client/client.go
@@ -25,6 +25,7 @@ const (
 // GetOperatorClient returns a new k8s operator client and the underlying connection.
 // If a cert chain is given, a TLS connection will be established.
 func GetOperatorClient(ctx context.Context,
+	metrics *diag.Metrics,
 	address, serverName string, certChain *daprCredentials.CertChain,
 ) (operatorv1pb.OperatorClient, *grpc.ClientConn, error) {
 	if certChain == nil {
@@ -33,10 +34,10 @@ func GetOperatorClient(ctx context.Context,
 
 	unaryClientInterceptor := grpcRetry.UnaryClientInterceptor()
 
-	if diag.DefaultGRPCMonitoring.IsEnabled() {
+	if metrics.GRPC.IsEnabled() {
 		unaryClientInterceptor = grpcMiddleware.ChainUnaryClient(
 			unaryClientInterceptor,
-			diag.DefaultGRPCMonitoring.UnaryClientInterceptor(),
+			metrics.GRPC.UnaryClientInterceptor(),
 		)
 	}
 

--- a/pkg/operator/monitoring/metrics.go
+++ b/pkg/operator/monitoring/metrics.go
@@ -17,10 +17,10 @@ import (
 	"context"
 
 	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/dapr/pkg/diagnostics/utils"
 )
 
 const (
@@ -46,27 +46,34 @@ var (
 )
 
 // RecordServiceCreatedCount records the number of dapr service created.
-func RecordServiceCreatedCount(appID string) {
-	stats.RecordWithTags(context.Background(), diagUtils.WithTags(serviceCreatedTotal.Name(), appIDKey, appID), serviceCreatedTotal.M(1))
+func RecordServiceCreatedCount(metrics *diag.Metrics, appID string) {
+	stats.RecordWithOptions(context.Background(),
+		metrics.Rules.WithTags(serviceCreatedTotal.Name(), appIDKey, appID),
+		stats.WithMeasurements(serviceCreatedTotal.M(1)),
+	)
 }
 
 // RecordServiceDeletedCount records the number of dapr service deleted.
-func RecordServiceDeletedCount(appID string) {
-	stats.RecordWithTags(context.Background(), diagUtils.WithTags(serviceDeletedTotal.Name(), appIDKey, appID), serviceDeletedTotal.M(1))
+func RecordServiceDeletedCount(metrics *diag.Metrics, appID string) {
+	stats.RecordWithOptions(context.Background(),
+		metrics.Rules.WithTags(serviceDeletedTotal.Name(), appIDKey, appID),
+		stats.WithMeasurements(serviceDeletedTotal.M(1)),
+	)
 }
 
 // RecordServiceUpdatedCount records the number of dapr service updated.
-func RecordServiceUpdatedCount(appID string) {
-	stats.RecordWithTags(context.Background(), diagUtils.WithTags(serviceUpdatedTotal.Name(), appIDKey, appID), serviceUpdatedTotal.M(1))
+func RecordServiceUpdatedCount(metrics *diag.Metrics, appID string) {
+	stats.RecordWithOptions(context.Background(),
+		metrics.Rules.WithTags(serviceUpdatedTotal.Name(), appIDKey, appID),
+		stats.WithMeasurements(serviceUpdatedTotal.M(1)),
+	)
 }
 
 // InitMetrics initialize the operator service metrics.
-func InitMetrics() error {
-	err := view.Register(
-		diagUtils.NewMeasureView(serviceCreatedTotal, []tag.Key{appIDKey}, view.Count()),
-		diagUtils.NewMeasureView(serviceDeletedTotal, []tag.Key{appIDKey}, view.Count()),
-		diagUtils.NewMeasureView(serviceUpdatedTotal, []tag.Key{appIDKey}, view.Count()),
+func InitMetrics(metrics *diag.Metrics) error {
+	return metrics.Meter.Register(
+		utils.NewMeasureView(serviceCreatedTotal, []tag.Key{appIDKey}, utils.Count()),
+		utils.NewMeasureView(serviceDeletedTotal, []tag.Key{appIDKey}, utils.Count()),
+		utils.NewMeasureView(serviceUpdatedTotal, []tag.Key{appIDKey}, utils.Count()),
 	)
-
-	return err
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -41,6 +41,7 @@ import (
 	subscriptionsapiV1alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	subscriptionsapiV2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/pkg/credentials"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/health"
 	"github.com/dapr/dapr/pkg/operator/api"
 	operatorcache "github.com/dapr/dapr/pkg/operator/cache"
@@ -100,7 +101,7 @@ func init() {
 }
 
 // NewOperator returns a new Dapr Operator.
-func NewOperator(ctx context.Context, opts Options) (Operator, error) {
+func NewOperator(ctx context.Context, metrics *diag.Metrics, opts Options) (Operator, error) {
 	conf, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get controller runtime configuration, err: %s", err)
@@ -140,7 +141,7 @@ func NewOperator(ctx context.Context, opts Options) (Operator, error) {
 	}
 
 	if opts.ServiceReconcilerEnabled {
-		daprHandler := handlers.NewDaprHandlerWithOptions(mgr, &handlers.Options{ArgoRolloutServiceReconcilerEnabled: opts.ArgoRolloutServiceReconcilerEnabled})
+		daprHandler := handlers.NewDaprHandlerWithOptions(mgr, metrics, &handlers.Options{ArgoRolloutServiceReconcilerEnabled: opts.ArgoRolloutServiceReconcilerEnabled})
 		if err := daprHandler.Init(ctx); err != nil {
 			return nil, fmt.Errorf("unable to initialize handler: %w", err)
 		}

--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -319,8 +319,8 @@ func (p *Service) performTableDissemination(ctx context.Context) error {
 	p.streamConnPoolLock.RUnlock()
 	nTargetConns := len(p.raftNode.FSM().State().Members())
 
-	monitoring.RecordRuntimesCount(nStreamConnPool)
-	monitoring.RecordActorRuntimesCount(nTargetConns)
+	monitoring.RecordRuntimesCount(p.metrics, nStreamConnPool)
+	monitoring.RecordActorRuntimesCount(p.metrics, nTargetConns)
 
 	// ignore dissemination if there is no member update.
 	if cnt := p.memberUpdateCount.Load(); cnt > 0 {

--- a/pkg/placement/monitoring/metrics.go
+++ b/pkg/placement/monitoring/metrics.go
@@ -20,7 +20,8 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/dapr/pkg/diagnostics/utils"
 )
 
 var (
@@ -37,21 +38,25 @@ var (
 )
 
 // RecordRuntimesCount records the number of connected runtimes.
-func RecordRuntimesCount(count int) {
-	stats.Record(context.Background(), runtimesTotal.M(int64(count)))
+func RecordRuntimesCount(metrics *diag.Metrics, count int) {
+	stats.RecordWithOptions(context.Background(),
+		stats.WithRecorder(metrics.Meter),
+		stats.WithMeasurements(runtimesTotal.M(int64(count))),
+	)
 }
 
 // RecordActorRuntimesCount records the number of valid actor runtimes.
-func RecordActorRuntimesCount(count int) {
-	stats.Record(context.Background(), actorRuntimesTotal.M(int64(count)))
+func RecordActorRuntimesCount(metrics *diag.Metrics, count int) {
+	stats.RecordWithOptions(context.Background(),
+		stats.WithRecorder(metrics.Meter),
+		stats.WithMeasurements(actorRuntimesTotal.M(int64(count))),
+	)
 }
 
 // InitMetrics initialize the placement service metrics.
-func InitMetrics() error {
-	err := view.Register(
-		diagUtils.NewMeasureView(runtimesTotal, noKeys, view.LastValue()),
-		diagUtils.NewMeasureView(actorRuntimesTotal, noKeys, view.LastValue()),
+func InitMetrics(metrics *diag.Metrics) error {
+	return metrics.Meter.Register(
+		utils.NewMeasureView(runtimesTotal, noKeys, view.LastValue()),
+		utils.NewMeasureView(actorRuntimesTotal, noKeys, view.LastValue()),
 	)
-
-	return err
 }

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/clock"
 
 	daprCredentials "github.com/dapr/dapr/pkg/credentials"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/placement/raft"
 	placementv1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 	"github.com/dapr/kit/logger"
@@ -115,6 +116,7 @@ type Service struct {
 	// clock keeps time. Mocked in tests.
 	clock clock.WithTicker
 
+	metrics  *diag.Metrics
 	running  atomic.Bool
 	closed   atomic.Bool
 	closedCh chan struct{}
@@ -122,7 +124,7 @@ type Service struct {
 }
 
 // NewPlacementService returns a new placement service.
-func NewPlacementService(raftNode *raft.Server, certChain *daprCredentials.CertChain) (*Service, error) {
+func NewPlacementService(raftNode *raft.Server, certChain *daprCredentials.CertChain, metrics *diag.Metrics) (*Service, error) {
 	fhdd := &atomic.Int64{}
 	fhdd.Store(int64(faultyHostDetectInitialDuration))
 
@@ -139,6 +141,7 @@ func NewPlacementService(raftNode *raft.Server, certChain *daprCredentials.CertC
 		grpcServer:               grpc.NewServer(opts...),
 		clock:                    &clock.RealClock{},
 		closedCh:                 make(chan struct{}),
+		metrics:                  metrics,
 	}
 
 	placementv1pb.RegisterPlacementServer(p.grpcServer, p)

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/status"
 	clocktesting "k8s.io/utils/clock/testing"
 
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/placement/raft"
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 )
@@ -39,7 +40,9 @@ const testStreamSendLatency = time.Second
 func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Service, *clocktesting.FakeClock, context.CancelFunc) {
 	t.Helper()
 
-	testServer, err := NewPlacementService(raftServer, nil)
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+	testServer, err := NewPlacementService(raftServer, nil, metrics)
 	require.NoError(t, err)
 	clock := clocktesting.NewFakeClock(time.Now())
 	testServer.clock = clock

--- a/pkg/runtime/bulk_subscriber_test.go
+++ b/pkg/runtime/bulk_subscriber_test.go
@@ -112,7 +112,7 @@ func TestBulkSubscribe(t *testing.T) {
 	}
 
 	t.Run("bulk Subscribe Message for raw payload", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -160,7 +160,7 @@ func TestBulkSubscribe(t *testing.T) {
 	})
 
 	t.Run("bulk Subscribe Message for cloud event", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -208,7 +208,7 @@ func TestBulkSubscribe(t *testing.T) {
 	})
 
 	t.Run("bulk Subscribe multiple Messages at once for cloud events", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -259,7 +259,7 @@ func TestBulkSubscribe(t *testing.T) {
 	})
 
 	t.Run("bulk Subscribe events on different paths", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -325,7 +325,7 @@ func TestBulkSubscribe(t *testing.T) {
 	})
 
 	t.Run("verify Responses when bulk Subscribe events on different paths", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -445,7 +445,7 @@ func TestBulkSubscribe(t *testing.T) {
 	})
 
 	t.Run("verify Responses when entryId supplied blank while sending messages", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -527,7 +527,7 @@ func TestBulkSubscribe(t *testing.T) {
 	})
 
 	t.Run("verify bulk Subscribe Responses when App sends back out of order entryIds", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -613,7 +613,7 @@ func TestBulkSubscribe(t *testing.T) {
 	})
 
 	t.Run("verify bulk Subscribe Responses when App sends back wrong entryIds", func(t *testing.T) {
-		rt := NewTestDaprRuntime(modes.StandaloneMode)
+		rt := NewTestDaprRuntime(t, modes.StandaloneMode)
 		defer stopRuntime(t, rt)
 		rt.pubSubRegistry.RegisterComponent(
 			func(_ logger.Logger) pubsub.PubSub {
@@ -713,7 +713,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 
 	t.Run("GRPC - bulk Subscribe Message for raw payload", func(t *testing.T) {
 		port, _ := freeport.GetFreePort()
-		rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, string(GRPCProtocol), port)
+		rt := NewTestDaprRuntimeWithProtocol(t, modes.StandaloneMode, string(GRPCProtocol), port)
 		defer stopRuntime(t, rt)
 
 		rt.pubSubRegistry.RegisterComponent(
@@ -798,7 +798,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 
 	t.Run("GRPC - bulk Subscribe cloud event Message on different paths and verify response", func(t *testing.T) {
 		port, _ := freeport.GetFreePort()
-		rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, string(GRPCProtocol), port)
+		rt := NewTestDaprRuntimeWithProtocol(t, modes.StandaloneMode, string(GRPCProtocol), port)
 		defer stopRuntime(t, rt)
 
 		rt.pubSubRegistry.RegisterComponent(
@@ -921,7 +921,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 
 	t.Run("GRPC - verify Responses when entryId supplied blank while sending messages", func(t *testing.T) {
 		port, _ := freeport.GetFreePort()
-		rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, string(GRPCProtocol), port)
+		rt := NewTestDaprRuntimeWithProtocol(t, modes.StandaloneMode, string(GRPCProtocol), port)
 		defer stopRuntime(t, rt)
 
 		rt.pubSubRegistry.RegisterComponent(
@@ -1001,7 +1001,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 
 	t.Run("GRPC - verify bulk Subscribe Responses when App sends back out of order entryIds", func(t *testing.T) {
 		port, _ := freeport.GetFreePort()
-		rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, string(GRPCProtocol), port)
+		rt := NewTestDaprRuntimeWithProtocol(t, modes.StandaloneMode, string(GRPCProtocol), port)
 		defer stopRuntime(t, rt)
 
 		rt.pubSubRegistry.RegisterComponent(
@@ -1093,7 +1093,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 
 	t.Run("GRPC - verify bulk Subscribe Responses when App sends back wrong entryIds", func(t *testing.T) {
 		port, _ := freeport.GetFreePort()
-		rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, string(GRPCProtocol), port)
+		rt := NewTestDaprRuntimeWithProtocol(t, modes.StandaloneMode, string(GRPCProtocol), port)
 		defer stopRuntime(t, rt)
 
 		rt.pubSubRegistry.RegisterComponent(
@@ -1179,7 +1179,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 
 	t.Run("GRPC - verify bulk Subscribe Response when error while fetching Entry due to wrong dataContentType", func(t *testing.T) {
 		port, _ := freeport.GetFreePort()
-		rt := NewTestDaprRuntimeWithProtocol(modes.StandaloneMode, string(GRPCProtocol), port)
+		rt := NewTestDaprRuntimeWithProtocol(t, modes.StandaloneMode, string(GRPCProtocol), port)
 		defer stopRuntime(t, rt)
 
 		rt.pubSubRegistry.RegisterComponent(

--- a/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
+++ b/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
@@ -21,9 +21,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	contribPubsub "github.com/dapr/components-contrib/pubsub"
 	resiliencyV1alpha "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/resiliency/breaker"
 	"github.com/dapr/kit/logger"
@@ -181,7 +183,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		shortRetry.MaxRetries = ptr.Of(3)
 
 		// timeout will not be triggered here
-		policyProvider := createResPolicyProvider(resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -213,7 +215,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		shortRetry.MaxRetries = ptr.Of(2)
 
 		// timeout will not be triggered here
-		policyProvider := createResPolicyProvider(resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -247,7 +249,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		shortRetry.MaxRetries = ptr.Of(3)
 
 		// timeout will not be triggered here
-		policyProvider := createResPolicyProvider(resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -279,7 +281,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		shortRetry.MaxRetries = ptr.Of(3)
 
 		// timeout will not be triggered here
-		policyProvider := createResPolicyProvider(resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, resiliencyV1alpha.CircuitBreaker{}, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -315,7 +317,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// timeout will be triggered here
 		// no retries
-		policyProvider := createResPolicyProvider(resiliencyV1alpha.CircuitBreaker{}, shortTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, resiliencyV1alpha.CircuitBreaker{}, shortTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -344,7 +346,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		// set short retry with 3 retries max
 		shortRetry.MaxRetries = ptr.Of(3)
 		// timeout will not be triggered here
-		policyProvider := createResPolicyProvider(cb, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, cb, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -402,7 +404,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		shortRetry.MaxRetries = ptr.Of(3)
 		// timeout will not be triggered here
 
-		policyProvider := createResPolicyProvider(cb, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, cb, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -459,7 +461,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		// set short retry with 3 retries max
 		shortRetry.MaxRetries = ptr.Of(3)
 		// timeout will not be triggered here
-		policyProvider := createResPolicyProvider(cb, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, cb, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -502,7 +504,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		// set short retry with 3 retries max
 		shortRetry.MaxRetries = ptr.Of(3)
 		// timeout will not be triggered here
-		policyProvider := createResPolicyProvider(cb, longTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, cb, longTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -574,7 +576,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		shortRetry.MaxRetries = ptr.Of(2)
 
 		// timeout will be triggered here
-		policyProvider := createResPolicyProvider(cb, shortTimeout, shortRetry)
+		policyProvider := createResPolicyProvider(t, cb, shortTimeout, shortRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -623,7 +625,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 			Timeout:     "30s",                     // half-open after 30s. So in test this will not be triggered
 		}
 		// timeout will be triggered here
-		policyProvider := createResPolicyProvider(cb, shortTimeout, longRetry)
+		policyProvider := createResPolicyProvider(t, cb, shortTimeout, longRetry)
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
@@ -650,7 +652,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 	})
 }
 
-func createResPolicyProvider(ciruitBreaker resiliencyV1alpha.CircuitBreaker, timeout string, retry resiliencyV1alpha.Retry) *resiliency.Resiliency {
+func createResPolicyProvider(t *testing.T, ciruitBreaker resiliencyV1alpha.CircuitBreaker, timeout string, retry resiliencyV1alpha.Retry) *resiliency.Resiliency {
 	r := &resiliencyV1alpha.Resiliency{
 		Spec: resiliencyV1alpha.ResiliencySpec{
 			Policies: resiliencyV1alpha.Policies{
@@ -677,7 +679,9 @@ func createResPolicyProvider(ciruitBreaker resiliencyV1alpha.CircuitBreaker, tim
 			},
 		},
 	}
-	return resiliency.FromConfigurations(testLogger, r)
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+	return resiliency.FromConfigurations(testLogger, metrics, r)
 }
 
 func assertRetryCount(t *testing.T, expectedIDRetryCountMap map[string]int, actualRetryCountMap map[string]int) {

--- a/pkg/runtime/pubsub/subscriptions_test.go
+++ b/pkg/runtime/pubsub/subscriptions_test.go
@@ -22,6 +22,7 @@ import (
 	subscriptionsapiV1alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	subscriptionsapiV2alpha1 "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/pkg/channel"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -439,9 +440,12 @@ func (m *mockHTTPSubscriptions) InvokeMethod(ctx context.Context, req *invokev1.
 }
 
 func TestHTTPSubscriptions(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	t.Run("topics received, no errors", func(t *testing.T) {
 		m := mockHTTPSubscriptions{}
-		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log, metrics))
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
 			assert.Equal(t, "topic1", subs[0].Topic)
@@ -460,7 +464,7 @@ func TestHTTPSubscriptions(t *testing.T) {
 			successThreshold: 3,
 		}
 
-		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log, metrics))
 		assert.Equal(t, m.successThreshold, m.callCount)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
@@ -480,7 +484,7 @@ func TestHTTPSubscriptions(t *testing.T) {
 			alwaysError: true,
 		}
 
-		_, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log))
+		_, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log, metrics))
 		require.Error(t, err)
 	})
 
@@ -489,7 +493,7 @@ func TestHTTPSubscriptions(t *testing.T) {
 			successThreshold: 3,
 		}
 
-		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log, metrics))
 		assert.Equal(t, m.successThreshold, m.callCount)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
@@ -509,7 +513,7 @@ func TestHTTPSubscriptions(t *testing.T) {
 			alwaysError: true,
 		}
 
-		_, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log))
+		_, err := GetSubscriptionsHTTP(&m, log, resiliency.FromConfigurations(log, metrics))
 		require.Error(t, err)
 	})
 }
@@ -590,9 +594,12 @@ func (m *mockGRPCSubscriptions) ListTopicSubscriptions(ctx context.Context, in *
 }
 
 func TestGRPCSubscriptions(t *testing.T) {
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	t.Run("topics received, no errors", func(t *testing.T) {
 		m := mockGRPCSubscriptions{}
-		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log, metrics))
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
 			assert.Equal(t, "topic1", subs[0].Topic)
@@ -611,7 +618,7 @@ func TestGRPCSubscriptions(t *testing.T) {
 			successThreshold: 3,
 		}
 
-		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log, metrics))
 		assert.Equal(t, m.successThreshold, m.callCount)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
@@ -632,7 +639,7 @@ func TestGRPCSubscriptions(t *testing.T) {
 			unimplemented:    true,
 		}
 
-		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log, metrics))
 		// not implemented error is not retried and is returned as "zero" subscriptions
 		require.NoError(t, err)
 		assert.Equal(t, 1, m.callCount)
@@ -644,7 +651,7 @@ func TestGRPCSubscriptions(t *testing.T) {
 			successThreshold: 3,
 		}
 
-		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log, metrics))
 		assert.Equal(t, m.successThreshold, m.callCount)
 		require.NoError(t, err)
 		if assert.Len(t, subs, 1) {
@@ -665,7 +672,7 @@ func TestGRPCSubscriptions(t *testing.T) {
 			unimplemented:    true,
 		}
 
-		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log))
+		subs, err := GetSubscriptionsGRPC(&m, log, resiliency.FromConfigurations(log, metrics))
 		// not implemented error is not retried and is returned as "zero" subscriptions
 		require.NoError(t, err)
 		assert.Equal(t, 1, m.callCount)

--- a/pkg/runtime/security/auth_test.go
+++ b/pkg/runtime/security/auth_test.go
@@ -5,24 +5,30 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 )
 
-func mockGenCSR(id string) ([]byte, []byte, error) {
+func mockGenCSR(id string, _ *diag.Metrics) ([]byte, []byte, error) {
 	return []byte{1}, []byte{2}, nil
 }
 
-func getTestAuthenticator() Authenticator {
-	return newAuthenticator("test", x509.NewCertPool(), nil, nil, mockGenCSR)
+func getTestAuthenticator(t *testing.T) Authenticator {
+	t.Helper()
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+	return newAuthenticator("test", metrics, x509.NewCertPool(), nil, nil, mockGenCSR)
 }
 
 func TestGetTrustAuthAnchors(t *testing.T) {
-	a := getTestAuthenticator()
+	a := getTestAuthenticator(t)
 	ta := a.GetTrustAnchors()
 	assert.NotNil(t, ta)
 }
 
 func TestGetCurrentSignedCert(t *testing.T) {
-	a := getTestAuthenticator()
+	a := getTestAuthenticator(t)
 	a.(*authenticator).currentSignedCert = &SignedCertificate{}
 	c := a.GetCurrentSignedCert()
 	assert.NotNil(t, c)

--- a/pkg/runtime/security/security_test.go
+++ b/pkg/runtime/security/security_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	diag "github.com/dapr/dapr/pkg/diagnostics"
 	sentryConsts "github.com/dapr/dapr/pkg/sentry/consts"
 )
 
@@ -52,13 +54,16 @@ func TestGenerateSidecarCSR(t *testing.T) {
 		return
 	}
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	t.Run("empty id", func(t *testing.T) {
-		_, _, err := generateCSRAndPrivateKey("")
+		_, _, err := generateCSRAndPrivateKey("", metrics)
 		assert.NotNil(t, err)
 	})
 
 	t.Run("with id", func(t *testing.T) {
-		csr, pk, err := generateCSRAndPrivateKey("test")
+		csr, pk, err := generateCSRAndPrivateKey("test", metrics)
 		assert.Nil(t, err)
 		assert.True(t, len(csr) > 0)
 		assert.True(t, len(pk) > 0)
@@ -70,7 +75,10 @@ func TestInitSidecarAuthenticator(t *testing.T) {
 	t.Setenv(sentryConsts.CertChainEnvVar, "111")
 	t.Setenv(sentryConsts.CertKeyEnvVar, "111")
 
+	metrics, err := diag.NewMetrics(nil)
+	require.NoError(t, err)
+
 	certChain, _ := GetCertChain()
-	_, err := GetSidecarAuthenticator("localhost:5050", certChain)
+	_, err = GetSidecarAuthenticator("localhost:5050", metrics, certChain)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
As part of fixing https://github.com/dapr/dapr/issues/6356, I found that diagnostics was making use of global variables. This means that there are race conditions reading and writing to those global variables, especially when running tests in parallel.

Dapr will now create a new instance of a Meter, which is shared across the code base. Updated diagnostics/utils to also no longer rely on global variables.

/cc @artursouza 