### PR TITLE
Enable ServiceInvocationStreaming by default in builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ BASE_PACKAGE_NAME := github.com/dapr/dapr
 LOGGER_PACKAGE_NAME := github.com/dapr/kit/logger
 
 # Comma-separated list of features to enable
-ENABLED_FEATURES ?= 
+ENABLED_FEATURES ?= ServiceInvocationStreaming
 
 DEFAULT_LDFLAGS:=-X $(BASE_PACKAGE_NAME)/pkg/buildinfo.gitcommit=$(GIT_COMMIT) \
   -X $(BASE_PACKAGE_NAME)/pkg/buildinfo.gitversion=$(GIT_VERSION) \

--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -138,8 +138,8 @@ func (g *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 
 	// If the data has a type_url, set protobuf as content type
 	// This is necessary to support the HTTP->gRPC service invocation path correctly
-	typeUrl := resp.GetData().GetTypeUrl()
-	if typeUrl != "" {
+	typeURL := resp.GetData().GetTypeUrl()
+	if typeURL != "" {
 		rsp.WithContentType(invokev1.ProtobufContentType)
 	}
 

--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -136,6 +136,13 @@ func (g *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 		WithTrailers(trailer).
 		WithMessage(resp)
 
+	// If the data has a type_url, set protobuf as content type
+	// This is necessary to support the HTTP->gRPC service invocation path correctly
+	typeUrl := resp.GetData().GetTypeUrl()
+	if typeUrl != "" {
+		rsp.WithContentType(invokev1.ProtobufContentType)
+	}
+
 	return rsp, nil
 }
 


### PR DESCRIPTION
Re-do of #6477

Includes:

- A fix for HTTP->gRPC service invocation which should fix the Python SDK test failures:
    - When invoking HTTP -> gRPC, Dapr needs to read the response from the gRPC callee to see if the `Value` property (of type `anypb.Any`) contains a `TypeURL` property. If that's present, it must set the Content Type for the HTTP response to the protobuf one.    
    - Normally InvokeMethodResponse does that check [when returning the ContentType](https://github.com/dapr/dapr/blob/7386ac7755324e061ea723b2dcd0dd5004b48712/pkg/messaging/v1/invoke_method_response.go#L225-L238). This is fine when sidecars don't use streaming to talk to each other
    - The operation above requires knowing the body, to be able to see if it contains a Value with a TypeURL
    - However, when we use streaming for communication between sidecars, the body isn't populated until it's sent to the client. So InvokeMethodResponse can't check if the Value contains a TypeURL
    - The solution was to set an explicit content type in the gRPC channel while creating the InvokeMethodResponse. Since the gRPC channel only makes unary calls, it sees the full data and can see if there's a TypeURL in the Value
- A fix related to tracing of internal invocations when the feature flag is enabled
   -  Trace spans have names that are built from the data and include the method. All internal service invocation calls appear in traces as `calllocal/app-id/method-name`.
   - The above did not happen for calls to CallLocalStream, where the traces appeared with the method's full name (`/dapr.proto.internals.v1.ServiceInvocation/CallLocalStream`)
   - This has been fixed so it now reports the short name.
   - Additionally, the handler has been updated to include the method name in the metadata in the context. This is needed because the interceptor doesn't have the data when it's streamed.