### PR TITLE
style(logs): infof -> debugf

### DIFF
--- a/pkg/channel/external/http_channel.go
+++ b/pkg/channel/external/http_channel.go
@@ -94,7 +94,7 @@ func (h *HTTPEndpointAppChannel) InvokeMethod(ctx context.Context, req *invokev1
 	switch req.APIVersion() {
 	case internalv1pb.APIVersion_V1: //nolint:nosnakecase
 		rsp, err = h.invokeMethodV1(ctx, req, appID)
-		log.Infof("external http endpoint response %v and err %v", rsp, err)
+		log.Debugf("external http endpoint response %v and err %v", rsp, err)
 
 	default:
 		// Reject unsupported version
@@ -107,7 +107,7 @@ func (h *HTTPEndpointAppChannel) InvokeMethod(ctx context.Context, req *invokev1
 // invokeMethodV1 constructs the http endpoint request and performs the request while collecting metrics.
 func (h *HTTPEndpointAppChannel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethodRequest, appID string) (*invokev1.InvokeMethodResponse, error) {
 	channelReq, err := h.constructRequest(ctx, req, appID)
-	log.Infof("channelReq %v and err %v", channelReq, err)
+	log.Debugf("channelReq %v and err %v", channelReq, err)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Switch log level on messages to debugf. Currently there are lots of logs created as level `Info`, so this will help remove some of the noise. I figured it was good to keep the logs "just in case" for "preview functionality" here on external http invocations, but open to feedback if they should just be removed.

## Issue reference

https://github.com/dapr/dapr/issues/6401

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
