### PR TITLE
Fix developing-dapr docs

### DIFF
--- a/docs/development/developing-dapr.md
+++ b/docs/development/developing-dapr.md
@@ -73,9 +73,14 @@ This section introduces how to start debugging with the Delve CLI. Please refer 
 
 ### Start the Dapr runtime with a debugger
 
+To start the Dapr runtime with a debugger, you need to use build tags to include the components you want to debug. The following build tags are available:
+
+- allcomponents - (default) includes all components in Dapr sidecar
+- stablecomponents - includes all stable components in Dapr sidecar
+
 ```bash
 $ cd dapr/dapr/cmd/daprd
-$ dlv debug .
+$ dlv debug . --build-flags=--tags=allcomponents
 Type 'help' for list of commands.
 (dlv) break main.main
 (dlv) continue


### PR DESCRIPTION
Signed-off-by: Risto Kochev <kochrick86@gmail.com>

# Description

Fix documentation regarding start the Dapr runtime with a debugger
Missing the build flags when debugging with `dlv`
List  and description of the available build flags

## Issue reference

Small fix for documentation, I didn't find a type of issue for this kind of PR.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
