### PR TITLE
E2E tests: reduce flakiness by improving initial healthchecks

### DIFF
--- a/tests/e2e/allowlists/allowlists_service_invocation_test.go
+++ b/tests/e2e/allowlists/allowlists_service_invocation_test.go
@@ -98,7 +98,7 @@ func TestMain(m *testing.M) {
 		},
 	}
 
-	tr = runner.NewTestRunner("hellodapr", testApps, nil, nil)
+	tr = runner.NewTestRunner("allowlists", testApps, nil, nil)
 	os.Exit(tr.Start(m))
 }
 

--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -44,9 +44,6 @@ import (
 var tr *runner.TestRunner
 
 const (
-	// Number of get calls before starting tests.
-	numHealthChecks = 60
-
 	// used as the exclusive max of a random number that is used as a suffix to the first message sent.  Each subsequent message gets this number+1.
 	// This is random so the first message name is not the same every time.
 	randomOffsetMax           = 49
@@ -770,13 +767,9 @@ func TestPubSubHTTP(t *testing.T) {
 		subscriberExternalURL := tr.Platform.AcquireAppExternalURL(app.subscriber)
 		require.NotEmpty(t, subscriberExternalURL, "subscriberExternalURLHTTP must not be empty!")
 
-		// This initial probe makes the test wait a little bit longer when needed,
-		// making this test less flaky due to delays in the deployment.
-		_, err := utils.HTTPGetNTimes(publisherExternalURL, numHealthChecks)
-		require.NoError(t, err)
-
-		_, err = utils.HTTPGetNTimes(subscriberExternalURL, numHealthChecks)
-		require.NoError(t, err)
+		// Makes the test wait for the apps and load balancers to be ready
+		err := utils.HealthCheckApps(publisherExternalURL, subscriberExternalURL)
+		require.NoError(t, err, "Health checks failed")
 
 		err = publishHealthCheck(publisherExternalURL)
 		require.NoError(t, err)

--- a/tests/e2e/pubsub_grpc/pubsub_grpc_test.go
+++ b/tests/e2e/pubsub_grpc/pubsub_grpc_test.go
@@ -44,9 +44,6 @@ import (
 var tr *runner.TestRunner
 
 const (
-	// Number of get calls before starting tests.
-	numHealthChecks = 60
-
 	// used as the exclusive max of a random number that is used as a suffix to the first message sent.  Each subsequent message gets this number+1.
 	// This is random so the first message name is not the same every time.
 	randomOffsetMax           = 49
@@ -412,9 +409,9 @@ func testPublishWithoutTopic(t *testing.T, publisherExternalURL, subscriberExter
 func testValidateRedeliveryOrEmptyJSON(t *testing.T, publisherExternalURL, subscriberExternalURL, subscriberResponse, subscriberAppName, protocol string) string {
 	var err error
 	var code int
-	log.Printf("Validating publisher health...\n")
-	_, err = utils.HTTPGetNTimes(publisherExternalURL, numHealthChecks)
-	require.NoError(t, err)
+	log.Print("Validating publisher health...")
+	err = utils.HealthCheckApps(publisherExternalURL)
+	require.NoError(t, err, "Health checks failed")
 
 	log.Printf("Set subscriber to respond with %s\n", subscriberResponse)
 	if subscriberResponse == "empty-json" {
@@ -463,8 +460,8 @@ func testValidateRedeliveryOrEmptyJSON(t *testing.T, publisherExternalURL, subsc
 	subscriberExternalURL = tr.Platform.AcquireAppExternalURL(subscriberAppName)
 	require.NotEmpty(t, subscriberExternalURL, "subscriberExternalURL must not be empty!")
 	if protocol == "http" {
-		_, err = utils.HTTPGetNTimes(subscriberExternalURL, numHealthChecks)
-		require.NoError(t, err)
+		err = utils.HealthCheckApps(subscriberExternalURL)
+		require.NoError(t, err, "Health checks failed")
 	} else {
 		conn, err := grpc.Dial(subscriberExternalURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
@@ -823,10 +820,9 @@ func TestPubSubGRPC(t *testing.T) {
 	subscriberExternalURL := tr.Platform.AcquireAppExternalURL(subscriberAppName)
 	require.NotEmpty(t, subscriberExternalURL, "subscriberExternalURL must not be empty!")
 
-	// This initial probe makes the test wait a little bit longer when needed,
-	// making this test less flaky due to delays in the deployment.
-	_, err := utils.HTTPGetNTimes(publisherExternalURL, numHealthChecks)
-	require.NoError(t, err)
+	// Makes the test wait for the apps and load balancers to be ready
+	err := utils.HealthCheckApps(publisherExternalURL, subscriberExternalURL)
+	require.NoError(t, err, "Health checks failed")
 
 	err = publishHealthCheck(publisherExternalURL)
 	require.NoError(t, err)

--- a/tests/e2e/pubsub_routing/pubsub_routing_test.go
+++ b/tests/e2e/pubsub_routing/pubsub_routing_test.go
@@ -41,9 +41,6 @@ import (
 var tr *runner.TestRunner
 
 const (
-	// Number of get calls before starting tests.
-	numHealthChecks = 60
-
 	// used as the exclusive max of a random number that is used as a suffix to the first message sent.  Each subsequent message gets this number+1.
 	// This is random so the first message name is not the same every time.
 	randomOffsetMax           = 49
@@ -343,8 +340,9 @@ func TestPubSubHTTPRouting(t *testing.T) {
 	subscriberRoutingExternalURL := tr.Platform.AcquireAppExternalURL(subscriberAppName)
 	require.NotEmpty(t, subscriberRoutingExternalURL, "subscriberRoutingExternalURL must not be empty!")
 
-	_, err := utils.HTTPGetNTimes(subscriberRoutingExternalURL, numHealthChecks)
-	require.NoError(t, err)
+	// Makes the test wait for the apps and load balancers to be ready
+	err := utils.HealthCheckApps(publisherExternalURL, subscriberRoutingExternalURL)
+	require.NoError(t, err, "Health checks failed")
 
 	testPublishSubscribeRouting(t, publisherExternalURL, subscriberRoutingExternalURL, subscriberAppName, "http")
 }

--- a/tests/e2e/pubsub_routing_grpc/pubsub_routing_grpc_test.go
+++ b/tests/e2e/pubsub_routing_grpc/pubsub_routing_grpc_test.go
@@ -340,8 +340,9 @@ func TestPubSubGRPCRouting(t *testing.T) {
 	subscriberRoutingExternalURL := tr.Platform.AcquireAppExternalURL(subscriberAppName)
 	require.NotEmpty(t, subscriberRoutingExternalURL, "subscriberRoutingExternalURL must not be empty!")
 
-	_, err := utils.HTTPGetNTimes(publisherExternalURL, numHealthChecks)
-	require.NoError(t, err)
+	// Makes the test wait for the apps and load balancers to be ready
+	err := utils.HealthCheckApps(publisherExternalURL, subscriberRoutingExternalURL)
+	require.NoError(t, err, "Health checks failed")
 
 	testPublishSubscribeRouting(t, publisherExternalURL, subscriberRoutingExternalURL, subscriberAppName, "grpc")
 }


### PR DESCRIPTION
Similar to #6639, it looks like other E2E tests had a similar issue where not all apps were "health-checked" before the tests started. In fact, our experience shows there can be delays before the apps are deployed and the load balancers work.

This adds the same logic implemented in #6639 (for the middleware test) to a few more E2E tests:

- pubsub
- pubsub_grpc
- pubsub_routing
- pubsub_routing_grpc

Should fix failures such as https://github.com/dapr/dapr/actions/runs/5548210664/jobs/10131295884