### PR TITLE
Remove `ActorScanInterval`

### DIFF
--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	kclock "k8s.io/utils/clock"
@@ -54,7 +55,6 @@ const (
 var DefaultAppConfig = config.ApplicationConfig{
 	Entities:                   []string{"1", "reentrantActor"},
 	ActorIdleTimeout:           "1s",
-	ActorScanInterval:          "2s",
 	DrainOngoingCallTimeout:    "3s",
 	DrainRebalancedActors:      true,
 	Reentrancy:                 config.ReentrancyConfig{},
@@ -297,57 +297,26 @@ func fakeStore() state.Store {
 
 func fakeCallAndActivateActor(actors *actorsRuntime, actorType, actorID string, clock kclock.WithTicker) {
 	actorKey := constructCompositeKey(actorType, actorID)
-	actors.actorsTable.LoadOrStore(actorKey, newActor(actorType, actorID, &reentrancyStackDepth, clock))
+	act := newActor(actorType, actorID, &reentrancyStackDepth, actors.actorsConfig.GetIdleTimeoutForType(actorType), clock)
+	actors.actorsTable.LoadOrStore(actorKey, act)
+	actors.idleActorProcessor.Enqueue(act)
 }
 
-func deactivateActorWithDuration(testActorsRuntime *actorsRuntime, actorType, actorID string) <-chan struct{} {
-	fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
+func deactivateActorsCh(testActorsRuntime *actorsRuntime) <-chan string {
+	ch := make(chan string, 2)
 
-	ch := make(chan struct{}, 1)
-	go testActorsRuntime.deactivationTicker(testActorsRuntime.actorsConfig, func(at, aid string) error {
-		if actorType == at {
-			testActorsRuntime.removeActorFromTable(at, aid)
-			ch <- struct{}{}
-		}
-		return nil
-	})
-	return ch
-}
-
-func assertTestSignal(t *testing.T, clock *clocktesting.FakeClock, ch <-chan struct{}) {
-	t.Helper()
-
-	end := clock.Now().Add(700 * time.Millisecond)
-
-	for {
-		select {
-		case <-ch:
-			// all good
+	// Replace the processor with a mock one that returns deactivated actors in a channel
+	testActorsRuntime.idleActorProcessor = internal.NewProcessor[*actor](func(act *actor) {
+		if !testActorsRuntime.idleActorBusyCheck(act) {
 			return
-		default:
 		}
 
-		if clock.Now().After(end) {
-			require.Fail(t, "did not receive signal in 700ms")
-		}
+		key := act.Key()
+		testActorsRuntime.actorsTable.Delete(key)
+		ch <- constructCompositeKey(key)
+	}, testActorsRuntime.clock)
 
-		// The signal is sent in a background goroutine, so we need to use a wall
-		// clock here
-		time.Sleep(time.Millisecond * 5)
-		advanceTickers(t, clock, time.Millisecond*10)
-	}
-}
-
-func assertNoTestSignal(t *testing.T, ch <-chan struct{}) {
-	t.Helper()
-
-	// The signal is sent in a background goroutine, so we need to use a wall clock here
-	select {
-	case <-ch:
-		t.Fatalf("received unexpected signal")
-	case <-time.After(500 * time.Millisecond):
-		// all good
-	}
+	return ch
 }
 
 // Makes tickers advance
@@ -362,49 +331,55 @@ func advanceTickers(t *testing.T, clock *clocktesting.FakeClock, step time.Durat
 	clock.Step(step)
 }
 
-func TestDeactivationTicker(t *testing.T) {
-	t.Run("actor is deactivated", func(t *testing.T) {
+func TestDeactivateIdleActors(t *testing.T) {
+	actorType, actorID := getTestActorTypeAndID()
+	actorKey := constructCompositeKey(actorType, actorID)
+
+	t.Run("idle actor is deactivated", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
+		testActorsRuntime.actorsConfig.ActorIdleTimeout = time.Second * 2
 		defer testActorsRuntime.Stop()
 		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
-		actorType, actorID := getTestActorTypeAndID()
-		actorKey := constructCompositeKey(actorType, actorID)
+		ch := deactivateActorsCh(testActorsRuntime)
 
-		testActorsRuntime.actorsConfig.ActorIdleTimeout = time.Second * 2
-		testActorsRuntime.actorsConfig.ActorDeactivationScanInterval = time.Second * 1
-
-		ch := deactivateActorWithDuration(testActorsRuntime, actorType, actorID)
+		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
 
 		_, exists := testActorsRuntime.actorsTable.Load(actorKey)
 		assert.True(t, exists)
 
-		advanceTickers(t, clock, time.Second*3)
-
-		assertTestSignal(t, clock, ch)
+		clock.Step(2 * time.Second)
+		select {
+		case deactivatedKey := <-ch:
+			assert.Equal(t, actorKey, deactivatedKey)
+		case <-time.After(700 * time.Millisecond):
+			t.Errorf("Did not receive signal in time")
+		}
 
 		_, exists = testActorsRuntime.actorsTable.Load(actorKey)
 		assert.False(t, exists)
 	})
 
-	t.Run("actor is not deactivated", func(t *testing.T) {
+	t.Run("non-idle actor is not deactivated", func(t *testing.T) {
 		testActorsRuntime := newTestActorsRuntime()
+		testActorsRuntime.actorsConfig.ActorIdleTimeout = time.Second * 5
 		defer testActorsRuntime.Stop()
 		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
-		actorType, actorID := getTestActorTypeAndID()
-		actorKey := constructCompositeKey(actorType, actorID)
+		ch := deactivateActorsCh(testActorsRuntime)
 
-		testActorsRuntime.actorsConfig.ActorIdleTimeout = time.Second * 5
-		testActorsRuntime.actorsConfig.ActorDeactivationScanInterval = time.Second * 1
-
-		ch := deactivateActorWithDuration(testActorsRuntime, actorType, actorID)
+		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
 
 		_, exists := testActorsRuntime.actorsTable.Load(actorKey)
 		assert.True(t, exists)
 
-		advanceTickers(t, clock, time.Second*3)
-		assertNoTestSignal(t, ch)
+		clock.Step(3 * time.Second)
+		select {
+		case <-ch:
+			t.Errorf("Received unexpected signal")
+		case <-time.After(500 * time.Millisecond):
+			// all good
+		}
 
 		_, exists = testActorsRuntime.actorsTable.Load(actorKey)
 		assert.True(t, exists)
@@ -415,26 +390,120 @@ func TestDeactivationTicker(t *testing.T) {
 		defer testActorsRuntime.Stop()
 		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
 
-		firstType := "a"
-		secondType := "b"
-		actorID := "1"
+		ch := deactivateActorsCh(testActorsRuntime)
 
-		testActorsRuntime.actorsConfig.EntityConfigs[firstType] = internal.EntityConfig{Entities: []string{firstType}, ActorIdleTimeout: time.Second * 2}
-		testActorsRuntime.actorsConfig.EntityConfigs[secondType] = internal.EntityConfig{Entities: []string{secondType}, ActorIdleTimeout: time.Second * 5}
-		testActorsRuntime.actorsConfig.ActorDeactivationScanInterval = time.Second * 1
+		testActorsRuntime.actorsConfig.EntityConfigs["a"] = internal.EntityConfig{
+			Entities:         []string{"a"},
+			ActorIdleTimeout: time.Second * 2,
+		}
+		testActorsRuntime.actorsConfig.EntityConfigs["b"] = internal.EntityConfig{
+			Entities:         []string{"b"},
+			ActorIdleTimeout: time.Second * 5,
+		}
 
-		ch1 := deactivateActorWithDuration(testActorsRuntime, firstType, actorID)
-		ch2 := deactivateActorWithDuration(testActorsRuntime, secondType, actorID)
+		// Actors a||1 and a||2 should be deactivated in 2s, while b||1 in 5s
+		fakeCallAndActivateActor(testActorsRuntime, "a", "1", testActorsRuntime.clock)
+		fakeCallAndActivateActor(testActorsRuntime, "a", "2", testActorsRuntime.clock)
+		fakeCallAndActivateActor(testActorsRuntime, "b", "1", testActorsRuntime.clock)
 
-		advanceTickers(t, clock, time.Second*2)
-		assertTestSignal(t, clock, ch1)
-		assertNoTestSignal(t, ch2)
+		collectSignals := func() []string {
+			signals := make([]string, 0)
+			deadline := time.After(700 * time.Millisecond)
+			for {
+				select {
+				case <-deadline:
+					slices.Sort(signals)
+					return signals
+				case key := <-ch:
+					signals = append(signals, key)
+				}
+			}
+		}
 
-		_, exists := testActorsRuntime.actorsTable.Load(constructCompositeKey(firstType, actorID))
-		assert.False(t, exists)
+		assertActorExists := func(t *testing.T, actorKey string, expectExists bool) {
+			_, exists := testActorsRuntime.actorsTable.Load(actorKey)
+			assert.Equal(t, expectExists, exists)
+		}
 
-		_, exists = testActorsRuntime.actorsTable.Load(constructCompositeKey(secondType, actorID))
-		assert.True(t, exists)
+		// After 2s, we should have a||1 and a||2 deactivated only
+		advanceTickers(t, clock, 2*time.Second)
+		assert.Equal(t, []string{constructCompositeKey("a", "1"), constructCompositeKey("a", "2")}, collectSignals())
+		assertActorExists(t, constructCompositeKey("a", "1"), false)
+		assertActorExists(t, constructCompositeKey("a", "2"), false)
+		assertActorExists(t, constructCompositeKey("b", "1"), true)
+
+		// Activate a||3 which should be deactivated in 2s, before b||1
+		fakeCallAndActivateActor(testActorsRuntime, "a", "3", testActorsRuntime.clock)
+		advanceTickers(t, clock, 2*time.Second)
+		assert.Equal(t, []string{constructCompositeKey("a", "3")}, collectSignals())
+		assertActorExists(t, constructCompositeKey("a", "3"), false)
+		assertActorExists(t, constructCompositeKey("b", "1"), true)
+
+		// Activate a||4 which should be deactivated in 2s
+		// But first, in 1s, b||1 should be deactivated too
+		fakeCallAndActivateActor(testActorsRuntime, "a", "4", testActorsRuntime.clock)
+		advanceTickers(t, clock, 1*time.Second)
+		assert.Equal(t, []string{constructCompositeKey("b", "1")}, collectSignals())
+		assertActorExists(t, constructCompositeKey("b", "1"), false)
+		assertActorExists(t, constructCompositeKey("a", "4"), true)
+
+		// Lastly, a||4 should be deactivated in 1s
+		advanceTickers(t, clock, 1*time.Second)
+		assert.Equal(t, []string{constructCompositeKey("a", "4")}, collectSignals())
+		assertActorExists(t, constructCompositeKey("a", "4"), false)
+	})
+
+	t.Run("actor is still busy", func(t *testing.T) {
+		testActorsRuntime := newTestActorsRuntime()
+		testActorsRuntime.actorsConfig.ActorIdleTimeout = time.Second * 2
+		defer testActorsRuntime.Stop()
+		clock := testActorsRuntime.clock.(*clocktesting.FakeClock)
+
+		ch := deactivateActorsCh(testActorsRuntime)
+
+		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
+
+		actAny, ok := testActorsRuntime.actorsTable.Load(actorKey)
+		require.True(t, ok)
+		act, ok := actAny.(*actor)
+		require.True(t, ok)
+
+		// Get the idleAt timeout
+		idleAt := *act.idleAt.Load()
+		require.Equal(t, clock.Now().Add(2*time.Second), idleAt)
+
+		// Lock the actor so it's busy
+		act.lock(nil)
+
+		// Advance by 3s which should trigger the tick
+		// The actor should not be deactivated
+		clock.Step(3 * time.Second)
+		select {
+		case <-ch:
+			t.Errorf("Received unexpected signal")
+		case <-time.After(500 * time.Millisecond):
+			// all good
+		}
+		_, ok = testActorsRuntime.actorsTable.Load(actorKey)
+		require.True(t, ok)
+
+		// The actor's idleAt time should have increased
+		newIdleAt := *act.idleAt.Load()
+		require.Equal(t, clock.Now().Add(actorBusyReEnqueueInterval), newIdleAt)
+
+		// Unlock the actor
+		act.unlock()
+
+		// Advance by actorBusyReEnqueueInterval and ensure the actor now is deactivated
+		clock.Step(actorBusyReEnqueueInterval)
+		select {
+		case deactivatedKey := <-ch:
+			assert.Equal(t, actorKey, deactivatedKey)
+		case <-time.After(700 * time.Millisecond):
+			t.Errorf("Did not receive signal in time")
+		}
+		_, ok = testActorsRuntime.actorsTable.Load(actorKey)
+		require.False(t, ok)
 	})
 }
 
@@ -758,7 +827,7 @@ func TestCallLocalActor(t *testing.T) {
 		defer testActorsRuntime.Stop()
 
 		actorKey := constructCompositeKey(testActorType, testActorID)
-		act := newActor(testActorType, testActorID, &reentrancyStackDepth, testActorsRuntime.clock)
+		act := newActor(testActorType, testActorID, &reentrancyStackDepth, 2*time.Second, testActorsRuntime.clock)
 
 		// add test actor
 		testActorsRuntime.actorsTable.LoadOrStore(actorKey, act)

--- a/pkg/actors/config.go
+++ b/pkg/actors/config.go
@@ -31,7 +31,6 @@ type Config struct {
 const (
 	defaultActorIdleTimeout     = time.Minute * 60
 	defaultHeartbeatInterval    = time.Second * 1
-	defaultActorScanInterval    = time.Second * 30
 	defaultOngoingCallTimeout   = time.Second * 60
 	defaultReentrancyStackLimit = 32
 )
@@ -53,29 +52,23 @@ type ConfigOpts struct {
 // NewConfig returns the actor runtime configuration.
 func NewConfig(opts ConfigOpts) Config {
 	c := internal.Config{
-		HostAddress:                   opts.HostAddress,
-		AppID:                         opts.AppID,
-		PlacementAddresses:            opts.PlacementAddresses,
-		Port:                          opts.Port,
-		Namespace:                     opts.Namespace,
-		DrainRebalancedActors:         opts.AppConfig.DrainRebalancedActors,
-		HostedActorTypes:              internal.NewHostedActors(opts.AppConfig.Entities),
-		Reentrancy:                    opts.AppConfig.Reentrancy,
-		RemindersStoragePartitions:    opts.AppConfig.RemindersStoragePartitions,
-		HealthHTTPClient:              opts.HealthHTTPClient,
-		HealthEndpoint:                opts.HealthEndpoint,
-		HeartbeatInterval:             defaultHeartbeatInterval,
-		ActorDeactivationScanInterval: defaultActorScanInterval,
-		ActorIdleTimeout:              defaultActorIdleTimeout,
-		DrainOngoingCallTimeout:       defaultOngoingCallTimeout,
-		EntityConfigs:                 make(map[string]internal.EntityConfig),
-		AppChannelAddress:             opts.AppChannelAddress,
-		PodName:                       opts.PodName,
-	}
-
-	scanDuration, err := time.ParseDuration(opts.AppConfig.ActorScanInterval)
-	if err == nil {
-		c.ActorDeactivationScanInterval = scanDuration
+		HostAddress:                opts.HostAddress,
+		AppID:                      opts.AppID,
+		PlacementAddresses:         opts.PlacementAddresses,
+		Port:                       opts.Port,
+		Namespace:                  opts.Namespace,
+		DrainRebalancedActors:      opts.AppConfig.DrainRebalancedActors,
+		HostedActorTypes:           internal.NewHostedActors(opts.AppConfig.Entities),
+		Reentrancy:                 opts.AppConfig.Reentrancy,
+		RemindersStoragePartitions: opts.AppConfig.RemindersStoragePartitions,
+		HealthHTTPClient:           opts.HealthHTTPClient,
+		HealthEndpoint:             opts.HealthEndpoint,
+		HeartbeatInterval:          defaultHeartbeatInterval,
+		ActorIdleTimeout:           defaultActorIdleTimeout,
+		DrainOngoingCallTimeout:    defaultOngoingCallTimeout,
+		EntityConfigs:              make(map[string]internal.EntityConfig),
+		AppChannelAddress:          opts.AppChannelAddress,
+		PodName:                    opts.PodName,
 	}
 
 	idleDuration, err := time.ParseDuration(opts.AppConfig.ActorIdleTimeout)

--- a/pkg/actors/config_test.go
+++ b/pkg/actors/config_test.go
@@ -34,7 +34,6 @@ const (
 func TestConfig(t *testing.T) {
 	config := config.ApplicationConfig{
 		Entities:                   []string{"1"},
-		ActorScanInterval:          "1s",
 		ActorIdleTimeout:           "2s",
 		DrainOngoingCallTimeout:    "3s",
 		DrainRebalancedActors:      true,
@@ -55,7 +54,6 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, []string{"placement:5050"}, c.PlacementAddresses)
 	assert.Equal(t, internal.NewHostedActors([]string{"1"}), c.HostedActorTypes)
 	assert.Equal(t, 3500, c.Port)
-	assert.Equal(t, "1s", c.ActorDeactivationScanInterval.String())
 	assert.Equal(t, "2s", c.ActorIdleTimeout.String())
 	assert.Equal(t, "3s", c.DrainOngoingCallTimeout.String())
 	assert.Equal(t, true, c.DrainRebalancedActors)
@@ -154,7 +152,6 @@ func TestDefaultConfigValuesSet(t *testing.T) {
 	assert.Equal(t, Port, config.Port)
 	assert.Equal(t, Namespace, config.Namespace)
 	assert.NotNil(t, config.ActorIdleTimeout)
-	assert.NotNil(t, config.ActorDeactivationScanInterval)
 	assert.NotNil(t, config.DrainOngoingCallTimeout)
 	assert.NotNil(t, config.DrainRebalancedActors)
 }
@@ -163,7 +160,6 @@ func TestPerActorTypeConfigurationValues(t *testing.T) {
 	appConfig := config.ApplicationConfig{
 		Entities:                   []string{"actor1", "actor2", "actor3", "actor4"},
 		ActorIdleTimeout:           "1s",
-		ActorScanInterval:          "2s",
 		DrainOngoingCallTimeout:    "5s",
 		DrainRebalancedActors:      true,
 		RemindersStoragePartitions: 1,
@@ -202,7 +198,6 @@ func TestPerActorTypeConfigurationValues(t *testing.T) {
 	assert.Equal(t, Port, config.Port)
 	assert.Equal(t, Namespace, config.Namespace)
 	assert.Equal(t, time.Second, config.ActorIdleTimeout)
-	assert.Equal(t, time.Second*2, config.ActorDeactivationScanInterval)
 	assert.Equal(t, time.Second*5, config.DrainOngoingCallTimeout)
 	assert.True(t, config.DrainRebalancedActors)
 
@@ -235,7 +230,6 @@ func TestOnlyHostedActorTypesAreIncluded(t *testing.T) {
 	appConfig := config.ApplicationConfig{
 		Entities:                   []string{"actor1", "actor2"},
 		ActorIdleTimeout:           "1s",
-		ActorScanInterval:          "2s",
 		DrainOngoingCallTimeout:    "5s",
 		DrainRebalancedActors:      true,
 		RemindersStoragePartitions: 1,

--- a/pkg/actors/internal/config.go
+++ b/pkg/actors/internal/config.go
@@ -24,24 +24,23 @@ import (
 
 // Config is the actor runtime configuration.
 type Config struct {
-	HostAddress                   string
-	AppID                         string
-	PlacementAddresses            []string
-	HostedActorTypes              hostedActors
-	Port                          int
-	HeartbeatInterval             time.Duration
-	ActorDeactivationScanInterval time.Duration
-	ActorIdleTimeout              time.Duration
-	DrainOngoingCallTimeout       time.Duration
-	DrainRebalancedActors         bool
-	Namespace                     string
-	Reentrancy                    daprAppConfig.ReentrancyConfig
-	RemindersStoragePartitions    int
-	EntityConfigs                 map[string]EntityConfig
-	HealthHTTPClient              *http.Client
-	HealthEndpoint                string
-	AppChannelAddress             string
-	PodName                       string
+	HostAddress                string
+	AppID                      string
+	PlacementAddresses         []string
+	HostedActorTypes           hostedActors
+	Port                       int
+	HeartbeatInterval          time.Duration
+	ActorIdleTimeout           time.Duration
+	DrainOngoingCallTimeout    time.Duration
+	DrainRebalancedActors      bool
+	Namespace                  string
+	Reentrancy                 daprAppConfig.ReentrancyConfig
+	RemindersStoragePartitions int
+	EntityConfigs              map[string]EntityConfig
+	HealthHTTPClient           *http.Client
+	HealthEndpoint             string
+	AppChannelAddress          string
+	PodName                    string
 }
 
 // Remap of daprAppConfig.EntityConfig but with more useful types for actors.go.

--- a/pkg/actors/internal/processor.go
+++ b/pkg/actors/internal/processor.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	kclock "k8s.io/utils/clock"
+)
+
+// ErrProcessorStopped is returned when the processor is not running.
+var ErrProcessorStopped = errors.New("processor is stopped")
+
+// Processor manages the queue of items and processes them at the correct time.
+type Processor[T queueable] struct {
+	executeFn          func(r T)
+	queue              *Queue[T]
+	clock              kclock.Clock
+	queueLock          sync.Mutex
+	processorRunningCh chan struct{}
+	stopCh             chan struct{}
+	resetCh            chan struct{}
+	stopped            atomic.Bool
+}
+
+// NewProcessor returns a new Processor object.
+// executeFn is the callback invoked when the item is to be executed; this will be invoked in a background goroutine.
+func NewProcessor[T queueable](executeFn func(r T), clock kclock.Clock) *Processor[T] {
+	return &Processor[T]{
+		executeFn:          executeFn,
+		queue:              NewQueue[T](),
+		processorRunningCh: make(chan struct{}, 1),
+		stopCh:             make(chan struct{}),
+		resetCh:            make(chan struct{}, 1),
+		clock:              clock,
+	}
+}
+
+// Enqueue adds a new item to the queue.
+// If a item with the same ID already exists, it'll be replaced.
+func (p *Processor[T]) Enqueue(r T) error {
+	if p.stopped.Load() {
+		return ErrProcessorStopped
+	}
+
+	// Insert or replace the item in the queue
+	// If the item added or replaced is the first one in the queue, we need to know that
+	p.queueLock.Lock()
+	peek, ok := p.queue.Peek()
+	isFirst := (ok && peek.Key() == r.Key()) // This is going to be true if the item being replaced is the first one in the queue
+	p.queue.Insert(r, true)
+	peek, _ = p.queue.Peek()         // No need to check for "ok" here because we know this will return an item
+	isFirst = isFirst || (peek == r) // This is also going to be true if the item just added landed at the front of the queue
+	p.process(isFirst)
+	p.queueLock.Unlock()
+
+	return nil
+}
+
+// Dequeue removes a item from the queue.
+func (p *Processor[T]) Dequeue(r T) error {
+	if p.stopped.Load() {
+		return ErrProcessorStopped
+	}
+
+	// We need to check if this is the next item in the queue, as that requires stopping the processor
+	p.queueLock.Lock()
+	peek, ok := p.queue.Peek()
+	p.queue.Remove(r)
+	if ok && peek.Key() == r.Key() {
+		// If the item was the first one in the queue, restart the processor
+		p.process(true)
+	}
+	p.queueLock.Unlock()
+
+	return nil
+}
+
+// Stop the processor.
+func (p *Processor[T]) Close() error {
+	if !p.stopped.CompareAndSwap(false, true) {
+		// Already stopped
+		return nil
+	}
+
+	// Send a signal to stop
+	close(p.stopCh)
+
+	// Blocks until process loop ends
+	t := time.NewTimer(5 * time.Second)
+	select {
+	case p.processorRunningCh <- struct{}{}:
+		// All good
+		if !t.Stop() {
+			<-t.C
+		}
+	case <-t.C:
+		return errors.New("Processor loop did not stop in 5s")
+	}
+
+	return nil
+}
+
+// Start the processing loop if it's not already running.
+// This must be invoked while the caller has a lock.
+func (p *Processor[T]) process(isNext bool) {
+	// Do not start a loop if it's already running
+	select {
+	case p.processorRunningCh <- struct{}{}:
+		// Nop - fallthrough
+	default:
+		// Already running
+		if isNext {
+			// If this is the next item, send a reset signal
+			// Use a select in case another goroutine is sending a reset signal too
+			select {
+			case p.resetCh <- struct{}{}:
+			default:
+			}
+		}
+		return
+	}
+
+	go p.processLoop()
+}
+
+// Processing loop.
+func (p *Processor[T]) processLoop() {
+	defer func() {
+		// Release the channel when exiting
+		<-p.processorRunningCh
+	}()
+
+	var (
+		r             T
+		ok            bool
+		t             kclock.Timer
+		scheduledTime time.Time
+		deadline      time.Duration
+	)
+
+	for {
+		// Continue processing items until the queue is empty
+		p.queueLock.Lock()
+		r, ok = p.queue.Peek()
+		p.queueLock.Unlock()
+		if !ok {
+			return
+		}
+
+		// Check if after obtaining the lock we have a stop or reset signals
+		// Do this before we create a timer
+		select {
+		case <-p.stopCh:
+			// Exit on stop signals
+			return
+		case <-p.resetCh:
+			// Restart the loop on reset signals
+			continue
+		default:
+			// Nop, proceed
+		}
+
+		scheduledTime = r.ScheduledTime()
+		deadline = scheduledTime.Sub(p.clock.Now())
+
+		// If the deadline is less than 0.5ms away, execute it right away
+		// This is more efficient than creating a timer
+		if deadline < 500*time.Microsecond {
+			p.execute(r)
+			continue
+		}
+
+		t = p.clock.NewTimer(deadline)
+		select {
+		// Wait for when it's time to execute the item
+		case <-t.C():
+			p.execute(r)
+
+		// If we get a reset signal, restart the loop
+		case <-p.resetCh:
+			// Restart the loop
+			continue
+
+		// If we receive a stop signal, exit
+		case <-p.stopCh:
+			// Stop the timer and exit the loop
+			if !t.Stop() {
+				<-t.C()
+			}
+			return
+		}
+	}
+}
+
+// Executes a item when it's time.
+func (p *Processor[T]) execute(r T) {
+	// Pop the item now that we're ready to process it
+	// There's a small chance this is a different item than the one we peeked before
+	p.queueLock.Lock()
+	// For safety, let's peek at the first item before popping it and make sure it's the same object
+	// It's unlikely, but if it's a different object then restart the loop
+	peek, ok := p.queue.Peek()
+	if !ok || peek != r {
+		p.queueLock.Unlock()
+		return
+	}
+	r, ok = p.queue.Pop()
+	p.queueLock.Unlock()
+	if !ok {
+		return
+	}
+
+	go p.executeFn(r)
+}

--- a/pkg/actors/internal/processor_test.go
+++ b/pkg/actors/internal/processor_test.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"math/rand"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+func TestProcessor(t *testing.T) {
+	// Create the processor
+	clock := clocktesting.NewFakeClock(time.Now())
+	executeCh := make(chan *Reminder)
+	processor := NewProcessor(func(r *Reminder) {
+		executeCh <- r
+	}, clock)
+
+	assertExecutedReminder := func(t *testing.T) *Reminder {
+		t.Helper()
+
+		// The signal is sent in a background goroutine, so we need to use a wall clock here
+		runtime.Gosched()
+		select {
+		case r := <-executeCh:
+			return r
+		case <-time.After(700 * time.Millisecond):
+			t.Fatal("did not receive signal in 700ms")
+		}
+
+		return nil
+	}
+
+	assertNoExecutedReminder := func(t *testing.T) {
+		t.Helper()
+
+		// The signal is sent in a background goroutine, so we need to use a wall clock here
+		runtime.Gosched()
+		select {
+		case r := <-executeCh:
+			t.Fatalf("received unexpected reminder: %s", r.Name)
+		case <-time.After(500 * time.Millisecond):
+			// all good
+		}
+	}
+
+	// Makes tickers advance
+	// Note that step must be > 500ms
+	advanceTickers := func(step time.Duration, count int) {
+		clock.Step(50 * time.Millisecond)
+		// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
+		runtime.Gosched()
+		time.Sleep(50 * time.Millisecond)
+		for i := 0; i < count; i++ {
+			clock.Step(step)
+			// Sleep on the wall clock for a few ms to allow the background goroutine to get in sync (especially when testing with -race)
+			runtime.Gosched()
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	t.Run("enqueue reminders", func(t *testing.T) {
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by 500ms to start
+		advanceTickers(500*time.Millisecond, 1)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 5; i++ {
+			t.Logf("Waiting for signal %d", i)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(i), received.Name)
+		}
+	})
+
+	t.Run("enqueue reminder to be executed right away", func(t *testing.T) {
+		r := newTestReminder(1, clock.Now())
+		err := processor.Enqueue(r)
+		require.NoError(t, err)
+
+		advanceTickers(500*time.Millisecond, 1)
+
+		received := assertExecutedReminder(t)
+		assert.Equal(t, "1", received.Name)
+	})
+
+	t.Run("enqueue reminder at the front of the queue", func(t *testing.T) {
+		// Enqueue 4 reminders
+		for i := 1; i <= 4; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by 1500ms to trigger the first reminder
+		t.Log("Waiting for signal 1")
+		advanceTickers(500*time.Millisecond, 3)
+
+		received := assertExecutedReminder(t)
+		assert.Equal(t, "1", received.Name)
+
+		// Add a new reminder at the front of the queue
+		err := processor.Enqueue(
+			newTestReminder(99, clock.Now()),
+		)
+		require.NoError(t, err)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 4; i++ {
+			// First reminder should be 99
+			expect := strconv.Itoa(i)
+			if i == 1 {
+				expect = "99"
+			}
+			t.Logf("Waiting for signal %s", expect)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, expect, received.Name)
+		}
+	})
+
+	t.Run("dequeue reminder", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Dequeue reminders 2 and 4
+		err := processor.Dequeue(newTestReminder(2, 0)) // Time is irrelevant
+		require.NoError(t, err)
+		err = processor.Dequeue(newTestReminder(4, 0)) // Time is irrelevant
+		require.NoError(t, err)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 5; i++ {
+			if i == 2 || i == 4 {
+				// Skip reminders that have been removed
+				t.Logf("Should not receive signal %d", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+			t.Logf("Waiting for signal %d", i)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(i), received.Name)
+		}
+	})
+
+	t.Run("dequeue reminder from the front of the queue", func(t *testing.T) {
+		// Enqueue 6 reminders
+		for i := 1; i <= 6; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 6; i++ {
+			// On messages 2 and 5, dequeue the reminder when it's at the front of the queue
+			if i == 2 || i == 5 {
+				// Dequeue the reminder at the front of the queue
+				err := processor.Dequeue(newTestReminder(i, 0)) // Time is irrelevant
+				require.NoError(t, err)
+
+				// Skip reminders that have been removed
+				t.Logf("Should not receive signal %d", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+			t.Logf("Waiting for signal %d", i)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(i), received.Name)
+		}
+	})
+
+	t.Run("replace reminder", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Replace reminder 4, bumping its priority down
+		err := processor.Enqueue(newTestReminder(4, clock.Now().Add(6*time.Second)))
+		require.NoError(t, err)
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 6; i++ {
+			if i == 4 {
+				// This reminder has been pushed down
+				t.Logf("Should not receive signal %d now", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+
+			expect := i
+			if i == 6 {
+				// Reminder 4 should come now
+				expect = 4
+			}
+			t.Logf("Waiting for signal %d", expect)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(expect), received.Name)
+		}
+	})
+
+	t.Run("replace reminder at the front of the queue", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Advance tickers and assert messages are coming in order
+		for i := 1; i <= 6; i++ {
+			if i == 2 {
+				// Replace reminder 2, bumping its priority down, while it's at the front of the queue
+				err := processor.Enqueue(newTestReminder(2, clock.Now().Add(5*time.Second)))
+				require.NoError(t, err)
+
+				// This reminder has been pushed down
+				t.Logf("Should not receive signal %d now", i)
+				advanceTickers(time.Second, 1)
+				assertNoExecutedReminder(t)
+				continue
+			}
+
+			expect := i
+			if i == 6 {
+				// Reminder 2 should come now
+				expect = 2
+			}
+			t.Logf("Waiting for signal %d", expect)
+			advanceTickers(time.Second, 1)
+			received := assertExecutedReminder(t)
+			assert.Equal(t, strconv.Itoa(expect), received.Name)
+		}
+	})
+
+	t.Run("enqueue multiple reminders concurrently that to be executed randomly", func(t *testing.T) {
+		const (
+			count    = 150
+			maxDelay = 30
+		)
+		now := clock.Now()
+		wg := sync.WaitGroup{}
+		for i := 0; i < count; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				execTime := now.Add(time.Second * time.Duration(rand.Intn(maxDelay))) //nolint:gosec
+				err := processor.Enqueue(newTestReminder(i, execTime))
+				require.NoError(t, err)
+			}(i)
+		}
+		wg.Wait()
+
+		// Collect
+		collected := make([]bool, count)
+		var collectedCount int64
+		doneCh := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-doneCh:
+					return
+				case r := <-executeCh:
+					n, err := strconv.Atoi(r.Name)
+					if err == nil {
+						collected[n] = true
+						atomic.AddInt64(&collectedCount, 1)
+					}
+				}
+			}
+		}()
+
+		// Advance tickers and assert messages are coming in order
+		for i := 0; i <= maxDelay; i++ {
+			advanceTickers(time.Second, 1)
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		// Allow for synchronization
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt64(&collectedCount) == count
+		}, 5*time.Second, 50*time.Millisecond)
+		close(doneCh)
+
+		// Ensure all items are true
+		for i := 0; i < count; i++ {
+			assert.Truef(t, collected[i], "item %d not received", i)
+		}
+	})
+
+	t.Run("stop processor", func(t *testing.T) {
+		// Enqueue 5 reminders
+		for i := 1; i <= 5; i++ {
+			err := processor.Enqueue(
+				newTestReminder(i, clock.Now().Add(time.Second*time.Duration(i))),
+			)
+			require.NoError(t, err)
+		}
+
+		// Advance tickers by a few ms to start
+		advanceTickers(0, 0)
+
+		// Stop the processor
+		require.NoError(t, processor.Close())
+
+		// Queue should not be processed
+		advanceTickers(time.Second, 2)
+		assertNoExecutedReminder(t)
+
+		// Enqueuing and dequeueing should fail
+		err := processor.Enqueue(newTestReminder(99, clock.Now()))
+		require.ErrorIs(t, err, ErrProcessorStopped)
+		err = processor.Dequeue(newTestReminder(99, clock.Now()))
+		require.ErrorIs(t, err, ErrProcessorStopped)
+
+		// Stopping again is a nop (should not crash)
+		require.NoError(t, processor.Close())
+	})
+}

--- a/pkg/actors/internal/queue.go
+++ b/pkg/actors/internal/queue.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"container/heap"
+	"time"
+)
+
+type queueable interface {
+	comparable
+	Key() string
+	ScheduledTime() time.Time
+}
+
+// Queue implements a queue for Reminder and actor objects.
+// It acts as a "priority queue", in which items are added in order of when they're scheduled.
+// Internally, it uses a heap (from container/heap) that allows Insert and Pop operations to be completed in O(log N) time (where N is the queue's length).
+// Note: methods in this struct are not safe for concurrent use. Callers should use locks to ensure consistency.
+type Queue[T queueable] struct {
+	heap  *queueHeap[T]
+	items map[string]*queueItem[T]
+}
+
+// NewQueue creates a new queue.
+func NewQueue[T queueable]() *Queue[T] {
+	return &Queue[T]{
+		heap:  &queueHeap[T]{},
+		items: make(map[string]*queueItem[T]),
+	}
+}
+
+// Len returns the number of items in the queue.
+func (p *Queue[T]) Len() int {
+	return p.heap.Len()
+}
+
+// Insert inserts a new item into the queue.
+// If replace is true, existing items are replaced
+func (p *Queue[T]) Insert(r T, replace bool) {
+	key := r.Key()
+
+	// Check if the item already exists
+	item, ok := p.items[key]
+	if ok {
+		if replace {
+			item.value = r
+			heap.Fix(p.heap, item.index)
+		}
+		return
+	}
+
+	item = &queueItem[T]{
+		value: r,
+	}
+	heap.Push(p.heap, item)
+	p.items[key] = item
+}
+
+// Pop removes the next item in the queue and returns it.
+// The returned boolean value will be "true" if an item was found.
+func (p *Queue[T]) Pop() (T, bool) {
+	if p.Len() == 0 {
+		var zero T
+		return zero, false
+	}
+
+	item, ok := heap.Pop(p.heap).(*queueItem[T])
+	if !ok || item == nil {
+		var zero T
+		return zero, false
+	}
+
+	delete(p.items, item.value.Key())
+	return item.value, true
+}
+
+// Peek returns the next item in the queue, without removing it.
+// The returned boolean value will be "true" if an item was found.
+func (p *Queue[T]) Peek() (T, bool) {
+	if p.Len() == 0 {
+		var zero T
+		return zero, false
+	}
+
+	return (*p.heap)[0].value, true
+}
+
+// Remove an item from the queue.
+func (p *Queue[T]) Remove(r T) {
+	key := r.Key()
+
+	// If the item is not in the queue, this is a nop
+	item, ok := p.items[key]
+	if !ok {
+		return
+	}
+
+	heap.Remove(p.heap, item.index)
+	delete(p.items, key)
+}
+
+// Update an item in the queue.
+func (p *Queue[T]) Update(r T) {
+	// If the item is not in the queue, this is a nop
+	item, ok := p.items[r.Key()]
+	if !ok {
+		return
+	}
+
+	item.value = r
+	heap.Fix(p.heap, item.index)
+}
+
+type queueItem[T queueable] struct {
+	value T
+
+	// The index of the item in the heap. This is maintained by the heap.Interface methods.
+	index int
+}
+
+type queueHeap[T queueable] []*queueItem[T]
+
+func (pq queueHeap[T]) Len() int {
+	return len(pq)
+}
+
+func (pq queueHeap[T]) Less(i, j int) bool {
+	return pq[i].value.ScheduledTime().Before(pq[j].value.ScheduledTime())
+}
+
+func (pq queueHeap[T]) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *queueHeap[T]) Push(x any) {
+	n := len(*pq)
+	item := x.(*queueItem[T])
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *queueHeap[T]) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // Avoid memory leak
+	item.index = -1 // For safety
+	*pq = old[0 : n-1]
+	return item
+}

--- a/pkg/actors/internal/queue_test.go
+++ b/pkg/actors/internal/queue_test.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+	queue := NewQueue[*Reminder]()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	i := 0
+	for {
+		// Pop an element from the queue
+		r, ok := queue.Pop()
+
+		if i < 5 {
+			require.True(t, ok)
+			require.NotNil(t, r)
+		} else {
+			require.False(t, ok)
+			break
+		}
+		i++
+
+		// Results should be in order
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+}
+
+func TestQueueSkipDuplicates(t *testing.T) {
+	queue := NewQueue[*Reminder]()
+
+	// Add 2 reminders
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Add a duplicate reminder (same actor type, actor ID, name), but different time
+	queue.Insert(newTestReminder(2, "2029-09-09T09:09:09Z"), false)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Pop the items and check only the 2 original ones were in the queue
+	popAndCompare(t, queue, 1, "2021-01-01T01:01:01Z")
+	popAndCompare(t, queue, 2, "2022-02-02T02:02:02Z")
+
+	_, ok := queue.Pop()
+	require.False(t, ok)
+}
+
+func TestQueueReplaceDuplicates(t *testing.T) {
+	queue := NewQueue[*Reminder]()
+
+	// Add 2 reminders
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Replace a reminder
+	queue.Insert(newTestReminder(1, "2029-09-09T09:09:09Z"), true)
+
+	require.Equal(t, 2, queue.Len())
+
+	// Pop the items and validate the new order
+	popAndCompare(t, queue, 2, "2022-02-02T02:02:02Z")
+	popAndCompare(t, queue, 1, "2029-09-09T09:09:09Z")
+
+	_, ok := queue.Pop()
+	require.False(t, ok)
+}
+
+func TestAddToQueue(t *testing.T) {
+	queue := NewQueue[*Reminder]()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(5, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(8, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(7, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	// Pop 2 elements from the queue
+	for i := 1; i <= 2; i++ {
+		r, ok := queue.Pop()
+		require.True(t, ok)
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	// Add 4 more elements
+	// Two are at the very beginning (including one that had the same time as one popped before)
+	// One is in the middle
+	// One is at the end
+	queue.Insert(newTestReminder(3, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(4, "2021-01-11T11:11:11Z"), false)
+	queue.Insert(newTestReminder(6, "2023-03-13T13:13:13Z"), false)
+	queue.Insert(newTestReminder(9, "2030-10-30T10:10:10Z"), false)
+
+	require.Equal(t, 7, queue.Len())
+
+	// Pop all the remaining elements and make sure they're in order
+	for i := 3; i <= 9; i++ {
+		r, ok := queue.Pop()
+		require.True(t, ok)
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	// Queue should be empty now
+	_, ok := queue.Pop()
+	require.False(t, ok)
+	require.Equal(t, 0, queue.Len())
+}
+
+func TestRemoveFromQueue(t *testing.T) {
+	queue := NewQueue[*Reminder]()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	// Pop 2 elements from the queue
+	for i := 1; i <= 2; i++ {
+		r, ok := queue.Pop()
+		require.True(t, ok)
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	require.Equal(t, 3, queue.Len())
+
+	// Remove the reminder with number "4"
+	queue.Remove(newTestReminder(4, 0)) // DueTime is irrelevant here
+
+	// Removing non-existing reminders is a nop
+	queue.Remove(newTestReminder(10, 0)) // DueTime is irrelevant here
+
+	require.Equal(t, 2, queue.Len())
+
+	// Pop all the remaining elements and make sure they're in order
+	popAndCompare(t, queue, 3, "2023-03-03T03:03:03Z")
+	popAndCompare(t, queue, 5, "2029-09-09T09:09:09Z")
+
+	_, ok := queue.Pop()
+	require.False(t, ok)
+}
+
+func TestUpdateInQueue(t *testing.T) {
+	queue := NewQueue[*Reminder]()
+
+	// Add 5 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+
+	require.Equal(t, 5, queue.Len())
+
+	// Pop 2 elements from the queue
+	for i := 1; i <= 2; i++ {
+		r, ok := queue.Pop()
+		require.True(t, ok)
+		require.NotNil(t, r)
+
+		ri, err := strconv.Atoi(r.Name)
+		require.NoError(t, err)
+		assert.Equal(t, i, ri)
+	}
+
+	require.Equal(t, 3, queue.Len())
+
+	// Update the reminder with number "4" but maintain priority
+	queue.Update(newTestReminder(4, "2024-04-04T14:14:14Z"))
+
+	// Update the reminder with number "5" and increase the priority
+	queue.Update(newTestReminder(5, "2021-01-01T01:01:01Z"))
+
+	// Updating non-existing reminders is a nop
+	queue.Update(newTestReminder(10, "2021-01-01T01:01:01Z"))
+
+	require.Equal(t, 3, queue.Len())
+
+	// Pop all the remaining elements and make sure they're in order
+	popAndCompare(t, queue, 5, "2021-01-01T01:01:01Z") // 5 comes before 3 now
+	popAndCompare(t, queue, 3, "2023-03-03T03:03:03Z")
+	popAndCompare(t, queue, 4, "2024-04-04T14:14:14Z")
+
+	_, ok := queue.Pop()
+	require.False(t, ok)
+}
+
+func TestQueuePeek(t *testing.T) {
+	queue := NewQueue[*Reminder]()
+
+	// Peeking an empty queue returns false
+	_, ok := queue.Peek()
+	require.False(t, ok)
+
+	// Add 6 reminders, which are not in order
+	queue.Insert(newTestReminder(2, "2022-02-02T02:02:02Z"), false)
+	require.Equal(t, 1, queue.Len())
+	peekAndCompare(t, queue, 2, "2022-02-02T02:02:02Z")
+
+	queue.Insert(newTestReminder(3, "2023-03-03T03:03:03Z"), false)
+	require.Equal(t, 2, queue.Len())
+	peekAndCompare(t, queue, 2, "2022-02-02T02:02:02Z")
+
+	queue.Insert(newTestReminder(1, "2021-01-01T01:01:01Z"), false)
+	require.Equal(t, 3, queue.Len())
+	peekAndCompare(t, queue, 1, "2021-01-01T01:01:01Z")
+
+	queue.Insert(newTestReminder(5, "2029-09-09T09:09:09Z"), false)
+	require.Equal(t, 4, queue.Len())
+	peekAndCompare(t, queue, 1, "2021-01-01T01:01:01Z")
+
+	queue.Insert(newTestReminder(4, "2024-04-04T04:04:04Z"), false)
+	require.Equal(t, 5, queue.Len())
+	peekAndCompare(t, queue, 1, "2021-01-01T01:01:01Z")
+
+	queue.Insert(newTestReminder(6, "2019-01-19T01:01:01Z"), false)
+	require.Equal(t, 6, queue.Len())
+	peekAndCompare(t, queue, 6, "2019-01-19T01:01:01Z")
+
+	// Pop from the queue
+	popAndCompare(t, queue, 6, "2019-01-19T01:01:01Z")
+	peekAndCompare(t, queue, 1, "2021-01-01T01:01:01Z")
+
+	// Update a reminder to bring it to first
+	queue.Update(newTestReminder(2, "2019-01-19T01:01:01Z"))
+	peekAndCompare(t, queue, 2, "2019-01-19T01:01:01Z")
+
+	// Replace the first reminder to push it back
+	queue.Insert(newTestReminder(2, "2039-01-19T01:01:01Z"), true)
+	peekAndCompare(t, queue, 1, "2021-01-01T01:01:01Z")
+}
+
+func newTestReminder(n int, dueTime any) *Reminder {
+	r := &Reminder{
+		Name:      strconv.Itoa(n),
+		ActorID:   "id",
+		ActorType: "type",
+	}
+
+	switch t := dueTime.(type) {
+	case time.Time:
+		r.RegisteredTime = t
+	case string:
+		r.RegisteredTime, _ = time.Parse(time.RFC3339, t)
+	case int64:
+		r.RegisteredTime = time.Unix(t, 0)
+	}
+
+	return r
+}
+
+func popAndCompare(t *testing.T, queue *Queue[*Reminder], expectN int, expectDueTime string) {
+	r, ok := queue.Pop()
+	require.True(t, ok)
+	require.NotNil(t, r)
+	assert.Equal(t, strconv.Itoa(expectN), r.Name)
+	assert.Equal(t, expectDueTime, r.RegisteredTime.Format(time.RFC3339))
+}
+
+func peekAndCompare(t *testing.T, queue *Queue[*Reminder], expectN int, expectDueTime string) {
+	r, ok := queue.Peek()
+	require.True(t, ok)
+	require.NotNil(t, r)
+	assert.Equal(t, strconv.Itoa(expectN), r.Name)
+	assert.Equal(t, expectDueTime, r.RegisteredTime.Format(time.RFC3339))
+}

--- a/pkg/actors/internal/reminder.go
+++ b/pkg/actors/internal/reminder.go
@@ -95,6 +95,12 @@ func (r *Reminder) UpdateFromTrack(track *ReminderTrack) {
 	r.RegisteredTime = r.Period.GetFollowing(track.LastFiredTime)
 }
 
+// ScheduledTime returns the time the reminder is scheduled to be executed at.
+// This is implemented to comply with the queueable interface.
+func (r *Reminder) ScheduledTime() time.Time {
+	return r.RegisteredTime
+}
+
 func (r *Reminder) MarshalJSON() ([]byte, error) {
 	type reminderAlias Reminder
 

--- a/pkg/actors/internal_actor_test.go
+++ b/pkg/actors/internal_actor_test.go
@@ -238,7 +238,11 @@ func TestInternalActorDeactivation(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Deactivate the actor, ensuring no errors and that the correct actor ID was provided.
-	err = testActorRuntime.deactivateActor(testActorType, testActorID)
+	actAny, ok := testActorRuntime.actorsTable.Load(constructCompositeKey(testActorType, testActorID))
+	require.True(t, ok)
+	act, ok := actAny.(*actor)
+	require.True(t, ok)
+	err = testActorRuntime.deactivateActor(act)
 	require.NoError(t, err)
 	if assert.Len(t, ia.DeactivationCalls, 1) {
 		assert.Equal(t, testActorID, ia.DeactivationCalls[0])

--- a/pkg/actors/reminders/reminders_test.go
+++ b/pkg/actors/reminders/reminders_test.go
@@ -466,10 +466,6 @@ func newTestRemindersWithMockAndActorMetadataPartition() *reminders {
 		RemindersStoragePartitions: appConfig.RemindersStoragePartitions,
 		EntityConfigs:              make(map[string]internal.EntityConfig),
 	}
-	scanDuration, err := time.ParseDuration(appConfig.ActorScanInterval)
-	if err == nil {
-		conf.ActorDeactivationScanInterval = scanDuration
-	}
 
 	idleDuration, err := time.ParseDuration(appConfig.ActorIdleTimeout)
 	if err == nil {

--- a/pkg/actors/requests_responses.go
+++ b/pkg/actors/requests_responses.go
@@ -25,6 +25,11 @@ type ActorHostedRequest struct {
 	ActorType string `json:"actorType"`
 }
 
+// Key returns the key for this unique actor.
+func (req ActorHostedRequest) Key() string {
+	return req.ActorType + daprSeparator + req.ActorID
+}
+
 // CreateReminderRequest is the request object to create a new reminder.
 type CreateReminderRequest = internal.CreateReminderRequest
 

--- a/pkg/config/app_configuration.go
+++ b/pkg/config/app_configuration.go
@@ -18,8 +18,6 @@ type ApplicationConfig struct {
 	Entities []string `json:"entities"`
 	// Duration. example: "1h".
 	ActorIdleTimeout string `json:"actorIdleTimeout"`
-	// Duration. example: "30s". This value is global.
-	ActorScanInterval string `json:"actorScanInterval"`
 	// Duration. example: "30s".
 	DrainOngoingCallTimeout    string           `json:"drainOngoingCallTimeout"`
 	DrainRebalancedActors      bool             `json:"drainRebalancedActors"`

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2139,7 +2139,6 @@ func TestActorReentrancyConfig(t *testing.T) {
 	fullConfig := `{
 		"entities":["actorType1", "actorType2"],
 		"actorIdleTimeout": "1h",
-		"actorScanInterval": "30s",
 		"drainOngoingCallTimeout": "30s",
 		"drainRebalancedActors": true,
 		"reentrancy": {
@@ -2152,7 +2151,6 @@ func TestActorReentrancyConfig(t *testing.T) {
 	minimumConfig := `{
 		"entities":["actorType1", "actorType2"],
 		"actorIdleTimeout": "1h",
-		"actorScanInterval": "30s",
 		"drainOngoingCallTimeout": "30s",
 		"drainRebalancedActors": true,
 		"reentrancy": {
@@ -2163,7 +2161,6 @@ func TestActorReentrancyConfig(t *testing.T) {
 	emptyConfig := `{
 		"entities":["actorType1", "actorType2"],
 		"actorIdleTimeout": "1h",
-		"actorScanInterval": "30s",
 		"drainOngoingCallTimeout": "30s",
 		"drainRebalancedActors": true
 	  }`

--- a/tests/apps/actorapp/app.go
+++ b/tests/apps/actorapp/app.go
@@ -35,7 +35,6 @@ const (
 
 	registeredActorType     = "testactor" // Actor type must be unique per test app.
 	actorIdleTimeout        = "5s"        // Short idle timeout.
-	actorScanInterval       = "1s"        // Smaller then actorIdleTimeout and short for speedy test.
 	drainOngoingCallTimeout = "1s"
 	drainRebalancedActors   = true
 )
@@ -57,7 +56,6 @@ type actorLogEntry struct {
 type daprConfig struct {
 	Entities                []string `json:"entities,omitempty"`
 	ActorIdleTimeout        string   `json:"actorIdleTimeout,omitempty"`
-	ActorScanInterval       string   `json:"actorScanInterval,omitempty"`
 	DrainOngoingCallTimeout string   `json:"drainOngoingCallTimeout,omitempty"`
 	DrainRebalancedActors   bool     `json:"drainRebalancedActors,omitempty"`
 }
@@ -65,7 +63,6 @@ type daprConfig struct {
 var daprConfigResponse = daprConfig{
 	[]string{registeredActorType},
 	actorIdleTimeout,
-	actorScanInterval,
 	drainOngoingCallTimeout,
 	drainRebalancedActors,
 }

--- a/tests/apps/actorfeatures/app.go
+++ b/tests/apps/actorfeatures/app.go
@@ -41,7 +41,6 @@ const (
 	actorTypeEnvName                = "TEST_APP_ACTOR_TYPE"                 // To set to change actor type.
 	actorRemindersPartitionsEnvName = "TEST_APP_ACTOR_REMINDERS_PARTITIONS" // To set actor type partition count.
 	actorIdleTimeout                = "1h"
-	actorScanInterval               = "30s"
 	drainOngoingCallTimeout         = "30s"
 	drainRebalancedActors           = true
 	secondsToWaitInMethod           = 5
@@ -82,7 +81,6 @@ type actorLogEntry struct {
 type daprConfig struct {
 	Entities                   []string `json:"entities,omitempty"`
 	ActorIdleTimeout           string   `json:"actorIdleTimeout,omitempty"`
-	ActorScanInterval          string   `json:"actorScanInterval,omitempty"`
 	DrainOngoingCallTimeout    string   `json:"drainOngoingCallTimeout,omitempty"`
 	DrainRebalancedActors      bool     `json:"drainRebalancedActors,omitempty"`
 	RemindersStoragePartitions int      `json:"remindersStoragePartitions,omitempty"`
@@ -229,7 +227,6 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 	daprConfigResponse := daprConfig{
 		[]string{getActorType()},
 		actorIdleTimeout,
-		actorScanInterval,
 		drainOngoingCallTimeout,
 		drainRebalancedActors,
 		getActorRemindersPartitions(),

--- a/tests/apps/actorinvocationapp/app.go
+++ b/tests/apps/actorinvocationapp/app.go
@@ -32,7 +32,6 @@ const (
 	daprActorMethodURL = daprBaseURL + "/actors/%s/%s/method/%s"
 
 	actorIdleTimeout        = "5s" // Short idle timeout.
-	actorScanInterval       = "1s" // Smaller then actorIdleTimeout and short for speedy test.
 	drainOngoingCallTimeout = "1s"
 	drainRebalancedActors   = true
 )
@@ -48,7 +47,6 @@ type callRequest struct {
 type daprConfig struct {
 	Entities                []string `json:"entities,omitempty"`
 	ActorIdleTimeout        string   `json:"actorIdleTimeout,omitempty"`
-	ActorScanInterval       string   `json:"actorScanInterval,omitempty"`
 	DrainOngoingCallTimeout string   `json:"drainOngoingCallTimeout,omitempty"`
 	DrainRebalancedActors   bool     `json:"drainRebalancedActors,omitempty"`
 }
@@ -56,7 +54,6 @@ type daprConfig struct {
 var daprConfigResponse = daprConfig{
 	[]string{"actor1", "actor2"},
 	actorIdleTimeout,
-	actorScanInterval,
 	drainOngoingCallTimeout,
 	drainRebalancedActors,
 }

--- a/tests/apps/actorjava/src/main/java/io/dapr/apps/actor/Application.java
+++ b/tests/apps/actorjava/src/main/java/io/dapr/apps/actor/Application.java
@@ -26,7 +26,6 @@ public class Application {
 
     public static void main(String[] args) {
         ActorRuntime.getInstance().getConfig().setActorIdleTimeout(Duration.ofSeconds(1));
-        ActorRuntime.getInstance().getConfig().setActorScanInterval(Duration.ofSeconds(1));
         ActorRuntime.getInstance().registerActor(CarActorImpl.class);
         SpringApplication.run(Application.class, args);
     }

--- a/tests/apps/actorload/cmd/stateactor/main.go
+++ b/tests/apps/actorload/cmd/stateactor/main.go
@@ -104,7 +104,6 @@ func main() {
 	service := serve.NewActorService(*appPort, &rt.DaprConfig{
 		Entities:                actorTypes,
 		ActorIdleTimeout:        "5m",
-		ActorScanInterval:       "10s",
 		DrainOngoingCallTimeout: "10s",
 		DrainRebalancedActors:   true,
 	})

--- a/tests/apps/actorload/cmd/stateactor/service/server.go
+++ b/tests/apps/actorload/cmd/stateactor/service/server.go
@@ -56,7 +56,6 @@ func NewActorService(port int, config *rt.DaprConfig) *ActorService {
 		daprConfig = rt.DaprConfig{
 			Entities:                []string{},
 			ActorIdleTimeout:        "60m",
-			ActorScanInterval:       "10s",
 			DrainOngoingCallTimeout: "10s",
 			DrainRebalancedActors:   true,
 		}

--- a/tests/apps/actorload/pkg/actor/runtime/config.go
+++ b/tests/apps/actorload/pkg/actor/runtime/config.go
@@ -17,7 +17,6 @@ package runtime
 type DaprConfig struct {
 	Entities                []string `json:"entities,omitempty"`
 	ActorIdleTimeout        string   `json:"actorIdleTimeout,omitempty"`
-	ActorScanInterval       string   `json:"actorScanInterval,omitempty"`
 	DrainOngoingCallTimeout string   `json:"drainOngoingCallTimeout,omitempty"`
 	DrainRebalancedActors   bool     `json:"drainRebalancedActors,omitempty"`
 }

--- a/tests/apps/actorreentrancy/app.go
+++ b/tests/apps/actorreentrancy/app.go
@@ -34,7 +34,6 @@ const (
 	actorMethodURLFormat    = daprV1URL + "/actors/%s/%s/method/%s"
 	defaultActorType        = "reentrantActor"
 	actorIdleTimeout        = "1h"
-	actorScanInterval       = "30s"
 	drainOngoingCallTimeout = "30s"
 	drainRebalancedActors   = true
 	reentrantMethod         = "reentrantMethod"
@@ -51,7 +50,6 @@ type actorLogEntry struct {
 type daprConfig struct {
 	Entities                []string                `json:"entities,omitempty"`
 	ActorIdleTimeout        string                  `json:"actorIdleTimeout,omitempty"`
-	ActorScanInterval       string                  `json:"actorScanInterval,omitempty"`
 	DrainOngoingCallTimeout string                  `json:"drainOngoingCallTimeout,omitempty"`
 	DrainRebalancedActors   bool                    `json:"drainRebalancedActors,omitempty"`
 	Reentrancy              config.ReentrancyConfig `json:"reentrancy,omitempty"`
@@ -79,7 +77,6 @@ var (
 var daprConfigResponse = daprConfig{
 	Entities:                []string{defaultActorType},
 	ActorIdleTimeout:        actorIdleTimeout,
-	ActorScanInterval:       actorScanInterval,
 	DrainOngoingCallTimeout: drainOngoingCallTimeout,
 	DrainRebalancedActors:   drainRebalancedActors,
 	Reentrancy:              config.ReentrancyConfig{Enabled: false},

--- a/tests/apps/actorstate/app.go
+++ b/tests/apps/actorstate/app.go
@@ -181,13 +181,11 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(struct {
 		Entities                []string `json:"entities,omitempty"`
 		ActorIdleTimeout        string   `json:"actorIdleTimeout,omitempty"`
-		ActorScanInterval       string   `json:"actorScanInterval,omitempty"`
 		DrainOngoingCallTimeout string   `json:"drainOngoingCallTimeout,omitempty"`
 		DrainRebalancedActors   bool     `json:"drainRebalancedActors,omitempty"`
 	}{
 		Entities:                []string{"httpMyActorType", "grpcMyActorType"},
 		ActorIdleTimeout:        "30s",
-		ActorScanInterval:       "10s",
 		DrainOngoingCallTimeout: "20s",
 		DrainRebalancedActors:   true,
 	})

--- a/tests/apps/perf/actorfeatures/app.go
+++ b/tests/apps/perf/actorfeatures/app.go
@@ -33,7 +33,6 @@ const (
 	defaultActorType        = "testactorfeatures"   // Actor type must be unique per test app.
 	actorTypeEnvName        = "TEST_APP_ACTOR_TYPE" // Env variable tests can set to change actor type.
 	actorIdleTimeout        = "1h"
-	actorScanInterval       = "30s"
 	drainOngoingCallTimeout = "30s"
 	drainRebalancedActors   = true
 	secondsToWaitInMethod   = 5
@@ -42,7 +41,6 @@ const (
 type daprConfig struct {
 	Entities                []string `json:"entities,omitempty"`
 	ActorIdleTimeout        string   `json:"actorIdleTimeout,omitempty"`
-	ActorScanInterval       string   `json:"actorScanInterval,omitempty"`
 	DrainOngoingCallTimeout string   `json:"drainOngoingCallTimeout,omitempty"`
 	DrainRebalancedActors   bool     `json:"drainRebalancedActors,omitempty"`
 }
@@ -52,7 +50,6 @@ var registeredActorType = map[string]bool{}
 var daprConfigResponse = daprConfig{
 	getActorType(),
 	actorIdleTimeout,
-	actorScanInterval,
 	drainOngoingCallTimeout,
 	drainRebalancedActors,
 }


### PR DESCRIPTION
Small refactoring to the actors subsystem to remove the "ActorScanInterval" configuration. Idle actors are now deactivated automatically shortly after the idle timeout for their actor type.

> The priority queue implemented in this PR in `pkg/actors/internal` is the same code used in #6716 . It should be possible to review and merge the 2 PRs independently.

Benefits:

- Simplifies the experience for users who now need to worry about one less property
- Makes the actor subsystem more predictable: idle actors are now deactivated after the idle timeout, and there's no uncertainty due to the next scan interval.
- Offers perf improvements since we are not scanning the map of active actors on regular intervals (by default 30s)
   - All active actors are placed in a priority queue (heap-based), with the actor that is the first to reach its "deadline" at the top. Lookups for the first actor are O(1)
   - Every time an actor gets invoked, its "idle at" time, and thus its position in the queue, are updated. This operation's complexity is an efficient O(log n)
   - A goroutine is blocked waiting on the time the next actor becomes idle at, and ready to be deactivated.
   - There's no background goroutine if there's no active actor running.

Why this is **not** a breaking change:

- Actors are considered in a state where they can be deactivated after they are idle for "idle timeout".
- The current implementation performs deactivation using a "garbage collection" loop that runs every "scan interval". This is 30s by default. This means that there are "optimistic" and "pessimistic" cases:
   - In the optimistic case, the GC loop happens right after the actor becomes idle and gets deactivated right away.
   - In the pessimistic case, an actor's lifetime is extended by a full "scan interval" duration
- The point of the "scan interval" property is to configure the pessimistic case, knowing that:
   - A short "scan interval" uses more resources
   - A long "scan interval" makes actors alive for longer, thus using more resources in a different way.
      - Additionally, an actor that is idle but hasn't been GC'd yet could be re-activated right away if a call comes in. This is a potentially unexpected behavior for users, and _could be considered a bug_. Developers should expect an actor to become deactivated after its idle timeout has passed, and additional calls should activate the actor again possibly on a different host, not keeping it alive for longer
- Because this PR makes the "optimistic case" the only possible case, the scan interval property becomes irrelevant, not deprecated. There's no change in user-facing behavior, as the contract stating that actors are deactivated after _at least_ "idle timeout" remains valid.
   - We have removed other configuration options from Dapr in the past without any fuss or deprecation notice when they became irrelevant and their absence did not cause the user-observed behavior to change.