### PR TITLE
reduce allocations on hot path for metrics

### DIFF
--- a/pkg/diagnostics/grpc_monitoring.go
+++ b/pkg/diagnostics/grpc_monitoring.go
@@ -230,11 +230,11 @@ func (g *grpcMetrics) AppHealthProbeCompleted(ctx context.Context, status string
 		elapsed := float64(time.Since(start) / time.Millisecond)
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(g.healthProbeCompletedCount.Name(), g.appID, KeyClientStatus, status),
+			diagUtils.WithTags(g.healthProbeCompletedCount.Name(), appIDKey, g.appID, KeyClientStatus, status),
 			g.healthProbeCompletedCount.M(1))
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(g.healthProbeRoundripLatency.Name(), g.appID, KeyClientStatus, status),
+			diagUtils.WithTags(g.healthProbeRoundripLatency.Name(), appIDKey, g.appID, KeyClientStatus, status),
 			g.healthProbeRoundripLatency.M(elapsed))
 	}
 }

--- a/pkg/diagnostics/utils/metrics_utils.go
+++ b/pkg/diagnostics/utils/metrics_utils.go
@@ -46,7 +46,7 @@ func NewMeasureView(measure stats.Measure, keys []tag.Key, aggregation *view.Agg
 // WithTags(key1, value1, key2, value2) returns
 // []tag.Mutator{tag.Upsert(key1, value1), tag.Upsert(key2, value2)}.
 func WithTags(name string, opts ...interface{}) []tag.Mutator {
-	tagMutators := []tag.Mutator{}
+	tagMutators := make([]tag.Mutator, 0, len(opts)/2)
 	for i := 0; i < len(opts)-1; i += 2 {
 		key, ok := opts[i].(tag.Key)
 		if !ok {


### PR DESCRIPTION
# Description

While troubleshooting a user memory problem, and checking pprof output it was notice that we have a good amount of these allocations that could be improved.

This is not the main contributor to the memory allocation issue but a small improvement

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
