### PR TITLE
Make logging consistent across control plane and respect log-as-json flag

### DIFF
--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -30,24 +30,28 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var log = logger.NewLogger("dapr.injector")
+var (
+	log  = logger.NewLogger("dapr.injector")
+	opts = options.New()
+)
+
+func init() {
+	// Apply options to all loggers
+	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
+		log.Fatal(err)
+	}
+}
 
 func main() {
-	log.Infof("starting Dapr Sidecar Injector -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
+	log.Infof("Starting Dapr Sidecar Injector -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
+	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
 
-	opts := options.New()
-
-	metricsExporter := metrics.NewExporterWithOptions(metrics.DefaultMetricNamespace, opts.Metrics)
+	metricsExporter := metrics.NewExporterWithOptions(log, metrics.DefaultMetricNamespace, opts.Metrics)
 
 	if err := utils.SetEnvVariables(map[string]string{
 		utils.KubeConfigVar: opts.Kubeconfig,
 	}); err != nil {
 		log.Fatalf("error set env failed:  %s", err.Error())
-	}
-
-	// Apply options to all loggers
-	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
-		log.Fatal(err)
 	}
 
 	// Initialize dapr metrics exporter

--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -30,19 +30,16 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var (
-	log  = logger.NewLogger("dapr.injector")
-	opts = options.New()
-)
+var log = logger.NewLogger("dapr.injector")
 
-func init() {
+func main() {
+	opts := options.New()
+
 	// Apply options to all loggers
 	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
 		log.Fatal(err)
 	}
-}
 
-func main() {
 	log.Infof("Starting Dapr Sidecar Injector -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
 	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -23,30 +23,30 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var log = logger.NewLogger("dapr.operator")
+var (
+	log  = logger.NewLogger("dapr.operator")
+	opts = options.New()
+)
+
+func init() {
+	// Apply options to all loggers.
+	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
+		log.Fatal(err)
+	}
+}
 
 func main() {
-	log.Infof("starting Dapr Operator -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
+	log.Infof("Starting Dapr Operator -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
+	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
 
-	opts, err := options.New()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	metricsExporter := metrics.NewExporterWithOptions(metrics.DefaultMetricNamespace, opts.Metrics)
-
-	// Apply options to all loggers
-	if err = logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
-		log.Fatal(err)
-	}
-	log.Infof("log level set to: %s", opts.Logger.OutputLevel)
+	metricsExporter := metrics.NewExporterWithOptions(log, metrics.DefaultMetricNamespace, opts.Metrics)
 
 	// Initialize dapr metrics exporter
-	if err = metricsExporter.Init(); err != nil {
+	if err := metricsExporter.Init(); err != nil {
 		log.Fatal(err)
 	}
 
-	if err = monitoring.InitMetrics(); err != nil {
+	if err := monitoring.InitMetrics(); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -23,19 +23,16 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var (
-	log  = logger.NewLogger("dapr.operator")
-	opts = options.New()
-)
+var log = logger.NewLogger("dapr.operator")
 
-func init() {
+func main() {
+	opts := options.New()
+
 	// Apply options to all loggers.
 	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
 		log.Fatal(err)
 	}
-}
 
-func main() {
 	log.Infof("Starting Dapr Operator -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
 	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
 

--- a/cmd/operator/options/options.go
+++ b/cmd/operator/options/options.go
@@ -57,7 +57,7 @@ type Options struct {
 	Metrics                            *metrics.Options
 }
 
-func New() (*Options, error) {
+func New() *Options {
 	var opts Options
 
 	// This resets the flags on klog, which will otherwise try to log to the FS.
@@ -107,5 +107,5 @@ func New() (*Options, error) {
 		}
 	}
 
-	return &opts, nil
+	return &opts
 }

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -32,20 +32,23 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var log = logger.NewLogger("dapr.placement")
+var (
+	log  = logger.NewLogger("dapr.placement")
+	opts = options.New()
+)
 
-func main() {
-	log.Infof("Starting Dapr Placement Service -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
-
-	opts := options.New()
-
-	metricsExporter := metrics.NewExporterWithOptions(metrics.DefaultMetricNamespace, opts.Metrics)
-
+func init() {
 	// Apply options to all loggers.
 	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func main() {
+	log.Infof("Starting Dapr Placement Service -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
 	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
+
+	metricsExporter := metrics.NewExporterWithOptions(log, metrics.DefaultMetricNamespace, opts.Metrics)
 
 	// Initialize dapr metrics for placement.
 	err := metricsExporter.Init()

--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -32,19 +32,16 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var (
-	log  = logger.NewLogger("dapr.placement")
-	opts = options.New()
-)
+var log = logger.NewLogger("dapr.placement")
 
-func init() {
+func main() {
+	opts := options.New()
+
 	// Apply options to all loggers.
 	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
 		log.Fatal(err)
 	}
-}
 
-func main() {
 	log.Infof("Starting Dapr Placement Service -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
 	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
 

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -34,19 +34,16 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var (
-	log  = logger.NewLogger("dapr.sentry")
-	opts = options.New()
-)
+var log = logger.NewLogger("dapr.sentry")
 
-func init() {
+func main() {
+	opts := options.New()
+
 	// Apply options to all loggers
 	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
 		log.Fatal(err)
 	}
-}
 
-func main() {
 	log.Infof("Starting Dapr Sentry certificate authority -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
 	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
 

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -34,27 +34,29 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-var log = logger.NewLogger("dapr.sentry")
+var (
+	log  = logger.NewLogger("dapr.sentry")
+	opts = options.New()
+)
+
+func init() {
+	// Apply options to all loggers
+	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
+		log.Fatal(err)
+	}
+}
 
 func main() {
-	log.Infof("starting sentry certificate authority -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
+	log.Infof("Starting Dapr Sentry certificate authority -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
+	log.Infof("Log level set to: %s", opts.Logger.OutputLevel)
 
-	opts := options.New()
-
-	metricsExporter := metrics.NewExporterWithOptions(metrics.DefaultMetricNamespace, opts.Metrics)
+	metricsExporter := metrics.NewExporterWithOptions(log, metrics.DefaultMetricNamespace, opts.Metrics)
 
 	if err := utils.SetEnvVariables(map[string]string{
 		utils.KubeConfigVar: opts.Kubeconfig,
 	}); err != nil {
 		log.Fatalf("error set env failed:  %s", err.Error())
 	}
-
-	// Apply options to all loggers
-	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
-		log.Fatal(err)
-	}
-
-	log.Infof("log level set to: %s", opts.Logger.OutputLevel)
 
 	// Initialize dapr metrics exporter
 	if err := metricsExporter.Init(); err != nil {

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -26,18 +26,18 @@ type Exporter interface {
 }
 
 // NewExporter creates new MetricsExporter instance.
-func NewExporter(namespace string) Exporter {
-	return NewExporterWithOptions(namespace, DefaultMetricOptions())
+func NewExporter(logger logger.Logger, namespace string) Exporter {
+	return NewExporterWithOptions(logger, namespace, DefaultMetricOptions())
 }
 
 // NewExporterWithOptions creates new MetricsExporter instance with options.
-func NewExporterWithOptions(namespace string, options *Options) Exporter {
+func NewExporterWithOptions(logger logger.Logger, namespace string, options *Options) Exporter {
 	// TODO: support multiple exporters
 	return &promMetricsExporter{
 		&exporter{
 			namespace: namespace,
 			options:   options,
-			logger:    logger.NewLogger("dapr.metrics"),
+			logger:    logger,
 		},
 		nil,
 	}

--- a/pkg/metrics/exporter_test.go
+++ b/pkg/metrics/exporter_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMetricsExporter(t *testing.T) {
-	var logger = logger.NewLogger("test.logger")
+	logger := logger.NewLogger("test.logger")
 
 	t.Run("returns default options", func(t *testing.T) {
 		e := NewExporter(logger, "test")

--- a/pkg/metrics/exporter_test.go
+++ b/pkg/metrics/exporter_test.go
@@ -22,8 +22,10 @@ import (
 )
 
 func TestMetricsExporter(t *testing.T) {
+	var logger = logger.NewLogger("test.logger")
+
 	t.Run("returns default options", func(t *testing.T) {
-		e := NewExporter("test")
+		e := NewExporter(logger, "test")
 		op := e.Options()
 		assert.Equal(t, DefaultMetricOptions(), op)
 	})
@@ -33,7 +35,7 @@ func TestMetricsExporter(t *testing.T) {
 			&exporter{
 				namespace: "test",
 				options:   DefaultMetricOptions(),
-				logger:    logger.NewLogger("dapr.metrics"),
+				logger:    logger,
 			},
 			nil,
 		}
@@ -41,7 +43,7 @@ func TestMetricsExporter(t *testing.T) {
 	})
 
 	t.Run("skip starting metric server", func(t *testing.T) {
-		e := NewExporter("test")
+		e := NewExporter(logger, "test")
 		e.Options().MetricsEnabled = false
 		err := e.Init()
 		assert.NoError(t, err)

--- a/pkg/metrics/options.go
+++ b/pkg/metrics/options.go
@@ -22,11 +22,11 @@ const (
 	defaultMetricsEnabled = true
 )
 
-// Options defines the sets of options for Dapr logging.
+// Options defines the sets of options for exporting metrics.
 type Options struct {
-	// OutputLevel is the level of logging
+	// MetricsEnabled indicates whether a metrics server should be started.
 	MetricsEnabled bool
-
+	// Port to start metrics server on.
 	Port string
 }
 

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -150,7 +150,7 @@ func FromConfig(cfg *Config) (*DaprRuntime, error) {
 	}
 
 	// Initialize dapr metrics exporter
-	metricsExporter := metrics.NewExporterWithOptions(metrics.DefaultMetricNamespace, cfg.Metrics)
+	metricsExporter := metrics.NewExporterWithOptions(log, metrics.DefaultMetricNamespace, cfg.Metrics)
 	if err = metricsExporter.Init(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

This PR makes logging consistent across various control plane components and makes all log statements respect the `log-as-json` flag. 

After these changes, all the logs are in the correct format and the first two lines are consistent.
![image](https://github.com/dapr/dapr/assets/22132944/506003c1-6d0b-4ec2-800e-d6d4ce174f90)


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #6693

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
