### PR TITLE
[Workflow] Fix unbounded history batch save issue

### DIFF
--- a/pkg/runtime/wfengine/workflowstate_test.go
+++ b/pkg/runtime/wfengine/workflowstate_test.go
@@ -59,7 +59,7 @@ func TestAddingToInbox(t *testing.T) {
 		assert.Equal(t, workflowActorType, req.ActorType)
 
 		upsertCount, deleteCount := countOperations(t, req)
-		assert.Equal(t, 12, upsertCount) // 10x inbox + metadata + customStatus
+		assert.Equal(t, 11, upsertCount) // 10x inbox + metadata
 		assert.Equal(t, 0, deleteCount)
 	}
 }
@@ -78,7 +78,7 @@ func TestClearingInbox(t *testing.T) {
 		assert.Equal(t, workflowActorType, req.ActorType)
 
 		upsertCount, deleteCount := countOperations(t, req)
-		assert.Equal(t, 2, upsertCount)  // metadata + customStatus
+		assert.Equal(t, 1, upsertCount)  // metadata only
 		assert.Equal(t, 10, deleteCount) // the 10 inbox messages should get deleted
 	}
 }


### PR DESCRIPTION
# Description

Upon investigating #6617, a bug was found in the workflow engine code that causes the engine to save the full workflow history on each checkpoint rather than saving only the deltas. This is resulting in two problems:

1. The I/O cost of saving workflow state increases over the lifetime of the workflow
2. State stores, like Cosmos DB, which have limits on transaction batch sizes, cause workflows with more than a few actions to fail permanently

The actual bug is largely a silly struct pointer issue where we're updating a copy of a struct rather than the struct itself, thus my counting changes weren't being persisted in memory. To fix the problem, I'm changing all functions to use `*workflowState` instead of `workflowState` to ensure that any state changes I make to the struct actually stick. The fact that it was `workflowState` to begin with is a rookie mistake on my part, not understanding the possible implications, when I first wrote this code.

After this PR is merged, the two problems listed above will be resolved.

Note that this doesn't resolve the Cosmos DB limitation in all cases. Fanning out to ~97 or more parallel tasks can still cause users to run into the batch size limitations, even with this fix. A separate PR tracks breaking up the batches into smaller chunks so that large fan-outs can be used with state stores like Cosmos DB: https://github.com/dapr/dapr/pull/6617.

Also included in this PR is some opportunistic test code cleanup to remove panics and unnecessary redundancy.

Note that we don't have any automated tests the specifically cover this change. This is because we don't have a good way to test how many records are being saved in a batch, nor is there a reliable way to measure this just for workflows. I instead validated the fix manually in two ways:

* I watched the logs (which record how many keys we save in any given batch) while running the existing workflow tests to ensure that all batch sizes were the expected size.
* I used the minimal repro that I shared [here](https://github.com/dapr/dapr/issues/6544#issuecomment-1615150285) and ensured that the batch sizes were correct (the max batch size ended up being ~55 in one test).

With this PR, everything is looking good.

## Issue reference

This is part 1 of two fixes needed to fully resolve https://github.com/dapr/dapr/pull/6617.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_

/cc @RyanLettieri 