### PR TITLE
Build full Operator scheme before creating controller runtime manager

### DIFF
--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -136,7 +136,6 @@ func (h *DaprHandler) Init(ctx context.Context) error {
 	}
 
 	if h.argoRolloutServiceReconcilerEnabled {
-		_ = argov1alpha1.AddToScheme(h.Scheme)
 		err = ctrl.NewControllerManagedBy(h.mgr).
 			For(&argov1alpha1.Rollout{}).
 			Owns(&corev1.Service{}).

--- a/pkg/operator/handlers/dapr_handler_test.go
+++ b/pkg/operator/handlers/dapr_handler_test.go
@@ -240,6 +240,7 @@ func TestInit(t *testing.T) {
 	mgr := dapr_testing.NewMockManager()
 
 	_ = scheme.AddToScheme(mgr.GetScheme())
+	_ = argov1alpha1.AddToScheme(mgr.GetScheme())
 
 	handler := NewDaprHandlerWithOptions(mgr, &Options{
 		ArgoRolloutServiceReconcilerEnabled: true,


### PR DESCRIPTION
Fixes https://github.com/dapr/dapr/issues/6655

Ensures the operator controller manager receives a fully registered scheme before starting. We now also create a new scheme per operator instance, and check the returned errors.

This should likely be backported to v1.11