### PR TITLE
Helm: Allow configuring HA mode for placement separately from `global.ha.enabled`

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -80,7 +80,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `global.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
 | `global.imagePullSecrets`                 | Control plane service images pull secrets for docker registry           | `""`                    |
 | `global.ha.enabled`                       | Highly Availability mode enabled for control plane                      | `false`                 |
-| `global.ha.replicaCount`                  | Number of replicas of control plane services in Highly Availability mode  | `3`                   |
+| `global.ha.replicaCount`                  | Number of replicas of control plane services in Highly Availability mode<br>Note that in HA mode, Dapr Placement has 3 replicas and that cannot be configured. | `3`                   |
 | `global.ha.disruption.minimumAvailable`   | Minimum amount of available instances for control plane. This can either be effective count or %. | ``             |
 | `global.ha.disruption.maximumUnavailable` | Maximum amount of instances that are allowed to be unavailable for control plane. This can either be effective count or %. | `25%`             |
 | `global.prometheus.enabled`               | Prometheus metrics enablement for control plane services                | `true`                  |
@@ -119,12 +119,13 @@ The Helm chart has the follow configuration options that can be supplied:
 ### Dapr Placement options:
 | Parameter                                 | Description                                                             | Default                 |
 |-------------------------------------------|-------------------------------------------------------------------------|-------------------------|
+| `dapr_placement.ha` | If set to true, deploys the Placement service with 3 nodes regardless of the value of `global.ha.enabled` | `false` |
 | `dapr_placement.replicationFactor`        | Number of consistent hashing virtual node | `100`   |
 | `dapr_placement.logLevel`                 | Service Log level                                                       | `info`                  |
 | `dapr_placement.image.name`               | Service docker image name (`global.registry/dapr_placement.image.name`) | `dapr`   |
-| `dapr_placement.cluster.forceInMemoryLog` | Use in-memory log store and disable volume attach when `global.ha.enabled` is true | `false`   |
-| `dapr_placement.cluster.logStorePath`     | Mount path for persistent volume for log store in unix-like system when `global.ha.enabled` is true | `/var/run/dapr/raft-log`   |
-| `dapr_placement.cluster.logStoreWinPath`  | Mount path for persistent volume for log store in windows when `global.ha.enabled` is true | `C:\\raft-log`   |
+| `dapr_placement.cluster.forceInMemoryLog` | Use in-memory log store and disable volume attach when HA is true | `false`   |
+| `dapr_placement.cluster.logStorePath`     | Mount path for persistent volume for log store in unix-like system when HA is true | `/var/run/dapr/raft-log`   |
+| `dapr_placement.cluster.logStoreWinPath`  | Mount path for persistent volume for log store in windows when HA is true | `C:\\raft-log`   |
 | `dapr_placement.volumeclaims.storageSize` | Attached volume size | `1Gi`   |
 | `dapr_placement.volumeclaims.storageClassName` | storage class name |    |
 | `dapr_placement.runAsNonRoot`             | Boolean value for `securityContext.runAsNonRoot`. Does not apply unless `forceInMemoryLog` is set to `true`. You may have to set this to `false` when running in Minikube | `false` |

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
@@ -10,7 +10,7 @@ metadata:
     {{ $key }}: {{ tpl $value $ }}
     {{- end }}
 spec:
-{{- if eq .Values.global.ha.enabled true }}
+{{- if or (eq .Values.global.ha.enabled true) (eq .Values.ha true) }}
   replicas: 3
 {{- else }}
   replicas: 1
@@ -73,7 +73,7 @@ spec:
           - name: credentials
             mountPath: /var/run/dapr/credentials
             readOnly: true
-{{- if eq .Values.global.ha.enabled true }}
+{{- if or (eq .Values.global.ha.enabled true) (eq .Values.ha true) }}
   {{- if eq .Values.cluster.forceInMemoryLog false }}
           - name: raft-log
     {{- if eq .Values.global.daprControlPlaneOs "windows" }}
@@ -110,7 +110,7 @@ spec:
         - "/placement"
         - "--"
 {{- end }}
-{{- if eq .Values.global.ha.enabled true }}
+{{- if or (eq .Values.global.ha.enabled true) (eq .Values.ha true) }}
         - "--id"
         - "$(PLACEMENT_ID)"
         - "--initial-cluster"
@@ -214,7 +214,7 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
-{{- if eq .Values.global.ha.enabled true }}
+{{- if or (eq .Values.global.ha.enabled true) (eq .Values.ha true) }}
   {{- if eq .Values.cluster.forceInMemoryLog false }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/dapr/charts/dapr_placement/values.yaml
+++ b/charts/dapr/charts/dapr_placement/values.yaml
@@ -15,6 +15,8 @@ ports:
   apiPort: 50005
   raftRPCPort: 8201
 
+ha: false
+
 cluster:
   forceInMemoryLog: false
   logStorePath: /var/run/dapr/raft-log


### PR DESCRIPTION
For all control plane services except Placement, it's possible to set a `replicaCount` (for example, `dapr_operator.replicaCount`) regardless of whether HA mode is enabled for the control plane (`global.ha.enabled`).

Placement is the only service where insofar it's not possible to enable HA mode without setting `global.ha.enabled`. This is a problem because it doesn't allow controlling the number of replicas for each control plane service.

This PR adds the option `dapr_placement.ha` which if set to true, makes Placement deployed in HA mode (with exactly 3 replicas), even if `global.ha.enabled` is false.