### PR TITLE
Fix fortio Docker image not building

### DIFF
--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,18 +1,18 @@
-FROM golang:1.20 as build_env
+FROM golang:1.20-bullseye as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY app.go go.mod ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.20 as fortio_build_env
+FROM golang:1.20-bullseye as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache
 RUN git clone https://github.com/dapr/fortio.git
 RUN cd fortio && git checkout v1.38.4-dapr && go build
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 WORKDIR /
 COPY --from=build_env /app/tester /
 COPY --from=fortio_build_env /fortio/fortio/fortio /usr/local/bin


### PR DESCRIPTION
The fortio Docker image, used in some of our perf tests, was not working anymore when built from scratch (it currently works in our repo because we have cached images, but it will fail next time we try to build it).

Logs show failures:

```
fortio: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by fortio)
fortio: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by fortio)
```

The reason seems to be that:

1. Fortio is built with CGo enabled
2. The builder image was `golang:1.20` which recently switched to be based on Debian 12 Bookworm (released just a few days ago)
3. The runtime image was `debian:buster-slim` (Debian 10), which uses a different version of libc. That causes fortio to fail to start

It seems that Go doesn't publish Docker images based on Debian 10 Buster anymore. So I've updated all images (builder and runtime) to be based on Debian 11 Bullseye.