### PR TITLE
Increase integration test timeout to 180 seconds

### DIFF
--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -36,7 +36,7 @@ func RunIntegrationTests(t *testing.T) {
 			t.Logf("setting up test case")
 			options := tcase.Setup(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 			t.Cleanup(cancel)
 
 			f := framework.Run(t, ctx, options...)


### PR DESCRIPTION
On slower CI runners, the integration tests are not completing before the test case timeout (60 seconds).

PR increases the test case timeout to 180 seconds.