### PR TITLE
FIx Version Skew Workflow tests: Pin kafka to 23.0.7

### DIFF
--- a/.github/workflows/version-skew-e2e.yaml
+++ b/.github/workflows/version-skew-e2e.yaml
@@ -216,7 +216,12 @@ jobs:
       run: |
         cd latest-release
 
-        make setup-test-env
+        make setup-helm-init
+        make setup-test-env-redis
+        make setup-test-env-kafka
+        make setup-test-env-mongodb
+        make setup-test-env-zipkin
+        helm upgrade --install dapr-kafka bitnami/kafka --version 23.0.7 -f ./tests/config/kafka_override.yaml --namespace ${{ env.DAPR_NAMESPACE }} --timeout 10m0s
         make setup-test-components
 
     - name: Free up some diskspace


### PR DESCRIPTION
As in [this](https://github.com/dapr/dapr/pull/6765) PR, the new default helm kafka chart is now incompatible with v1.11 e2e tests (the kafka Service exposes a different port, but there may be other incompatibilities). Because we don't want to cut a patch release in `v1.11` just to fix the version skew workflow, this PR manually pins the chart version in the workflow script.

PR fixes the version skew workflow. [Here](https://github.com/JoshVanL/dapr/actions/runs/5801499261) is an example run on my personal fork.