### PR TITLE
mDNS and K8s nameresolvers are stable components

### DIFF
--- a/cmd/daprd/components/nameresolution_kubernetes.go
+++ b/cmd/daprd/components/nameresolution_kubernetes.go
@@ -1,4 +1,4 @@
-//go:build all_components
+//go:build all_components || stable_components
 
 /*
 Copyright 2021 The Dapr Authors

--- a/cmd/daprd/components/nameresolution_mdns.go
+++ b/cmd/daprd/components/nameresolution_mdns.go
@@ -1,4 +1,4 @@
-//go:build all_components
+//go:build all_components || stable_components
 
 /*
 Copyright 2021 The Dapr Authors


### PR DESCRIPTION
These must be included in `-stable` builds