### PR TITLE
[release-1.11] Fix fortio Docker image not building

### DIFF
--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,18 +1,18 @@
-FROM golang:1.20 as build_env
+FROM golang:1.20-bullseye as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY app.go go.mod ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.20 as fortio_build_env
+FROM golang:1.20-bullseye as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache
 RUN git clone https://github.com/dapr/fortio.git
 RUN cd fortio && git checkout v1.38.4-dapr && go build
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 WORKDIR /
 COPY --from=build_env /app/tester /
 COPY --from=fortio_build_env /fortio/fortio/fortio /usr/local/bin


### PR DESCRIPTION
Porting #6597 into the release-1.11 branch, so we can continue to run perf tests in the release branch.