### PR TITLE
Dapr Helm Chart: Config: Change sentry address port `80` -> `443`

### DIFF
--- a/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
+++ b/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
@@ -14,5 +14,5 @@ spec:
     workloadCertTTL: {{ .Values.global.mtls.workloadCertTTL }}
     allowedClockSkew: {{ .Values.global.mtls.allowedClockSkew }}
     controlPlaneTrustDomain: {{ .Values.global.mtls.controlPlaneTrustDomain }}
-    sentryAddress: {{ if .Values.global.mtls.sentryAddress }}{{ .Values.global.mtls.sentryAddress }}{{ else }}dapr-sentry.{{ .Release.Namespace }}.svc:80{{ end }}
+    sentryAddress: {{ if .Values.global.mtls.sentryAddress }}{{ .Values.global.mtls.sentryAddress }}{{ else }}dapr-sentry.{{ .Release.Namespace }}.svc:443{{ end }}
 {{- end }}


### PR DESCRIPTION
This should have been changed in the related PR #6854 