### PR TITLE
Remove `--race` flag from `make test-integration` to reduce resource constraint related flakes in CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ test-integration: test-deps
 			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
 			--format testname \
 			-- \
-			./tests/integration -count=1 -v -race -tags="integration"
+			./tests/integration -count=1 -v -tags="integration"
 
 ################################################################################
 # Target: lint                                                                 #


### PR DESCRIPTION
See https://github.com/dapr/dapr/pull/6704#issuecomment-1644664791