### PR TITLE
Only use `gopkg.in/yaml.v3`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,6 +135,7 @@ linters-settings:
       - "github.com/cenkalti/backoff/v3": "must use github.com/cenkalti/backoff/v4"
       - "github.com/benbjohnson/clock": "must use k8s.io/utils/clock"
       - "github.com/ghodss/yaml": "must use sigs.k8s.io/yaml"
+      - "gopkg.in/yaml.v2": "must use gopkg.in/yaml.v3"
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.3
 	k8s.io/apiextensions-apiserver v0.26.3
 	k8s.io/apimachinery v0.26.3
@@ -399,7 +399,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/component-base v0.26.3 // indirect
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -25,7 +25,7 @@ import (
 	env "github.com/dapr/dapr/pkg/config/env"
 
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 

--- a/pkg/httpendpoint/http_endpoint.go
+++ b/pkg/httpendpoint/http_endpoint.go
@@ -23,7 +23,7 @@ import (
 	"github.com/dapr/dapr/utils"
 	"github.com/dapr/kit/logger"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/perf/pubsub_subscribe_http/pubsub_subscribe_test.go
+++ b/tests/perf/pubsub_subscribe_http/pubsub_subscribe_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/dapr/dapr/tests/runner/summary"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (


### PR DESCRIPTION
See #6607

Some packages were using v2, some were using v3. Despite the "major" version change, they are compatible.