### PR TITLE
Pass "dapr-app-id" in calls to `/dapr/config`

### DIFF
--- a/pkg/actors/internal_actor.go
+++ b/pkg/actors/internal_actor.go
@@ -71,7 +71,7 @@ func (c *internalActorChannel) Contains(actorType string) bool {
 }
 
 // GetAppConfig implements channel.AppChannel
-func (c *internalActorChannel) GetAppConfig() (*config.ApplicationConfig, error) {
+func (c *internalActorChannel) GetAppConfig(appID string) (*config.ApplicationConfig, error) {
 	actorTypes := make([]string, 0, len(c.actors))
 	for actorType := range c.actors {
 		actorTypes = append(actorTypes, actorType)

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -29,7 +29,7 @@ const (
 
 // AppChannel is an abstraction over communications with user code.
 type AppChannel interface {
-	GetAppConfig() (*config.ApplicationConfig, error)
+	GetAppConfig(appID string) (*config.ApplicationConfig, error)
 	InvokeMethod(ctx context.Context, req *invokev1.InvokeMethodRequest, appID string) (*invokev1.InvokeMethodResponse, error)
 	HealthProbe(ctx context.Context) (bool, error)
 	SetAppHealth(ah *apphealth.AppHealth)

--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -66,7 +66,7 @@ func CreateLocalChannel(port, maxConcurrency int, conn *grpc.ClientConn, spec co
 }
 
 // GetAppConfig gets application config from user application.
-func (g *Channel) GetAppConfig() (*config.ApplicationConfig, error) {
+func (g *Channel) GetAppConfig(appID string) (*config.ApplicationConfig, error) {
 	return nil, nil
 }
 

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -99,10 +99,13 @@ func CreateHTTPChannel(config ChannelConfiguration) (channel.AppChannel, error) 
 
 // GetAppConfig gets application config from user application
 // GET http://localhost:<app_port>/dapr/config
-func (h *Channel) GetAppConfig() (*config.ApplicationConfig, error) {
+func (h *Channel) GetAppConfig(appID string) (*config.ApplicationConfig, error) {
 	req := invokev1.NewInvokeMethodRequest(appConfigEndpoint).
 		WithHTTPExtension(http.MethodGet, "").
-		WithContentType(invokev1.JSONContentType)
+		WithContentType(invokev1.JSONContentType).
+		WithMetadata(map[string][]string{
+			"dapr-app-id": {appID},
+		})
 	defer req.Close()
 
 	resp, err := h.InvokeMethod(context.TODO(), req, "")

--- a/pkg/channel/testing/channel_mock.go
+++ b/pkg/channel/testing/channel_mock.go
@@ -21,7 +21,7 @@ type MockAppChannel struct {
 }
 
 // GetAppConfig provides a mock function with given fields:
-func (_m *MockAppChannel) GetAppConfig() (*config.ApplicationConfig, error) {
+func (_m *MockAppChannel) GetAppConfig(_ string) (*config.ApplicationConfig, error) {
 	ret := _m.Called()
 
 	var r0 *config.ApplicationConfig

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -3155,7 +3155,7 @@ func (a *DaprRuntime) loadAppConfiguration() {
 		return
 	}
 
-	appConfig, err := a.appChannel.GetAppConfig()
+	appConfig, err := a.appChannel.GetAppConfig(a.runtimeConfig.ID)
 	if err != nil {
 		return
 	}

--- a/pkg/testing/app_channel_mock.go
+++ b/pkg/testing/app_channel_mock.go
@@ -28,7 +28,7 @@ type FailingAppChannel struct {
 	KeyFunc func(req *invokev1.InvokeMethodRequest) string
 }
 
-func (f *FailingAppChannel) GetAppConfig() (*config.ApplicationConfig, error) {
+func (f *FailingAppChannel) GetAppConfig(appID string) (*config.ApplicationConfig, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Small change to include the `dapr-app-id` header, with the value set to the app ID property, in calls to `/dapr/config`.

This allows the app to know the app ID when daprd is requesting the actors configuration. It allows the app to respond more dynamically to list the supported actors.

This PR came to be first of all as something that I found very useful during development, as it allows me to run tests more easily while working on actors. However, it seems a harmless change that could enable other scenarios.