### PR TITLE
helm: add delete verb for sentry

### DIFF
--- a/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
@@ -55,7 +55,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "update"]
+    verbs: ["get", "update","delete"]
     resourceNames: ["dapr-trust-bundle"]
 {{- if eq .Values.global.rbac.namespaced true }}
   - apiGroups: ["dapr.io"]


### PR DESCRIPTION
# Description

Add the verb `delete` to the Role definition of dapr sentry to allow to delete the kubernetes secret that its own.

## Issue reference

Issue: #6405

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
