### PR TITLE
Fix race condition in `runtime_test.go`.

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -6422,7 +6422,7 @@ func TestStartReadingFromBindings(t *testing.T) {
 		err := rt.startReadingFromBindings()
 
 		assert.NoError(t, err)
-		assert.Len(t, mockAppChannel.Calls, 1)
+		assert.True(t, mockAppChannel.AssertCalled(t, "InvokeMethod", mock.Anything, mock.Anything))
 	})
 
 	t.Run("No OPTIONS request when direction is specified", func(t *testing.T) {
@@ -6459,6 +6459,6 @@ func TestStartReadingFromBindings(t *testing.T) {
 		err := rt.startReadingFromBindings()
 
 		assert.NoError(t, err)
-		assert.Len(t, mockAppChannel.Calls, 0)
+		assert.True(t, mockAppChannel.AssertNotCalled(t, "InvokeMethod", mock.Anything, mock.Anything))
 	})
 }


### PR DESCRIPTION
PR fixes a data race warning by using the library's `Assert` func.

```
==================
WARNING: DATA RACE
Write at 0x00c00059ad98 by goroutine 41:
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /home/josh/go/pkg/mod/github.com/stretchr/testify@v1.8.4/mock/mock.go:530 +0xba0
  github.com/stretchr/testify/mock.(*Mock).Called()
      /home/josh/go/pkg/mod/github.com/stretchr/testify@v1.8.4/mock/mock.go:464 +0x140
  github.com/dapr/dapr/pkg/channel/testing.(*MockAppChannel).InvokeMethod()
      /home/josh/go/src/github.com/dapr/dapr/pkg/channel/testing/channel_mock.go:89 +0x318
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).sendBindingEventToApp.func3()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1461 +0x84
  github.com/dapr/dapr/pkg/resiliency.NewRunnerWithOptions[...].func2()
      /home/josh/go/src/github.com/dapr/dapr/pkg/resiliency/policy.go:184 +0x548
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).sendBindingEventToApp()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1460 +0x1978
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).readFromBinding.func1()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1517 +0xa8
  github.com/dapr/dapr/pkg/runtime.(*mockBinding).Read.func1()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:4457 +0x158

Previous read at 0x00c00059ad98 by goroutine 39:
  github.com/dapr/dapr/pkg/runtime.TestStartReadingFromBindings.func1()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:6425 +0x56c
  testing.tRunner()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x40

Goroutine 41 (running) created at:
  github.com/dapr/dapr/pkg/runtime.(*mockBinding).Read()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:4456 +0x1c0
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).readFromBinding()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1511 +0xf0
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).startReadingFromBindings()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:3522 +0x418
  github.com/dapr/dapr/pkg/runtime.TestStartReadingFromBindings.func1()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:6422 +0x53c
  testing.tRunner()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x40

Goroutine 39 (running) created at:
  testing.(*T).Run()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x5b4
  github.com/dapr/dapr/pkg/runtime.TestStartReadingFromBindings()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:6411 +0x3c
  testing.tRunner()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x40
==================
    testing.go:1446: race detected during execution of test
=== RUN   TestStartReadingFromBindings/No_OPTIONS_request_when_direction_is_specified
INFO[0000] Shutting down all remaining components        instance=purple scope=dapr.runtime type=log ver=unknown
==================
WARNING: DATA RACE
Write at 0x00c0006c63d8 by goroutine 45:
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /home/josh/go/pkg/mod/github.com/stretchr/testify@v1.8.4/mock/mock.go:530 +0xba0
  github.com/stretchr/testify/mock.(*Mock).Called()
      /home/josh/go/pkg/mod/github.com/stretchr/testify@v1.8.4/mock/mock.go:464 +0x140
  github.com/dapr/dapr/pkg/channel/testing.(*MockAppChannel).InvokeMethod()
      /home/josh/go/src/github.com/dapr/dapr/pkg/channel/testing/channel_mock.go:89 +0x318
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).sendBindingEventToApp.func3()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1461 +0x84
  github.com/dapr/dapr/pkg/resiliency.NewRunnerWithOptions[...].func2()
      /home/josh/go/src/github.com/dapr/dapr/pkg/resiliency/policy.go:184 +0x548
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).sendBindingEventToApp()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1460 +0x1978
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).readFromBinding.func1()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1517 +0xa8
  github.com/dapr/dapr/pkg/runtime.(*mockBinding).Read.func1()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:4457 +0x158

Previous read at 0x00c0006c63d8 by goroutine 43:
  github.com/dapr/dapr/pkg/runtime.TestStartReadingFromBindings.func2()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:6462 +0x750
  testing.tRunner()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x40

Goroutine 45 (running) created at:
  github.com/dapr/dapr/pkg/runtime.(*mockBinding).Read()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:4456 +0x1c0
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).readFromBinding()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:1511 +0xf0
  github.com/dapr/dapr/pkg/runtime.(*DaprRuntime).startReadingFromBindings()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime.go:3522 +0x418
  github.com/dapr/dapr/pkg/runtime.TestStartReadingFromBindings.func2()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:6459 +0x720
  testing.tRunner()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x40

Goroutine 43 (running) created at:
  testing.(*T).Run()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x5b4
  github.com/dapr/dapr/pkg/runtime.TestStartReadingFromBindings()
      /home/josh/go/src/github.com/dapr/dapr/pkg/runtime/runtime_test.go:6428 +0x58
  testing.tRunner()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1576 +0x180
  testing.(*T).Run.func1()
      /nix/store/frm6jqvk13n1hr2379hsazsw381k79yb-go-1.20.4/share/go/src/testing/testing.go:1629 +0x40
==================
    testing.go:1446: race detected during execution of test
=== NAME  TestStartReadingFromBindings
    testing.go:1446: race detected during execution of test
--- FAIL: TestStartReadingFromBindings (0.21s)
    --- FAIL: TestStartReadingFromBindings/OPTIONS_request_when_direction_is_not_specified (0.10s)
    --- FAIL: TestStartReadingFromBindings/No_OPTIONS_request_when_direction_is_specified (0.10s)
=== NAME
    testing.go:1446: race detected during execution of test
FAIL
exit status 1
FAIL	github.com/dapr/dapr/pkg/runtime	0.294s
````