### PR TITLE
Register updated OAuth2 middlewares

### DIFF
--- a/cmd/daprd/components/middleware_http_oauth2_cookie.go
+++ b/cmd/daprd/components/middleware_http_oauth2_cookie.go
@@ -1,0 +1,34 @@
+//go:build allcomponents
+
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"context"
+
+	"github.com/dapr/components-contrib/middleware"
+	oauth2header "github.com/dapr/components-contrib/middleware/http/oauth2/header"
+	httpMiddlewareLoader "github.com/dapr/dapr/pkg/components/middleware/http"
+	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
+	"github.com/dapr/kit/logger"
+)
+
+func init() {
+	httpMiddlewareLoader.DefaultRegistry.RegisterComponent(func(log logger.Logger) httpMiddlewareLoader.FactoryMethod {
+		return func(metadata middleware.Metadata) (httpMiddleware.Middleware, error) {
+			return oauth2header.NewOAuth2HeaderMiddleware(log).GetHandler(context.TODO(), metadata)
+		}
+	}, "oauth2.header")
+}

--- a/cmd/daprd/components/middleware_http_oauth2_header.go
+++ b/cmd/daprd/components/middleware_http_oauth2_header.go
@@ -19,7 +19,7 @@ import (
 	"context"
 
 	"github.com/dapr/components-contrib/middleware"
-	"github.com/dapr/components-contrib/middleware/http/oauth2"
+	oauth2cookie "github.com/dapr/components-contrib/middleware/http/oauth2/cookie"
 	httpMiddlewareLoader "github.com/dapr/dapr/pkg/components/middleware/http"
 	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
 	"github.com/dapr/kit/logger"
@@ -28,7 +28,7 @@ import (
 func init() {
 	httpMiddlewareLoader.DefaultRegistry.RegisterComponent(func(log logger.Logger) httpMiddlewareLoader.FactoryMethod {
 		return func(metadata middleware.Metadata) (httpMiddleware.Middleware, error) {
-			return oauth2.NewOAuth2Middleware(log).GetHandler(context.TODO(), metadata)
+			return oauth2cookie.NewOAuth2CookieMiddleware(log).GetHandler(context.TODO(), metadata)
 		}
-	}, "oauth2")
+	}, "oauth2.cookie", "oauth2")
 }


### PR DESCRIPTION
> Builds will fail until dapr/components-contrib#2964 is merged and a new contrib is pinned

See dapr/components-contrib#2964 for context
