### PR TITLE
[release-1.10] Component Name Valdiation

### DIFF
--- a/docs/release_notes/v1.10.8.md
+++ b/docs/release_notes/v1.10.8.md
@@ -1,0 +1,21 @@
+# Dapr 1.10.8
+
+## Fixed Dapr accepting components with impossible names in self hosted mode.
+
+### Problem
+
+When running in self hosted mode, Dapr would parse and accept components which
+had impossible names, making them unusable.
+
+### Impact
+
+Impacts users running Dapr in self hosted mode.
+
+### Root cause
+
+Dapr was not validating the component name when running in self hosted mode.
+
+### Solution
+
+Added validation of the component name when running in self hosted mode.
+Components with impossible names will be rejected during startup.

--- a/pkg/components/disk_manifest_loader.go
+++ b/pkg/components/disk_manifest_loader.go
@@ -16,12 +16,15 @@ package components
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dapr/dapr/utils"
 
 	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/api/validation/path"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -118,7 +121,13 @@ func (m DiskManifestLoader[T]) decodeYaml(b []byte) ([]T, []error) {
 			continue
 		}
 
+		if errs := path.IsValidPathSegmentName(ti.Name); len(errs) > 0 {
+			errors = append(errors, fmt.Errorf("invalid name %q for %q: %s", ti.Name, m.kind, strings.Join(errs, "; ")))
+			continue
+		}
+
 		manifest := m.zv()
+
 		if err := yaml.Unmarshal(scannerBytes, &manifest); err != nil {
 			errors = append(errors, err)
 

--- a/pkg/components/disk_manifest_loader.go
+++ b/pkg/components/disk_manifest_loader.go
@@ -87,7 +87,8 @@ func (m DiskManifestLoader[T]) loadManifestsFromFile(manifestPath string) []T {
 }
 
 type typeInfo struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
 // decodeYaml decodes the yaml document.


### PR DESCRIPTION
Backports relevant commits from https://github.com/dapr/dapr/pull/6489

/cc @artursouza 