### PR TITLE
Grafana Visualization of perf-test Metrics

### DIFF
--- a/tests/config/grafana-perf-test-dashboard.json
+++ b/tests/config/grafana-perf-test-dashboard.json
@@ -1,0 +1,447 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "liveNow": true,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlPu"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 25,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 123124,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "DAPR_LATENCY{building_block=\"state_get_http\"}",
+            "format": "time_series",
+            "interval": "",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "DAPR_LATENCY{building_block=\"service_invocation_http\"}",
+            "hide": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Dapr Latency",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-RdYlGr"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 25,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "mCPU"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 123125,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "DAPR_SIDECAR_CPU_USAGE{building_block=\"state_get_http\"}",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "DAPR_SIDECAR_CPU_USAGE{building_block=\"service_invocation_http\"}",
+            "hide": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Dapr Sidecar CPU Usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-BlYlRd"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 25,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "decmbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 123126,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "DAPR_SIDECAR_MEMORY_USAGE{building_block=\"state_get_http\"}",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "DAPR_SIDECAR_MEMORY_USAGE{building_block=\"service_invocation_http\"}",
+            "hide": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Dapr Sidecar Memory Usage",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "continuous-GrYlRd"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Actual QPS",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 25,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 123127,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "APPLICATION_THROUGHPUT{building_block=\"state_get_http\"}",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "a62defba-8d68-4582-94f0-37797ff55577"
+            },
+            "editorMode": "builder",
+            "expr": "APPLICATION_THROUGHPUT{building_block=\"service_invocation_http\"}",
+            "hide": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Application Throughput",
+        "type": "timeseries"
+      }
+    ]
+}

--- a/tests/perf/service_invocation_http/service_invocation_http_test.go
+++ b/tests/perf/service_invocation_http/service_invocation_http_test.go
@@ -183,6 +183,15 @@ func TestServiceInvocationHTTPPerformance(t *testing.T) {
 	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
 
+	dapr_metrics:=utils.DaprMetrics{
+		Dapr_latency: daprLatency,
+		Sidecar_cpu: sidecarUsage.CPUm,
+		Sidecar_memory: sidecarUsage.MemoryMb,
+		Application_throughput: daprResult.ActualQPS,
+	}
+
+	utils.PrometheusMetrics(dapr_metrics,"service_invocation_http","")
+
 	summary.ForTest(t).
 		Service("testapp").
 		CPU(appUsage.CPUm).

--- a/tests/perf/state_get_http/state_get_http_test.go
+++ b/tests/perf/state_get_http/state_get_http_test.go
@@ -152,6 +152,15 @@ func TestStateGetGrpcPerformance(t *testing.T) {
 	t.Logf("dapr latency avg: %sms", fmt.Sprintf("%.2f", daprLatency))
 	t.Logf("added latency avg: %sms", fmt.Sprintf("%.2f", avg))
 
+	dapr_metrics:=utils.DaprMetrics{
+		Dapr_latency: daprLatency,
+		Sidecar_cpu: sidecarUsage.CPUm,
+		Sidecar_memory: sidecarUsage.MemoryMb,
+		Application_throughput: daprResult.ActualQPS,
+	}
+
+	utils.PrometheusMetrics(dapr_metrics,"state_get_http","inmemory")
+
 	summary.ForTest(t).
 		Service("tester").
 		CPU(appUsage.CPUm).

--- a/tests/perf/utils/prometheus_metrics.go
+++ b/tests/perf/utils/prometheus_metrics.go
@@ -1,0 +1,82 @@
+//go:build perf
+// +build perf
+
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"log"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+)
+
+type DaprMetrics struct {
+	Dapr_latency           float64
+	Sidecar_cpu            int64
+	Sidecar_memory         float64
+	Application_throughput float64
+}
+
+func PrometheusMetrics(metrics DaprMetrics, building_block string, component string) {
+	
+	//Create and register the dapr metrics required
+
+	daprLatencyGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "DAPR_LATENCY",
+		Help: "Average Latency by Dapr Sidecar",
+	})
+	sidecarCpuGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "DAPR_SIDECAR_CPU_USAGE",
+		Help: "CPU Usage by Dapr Sidecar",
+	})
+	sidecarMemoryGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "DAPR_SIDECAR_MEMORY_USAGE",
+		Help: "Memory Usage by Dapr Sidecar",
+	})
+	applicationThroughputGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "APPLICATION_THROUGHPUT",
+		Help: "Actual QPS",
+	})
+
+	//Create a pusher to push metrics to the Prometheus Pushgateway
+
+	pusher := push.New("http://localhost:9091", building_block).
+		Collector(daprLatencyGauge).
+		Collector(sidecarCpuGauge).
+		Collector(sidecarMemoryGauge).
+		Collector(applicationThroughputGauge).
+		Grouping("building_block", building_block)
+
+	// Add the component Grouping only if specified
+
+	if len(component) > 0 {
+		pusher.Grouping("component", component)
+	}
+
+	// Set the dapr_metrics values to the Gauges created
+
+	daprLatencyGauge.Set(metrics.Dapr_latency)
+	sidecarCpuGauge.Set(float64(metrics.Sidecar_cpu))
+	sidecarMemoryGauge.Set(metrics.Sidecar_memory)
+	applicationThroughputGauge.Set(metrics.Application_throughput)
+
+	// Push the metrics value to the Pushgateway
+
+	if err := pusher.Push(); err != nil {
+		log.Println("Failed to push metrics:", err)
+	}
+
+}


### PR DESCRIPTION
# Description

In this PR, a function PrometheusMetrics() has been created in the prometheus_metrics.go file which is accessed in the perf-tests of state_get_http and service_invocation_http in order to collect the following metrics and push it to Prometheus Pushgateway:

- DAPR_LATENCY
- DAPR_SIDECAR_CPU_USAGE
- DAPR_SIDECAR_MEMORY_USAGE
- APPLICATION_THROUGHPUT

These metrics are then scraped by Prometheus and is made available for visualization in Grafana.

There have been steps introduced in the running-perf-tests.md file to setup the following in AKS:

- Prometheus Server
- Pushgateway
- Grafana

On running the perf-tests now for state-get-http and service-invocation-http, the users will be able to visualize the metrics mentioned above in the form of a Grafana dashboard by importing the template as written in the grafana-perf-test-dashboard.json file.