### PR TITLE
Fix: AKS tests not working due to invalid K8s version

### DIFF
--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -184,8 +184,8 @@ resource aks 'Microsoft.ContainerService/managedClusters@2023-05-01' = {
   }
   tags: {}
   sku: {
-    name: 'Basic'
-    tier: 'Paid'
+    name: 'Base'
+    tier: 'Standard'
   }
   identity: {
     type: 'SystemAssigned'

--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -43,7 +43,7 @@ param diagStorageResourceId string = ''
 var osDiskSizeGB = 0
 
 // Version of Kubernetes
-var kubernetesVersion = '1.25.5'
+var kubernetesVersion = '1.26'
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
   name: '${namePrefix}acr'
@@ -82,7 +82,7 @@ var networkProfileLinux = {
   networkPlugin: 'kubenet'
 }
 
-resource aks 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
+resource aks 'Microsoft.ContainerService/managedClusters@2023-05-01' = {
   location: location
   name: '${namePrefix}-aks'
   properties: {


### PR DESCRIPTION
The Bicep file specified a version of K8s that is not available anymore, so deploying AKS clusters is failing. See: https://github.com/dapr/dapr/actions/runs/5766416917

Currently we specify a K8s version with a patch version too. If we upgrade the ARM APIs to a newer version (like [2023-05-01](https://learn.microsoft.com/en-us/azure/templates/microsoft.containerservice/2023-05-01/managedclusters?pivots=deployment-language-bicep)) we can pick a "major.minor" format which should allow us to have less issues in the future.