### PR TITLE
GitHub Actions Version Skew: use `github.rest` object

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -474,7 +474,7 @@ async function cmdTestVersionSkew(
     }
 
     // Get pull request
-    const pull = await github.pulls.get({
+    const pull = await github.rest.pulls.get({
         owner: issue.owner,
         repo: issue.repo,
         pull_number: issue.number,
@@ -492,7 +492,7 @@ async function cmdTestVersionSkew(
         }
 
         // Fire repository_dispatch event to trigger e2e test
-        await github.repos.createDispatchEvent({
+        await github.rest.repos.createDispatchEvent({
             owner: issue.owner,
             repo: issue.repo,
             event_type: command.substring(1),


### PR DESCRIPTION
Fixes the `/test-version-skew` github action bot command.

Current failing run: https://github.com/dapr/dapr/actions/runs/5772365211/job/15647270622

Example of fix on my fork: https://github.com/JoshVanL/dapr/pull/26