### PR TITLE
Fix validate-sidecar-resources workflow.

### DIFF
--- a/.github/scripts/validate-sidecar-resources.sh
+++ b/.github/scripts/validate-sidecar-resources.sh
@@ -40,17 +40,21 @@ echo "Resident memory: $RESIDENT_MEM KB compared to baseline of $BASELINE_RESIDE
 echo "Virtual memory: $VIRT_MEM KB compared to baseline of $BASELINE_VIRT_MEM KB ($DELTA_VIRT_MEM KB)"
 echo "Number of Go routines: $GO_ROUTINES compared to baseline of $BASELINE_GO_ROUTINES ($DELTA_GO_ROUTINES)"
 
+EXIT_CODE=0
+
 if [[ $DELTA_BINARY_SIZE -gt $LIMIT_DELTA_BINARY_SIZE ]]; then
    echo "New version's binary size is too large: $DELTA_BINARY_SIZE KB"
-   exit 1
+   EXIT_CODE=1
 fi
 
 if [[ $DELTA_VIRT_MEM -gt $LIMIT_DELTA_VIRT_MEM ]]; then
    echo "New version is consuming too much virtual memory: $DELTA_VIRT_MEM KB"
-   exit 1
+   EXIT_CODE=1
 fi
 
 if [[ $DELTA_GO_ROUTINES -gt $LIMIT_DELTA_GO_ROUTINES ]]; then
    echo "New version is spawning an additional $DELTA_GO_ROUTINES Go routines"
-   exit 1
+   EXIT_CODE=1
 fi
+
+exit $EXIT_CODE

--- a/.github/scripts/validate-sidecar-resources.sh
+++ b/.github/scripts/validate-sidecar-resources.sh
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ue
+
+SECONDS_FOR_PROCESS_TO_RUN=${SECONDS_FOR_PROCESS_TO_RUN:-5}
+GOOS=${GOOS:-$(go env GOOS)}
+GOARCH=${GOARCH:-$(go env GOARCH)}
+LIMIT_DELTA_BINARY_SIZE=${LIMIT_DELTA_BINARY_SIZE:-1024} # KB (1 MB)
+LIMIT_DELTA_VIRT_MEM=${LIMIT_DELTA_VIRT_MEM:-3200}  # KB
+LIMIT_DELTA_GO_ROUTINES=${LIMIT_DELTA_GO_ROUTINES:-0} # Does not accept any extra Go routines
 
 ./dist/${GOOS}_${GOARCH}/release/daprd --app-id target &
 pid=$!
@@ -8,9 +15,9 @@ sleep $SECONDS_FOR_PROCESS_TO_RUN
 BINARY_SIZE=$(( `wc -c ./dist/${GOOS}_${GOARCH}/release/daprd | awk '{print $1}'` / 1024 ))
 RESIDENT_MEM=`ps -o rss= $pid`
 VIRT_MEM=`ps -o vsz= $pid`
-GO_ROUTINES=`curl http://localhost:9090/metrics | grep go_goroutines | grep -v \# | cut -d\  -f2`
+GO_ROUTINES=`curl -s http://localhost:9090/metrics | grep go_goroutines | grep -v \# | cut -d\  -f2`
 kill -TERM $pid
-lsof -p $pid +r 1 &>/dev/null
+wait $pid
 
 BASELINE_BINARY=`readlink -f ~/.dapr/bin/daprd`
 $BASELINE_BINARY --app-id baseline &
@@ -19,9 +26,9 @@ sleep $SECONDS_FOR_PROCESS_TO_RUN
 BASELINE_BINARY_SIZE=$(( `wc -c $BASELINE_BINARY | awk '{print $1}'` / 1024 ))
 BASELINE_RESIDENT_MEM=`ps -o rss= $baseline_pid`
 BASELINE_VIRT_MEM=`ps -o vsz= $baseline_pid`
-BASELINE_GO_ROUTINES=`curl http://localhost:9090/metrics | grep go_goroutines | grep -v \# | cut -d\  -f2`
+BASELINE_GO_ROUTINES=`curl -s http://localhost:9090/metrics | grep go_goroutines | grep -v \# | cut -d\  -f2`
 kill -TERM $baseline_pid
-lsof -p $baseline_pid +r 1 &>/dev/null
+wait $baseline_pid
 
 DELTA_BINARY_SIZE=$(( $BINARY_SIZE - $BASELINE_BINARY_SIZE ))
 DELTA_RESIDENT_MEM=$(( $RESIDENT_MEM - $BASELINE_RESIDENT_MEM ))

--- a/.github/workflows/dapr-standalone-validation.yml
+++ b/.github/workflows/dapr-standalone-validation.yml
@@ -75,6 +75,4 @@ jobs:
         env:
           SECONDS_FOR_PROCESS_TO_RUN: 30
           LIMIT_DELTA_BINARY_SIZE: 7168  # KB (7 MB)
-          LIMIT_DELTA_VIRT_MEM: 3200  # KB
-          LIMIT_DELTA_GO_ROUTINES: 0  # Does not accept any extra Go routines
         run: ./.github/scripts/validate-sidecar-resources.sh


### PR DESCRIPTION
The validate sidecar resources has been broken since #6688 

Use `wait` rather than `lsof` to wait for the sidecar process to shutdown. `wait $pid` can be used as the daprd processes are spawned as a child of the script process.

Echo all issues with resource usage, not just the first and error exit if any of them are over.

Default variables used in script so `./.github/scripts/validate-sidecar-resources.sh` can be run from the repo.

Make curl silent.

Use `/usr/bin/env bash` rather than `/bin/bash` as this path is not available on all systems.
