### PR TITLE
Fixed: operations on reminders should not be allowed if the sidecar isn't hosting actors of that type

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -1017,6 +1017,10 @@ func (a *api) RegisterActorReminder(ctx context.Context, in *runtimev1pb.Registe
 		req.Data = j
 	}
 	err := a.UniversalAPI.Actors.CreateReminder(ctx, req)
+	if err != nil && errors.Is(err, actors.ErrReminderOpActorNotHosted) {
+		apiServerLogger.Debug(messages.ErrActorReminderOpActorNotHosted)
+		return nil, messages.ErrActorReminderOpActorNotHosted
+	}
 	return &emptypb.Empty{}, err
 }
 
@@ -1034,6 +1038,10 @@ func (a *api) UnregisterActorReminder(ctx context.Context, in *runtimev1pb.Unreg
 	}
 
 	err := a.UniversalAPI.Actors.DeleteReminder(ctx, req)
+	if err != nil && errors.Is(err, actors.ErrReminderOpActorNotHosted) {
+		apiServerLogger.Debug(messages.ErrActorReminderOpActorNotHosted)
+		return nil, messages.ErrActorReminderOpActorNotHosted
+	}
 	return &emptypb.Empty{}, err
 }
 
@@ -1052,6 +1060,10 @@ func (a *api) RenameActorReminder(ctx context.Context, in *runtimev1pb.RenameAct
 	}
 
 	err := a.UniversalAPI.Actors.RenameReminder(ctx, req)
+	if err != nil && errors.Is(err, actors.ErrReminderOpActorNotHosted) {
+		apiServerLogger.Debug(messages.ErrActorReminderOpActorNotHosted)
+		return nil, messages.ErrActorReminderOpActorNotHosted
+	}
 	return &emptypb.Empty{}, err
 }
 

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -1321,12 +1321,20 @@ func (a *api) onCreateActorReminder(reqCtx *fasthttp.RequestCtx) {
 
 	err = a.universal.Actors.CreateReminder(reqCtx, &req)
 	if err != nil {
+		if errors.Is(err, actors.ErrReminderOpActorNotHosted) {
+			msg := messages.ErrActorReminderOpActorNotHosted
+			universalFastHTTPErrorResponder(reqCtx, msg)
+			log.Debug(msg)
+			return
+		}
+
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_CREATE", fmt.Sprintf(messages.ErrActorReminderCreate, err))
 		fasthttpRespond(reqCtx, fasthttpResponseWithError(nethttp.StatusInternalServerError, msg))
 		log.Debug(msg)
-	} else {
-		fasthttpRespond(reqCtx, fasthttpResponseWithEmpty())
+		return
 	}
+
+	fasthttpRespond(reqCtx, fasthttpResponseWithEmpty())
 }
 
 func (a *api) onRenameActorReminder(reqCtx *fasthttp.RequestCtx) {
@@ -1355,12 +1363,20 @@ func (a *api) onRenameActorReminder(reqCtx *fasthttp.RequestCtx) {
 
 	err = a.universal.Actors.RenameReminder(reqCtx, &req)
 	if err != nil {
+		if errors.Is(err, actors.ErrReminderOpActorNotHosted) {
+			msg := messages.ErrActorReminderOpActorNotHosted
+			universalFastHTTPErrorResponder(reqCtx, msg)
+			log.Debug(msg)
+			return
+		}
+
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_RENAME", fmt.Sprintf(messages.ErrActorReminderRename, err))
 		fasthttpRespond(reqCtx, fasthttpResponseWithError(nethttp.StatusInternalServerError, msg))
 		log.Debug(msg)
-	} else {
-		fasthttpRespond(reqCtx, fasthttpResponseWithEmpty())
+		return
 	}
+
+	fasthttpRespond(reqCtx, fasthttpResponseWithEmpty())
 }
 
 func (a *api) onCreateActorTimer(reqCtx *fasthttp.RequestCtx) {
@@ -1418,12 +1434,20 @@ func (a *api) onDeleteActorReminder(reqCtx *fasthttp.RequestCtx) {
 
 	err := a.universal.Actors.DeleteReminder(reqCtx, &req)
 	if err != nil {
+		if errors.Is(err, actors.ErrReminderOpActorNotHosted) {
+			msg := messages.ErrActorReminderOpActorNotHosted
+			universalFastHTTPErrorResponder(reqCtx, msg)
+			log.Debug(msg)
+			return
+		}
+
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_DELETE", fmt.Sprintf(messages.ErrActorReminderDelete, err))
 		fasthttpRespond(reqCtx, fasthttpResponseWithError(nethttp.StatusInternalServerError, msg))
 		log.Debug(msg)
-	} else {
-		fasthttpRespond(reqCtx, fasthttpResponseWithEmpty())
+		return
 	}
+
+	fasthttpRespond(reqCtx, fasthttpResponseWithEmpty())
 }
 
 func (a *api) onActorStateTransaction(reqCtx *fasthttp.RequestCtx) {
@@ -1493,11 +1517,19 @@ func (a *api) onGetActorReminder(reqCtx *fasthttp.RequestCtx) {
 		Name:      name,
 	})
 	if err != nil {
+		if errors.Is(err, actors.ErrReminderOpActorNotHosted) {
+			msg := messages.ErrActorReminderOpActorNotHosted
+			universalFastHTTPErrorResponder(reqCtx, msg)
+			log.Debug(msg)
+			return
+		}
+
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_GET", fmt.Sprintf(messages.ErrActorReminderGet, err))
 		fasthttpRespond(reqCtx, fasthttpResponseWithError(nethttp.StatusInternalServerError, msg))
 		log.Debug(msg)
 		return
 	}
+
 	b, err := json.Marshal(resp)
 	if err != nil {
 		msg := NewErrorResponse("ERR_ACTOR_REMINDER_GET", fmt.Sprintf(messages.ErrActorReminderGet, err))

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -2249,7 +2249,26 @@ func TestV1ActorEndpoints(t *testing.T) {
 		mockActors.AssertNumberOfCalls(t, "CreateReminder", 1)
 	})
 
-	t.Run("Reminder Rename - 204 when RenameReminderFails", func(t *testing.T) {
+	t.Run("Reminder Create - 403 when actor type is not hosted", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1"
+
+		mockActors := new(actors.MockActors)
+		mockActors.
+			On("CreateReminder", mock.AnythingOfType("*reminders.CreateReminderRequest")).
+			Return(actors.ErrReminderOpActorNotHosted)
+
+		testAPI.universal.Actors = mockActors
+
+		// act
+		resp := fakeServer.DoRequest("POST", apiPath, []byte("{}"), nil)
+
+		// assert
+		assert.Equal(t, 403, resp.StatusCode)
+		assert.Equal(t, "ERR_ACTOR_REMINDER_NON_HOSTED", resp.ErrorBody["errorCode"])
+		mockActors.AssertNumberOfCalls(t, "CreateReminder", 1)
+	})
+
+	t.Run("Reminder Rename - 204 No Content", func(t *testing.T) {
 		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1"
 
 		reminderRequest := actors.RenameReminderRequest{
@@ -2302,6 +2321,25 @@ func TestV1ActorEndpoints(t *testing.T) {
 		mockActors.AssertNumberOfCalls(t, "RenameReminder", 1)
 	})
 
+	t.Run("Reminder Rename - 403 when actor type is not hosted", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1"
+
+		mockActors := new(actors.MockActors)
+		mockActors.
+			On("RenameReminder", mock.AnythingOfType("*actors.RenameReminderRequest")).
+			Return(actors.ErrReminderOpActorNotHosted)
+
+		testAPI.universal.Actors = mockActors
+
+		// act
+		resp := fakeServer.DoRequest("PATCH", apiPath, []byte("{}"), nil)
+
+		// assert
+		assert.Equal(t, 403, resp.StatusCode)
+		assert.Equal(t, "ERR_ACTOR_REMINDER_NON_HOSTED", resp.ErrorBody["errorCode"])
+		mockActors.AssertNumberOfCalls(t, "RenameReminder", 1)
+	})
+
 	t.Run("Reminder Delete - 204 No Content", func(t *testing.T) {
 		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1"
 		reminderRequest := actors.DeleteReminderRequest{
@@ -2348,6 +2386,25 @@ func TestV1ActorEndpoints(t *testing.T) {
 		mockActors.AssertNumberOfCalls(t, "DeleteReminder", 1)
 	})
 
+	t.Run("Reminder Delete - 403 when actor type is not hosted", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1"
+
+		mockActors := new(actors.MockActors)
+		mockActors.
+			On("DeleteReminder", mock.AnythingOfType("*actors.DeleteReminderRequest")).
+			Return(actors.ErrReminderOpActorNotHosted)
+
+		testAPI.universal.Actors = mockActors
+
+		// act
+		resp := fakeServer.DoRequest("DELETE", apiPath, []byte("{}"), nil)
+
+		// assert
+		assert.Equal(t, 403, resp.StatusCode)
+		assert.Equal(t, "ERR_ACTOR_REMINDER_NON_HOSTED", resp.ErrorBody["errorCode"])
+		mockActors.AssertNumberOfCalls(t, "DeleteReminder", 1)
+	})
+
 	t.Run("Reminder Get - 200 OK", func(t *testing.T) {
 		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1"
 		reminderRequest := actors.GetReminderRequest{
@@ -2390,6 +2447,25 @@ func TestV1ActorEndpoints(t *testing.T) {
 		// assert
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.Equal(t, "ERR_ACTOR_REMINDER_GET", resp.ErrorBody["errorCode"])
+		mockActors.AssertNumberOfCalls(t, "GetReminder", 1)
+	})
+
+	t.Run("Reminder Get - 403 when actor type is not hosted", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1"
+
+		mockActors := new(actors.MockActors)
+		mockActors.
+			On("GetReminder", mock.AnythingOfType("*actors.GetReminderRequest")).
+			Return(nil, actors.ErrReminderOpActorNotHosted)
+
+		testAPI.universal.Actors = mockActors
+
+		// act
+		resp := fakeServer.DoRequest("GET", apiPath, nil, nil)
+
+		// assert
+		assert.Equal(t, 403, resp.StatusCode)
+		assert.Equal(t, "ERR_ACTOR_REMINDER_NON_HOSTED", resp.ErrorBody["errorCode"])
 		mockActors.AssertNumberOfCalls(t, "GetReminder", 1)
 	})
 

--- a/pkg/messages/predefined.go
+++ b/pkg/messages/predefined.go
@@ -121,6 +121,9 @@ var (
 	ErrCryptoGetKey                 = APIError{"failed to retrieve key %s: %v", "ERR_CRYPTO_KEY", http.StatusInternalServerError, grpcCodes.Internal}
 	ErrCryptoOperation              = APIError{"failed to perform operation: %v", "ERR_CRYPTO", http.StatusInternalServerError, grpcCodes.Internal}
 
+	// Actor.
+	ErrActorReminderOpActorNotHosted = APIError{"operations on actor reminders are only possible on hosted actor types", "ERR_ACTOR_REMINDER_NON_HOSTED", http.StatusForbidden, grpcCodes.PermissionDenied}
+
 	// Lock.
 	ErrLockStoresNotConfigured    = APIError{"lock store is not configured", "ERR_LOCK_STORE_NOT_CONFIGURED", http.StatusInternalServerError, grpcCodes.FailedPrecondition}
 	ErrResourceIDEmpty            = APIError{"ResourceId is empty in lock store %s", "ERR_MALFORMED_REQUEST", http.StatusBadRequest, grpcCodes.InvalidArgument}

--- a/tests/e2e/actor_reminder/actor_reminder_test.go
+++ b/tests/e2e/actor_reminder/actor_reminder_test.go
@@ -528,3 +528,15 @@ func TestActorReminderTTL(t *testing.T) {
 		require.Equal(t, 5, count)
 	})
 }
+
+func TestActorReminderNonHostedActor(t *testing.T) {
+	externalURL := tr.Platform.AcquireAppExternalURL(appName)
+	require.NotEmpty(t, externalURL, "external URL must not be empty!")
+
+	t.Run("Operations on actor reminders should fail if actor type is not hosted", func(t *testing.T) {
+		// Run the tests
+		res, err := utils.HTTPPost(externalURL+"/test/nonhosted", nil)
+		require.NoError(t, err)
+		require.Equal(t, "OK", string(res))
+	})
+}


### PR DESCRIPTION
Fixes #6150

# Description

Although endpoints to modify actor reminders are meant to be invoked by running actors only, there's currently nothing preventing them from being invoked by anyone. This causes interesting issues such as #6150, where operations on reminders can fail if they are being executed by a sidecar that doesn't host actors of the given type.

This implements the fix discussed on the issue (https://github.com/dapr/dapr/issues/6150#issuecomment-1489665935), disabling operations on actor reminders if the sidecar isn't hosting actors of the given type.

This should be considered a **breaking change**, even if (hopefully) of small impact. It prevents behaviors that were never intended to be used (but may have been used by someone, per Hyrum's law) and that were buggy and not always working as intended.

## Release Note

RELEASE NOTE: **FIXED** Disallow operations on reminders for actor types that are not currently being hosted