### PR TITLE
Release 1.11: Pin contrib `v1.11.0-rc.9`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/PuerkitoBio/purell v1.2.0
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/dapr/components-contrib v1.11.0-rc.8
+	github.com/dapr/components-contrib v1.11.0-rc.9
 	github.com/dapr/kit v0.11.0
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/fasthttp/router v1.4.18

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.11.0-rc.8 h1:YhNXn0yXaeGd99WqE4a3F3luWPvGhB53rjDm7wGIgcU=
-github.com/dapr/components-contrib v1.11.0-rc.8/go.mod h1:t+TU1OsfDjtmNKoFIofIS96HTdDT77Gpepq+KJC10Dg=
+github.com/dapr/components-contrib v1.11.0-rc.9 h1:Kz6SY553Cf3Km3E9ZSSTdyS/iMgSnMxVASGKBmvXc0Q=
+github.com/dapr/components-contrib v1.11.0-rc.9/go.mod h1:t+TU1OsfDjtmNKoFIofIS96HTdDT77Gpepq+KJC10Dg=
 github.com/dapr/kit v0.11.0 h1:bBceMtxsek9RTrMrZOWw6tAZw0ch+5etClX+VNR3g8s=
 github.com/dapr/kit v0.11.0/go.mod h1:dqcCSK9ethcPW4L9jC2t4WrPUU3mPA4oa53fJRhl34E=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
# Description

Pins contrib v1.11.0-rc.9 for a Azure Service Bus improvement to delay message sending. The existing implementation was swallowing errors and was not user friendly.

https://github.com/dapr/components-contrib/pull/2875