### PR TITLE
Skip OPTIONS request for input binding if direction is specified

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1721,6 +1721,22 @@ func isBindingOfDirection(direction string, metadata []commonapi.NameValuePair) 
 	return !directionFound
 }
 
+func isBindingOfExplicitDirection(direction string, metadata map[string]string) bool {
+	for k, v := range metadata {
+		if strings.EqualFold(k, bindingDirection) {
+
+			directions := strings.Split(v, ",")
+			for _, d := range directions {
+				if strings.TrimSpace(strings.ToLower(d)) == direction {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
 func (a *DaprRuntime) initInputBinding(c componentsV1alpha1.Component) error {
 	if !isBindingOfDirection(inputBinding, c.Spec.Metadata) {
 		return nil
@@ -3476,10 +3492,18 @@ func (a *DaprRuntime) startReadingFromBindings() (err error) {
 	a.inputBindingsCtx, a.inputBindingsCancel = context.WithCancel(a.ctx)
 
 	for name, binding := range a.compStore.ListInputBindings() {
-		isSubscribed, err := a.isAppSubscribedToBinding(name)
-		if err != nil {
-			return err
+		var isSubscribed bool
+		m := binding.GetComponentMetadata()
+
+		if isBindingOfExplicitDirection(inputBinding, m) {
+			isSubscribed = true
+		} else {
+			isSubscribed, err = a.isAppSubscribedToBinding(name)
+			if err != nil {
+				return err
+			}
 		}
+
 		if !isSubscribed {
 			log.Infof("app has not subscribed to binding %s.", name)
 			continue

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1724,7 +1724,6 @@ func isBindingOfDirection(direction string, metadata []commonapi.NameValuePair) 
 func isBindingOfExplicitDirection(direction string, metadata map[string]string) bool {
 	for k, v := range metadata {
 		if strings.EqualFold(k, bindingDirection) {
-
 			directions := strings.Split(v, ",")
 			for _, d := range directions {
 				if strings.TrimSpace(strings.ToLower(d)) == direction {


### PR DESCRIPTION
Follow up for https://github.com/dapr/dapr/pull/6509, this completes the feature by not probing the app with an OPTIONS call if the user explicitly set the binding as input.
