### PR TITLE
Skip pushing latest windows tags and remove duplicates from dapr-publish step

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -496,10 +496,6 @@ jobs:
       fail-fast: false
       matrix:
         sidecar_flavor: ["allcomponents", "stablecomponents"]
-        target_os: ["linux", "windows"]
-        exclude:
-          - sidecar_flavor: "stablecomponents"
-            target_os: "windows"
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -516,7 +512,6 @@ jobs:
           echo "BINARIES=daprd" >>${GITHUB_ENV}
         shell: bash
       - name: Set REPO_OWNER
-        if: matrix.target_os != 'darwin'
         shell: bash
         run: |
           REPO_OWNER=${{ github.repository_owner }}
@@ -524,19 +519,18 @@ jobs:
           echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_ENV}
       - name: Docker Hub Login
         uses: docker/login-action@v2
-        if: matrix.target_os != 'darwin' && env.DOCKER_REGISTRY != ''
+        if: env.DOCKER_REGISTRY != ''
         with:
           username: ${{ secrets.DOCKER_REGISTRY_ID }}
           password: ${{ secrets.DOCKER_REGISTRY_PASS }}
       - name: GitHub Container Registry login
         uses: docker/login-action@v2
-        if: matrix.target_os != 'darwin'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker multiarch manifest to Docker Hub
-        if: matrix.target_os != 'darwin' && env.DOCKER_REGISTRY_ID != ''
+        if: env.DOCKER_REGISTRY_ID != ''
         env:
           DOCKER_REGISTRY_ID: ${{ secrets.DOCKER_REGISTRY_ID }}
           DAPR_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
@@ -553,21 +547,21 @@ jobs:
             make docker-publish
         shell: bash
       - name: Build and push Docker multiarch Windows manifest to Docker Hub
-        if: matrix.target_os != 'darwin' && env.DOCKER_REGISTRY_ID != '' && matrix.sidecar_flavor == 'allcomponents'
+        if: env.DOCKER_REGISTRY_ID != '' && matrix.sidecar_flavor == 'allcomponents'
         env:
           DOCKER_REGISTRY_ID: ${{ secrets.DOCKER_REGISTRY_ID }}
           DAPR_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
         run: |
           # Publish the `-windows-amd64` manifest.
+          # Note, the "latest" tag from the previous step already contains 
+          # the windows images, so we don't need to publish the "latest-windows-amd64" tag.
           DOCKER_MULTI_ARCH="windows-1809-amd64 windows-ltsc2022-amd64" \
           DAPR_TAG="${{ env.REL_VERSION }}-windows-amd64" \
-          LATEST_TAG=latest-windows-amd64 \
+          LATEST_RELEASE=false \
           MANIFEST_TAG="${{ env.REL_VERSION }}" \
-          MANIFEST_LATEST_TAG="${{ env.LATEST_TAG }}" \
             make docker-publish
         shell: bash
       - name: Build and push Docker multiarch manifest to GHCR
-        if: matrix.target_os != 'darwin'
         env:
           DAPR_REGISTRY: ghcr.io/${{ env.REPO_OWNER }}
         run: |
@@ -582,16 +576,17 @@ jobs:
           LATEST_TAG=${{ env.LATEST_TAG }}-mariner \
             make docker-publish
       - name: Build and push Docker multiarch Windows manifest to GHCR
-        if: matrix.target_os != 'darwin' && matrix.sidecar_flavor == 'allcomponents'
+        if: matrix.sidecar_flavor == 'allcomponents'
         env:
           DAPR_REGISTRY: ghcr.io/${{ env.REPO_OWNER }}
         run: |
           # Publish the `-windows-amd64` manifest.
+          # Note, the "latest" tag from the previous step already contains 
+          # the windows images, so we don't need to publish the "latest-windows-amd64" tag.
           DOCKER_MULTI_ARCH="windows-1809-amd64 windows-ltsc2022-amd64" \
           DAPR_TAG="${{ env.REL_VERSION }}-windows-amd64" \
-          LATEST_TAG=latest-windows-amd64 \
+          LATEST_RELEASE=false \
           MANIFEST_TAG="${{ env.REL_VERSION }}" \
-          MANIFEST_LATEST_TAG="${{ env.LATEST_TAG }}" \
             make docker-publish
         shell: bash
   helm:


### PR DESCRIPTION
# Description

This PR
1. Skips pushing latest-windows-amd64 tags. We have historically not pushed latest-linux or latest-windows tags separately, the `latest` tag contains both linux and windows versions already.
2. Skips running duplicate manifest publishing code by removing the target_os from matrix in dapr-publish

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
