### PR TITLE
Fix latest manifest tag

### DIFF
--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -77,7 +77,9 @@ ifeq ($(MANIFEST_TAG),)
 	MANIFEST_TAG=$(DAPR_TAG)
 endif
 ifeq ($(MANIFEST_LATEST_TAG),)
-	MANIFEST_LATEST_TAG=$(LATEST_TAG)
+    # artursouza: this is intentional - latest manifest tag will point to immutable version tags.
+    # For example: latest -> 1.11.0-linux-amd64 1.11.0-linux-arm 1.11.0-linux-arm64 ...
+	MANIFEST_LATEST_TAG=$(DAPR_TAG)
 endif
 
 LINUX_BINS_OUT_DIR=$(OUT_DIR)/linux_$(GOARCH)


### PR DESCRIPTION
# Description

Fix latest manifest tag, since the latest tag should point to the versioned tags - we don't copy every variant into a latest.

For example: latest -> 1.11.0-linux-amd64 1.11.0-linux-arm 1.11.0-linux-arm64 ...

Release for 1.11 is failing because it is trying to create a manifest pointing to unknown tags:
```
docker manifest create ***/dapr:latest ***/dapr:latest-linux-amd64 ***/dapr:latest-linux-arm ***/dapr:latest-linux-arm64 ***/dapr:latest-windows-1809-amd64 ***/dapr:latest-windows-ltsc2022-amd64
```

In the command above, `dapr:latest-linux-amd64` doesn't exist. Same for the others. It should point to an actual version, like `dapr:1.11.0-linux-amd64`.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
