### PR TITLE
[Security] Fixed API token authentication bypassed when path contains `/healthz`

### DIFF
--- a/pkg/runtime/security/token.go
+++ b/pkg/runtime/security/token.go
@@ -15,12 +15,9 @@ package security
 
 import (
 	"os"
-	"strings"
 
 	"github.com/dapr/dapr/pkg/runtime/security/consts"
 )
-
-var excludedRoutes = []string{"/healthz"}
 
 // GetAPIToken returns the value of the api token from an environment variable.
 func GetAPIToken() string {
@@ -30,14 +27,4 @@ func GetAPIToken() string {
 // GetAppToken returns the value of the app api token from an environment variable.
 func GetAppToken() string {
 	return os.Getenv(consts.AppAPITokenEnvVar)
-}
-
-// ExcludedRoute returns whether a given route should be excluded from a token check.
-func ExcludedRoute(route string) bool {
-	for _, r := range excludedRoutes {
-		if strings.Contains(route, r) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/runtime/security/token_test.go
+++ b/pkg/runtime/security/token_test.go
@@ -54,17 +54,3 @@ func TestAppToken(t *testing.T) {
 		assert.Equal(t, "", token)
 	})
 }
-
-func TestExcludedRoute(t *testing.T) {
-	t.Run("healthz route is excluded", func(t *testing.T) {
-		route := "v1.0/healthz"
-		excluded := ExcludedRoute(route)
-		assert.True(t, excluded)
-	})
-
-	t.Run("custom route is not excluded", func(t *testing.T) {
-		route := "v1.0/state"
-		excluded := ExcludedRoute(route)
-		assert.False(t, excluded)
-	})
-}


### PR DESCRIPTION
- Advisory: https://github.com/dapr/dapr/security/advisories/GHSA-59m6-82qm-vqgj
- Already merged in release-1.10 (1.10.9) and release-1.11 (1.11.2)

The APITokenAuthMiddleware allowed bypassing the check if the path included `/healthz`. An attacker only needed to include `/healthz` in the URL, even the querystring, to bypass the API token check, for example `/v1.0/invoke/myapp/method/something?foo=/healthz`.

Additionally, this was not checking the method of the request, so requests to `POST /healthz` would cause a service invocation to happen.

This fixes the issue by making the check a lot more strict. The API token check can be bypassed only if:

- The path is exactly `/v1.0/healthz` or `/v1.0/healthz/outbound` (slashes are trimmed on each side)
- The method is `GET`
