### PR TITLE
Update devcontainer for 1.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,13 +17,6 @@
         // Necessary for components-contrib's certification tests
         "GOLANG_PROTOBUF_REGISTRATION_CONFLICT": "ignore"
     },
-    "extensions": [
-        "davidanson.vscode-markdownlint",
-        "golang.go",
-        "ms-azuretools.vscode-dapr",
-        "ms-azuretools.vscode-docker",
-        "ms-kubernetes-tools.vscode-kubernetes-tools"
-    ],
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
@@ -64,14 +57,25 @@
         // Run the entrypoint defined in container image.
         "--init"
     ],
-    "settings": {
-        "go.toolsManagement.checkForUpdates": "local",
-        "go.useLanguageServer": true,
-        "go.gopath": "/go",
-        "go.buildTags": "e2e,perf,conftests,unit,integration_test,certtests",
-        "git.alwaysSignOff": true,
-        "terminal.integrated.env.linux": {
-            "GOLANG_PROTOBUF_REGISTRATION_CONFLICT": "ignore"
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "davidanson.vscode-markdownlint",
+                "golang.go",
+                "ms-azuretools.vscode-dapr",
+                "ms-azuretools.vscode-docker",
+                "ms-kubernetes-tools.vscode-kubernetes-tools"
+            ],
+            "settings": {
+                "go.toolsManagement.checkForUpdates": "local",
+                "go.useLanguageServer": true,
+                "go.gopath": "/go",
+                "go.buildTags": "e2e,perf,conftests,unit,integration_test,certtests,all_components",
+                "git.alwaysSignOff": true,
+                "terminal.integrated.env.linux": {
+                    "GOLANG_PROTOBUF_REGISTRATION_CONFLICT": "ignore"
+                }
+            },
         }
     },
     "workspaceFolder": "/workspaces/dapr",


### PR DESCRIPTION
1. Add `all_components` to the `go.buildTags` settings
   - Without this, users in VS Code / Codespaces will have issues reported by the Go language server, for example trying to use the debugger
2. Move `extensions` and `settings` into `customizations/vscode` per the updated Dev Container specs

Note: this needs to be merged into master and not release-1.11