### PR TITLE
Ensure parts is longer than 5. Components name validation

### DIFF
--- a/pkg/components/disk_manifest_loader.go
+++ b/pkg/components/disk_manifest_loader.go
@@ -107,7 +107,8 @@ func (m DiskManifestLoader[T]) loadManifestsFromFile(manifestPath string) []T {
 }
 
 type typeInfo struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
 // decodeYaml decodes the yaml document.

--- a/pkg/components/disk_manifest_loader.go
+++ b/pkg/components/disk_manifest_loader.go
@@ -16,11 +16,14 @@ package components
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dapr/dapr/utils"
 
+	"k8s.io/apimachinery/pkg/api/validation/path"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -133,6 +136,11 @@ func (m DiskManifestLoader[T]) decodeYaml(b []byte) ([]T, []error) {
 		}
 
 		if ti.Kind != m.kind {
+			continue
+		}
+
+		if errs := path.IsValidPathSegmentName(ti.Name); len(errs) > 0 {
+			errors = append(errors, fmt.Errorf("invalid name %q for %q: %s", ti.Name, m.kind, strings.Join(errs, "; ")))
 			continue
 		}
 

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -1545,6 +1545,9 @@ func (a *api) findTargetID(reqCtx *fasthttp.RequestCtx) string {
 	uri := string(reqCtx.URI().Path())
 	if strings.HasPrefix(uri, "/v1.0/invoke/") {
 		parts := strings.Split(uri, "/")
+		if len(parts) < 5 {
+			return ""
+		}
 		// Example: http://localhost:3500/v1.0/invoke/http://api.github.com/method/<method>
 		// parts[0]: /
 		// parts[1]: v1.0


### PR DESCRIPTION
Prevent panic in parts splice check.

Ensure component names are a valid URL path segment when in self hosted mode.