### PR TITLE
Actor State TTL: Put feature being feature gate

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -130,6 +130,7 @@ type actorsRuntime struct {
 	clock                 clock.WithTicker
 	internalActors        map[string]InternalActor
 	internalActorChannel  *internalActorChannel
+	stateTTLEnabled       bool
 }
 
 // ActiveActorsCount contain actorType and count of actors each type has.
@@ -172,6 +173,7 @@ type ActorsOpts struct {
 	TracingSpec      configuration.TracingSpec
 	Resiliency       resiliency.Provider
 	StateStoreName   string
+	StateTTLEnabled  bool
 	CompStore        *compstore.ComponentStore
 
 	// MockPlacement is a placement service implementation used for testing
@@ -209,6 +211,7 @@ func newActorsWithClock(opts ActorsOpts, clock clock.WithTicker) Actors {
 		internalActors:       map[string]InternalActor{},
 		internalActorChannel: newInternalActorChannel(),
 		compStore:            opts.CompStore,
+		stateTTLEnabled:      opts.StateTTLEnabled,
 	}
 }
 
@@ -650,7 +653,8 @@ func (a *actorsRuntime) TransactionalStateOperation(ctx context.Context, req *Tr
 	baseKey += daprSeparator
 	for i, o := range req.Operations {
 		operations[i], err = o.StateOperation(baseKey, StateOperationOpts{
-			Metadata: metadata,
+			Metadata:        metadata,
+			StateTTLEnabled: a.stateTTLEnabled,
 		})
 		if err != nil {
 			return err

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -130,7 +130,9 @@ type actorsRuntime struct {
 	clock                 clock.WithTicker
 	internalActors        map[string]InternalActor
 	internalActorChannel  *internalActorChannel
-	stateTTLEnabled       bool
+
+	// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
+	stateTTLEnabled bool
 }
 
 // ActiveActorsCount contain actorType and count of actors each type has.
@@ -173,8 +175,10 @@ type ActorsOpts struct {
 	TracingSpec      configuration.TracingSpec
 	Resiliency       resiliency.Provider
 	StateStoreName   string
-	StateTTLEnabled  bool
 	CompStore        *compstore.ComponentStore
+
+	// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
+	StateTTLEnabled bool
 
 	// MockPlacement is a placement service implementation used for testing
 	MockPlacement PlacementService
@@ -211,7 +215,8 @@ func newActorsWithClock(opts ActorsOpts, clock clock.WithTicker) Actors {
 		internalActors:       map[string]InternalActor{},
 		internalActorChannel: newInternalActorChannel(),
 		compStore:            opts.CompStore,
-		stateTTLEnabled:      opts.StateTTLEnabled,
+		// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
+		stateTTLEnabled: opts.StateTTLEnabled,
 	}
 }
 
@@ -653,7 +658,8 @@ func (a *actorsRuntime) TransactionalStateOperation(ctx context.Context, req *Tr
 	baseKey += daprSeparator
 	for i, o := range req.Operations {
 		operations[i], err = o.StateOperation(baseKey, StateOperationOpts{
-			Metadata:        metadata,
+			Metadata: metadata,
+			// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
 			StateTTLEnabled: a.stateTTLEnabled,
 		})
 		if err != nil {

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -2547,6 +2547,29 @@ func TestTransactionalOperation(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "base||"+TestKeyName, res.Key)
 	})
+
+	t.Run("error if ttlInSeconds and actor state TTL not enabled", func(t *testing.T) {
+		op := TransactionalOperation{
+			Operation: Upsert,
+			Request: map[string]any{
+				"key":      TestKeyName,
+				"metadata": map[string]string{"ttlInSeconds": "1"},
+			},
+		}
+		resI, err := op.StateOperation("base||", StateOperationOpts{
+			StateTTLEnabled: false,
+		})
+		assert.ErrorContains(t, err, `ttlInSeconds is not supported without the "ActorStateTTL" feature enabled`)
+
+		resI, err = op.StateOperation("base||", StateOperationOpts{
+			StateTTLEnabled: true,
+		})
+		assert.NoError(t, err)
+
+		res, ok := resI.(state.SetRequest)
+		require.True(t, ok)
+		assert.Equal(t, "base||"+TestKeyName, res.Key)
+	})
 }
 
 func TestCallLocalActor(t *testing.T) {

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -2556,12 +2556,12 @@ func TestTransactionalOperation(t *testing.T) {
 				"metadata": map[string]string{"ttlInSeconds": "1"},
 			},
 		}
-		resI, err := op.StateOperation("base||", StateOperationOpts{
+		_, err := op.StateOperation("base||", StateOperationOpts{
 			StateTTLEnabled: false,
 		})
 		assert.ErrorContains(t, err, `ttlInSeconds is not supported without the "ActorStateTTL" feature enabled`)
 
-		resI, err = op.StateOperation("base||", StateOperationOpts{
+		resI, err := op.StateOperation("base||", StateOperationOpts{
 			StateTTLEnabled: true,
 		})
 		assert.NoError(t, err)

--- a/pkg/actors/transactional_state_request.go
+++ b/pkg/actors/transactional_state_request.go
@@ -36,8 +36,10 @@ const (
 
 // Options for the StateOperation method
 type StateOperationOpts struct {
-	Metadata        map[string]string
-	ContentType     *string
+	Metadata    map[string]string
+	ContentType *string
+
+	// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
 	StateTTLEnabled bool
 }
 
@@ -136,6 +138,7 @@ func (t TransactionalUpsert) StateOperation(baseKey string, opts StateOperationO
 		maps.Copy(t.Metadata, opts.Metadata)
 	}
 
+	// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
 	if !opts.StateTTLEnabled {
 		if _, ok := t.Metadata["ttlInSeconds"]; ok {
 			return op, fmt.Errorf("ttlInSeconds is not supported without the %q feature enabled", config.ActorStateTTL)

--- a/pkg/actors/transactional_state_request.go
+++ b/pkg/actors/transactional_state_request.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/config"
 )
 
 // OperationType describes a CRUD operation performed against a state store.
@@ -35,8 +36,9 @@ const (
 
 // Options for the StateOperation method
 type StateOperationOpts struct {
-	Metadata    map[string]string
-	ContentType *string
+	Metadata        map[string]string
+	ContentType     *string
+	StateTTLEnabled bool
 }
 
 // TransactionalRequest describes a set of stateful operations for a given actor that are performed in a transactional manner.
@@ -132,6 +134,12 @@ func (t TransactionalUpsert) StateOperation(baseKey string, opts StateOperationO
 		t.Metadata = opts.Metadata
 	} else {
 		maps.Copy(t.Metadata, opts.Metadata)
+	}
+
+	if !opts.StateTTLEnabled {
+		if _, ok := t.Metadata["ttlInSeconds"]; ok {
+			return op, fmt.Errorf("ttlInSeconds is not supported without the %q feature enabled", config.ActorStateTTL)
+		}
 	}
 
 	return state.SetRequest{

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -44,6 +44,9 @@ const (
 	// Disables enforcing minimum TLS version 1.2 in AppChannel, which is insecure.
 	// TODO: Remove this feature flag in Dapr 1.13.
 	AppChannelAllowInsecureTLS Feature = "AppChannelAllowInsecureTLS"
+	// Enables support for setting TTL on Actor state keys. Remove this flag in
+	// Dapr 1.12.
+	ActorStateTTL Feature = "ActorStateTTL"
 )
 
 // end feature flags section

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2526,6 +2526,7 @@ func (a *DaprRuntime) initActors() error {
 		Resiliency:       a.resiliency,
 		StateStoreName:   a.actorStateStoreName,
 		CompStore:        a.compStore,
+		StateTTLEnabled:  a.globalConfig.IsFeatureEnabled(config.ActorStateTTL),
 	})
 	err = act.Init()
 	if err == nil {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2526,7 +2526,8 @@ func (a *DaprRuntime) initActors() error {
 		Resiliency:       a.resiliency,
 		StateStoreName:   a.actorStateStoreName,
 		CompStore:        a.compStore,
-		StateTTLEnabled:  a.globalConfig.IsFeatureEnabled(config.ActorStateTTL),
+		// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
+		StateTTLEnabled: a.globalConfig.IsFeatureEnabled(config.ActorStateTTL),
 	})
 	err = act.Init()
 	if err == nil {

--- a/tests/config/preview_configurations.yaml
+++ b/tests/config/preview_configurations.yaml
@@ -20,5 +20,14 @@ spec:
   features:
     - name: ServiceInvocationStreaming
       enabled: true
+---
+# TODO: @joshvanl: Remove once ActorStateTTL feature is finalized (probably in
+# v1.12 release).
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: actorstatettl
+spec:
+  features:
     - name: ActorStateTTL
       enabled: true

--- a/tests/config/preview_configurations.yaml
+++ b/tests/config/preview_configurations.yaml
@@ -20,3 +20,5 @@ spec:
   features:
     - name: ServiceInvocationStreaming
       enabled: true
+    - name: ActorStateTTL
+      enabled: true

--- a/tests/e2e/actor_state/actor_state_test.go
+++ b/tests/e2e/actor_state/actor_state_test.go
@@ -57,6 +57,7 @@ func TestMain(m *testing.M) {
 			Replicas:       1,
 			IngressEnabled: true,
 			MetricsEnabled: true,
+			Config:         "actorstatettl",
 		},
 	}
 
@@ -207,8 +208,10 @@ func TestActorState(t *testing.T) {
 			b, err := json.Marshal(&runtimev1.ExecuteActorStateTransactionRequest{
 				ActorType: "grpcMyActorType", ActorId: fmt.Sprintf("%s-myActorID", actuid),
 				Operations: []*runtimev1.TransactionalActorStateOperation{
-					{OperationType: "upsert", Key: "myKey",
-						Value: &anypb.Any{Value: []byte("myData")}},
+					{
+						OperationType: "upsert", Key: "myKey",
+						Value: &anypb.Any{Value: []byte("myData")},
+					},
 				},
 			})
 			require.NoError(t, err)
@@ -239,8 +242,10 @@ func TestActorState(t *testing.T) {
 			b, err = json.Marshal(&runtimev1.ExecuteActorStateTransactionRequest{
 				ActorType: "grpcMyActorType", ActorId: fmt.Sprintf("%s-myActorID", actuid),
 				Operations: []*runtimev1.TransactionalActorStateOperation{
-					{OperationType: "upsert", Key: "myKey",
-						Value: &anypb.Any{Value: []byte("newData")}},
+					{
+						OperationType: "upsert", Key: "myKey",
+						Value: &anypb.Any{Value: []byte("newData")},
+					},
 				},
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
Due to the fact that actor client SDKs cache state, when a client has a cold cache (like when restarting), client's would have to either cache data past their TTL time or always query the DB on gets. Until https://github.com/dapr/components-contrib/issues/2857 is implements, and this value passed to the actor SDK clients, we should actor state TTLs behind a feature preview flag.

PR adds the `ActorStateTTL` feature gate. Unless enabled, the actor transactional state operator API will return an error whenever an `Upsert` with a Metadata key `ttlInSeconds` is given. 

/cc @artursouza 