### PR TITLE
Fixes from #6573

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ test-race:
 ################################################################################
 .PHONY: test-integration
 test-integration: test-deps
-		gotestsum \
+		CGO_ENABLED=1 gotestsum \
 			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
 			--format testname \
 			-- \

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -32,7 +32,6 @@ import (
 	_ "net/http/pprof"
 
 	chi "github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 
 	"github.com/dapr/dapr/pkg/config"
@@ -228,7 +227,7 @@ func (s *server) Close() error {
 
 func (s *server) getRouter() *chi.Mux {
 	r := chi.NewRouter()
-	r.Use(middleware.CleanPath, StripSlashesMiddleware)
+	r.Use(CleanPathMiddleware, StripSlashesMiddleware)
 	return r
 }
 

--- a/tests/integration/suite/daprd/pubsub/http/fuzz.go
+++ b/tests/integration/suite/daprd/pubsub/http/fuzz.go
@@ -233,7 +233,7 @@ func (f *fuzzpubsub) Run(t *testing.T, ctx context.Context) {
 
 				t.Parallel()
 
-				reqURL := fmt.Sprintf("http://127.0.0.1:%d/v1.0/publish/%s/%s", f.daprd.HTTPPort(), url.PathEscape(pubsubName), url.PathEscape(topicName))
+				reqURL := fmt.Sprintf("http://127.0.0.1:%d/v1.0/publish/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(pubsubName), url.QueryEscape(topicName))
 				// TODO: @joshvanl: under heavy load, messages seem to get lost here
 				// with no response from Dapr. Until this is fixed, we use to smaller
 				// timeout, and retry on context deadline exceeded.

--- a/tests/integration/suite/daprd/secret/http/compname.go
+++ b/tests/integration/suite/daprd/secret/http/compname.go
@@ -108,7 +108,7 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 		secretStoreName := secretStoreName
 		t.Run(secretStoreName, func(t *testing.T) {
 			t.Parallel()
-			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/key1", c.daprd.HTTPPort(), url.PathEscape(secretStoreName))
+			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/key1", c.daprd.HTTPPort(), url.QueryEscape(secretStoreName))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)

--- a/tests/integration/suite/daprd/secret/http/fuzz.go
+++ b/tests/integration/suite/daprd/secret/http/fuzz.go
@@ -62,7 +62,8 @@ func (f *fuzzsecret) Setup(t *testing.T) []framework.Option {
 		for *s == "" ||
 			takenNames[*s] ||
 			len(path.IsValidPathSegmentName(*s)) > 0 ||
-			!reg.MatchString(*s) {
+			!reg.MatchString(*s) ||
+			strings.HasSuffix(*s, ".") {
 			*s = c.RandString()
 		}
 		takenNames[*s] = true

--- a/tests/integration/suite/daprd/secret/http/fuzz.go
+++ b/tests/integration/suite/daprd/secret/http/fuzz.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -129,9 +128,9 @@ func (f *fuzzsecret) Run(t *testing.T, ctx context.Context) {
 		t.Run(key+":"+value, func(t *testing.T) {
 			t.Parallel()
 			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.secretStoreName), url.QueryEscape(key))
-			t.Log("URL", getURL)
-			t.Log("Secret store name", f.secretStoreName, printRunes(f.secretStoreName))
-			t.Log("Key", key, printRunes(key))
+			// t.Log("URL", getURL)
+			// t.Log("Secret store name", f.secretStoreName, printRunes(f.secretStoreName))
+			// t.Log("Key", key, printRunes(key))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
@@ -147,6 +146,7 @@ func (f *fuzzsecret) Run(t *testing.T, ctx context.Context) {
 	// TODO: Bulk APIs, nesting, multi-valued
 }
 
+/*
 func printRunes(str string) []string {
 	result := make([]string, 0, len(str))
 	for _, r := range str {
@@ -154,3 +154,4 @@ func printRunes(str string) []string {
 	}
 	return result
 }
+*/

--- a/tests/integration/suite/daprd/secret/http/fuzz.go
+++ b/tests/integration/suite/daprd/secret/http/fuzz.go
@@ -63,7 +63,7 @@ func (f *fuzzsecret) Setup(t *testing.T) []framework.Option {
 			takenNames[*s] ||
 			len(path.IsValidPathSegmentName(*s)) > 0 ||
 			!reg.MatchString(*s) ||
-			strings.HasSuffix(*s, ".") {
+			*s == "." {
 			*s = c.RandString()
 		}
 		takenNames[*s] = true

--- a/tests/integration/suite/daprd/secret/http/fuzz.go
+++ b/tests/integration/suite/daprd/secret/http/fuzz.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -126,7 +127,10 @@ func (f *fuzzsecret) Run(t *testing.T, ctx context.Context) {
 		value := value
 		t.Run(key+":"+value, func(t *testing.T) {
 			t.Parallel()
-			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/%s", f.daprd.HTTPPort(), url.PathEscape(f.secretStoreName), url.PathEscape(key))
+			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.secretStoreName), url.QueryEscape(key))
+			t.Log("URL", getURL)
+			t.Log("Secret store name", f.secretStoreName, printRunes(f.secretStoreName))
+			t.Log("Key", key, printRunes(key))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
@@ -135,9 +139,17 @@ func (f *fuzzsecret) Run(t *testing.T, ctx context.Context) {
 			respBody, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
-			assert.Equal(t, `{"`+key+`":"`+value+`"}`, string(respBody))
+			assert.Equal(t, `{"`+key+`":"`+value+`"}`, strings.TrimSpace(string(respBody)))
 		})
 	}
 
 	// TODO: Bulk APIs, nesting, multi-valued
+}
+
+func printRunes(str string) []string {
+	result := make([]string, 0, len(str))
+	for _, r := range str {
+		result = append(result, strconv.Itoa(int(r)))
+	}
+	return result
 }

--- a/tests/integration/suite/daprd/serviceinvocation/http/basic.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/basic.go
@@ -44,7 +44,6 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 	newHTTPServer := func() *prochttp.HTTP {
 		handler := http.NewServeMux()
 		handler.HandleFunc("/foo", func(w http.ResponseWriter, r *http.Request) {
-			fmt.Println("INVOKED /FOO", r.URL, r.Method)
 			switch r.Method {
 			case http.MethodPatch:
 				w.WriteHeader(http.StatusBadGateway)
@@ -59,10 +58,12 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 			}
 			w.Write([]byte(r.Method))
 		})
+
 		handler.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("x-method", r.Method)
 			io.Copy(w, r.Body)
 		})
+
 		handler.HandleFunc("/with-headers-and-body", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
@@ -79,6 +80,7 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 			}
 			w.WriteHeader(http.StatusOK)
 		})
+
 		handler.HandleFunc("/multiple/segments", func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != "/multiple/segments" {
 				w.WriteHeader(http.StatusBadRequest)
@@ -223,7 +225,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusCreated, resp.StatusCode)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())

--- a/tests/integration/suite/daprd/serviceinvocation/http/basic.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/basic.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -43,6 +44,7 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 	newHTTPServer := func() *prochttp.HTTP {
 		handler := http.NewServeMux()
 		handler.HandleFunc("/foo", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Println("INVOKED /FOO", r.URL, r.Method)
 			switch r.Method {
 			case http.MethodPatch:
 				w.WriteHeader(http.StatusBadGateway)
@@ -56,6 +58,10 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 				w.WriteHeader(http.StatusConflict)
 			}
 			w.Write([]byte(r.Method))
+		})
+		handler.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-method", r.Method)
+			io.Copy(w, r.Body)
 		})
 		handler.HandleFunc("/with-headers-and-body", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
@@ -114,7 +120,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			return resp.StatusCode, string(body)
 		}
 
-		for _, ts := range []struct {
+		for i, ts := range []struct {
 			url     string
 			headers map[string]string
 		}{
@@ -122,30 +128,35 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			{url: fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/foo", b.daprd2.HTTPPort(), b.daprd1.AppID())},
 			{url: fmt.Sprintf("http://localhost:%d/v1.0////invoke/%s/method/foo", b.daprd2.HTTPPort(), b.daprd1.AppID())},
 			{url: fmt.Sprintf("http://localhost:%d/v1.0//invoke//%s/method//foo", b.daprd1.HTTPPort(), b.daprd2.AppID())},
-			{url: fmt.Sprintf("http://localhost:%d///foo", b.daprd1.HTTPPort()), headers: map[string]string{
+			// We cannot use `///foo` here because the test app uses the standard Go mux which responds with a 301 status code if the invocation is for `///foo`
+			// This makes Dapr retry with a GET request in all cases, as per specs
+			// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301
+			{url: fmt.Sprintf("http://localhost:%d/foo", b.daprd1.HTTPPort()), headers: map[string]string{
 				"foo":         "bar",
 				"dapr-app-id": b.daprd2.AppID(),
 			}},
 		} {
-			status, body := doReq(http.MethodGet, ts.url, ts.headers)
-			assert.Equal(t, http.StatusOK, status)
-			assert.Equal(t, "GET", body)
+			t.Run(fmt.Sprintf("url %d", i), func(t *testing.T) {
+				status, body := doReq(http.MethodGet, ts.url, ts.headers)
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, "GET", body)
 
-			status, body = doReq(http.MethodPost, ts.url, ts.headers)
-			assert.Equal(t, http.StatusCreated, status)
-			assert.Equal(t, "POST", body)
+				status, body = doReq(http.MethodPost, ts.url, ts.headers)
+				assert.Equal(t, http.StatusCreated, status)
+				assert.Equal(t, "POST", body)
 
-			status, body = doReq(http.MethodPut, ts.url, ts.headers)
-			assert.Equal(t, http.StatusAccepted, status)
-			assert.Equal(t, "PUT", body)
+				status, body = doReq(http.MethodPut, ts.url, ts.headers)
+				assert.Equal(t, http.StatusAccepted, status)
+				assert.Equal(t, "PUT", body)
 
-			status, body = doReq(http.MethodDelete, ts.url, ts.headers)
-			assert.Equal(t, http.StatusConflict, status)
-			assert.Equal(t, "DELETE", body)
+				status, body = doReq(http.MethodDelete, ts.url, ts.headers)
+				assert.Equal(t, http.StatusConflict, status)
+				assert.Equal(t, "DELETE", body)
 
-			status, body = doReq(http.MethodPatch, ts.url, ts.headers)
-			assert.Equal(t, http.StatusBadGateway, status)
-			assert.Equal(t, "PATCH", body)
+				status, body = doReq(http.MethodPatch, ts.url, ts.headers)
+				assert.Equal(t, http.StatusBadGateway, status)
+				assert.Equal(t, "PATCH", body)
+			})
 		}
 	})
 
@@ -206,8 +217,9 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	for i := 0; i < 100; i++ {
 		t.Run("parallel requests", func(t *testing.T) {
 			t.Parallel()
-			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/foo", b.daprd1.HTTPPort(), b.daprd2.AppID())
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+			u := uuid.New().String()
+			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo", b.daprd1.HTTPPort(), b.daprd2.AppID())
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(u))
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -215,7 +227,8 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
-			assert.Equal(t, "POST", string(body))
+			assert.Equal(t, "POST", resp.Header.Get("x-method"))
+			assert.Equal(t, u, string(body))
 			assert.NoError(t, resp.Body.Close())
 		})
 	}

--- a/tests/integration/suite/daprd/state/http/compname.go
+++ b/tests/integration/suite/daprd/state/http/compname.go
@@ -92,7 +92,7 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 		storeName := storeName
 		t.Run(storeName, func(t *testing.T) {
 			t.Parallel()
-			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", c.daprd.HTTPPort(), url.PathEscape(storeName))
+			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", c.daprd.HTTPPort(), url.QueryEscape(storeName))
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(`[{"key": "key1", "value": "value1"}]`))
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
@@ -103,7 +103,7 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 			require.NoError(t, resp.Body.Close())
 			assert.Empty(t, string(respBody))
 
-			getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/key1", c.daprd.HTTPPort(), url.PathEscape(storeName))
+			getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/key1", c.daprd.HTTPPort(), url.QueryEscape(storeName))
 			req, err = http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 			require.NoError(t, err)
 			resp, err = http.DefaultClient.Do(req)

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -75,7 +75,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 	fuzzFuncs := []any{
 		func(s *saveReqBinary, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(s.Key, ".") || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}
@@ -85,7 +85,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 		},
 		func(s *saveReqString, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(s.Key, ".") || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}
@@ -95,7 +95,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 		},
 		func(s *saveReqAny, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(s.Key, ".") || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -156,9 +155,9 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 		t.Parallel()
 		for i := range f.getFuzzKeys {
 			getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName), url.QueryEscape(f.getFuzzKeys[i]))
-			t.Log("URL", getURL)
-			t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
-			t.Log("Key", f.getFuzzKeys[i], printRunes(f.getFuzzKeys[i]))
+			// t.Log("URL", getURL)
+			// t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
+			// t.Log("Key", f.getFuzzKeys[i], printRunes(f.getFuzzKeys[i]))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 			require.NoError(t, err)
 			resp, err := http.DefaultClient.Do(req)
@@ -179,8 +178,8 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 				postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName))
 				b := new(bytes.Buffer)
 				require.NoError(t, json.NewEncoder(b).Encode(req))
-				t.Log("URL", postURL)
-				t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
+				// t.Log("URL", postURL)
+				// t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
 				req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, b)
 				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(req)
@@ -194,9 +193,9 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 
 			for _, s := range f.saveReqBinaries[i] {
 				getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName), url.QueryEscape(s.Key))
-				t.Log("URL", getURL)
-				t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
-				t.Log("Key", s.Key, hex.EncodeToString([]byte(s.Key)), printRunes(s.Key))
+				// t.Log("URL", getURL)
+				// t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
+				// t.Log("Key", s.Key, hex.EncodeToString([]byte(s.Key)), printRunes(s.Key))
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(req)
@@ -213,9 +212,9 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 
 			for _, s := range f.saveReqStrings[i] {
 				getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName), url.QueryEscape(s.Key))
-				t.Log("URL", getURL)
-				t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
-				t.Log("Key", s.Key, hex.EncodeToString([]byte(s.Key)), printRunes(s.Key))
+				// t.Log("URL", getURL)
+				// t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
+				// t.Log("Key", s.Key, hex.EncodeToString([]byte(s.Key)), printRunes(s.Key))
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 				require.NoError(t, err)
 				resp, err := http.DefaultClient.Do(req)
@@ -241,6 +240,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	}
 }
 
+/*
 func printRunes(str string) []string {
 	result := make([]string, 0, len(str))
 	for _, r := range str {
@@ -248,3 +248,4 @@ func printRunes(str string) []string {
 	}
 	return result
 }
+*/

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -75,7 +75,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 	fuzzFuncs := []any{
 		func(s *saveReqBinary, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}
@@ -85,7 +85,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 		},
 		func(s *saveReqString, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}
@@ -95,7 +95,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 		},
 		func(s *saveReqAny, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -75,7 +75,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 	fuzzFuncs := []any{
 		func(s *saveReqBinary, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(s.Key, ".") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || s.Key == "." || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}
@@ -85,7 +85,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 		},
 		func(s *saveReqString, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(s.Key, ".") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || s.Key == "." || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}
@@ -95,7 +95,7 @@ func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
 		},
 		func(s *saveReqAny, c fuzz.Continue) {
 			var ok bool
-			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || strings.HasSuffix(s.Key, ".") || ok {
+			for len(s.Key) == 0 || strings.Contains(s.Key, "||") || s.Key == "." || ok {
 				s.Key = c.RandString()
 				_, ok = takenKeys.LoadOrStore(s.Key, true)
 			}
@@ -133,7 +133,7 @@ spec:
 	for i := 0; i < numTests; i++ {
 		fz.Fuzz(&f.getFuzzKeys[i])
 		// Prevent invalid names
-		if strings.Contains(f.getFuzzKeys[i], "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || len(path.IsValidPathSegmentName(f.getFuzzKeys[i])) > 0 {
+		if strings.Contains(f.getFuzzKeys[i], "||") || f.getFuzzKeys[i] == "." || len(path.IsValidPathSegmentName(f.getFuzzKeys[i])) > 0 {
 			f.getFuzzKeys[i] = ""
 			i--
 		}

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -132,7 +132,8 @@ spec:
 	fz := fuzz.New().Funcs(fuzzFuncs...)
 	for i := 0; i < numTests; i++ {
 		fz.Fuzz(&f.getFuzzKeys[i])
-		if strings.Contains(f.getFuzzKeys[i], "||") || len(path.IsValidPathSegmentName(f.getFuzzKeys[i])) > 0 {
+		// Prevent invalid names
+		if strings.Contains(f.getFuzzKeys[i], "||") || strings.HasSuffix(f.getFuzzKeys[i], ".") || len(path.IsValidPathSegmentName(f.getFuzzKeys[i])) > 0 {
 			f.getFuzzKeys[i] = ""
 			i--
 		}


### PR DESCRIPTION
Fixes the errors reported by #6573
Fixes #6588

Among the 3 issues reported in #6588:

1. **Service invocation HTTP looks to no longer pass-through the HTTP method from the caller to the app.**
   - This was determined to be not an issue in Dapr.
   - As explained in #6588, the service invocation handler is the only one that, by design, doesn't always remove double slashes. So, when the invocation was made for `localhost:port////foo`, Dapr would have invoked the app at `app:port///foo`. The request was made with the correct HTTP verb. The test app uses the Go  mux from the standard library, which detected the extra `/` at the beginning and responded with a 301 redirect pointing Dapr to retry with `/foo`. However, 301 redirects do not respect the verb [per specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301) and retries used the GET verb. 
   - The issue was fixed by changing the test to not test for `localhost:port////foo` and use a single slash
   - In #6594 this has been changed to allow using `///foo` again. The extra slashes are cleaned there.
2. **Secret HTTP GET responses now include a newline at the end of the message.**
   - Maintainers agree this is a non-issue, since we fulfill the contract of returning valid JSON.
3. **State store HTTP request parsing seems totally broken on fuzzed inputs**, or to be more precise, issues with path encoding (in state stores and secret stores).
   - This was a combination of issues in the runtime and in tests:
   - In the runtime, we had to switch the way we grab the path. This was fixed by using a custom version of the CleanPath middleware See go-chi/chi#641 
   - In the test framework, we're using `url.QueryEscape` rather than `url.PathEscape` which is more complete
     - Filter keys that are only dots