### PR TITLE
Update durabletask-go to fix concurrent map access panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/labstack/gommon v0.4.0
 	github.com/lestrrat-go/jwx/v2 v2.0.9
-	github.com/microsoft/durabletask-go v0.2.1
+	github.com/microsoft/durabletask-go v0.2.2
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5

--- a/go.sum
+++ b/go.sum
@@ -1115,8 +1115,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
-github.com/microsoft/durabletask-go v0.2.1 h1:ZSEJi43KOEALwWOlj0oJI2LezEgwQeUsITyTUbH2DYQ=
-github.com/microsoft/durabletask-go v0.2.1/go.mod h1:UtJXHmKalksdccRiN9Y16cHJYYtZN0bqmqOSiy56V8g=
+github.com/microsoft/durabletask-go v0.2.2 h1:hJkr8w9mRWAggGDm+1j8IlXKLtHgRmu/3ErWmzjpUMI=
+github.com/microsoft/durabletask-go v0.2.2/go.mod h1:UtJXHmKalksdccRiN9Y16cHJYYtZN0bqmqOSiy56V8g=
 github.com/microsoft/go-mssqldb v0.21.0 h1:p2rpHIL7TlSv1QrbXJUAcbyRKnIT0C9rRkH2E4OjLn8=
 github.com/microsoft/go-mssqldb v0.21.0/go.mod h1:+4wZTUnz/SV6nffv+RRRB/ss8jPng5Sho2SmM1l2ts4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=


### PR DESCRIPTION
# Description

This PR updates the [durabletask-go](https://github.com/microsoft/durabletask-go) dependency to [v2.2](https://github.com/microsoft/durabletask-go/releases/tag/v0.2.2) to fix a panic that is observed under high, concurrent workflow load.

The panic was reported by two users in https://github.com/dapr/dapr/issues/6373.

You can see the actual fix in https://github.com/microsoft/durabletask-go/commit/1eec25500d75b1a9f908945525c7d123ddb1ad42.

## Issue reference

Fixes https://github.com/dapr/dapr/issues/6373

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
