### PR TITLE
tests/integration/suite/daprd/pubsub/grpc/compname: revert numTests `1` -> `1000`

### DIFF
--- a/tests/integration/suite/daprd/pubsub/grpc/compname.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/compname.go
@@ -45,7 +45,7 @@ type componentName struct {
 }
 
 func (c *componentName) Setup(t *testing.T) []framework.Option {
-	const numTests = 1
+	const numTests = 1000
 	takenNames := make(map[string]bool)
 
 	reg, err := regexp.Compile("^([a-zA-Z].*)$")


### PR DESCRIPTION
The number of pubsub grpc component loader fuzz test cases was mistakenly reduced from `1000` to `1` in https://github.com/dapr/dapr/pull/6688. This reverts that change.

/cc @ItalyPaleAle 