### PR TITLE
Pin redis version in version-skew setup workflow test

### DIFF
--- a/.github/workflows/version-skew-e2e.yaml
+++ b/.github/workflows/version-skew-e2e.yaml
@@ -217,7 +217,7 @@ jobs:
         cd latest-release
 
         make setup-helm-init
-        make setup-test-env-redis
+        helm upgrade --install dapr-redis bitnami/redis --version 17.14.5 --wait --timeout 5m0s --namespace ${{ env.DAPR_NAMESPACE }} -f ./tests/config/redis_override.yaml
         make setup-test-env-kafka
         make setup-test-env-mongodb
         make setup-test-env-zipkin


### PR DESCRIPTION
Fixes redis installation which is currently broken in the version-skew workflow because of an error in the latest chart. Pins to the same version as in master https://github.com/dapr/dapr/blob/cc25c181bc45733c9cefae15d551ad25b868e886/tests/dapr_tests.mk#L448

https://github.com/dapr/dapr/actions/runs/6025664924

/cc @mukundansundar 