### PR TITLE
Inject APP_PROTOCOL in app containers

### DIFF
--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -147,7 +148,7 @@ func (i *injector) getPodPatchOperations(ctx context.Context, ar *v1.AdmissionRe
 		sidecar.AddDaprSideCarMetricsEnabledLabel(metricsEnabled, pod.Labels))
 
 	patchOps = append(patchOps,
-		sidecar.AddDaprEnvVarsToContainers(appContainers)...)
+		sidecar.AddDaprEnvVarsToContainers(appContainers, getAppProtocol(an))...)
 	patchOps = append(patchOps,
 		sidecar.AddSocketVolumeMountToContainers(appContainers, socketVolumeMount)...)
 	volumePatchOps := sidecar.GetVolumesPatchOperations(
@@ -175,4 +176,34 @@ func mTLSEnabled(daprClient scheme.Interface) bool {
 	}
 	log.Infof("Dapr system configuration (%s) is not found, use default value %t for mTLSEnabled", defaultConfig, defaultMtlsEnabled)
 	return defaultMtlsEnabled
+}
+
+func getAppProtocol(an annotations.Map) string {
+	appProtocol := strings.ToLower(an.GetString(annotations.KeyAppProtocol))
+	appSSL := an.GetBoolOrDefault(annotations.KeyAppSSL, annotations.DefaultAppSSL)
+
+	switch appProtocol {
+	case string(sidecar.GRPCSProtocol), string(sidecar.HTTPSProtocol), string(sidecar.H2CProtocol):
+		return appProtocol
+	case string(sidecar.HTTPProtocol):
+		// For backwards compatibility, when protocol is HTTP and --app-ssl is set, use "https"
+		// TODO: Remove in a future Dapr version
+		if appSSL {
+			return string(sidecar.HTTPSProtocol)
+		} else {
+			return string(sidecar.HTTPProtocol)
+		}
+	case string(sidecar.GRPCProtocol):
+		// For backwards compatibility, when protocol is GRPC and --app-ssl is set, use "grpcs"
+		// TODO: Remove in a future Dapr version
+		if appSSL {
+			return string(sidecar.GRPCSProtocol)
+		} else {
+			return string(sidecar.GRPCProtocol)
+		}
+	case "":
+		return string(sidecar.HTTPProtocol)
+	default:
+		return ""
+	}
 }

--- a/pkg/injector/sidecar/consts.go
+++ b/pkg/injector/sidecar/consts.go
@@ -31,9 +31,16 @@ const (
 	SidecarMetricsEnabledLabel     = "dapr.io/metrics-enabled"
 	APIVersionV1                   = "v1.0"
 	UnixDomainSocketVolume         = "dapr-unix-domain-socket" // Name of the Unix domain socket volume.
+	UserContainerAppProtocolName   = "APP_PROTOCOL"            // Name of the variable exposed to the app containing the app protocol.
 	UserContainerDaprHTTPPortName  = "DAPR_HTTP_PORT"          // Name of the variable exposed to the app containing the Dapr HTTP port.
 	UserContainerDaprGRPCPortName  = "DAPR_GRPC_PORT"          // Name of the variable exposed to the app containing the Dapr gRPC port.
 	PatchPathLabels                = "/metadata/labels"
 	TokenVolumeKubernetesMountPath = "/var/run/secrets/dapr.io/sentrytoken" /* #nosec */ // Mount path for the Kubernetes service account volume with the sentry token.
 	TokenVolumeName                = "dapr-identity-token"                  /* #nosec */ // Name of the volume with the service account token for daprd.
+
+	GRPCProtocol  = "grpc"  // GRPCProtocol is the gRPC communication protocol.
+	GRPCSProtocol = "grpcs" // GRPCSProtocol is the gRPC communication protocol with TLS (without validating certificates).
+	HTTPProtocol  = "http"  // HTTPProtocol is the HTTP communication protocol.
+	HTTPSProtocol = "https" // HTTPSProtocol is the HTTPS communication protocol with TLS (without validating certificates).
+	H2CProtocol   = "h2c"   // H2CProtocol is the HTTP/2 Cleartext communication protocol (HTTP/2 without TLS).
 )

--- a/tests/apps/healthapp/app.go
+++ b/tests/apps/healthapp/app.go
@@ -72,6 +72,11 @@ func main() {
 
 	appProtocol = os.Getenv("APP_PROTOCOL")
 
+	expectAppProtocol := os.Getenv("EXPECT_APP_PROTOCOL")
+	if expectAppProtocol != "" && appProtocol != expectAppProtocol {
+		log.Fatalf("Expected injected APP_PROTOCOL to be %q, but got %q", expectAppProtocol, appProtocol)
+	}
+
 	controlPort = os.Getenv("CONTROL_PORT")
 	if controlPort == "" {
 		controlPort = "3000"

--- a/tests/e2e/healthcheck/healthcheck_test.go
+++ b/tests/e2e/healthcheck/healthcheck_test.go
@@ -65,9 +65,9 @@ func TestMain(m *testing.M) {
 			AppHealthProbeTimeout:  200,
 			AppHealthThreshold:     3,
 			AppEnv: map[string]string{
-				"APP_PROTOCOL": "http",
-				"APP_PORT":     "4000",
-				"CONTROL_PORT": "3000",
+				"APP_PORT":            "4000",
+				"CONTROL_PORT":        "3000",
+				"EXPECT_APP_PROTOCOL": "http",
 			},
 		},
 		{
@@ -86,9 +86,9 @@ func TestMain(m *testing.M) {
 			AppHealthProbeTimeout:  200,
 			AppHealthThreshold:     3,
 			AppEnv: map[string]string{
-				"APP_PROTOCOL": "grpc",
-				"APP_PORT":     "4000",
-				"CONTROL_PORT": "3000",
+				"APP_PORT":            "4000",
+				"CONTROL_PORT":        "3000",
+				"EXPECT_APP_PROTOCOL": "grpc",
 			},
 		},
 		{
@@ -107,9 +107,9 @@ func TestMain(m *testing.M) {
 			AppHealthProbeTimeout:  200,
 			AppHealthThreshold:     3,
 			AppEnv: map[string]string{
-				"APP_PROTOCOL": "h2c",
-				"APP_PORT":     "4000",
-				"CONTROL_PORT": "3000",
+				"APP_PORT":            "4000",
+				"CONTROL_PORT":        "3000",
+				"EXPECT_APP_PROTOCOL": "h2c",
 			},
 		},
 	}


### PR DESCRIPTION
Changes the Dapr Injector to inject the APP_PROTOCOL variable into the app containers. This will contain the value of the (computed) `--app-protocol` flag, such as "http", "grpc", "https", "grpcs", or "h2c".

This can be used by SDKs (and users) to determine if they need to start a server with TLS or with H2C support, for example. It may be possible for the SDKs to use this to determine if they should use HTTP or gRPC too, possibly.

See: https://github.com/dapr/dapr/issues/6035#issuecomment-1590624276