### PR TITLE
Fixed flaky outbox unit tests

### DIFF
--- a/pkg/runtime/pubsub/outbox_test.go
+++ b/pkg/runtime/pubsub/outbox_test.go
@@ -18,10 +18,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/dapr/dapr/pkg/apis/common"
 	"github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/outbox"
+	"github.com/dapr/kit/ptr"
 )
 
 func newTestOutbox() outbox.Outbox {
@@ -256,7 +259,7 @@ func TestPublishInternal(t *testing.T) {
 			},
 		})
 
-		_, err := o.PublishInternal(context.TODO(), "test", []state.TransactionalStateOperation{
+		_, err := o.PublishInternal(context.Background(), "test", []state.TransactionalStateOperation{
 			state.SetRequest{
 				Key:   "key",
 				Value: "test",
@@ -419,19 +422,24 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 		o := newTestOutbox().(*outboxImpl)
 		o.cloudEventExtractorFn = extractCloudEventProperty
 
-		outboxTopic := "test1outbox"
+		const outboxTopic = "test1outbox"
 
 		psMock := &outboxPubsubMock{
 			expectedOutboxTopic: outboxTopic,
 			t:                   t,
 		}
-		stateMock := &outboxStateMock{}
+		stateMock := &outboxStateMock{
+			receivedKey: make(chan string, 1),
+		}
+
+		internalCalledCh := make(chan struct{})
+		externalCalledCh := make(chan struct{})
 
 		o.publishFn = func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
 			if pr.Topic == outboxTopic {
-				psMock.internalCalled = true
+				close(internalCalledCh)
 			} else if pr.Topic == "1" {
-				psMock.externalCalled = true
+				close(externalCalledCh)
 			}
 
 			return psMock.Publish(ctx, pr)
@@ -479,37 +487,71 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 			},
 		})
 
-		appID := "test"
-		err := o.SubscribeToInternalTopics(context.TODO(), appID)
-		assert.NoError(t, err)
+		const appID = "test"
+		err := o.SubscribeToInternalTopics(context.Background(), appID)
+		require.NoError(t, err)
 
+		errCh := make(chan error, 1)
 		go func() {
-			trs, pErr := o.PublishInternal(context.TODO(), "test", []state.TransactionalStateOperation{
+			trs, pErr := o.PublishInternal(context.Background(), "test", []state.TransactionalStateOperation{
 				state.SetRequest{
 					Key:   "1",
 					Value: "hello",
 				},
 			}, appID)
 
-			assert.NoError(t, pErr)
-			assert.Len(t, trs, 1)
+			if pErr != nil {
+				errCh <- pErr
+				return
+			}
+			if len(trs) != 1 {
+				errCh <- fmt.Errorf("expected trs to have len(1), but got: %d", len(trs))
+				return
+			}
 
-			stateMock.expectedKey = trs[0].GetKey()
+			errCh <- nil
+			stateMock.expectedKey.Store(ptr.Of(trs[0].GetKey()))
 		}()
 
 		d, err := time.ParseDuration(stateScan)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		time.Sleep(d * 2)
-		assert.True(t, psMock.internalCalled)
-		assert.True(t, psMock.externalCalled)
-		assert.Equal(t, stateMock.expectedKey, stateMock.receivedKey)
+		start := time.Now()
+		doneCh := make(chan error, 2)
+		timeout := time.After(5 * time.Second)
+		go func() {
+			select {
+			case <-internalCalledCh:
+				doneCh <- nil
+			case <-timeout:
+				doneCh <- errors.New("timeout waiting for internalCalledCh")
+			}
+		}()
+		go func() {
+			select {
+			case <-externalCalledCh:
+				doneCh <- nil
+			case <-timeout:
+				doneCh <- errors.New("timeout waiting for externalCalledCh")
+			}
+		}()
+		for i := 0; i < 2; i++ {
+			require.NoError(t, <-doneCh)
+		}
+		require.GreaterOrEqual(t, time.Since(start), d)
+
+		// Publishing should not have errored
+		require.NoError(t, <-errCh)
+
+		expected := stateMock.expectedKey.Load()
+		require.NotNil(t, expected)
+		assert.Equal(t, *expected, <-stateMock.receivedKey)
 	})
 
 	t.Run("state store not present", func(t *testing.T) {
 		o := newTestOutbox().(*outboxImpl)
 
-		outboxTopic := "test1outbox"
+		const outboxTopic = "test1outbox"
 
 		psMock := &outboxPubsubMock{
 			expectedOutboxTopic: outboxTopic,
@@ -517,12 +559,6 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 		}
 
 		o.publishFn = func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
-			if pr.Topic == outboxTopic {
-				psMock.internalCalled = true
-			} else if pr.Topic == "1" {
-				psMock.externalCalled = true
-			}
-
 			return psMock.Publish(ctx, pr)
 		}
 		o.getPubsubFn = func(s string) (contribPubsub.PubSub, bool) {
@@ -532,11 +568,11 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 			return nil, false
 		}
 
-		appID := "test"
-		err := o.SubscribeToInternalTopics(context.TODO(), appID)
-		assert.NoError(t, err)
+		const appID = "test"
+		err := o.SubscribeToInternalTopics(context.Background(), appID)
+		require.NoError(t, err)
 
-		trs, pErr := o.PublishInternal(context.TODO(), "test", []state.TransactionalStateOperation{
+		trs, pErr := o.PublishInternal(context.Background(), "test", []state.TransactionalStateOperation{
 			state.SetRequest{
 				Key:   "1",
 				Value: "hello",
@@ -550,7 +586,7 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 	t.Run("outbox state not present", func(t *testing.T) {
 		o := newTestOutbox().(*outboxImpl)
 
-		outboxTopic := "test1outbox"
+		const outboxTopic = "test1outbox"
 
 		psMock := &outboxPubsubMock{
 			expectedOutboxTopic: outboxTopic,
@@ -558,11 +594,14 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 		}
 		stateMock := &outboxStateMock{}
 
+		internalCalledCh := make(chan struct{})
+		externalCalledCh := make(chan struct{})
+
 		o.publishFn = func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
 			if pr.Topic == outboxTopic {
-				psMock.internalCalled = true
+				close(internalCalledCh)
 			} else if pr.Topic == "1" {
-				psMock.externalCalled = true
+				close(externalCalledCh)
 			}
 
 			return psMock.Publish(ctx, pr)
@@ -574,7 +613,7 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 			return stateMock, true
 		}
 
-		stateScan := "100ms"
+		const stateScan = "100ms"
 
 		o.AddOrUpdateOutbox(v1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
@@ -610,28 +649,60 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 			},
 		})
 
-		appID := "test"
-		err := o.SubscribeToInternalTopics(context.TODO(), appID)
-		assert.NoError(t, err)
+		const appID = "test"
+		err := o.SubscribeToInternalTopics(context.Background(), appID)
+		require.NoError(t, err)
 
+		errCh := make(chan error, 1)
 		go func() {
-			trs, pErr := o.PublishInternal(context.TODO(), "test", []state.TransactionalStateOperation{
+			trs, pErr := o.PublishInternal(context.Background(), "test", []state.TransactionalStateOperation{
 				state.SetRequest{
 					Key:   "1",
 					Value: "hello",
 				},
 			}, appID)
 
-			assert.NoError(t, pErr)
-			assert.Len(t, trs, 1)
+			if pErr != nil {
+				errCh <- pErr
+				return
+			}
+			if len(trs) != 1 {
+				errCh <- fmt.Errorf("expected trs to have len(1), but got: %d", len(trs))
+				return
+			}
+			errCh <- nil
 		}()
 
 		d, err := time.ParseDuration(stateScan)
 		assert.NoError(t, err)
 
-		time.Sleep(d * 2)
-		assert.True(t, psMock.internalCalled)
-		assert.False(t, psMock.externalCalled)
+		start := time.Now()
+		doneCh := make(chan error, 2)
+		timeout := time.After(2 * time.Second)
+		go func() {
+			select {
+			case <-internalCalledCh:
+				doneCh <- nil
+			case <-timeout:
+				doneCh <- errors.New("timeout waiting for internalCalledCh")
+			}
+		}()
+		go func() {
+			// Here we expect no signal
+			select {
+			case <-externalCalledCh:
+				doneCh <- errors.New("received unexpected signal on externalCalledCh")
+			case <-timeout:
+				doneCh <- nil
+			}
+		}()
+		for i := 0; i < 2; i++ {
+			require.NoError(t, <-doneCh)
+		}
+		require.GreaterOrEqual(t, time.Since(start), d)
+
+		// Publishing should not have errored
+		require.NoError(t, <-errCh)
 	})
 }
 
@@ -639,8 +710,6 @@ type outboxPubsubMock struct {
 	expectedOutboxTopic string
 	t                   *testing.T
 	handler             contribPubsub.Handler
-	internalCalled      bool
-	externalCalled      bool
 }
 
 func (o *outboxPubsubMock) Init(ctx context.Context, metadata contribPubsub.Metadata) error {
@@ -653,7 +722,7 @@ func (o *outboxPubsubMock) Features() []contribPubsub.Feature {
 
 func (o *outboxPubsubMock) Publish(ctx context.Context, req *contribPubsub.PublishRequest) error {
 	go func() {
-		err := o.handler(context.TODO(), &contribPubsub.NewMessage{
+		err := o.handler(context.Background(), &contribPubsub.NewMessage{
 			Data:  req.Data,
 			Topic: req.Topic,
 		})
@@ -677,8 +746,8 @@ func (o *outboxPubsubMock) Close() error {
 }
 
 type outboxStateMock struct {
-	expectedKey string
-	receivedKey string
+	expectedKey atomic.Pointer[string]
+	receivedKey chan string
 }
 
 func (o *outboxStateMock) Init(ctx context.Context, metadata state.Metadata) error {
@@ -694,9 +763,13 @@ func (o *outboxStateMock) Delete(ctx context.Context, req *state.DeleteRequest) 
 }
 
 func (o *outboxStateMock) Get(ctx context.Context, req *state.GetRequest) (*state.GetResponse, error) {
-	o.receivedKey = req.Key
+	if o.receivedKey != nil {
+		o.receivedKey <- req.Key
+	}
 
-	if o.expectedKey != "" && o.expectedKey == o.receivedKey {
+	expected := o.expectedKey.Load()
+
+	if expected != nil && *expected != "" && *expected == req.Key {
 		return &state.GetResponse{
 			Data: []byte("0"),
 		}, nil


### PR DESCRIPTION
On my dev box, these tests were failing over 50% of times, due to race conditions in the tests (not in the code). They are failing in the CI too, for example: https://github.com/dapr/dapr/actions/runs/5757117107/job/15607801969

Updated tests have been verified with `go test -race`