### PR TITLE
Hot reloading: Dynamic Channels

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -38,7 +38,6 @@ import (
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/actors"
-	"github.com/dapr/dapr/pkg/channel"
 	stateLoader "github.com/dapr/dapr/pkg/components/state"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -47,13 +46,13 @@ import (
 	"github.com/dapr/dapr/pkg/grpc/metadata"
 	"github.com/dapr/dapr/pkg/grpc/universalapi"
 	"github.com/dapr/dapr/pkg/messages"
-	"github.com/dapr/dapr/pkg/messaging"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/resiliency/breaker"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/utils"
 )
@@ -71,15 +70,13 @@ type API interface {
 	runtimev1pb.DaprServer
 
 	// Methods internal to the object
-	SetAppChannel(appChannel channel.AppChannel)
-	SetDirectMessaging(directMessaging messaging.DirectMessaging)
 	SetActorRuntime(actor actors.Actors)
 }
 
 type api struct {
 	*universalapi.UniversalAPI
-	directMessaging       messaging.DirectMessaging
-	appChannel            channel.AppChannel
+	directMessaging       invokev1.DirectMessaging
+	channels              *channels.Channels
 	pubsubAdapter         runtimePubsub.Adapter
 	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	tracingSpec           config.TracingSpec
@@ -92,9 +89,9 @@ type api struct {
 // APIOpts contains options for NewAPI.
 type APIOpts struct {
 	UniversalAPI          *universalapi.UniversalAPI
-	AppChannel            channel.AppChannel
+	Channels              *channels.Channels
 	PubsubAdapter         runtimePubsub.Adapter
-	DirectMessaging       messaging.DirectMessaging
+	DirectMessaging       invokev1.DirectMessaging
 	SendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	TracingSpec           config.TracingSpec
 	AccessControlList     *config.AccessControlList
@@ -105,7 +102,7 @@ func NewAPI(opts APIOpts) API {
 	return &api{
 		UniversalAPI:          opts.UniversalAPI,
 		directMessaging:       opts.DirectMessaging,
-		appChannel:            opts.AppChannel,
+		channels:              opts.Channels,
 		pubsubAdapter:         opts.PubsubAdapter,
 		sendToOutputBindingFn: opts.SendToOutputBindingFn,
 		tracingSpec:           opts.TracingSpec,
@@ -1242,14 +1239,6 @@ func (a *api) InvokeActor(ctx context.Context, in *runtimev1pb.InvokeActorReques
 		return nil, fmt.Errorf("failed to read response data: %w", err)
 	}
 	return response, nil
-}
-
-func (a *api) SetAppChannel(appChannel channel.AppChannel) {
-	a.appChannel = appChannel
-}
-
-func (a *api) SetDirectMessaging(directMessaging messaging.DirectMessaging) {
-	a.directMessaging = directMessaging
 }
 
 func (a *api) SetActorRuntime(actor actors.Actors) {

--- a/pkg/grpc/api_daprinternal_test.go
+++ b/pkg/grpc/api_daprinternal_test.go
@@ -28,6 +28,7 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 )
 
 func TestCallLocal(t *testing.T) {
@@ -36,7 +37,7 @@ func TestCallLocal(t *testing.T) {
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-			appChannel: nil,
+			channels: new(channels.Channels),
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -57,7 +58,7 @@ func TestCallLocal(t *testing.T) {
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-			appChannel: mockAppChannel,
+			channels: (new(channels.Channels)).WithAppChannel(mockAppChannel),
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -83,7 +84,7 @@ func TestCallLocal(t *testing.T) {
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-			appChannel: mockAppChannel,
+			channels: (new(channels.Channels)).WithAppChannel(mockAppChannel),
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -105,7 +106,7 @@ func TestCallLocalStream(t *testing.T) {
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-			appChannel: nil,
+			channels: new(channels.Channels),
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -135,7 +136,7 @@ func TestCallLocalStream(t *testing.T) {
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-			appChannel: mockAppChannel,
+			channels: (new(channels.Channels)).WithAppChannel(mockAppChannel),
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()
@@ -172,7 +173,7 @@ func TestCallLocalStream(t *testing.T) {
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-			appChannel: mockAppChannel,
+			channels: (new(channels.Channels)).WithAppChannel(mockAppChannel),
 		}
 		server, lis := startInternalServer(fakeAPI)
 		defer server.Stop()

--- a/pkg/grpc/manager/dial.go
+++ b/pkg/grpc/manager/dial.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build !windows
+// +build !windows
 
 /*
 Copyright 2021 The Dapr Authors
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpc
+package manager
 
 import (
 	"github.com/dapr/dapr/pkg/modes"
 )
 
 // GetDialAddressPrefix returns a dial prefix for a gRPC client connections for a given DaprMode.
-// This is used on Windows hosts.
+// This is used on non-Windows hosts.
 func GetDialAddressPrefix(mode modes.DaprMode) string {
-	return ""
+	switch mode {
+	case modes.KubernetesMode:
+		return "dns:///"
+	default:
+		return ""
+	}
 }

--- a/pkg/grpc/manager/dial_test.go
+++ b/pkg/grpc/manager/dial_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package manager
 
 import (

--- a/pkg/grpc/manager/dial_test.go
+++ b/pkg/grpc/manager/dial_test.go
@@ -1,4 +1,4 @@
-package grpc
+package manager
 
 import (
 	"runtime"

--- a/pkg/grpc/manager/dial_windows.go
+++ b/pkg/grpc/manager/dial_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2021 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"github.com/dapr/dapr/pkg/modes"
+)
+
+// GetDialAddressPrefix returns a dial prefix for a gRPC client connections for a given DaprMode.
+// This is used on Windows hosts.
+func GetDialAddressPrefix(mode modes.DaprMode) string {
+	return ""
+}

--- a/pkg/grpc/manager/manager.go
+++ b/pkg/grpc/manager/manager.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpc
+package manager
 
 import (
 	"context"
@@ -71,8 +71,8 @@ type Manager struct {
 	closeCh       chan struct{}
 }
 
-// NewGRPCManager returns a new grpc manager.
-func NewGRPCManager(mode modes.DaprMode, channelConfig *AppChannelConfig) *Manager {
+// NewManager returns a new grpc manager.
+func NewManager(mode modes.DaprMode, channelConfig *AppChannelConfig) *Manager {
 	return &Manager{
 		remoteConns:   NewRemoteConnectionPool(),
 		mode:          mode,

--- a/pkg/grpc/manager/manager_test.go
+++ b/pkg/grpc/manager/manager_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpc
+package manager
 
 import (
 	"crypto/x509"
@@ -37,15 +37,15 @@ func (a *authenticatorMock) CreateSignedWorkloadCert(id, namespace, trustDomain 
 	return nil, nil
 }
 
-func TestNewGRPCManager(t *testing.T) {
+func TestNewManager(t *testing.T) {
 	t.Run("with self hosted", func(t *testing.T) {
-		m := NewGRPCManager(modes.StandaloneMode, &AppChannelConfig{})
+		m := NewManager(modes.StandaloneMode, &AppChannelConfig{})
 		assert.NotNil(t, m)
 		assert.Equal(t, modes.StandaloneMode, m.mode)
 	})
 
 	t.Run("with kubernetes", func(t *testing.T) {
-		m := NewGRPCManager(modes.KubernetesMode, &AppChannelConfig{})
+		m := NewManager(modes.KubernetesMode, &AppChannelConfig{})
 		assert.NotNil(t, m)
 		assert.Equal(t, modes.KubernetesMode, m.mode)
 	})
@@ -53,7 +53,7 @@ func TestNewGRPCManager(t *testing.T) {
 
 func TestSetAuthenticator(t *testing.T) {
 	a := &authenticatorMock{}
-	m := NewGRPCManager(modes.StandaloneMode, &AppChannelConfig{})
+	m := NewManager(modes.StandaloneMode, &AppChannelConfig{})
 	m.SetAuthenticator(a)
 
 	assert.Equal(t, a, m.auth)

--- a/pkg/grpc/manager/pool.go
+++ b/pkg/grpc/manager/pool.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpc
+package manager
 
 import (
 	"sync"

--- a/pkg/grpc/manager/pool_test.go
+++ b/pkg/grpc/manager/pool_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpc
+package manager
 
 import (
 	"context"

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/martian/log"
 	"github.com/mitchellh/mapstructure"
 	"github.com/valyala/fasthttp"
 	"go.opentelemetry.io/otel/trace"
@@ -67,7 +66,7 @@ type api struct {
 	universal             *universalapi.UniversalAPI
 	endpoints             []Endpoint
 	publicEndpoints       []Endpoint
-	directMessaging       messaging.DirectMessaging
+	directMessaging       invokev1.DirectMessaging
 	channels              *channels.Channels
 	pubsubAdapter         runtimePubsub.Adapter
 	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/martian/log"
 	"github.com/mitchellh/mapstructure"
 	"github.com/valyala/fasthttp"
 	"go.opentelemetry.io/otel/trace"
@@ -37,7 +38,6 @@ import (
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/actors"
-	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/channel/http"
 	stateLoader "github.com/dapr/dapr/pkg/components/state"
 	"github.com/dapr/dapr/pkg/config"
@@ -46,10 +46,10 @@ import (
 	"github.com/dapr/dapr/pkg/encryption"
 	"github.com/dapr/dapr/pkg/grpc/universalapi"
 	"github.com/dapr/dapr/pkg/messages"
-	"github.com/dapr/dapr/pkg/messaging"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/utils"
 )
@@ -60,8 +60,6 @@ type API interface {
 	PublicEndpoints() []Endpoint
 	MarkStatusAsReady()
 	MarkStatusAsOutboundReady()
-	SetAppChannel(appChannel channel.AppChannel)
-	SetDirectMessaging(directMessaging messaging.DirectMessaging)
 	SetActorRuntime(actor actors.Actors)
 }
 
@@ -70,7 +68,7 @@ type api struct {
 	endpoints             []Endpoint
 	publicEndpoints       []Endpoint
 	directMessaging       messaging.DirectMessaging
-	appChannel            channel.AppChannel
+	channels              *channels.Channels
 	pubsubAdapter         runtimePubsub.Adapter
 	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	readyStatus           bool
@@ -110,8 +108,8 @@ const (
 // APIOpts contains the options for NewAPI.
 type APIOpts struct {
 	UniversalAPI          *universalapi.UniversalAPI
-	AppChannel            channel.AppChannel
-	DirectMessaging       messaging.DirectMessaging
+	Channels              *channels.Channels
+	DirectMessaging       invokev1.DirectMessaging
 	PubsubAdapter         runtimePubsub.Adapter
 	SendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	TracingSpec           config.TracingSpec
@@ -122,7 +120,7 @@ type APIOpts struct {
 func NewAPI(opts APIOpts) API {
 	api := &api{
 		universal:             opts.UniversalAPI,
-		appChannel:            opts.AppChannel,
+		channels:              opts.Channels,
 		directMessaging:       opts.DirectMessaging,
 		pubsubAdapter:         opts.PubsubAdapter,
 		sendToOutputBindingFn: opts.SendToOutputBindingFn,
@@ -632,14 +630,15 @@ type UnsubscribeConfigurationResponse struct {
 }
 
 type configurationEventHandler struct {
-	api        *api
-	storeName  string
-	appChannel channel.AppChannel
-	res        resiliency.Provider
+	api       *api
+	storeName string
+	channels  *channels.Channels
+	res       resiliency.Provider
 }
 
 func (h *configurationEventHandler) updateEventHandler(ctx context.Context, e *configuration.UpdateEvent) error {
-	if h.appChannel == nil {
+	appChannel := h.channels.AppChannel()
+	if appChannel == nil {
 		err := fmt.Errorf("app channel is nil. unable to send configuration update from %s", h.storeName)
 		log.Error(err)
 		return err
@@ -661,7 +660,7 @@ func (h *configurationEventHandler) updateEventHandler(ctx context.Context, e *c
 
 		policyRunner := resiliency.NewRunner[struct{}](ctx, policyDef)
 		_, err := policyRunner(func(ctx context.Context) (struct{}, error) {
-			rResp, rErr := h.appChannel.InvokeMethod(ctx, req, "")
+			rResp, rErr := appChannel.InvokeMethod(ctx, req, "")
 			if rErr != nil {
 				return struct{}{}, rErr
 			}
@@ -687,7 +686,7 @@ func (a *api) onSubscribeConfiguration(reqCtx *fasthttp.RequestCtx) {
 		log.Debug(err)
 		return
 	}
-	if a.appChannel == nil {
+	if a.channels.AppChannel() == nil {
 		msg := NewErrorResponse("ERR_APP_CHANNEL_NIL", "app channel is not initialized. cannot subscribe to configuration updates")
 		fasthttpRespond(reqCtx, fasthttpResponseWithError(nethttp.StatusInternalServerError, msg))
 		log.Debug(msg)
@@ -713,10 +712,10 @@ func (a *api) onSubscribeConfiguration(reqCtx *fasthttp.RequestCtx) {
 
 	// create handler
 	handler := &configurationEventHandler{
-		api:        a,
-		storeName:  storeName,
-		appChannel: a.appChannel,
-		res:        a.universal.Resiliency,
+		api:       a,
+		storeName: storeName,
+		channels:  a.channels,
+		res:       a.universal.Resiliency,
 	}
 
 	start := time.Now()
@@ -1972,14 +1971,6 @@ func (a *api) onQueryStateHandler() nethttp.HandlerFunc {
 			},
 		},
 	)
-}
-
-func (a *api) SetAppChannel(appChannel channel.AppChannel) {
-	a.appChannel = appChannel
-}
-
-func (a *api) SetDirectMessaging(directMessaging messaging.DirectMessaging) {
-	a.directMessaging = directMessaging
 }
 
 func (a *api) SetActorRuntime(actor actors.Actors) {

--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -197,7 +197,7 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 // 1. HTTP header 'dapr-app-id' (path is method)
 // 2. Basic auth header: `http://dapr-app-id:<service-id>@localhost:3500/<method>`
 // 3. URL parameter: `http://localhost:3500/v1.0/invoke/<app-id>/method/<method>`
-func findTargetIDAndMethod(reqPath string, headers http.Header) (string, string) {
+func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string, method string) {
 	if appID := headers.Get(daprAppID); appID != "" {
 		return appID, strings.TrimPrefix(path.Clean(reqPath), "/")
 	}

--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -197,7 +197,7 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 // 1. HTTP header 'dapr-app-id' (path is method)
 // 2. Basic auth header: `http://dapr-app-id:<service-id>@localhost:3500/<method>`
 // 3. URL parameter: `http://localhost:3500/v1.0/invoke/<app-id>/method/<method>`
-func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string, method string) {
+func findTargetIDAndMethod(reqPath string, headers http.Header) (string, string) {
 	if appID := headers.Get(daprAppID); appID != "" {
 		return appID, strings.TrimPrefix(path.Clean(reqPath), "/")
 	}
@@ -225,12 +225,12 @@ func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string
 		// - `https://example.com/method/mymethod`
 		// - `http%3A%2F%2Fexample.com/method/mymethod`
 		if idx = strings.Index(reqPath, "/method/"); idx > 0 {
-			targetID = reqPath[:idx]
-			method = reqPath[(idx + len("/method/")):]
+			targetID := reqPath[:idx]
+			method := reqPath[(idx + len("/method/")):]
 			if t, _ := url.QueryUnescape(targetID); t != "" {
 				targetID = t
 			}
-			return
+			return targetID, method
 		}
 	}
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -60,6 +60,7 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	daprt "github.com/dapr/dapr/pkg/testing"
@@ -2465,6 +2466,7 @@ func TestV1Alpha1ConfigurationUnsubscribe(t *testing.T) {
 			Resiliency: resiliency.New(nil),
 			CompStore:  compStore,
 		},
+		channels: new(channels.Channels),
 	}
 	fakeServer.StartServer(testAPI.constructConfigurationEndpoints(), nil)
 

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -54,22 +54,21 @@ const streamingUnsupportedErr = "streaming-based service invocation is enabled, 
 type messageClientConnection func(ctx context.Context, address string, id string, namespace string, customOpts ...grpc.DialOption) (*grpc.ClientConn, func(destroy bool), error)
 
 type directMessaging struct {
-	channels                       *channels.Channels
-	nonResourceHTTPEndpointChannel channel.HTTPEndpointAppChannel
-	resourceHTTPEndpointChannels   map[string]channel.HTTPEndpointAppChannel
-	connectionCreatorFn            messageClientConnection
-	appID                          string
-	mode                           modes.DaprMode
-	grpcPort                       int
-	namespace                      string
-	resolver                       nr.Resolver
-	hostAddress                    string
-	hostName                       string
-	maxRequestBodySizeMB           int
-	proxy                          Proxy
-	readBufferSize                 int
-	resiliency                     resiliency.Provider
-	compStore                      *compstore.ComponentStore
+	channels                     *channels.Channels
+	resourceHTTPEndpointChannels map[string]channel.HTTPEndpointAppChannel
+	connectionCreatorFn          messageClientConnection
+	appID                        string
+	mode                         modes.DaprMode
+	grpcPort                     int
+	namespace                    string
+	resolver                     nr.Resolver
+	hostAddress                  string
+	hostName                     string
+	maxRequestBodySizeMB         int
+	proxy                        Proxy
+	readBufferSize               int
+	resiliency                   resiliency.Provider
+	compStore                    *compstore.ComponentStore
 }
 
 type remoteApp struct {

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -35,6 +35,7 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 	"github.com/dapr/kit/logger"
 )
 
@@ -469,7 +470,7 @@ func (x *serviceInvocationCallLocalStreamServer) Recv() (*internalv1pb.InternalI
 func TestInvokeRemoteUnaryForHTTPEndpoint(t *testing.T) {
 	t.Run("channel found", func(t *testing.T) {
 		d := directMessaging{
-			resourceHTTPEndpointChannels: map[string]channel.HTTPEndpointAppChannel{"abc": &mockChannel{}},
+			channels: (new(channels.Channels)).WithEndpointChannels(map[string]channel.HTTPEndpointAppChannel{"abc": &mockChannel{}}),
 		}
 
 		_, err := d.invokeRemoteUnaryForHTTPEndpoint(context.Background(), nil, "abc")
@@ -477,7 +478,9 @@ func TestInvokeRemoteUnaryForHTTPEndpoint(t *testing.T) {
 	})
 
 	t.Run("channel not found", func(t *testing.T) {
-		d := directMessaging{}
+		d := directMessaging{
+			channels: new(channels.Channels),
+		}
 
 		_, err := d.invokeRemoteUnaryForHTTPEndpoint(context.Background(), nil, "abc")
 		assert.Error(t, err)

--- a/pkg/messaging/v1/messaging.go
+++ b/pkg/messaging/v1/messaging.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 /*
 Copyright 2021 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,19 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpc
+package v1
 
 import (
-	"github.com/dapr/dapr/pkg/modes"
+	"context"
 )
 
-// GetDialAddressPrefix returns a dial prefix for a gRPC client connections for a given DaprMode.
-// This is used on non-Windows hosts.
-func GetDialAddressPrefix(mode modes.DaprMode) string {
-	switch mode {
-	case modes.KubernetesMode:
-		return "dns:///"
-	default:
-		return ""
-	}
+// DirectMessaging is the API interface for invoking a remote app.
+type DirectMessaging interface {
+	Invoke(ctx context.Context, targetAppID string, req *InvokeMethodRequest) (*InvokeMethodResponse, error)
 }

--- a/pkg/runtime/channels/channels.go
+++ b/pkg/runtime/channels/channels.go
@@ -259,7 +259,6 @@ func (c *Channels) initEndpointChannels() (map[string]channel.HTTPEndpointAppCha
 
 	channels := make(map[string]channel.HTTPEndpointAppChannel, len(endpoints))
 	if len(endpoints) > 0 {
-
 		pipeline, err := c.buildHTTPPipeline(c.appHTTPPipelineSpec)
 		if err != nil {
 			return nil, err

--- a/pkg/runtime/channels/unittest.go
+++ b/pkg/runtime/channels/unittest.go
@@ -1,0 +1,36 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channels
+
+import "github.com/dapr/dapr/pkg/channel"
+
+// WithAppChannel is used for testing to override the underlying app channel.
+func (c *Channels) WithAppChannel(appChannel channel.AppChannel) *Channels {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.appChannel = appChannel
+	return c
+}
+
+// WithEndpointChannels is used for testing to override the underlying endpoint
+// channels.
+func (c *Channels) WithEndpointChannels(endpChannels map[string]channel.HTTPEndpointAppChannel) *Channels {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.endpChannels = endpChannels
+	return c
+}

--- a/pkg/runtime/processor/binding/binding.go
+++ b/pkg/runtime/processor/binding/binding.go
@@ -24,12 +24,12 @@ import (
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/apis/common"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
-	"github.com/dapr/dapr/pkg/channel"
 	compbindings "github.com/dapr/dapr/pkg/components/bindings"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
-	"github.com/dapr/dapr/pkg/grpc"
+	"github.com/dapr/dapr/pkg/grpc/manager"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/meta"
@@ -55,8 +55,9 @@ type Options struct {
 	ComponentStore *compstore.ComponentStore
 	Meta           *meta.Meta
 	Resiliency     resiliency.Provider
-	GRPC           *grpc.Manager
+	GRPC           *manager.Manager
 	TracingSpec    *config.TracingSpec
+	Channels       *channels.Channels
 }
 
 type binding struct {
@@ -66,9 +67,9 @@ type binding struct {
 	resiliency  resiliency.Provider
 	compStore   *compstore.ComponentStore
 	meta        *meta.Meta
-	appChannel  channel.AppChannel
+	channels    *channels.Channels
 	tracingSpec *config.TracingSpec
-	grpc        *grpc.Manager
+	grpc        *manager.Manager
 
 	lock sync.Mutex
 
@@ -86,11 +87,8 @@ func New(opts Options) *binding {
 		resiliency:  opts.Resiliency,
 		tracingSpec: opts.TracingSpec,
 		grpc:        opts.GRPC,
+		channels:    opts.Channels,
 	}
-}
-
-func (b *binding) SetAppChannel(appChannel channel.AppChannel) {
-	b.appChannel = appChannel
 }
 
 func (b *binding) Init(ctx context.Context, comp compapi.Component) error {

--- a/pkg/runtime/processor/binding/send.go
+++ b/pkg/runtime/processor/binding/send.go
@@ -43,7 +43,7 @@ func (b *binding) StartReadingFromBindings(ctx context.Context) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	if b.appChannel == nil {
+	if b.channels.AppChannel() == nil {
 		return errors.New("app channel not initialized")
 	}
 
@@ -334,7 +334,7 @@ func (b *binding) sendBindingEventToApp(ctx context.Context, bindingName string,
 			},
 		)
 		resp, err := policyRunner(func(ctx context.Context) (*invokev1.InvokeMethodResponse, error) {
-			rResp, rErr := b.appChannel.InvokeMethod(ctx, req, "")
+			rResp, rErr := b.channels.AppChannel().InvokeMethod(ctx, req, "")
 			if rErr != nil {
 				return rResp, rErr
 			}
@@ -441,7 +441,7 @@ func (b *binding) isAppSubscribedToBinding(ctx context.Context, binding string) 
 			WithContentType(invokev1.JSONContentType)
 		defer req.Close()
 
-		resp, err := b.appChannel.InvokeMethod(ctx, req, "")
+		resp, err := b.channels.AppChannel().InvokeMethod(ctx, req, "")
 		if err != nil {
 			log.Fatalf("could not invoke OPTIONS method on input binding subscription endpoint %q: %v", path, err)
 		}

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -43,7 +43,6 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/processor/secret"
 	"github.com/dapr/dapr/pkg/runtime/processor/state"
 	"github.com/dapr/dapr/pkg/runtime/processor/workflow"
-	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/pkg/runtime/registry"
 )
 
@@ -149,15 +148,12 @@ func New(opts Options) *Processor {
 		ResourcesPath:  opts.Standalone.ResourcesPath,
 	})
 
-	outbox := runtimePubsub.NewOutbox(ps.Publish, opts.ComponentStore.GetPubSubComponent, opts.ComponentStore.GetStateStore, pubsub.ExtractCloudEventProperty, opts.Namespace)
-	ps.SetOutbox(outbox)
-
 	state := state.New(state.Options{
 		PlacementEnabled: opts.PlacementEnabled,
 		Registry:         opts.Registry.StateStores(),
 		ComponentStore:   opts.ComponentStore,
 		Meta:             opts.Meta,
-		Outbox:           outbox,
+		Outbox:           ps.Outbox(),
 	})
 
 	binding := binding.New(binding.Options{

--- a/pkg/runtime/processor/pubsub/bulk_subscriber.go
+++ b/pkg/runtime/processor/pubsub/bulk_subscriber.go
@@ -389,7 +389,7 @@ func (p *pubsub) publishBulkMessageHTTP(ctx context.Context, bulkSubCallData *bu
 	spans = spans[:n]
 	defer endSpans(spans)
 	start := time.Now()
-	resp, err := p.appChannel.InvokeMethod(ctx, req, "")
+	resp, err := p.channels.AppChannel().InvokeMethod(ctx, req, "")
 	elapsed := diag.ElapsedSince(start)
 	if err != nil {
 		bscData.bulkSubDiag.statusWiseDiag[string(contribpubsub.Retry)] += int64(len(rawMsgEntries))

--- a/pkg/runtime/processor/pubsub/bulk_subscriber_test.go
+++ b/pkg/runtime/processor/pubsub/bulk_subscriber_test.go
@@ -36,7 +36,7 @@ import (
 	componentsV1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
 	"github.com/dapr/dapr/pkg/config"
-	daprgrpc "github.com/dapr/dapr/pkg/grpc"
+	"github.com/dapr/dapr/pkg/grpc/manager"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -145,6 +145,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.registry.RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -168,7 +169,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(fakeResp, nil)
 
@@ -198,6 +199,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.registry.RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -219,7 +221,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(fakeResp, nil)
 
@@ -251,6 +253,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ms := &mockSubscribePubSub{
 			features: []contribpubsub.Feature{contribpubsub.FeatureBulkPublish},
@@ -276,7 +279,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 		fakeResp1 := invokev1.NewInvokeMethodResponse(200, "OK", nil)
 		defer fakeResp1.Close()
@@ -311,7 +314,7 @@ func TestBulkSubscribe(t *testing.T) {
 		defer fakeResp2.Close()
 		mockAppChannel1 := new(channelt.MockAppChannel)
 		mockAppChannel1.Init()
-		ps.appChannel = mockAppChannel1
+		ps.channels.WithAppChannel(mockAppChannel1)
 		mockAppChannel1.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(fakeResp2, nil)
 
 		msgArr = getBulkMessageEntries(3)
@@ -338,7 +341,7 @@ func TestBulkSubscribe(t *testing.T) {
 		defer fakeResp3.Close()
 		mockAppChannel2 := new(channelt.MockAppChannel)
 		mockAppChannel2.Init()
-		ps.appChannel = mockAppChannel2
+		ps.channels.WithAppChannel(mockAppChannel2)
 		mockAppChannel2.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(fakeResp3, nil)
 
 		msgArr = getBulkMessageEntries(4)
@@ -364,7 +367,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel3 := new(channelt.MockAppChannel)
 		mockAppChannel3.Init()
-		ps.appChannel = mockAppChannel3
+		ps.channels.WithAppChannel(mockAppChannel3)
 		mockAppChannel3.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(nil, errors.New("Mock error"))
 		msgArr = getBulkMessageEntries(1)
 
@@ -393,6 +396,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.registry.RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -430,7 +434,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(fakeResp, nil)
 
@@ -467,6 +471,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.registry.RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -504,7 +509,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -595,6 +600,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.registry.RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -621,7 +627,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -685,6 +691,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.registry.RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -711,7 +718,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -779,6 +786,7 @@ func TestBulkSubscribe(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.registry.RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -805,7 +813,7 @@ func TestBulkSubscribe(t *testing.T) {
 
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).Return(fakeResp, nil)
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -887,6 +895,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         false,
+			Channels:       new(channels.Channels),
 		})
 		ms := &mockSubscribePubSub{
 			features: []contribpubsub.Feature{contribpubsub.FeatureBulkPublish},
@@ -942,10 +951,10 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			defer grpcServer.Stop()
 		}
 
-		grpc := daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port})
+		grpc := manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port})
 
 		// create a new AppChannel and gRPC client for every test
-		ch, err := channels.New(channels.Options{
+		ps.channels = channels.New(channels.Options{
 			ComponentStore: compstore.New(),
 			Registry:       reg,
 			GlobalConfig:   new(config.Configuration),
@@ -954,8 +963,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 				Port: port,
 			},
 		})
-		require.NoError(t, err)
-		ps.appChannel = ch.AppChannel()
+		require.NoError(t, ps.channels.Refresh())
 		ps.grpc = grpc
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -1017,6 +1025,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         false,
+			Channels:       new(channels.Channels),
 		})
 
 		ps.registry.RegisterComponent(
@@ -1103,16 +1112,15 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 		}
 
 		// create a new AppChannel and gRPC client for every test
-		grpc := daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port})
-		ch, err := channels.New(channels.Options{
+		grpc := manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port})
+		ps.channels = channels.New(channels.Options{
 			ComponentStore:      compstore.New(),
 			Registry:            reg,
 			GlobalConfig:        new(config.Configuration),
 			AppConnectionConfig: config.AppConnectionConfig{Port: port},
 			GRPC:                grpc,
 		})
-		require.NoError(t, err)
-		ps.appChannel = ch.AppChannel()
+		require.NoError(t, ps.channels.Refresh())
 		ps.grpc = grpc
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -1159,6 +1167,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         false,
+			Channels:       new(channels.Channels),
 		})
 
 		ps.registry.RegisterComponent(
@@ -1210,8 +1219,8 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			defer grpcServer.Stop()
 		}
 
-		grpc := daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port})
-		ch, err := channels.New(channels.Options{
+		grpc := manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port})
+		ps.channels = channels.New(channels.Options{
 			ComponentStore:      compstore.New(),
 			Registry:            reg,
 			GlobalConfig:        new(config.Configuration),
@@ -1219,7 +1228,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			AppConnectionConfig: config.AppConnectionConfig{Port: port},
 		})
 		require.NoError(t, err)
-		ps.appChannel = ch.AppChannel()
+		require.NoError(t, ps.channels.Refresh())
 		ps.grpc = grpc
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -1257,6 +1266,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         false,
+			Channels:       new(channels.Channels),
 		})
 
 		ps.registry.RegisterComponent(
@@ -1319,8 +1329,8 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			defer grpcServer.Stop()
 		}
 
-		grpc := daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port})
-		ch, err := channels.New(channels.Options{
+		grpc := manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port})
+		ps.channels = channels.New(channels.Options{
 			ComponentStore:      compstore.New(),
 			Registry:            reg,
 			GlobalConfig:        new(config.Configuration),
@@ -1328,7 +1338,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			AppConnectionConfig: config.AppConnectionConfig{Port: port},
 		})
 		require.NoError(t, err)
-		ps.appChannel = ch.AppChannel()
+		require.NoError(t, ps.channels.Refresh())
 		ps.grpc = grpc
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -1367,6 +1377,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         false,
+			Channels:       new(channels.Channels),
 		})
 
 		ps.registry.RegisterComponent(
@@ -1423,8 +1434,8 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			defer grpcServer.Stop()
 		}
 
-		grpc := daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port})
-		ch, err := channels.New(channels.Options{
+		grpc := manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port})
+		ps.channels = channels.New(channels.Options{
 			ComponentStore:      compstore.New(),
 			Registry:            reg,
 			GlobalConfig:        new(config.Configuration),
@@ -1432,7 +1443,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			AppConnectionConfig: config.AppConnectionConfig{Port: port},
 		})
 		require.NoError(t, err)
-		ps.appChannel = ch.AppChannel()
+		require.NoError(t, ps.channels.Refresh())
 		ps.grpc = grpc
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -1471,6 +1482,7 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         false,
+			Channels:       new(channels.Channels),
 		})
 
 		ps.registry.RegisterComponent(
@@ -1513,16 +1525,15 @@ func TestBulkSubscribeGRPC(t *testing.T) {
 			defer grpcServer.Stop()
 		}
 
-		grpc := daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port})
-		ch, err := channels.New(channels.Options{
+		grpc := manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port})
+		ps.channels = channels.New(channels.Options{
 			ComponentStore:      compstore.New(),
 			Registry:            reg,
 			GlobalConfig:        new(config.Configuration),
 			GRPC:                grpc,
 			AppConnectionConfig: config.AppConnectionConfig{Port: port},
 		})
-		require.NoError(t, err)
-		ps.appChannel = ch.AppChannel()
+		require.NoError(t, ps.channels.Refresh())
 		ps.grpc = grpc
 
 		require.NoError(t, ps.Init(context.TODO(), pubsubComponent))
@@ -1761,6 +1772,7 @@ func TestPubSubDeadLetter(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		reg.PubSubs().RegisterComponent(
 			func(_ logger.Logger) contribpubsub.PubSub {
@@ -1780,7 +1792,7 @@ func TestPubSubDeadLetter(t *testing.T) {
 		defer fakeResp.Close()
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.
 			On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).
 			Return(fakeResp, nil)
@@ -1815,6 +1827,7 @@ func TestPubSubDeadLetter(t *testing.T) {
 			Resiliency:     resiliency.New(log),
 			ComponentStore: compstore.New(),
 			IsHTTP:         true,
+			Channels:       new(channels.Channels),
 		})
 		ps.resiliency = resiliency.FromConfigurations(logger.NewLogger("test"), daprt.TestResiliency)
 		reg.PubSubs().RegisterComponent(
@@ -1835,7 +1848,7 @@ func TestPubSubDeadLetter(t *testing.T) {
 		defer fakeResp.Close()
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels.WithAppChannel(mockAppChannel)
 		mockAppChannel.
 			On("InvokeMethod", mock.MatchedBy(matchContextInterface), matchDaprRequestMethod("dapr/subscribe")).
 			Return(fakeResp, nil)

--- a/pkg/runtime/processor/pubsub/bulksub_resiliency_test.go
+++ b/pkg/runtime/processor/pubsub/bulksub_resiliency_test.go
@@ -28,6 +28,7 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/resiliency/breaker"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/pkg/runtime/registry"
 	"github.com/dapr/kit/logger"
@@ -221,7 +222,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 			IsHTTP:     true,
 			Resiliency: resiliency.New(logger.NewLogger("test")),
 		})
-		ps.SetAppChannel(mockAppChannel)
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -290,7 +291,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -359,7 +360,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -428,7 +429,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -497,7 +498,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -555,7 +556,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -640,7 +641,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -725,7 +726,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -801,7 +802,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -914,7 +915,7 @@ func TestBulkSubscribeResiliency(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -987,7 +988,7 @@ func TestBulkSubscribeResiliencyStateConversionsFromHalfOpen(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},
@@ -1154,7 +1155,7 @@ func TestBulkSubscribeResiliencyWithLongRetries(t *testing.T) {
 		})
 		mockAppChannel := new(channelt.MockAppChannel)
 		mockAppChannel.Init()
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		ts := testSettings{
 			entryIdRetryTimes: map[string]int{},

--- a/pkg/runtime/processor/pubsub/publish.go
+++ b/pkg/runtime/processor/pubsub/publish.go
@@ -116,7 +116,7 @@ func (p *pubsub) publishMessageHTTP(ctx context.Context, msg *subscribedMessage)
 	}
 
 	start := time.Now()
-	resp, err := p.appChannel.InvokeMethod(ctx, req, "")
+	resp, err := p.channels.AppChannel().InvokeMethod(ctx, req, "")
 	elapsed := diag.ElapsedSince(start)
 
 	if err != nil {

--- a/pkg/runtime/processor/pubsub/publish_test.go
+++ b/pkg/runtime/processor/pubsub/publish_test.go
@@ -35,7 +35,7 @@ import (
 	contribpubsub "github.com/dapr/components-contrib/pubsub"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
 	"github.com/dapr/dapr/pkg/config"
-	daprgrpc "github.com/dapr/dapr/pkg/grpc"
+	"github.com/dapr/dapr/pkg/grpc/manager"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -89,7 +89,7 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 
 	t.Run("ok without result body", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 
@@ -110,7 +110,7 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 
 	t.Run("ok with retry", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 
@@ -130,7 +130,7 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 
 	t.Run("ok with drop", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 
@@ -150,7 +150,7 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 
 	t.Run("ok with unknown", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 
@@ -170,7 +170,7 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 
 	t.Run("not found response", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 
@@ -207,7 +207,7 @@ func TestErrorPublishedNonCloudEventGRPC(t *testing.T) {
 		Mode:           modes.StandaloneMode,
 		Namespace:      "ns1",
 		ID:             TestRuntimeConfigID,
-		GRPC:           daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{}),
+		GRPC:           manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{}),
 	})
 	ps.compStore.SetTopicRoutes(map[string]compstore.TopicRoutes{
 		TestPubsubName: map[string]compstore.TopicRouteElem{
@@ -321,7 +321,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app with empty response", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		var appResp contribpubsub.AppResponse
@@ -342,7 +342,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message without TraceID", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		var appResp contribpubsub.AppResponse
@@ -385,7 +385,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app with non-json response", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
@@ -405,7 +405,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app with status", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
@@ -425,7 +425,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app but app ask for retry", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
@@ -448,7 +448,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app but app ask to drop", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
@@ -468,7 +468,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app but app returned unknown status code", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
@@ -488,7 +488,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app but app returned empty status code", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
@@ -508,7 +508,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("succeeded to publish message to user app and app returned unexpected json response", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
@@ -528,7 +528,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("failed to publish message error on invoking method", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 		invokeError := errors.New("error invoking method")
 
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), fakeReq).Return(nil, invokeError)
@@ -544,7 +544,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("failed to publish message to user app with 404", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		fakeResp := invokev1.NewInvokeMethodResponse(404, "Not Found", nil).
 			WithRawDataString("Not found").
@@ -563,7 +563,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 	t.Run("failed to publish message to user app with 500", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		fakeResp := invokev1.NewInvokeMethodResponse(500, "Internal Error", nil).
 			WithRawDataString("Internal Error").
@@ -738,7 +738,7 @@ func TestOnNewPublishedMessageGRPC(t *testing.T) {
 				Mode:           modes.StandaloneMode,
 				Namespace:      "ns1",
 				ID:             TestRuntimeConfigID,
-				GRPC:           daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port}),
+				GRPC:           manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port}),
 			})
 			ps.compStore.SetTopicRoutes(map[string]compstore.TopicRoutes{
 				TestPubsubName: map[string]compstore.TopicRouteElem{
@@ -768,16 +768,15 @@ func TestOnNewPublishedMessageGRPC(t *testing.T) {
 				defer grpcServer.Stop()
 			}
 
-			grpc := daprgrpc.NewGRPCManager(modes.StandaloneMode, &daprgrpc.AppChannelConfig{Port: port})
-			ch, err := channels.New(channels.Options{
+			grpc := manager.NewManager(modes.StandaloneMode, &manager.AppChannelConfig{Port: port})
+			ps.channels = channels.New(channels.Options{
 				ComponentStore:      compstore.New(),
 				Registry:            reg,
 				GlobalConfig:        new(config.Configuration),
 				AppConnectionConfig: config.AppConnectionConfig{Port: port},
 				GRPC:                grpc,
 			})
-			require.NoError(t, err)
-			ps.appChannel = ch.AppChannel()
+			require.NoError(t, ps.channels.Refresh())
 			ps.grpc = grpc
 
 			// act

--- a/pkg/runtime/processor/pubsub/pubsub.go
+++ b/pkg/runtime/processor/pubsub/pubsub.go
@@ -78,7 +78,6 @@ type Options struct {
 	GRPC           *manager.Manager
 	Channels       *channels.Channels
 	OperatorClient operatorv1.OperatorClient
-	Outbox         outbox.Outbox
 }
 
 type pubsub struct {
@@ -114,7 +113,7 @@ type subscribedMessage struct {
 }
 
 func New(opts Options) *pubsub {
-	return &pubsub{
+	ps := &pubsub{
 		id:             opts.ID,
 		namespace:      opts.Namespace,
 		isHTTP:         opts.IsHTTP,
@@ -129,9 +128,11 @@ func New(opts Options) *pubsub {
 		grpc:           opts.GRPC,
 		channels:       opts.Channels,
 		operatorClient: opts.OperatorClient,
-		outbox:         opts.Outbox,
 		topicCancels:   make(map[string]context.CancelFunc),
 	}
+
+	ps.outbox = rtpubsub.NewOutbox(ps.Publish, opts.ComponentStore.GetPubSubComponent, opts.ComponentStore.GetStateStore, ExtractCloudEventProperty, opts.Namespace)
+	return ps
 }
 
 func (p *pubsub) Init(ctx context.Context, comp compapi.Component) error {
@@ -201,6 +202,10 @@ func (p *pubsub) Close(comp compapi.Component) error {
 	p.compStore.DeletePubSub(comp.Name)
 
 	return nil
+}
+
+func (p *pubsub) Outbox() outbox.Outbox {
+	return p.outbox
 }
 
 // findMatchingRoute selects the path based on routing rules. If there are

--- a/pkg/runtime/processor/pubsub/pubsub_test.go
+++ b/pkg/runtime/processor/pubsub/pubsub_test.go
@@ -45,6 +45,7 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/channels"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	"github.com/dapr/dapr/pkg/runtime/meta"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
@@ -131,7 +132,7 @@ func TestInitPubSub(t *testing.T) {
 			mock.AnythingOfType("pubsub.Handler")).Return(nil)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 		ps.StopSubscriptions()
 		ps.compStore.SetTopicRoutes(nil)
 		ps.compStore.SetSubscriptions(nil)
@@ -146,7 +147,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 		// User App subscribes 2 topics via http app channel
 		subs := getSubscriptionsJSONString(
 			[]string{"topic0", "topic1"}, // first pubsub
@@ -180,7 +181,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, _ := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes to a topic via http app channel
 		sub := getSubscriptionCustom("topic0", "customroute/topic0")
@@ -210,7 +211,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, _ := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		fakeResp := invokev1.NewInvokeMethodResponse(404, "Not Found", nil)
 		defer fakeResp.Close()
@@ -242,6 +243,7 @@ func TestInitPubSub(t *testing.T) {
 			Mode:           modes.StandaloneMode,
 			Namespace:      "ns1",
 			ID:             TestRuntimeConfigID,
+			Channels:       new(channels.Channels),
 		})
 		routes, err := pst.topicRoutes(context.Background())
 		assert.NoError(t, err)
@@ -257,6 +259,7 @@ func TestInitPubSub(t *testing.T) {
 			Mode:       modes.StandaloneMode,
 			Namespace:  "ns1",
 			ID:         TestRuntimeConfigID,
+			Channels:   new(channels.Channels),
 		})
 
 		require.NoError(t, os.Mkdir(resourcesDir, 0o777))
@@ -288,6 +291,7 @@ func TestInitPubSub(t *testing.T) {
 			Mode:       modes.StandaloneMode,
 			Namespace:  "ns1",
 			ID:         TestRuntimeConfigID,
+			Channels:   new(channels.Channels),
 		})
 
 		require.NoError(t, os.Mkdir(resourcesDir, 0o777))
@@ -320,6 +324,7 @@ func TestInitPubSub(t *testing.T) {
 			Resiliency: resiliency.New(logger.NewLogger("test")),
 			Namespace:  "ns1",
 			ID:         TestRuntimeConfigID,
+			Channels:   new(channels.Channels),
 		})
 
 		require.NoError(t, os.Mkdir(resourcesDir, 0o777))
@@ -341,7 +346,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic0"}, []string{"topic1"})
@@ -371,7 +376,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic10"}, []string{"topic11"})
@@ -401,7 +406,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 2 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic0", "topic1"}, []string{"topic0"})
@@ -431,7 +436,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 2 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic10", "topic11"}, []string{"topic10"})
@@ -461,7 +466,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic3"}, []string{"topic5"})
@@ -489,7 +494,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic12"}, []string{"topic12"})
@@ -517,7 +522,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		// topic0 is allowed, topic3 and topic5 are not
@@ -548,7 +553,7 @@ func TestInitPubSub(t *testing.T) {
 		mockPubSub, mockPubSub2 := initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		// topic0 is allowed, topic3 and topic5 are not
@@ -795,7 +800,7 @@ func TestInitPubSub(t *testing.T) {
 		initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic0"}, []string{"topic1"})
@@ -839,7 +844,7 @@ func TestInitPubSub(t *testing.T) {
 		initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic0"}, []string{"topic1"})
@@ -887,7 +892,7 @@ func TestInitPubSub(t *testing.T) {
 		initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic0"}, []string{"topic0"})
@@ -928,7 +933,7 @@ func TestInitPubSub(t *testing.T) {
 		initMockPubSubForRuntime(ps)
 
 		mockAppChannel := new(channelt.MockAppChannel)
-		ps.appChannel = mockAppChannel
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
 		// User App subscribes 1 topics via http app channel
 		subs := getSubscriptionsJSONString([]string{"topic0"}, []string{"topic0"})
@@ -1375,7 +1380,7 @@ func TestPubsubWithResiliency(t *testing.T) {
 	})
 
 	ps.isHTTP = true
-	ps.appChannel = &failingAppChannel
+	ps.channels = new(channels.Channels).WithAppChannel(&failingAppChannel)
 
 	t.Run("pubsub retries subscription event with resiliency", func(t *testing.T) {
 		ps.compStore.SetTopicRoutes(map[string]compstore.TopicRoutes{

--- a/pkg/runtime/processor/pubsub/subscribe.go
+++ b/pkg/runtime/processor/pubsub/subscribe.go
@@ -85,7 +85,7 @@ func (p *pubsub) topicRoutes(ctx context.Context) (map[string]compstore.TopicRou
 
 	topicRoutes := make(map[string]compstore.TopicRoutes)
 
-	if p.appChannel == nil {
+	if p.channels.AppChannel() == nil {
 		log.Warn("app channel not initialized, make sure -app-port is specified if pubsub subscription is required")
 		return topicRoutes, nil
 	}
@@ -132,7 +132,8 @@ func (p *pubsub) subscriptions(ctx context.Context) ([]rtpubsub.Subscription, er
 		return subs, nil
 	}
 
-	if p.appChannel == nil {
+	appChannel := p.channels.AppChannel()
+	if appChannel == nil {
 		log.Warn("app channel not initialized, make sure -app-port is specified if pubsub subscription is required")
 		return nil, nil
 	}
@@ -144,7 +145,7 @@ func (p *pubsub) subscriptions(ctx context.Context) ([]rtpubsub.Subscription, er
 
 	// handle app subscriptions
 	if p.isHTTP {
-		subscriptions, err = rtpubsub.GetSubscriptionsHTTP(ctx, p.appChannel, log, p.resiliency)
+		subscriptions, err = rtpubsub.GetSubscriptionsHTTP(ctx, appChannel, log, p.resiliency)
 	} else {
 		var conn grpc.ClientConnInterface
 		conn, err = p.grpc.GetAppClient()

--- a/pkg/runtime/registry/registry.go
+++ b/pkg/runtime/registry/registry.go
@@ -25,7 +25,7 @@ import (
 	"github.com/dapr/dapr/pkg/components/secretstores"
 	"github.com/dapr/dapr/pkg/components/state"
 	"github.com/dapr/dapr/pkg/components/workflows"
-	"github.com/dapr/dapr/pkg/messaging"
+	messagingv1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 )
 
@@ -33,7 +33,7 @@ type ComponentsCallback func(components ComponentRegistry) error
 
 type ComponentRegistry struct {
 	Actors          actors.Actors
-	DirectMessaging messaging.DirectMessaging
+	DirectMessaging messagingv1.DirectMessaging
 	CompStore       *compstore.ComponentStore
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -53,11 +53,13 @@ import (
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/dapr/dapr/pkg/grpc"
+	"github.com/dapr/dapr/pkg/grpc/manager"
 	"github.com/dapr/dapr/pkg/grpc/universalapi"
 	"github.com/dapr/dapr/pkg/http"
 	"github.com/dapr/dapr/pkg/httpendpoint"
 	"github.com/dapr/dapr/pkg/internal/apis"
 	"github.com/dapr/dapr/pkg/messaging"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
 	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/operator/client"
@@ -109,10 +111,10 @@ type DaprRuntime struct {
 	runtimeConfig     *internalConfig
 	globalConfig      *config.Configuration
 	accessControlList *config.AccessControlList
-	grpc              *grpc.Manager
+	grpc              *manager.Manager
 	channels          *channels.Channels
 	appConfig         config.ApplicationConfig
-	directMessaging   messaging.DirectMessaging
+	directMessaging   invokev1.DirectMessaging
 	actor             actors.Actors
 
 	nameResolver            nr.Resolver
@@ -178,6 +180,17 @@ func newDaprRuntime(ctx context.Context,
 	wfe := wfengine.NewWorkflowEngine(wfengine.NewWorkflowConfig(runtimeConfig.id))
 	wfe.ConfigureGrpcExecutor()
 
+	channels := channels.New(channels.Options{
+		Registry:            runtimeConfig.registry,
+		ComponentStore:      compStore,
+		Meta:                meta,
+		AppConnectionConfig: runtimeConfig.appConnectionConfig,
+		GlobalConfig:        globalConfig,
+		MaxRequestBodySize:  runtimeConfig.maxRequestBodySize,
+		ReadBufferSize:      runtimeConfig.readBufferSize,
+		GRPC:                grpc,
+	})
+
 	rt := &DaprRuntime{
 		runtimeConfig:              runtimeConfig,
 		globalConfig:               globalConfig,
@@ -193,6 +206,7 @@ func newDaprRuntime(ctx context.Context,
 		compStore:                  compStore,
 		meta:                       meta,
 		operatorClient:             operatorClient,
+		channels:                   channels,
 		processor: processor.New(processor.Options{
 			ID:               runtimeConfig.id,
 			Namespace:        getNamespace(),
@@ -208,6 +222,7 @@ func newDaprRuntime(ctx context.Context,
 			Standalone:       runtimeConfig.standalone,
 			OperatorClient:   operatorClient,
 			GRPC:             grpc,
+			Channels:         channels,
 		}),
 	}
 
@@ -407,6 +422,11 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 		log.Errorf(err.Error())
 	}
 
+	// Start proxy
+	a.initProxy()
+
+	a.initDirectMessaging(a.nameResolver)
+
 	a.initPluggableComponents(ctx)
 
 	if _, ok := os.LookupEnv(hotReloadingEnvVar); ok {
@@ -436,9 +456,11 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 		log.Warnf("failed to load HTTP endpoints: %s", err)
 	}
 
-	a.initChannels()
-
 	a.flushOutstandingHTTPEndpoints(ctx)
+
+	if err = a.channels.Refresh(); err != nil {
+		log.Warnf("failed to open %s channel to app: %s", string(a.runtimeConfig.appConnectionConfig.Protocol), err)
+	}
 
 	pipeline, err := a.channels.BuildHTTPPipeline(a.globalConfig.Spec.HTTPPipelineSpec)
 	if err != nil {
@@ -447,9 +469,6 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 
 	// Setup allow/deny list for secrets
 	a.populateSecretsConfiguration()
-
-	// Start proxy
-	a.initProxy()
 
 	// Create and start the external gRPC server
 	univAPI := &universalapi.UniversalAPI{
@@ -516,15 +535,6 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	if err := a.blockUntilAppIsReady(ctx); err != nil {
 		return err
 	}
-
-	a.daprHTTPAPI.SetAppChannel(a.channels.AppChannel())
-	a.daprGRPCAPI.SetAppChannel(a.channels.AppChannel())
-	a.directMessaging.SetAppChannel(a.channels.AppChannel())
-
-	a.directMessaging.SetHTTPEndpointsAppChannels(a.channels.HTTPEndpointsAppChannel(), a.channels.EndpointChannels())
-
-	a.daprHTTPAPI.SetDirectMessaging(a.directMessaging)
-	a.daprGRPCAPI.SetDirectMessaging(a.directMessaging)
 
 	if a.runtimeConfig.appConnectionConfig.MaxConcurrency > 0 {
 		log.Infof("app max concurrency set to %v", a.runtimeConfig.appConnectionConfig.MaxConcurrency)
@@ -673,7 +683,7 @@ func (a *DaprRuntime) initDirectMessaging(resolver nr.Resolver) {
 		Namespace:          a.namespace,
 		Port:               a.runtimeConfig.internalGRPCPort,
 		Mode:               a.runtimeConfig.mode,
-		AppChannel:         a.channels.AppChannel(),
+		Channels:           a.channels,
 		ClientConnFn:       a.grpc.GetGRPCConnection,
 		Resolver:           resolver,
 		MaxRequestBodySize: a.runtimeConfig.maxRequestBodySize,
@@ -693,24 +703,6 @@ func (a *DaprRuntime) initProxy() {
 		Resiliency:         a.resiliency,
 		MaxRequestBodySize: a.runtimeConfig.maxRequestBodySize,
 	})
-}
-
-func (a *DaprRuntime) initChannels() {
-	var err error
-	a.channels, err = channels.New(channels.Options{
-		Registry:            a.runtimeConfig.registry,
-		ComponentStore:      a.compStore,
-		Meta:                a.meta,
-		AppConnectionConfig: a.runtimeConfig.appConnectionConfig,
-		GlobalConfig:        a.globalConfig,
-		MaxRequestBodySize:  a.runtimeConfig.maxRequestBodySize,
-		ReadBufferSize:      a.runtimeConfig.readBufferSize,
-		GRPC:                a.grpc,
-	})
-	if err != nil {
-		log.Warnf("failed to open %s channel to app: %s", string(a.runtimeConfig.appConnectionConfig.Protocol), err)
-	}
-	a.processor.SetAppChannel(a.channels.AppChannel())
 }
 
 // begin components updates for kubernetes mode.
@@ -985,7 +977,7 @@ func (a *DaprRuntime) processHTTPEndpointSecrets(ctx context.Context, endpoint *
 func (a *DaprRuntime) startHTTPServer(port int, publicPort *int, profilePort int, allowedOrigins string, pipeline httpMiddleware.Pipeline, univAPI *universalapi.UniversalAPI) error {
 	a.daprHTTPAPI = http.NewAPI(http.APIOpts{
 		UniversalAPI:          univAPI,
-		AppChannel:            a.channels.AppChannel(),
+		Channels:              a.channels,
 		DirectMessaging:       a.directMessaging,
 		PubsubAdapter:         a.processor.PubSub(),
 		SendToOutputBindingFn: a.processor.Binding().SendToOutputBinding,
@@ -1747,8 +1739,8 @@ func componentDependency(compCategory components.Category, name string) string {
 	return fmt.Sprintf("%s:%s", compCategory, name)
 }
 
-func createGRPCManager(runtimeConfig *internalConfig, globalConfig *config.Configuration) *grpc.Manager {
-	grpcAppChannelConfig := &grpc.AppChannelConfig{}
+func createGRPCManager(runtimeConfig *internalConfig, globalConfig *config.Configuration) *manager.Manager {
+	grpcAppChannelConfig := &manager.AppChannelConfig{}
 	if globalConfig != nil {
 		grpcAppChannelConfig.TracingSpec = globalConfig.GetTracingSpec()
 		grpcAppChannelConfig.AllowInsecureTLS = globalConfig.IsFeatureEnabled(config.AppChannelAllowInsecureTLS)
@@ -1762,7 +1754,7 @@ func createGRPCManager(runtimeConfig *internalConfig, globalConfig *config.Confi
 		grpcAppChannelConfig.BaseAddress = runtimeConfig.appConnectionConfig.ChannelAddress
 	}
 
-	m := grpc.NewGRPCManager(runtimeConfig.mode, grpcAppChannelConfig)
+	m := manager.NewManager(runtimeConfig.mode, grpcAppChannelConfig)
 	m.StartCollector()
 	return m
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -486,7 +486,7 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	// Create and start internal and external gRPC servers
 	a.daprGRPCAPI = grpc.NewAPI(grpc.APIOpts{
 		UniversalAPI:          univAPI,
-		AppChannel:            a.channels.AppChannel(),
+		Channels:              a.channels,
 		PubsubAdapter:         a.processor.PubSub(),
 		DirectMessaging:       a.directMessaging,
 		SendToOutputBindingFn: a.processor.Binding().SendToOutputBinding,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1676,7 +1676,7 @@ func NewTestDaprRuntimeWithID(mode modes.DaprMode, id string) (*DaprRuntime, err
 		return nil, err
 	}
 	rt.runtimeConfig.mode = mode
-	rt.initChannels()
+	rt.channels.Refresh()
 	return rt, nil
 }
 
@@ -1687,7 +1687,7 @@ func NewTestDaprRuntimeWithProtocol(mode modes.DaprMode, protocol string, appPor
 		return nil, err
 	}
 	rt.runtimeConfig.mode = mode
-	rt.initChannels()
+	rt.channels.Refresh()
 	return rt, nil
 }
 
@@ -2108,7 +2108,7 @@ func TestInitActors(t *testing.T) {
 		}, &config.Configuration{}, &config.AccessControlList{}, resiliency.New(logger.NewLogger("test")))
 		require.NoError(t, err)
 		defer stopRuntime(t, r)
-		r.initChannels()
+		r.channels.Refresh()
 
 		err = r.initActors(context.TODO())
 		assert.NotNil(t, err)
@@ -2121,7 +2121,7 @@ func TestInitActors(t *testing.T) {
 		}, &config.Configuration{}, &config.AccessControlList{}, resiliency.New(logger.NewLogger("test")))
 		require.NoError(t, err)
 		defer stopRuntime(t, r)
-		r.initChannels()
+		r.channels.Refresh()
 
 		assert.Nil(t, r.actor)
 		assert.NotNil(t, r.compStore.ListStateStores())
@@ -2135,7 +2135,7 @@ func TestInitActors(t *testing.T) {
 		}, &config.Configuration{}, &config.AccessControlList{}, resiliency.New(logger.NewLogger("test")))
 		require.NoError(t, err)
 		defer stopRuntime(t, r)
-		r.initChannels()
+		r.channels.Refresh()
 
 		name, ok := r.processor.State().ActorStateStoreName()
 		assert.False(t, ok)
@@ -3094,9 +3094,9 @@ func TestGracefulShutdownPubSub(t *testing.T) {
 		Resiliency:       rt.resiliency,
 		Mode:             rt.runtimeConfig.mode,
 		Standalone:       rt.runtimeConfig.standalone,
+		Channels:         rt.channels,
 		GRPC:             rt.grpc,
 	})
-	rt.processor.SetAppChannel(mockAppChannel)
 
 	require.NoError(t, rt.processor.Init(context.Background(), cPubSub))
 


### PR DESCRIPTION
Branched from #2478 

In order to achieve [hot reloading](#1172), channel callers need to fetch the current channel dynamically. 

PR updates all callers to fetch the current channel type from `channels` during invocation to ensure they are using the latest configured.


/cc @yaron2 