### PR TITLE
Stop SubscribeConfiguration when client disconnects to prevent leaks

### DIFF
--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -18,13 +18,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	otelTrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -1389,49 +1389,32 @@ func (h *configurationEventHandler) updateEventHandler(ctx context.Context, e *c
 	return nil
 }
 
-func (a *api) SubscribeConfiguration(request *runtimev1pb.SubscribeConfigurationRequest, configurationServer runtimev1pb.Dapr_SubscribeConfigurationServer) error { //nolint:nosnakecase
+func (a *api) SubscribeConfiguration(request *runtimev1pb.SubscribeConfigurationRequest, stream runtimev1pb.Dapr_SubscribeConfigurationServer) error { //nolint:nosnakecase
 	store, err := a.getConfigurationStore(request.StoreName)
 	if err != nil {
 		apiServerLogger.Debug(err)
 		return err
 	}
 
-	sort.Strings(request.Keys)
-
-	// TODO(@halspang) provide a switch to use just resiliency or this.
-
-	req := &configuration.SubscribeRequest{
-		Keys:     request.Keys,
-		Metadata: request.GetMetadata(),
-	}
-
 	handler := &configurationEventHandler{
 		readyCh:      make(chan struct{}),
 		api:          a,
 		storeName:    request.StoreName,
-		serverStream: configurationServer,
+		serverStream: stream,
 	}
-	// Prevents a leak
+	// Prevents a leak if we return with an error
 	defer handler.ready()
 
-	// TODO(@laurence) deal with failed subscription and retires
-	start := time.Now()
-	policyRunner := resiliency.NewRunner[string](configurationServer.Context(),
-		a.resiliency.ComponentOutboundPolicy(request.StoreName, resiliency.Configuration),
-	)
-	subscribeID, err := policyRunner(func(ctx context.Context) (string, error) {
-		return store.Subscribe(ctx, req, handler.updateEventHandler)
-	})
-	elapsed := diag.ElapsedSince(start)
-
-	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), request.StoreName, diag.ConfigurationSubscribe, err == nil, elapsed)
-
+	// Subscribe
+	slices.Sort(request.Keys)
+	subscribeID, err := a.subscribeConfiguration(stream.Context(), request, handler, store)
 	if err != nil {
-		err = status.Errorf(codes.InvalidArgument, messages.ErrConfigurationSubscribe, req.Keys, request.StoreName, err.Error())
-		apiServerLogger.Debug(err)
+		// Error has already been logged
 		return err
 	}
 
+	// Send subscription ID
+	// This is primarily meant for backwards-compatibility with using the Unsubscribe method
 	err = handler.serverStream.Send(&runtimev1pb.SubscribeConfigurationResponse{
 		Id: subscribeID,
 	})
@@ -1446,10 +1429,69 @@ func (a *api) SubscribeConfiguration(request *runtimev1pb.SubscribeConfiguration
 	// We have sent the first message, so signal that we're ready to send messages in the stream
 	handler.ready()
 
-	// Wait until the channel is stopped
-	<-stop
+	// Wait until the channel is stopped or until the client disconnects
+	select {
+	case <-stream.Context().Done():
+	case <-stop:
+	}
+
+	// Unsubscribe
+	// We must use a background context here because stream.Context is likely canceled already
+	err = a.unsubscribeConfiguration(context.Background(), subscribeID, request.StoreName, store)
+	if err != nil {
+		// Error has already been logged
+		return err
+	}
+
+	// Delete the subscription ID (and the stop channel) if we got here because of the context being canceled
+	a.CompStore.DeleteConfigurationSubscribe(subscribeID)
 
 	return nil
+}
+
+func (a *api) subscribeConfiguration(ctx context.Context, request *runtimev1pb.SubscribeConfigurationRequest, handler *configurationEventHandler, store configuration.Store) (subscribeID string, err error) {
+	componentReq := &configuration.SubscribeRequest{
+		Keys:     request.Keys,
+		Metadata: request.GetMetadata(),
+	}
+
+	// TODO(@laurence) deal with failed subscription and retires
+	start := time.Now()
+	policyRunner := resiliency.NewRunner[string](ctx,
+		a.resiliency.ComponentOutboundPolicy(request.StoreName, resiliency.Configuration),
+	)
+	subscribeID, err = policyRunner(func(ctx context.Context) (string, error) {
+		return store.Subscribe(ctx, componentReq, handler.updateEventHandler)
+	})
+	elapsed := diag.ElapsedSince(start)
+
+	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), request.StoreName, diag.ConfigurationSubscribe, err == nil, elapsed)
+
+	if err != nil {
+		err = status.Errorf(codes.InvalidArgument, messages.ErrConfigurationSubscribe, componentReq.Keys, request.StoreName, err)
+		apiServerLogger.Debug(err)
+		return "", err
+	}
+
+	return subscribeID, nil
+}
+
+func (a *api) unsubscribeConfiguration(ctx context.Context, subscribeID string, storeName string, store configuration.Store) error {
+	policyRunner := resiliency.NewRunner[struct{}](ctx,
+		a.resiliency.ComponentOutboundPolicy(storeName, resiliency.Configuration),
+	)
+	start := time.Now()
+	storeReq := &configuration.UnsubscribeRequest{
+		ID: subscribeID,
+	}
+	_, err := policyRunner(func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, store.Unsubscribe(ctx, storeReq)
+	})
+	elapsed := diag.ElapsedSince(start)
+
+	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), storeName, diag.ConfigurationUnsubscribe, err == nil, elapsed)
+
+	return err
 }
 
 // TODO: Remove this method when the alpha API is removed.
@@ -1457,18 +1499,10 @@ func (a *api) SubscribeConfigurationAlpha1(request *runtimev1pb.SubscribeConfigu
 	return a.SubscribeConfiguration(request, configurationServer.(runtimev1pb.Dapr_SubscribeConfigurationServer))
 }
 
+// This method is deprecated and exists for backwards-compatibility only.
+// It causes an active SubscribeConfiguration RPC for the given subscription ID to be stopped if active
 func (a *api) UnsubscribeConfiguration(ctx context.Context, request *runtimev1pb.UnsubscribeConfigurationRequest) (*runtimev1pb.UnsubscribeConfigurationResponse, error) {
-	store, err := a.getConfigurationStore(request.GetStoreName())
-	if err != nil {
-		apiServerLogger.Debug(err)
-		return &runtimev1pb.UnsubscribeConfigurationResponse{
-			Ok:      false,
-			Message: err.Error(),
-		}, err
-	}
-
 	subscribeID := request.GetId()
-
 	_, ok := a.CompStore.GetConfigurationSubscribe(subscribeID)
 	if !ok {
 		return &runtimev1pb.UnsubscribeConfigurationResponse{
@@ -1477,27 +1511,9 @@ func (a *api) UnsubscribeConfiguration(ctx context.Context, request *runtimev1pb
 		}, nil
 	}
 
-	policyRunner := resiliency.NewRunner[any](ctx,
-		a.resiliency.ComponentOutboundPolicy(request.StoreName, resiliency.Configuration),
-	)
-	start := time.Now()
-	storeReq := &configuration.UnsubscribeRequest{
-		ID: subscribeID,
-	}
-	_, err = policyRunner(func(ctx context.Context) (any, error) {
-		return nil, store.Unsubscribe(ctx, storeReq)
-	})
-	elapsed := diag.ElapsedSince(start)
+	a.Logger.Warn("Unsubscribing using UnsubscribeConfiguration is deprecated. Disconnect from the SubscribeConfiguration RPC instead.")
 
-	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), request.StoreName, diag.ConfigurationUnsubscribe, err == nil, elapsed)
-
-	if err != nil {
-		return &runtimev1pb.UnsubscribeConfigurationResponse{
-			Ok:      false,
-			Message: err.Error(),
-		}, err
-	}
-
+	// This causes the subscription with the given ID to be stopped and that stream to be aborted, if active
 	a.CompStore.DeleteConfigurationSubscribe(subscribeID)
 
 	return &runtimev1pb.UnsubscribeConfigurationResponse{

--- a/pkg/grpc/api_test.go
+++ b/pkg/grpc/api_test.go
@@ -1463,11 +1463,12 @@ func TestGetConfiguration(t *testing.T) {
 func TestSubscribeConfiguration(t *testing.T) {
 	fakeConfigurationStore := &daprt.MockConfigurationStore{}
 	var tempReq *configuration.SubscribeRequest
+
 	fakeConfigurationStore.On("Subscribe",
 		mock.MatchedBy(matchContextInterface),
 		mock.MatchedBy(func(req *configuration.SubscribeRequest) bool {
 			tempReq = req
-			return len(tempReq.Keys) == 1 && tempReq.Keys[0] == goodKey
+			return len(req.Keys) == 1 && req.Keys[0] == goodKey
 		}),
 		mock.MatchedBy(func(f configuration.UpdateHandler) bool {
 			if len(tempReq.Keys) == 1 && tempReq.Keys[0] == goodKey {
@@ -1480,7 +1481,15 @@ func TestSubscribeConfiguration(t *testing.T) {
 				})
 			}
 			return true
-		})).Return("id", nil)
+		}),
+	).Return("id1", nil)
+	fakeConfigurationStore.On("Unsubscribe",
+		mock.MatchedBy(matchContextInterface),
+		mock.MatchedBy(func(req *configuration.UnsubscribeRequest) bool {
+			return req.ID == "id1"
+		}),
+	).Return(nil)
+
 	fakeConfigurationStore.On("Subscribe",
 		mock.MatchedBy(matchContextInterface),
 		mock.MatchedBy(func(req *configuration.SubscribeRequest) bool {
@@ -1501,13 +1510,22 @@ func TestSubscribeConfiguration(t *testing.T) {
 				})
 			}
 			return true
-		})).Return("id", nil)
+		}),
+	).Return("id2", nil)
+	fakeConfigurationStore.On("Unsubscribe",
+		mock.MatchedBy(matchContextInterface),
+		mock.MatchedBy(func(req *configuration.UnsubscribeRequest) bool {
+			return req.ID == "id2"
+		}),
+	).Return(nil)
+
 	fakeConfigurationStore.On("Subscribe",
 		mock.MatchedBy(matchContextInterface),
 		mock.MatchedBy(func(req *configuration.SubscribeRequest) bool {
 			return req.Keys[0] == "error-key"
 		}),
-		mock.AnythingOfType("configuration.UpdateHandler")).Return(nil, errors.New("failed to get state with error-key"))
+		mock.AnythingOfType("configuration.UpdateHandler"),
+	).Return(nil, errors.New("failed to get state with error-key"))
 
 	compStore := compstore.New()
 	compStore.AddConfiguration("store1", fakeConfigurationStore)
@@ -1603,7 +1621,7 @@ func TestSubscribeConfiguration(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, tt.expectedResponse, rsp.Items, "Expected response items to be same")
 				} else {
-					retry := 3
+					const retry = 3
 					count := 0
 					_, err := resp.Recv()
 					for {
@@ -1643,12 +1661,15 @@ func TestUnSubscribeConfiguration(t *testing.T) {
 	fakeConfigurationStore := &daprt.MockConfigurationStore{}
 	stop := make(chan struct{})
 	defer close(stop)
+
 	var tempReq *configuration.SubscribeRequest
 	fakeConfigurationStore.On("Unsubscribe",
 		mock.MatchedBy(matchContextInterface),
 		mock.MatchedBy(func(req *configuration.UnsubscribeRequest) bool {
 			return true
-		})).Return(nil)
+		}),
+	).Return(nil)
+
 	fakeConfigurationStore.On("Subscribe",
 		mock.MatchedBy(matchContextInterface),
 		mock.MatchedBy(func(req *configuration.SubscribeRequest) bool {
@@ -1680,7 +1701,9 @@ func TestUnSubscribeConfiguration(t *testing.T) {
 				}
 			}()
 			return true
-		})).Return(mockSubscribeID, nil)
+		}),
+	).Return(mockSubscribeID, nil)
+
 	fakeConfigurationStore.On("Subscribe",
 		mock.MatchedBy(matchContextInterface),
 		mock.MatchedBy(func(req *configuration.SubscribeRequest) bool {
@@ -1715,7 +1738,8 @@ func TestUnSubscribeConfiguration(t *testing.T) {
 				}
 			}()
 			return true
-		})).Return(mockSubscribeID, nil)
+		}),
+	).Return(mockSubscribeID, nil)
 
 	compStore := compstore.New()
 	compStore.AddConfiguration("store1", fakeConfigurationStore)
@@ -1724,6 +1748,7 @@ func TestUnSubscribeConfiguration(t *testing.T) {
 	fakeAPI := &api{
 		UniversalAPI: &universalapi.UniversalAPI{
 			AppID:     "fakeAPI",
+			Logger:    logger.NewLogger("grpc.api.test"),
 			CompStore: compStore,
 		},
 		resiliency: resiliency.New(nil),
@@ -1877,7 +1902,8 @@ func TestUnsubscribeConfigurationErrScenario(t *testing.T) {
 		mock.MatchedBy(matchContextInterface),
 		mock.MatchedBy(func(req *configuration.UnsubscribeRequest) bool {
 			return req.ID == mockSubscribeID
-		})).Return(nil)
+		}),
+	).Return(nil)
 
 	compStore := compstore.New()
 	compStore.AddConfiguration("store1", fakeConfigurationStore)
@@ -1886,6 +1912,7 @@ func TestUnsubscribeConfigurationErrScenario(t *testing.T) {
 	fakeAPI := &api{
 		UniversalAPI: &universalapi.UniversalAPI{
 			AppID:     "fakeAPI",
+			Logger:    logger.NewLogger("grpc.api.test"),
 			CompStore: compStore,
 		},
 		resiliency: resiliency.New(nil),
@@ -1911,13 +1938,6 @@ func TestUnsubscribeConfigurationErrScenario(t *testing.T) {
 			id:               "",
 			expectedResponse: true,
 			expectedError:    false,
-		},
-		{
-			testName:         "Test unsubscribe with incorrect store name",
-			storeName:        "no-store",
-			id:               mockSubscribeID,
-			expectedResponse: false,
-			expectedError:    true,
 		},
 	}
 
@@ -3494,6 +3514,7 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 	fakeAPI := &api{
 		UniversalAPI: &universalapi.UniversalAPI{
 			AppID:     "fakeAPI",
+			Logger:    logger.NewLogger("grpc.api.test"),
 			CompStore: compStore,
 		},
 		resiliency: resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), testResiliency),
@@ -3553,30 +3574,6 @@ func TestConfigurationAPIWithResiliency(t *testing.T) {
 		_, err = resp.Recv()
 		assert.Error(t, err)
 		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("timeoutSubscribeKey"))
-	})
-
-	t.Run("test unsubscribe configuration retries with resiliency", func(t *testing.T) {
-		fakeAPI.CompStore.AddConfigurationSubscribe("failingUnsubscribeKey", make(chan struct{}))
-
-		_, err := client.UnsubscribeConfiguration(context.Background(), &runtimev1pb.UnsubscribeConfigurationRequest{
-			StoreName: "failConfig",
-			Id:        "failingUnsubscribeKey",
-		})
-
-		assert.NoError(t, err)
-		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("failingUnsubscribeKey"))
-	})
-
-	t.Run("test unsubscribe configuration fails due to timeout with resiliency", func(t *testing.T) {
-		fakeAPI.CompStore.AddConfigurationSubscribe("timeoutUnsubscribeKey", make(chan struct{}))
-
-		_, err := client.UnsubscribeConfiguration(context.Background(), &runtimev1pb.UnsubscribeConfigurationRequest{
-			StoreName: "failConfig",
-			Id:        "timeoutUnsubscribeKey",
-		})
-
-		assert.Error(t, err)
-		assert.Equal(t, 2, failingConfigStore.Failure.CallCount("timeoutUnsubscribeKey"))
 	})
 }
 

--- a/pkg/messages/predefined.go
+++ b/pkg/messages/predefined.go
@@ -76,9 +76,9 @@ const (
 	// Configuration.
 	ErrConfigurationStoresNotConfigured = "configuration stores not configured"
 	ErrConfigurationStoreNotFound       = "configuration store %s not found"
-	ErrConfigurationGet                 = "failed to get %s from Configuration store %s: %s"
-	ErrConfigurationSubscribe           = "failed to subscribe %s from Configuration store %s: %s"
-	ErrConfigurationUnsubscribe         = "failed to unsubscribe to configuration request %s: %s"
+	ErrConfigurationGet                 = "failed to get %s from Configuration store %s: %v"
+	ErrConfigurationSubscribe           = "failed to subscribe %s from Configuration store %s: %v"
+	ErrConfigurationUnsubscribe         = "failed to unsubscribe to configuration request %s: %v"
 )
 
 var (

--- a/pkg/runtime/compstore/configuration.go
+++ b/pkg/runtime/compstore/configuration.go
@@ -65,8 +65,8 @@ func (c *ComponentStore) GetConfigurationSubscribe(name string) (chan struct{}, 
 func (c *ComponentStore) DeleteConfigurationSubscribe(name string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	stop, ok := c.configurationSubscribes[name]
-	if ok {
+	stop := c.configurationSubscribes[name]
+	if stop != nil {
 		close(stop)
 	}
 	delete(c.configurationSubscribes, name)


### PR DESCRIPTION
Fixes #6560

Clients can continue to call UnsubscribeConfiguration for backwards-compatibility. However, doing so will show a warning encouraging users to simply close the connection to the SubscribeConfiguration RPC.