### PR TITLE
Pinned specific versions of Helm charts

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -534,6 +534,7 @@ jobs:
           make setup-test-env-redis
           make setup-test-env-kafka
           make setup-test-env-zipkin
+          make setup-test-env-postgres
           if [ "${{ env.DAPR_TEST_STATE_STORE }}" == "" ] ; then
             make setup-test-env-mongodb
           fi

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -201,7 +201,6 @@ jobs:
         make setup-test-env-zipkin
 
     - name: Setup postgres
-      if: matrix.dapr-test-config-store == 'postgres'
       run: |
         make setup-test-env-postgres
 

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -254,7 +254,7 @@ create-test-namespace:
 delete-test-namespace:
 	kubectl delete namespace $(DAPR_TEST_NAMESPACE)
 
-setup-3rd-party: setup-helm-init setup-test-env-redis setup-test-env-kafka setup-test-env-mongodb setup-test-env-zipkin
+setup-3rd-party: setup-helm-init setup-test-env-redis setup-test-env-kafka setup-test-env-mongodb setup-test-env-zipkin setup-test-env-postgres
 
 setup-pubsub-subs-perf-test-components: setup-test-env-rabbitmq setup-test-env-pulsar setup-test-env-mqtt
 
@@ -443,30 +443,55 @@ delete-test-env-k6:
 
 # install redis to the cluster without password
 setup-test-env-redis:
-	$(HELM) upgrade --install dapr-redis bitnami/redis --wait --timeout 5m0s --namespace $(DAPR_TEST_NAMESPACE) -f ./tests/config/redis_override.yaml
+	$(HELM) upgrade \
+	  --install dapr-redis bitnami/redis \
+	  --version 17.14.5 \
+	  --wait \
+	  --timeout 5m0s \
+	  --namespace $(DAPR_TEST_NAMESPACE) \
+	  -f ./tests/config/redis_override.yaml
 
 delete-test-env-redis:
 	${HELM} del dapr-redis --namespace ${DAPR_TEST_NAMESPACE}
 
 # install kafka to the cluster
 setup-test-env-kafka:
-	$(HELM) upgrade --install dapr-kafka bitnami/kafka -f ./tests/config/kafka_override.yaml --namespace $(DAPR_TEST_NAMESPACE) --timeout 10m0s
+	$(HELM) upgrade \
+	  --install dapr-kafka bitnami/kafka \
+	  --version 23.0.7 \
+	  -f ./tests/config/kafka_override.yaml \
+	  --namespace $(DAPR_TEST_NAMESPACE) \
+	  --timeout 10m0s
 
 # install rabbitmq to the cluster
 setup-test-env-rabbitmq:
-	$(HELM) upgrade --install rabbitmq bitnami/rabbitmq --set auth.username='admin' --set auth.password='admin' --namespace $(DAPR_TEST_NAMESPACE) --timeout 10m0s
+	$(HELM) upgrade \
+	  --install rabbitmq bitnami/rabbitmq \
+	  --version 12.0.9 \
+	  --set auth.username='admin' \
+	  --set auth.password='admin' \
+	  --namespace $(DAPR_TEST_NAMESPACE) \
+	  --timeout 10m0s
 
 # install mqtt to the cluster
 setup-test-env-mqtt:
 	$(HELM) repo add emqx https://repos.emqx.io/charts 
 	$(HELM) repo update
-	$(HELM) upgrade --install perf-test-emqx emqx/emqx --namespace $(DAPR_TEST_NAMESPACE) --timeout 10m0s
+	$(HELM) upgrade \
+	  --install perf-test-emqx emqx/emqx \
+	  --version 5.1.4 \
+	  --namespace $(DAPR_TEST_NAMESPACE) \
+	  --timeout 10m0s
 
 # install mqtt to the cluster
 setup-test-env-pulsar:
 	$(HELM) repo add apache https://pulsar.apache.org/charts
 	$(HELM) repo update
-	$(HELM) upgrade --install perf-test-pulsar apache/pulsar --namespace $(DAPR_TEST_NAMESPACE) --timeout 10m0s
+	$(HELM) upgrade \
+	  --install perf-test-pulsar apache/pulsar \
+	  --version 3.0.0 \
+	  --namespace $(DAPR_TEST_NAMESPACE) \
+	  --timeout 10m0s
 
 # delete kafka from cluster
 delete-test-env-kafka:
@@ -474,11 +499,23 @@ delete-test-env-kafka:
 
 # install mongodb to the cluster without password
 setup-test-env-mongodb:
-	$(HELM) upgrade --install dapr-mongodb bitnami/mongodb -f ./tests/config/mongodb_override.yaml --namespace $(DAPR_TEST_NAMESPACE) --wait --timeout 5m0s
+	$(HELM) upgrade \
+	  --install dapr-mongodb bitnami/mongodb \
+	  --version 13.16.2 \
+	  -f ./tests/config/mongodb_override.yaml \
+	  --namespace $(DAPR_TEST_NAMESPACE) \
+	  --wait \
+	  --timeout 5m0s
 
 # install postgres to the cluster
 setup-test-env-postgres:
-	$(HELM) upgrade --install dapr-postgres bitnami/postgresql -f ./tests/config/postgres_override.yaml --namespace $(DAPR_TEST_NAMESPACE) --wait --timeout 5m0s
+	$(HELM) upgrade \
+	  --install dapr-postgres bitnami/postgresql \
+	  --version 12.8.0 \
+	  -f ./tests/config/postgres_override.yaml \
+	  --namespace $(DAPR_TEST_NAMESPACE) \
+	  --wait \
+	  --timeout 5m0s
 
 # delete postgres from cluster
 delete-test-env-postgres:
@@ -495,7 +532,7 @@ delete-test-env-zipkin:
 	$(KUBECTL) delete -f ./tests/config/zipkin.yaml -n $(DAPR_TEST_NAMESPACE)
 
 # Setup the test environment by installing components
-setup-test-env: setup-test-env-kafka setup-test-env-redis setup-test-env-mongodb setup-test-env-k6 setup-test-env-zipkin setup-test-env-postgres
+setup-test-env: setup-test-env-kafka setup-test-env-redis setup-test-env-mongodb setup-test-env-postgres setup-test-env-k6 setup-test-env-zipkin setup-test-env-postgres
 
 save-dapr-control-plane-k8s-resources:
 	mkdir -p '$(DAPR_CONTAINER_LOG_PATH)'


### PR DESCRIPTION
To prevent E2E tests failing when charts are upgraded (like they are today).

Also makes sure that Postgres is installed always.