### PR TITLE
Fixes `ActorReminder` data problems by adding a custom BSON Marshal function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/stretchr/testify v1.8.3
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde
 	github.com/valyala/fasthttp v1.47.0
+	go.mongodb.org/mongo-driver v1.11.6
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0
@@ -369,7 +370,6 @@ require (
 	go.etcd.io/etcd/api/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.5 // indirect
-	go.mongodb.org/mongo-driver v1.11.6 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect


### PR DESCRIPTION
# Description

Dapr 1.10.3 or so refactored ActorReminders in such a way that it completely changed how MongoDB as a result would store the data. This caused all kinds of problems.
The missing piece to address that was in addition to the existing custom JSON Marshal function also a custom BSON Marshal function, because Mongo DB uses BSON instead.

This PR adds the missing function. This has been extensively tested - manually however.

FURTHER TESTS: Done manually (paired with @ItalyPaleAle also). No other meaningful tests can be added here. IN THE FUTURE: Switch the Actor Reminder tests from Redis to MongoDB to exercise this code path.

Thanks to @ItalyPaleAle for helping investigate.

Fixes #6497
Fixes dapr/components-contrib#2837