### PR TITLE
runtime: Read lock mutex when [bulk] publishing to pubsub

### DIFF
--- a/pkg/runtime/processor/pubsub/publish.go
+++ b/pkg/runtime/processor/pubsub/publish.go
@@ -43,6 +43,9 @@ import (
 // And then forward them to the Pub/Sub component.
 // This method is used by the HTTP and gRPC APIs.
 func (p *pubsub) Publish(ctx context.Context, req *contribpubsub.PublishRequest) error {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
 	ps, ok := p.compStore.GetPubSub(req.PubsubName)
 	if !ok {
 		return rtpubsub.NotFoundError{PubsubName: req.PubsubName}
@@ -66,6 +69,9 @@ func (p *pubsub) Publish(ctx context.Context, req *contribpubsub.PublishRequest)
 }
 
 func (p *pubsub) BulkPublish(ctx context.Context, req *contribpubsub.BulkPublishRequest) (contribpubsub.BulkPublishResponse, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
 	ps, ok := p.compStore.GetPubSub(req.PubsubName)
 	if !ok {
 		return contribpubsub.BulkPublishResponse{}, rtpubsub.NotFoundError{PubsubName: req.PubsubName}

--- a/pkg/runtime/processor/pubsub/pubsub.go
+++ b/pkg/runtime/processor/pubsub/pubsub.go
@@ -95,7 +95,7 @@ type pubsub struct {
 	grpc           *grpc.Manager
 	operatorClient operatorv1.OperatorClient
 
-	lock sync.Mutex
+	lock sync.RWMutex
 
 	topicCancels map[string]context.CancelFunc
 }


### PR DESCRIPTION
Read lock the runtime processor pubsub when publishing and bulk publishing messages. This ensures the pubsubs have been init'ed before publishing is executed.

This PR fixes the 2 JS integrations test cases which were failing after https://github.com/dapr/dapr/pull/6688.

Previously failing tests: https://github.com/dapr/dapr/actions/runs/5664811154/job/15363864996