### PR TITLE
Fixes in AKS test pipelines

### DIFF
--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -60,13 +60,19 @@ jobs:
     name: Deploy test infrastructure
     runs-on: ubuntu-latest
     steps:
+      - name: Set up for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
+        shell: bash
       - name: Set up for scheduled test
-        if: github.event_name != 'repository_dispatch'
+        if: github.event_name == 'schedule'
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
         shell: bash
-      - name: Parse test payload
+      - name: Set up for dispatched events
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v6.2.0
         with:

--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -206,13 +206,19 @@ jobs:
       TARGET_OS: linux
       TARGET_ARCH: amd64
     steps:
+      - name: Set up for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
+        shell: bash
       - name: Set up for scheduled test
-        if: github.event_name != 'repository_dispatch'
+        if: github.event_name == 'schedule'
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
         shell: bash
-      - name: Parse test payload
+      - name: Set up for dispatched events
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v6.2.0
         with:
@@ -355,16 +361,22 @@ jobs:
           echo "DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/perf_tests" >> $GITHUB_ENV
           echo "DAPR_TEST_LOG_PATH=$GITHUB_WORKSPACE/test_logs/perf_tests" >> $GITHUB_ENV
         shell: bash
-      - name: Set up for scheduled test
-        if: github.event_name != 'repository_dispatch'
+      - name: Set up for manual runs
+        if: github.event_name == 'workflow_dispatch'
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
-          echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
           if [ "${{ inputs.tests }}" != "" ] ; then
             echo "DAPR_PERF_TEST=${{ inputs.tests }}" >> $GITHUB_ENV
           fi
         shell: bash
-      - name: Parse test payload
+      - name: Set up for scheduled test
+        if: github.event_name == 'schedule'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
+        shell: bash
+      - name: Set up for dispatched events
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v6.2.0
         with:
@@ -406,12 +418,12 @@ jobs:
           key: ${{ runner.os }}-go-perf-test-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-perf-test-
-      - uses: azure/setup-kubectl@v1
+      - uses: azure/setup-kubectl@v3
         with:
           version: ${{ env.KUBECTLVER }}
         id: install
       - name: Set up Helm ${{ env.HELMVER }}
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: ${{ env.HELMVER }}
       - name: Login to Azure

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -225,13 +225,19 @@ jobs:
             target_arch: amd64
             windows_version: ltsc2022
     steps:
+      - name: Set up for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
+        shell: bash
       - name: Set up for scheduled test
-        if: github.event_name != 'repository_dispatch'
+        if: github.event_name == 'schedule'
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
         shell: bash
-      - name: Parse test payload
+      - name: Set up for dispatched events
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v6.2.0
         with:
@@ -415,13 +421,19 @@ jobs:
           echo "DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/${{ matrix.target_os }}_${{ matrix.target_arch }}" | sed 's/\\/\//g' >> $GITHUB_ENV
           echo "DAPR_TEST_LOG_PATH=$GITHUB_WORKSPACE/test_logs/${{ matrix.target_os }}_${{ matrix.target_arch }}" | sed 's/\\/\//g' >> $GITHUB_ENV
         shell: bash
+      - name: Set up for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
+        shell: bash
       - name: Set up for scheduled test
-        if: github.event_name != 'repository_dispatch'
+        if: github.event_name == 'schedule'
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
         shell: bash
-      - name: Parse test payload
+      - name: Set up for dispatched events
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v6.2.0
         with:

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -48,6 +48,8 @@ env:
   MAX_TEST_TIMEOUT: 5400
   # Enable HA mode for tests
   HA_MODE: true
+  # Enable tests on ARM64
+  ENABLE_ARM: false
   # Space-separated of supported Azure regions: one will be picked randomly for each cluster
   AZURE_REGIONS: "westus3"
   AZURE_ARM_REGIONS: "eastus"
@@ -146,6 +148,7 @@ jobs:
               --template-file ./tests/test-infra/azure-all.bicep \
               --parameters \
                 namePrefix="${{ env.TEST_PREFIX }}" \
+                enableArm="${{ env.ENABLE_ARM }}" \
                 location1=${REGION1} \
                 location2=${REGION2} \
                 location3=${REGION3} \
@@ -207,17 +210,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
-        target_arch: [amd64]
         include:
           - os: ubuntu-22.04
             target_os: linux
+            target_arch: amd64
           - os: windows-2022
             target_os: windows
+            target_arch: amd64
             windows_version: ltsc2022
-          - target_arch: arm64
-            target_os: linux
-            os: ubuntu-latest
     steps:
       - name: Set up for scheduled test
         if: github.event_name != 'repository_dispatch'
@@ -397,9 +397,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target_os: [linux]
-        target_arch: [amd64, arm64]
         include:
+          - target_os: linux
+            target_arch: amd64
           - target_os: windows
             target_arch: amd64
             windows_version: ltsc2022
@@ -452,12 +452,12 @@ jobs:
           key: ${{ runner.os }}-go-tests-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-tests-
-      - uses: azure/setup-kubectl@v1
+      - uses: azure/setup-kubectl@v3
         with:
           version: ${{ env.KUBECTLVER }}
         id: install
       - name: Set up Helm ${{ env.HELMVER }}
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: ${{ env.HELMVER }}
       - name: Login to Azure
@@ -681,6 +681,7 @@ jobs:
           az group delete --no-wait --yes --name "Dapr-E2E-${{ env.TEST_PREFIX }}w" || true
         shell: bash
       - name: Delete Arm64 cluster
+        if: env.ENABLE_ARM
         run: |
           # We are not waiting for these commands to complete, and we're ignoring errors
           echo "Starting removal of resource group Dapr-E2E-${{ env.TEST_PREFIX }}la"

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -49,14 +49,14 @@ env:
   # Enable HA mode for tests
   HA_MODE: true
   # Enable tests on ARM64
-  ENABLE_ARM: false
+  ENABLE_ARM: "false"
   # Space-separated of supported Azure regions: one will be picked randomly for each cluster
   AZURE_REGIONS: "westus3"
   AZURE_ARM_REGIONS: "eastus"
   # Container registry where to cache e2e test images
   DAPR_CACHE_REGISTRY: "dapre2eacr.azurecr.io"
   # Whether to collect TCP dumps
-  TCP_DUMPS: false
+  TCP_DUMPS: "false"
 
 jobs:
   deploy-infrastructure:
@@ -687,7 +687,7 @@ jobs:
           az group delete --no-wait --yes --name "Dapr-E2E-${{ env.TEST_PREFIX }}w" || true
         shell: bash
       - name: Delete Arm64 cluster
-        if: env.ENABLE_ARM
+        if: env.ENABLE_ARM == 'true'
         run: |
           # We are not waiting for these commands to complete, and we're ignoring errors
           echo "Starting removal of resource group Dapr-E2E-${{ env.TEST_PREFIX }}la"

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -63,13 +63,19 @@ jobs:
     name: Deploy test infrastructure
     runs-on: ubuntu-22.04
     steps:
+      - name: Set up for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
+        shell: bash
       - name: Set up for scheduled test
-        if: github.event_name != 'repository_dispatch'
+        if: github.event_name == 'schedule'
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
         shell: bash
-      - name: Parse test payload
+      - name: Set up for dispatched events
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v6.2.0
         with:

--- a/tests/test-infra/azure-all.bicep
+++ b/tests/test-infra/azure-all.bicep
@@ -44,6 +44,9 @@ param armDiagLogAnalyticsWorkspaceResourceId string = ''
 @description('If set, sends certain Arm64 diagnostic logs to Azure Storage')
 param armDiagStorageResourceId string = ''
 
+@description('If enabled, deploy an Arm64 cluster')
+param enableArm bool = true
+
 @description('If enabled, deploy Cosmos DB')
 param enableCosmosDB bool = true
 
@@ -97,7 +100,7 @@ module windowsCluster 'azure.bicep' = {
 }
 
 // Deploy the Arm cluster in the third location
-resource ArmResources 'Microsoft.Resources/resourceGroups@2020-10-01' = {
+resource ArmResources 'Microsoft.Resources/resourceGroups@2020-10-01' = if (enableArm) {
   name: 'Dapr-E2E-${namePrefix}la'
   location: location3
   tags: dateTag != '' ? {

--- a/tests/test-infra/azure-all.bicep
+++ b/tests/test-infra/azure-all.bicep
@@ -107,7 +107,7 @@ resource ArmResources 'Microsoft.Resources/resourceGroups@2020-10-01' = if (enab
     date: dateTag
   } : {}
 }
-module armCluster 'azure.bicep' = {
+module armCluster 'azure.bicep' = if (enableArm) {
   name: 'armCluster'
   scope: ArmResources
   params: {


### PR DESCRIPTION
Two fixes in the AKS test pipeline:

1. Disables deploying the ARM64 cluster when not in use. We haven't been running tests on ARM64 in months, but we still deploy a cluster (and all resources) every time. This is unnecessarily expensive and helps burning through our Azure credits.
2. We've been able to trigger the workflow manually for a while, but when triggered from a branch (e.g. release-1.11) it was still cloning the code from master. Now, if the workflow is run manually from a branch, it clones the correct branch. This will allow us to run tests on the release branches at any time (and it's a better option than opening a PR against that branch because in this case the workflow YAML comes from the same branch)
  - This was fixed in the perf test YAML too
3. Updates some soon-to-be deprecated Actions that were triggering a warning

Tests:

- E2E: https://github.com/dapr/dapr/actions/runs/5214807072
- Perf: https://github.com/dapr/dapr/actions/runs/5214581409

PS: This PR was opened from a branch in dapr/dapr and not from my fork because otherwise there's no way to test the pipeline (using /ok-to-test here wouldn't work)