### PR TITLE
Supports using an existing "dapr-trust-bundle" secret

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -143,6 +143,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `dapr_sentry.replicaCount`                | Number of replicas                                                      | `1`                     |
 | `dapr_sentry.logLevel`                    | Log level                                                               | `info`                  |
 | `dapr_sentry.image.name`                  | Docker image name (`global.registry/dapr_sentry.image.name`)            | `dapr`                  |
+| `dapr_sentry.tls.useExistingSecret`       | Use an already created dapr-trust-bundle secret                                                | `false`                 |
 | `dapr_sentry.tls.issuer.certPEM`          | Issuer Certificate cert                                                 | `""`                    |
 | `dapr_sentry.tls.issuer.keyPEM`           | Issuer Private Key cert                                                 | `""`                    |
 | `dapr_sentry.tls.root.certPEM`            | Root Certificate cert                                                   | `""`                    |

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.tls.useExistingSecret }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "dapr-trust-bundle"}}
 ---
 apiVersion: v1
@@ -20,6 +21,7 @@ data:
   {{ if .Values.tls.root.certPEM }}ca.crt: {{ b64enc .Values.tls.root.certPEM | trim }}
   {{ else if $existingSecret }}ca.crt: {{ index $existingSecret.data "ca.crt" }}
   {{end}}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/dapr/charts/dapr_sentry/values.yaml
+++ b/charts/dapr/charts/dapr_sentry/values.yaml
@@ -19,6 +19,10 @@ ports:
   targetPort: 50001
 
 tls:
+  # If enabled, you have to provision your own Kubernetes Secret "dapr-trust-bundle" object
+  # following https://docs.dapr.io/operations/security/mtls/#bringing-your-own-certificates
+  # this is useful when using an external tool for handling secrets
+  useExistingSecret: false
   issuer:
     certPEM: ""
     keyPEM: ""


### PR DESCRIPTION
# Description

Added support for using an existing `dapr-trust-bundle` secret as another alternative to handling certificates.
This is useful to avoid including PEM content and private keys in a plain text way via `tls.issuer` and `tls.root` but also because tools like ArgoCD do not support `lookup` helm function.
Also, this is useful when secrets are handled externally with tools like Sealed Secrets, Vault, etc

This PR includes a new property `useExistingSecret` (default `false`) in the sentry helm chart:

```yaml
tls:
  useExistingSecret: false      # <---- here
  issuer:
    certPEM: ""
    keyPEM: ""
  root:
    certPEM: ""
  trustDomain: cluster.local
```

## Issue reference

#6507 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
