### PR TITLE
Fix for 404 error in workflow timer expiration

### DIFF
--- a/pkg/runtime/wfengine/workflow.go
+++ b/pkg/runtime/wfengine/workflow.go
@@ -322,31 +322,13 @@ func (wf *workflowActor) runWorkflow(ctx context.Context, actorID string, remind
 
 	// The logic/for loop below purges/removes any leftover state from a completed or failed activity
 	// TODO: for optimization make multiple go routines and run them in parallel
-	for num, e := range state.Inbox {
+	for _, e := range state.Inbox {
 		var taskID int32
 		if ts := e.GetTaskCompleted(); ts != nil {
 			taskID = ts.TaskScheduledId
 		} else if tf := e.GetTaskFailed(); tf != nil {
 			taskID = tf.TaskScheduledId
 		} else {
-			if strings.Contains(e.String(), "timerFired") {
-				numZero := 6 - len(fmt.Sprint(num))
-				req := actors.TransactionalRequest{
-					ActorType: wf.config.workflowActorType,
-					ActorID:   actorID,
-					Operations: []actors.TransactionalOperation{{
-						Operation: actors.Upsert,
-						Request: actors.TransactionalUpsert{
-							Key: inboxKeyPrefix + "-" + strings.Repeat("0", numZero) + fmt.Sprint(num),
-						},
-					}},
-				}
-				err = wf.actors.TransactionalStateOperation(ctx, &req)
-				if err != nil {
-					wfLogger.Infof("RRL failed to save timer with error: %w, and req: %v", err, req)
-					return fmt.Errorf("failed to save timer with error: %w", err)
-				}
-			}
 			continue
 		}
 		req := actors.TransactionalRequest{
@@ -546,12 +528,8 @@ func (wf *workflowActor) saveInternalState(ctx context.Context, actorID string, 
 
 func (wf *workflowActor) createReliableReminder(ctx context.Context, actorID string, namePrefix string, data any, delay time.Duration) (string, error) {
 	// Reminders need to have unique names or else they may not fire in certain race conditions.
-	var reminderName string
-	if strings.Contains(namePrefix, "timer") {
-		reminderName = fmt.Sprintf("timer-%s", uuid.NewString()[:8])
-	} else {
-		reminderName = fmt.Sprintf("%s-%s", namePrefix, uuid.NewString()[:8])
-	}
+	reminderName := fmt.Sprintf("%s-%s", namePrefix, uuid.NewString()[:8])
+	wfLogger.Debugf("%s: creating '%s' reminder with DueTime = %s", actorID, reminderName, delay)
 
 	dataEnc, err := json.Marshal(data)
 	if err != nil {

--- a/pkg/runtime/wfengine/workflowstate.go
+++ b/pkg/runtime/wfengine/workflowstate.go
@@ -99,6 +99,13 @@ func (s *workflowState) AddToInbox(e *backend.HistoryEvent) {
 
 func (s *workflowState) ClearInbox() {
 	s.inboxRemovedCount += len(s.Inbox)
+	for _, e := range s.Inbox {
+		if tf := e.GetTimerFired(); tf != nil {
+			// ignore timer events since those aren't saved into the state store
+			continue
+		}
+		s.inboxRemovedCount++
+	}
 	s.Inbox = nil
 	s.inboxAddedCount = 0
 }

--- a/pkg/runtime/wfengine/workflowstate.go
+++ b/pkg/runtime/wfengine/workflowstate.go
@@ -98,9 +98,8 @@ func (s *workflowState) AddToInbox(e *backend.HistoryEvent) {
 }
 
 func (s *workflowState) ClearInbox() {
-	// s.inboxRemovedCount += len(s.Inbox)
 	for _, e := range s.Inbox {
-		if tf := e.GetTimerFired(); tf != nil {
+		if e.GetTimerFired() != nil {
 			// ignore timer events since those aren't saved into the state store
 			continue
 		}

--- a/pkg/runtime/wfengine/workflowstate.go
+++ b/pkg/runtime/wfengine/workflowstate.go
@@ -98,7 +98,7 @@ func (s *workflowState) AddToInbox(e *backend.HistoryEvent) {
 }
 
 func (s *workflowState) ClearInbox() {
-	s.inboxRemovedCount += len(s.Inbox)
+	// s.inboxRemovedCount += len(s.Inbox)
 	for _, e := range s.Inbox {
 		if tf := e.GetTimerFired(); tf != nil {
 			// ignore timer events since those aren't saved into the state store


### PR DESCRIPTION
# Description

Currently, timers in workflow are not being stored into the statestore. The object is created, added to the inbox, and then removed. Later, an attempt is made to remove the timer from the statestore, but the timer was never stored so a 404 is returned by cosmosDB (other statestores mask this).

This PR now checks if the inbox item to be added is a timer and if it has fired, and if so, does not clear it out of the inbox.

This fix was verified by making the changes and re-running the workflow quickstart in the python sdk. No errors occurred and the correct number of keys were stored.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[[6647](https://github.com/dapr/dapr/issues/6647)]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ x] Code compiles correctly
* [ ] Created/updated tests
* [ x] Unit tests passing
* [ x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
