### PR TITLE
Misc fixes and tweaks from #6729

### DIFF
--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -247,7 +247,7 @@ func ApplyAccessControlPolicies(ctx context.Context, operation string, httpVerb 
 	spiffeID, err := GetAndParseSpiffeID(ctx)
 	if err != nil {
 		// Apply the default action
-		log.Debugf("error while reading spiffe id from client cert: %v. applying default global policy action", err.Error())
+		log.Debugf("Error while reading spiffe id from client cert: %v. applying default global policy action", err)
 	}
 	var appID, trustDomain, namespace string
 	if spiffeID != nil {
@@ -260,7 +260,7 @@ func ApplyAccessControlPolicies(ctx context.Context, operation string, httpVerb 
 	var errMessage string
 
 	if err != nil {
-		errMessage = fmt.Sprintf("error in method normalization: %s", err)
+		errMessage = fmt.Sprintf("error in method normalization: %v", err)
 		log.Debugf(errMessage)
 		return false, errMessage
 	}

--- a/pkg/diagnostics/grpc_monitoring.go
+++ b/pkg/diagnostics/grpc_monitoring.go
@@ -128,7 +128,7 @@ func (g *grpcMetrics) Init(appID string) error {
 }
 
 func (g *grpcMetrics) IsEnabled() bool {
-	return g.enabled
+	return g != nil && g.enabled
 }
 
 func (g *grpcMetrics) ServerRequestReceived(ctx context.Context, method string, contentSize int64) time.Time {

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -71,16 +71,13 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 		ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
 		ctx, span = tracer.Start(ctx, info.FullMethod, spanKind)
 
-		isSampled := span.SpanContext().IsSampled()
-		if isSampled {
+		resp, err := handler(ctx, req)
+
+		if span.SpanContext().IsSampled() {
 			// users can add dapr- prefix if they want to see the header values in span attributes.
 			prefixedMetadata = userDefinedMetadata(ctx)
 			reqSpanAttr = spanAttributesMapFromGRPC(appID, req, info.FullMethod)
-		}
 
-		resp, err := handler(ctx, req)
-
-		if isSampled {
 			// Populates dapr- prefixed header first
 			for key, value := range reqSpanAttr {
 				prefixedMetadata[key] = value

--- a/pkg/diagnostics/http_monitoring.go
+++ b/pkg/diagnostics/http_monitoring.go
@@ -38,10 +38,10 @@ var (
 	httpMethodKey     = tag.MustNewKey("method")
 )
 
-// Default distributions.
 var (
-	defaultSizeDistribution    = view.Distribution(1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
-	defaultLatencyDistribution = view.Distribution(1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+	// <<10 -> KBs; <<20 -> MBs; <<30 -> GBs
+	defaultSizeDistribution    = view.Distribution(1<<10, 2<<10, 4<<10, 16<<10, 64<<10, 256<<10, 1<<20, 4<<20, 16<<20, 64<<20, 256<<20, 1<<30, 4<<30)
+	defaultLatencyDistribution = view.Distribution(1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1_000, 2_000, 5_000, 10_000, 20_000, 50_000, 100_000)
 )
 
 type httpMetrics struct {
@@ -115,7 +115,7 @@ func newHTTPMetrics() *httpMetrics {
 }
 
 func (h *httpMetrics) IsEnabled() bool {
-	return h.enabled
+	return h != nil && h.enabled
 }
 
 func (h *httpMetrics) ServerRequestReceived(ctx context.Context, method, path string, contentSize int64) {

--- a/pkg/diagnostics/metrics.go
+++ b/pkg/diagnostics/metrics.go
@@ -68,5 +68,11 @@ func InitMetrics(appID, namespace string, rules []config.MetricsRule) error {
 
 	// Set reporting period of views
 	view.SetReportingPeriod(DefaultReportingPeriod)
-	return utils.CreateRulesMap(rules)
+
+	// Creates a rules map
+	err := utils.CreateRulesMap(rules)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/diagnostics/metrics.go
+++ b/pkg/diagnostics/metrics.go
@@ -68,11 +68,5 @@ func InitMetrics(appID, namespace string, rules []config.MetricsRule) error {
 
 	// Set reporting period of views
 	view.SetReportingPeriod(DefaultReportingPeriod)
-
-	// Creates a rules map
-	err := utils.CreateRulesMap(rules)
-	if err != nil {
-		return err
-	}
-	return nil
+	return utils.CreateRulesMap(rules)
 }

--- a/pkg/diagnostics/utils/metrics_utils_test.go
+++ b/pkg/diagnostics/utils/metrics_utils_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opencensus.io/tag"
 
 	"github.com/dapr/dapr/pkg/config"
@@ -26,14 +27,14 @@ func TestWithTags(t *testing.T) {
 	t.Run("one tag", func(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
 		mutators := WithTags("", appKey, "test")
-		assert.Equal(t, 1, len(mutators))
+		assert.Len(t, mutators, 1)
 	})
 
 	t.Run("two tags", func(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
 		operationKey := tag.MustNewKey("operation")
 		mutators := WithTags("", appKey, "test", operationKey, "op")
-		assert.Equal(t, 2, len(mutators))
+		assert.Len(t, mutators, 2)
 	})
 
 	t.Run("three tags", func(t *testing.T) {
@@ -41,14 +42,14 @@ func TestWithTags(t *testing.T) {
 		operationKey := tag.MustNewKey("operation")
 		methodKey := tag.MustNewKey("method")
 		mutators := WithTags("", appKey, "test", operationKey, "op", methodKey, "method")
-		assert.Equal(t, 3, len(mutators))
+		assert.Len(t, mutators, 3)
 	})
 
 	t.Run("two tags with wrong value type", func(t *testing.T) {
 		appKey := tag.MustNewKey("app_id")
 		operationKey := tag.MustNewKey("operation")
 		mutators := WithTags("", appKey, "test", operationKey, 1)
-		assert.Equal(t, 1, len(mutators))
+		assert.Len(t, mutators, 1)
 	})
 
 	t.Run("skip empty value key", func(t *testing.T) {
@@ -56,7 +57,7 @@ func TestWithTags(t *testing.T) {
 		operationKey := tag.MustNewKey("operation")
 		methodKey := tag.MustNewKey("method")
 		mutators := WithTags("", appKey, "", operationKey, "op", methodKey, "method")
-		assert.Equal(t, 2, len(mutators))
+		assert.Len(t, mutators, 2)
 	})
 }
 
@@ -93,7 +94,7 @@ func TestCreateRulesMap(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, metricsRules)
 		assert.Len(t, metricsRules, 1)
 		assert.Len(t, metricsRules["testlabel"], 1)

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -83,7 +83,6 @@ type api struct {
 	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	tracingSpec           config.TracingSpec
 	accessControlList     *config.AccessControlList
-	compStore             *compstore.ComponentStore
 }
 
 // APIOpts contains options for NewAPI.
@@ -125,7 +124,6 @@ func NewAPI(opts APIOpts) API {
 		sendToOutputBindingFn: opts.SendToOutputBindingFn,
 		tracingSpec:           opts.TracingSpec,
 		accessControlList:     opts.AccessControlList,
-		compStore:             opts.CompStore,
 	}
 }
 
@@ -140,7 +138,7 @@ func (a *api) validateAndGetPubsubAndTopic(pubsubName, topic string, reqMeta map
 		return nil, "", "", false, status.Error(codes.InvalidArgument, messages.ErrPubsubEmpty)
 	}
 
-	thepubsub, ok := a.compStore.GetPubSub(pubsubName)
+	thepubsub, ok := a.UniversalAPI.CompStore.GetPubSub(pubsubName)
 	if !ok {
 		return nil, "", "", false, status.Errorf(codes.InvalidArgument, messages.ErrPubsubNotFound, pubsubName)
 	}

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -2308,7 +2308,8 @@ func TestDeleteBulkState(t *testing.T) {
 func TestPublishTopic(t *testing.T) {
 	srv := &api{
 		UniversalAPI: &universalapi.UniversalAPI{
-			AppID: "fakeAPI",
+			AppID:     "fakeAPI",
+			CompStore: compstore.New(),
 		},
 		pubsubAdapter: &daprt.MockPubSubAdapter{
 			PublishFn: func(ctx context.Context, req *pubsub.PublishRequest) error {
@@ -2340,12 +2341,11 @@ func TestPublishTopic(t *testing.T) {
 				return pubsub.BulkPublishResponse{}, nil
 			},
 		},
-		compStore: compstore.New(),
 	}
 
 	mock := daprt.MockPubSub{}
 	mock.On("Features").Return([]pubsub.Feature{})
-	srv.compStore.AddPubSub("pubsub", compstore.PubsubItem{Component: &mock})
+	srv.UniversalAPI.CompStore.AddPubSub("pubsub", compstore.PubsubItem{Component: &mock})
 
 	server, lis := startTestServerAPI(srv)
 	defer server.Stop()
@@ -2506,7 +2506,8 @@ func TestPublishTopic(t *testing.T) {
 func TestBulkPublish(t *testing.T) {
 	fakeAPI := &api{
 		UniversalAPI: &universalapi.UniversalAPI{
-			AppID: "fakeAPI",
+			AppID:     "fakeAPI",
+			CompStore: compstore.New(),
 		},
 		pubsubAdapter: &daprt.MockPubSubAdapter{
 			BulkPublishFn: func(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
@@ -2535,12 +2536,11 @@ func TestBulkPublish(t *testing.T) {
 				return pubsub.BulkPublishResponse{FailedEntries: entries}, nil
 			},
 		},
-		compStore: compstore.New(),
 	}
 
 	mock := daprt.MockPubSub{}
 	mock.On("Features").Return([]pubsub.Feature{})
-	fakeAPI.compStore.AddPubSub("pubsub", compstore.PubsubItem{Component: &mock})
+	fakeAPI.UniversalAPI.CompStore.AddPubSub("pubsub", compstore.PubsubItem{Component: &mock})
 
 	server, lis := startDaprAPIServer(fakeAPI, "")
 	defer server.Stop()

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -139,11 +141,11 @@ func TestClose(t *testing.T) {
 	})
 }
 
-func Test_server_getGRPCAPILoggingMiddlewares(t *testing.T) {
+func TestGrpcAPILoggingMiddlewares(t *testing.T) {
 	logDest := &bytes.Buffer{}
 	infoLog := logger.NewLogger("test-api-logging")
 	infoLog.EnableJSONOutput(true)
-	infoLog.SetOutput(logDest)
+	infoLog.SetOutput(io.MultiWriter(logDest, os.Stderr))
 
 	s := &server{
 		infoLogger: infoLog,

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -80,7 +80,6 @@ type api struct {
 	outboundReadyStatus     bool
 	tracingSpec             config.TracingSpec
 	maxRequestBodySize      int64 // In bytes
-	compStore               *compstore.ComponentStore
 }
 
 const (
@@ -141,7 +140,6 @@ func NewAPI(opts APIOpts) API {
 		sendToOutputBindingFn:   opts.SendToOutputBindingFn,
 		tracingSpec:             opts.TracingSpec,
 		maxRequestBodySize:      opts.MaxRequestBodySize,
-		compStore:               opts.CompStore,
 		universal: &universalapi.UniversalAPI{
 			AppID:                      opts.AppID,
 			Logger:                     log,
@@ -1731,7 +1729,7 @@ func (a *api) validateAndGetPubsubAndTopic(reqCtx *fasthttp.RequestCtx) (pubsub.
 		return nil, "", "", nethttp.StatusNotFound, &msg
 	}
 
-	thepubsub, ok := a.compStore.GetPubSub(pubsubName)
+	thepubsub, ok := a.universal.CompStore.GetPubSub(pubsubName)
 	if !ok {
 		msg := NewErrorResponse("ERR_PUBSUB_NOT_FOUND", fmt.Sprintf(messages.ErrPubsubNotFound, pubsubName))
 

--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -41,10 +41,9 @@ func (a *api) constructDirectMessagingEndpoints() []Endpoint {
 			Methods: []string{},
 			Route:   "invoke/*",
 			// This is the fallback route for when no other method is matched by the router
-			IsFallback:            true,
-			Version:               apiVersionV1,
-			KeepWildcardUnescaped: true,
-			Handler:               a.onDirectMessage,
+			IsFallback: true,
+			Version:    apiVersionV1,
+			Handler:    a.onDirectMessage,
 		},
 	}
 }

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -141,7 +141,8 @@ func TestPubSubEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	testAPI := &api{
 		universal: &universalapi.UniversalAPI{
-			AppID: "fakeAPI",
+			AppID:     "fakeAPI",
+			CompStore: compstore.New(),
 		},
 		pubsubAdapter: &daprt.MockPubSubAdapter{
 			PublishFn: func(ctx context.Context, req *pubsub.PublishRequest) error {
@@ -160,15 +161,14 @@ func TestPubSubEndpoints(t *testing.T) {
 				return nil
 			},
 		},
-		compStore: compstore.New(),
 	}
 
 	mock := daprt.MockPubSub{}
 	mock.On("Features").Return([]pubsub.Feature{})
-	testAPI.compStore.AddPubSub("pubsubname", compstore.PubsubItem{Component: &mock})
-	testAPI.compStore.AddPubSub("errorpubsub", compstore.PubsubItem{Component: &mock})
-	testAPI.compStore.AddPubSub("errnotfound", compstore.PubsubItem{Component: &mock})
-	testAPI.compStore.AddPubSub("errnotallowed", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("pubsubname", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("errorpubsub", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("errnotfound", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("errnotallowed", compstore.PubsubItem{Component: &mock})
 
 	fakeServer.StartServer(testAPI.constructPubSubEndpoints(), nil)
 
@@ -311,7 +311,8 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	fakeServer := newFakeHTTPServer()
 	testAPI := &api{
 		universal: &universalapi.UniversalAPI{
-			AppID: "fakeAPI",
+			AppID:     "fakeAPI",
+			CompStore: compstore.New(),
 		},
 		pubsubAdapter: &daprt.MockPubSubAdapter{
 			BulkPublishFn: func(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
@@ -338,15 +339,14 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 				}
 			},
 		},
-		compStore: compstore.New(),
 	}
 
 	mock := daprt.MockPubSub{}
 	mock.On("Features").Return([]pubsub.Feature{})
-	testAPI.compStore.AddPubSub("pubsubname", compstore.PubsubItem{Component: &mock})
-	testAPI.compStore.AddPubSub("errorpubsub", compstore.PubsubItem{Component: &mock})
-	testAPI.compStore.AddPubSub("errnotfound", compstore.PubsubItem{Component: &mock})
-	testAPI.compStore.AddPubSub("errnotallowed", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("pubsubname", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("errorpubsub", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("errnotfound", compstore.PubsubItem{Component: &mock})
+	testAPI.universal.CompStore.AddPubSub("errnotallowed", compstore.PubsubItem{Component: &mock})
 
 	fakeServer.StartServer(testAPI.constructPubSubEndpoints(), nil)
 

--- a/pkg/http/endpoint.go
+++ b/pkg/http/endpoint.go
@@ -25,15 +25,14 @@ import (
 
 // Endpoint is a collection of route information for an Dapr API.
 type Endpoint struct {
-	Methods               []string
-	Route                 string
-	Version               string
-	IsFallback            bool // Endpoint is used as fallback when the method or URL isn't found
-	KeepWildcardUnescaped bool // Keeps the wildcard param in path unescaped
-	FastHTTPHandler       fasthttp.RequestHandler
-	Handler               http.HandlerFunc
-	AlwaysAllowed         bool // Endpoint is always allowed regardless of API access rules
-	IsHealthCheck         bool // Mark endpoint as healthcheck - for API logging purposes
+	Methods         []string
+	Route           string
+	Version         string
+	IsFallback      bool // Endpoint is used as fallback when the method or URL isn't found
+	FastHTTPHandler fasthttp.RequestHandler
+	Handler         http.HandlerFunc
+	AlwaysAllowed   bool // Endpoint is always allowed regardless of API access rules
+	IsHealthCheck   bool // Mark endpoint as healthcheck - for API logging purposes
 }
 
 // GetHandler returns the handler for the endpoint.

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -267,7 +267,7 @@ func (s *server) useMaxBodySize(r chi.Router) {
 	}
 
 	maxSize := int64(s.config.MaxRequestBodySizeMB) << 20 // To bytes
-	log.Infof("Enabled max body size HTTP middleware with size %d MB", maxSize)
+	log.Infof("Enabled max body size HTTP middleware with size %d bytes", maxSize)
 
 	r.Use(MaxBodySizeMiddleware(maxSize))
 }
@@ -321,11 +321,11 @@ func (s *server) useAPIAuthentication(r chi.Router) {
 	r.Use(APITokenAuthMiddleware(token))
 }
 
-func (s *server) unescapeRequestParametersHandler(keepWildcardUnescaped bool, next http.Handler) http.HandlerFunc {
+func (s *server) unescapeRequestParametersHandler(next http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		chiCtx := chi.RouteContext(r.Context())
 		if chiCtx != nil {
-			err := s.unespaceRequestParametersInContext(chiCtx, keepWildcardUnescaped)
+			err := s.unespaceRequestParametersInContext(chiCtx)
 			if err != nil {
 				errMsg := err.Error()
 				log.Debug(errMsg)
@@ -338,12 +338,8 @@ func (s *server) unescapeRequestParametersHandler(keepWildcardUnescaped bool, ne
 	})
 }
 
-func (s *server) unespaceRequestParametersInContext(chiCtx *chi.Context, keepWildcardUnescaped bool) (err error) {
+func (s *server) unespaceRequestParametersInContext(chiCtx *chi.Context) (err error) {
 	for i, key := range chiCtx.URLParams.Keys {
-		if keepWildcardUnescaped && key == "*" {
-			continue
-		}
-
 		chiCtx.URLParams.Values[i], err = url.QueryUnescape(chiCtx.URLParams.Values[i])
 		if err != nil {
 			return fmt.Errorf("failed to unescape request parameter %q. Error: %w", key, err)
@@ -378,7 +374,7 @@ func (s *server) handle(e Endpoint, path string, r chi.Router, unescapeParameter
 	handler := e.GetHandler()
 
 	if unescapeParameters {
-		handler = s.unescapeRequestParametersHandler(e.KeepWildcardUnescaped, handler)
+		handler = s.unescapeRequestParametersHandler(handler)
 	}
 
 	if apiLogging {

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -267,7 +267,7 @@ func (s *server) useMaxBodySize(r chi.Router) {
 	}
 
 	maxSize := int64(s.config.MaxRequestBodySizeMB) << 20 // To bytes
-	log.Infof("Enabled max body size HTTP middleware with size %d bytes", maxSize)
+	log.Infof("Enabled max body size HTTP middleware with size %d MB", s.config.MaxRequestBodySizeMB)
 
 	r.Use(MaxBodySizeMiddleware(maxSize))
 }

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -214,7 +215,7 @@ func TestUnescapeRequestParametersHandler(t *testing.T) {
 		for _, parameter := range parameters {
 			chiCtx := chi.NewRouteContext()
 			chiCtx.URLParams.Add(parameter["parameterName"], parameter["parameterValue"])
-			err := srv.unespaceRequestParametersInContext(chiCtx, false)
+			err := srv.unespaceRequestParametersInContext(chiCtx)
 			require.NoError(t, err)
 			assert.Equal(t, parameter["expectedParameterValue"], chiCtx.URLParam(parameter["parameterName"]))
 		}
@@ -241,7 +242,7 @@ func TestUnescapeRequestParametersHandler(t *testing.T) {
 		for _, parameter := range parameters {
 			chiCtx := chi.NewRouteContext()
 			chiCtx.URLParams.Add(parameter["parameterName"], parameter["parameterValue"])
-			err := srv.unespaceRequestParametersInContext(chiCtx, false)
+			err := srv.unespaceRequestParametersInContext(chiCtx)
 			require.Error(t, err)
 			assert.ErrorContains(t, err, "failed to unescape request parameter")
 		}
@@ -254,7 +255,7 @@ func TestAPILogging(t *testing.T) {
 	logDest := &bytes.Buffer{}
 	infoLog = logger.NewLogger("test-api-logging")
 	infoLog.EnableJSONOutput(true)
-	infoLog.SetOutput(logDest)
+	infoLog.SetOutput(io.MultiWriter(logDest, os.Stderr))
 	defer func() {
 		infoLog = prev
 	}()
@@ -336,7 +337,7 @@ func TestAPILoggingOmitHealthChecks(t *testing.T) {
 	logDest := &bytes.Buffer{}
 	infoLog = logger.NewLogger("test-api-logging")
 	infoLog.EnableJSONOutput(true)
-	infoLog.SetOutput(logDest)
+	infoLog.SetOutput(io.MultiWriter(logDest, os.Stderr))
 	defer func() {
 		infoLog = prev
 	}()


### PR DESCRIPTION
Includes some minor tweaks and fixes from the closed PR #6729

Nothing of substance or that changes behavior. Most relevant changes (and "most" is relative):

- Avoid unnecessary compStore property in gRPC and HTTP API structs
- Remove now-unused KeepWildcardUnescaped property (after #6750)
- Misc improvements to a few unit tests