### PR TITLE
Integration testing: sentry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ test-race:
 test-integration: test-deps
 		gotestsum \
 			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
-			--format standard-verbose \
+			--format dots \
 			-- \
 			./tests/integration $(COVERAGE_OPTS) -v -race -tags="integration"
 

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -44,7 +44,7 @@ const (
 	// defaultDaprSystemConfigName is the default resource object name for Dapr System Config.
 	defaultDaprSystemConfigName = "daprsystem"
 
-	healthzPort = 8080
+	defaultHealthzPort = 8080
 )
 
 func main() {
@@ -55,6 +55,8 @@ func main() {
 	flag.StringVar(&credentials.IssuerKeyFilename, "issuer-key-filename", credentials.IssuerKeyFilename, "Issuer private key filename")
 	trustDomain := flag.String("trust-domain", "localhost", "The CA trust domain")
 	tokenAudience := flag.String("token-audience", "", "Expected audience for tokens; multiple values can be separated by a comma")
+	port := flag.Int("port", config.DefaultPort, "The port for the sentry server to listen on")
+	healthzPort := flag.Int("healthz-port", defaultHealthzPort, "The port for the healthz server to listen on")
 
 	loggerOptions := logger.DefaultOptions()
 	loggerOptions.AttachCmdFlags(flag.StringVar, flag.BoolVar)
@@ -105,6 +107,7 @@ func main() {
 	config.IssuerKeyPath = issuerKeyPath
 	config.RootCertPath = rootCertPath
 	config.TrustDomain = *trustDomain
+	config.Port = *port
 	if *tokenAudience != "" {
 		config.TokenAudience = tokenAudience
 	}
@@ -171,7 +174,7 @@ func main() {
 	mngr.Add(func(ctx context.Context) error {
 		healthzServer := health.NewServer(log)
 		healthzServer.Ready()
-		if err := healthzServer.Run(ctx, healthzPort); err != nil {
+		if err := healthzServer.Run(ctx, *healthzPort); err != nil {
 			return fmt.Errorf("failed to start healthz server: %s", err)
 		}
 		return nil

--- a/pkg/sentry/certs/store.go
+++ b/pkg/sentry/certs/store.go
@@ -68,7 +68,18 @@ func CredentialsExist(ctx context.Context, conf config.SentryConfig) (bool, erro
 		}
 		return len(s.Data) > 0, nil
 	}
-	return false, nil
+
+	for _, path := range []string{conf.RootCertPath, conf.IssuerCertPath, conf.IssuerKeyPath} {
+		_, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
 }
 
 /* #nosec. */

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -20,12 +20,13 @@ const (
 	kubernetesServiceHostEnvVar = "KUBERNETES_SERVICE_HOST"
 	kubernetesConfig            = "kubernetes"
 	selfHostedConfig            = "selfhosted"
-	defaultPort                 = 50001
 	defaultWorkloadCertTTL      = time.Hour * 24
 	defaultAllowedClockSkew     = time.Minute * 15
 
 	// defaultDaprSystemConfigName is the default resource object name for Dapr System Config.
 	defaultDaprSystemConfigName = "daprsystem"
+
+	DefaultPort = 50001
 )
 
 var log = logger.NewLogger("dapr.sentry.config")
@@ -58,8 +59,8 @@ func (c SentryConfig) String() string {
 		caStore = c.CAStore
 	}
 
-	return fmt.Sprintf("Configuration: port:'%v' ca store:'%s', allowed clock skew:'%s', workload cert ttl:'%s'",
-		c.Port, caStore, c.AllowedClockSkew.String(), c.WorkloadCertTTL.String())
+	return fmt.Sprintf("Configuration: ca store:'%s', allowed clock skew:'%s', workload cert ttl:'%s'",
+		caStore, c.AllowedClockSkew.String(), c.WorkloadCertTTL.String())
 }
 
 var configGetters = map[string]func(string) (SentryConfig, error){
@@ -94,7 +95,7 @@ func IsKubernetesHosted() bool {
 
 func getDefaultConfig() SentryConfig {
 	return SentryConfig{
-		Port:             defaultPort,
+		Port:             DefaultPort,
 		WorkloadCertTTL:  defaultWorkloadCertTTL,
 		AllowedClockSkew: defaultAllowedClockSkew,
 	}

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -59,8 +59,8 @@ func (c SentryConfig) String() string {
 		caStore = c.CAStore
 	}
 
-	return fmt.Sprintf("Configuration: ca store:'%s', allowed clock skew:'%s', workload cert ttl:'%s'",
-		caStore, c.AllowedClockSkew.String(), c.WorkloadCertTTL.String())
+	return fmt.Sprintf("Configuration: port:'%v' ca store:'%s', allowed clock skew:'%s', workload cert ttl:'%s'",
+		c.Port, caStore, c.AllowedClockSkew.String(), c.WorkloadCertTTL.String())
 }
 
 var configGetters = map[string]func(string) (SentryConfig, error){

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -59,7 +59,7 @@ func Build(t *testing.T, name string) {
 		}
 
 		// Ensure CGO is disabled to avoid linking against system libraries.
-		os.Setenv("CGO_ENABLED", "0")
+		require.NoError(t, os.Setenv("CGO_ENABLED", "0"))
 
 		t.Logf("Root dir: %q", rootDir)
 		t.Logf("Compiling %q binary to: %q", name, binPath)

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -45,7 +45,7 @@ func BuildAll(t *testing.T) {
 func Build(t *testing.T, name string) {
 	t.Helper()
 	if _, ok := os.LookupEnv(EnvKey(name)); !ok {
-		t.Logf("%s not set, building %s binary", name, EnvKey(name))
+		t.Logf("%q not set, building %q binary", EnvKey(name), name)
 
 		_, tfile, _, ok := runtime.Caller(0)
 		require.True(t, ok)
@@ -62,7 +62,7 @@ func Build(t *testing.T, name string) {
 		os.Setenv("CGO_ENABLED", "0")
 
 		t.Logf("Root dir: %q", rootDir)
-		t.Logf("Building %s binary to: %q", name, binPath)
+		t.Logf("Compiling %q binary to: %q", name, binPath)
 		cmd := exec.Command("go", "build", "-tags=allcomponents", "-v", "-o", binPath, filepath.Join(rootDir, "cmd/"+name))
 		cmd.Dir = rootDir
 		cmd.Stdout = os.Stdout

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binary
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BuildAll(t *testing.T) {
+	t.Helper()
+
+	binaryNames := []string{"daprd", "placement", "sentry"}
+
+	var wg sync.WaitGroup
+	wg.Add(len(binaryNames))
+	for _, name := range binaryNames {
+		go func(name string) {
+			defer wg.Done()
+			Build(t, name)
+		}(name)
+	}
+	wg.Wait()
+}
+
+func Build(t *testing.T, name string) {
+	t.Helper()
+	if _, ok := os.LookupEnv(EnvKey(name)); !ok {
+		t.Logf("%s not set, building %s binary", name, EnvKey(name))
+
+		_, tfile, _, ok := runtime.Caller(0)
+		require.True(t, ok)
+		rootDir := filepath.Join(filepath.Dir(tfile), "../../../..")
+
+		// Use a consistent temp dir for the binary so that the binary is cached on
+		// subsequent runs.
+		binPath := filepath.Join(os.TempDir(), "dapr_integration_tests/"+name)
+		if runtime.GOOS == "windows" {
+			binPath += ".exe"
+		}
+
+		// Ensure CGO is disabled to avoid linking against system libraries.
+		os.Setenv("CGO_ENABLED", "0")
+
+		t.Logf("Root dir: %q", rootDir)
+		t.Logf("Building %s binary to: %q", name, binPath)
+		cmd := exec.Command("go", "build", "-tags=allcomponents", "-v", "-o", binPath, filepath.Join(rootDir, "cmd/"+name))
+		cmd.Dir = rootDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		require.NoError(t, cmd.Run())
+
+		require.NoError(t, os.Setenv(EnvKey(name), binPath))
+	}
+}
+
+func EnvValue(name string) string {
+	return os.Getenv(EnvKey(name))
+}
+
+func EnvKey(name string) string {
+	return fmt.Sprintf("DAPR_INTEGRATION_%s_PATH", strings.ToUpper(name))
+}

--- a/tests/integration/framework/framework.go
+++ b/tests/integration/framework/framework.go
@@ -57,6 +57,5 @@ func (f *Framework) Cleanup(t *testing.T) {
 
 	for _, proc := range f.procs {
 		proc.Cleanup(t)
-		proc.Cleanup(t)
 	}
 }

--- a/tests/integration/framework/framework.go
+++ b/tests/integration/framework/framework.go
@@ -57,5 +57,6 @@ func (f *Framework) Cleanup(t *testing.T) {
 
 	for _, proc := range f.procs {
 		proc.Cleanup(t)
+		proc.Cleanup(t)
 	}
 }

--- a/tests/integration/framework/options.go
+++ b/tests/integration/framework/options.go
@@ -21,7 +21,16 @@ import (
 func WithProcesses(procs ...process.Interface) Option {
 	return func(o *options) {
 		for _, proc := range procs {
-			o.procs = append(o.procs, once.Wrap(proc))
+			var found bool
+			for _, d := range o.procs {
+				if d == proc {
+					found = true
+					break
+				}
+			}
+			if !found {
+				o.procs = append(o.procs, once.Wrap(proc))
+			}
 		}
 	}
 }

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -55,14 +55,14 @@ type Daprd struct {
 	exec     process.Interface
 	freeport *freeport.FreePort
 
-	AppID            string
-	AppPort          int
-	GRPCPort         int
-	HTTPPort         int
-	InternalGRPCPort int
-	PublicPort       int
-	MetricsPort      int
-	ProfilePort      int
+	appID            string
+	appPort          int
+	grpcPort         int
+	httpPort         int
+	internalGRPCPort int
+	publicPort       int
+	metricsPort      int
+	profilePort      int
 }
 
 func New(t *testing.T, fopts ...Option) *Daprd {
@@ -124,14 +124,14 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	return &Daprd{
 		exec:             exec.New(t, binary.EnvValue("daprd"), args, opts.execOpts...),
 		freeport:         fp,
-		AppID:            opts.appID,
-		AppPort:          opts.appPort,
-		GRPCPort:         opts.grpcPort,
-		HTTPPort:         opts.httpPort,
-		InternalGRPCPort: opts.internalGRPCPort,
-		PublicPort:       opts.publicPort,
-		MetricsPort:      opts.metricsPort,
-		ProfilePort:      opts.profilePort,
+		appID:            opts.appID,
+		appPort:          opts.appPort,
+		grpcPort:         opts.grpcPort,
+		httpPort:         opts.httpPort,
+		internalGRPCPort: opts.internalGRPCPort,
+		publicPort:       opts.publicPort,
+		metricsPort:      opts.metricsPort,
+		profilePort:      opts.profilePort,
 	}
 }
 
@@ -142,4 +142,36 @@ func (d *Daprd) Run(t *testing.T, ctx context.Context) {
 
 func (d *Daprd) Cleanup(t *testing.T) {
 	d.exec.Cleanup(t)
+}
+
+func (d *Daprd) AppID() string {
+	return d.appID
+}
+
+func (d *Daprd) AppPort() int {
+	return d.appPort
+}
+
+func (d *Daprd) GRPCPort() int {
+	return d.grpcPort
+}
+
+func (d *Daprd) HTTPPort() int {
+	return d.httpPort
+}
+
+func (d *Daprd) InternalGRPCPort() int {
+	return d.internalGRPCPort
+}
+
+func (d *Daprd) PublicPort() int {
+	return d.publicPort
+}
+
+func (d *Daprd) MetricsPort() int {
+	return d.metricsPort
+}
+
+func (d *Daprd) ProfilePort() int {
+	return d.profilePort
 }

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -68,7 +68,7 @@ type Daprd struct {
 func New(t *testing.T, fopts ...Option) *Daprd {
 	t.Helper()
 
-	uid, err := uuid.NewUUID()
+	uid, err := uuid.NewRandom()
 	require.NoError(t, err)
 
 	appListener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"os"
 	"strconv"
 	"testing"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/dapr/tests/integration/framework/binary"
 	"github.com/dapr/dapr/tests/integration/framework/freeport"
 	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -122,7 +122,7 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	}
 
 	return &Daprd{
-		exec:             exec.New(t, os.Getenv("DAPR_INTEGRATION_DAPRD_PATH"), args, opts.execOpts...),
+		exec:             exec.New(t, binary.EnvValue("daprd"), args, opts.execOpts...),
 		freeport:         fp,
 		AppID:            opts.appID,
 		AppPort:          opts.appPort,

--- a/tests/integration/framework/process/exec/exec.go
+++ b/tests/integration/framework/process/exec/exec.go
@@ -34,7 +34,7 @@ type options struct {
 	stdout io.WriteCloser
 	stderr io.WriteCloser
 
-	runErrorFn func(error)
+	runErrorFn func(*testing.T, error)
 	exitCode   int
 }
 
@@ -46,7 +46,7 @@ type exec struct {
 
 	args       []string
 	binPath    string
-	runErrorFn func(error)
+	runErrorFn func(*testing.T, error)
 	exitCode   int
 	stdoutpipe io.WriteCloser
 	stderrpipe io.WriteCloser
@@ -64,7 +64,7 @@ func New(t *testing.T, binPath string, args []string, fopts ...Option) *exec {
 	opts := options{
 		stdout: iowriter.New(t, filepath.Base(binPath)),
 		stderr: iowriter.New(t, filepath.Base(binPath)),
-		runErrorFn: func(err error) {
+		runErrorFn: func(t *testing.T, err error) {
 			t.Helper()
 			if runtime.GOOS == "windows" {
 				// Windows returns 1 when we kill the process.
@@ -123,7 +123,7 @@ func (e *exec) checkExit(t *testing.T) {
 
 	t.Logf("waiting for %q process to exit", filepath.Base(e.binPath))
 
-	e.runErrorFn(e.cmd.Wait())
+	e.runErrorFn(t, e.cmd.Wait())
 	assert.NotNil(t, e.cmd.ProcessState, "process state should not be nil")
 	assert.Equalf(t, e.exitCode, e.cmd.ProcessState.ExitCode(), "expected exit code to be %d", e.exitCode)
 }

--- a/tests/integration/framework/process/exec/kill/kill.go
+++ b/tests/integration/framework/process/exec/kill/kill.go
@@ -29,10 +29,6 @@ func Kill(t *testing.T, cmd *exec.Cmd) {
 
 	t.Log("interrupting daprd process")
 
-	// TODO: daprd does not currently gracefully exit on a single interrupt
-	// signal. Remove once fixed.
-	interrupt(t, cmd)
-	time.Sleep(time.Millisecond * 300)
 	interrupt(t, cmd)
 
 	if filepath.Base(cmd.Path) == "daprd" {

--- a/tests/integration/framework/process/exec/options.go
+++ b/tests/integration/framework/process/exec/options.go
@@ -13,7 +13,10 @@ limitations under the License.
 
 package exec
 
-import "io"
+import (
+	"io"
+	"testing"
+)
 
 func WithStdout(stdout io.WriteCloser) Option {
 	return func(o *options) {
@@ -27,7 +30,7 @@ func WithStderr(stderr io.WriteCloser) Option {
 	}
 }
 
-func WithRunError(ferr func(error)) Option {
+func WithRunError(ferr func(*testing.T, error)) Option {
 	return func(o *options) {
 		o.runErrorFn = ferr
 	}

--- a/tests/integration/framework/process/once/once_test.go
+++ b/tests/integration/framework/process/once/once_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package once
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockProcess struct {
+	runCalled     int
+	cleanupCalled int
+}
+
+func (mp *mockProcess) Run(t *testing.T, ctx context.Context) {
+	mp.runCalled++
+}
+
+func (mp *mockProcess) Cleanup(t *testing.T) {
+	mp.cleanupCalled++
+}
+
+func (mp *mockProcess) Dispose() error {
+	return nil
+}
+
+func TestOnce(t *testing.T) {
+	mockProc := &mockProcess{}
+	onceProc := Wrap(mockProc)
+
+	runFailedCalled := false
+	cleanupFailedCalled := false
+	onceProc.(*once).failRun = func(*testing.T) {
+		runFailedCalled = true
+	}
+	onceProc.(*once).failCleanup = func(*testing.T) {
+		cleanupFailedCalled = true
+	}
+
+	t.Run("Run", func(t *testing.T) {
+		ctx := context.Background()
+
+		// First call should succeed
+		onceProc.Run(t, ctx)
+		assert.Equal(t, 1, mockProc.runCalled)
+		assert.False(t, runFailedCalled)
+
+		// Second call should fail
+		onceProc.Run(t, ctx)
+		assert.True(t, runFailedCalled)
+	})
+
+	t.Run("Cleanup", func(t *testing.T) {
+		// First call should succeed
+		onceProc.Cleanup(t)
+		assert.Equal(t, 1, mockProc.cleanupCalled)
+		assert.False(t, cleanupFailedCalled)
+
+		// Second call should fail
+		onceProc.Cleanup(t)
+		assert.True(t, cleanupFailedCalled)
+	})
+}

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -15,13 +15,13 @@ package placement
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/dapr/tests/integration/framework/binary"
 	"github.com/dapr/dapr/tests/integration/framework/freeport"
 	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -84,7 +84,7 @@ func New(t *testing.T, fopts ...Option) *Placement {
 	}
 
 	return &Placement{
-		exec:                exec.New(t, os.Getenv("DAPR_INTEGRATION_PLACEMENT_PATH"), args, opts.execOpts...),
+		exec:                exec.New(t, binary.EnvValue("placement"), args, opts.execOpts...),
 		freeport:            fp,
 		ID:                  opts.id,
 		Port:                opts.port,

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -46,12 +46,12 @@ type Placement struct {
 	exec     process.Interface
 	freeport *freeport.FreePort
 
-	ID                  string
-	Port                int
-	HealthzPort         int
-	MetricsPort         int
-	InitialCluster      string
-	InitialClusterPorts []int
+	id                  string
+	port                int
+	healthzPort         int
+	metricsPort         int
+	initialCluster      string
+	initialClusterPorts []int
 }
 
 func New(t *testing.T, fopts ...Option) *Placement {
@@ -86,12 +86,12 @@ func New(t *testing.T, fopts ...Option) *Placement {
 	return &Placement{
 		exec:                exec.New(t, binary.EnvValue("placement"), args, opts.execOpts...),
 		freeport:            fp,
-		ID:                  opts.id,
-		Port:                opts.port,
-		HealthzPort:         opts.healthzPort,
-		MetricsPort:         opts.metricsPort,
-		InitialCluster:      opts.initialCluster,
-		InitialClusterPorts: opts.initialClusterPorts,
+		id:                  opts.id,
+		port:                opts.port,
+		healthzPort:         opts.healthzPort,
+		metricsPort:         opts.metricsPort,
+		initialCluster:      opts.initialCluster,
+		initialClusterPorts: opts.initialClusterPorts,
 	}
 }
 
@@ -102,4 +102,28 @@ func (p *Placement) Run(t *testing.T, ctx context.Context) {
 
 func (p *Placement) Cleanup(t *testing.T) {
 	p.exec.Cleanup(t)
+}
+
+func (p *Placement) ID() string {
+	return p.id
+}
+
+func (p *Placement) Port() int {
+	return p.port
+}
+
+func (p *Placement) HealthzPort() int {
+	return p.healthzPort
+}
+
+func (p *Placement) MetricsPort() int {
+	return p.metricsPort
+}
+
+func (p *Placement) InitialCluster() string {
+	return p.initialCluster
+}
+
+func (p *Placement) InitialClusterPorts() []int {
+	return p.initialClusterPorts
 }

--- a/tests/integration/framework/process/sentry/options.go
+++ b/tests/integration/framework/process/sentry/options.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sentry
+
+import (
+	"github.com/dapr/dapr/pkg/sentry/certs"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+)
+
+func WithExecOptions(execOptions ...exec.Option) Option {
+	return func(o *options) {
+		o.execOpts = execOptions
+	}
+}
+
+func WithPort(port int) Option {
+	return func(o *options) {
+		o.port = port
+	}
+}
+
+func WithMetricsPort(port int) Option {
+	return func(o *options) {
+		o.metricsPort = port
+	}
+}
+
+func WithHealthzPort(port int) Option {
+	return func(o *options) {
+		o.healthzPort = port
+	}
+}
+
+func WithCA(ca *certs.Credentials, rootPEM, certPEM, keyPEM []byte) Option {
+	return func(o *options) {
+		o.ca = ca
+		o.rootPEM = rootPEM
+		o.certPEM = certPEM
+		o.keyPEM = keyPEM
+	}
+}

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sentry
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/sentry/ca"
+	"github.com/dapr/dapr/pkg/sentry/certs"
+	"github.com/dapr/dapr/tests/integration/framework/binary"
+	"github.com/dapr/dapr/tests/integration/framework/freeport"
+	"github.com/dapr/dapr/tests/integration/framework/process"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+)
+
+// options contains the options for running Sentry in integration tests.
+type options struct {
+	execOpts []exec.Option
+
+	ca          *certs.Credentials
+	rootPEM     []byte
+	certPEM     []byte
+	keyPEM      []byte
+	port        int
+	healthzPort int
+	metricsPort int
+}
+
+// Option is a function that configures the process.
+type Option func(*options)
+
+type Sentry struct {
+	exec     process.Interface
+	freeport *freeport.FreePort
+
+	CA          *certs.Credentials
+	Port        int
+	HealthzPort int
+	MetricsPort int
+}
+
+func New(t *testing.T, fopts ...Option) *Sentry {
+	t.Helper()
+
+	caPK, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	creds, rootPEM, certPEM, issuerKeyPEM, err := ca.GetNewSelfSignedCertificates(caPK, time.Minute, time.Second*5)
+	require.NoError(t, err)
+
+	fp := freeport.New(t, 3)
+	opts := options{
+		ca:          creds,
+		rootPEM:     rootPEM,
+		certPEM:     certPEM,
+		keyPEM:      issuerKeyPEM,
+		port:        fp.Port(t, 0),
+		healthzPort: fp.Port(t, 1),
+		metricsPort: fp.Port(t, 2),
+	}
+
+	for _, fopt := range fopts {
+		fopt(&opts)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "sentry-config.yaml")
+	require.NoError(t, os.WriteFile(configPath, nil, 0o600))
+
+	caPath := filepath.Join(t.TempDir(), "ca.crt")
+	issuerKeyPath := filepath.Join(t.TempDir(), "issuer.key")
+	issuerCertPath := filepath.Join(t.TempDir(), "issuer.crt")
+
+	for _, pair := range []struct {
+		path string
+		data []byte
+	}{
+		{caPath, opts.rootPEM},
+		{issuerKeyPath, opts.keyPEM},
+		{issuerCertPath, opts.certPEM},
+	} {
+		require.NoError(t, os.WriteFile(pair.path, pair.data, 0o600))
+	}
+
+	args := []string{
+		"-log-level=" + "debug",
+		"-port=" + strconv.Itoa(opts.port),
+		"-config=" + configPath,
+		"-issuer-ca-filename=" + caPath,
+		"-issuer-certificate-filename=" + issuerCertPath,
+		"-issuer-key-filename=" + issuerKeyPath,
+		"-metrics-port=" + strconv.Itoa(opts.metricsPort),
+		"-healthz-port=" + strconv.Itoa(opts.healthzPort),
+		// Disable issuer credentials prefix.
+		"-issuer-credentials=/",
+	}
+
+	return &Sentry{
+		exec:        exec.New(t, binary.EnvValue("sentry"), args, opts.execOpts...),
+		freeport:    fp,
+		CA:          opts.ca,
+		Port:        opts.port,
+		MetricsPort: opts.metricsPort,
+		HealthzPort: opts.healthzPort,
+	}
+}
+
+func (s *Sentry) Run(t *testing.T, ctx context.Context) {
+	s.freeport.Free(t)
+	s.exec.Run(t, ctx)
+}
+
+func (s *Sentry) Cleanup(t *testing.T) {
+	s.exec.Cleanup(t)
+}

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -54,10 +54,10 @@ type Sentry struct {
 	exec     process.Interface
 	freeport *freeport.FreePort
 
-	CA          *certs.Credentials
-	Port        int
-	HealthzPort int
-	MetricsPort int
+	ca          *certs.Credentials
+	port        int
+	healthzPort int
+	metricsPort int
 }
 
 func New(t *testing.T, fopts ...Option) *Sentry {
@@ -118,10 +118,10 @@ func New(t *testing.T, fopts ...Option) *Sentry {
 	return &Sentry{
 		exec:        exec.New(t, binary.EnvValue("sentry"), args, opts.execOpts...),
 		freeport:    fp,
-		CA:          opts.ca,
-		Port:        opts.port,
-		MetricsPort: opts.metricsPort,
-		HealthzPort: opts.healthzPort,
+		ca:          opts.ca,
+		port:        opts.port,
+		metricsPort: opts.metricsPort,
+		healthzPort: opts.healthzPort,
 	}
 }
 
@@ -132,4 +132,20 @@ func (s *Sentry) Run(t *testing.T, ctx context.Context) {
 
 func (s *Sentry) Cleanup(t *testing.T) {
 	s.exec.Cleanup(t)
+}
+
+func (s *Sentry) CA() *certs.Credentials {
+	return s.ca
+}
+
+func (s *Sentry) Port() int {
+	return s.port
+}
+
+func (s *Sentry) MetricsPort() int {
+	return s.metricsPort
+}
+
+func (s *Sentry) HealthzPort() int {
+	return s.healthzPort
 }

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -87,9 +87,10 @@ func New(t *testing.T, fopts ...Option) *Sentry {
 	configPath := filepath.Join(t.TempDir(), "sentry-config.yaml")
 	require.NoError(t, os.WriteFile(configPath, nil, 0o600))
 
-	caPath := filepath.Join(t.TempDir(), "ca.crt")
-	issuerKeyPath := filepath.Join(t.TempDir(), "issuer.key")
-	issuerCertPath := filepath.Join(t.TempDir(), "issuer.crt")
+	tmpDir := t.TempDir()
+	caPath := filepath.Join(tmpDir, "ca.crt")
+	issuerKeyPath := filepath.Join(tmpDir, "issuer.key")
+	issuerCertPath := filepath.Join(tmpDir, "issuer.crt")
 
 	for _, pair := range []struct {
 		path string
@@ -106,13 +107,12 @@ func New(t *testing.T, fopts ...Option) *Sentry {
 		"-log-level=" + "debug",
 		"-port=" + strconv.Itoa(opts.port),
 		"-config=" + configPath,
-		"-issuer-ca-filename=" + caPath,
-		"-issuer-certificate-filename=" + issuerCertPath,
-		"-issuer-key-filename=" + issuerKeyPath,
+		"-issuer-ca-filename=ca.crt",
+		"-issuer-certificate-filename=issuer.crt",
+		"-issuer-key-filename=issuer.key",
 		"-metrics-port=" + strconv.Itoa(opts.metricsPort),
 		"-healthz-port=" + strconv.Itoa(opts.healthzPort),
-		// Disable issuer credentials prefix.
-		"-issuer-credentials=/",
+		"-issuer-credentials=" + tmpDir,
 	}
 
 	return &Sentry{

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -15,20 +15,13 @@ package integration
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
-	"runtime"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/binary"
 	"github.com/dapr/dapr/tests/integration/suite"
 	_ "github.com/dapr/dapr/tests/integration/suite/healthz"
 	_ "github.com/dapr/dapr/tests/integration/suite/metadata"
@@ -36,7 +29,7 @@ import (
 )
 
 func RunIntegrationTests(t *testing.T) {
-	buildBinaries(t)
+	binary.BuildAll(t)
 
 	for _, tcase := range suite.All() {
 		tcase := tcase
@@ -61,53 +54,5 @@ func RunIntegrationTests(t *testing.T) {
 
 			t.Log("done")
 		})
-	}
-}
-
-func buildBinaries(t *testing.T) {
-	t.Helper()
-
-	binaryNames := []string{"daprd", "placement"}
-
-	var wg sync.WaitGroup
-	wg.Add(len(binaryNames))
-	for _, name := range binaryNames {
-		go func(name string) {
-			defer wg.Done()
-			buildBinary(t, name)
-		}(name)
-	}
-	wg.Wait()
-}
-
-func buildBinary(t *testing.T, name string) {
-	t.Helper()
-	env := fmt.Sprintf("DAPR_INTEGRATION_%s_PATH", strings.ToUpper(name))
-	if _, ok := os.LookupEnv(env); !ok {
-		t.Logf("%q not set, building %s binary", env, name)
-
-		_, tfile, _, ok := runtime.Caller(0)
-		require.True(t, ok)
-		rootDir := filepath.Join(filepath.Dir(tfile), "../..")
-
-		// Use a consistent temp dir for the binary so that the binary is cached on
-		// subsequent runs.
-		binPath := filepath.Join(os.TempDir(), "dapr_integration_tests/"+name)
-		if runtime.GOOS == "windows" {
-			binPath += ".exe"
-		}
-
-		// Ensure CGO is disabled to avoid linking against system libraries.
-		os.Setenv("CGO_ENABLED", "0")
-
-		t.Logf("Root dir: %q", rootDir)
-		t.Logf("Compiling %q binary to: %q", name, binPath)
-		cmd := exec.Command("go", "build", "-tags=allcomponents", "-v", "-o", binPath, filepath.Join(rootDir, "cmd/"+name))
-		cmd.Dir = rootDir
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		require.NoError(t, cmd.Run())
-
-		require.NoError(t, os.Setenv(env, binPath))
 	}
 }

--- a/tests/integration/suite/healthz/app.go
+++ b/tests/integration/suite/healthz/app.go
@@ -92,7 +92,7 @@ func (a *app) Run(t *testing.T, ctx context.Context) {
 	}()
 
 	assert.Eventually(t, func() bool {
-		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", a.daprd.InternalGRPCPort))
+		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", a.daprd.InternalGRPCPort()))
 		if err != nil {
 			return false
 		}
@@ -102,7 +102,7 @@ func (a *app) Run(t *testing.T, ctx context.Context) {
 
 	a.healthy.Store(true)
 
-	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/myfunc", a.daprd.HTTPPort, a.daprd.AppID)
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/myfunc", a.daprd.HTTPPort(), a.daprd.AppID())
 
 	a.healthy.Store(true)
 

--- a/tests/integration/suite/healthz/app.go
+++ b/tests/integration/suite/healthz/app.go
@@ -104,6 +104,8 @@ func (a *app) Run(t *testing.T, ctx context.Context) {
 
 	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/myfunc", a.daprd.HTTPPort, a.daprd.AppID)
 
+	a.healthy.Store(true)
+
 	assert.Eventually(t, func() bool {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 		require.NoError(t, err)

--- a/tests/integration/suite/healthz/daprd.go
+++ b/tests/integration/suite/healthz/daprd.go
@@ -47,7 +47,7 @@ func (d *daprd) Setup(t *testing.T) []framework.Option {
 
 func (d *daprd) Run(t *testing.T, ctx context.Context) {
 	assert.Eventually(t, func() bool {
-		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", d.proc.PublicPort))
+		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", d.proc.PublicPort()))
 		if err != nil {
 			return false
 		}
@@ -55,7 +55,7 @@ func (d *daprd) Run(t *testing.T, ctx context.Context) {
 		return true
 	}, time.Second*5, 100*time.Millisecond)
 
-	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/healthz", d.proc.PublicPort)
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/healthz", d.proc.PublicPort())
 
 	assert.Eventually(t, func() bool {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)

--- a/tests/integration/suite/healthz/placement.go
+++ b/tests/integration/suite/healthz/placement.go
@@ -47,15 +47,15 @@ func (d *placement) Setup(t *testing.T) []framework.Option {
 
 func (d *placement) Run(t *testing.T, ctx context.Context) {
 	assert.Eventuallyf(t, func() bool {
-		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", d.proc.HealthzPort))
+		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", d.proc.HealthzPort()))
 		if err != nil {
 			return false
 		}
 		require.NoError(t, conn.Close())
 		return true
-	}, time.Second*5, 100*time.Millisecond, "healthz port %d not ready", d.proc.HealthzPort)
+	}, time.Second*5, 100*time.Millisecond, "healthz port %d not ready", d.proc.HealthzPort())
 
-	reqURL := fmt.Sprintf("http://127.0.0.1:%d/healthz", d.proc.HealthzPort)
+	reqURL := fmt.Sprintf("http://127.0.0.1:%d/healthz", d.proc.HealthzPort())
 
 	assert.Eventually(t, func() bool {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)

--- a/tests/integration/suite/healthz/sentry.go
+++ b/tests/integration/suite/healthz/sentry.go
@@ -47,16 +47,16 @@ func (s *sentry) Setup(t *testing.T) []framework.Option {
 
 func (s *sentry) Run(t *testing.T, _ context.Context) {
 	assert.Eventuallyf(t, func() bool {
-		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.proc.HealthzPort))
+		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.proc.HealthzPort()))
 		if err != nil {
 			return false
 		}
 		require.NoError(t, conn.Close())
 		return true
-	}, time.Second*5, 100*time.Millisecond, "healthz port %d not ready", s.proc.HealthzPort)
+	}, time.Second*5, 100*time.Millisecond, "healthz port %d not ready", s.proc.HealthzPort())
 
 	assert.Eventually(t, func() bool {
-		resp, err := http.DefaultClient.Get(fmt.Sprintf("http://127.0.0.1:%d/healthz", s.proc.HealthzPort))
+		resp, err := http.DefaultClient.Get(fmt.Sprintf("http://127.0.0.1:%d/healthz", s.proc.HealthzPort()))
 		require.NoError(t, err)
 		require.NoError(t, resp.Body.Close())
 		return http.StatusOK == resp.StatusCode

--- a/tests/integration/suite/healthz/sentry.go
+++ b/tests/integration/suite/healthz/sentry.go
@@ -53,7 +53,7 @@ func (s *sentry) Run(t *testing.T, _ context.Context) {
 		}
 		require.NoError(t, conn.Close())
 		return true
-	}, time.Second*5, time.Millisecond, "healthz port %d not ready", s.proc.HealthzPort)
+	}, time.Second*5, 100*time.Millisecond, "healthz port %d not ready", s.proc.HealthzPort)
 
 	assert.Eventually(t, func() bool {
 		resp, err := http.DefaultClient.Get(fmt.Sprintf("http://127.0.0.1:%d/healthz", s.proc.HealthzPort))

--- a/tests/integration/suite/healthz/sentry.go
+++ b/tests/integration/suite/healthz/sentry.go
@@ -25,42 +25,38 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	procplace "github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
 func init() {
-	suite.Register(new(placement))
+	suite.Register(new(sentry))
 }
 
-// placement tests that Placement responds to healthz requests.
-type placement struct {
-	proc *procplace.Placement
+// sentry tests that Sentry responds to healthz requests.
+type sentry struct {
+	proc *procsentry.Sentry
 }
 
-func (d *placement) Setup(t *testing.T) []framework.Option {
-	d.proc = procplace.New(t)
+func (s *sentry) Setup(t *testing.T) []framework.Option {
+	s.proc = procsentry.New(t)
 	return []framework.Option{
-		framework.WithProcesses(d.proc),
+		framework.WithProcesses(s.proc),
 	}
 }
 
-func (d *placement) Run(t *testing.T, ctx context.Context) {
+func (s *sentry) Run(t *testing.T, _ context.Context) {
 	assert.Eventuallyf(t, func() bool {
-		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", d.proc.HealthzPort))
+		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", s.proc.HealthzPort))
 		if err != nil {
 			return false
 		}
 		require.NoError(t, conn.Close())
 		return true
-	}, time.Second*5, 100*time.Millisecond, "healthz port %d not ready", d.proc.HealthzPort)
-
-	reqURL := fmt.Sprintf("http://127.0.0.1:%d/healthz", d.proc.HealthzPort)
+	}, time.Second*5, time.Millisecond, "healthz port %d not ready", s.proc.HealthzPort)
 
 	assert.Eventually(t, func() bool {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Get(fmt.Sprintf("http://127.0.0.1:%d/healthz", s.proc.HealthzPort))
 		require.NoError(t, err)
 		require.NoError(t, resp.Body.Close())
 		return http.StatusOK == resp.StatusCode

--- a/tests/integration/suite/metadata/metadata.go
+++ b/tests/integration/suite/metadata/metadata.go
@@ -49,7 +49,7 @@ func (m *metadata) Setup(t *testing.T) []framework.Option {
 
 func (m *metadata) Run(t *testing.T, ctx context.Context) {
 	assert.Eventually(t, func() bool {
-		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", m.proc.InternalGRPCPort))
+		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", m.proc.InternalGRPCPort()))
 		if err != nil {
 			return false
 		}
@@ -57,7 +57,7 @@ func (m *metadata) Run(t *testing.T, ctx context.Context) {
 		return true
 	}, time.Second*5, 100*time.Millisecond)
 
-	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/metadata", m.proc.PublicPort)
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/metadata", m.proc.PublicPort())
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
@@ -72,7 +72,7 @@ func (m *metadata) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 
-	validateResponse(t, m.proc.AppID, m.proc.AppPort, string(resBody))
+	validateResponse(t, m.proc.AppID(), m.proc.AppPort(), string(resBody))
 }
 
 // validateResponse asserts that the response body is valid JSON

--- a/tests/integration/suite/ports/daprd.go
+++ b/tests/integration/suite/ports/daprd.go
@@ -46,12 +46,12 @@ func (d *daprd) Setup(t *testing.T) []framework.Option {
 
 func (d *daprd) Run(t *testing.T, _ context.Context) {
 	for name, port := range map[string]int{
-		"app":           d.proc.AppPort,
-		"grpc":          d.proc.GRPCPort,
-		"http":          d.proc.HTTPPort,
-		"metrics":       d.proc.MetricsPort,
-		"internal-grpc": d.proc.InternalGRPCPort,
-		"public":        d.proc.PublicPort,
+		"app":           d.proc.AppPort(),
+		"grpc":          d.proc.GRPCPort(),
+		"http":          d.proc.HTTPPort(),
+		"metrics":       d.proc.MetricsPort(),
+		"internal-grpc": d.proc.InternalGRPCPort(),
+		"public":        d.proc.PublicPort(),
 	} {
 		assert.Eventuallyf(t, func() bool {
 			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))

--- a/tests/integration/suite/ports/placement.go
+++ b/tests/integration/suite/ports/placement.go
@@ -46,10 +46,10 @@ func (p *placement) Setup(t *testing.T) []framework.Option {
 
 func (p *placement) Run(t *testing.T, _ context.Context) {
 	for name, port := range map[string]int{
-		"port":           p.proc.Port,
-		"metrics":        p.proc.MetricsPort,
-		"healthz":        p.proc.HealthzPort,
-		"initialCluster": p.proc.InitialClusterPorts[0],
+		"port":           p.proc.Port(),
+		"metrics":        p.proc.MetricsPort(),
+		"healthz":        p.proc.HealthzPort(),
+		"initialCluster": p.proc.InitialClusterPorts()[0],
 	} {
 		assert.Eventuallyf(t, func() bool {
 			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))

--- a/tests/integration/suite/ports/sentry.go
+++ b/tests/integration/suite/ports/sentry.go
@@ -46,9 +46,9 @@ func (s *sentry) Setup(t *testing.T) []framework.Option {
 
 func (s *sentry) Run(t *testing.T, _ context.Context) {
 	for name, port := range map[string]int{
-		"port":    s.proc.Port,
-		"healthz": s.proc.HealthzPort,
-		"metrics": s.proc.MetricsPort,
+		"port":    s.proc.Port(),
+		"healthz": s.proc.HealthzPort(),
+		"metrics": s.proc.MetricsPort(),
 	} {
 		assert.Eventuallyf(t, func() bool {
 			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))

--- a/tests/integration/suite/ports/sentry.go
+++ b/tests/integration/suite/ports/sentry.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ports
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(sentry))
+}
+
+// sentry tests that the ports are available when sentry is running.
+type sentry struct {
+	proc *procsentry.Sentry
+}
+
+func (s *sentry) Setup(t *testing.T) []framework.Option {
+	s.proc = procsentry.New(t)
+	return []framework.Option{
+		framework.WithProcesses(s.proc),
+	}
+}
+
+func (s *sentry) Run(t *testing.T, _ context.Context) {
+	for name, port := range map[string]int{
+		"port":    s.proc.Port,
+		"healthz": s.proc.HealthzPort,
+		"metrics": s.proc.MetricsPort,
+	} {
+		assert.Eventuallyf(t, func() bool {
+			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+			if err != nil {
+				return false
+			}
+			require.NoError(t, conn.Close())
+			return true
+		}, time.Second*5, time.Millisecond, "port %s (:%d) was not available in time", name, port)
+	}
+}

--- a/tests/integration/suite/ports/sentry.go
+++ b/tests/integration/suite/ports/sentry.go
@@ -57,6 +57,6 @@ func (s *sentry) Run(t *testing.T, _ context.Context) {
 			}
 			require.NoError(t, conn.Close())
 			return true
-		}, time.Second*5, time.Millisecond, "port %s (:%d) was not available in time", name, port)
+		}, time.Second*5, 100*time.Millisecond, "port %s (:%d) was not available in time", name, port)
 	}
 }


### PR DESCRIPTION
Branched from https://github.com/dapr/dapr/pull/6340

PR allows the port and healthz port to be configured on sentry.

Adds integration tests covering healthz and port for sentry.