### PR TITLE
Add namespace to all Helm chart resources

### DIFF
--- a/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
+++ b/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
@@ -3,6 +3,7 @@ apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
   name: {{ .Values.dapr_default_system_config_name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -11,6 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: dapr-webhook-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-operator
     {{- range $key, $value := .Values.global.k8sLabels }}
@@ -29,6 +30,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: dapr-webhook-ca
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-operator
     {{- range $key, $value := .Values.global.k8sLabels }}
@@ -43,6 +45,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dapr-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-operator
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_poddisruptionbudget.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_poddisruptionbudget.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: dapr-operator-disruption-budget
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-operator
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -2,6 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: dapr-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -18,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dapr-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_poddisruptionbudget.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_poddisruptionbudget.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: dapr-placement-server-disruption-budget
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-placement-server
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: dapr-placement-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-placement-server
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: dapr-placement-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-placement-server
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_rbac/templates/injector.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/injector.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dapr-injector
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -46,6 +47,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-injector
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_rbac/templates/operator.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/operator.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dapr-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -72,6 +73,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -126,6 +128,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_rbac/templates/placement.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/placement.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dapr-placement
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dapr-sentry
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -46,6 +47,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-sentry
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}
@@ -65,6 +67,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dapr-sentry
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: dapr-trust-bundle
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-sentry
     {{- range $key, $value := .Values.global.k8sLabels }}
@@ -24,6 +25,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dapr-sentry
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-sentry
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_poddisruptionbudget.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_poddisruptionbudget.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: dapr-sentry-budget
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-sentry
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
@@ -2,6 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: dapr-sentry
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dapr-sidecar-injector
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-sidecar-injector
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_poddisruptionbudget.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_poddisruptionbudget.yaml
@@ -8,6 +8,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: dapr-sidecar-injector-disruption-budget
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-sidecar-injector
     {{- range $key, $value := .Values.global.k8sLabels }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dapr-sidecar-injector
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- range $key, $value := .Values.global.k8sLabels }}
     {{ $key }}: {{ tpl $value $ }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: dapr-sidecar-injector-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     app: dapr-sidecar-injector
     {{- range $key, $value := .Values.global.k8sLabels }}


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Added `namespace` to all Helm chart resources. While it won't cause any technical changes, the absence of `namespace` causes some test tools, for example, kyverno-cli to fail due to missing namespace, which is a part of its best practice policies.  And having `namespace` filled also lets this chart be similar to other open source Helm charts.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #6375 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
