### PR TITLE
Split Actors interface betweeen runtime and internal

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -73,25 +73,39 @@ var (
 	ErrReminderCanceled              = internal.ErrReminderCanceled
 )
 
-// Actors allow calling into virtual actors as well as actor state management.
-//
-//nolint:interfacebloat
-type Actors interface {
+// ActorRuntime is the main runtime for the actors subsystem.
+type ActorRuntime interface {
+	Actors
 	io.Closer
-	Call(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error)
 	Init(context.Context) error
-	GetState(ctx context.Context, req *GetStateRequest) (*StateResponse, error)
-	GetBulkState(ctx context.Context, req *GetBulkStateRequest) (BulkStateResponse, error)
-	TransactionalStateOperation(ctx context.Context, req *TransactionalRequest) error
-	GetReminder(ctx context.Context, req *GetReminderRequest) (*internal.Reminder, error)
-	CreateReminder(ctx context.Context, req *CreateReminderRequest) error
-	DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error
-	RenameReminder(ctx context.Context, req *RenameReminderRequest) error
-	CreateTimer(ctx context.Context, req *CreateTimerRequest) error
-	DeleteTimer(ctx context.Context, req *DeleteTimerRequest) error
 	IsActorHosted(ctx context.Context, req *ActorHostedRequest) bool
 	GetActiveActorsCount(ctx context.Context) []*runtimev1pb.ActiveActorsCount
 	RegisterInternalActor(ctx context.Context, actorType string, actor InternalActor) error
+}
+
+// Actors allow calling into virtual actors as well as actor state management.
+type Actors interface {
+	// Call an actor.
+	Call(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error)
+	// GetState retrieves actor state.
+	GetState(ctx context.Context, req *GetStateRequest) (*StateResponse, error)
+	// GetBulkState retrieves actor state in bulk.
+	GetBulkState(ctx context.Context, req *GetBulkStateRequest) (BulkStateResponse, error)
+	// TransactionalStateOperation performs a transactional state operation with the actor state store.
+	TransactionalStateOperation(ctx context.Context, req *TransactionalRequest) error
+	// GetReminder retrieves an actor reminder.
+	GetReminder(ctx context.Context, req *GetReminderRequest) (*internal.Reminder, error)
+	// CreateReminder creates an actor reminder.
+	CreateReminder(ctx context.Context, req *CreateReminderRequest) error
+	// DeleteReminder deletes an actor reminder.
+	DeleteReminder(ctx context.Context, req *DeleteReminderRequest) error
+	// RenameReminder renames a reminder.
+	// TODO: remove in Dapr 1.13.
+	RenameReminder(ctx context.Context, req *RenameReminderRequest) error
+	// CreateTimer creates an actor timer.
+	CreateTimer(ctx context.Context, req *CreateTimerRequest) error
+	// DeleteTimer deletes an actor timer.
+	DeleteTimer(ctx context.Context, req *DeleteTimerRequest) error
 }
 
 // GRPCConnectionFn is the type of the function that returns a gRPC connection
@@ -141,11 +155,11 @@ type ActorsOpts struct {
 }
 
 // NewActors create a new actors runtime with given config.
-func NewActors(opts ActorsOpts) Actors {
+func NewActors(opts ActorsOpts) ActorRuntime {
 	return newActorsWithClock(opts, &clock.RealClock{})
 }
 
-func newActorsWithClock(opts ActorsOpts, clock clock.WithTicker) Actors {
+func newActorsWithClock(opts ActorsOpts, clock clock.WithTicker) ActorRuntime {
 	appHealthy := &atomic.Bool{}
 	appHealthy.Store(true)
 

--- a/pkg/actors/internal_actor.go
+++ b/pkg/actors/internal_actor.go
@@ -96,8 +96,10 @@ func (c *internalActorChannel) InvokeMethod(ctx context.Context, req *invokev1.I
 		return nil, fmt.Errorf("internal actor type '%s' not recognized", actorType)
 	}
 
-	var result interface{} = nil
-	var err error
+	var (
+		result any
+		err    error
+	)
 
 	verb := req.Message().GetHttpExtension().GetVerb()
 	actorID := req.Actor().GetActorId()

--- a/pkg/grpc/api.go
+++ b/pkg/grpc/api.go
@@ -70,7 +70,7 @@ type API interface {
 	runtimev1pb.DaprServer
 
 	// Methods internal to the object
-	SetActorRuntime(actor actors.Actors)
+	SetActorRuntime(actor actors.ActorRuntime)
 }
 
 type api struct {
@@ -1241,7 +1241,7 @@ func (a *api) InvokeActor(ctx context.Context, in *runtimev1pb.InvokeActorReques
 	return response, nil
 }
 
-func (a *api) SetActorRuntime(actor actors.Actors) {
+func (a *api) SetActorRuntime(actor actors.ActorRuntime) {
 	a.UniversalAPI.Actors = actor
 }
 

--- a/pkg/grpc/universalapi/universalapi.go
+++ b/pkg/grpc/universalapi/universalapi.go
@@ -30,7 +30,7 @@ type UniversalAPI struct {
 	AppID                       string
 	Logger                      logger.Logger
 	Resiliency                  resiliency.Provider
-	Actors                      actors.Actors
+	Actors                      actors.ActorRuntime
 	CompStore                   *compstore.ComponentStore
 	ShutdownFn                  func()
 	GetComponentsCapabilitiesFn func() map[string][]string

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -59,7 +59,7 @@ type API interface {
 	PublicEndpoints() []Endpoint
 	MarkStatusAsReady()
 	MarkStatusAsOutboundReady()
-	SetActorRuntime(actor actors.Actors)
+	SetActorRuntime(actor actors.ActorRuntime)
 }
 
 type api struct {
@@ -1972,6 +1972,6 @@ func (a *api) onQueryStateHandler() nethttp.HandlerFunc {
 	)
 }
 
-func (a *api) SetActorRuntime(actor actors.Actors) {
+func (a *api) SetActorRuntime(actor actors.ActorRuntime) {
 	a.universal.Actors = actor
 }

--- a/pkg/runtime/registry/registry.go
+++ b/pkg/runtime/registry/registry.go
@@ -14,7 +14,6 @@ limitations under the License.
 package registry
 
 import (
-	"github.com/dapr/dapr/pkg/actors"
 	"github.com/dapr/dapr/pkg/components/bindings"
 	"github.com/dapr/dapr/pkg/components/configuration"
 	"github.com/dapr/dapr/pkg/components/crypto"
@@ -32,7 +31,6 @@ import (
 type ComponentsCallback func(components ComponentRegistry) error
 
 type ComponentRegistry struct {
-	Actors          actors.Actors
 	DirectMessaging messagingv1.DirectMessaging
 	CompStore       *compstore.ComponentStore
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -114,7 +114,7 @@ type DaprRuntime struct {
 	channels          *channels.Channels
 	appConfig         config.ApplicationConfig
 	directMessaging   invokev1.DirectMessaging
-	actor             actors.Actors
+	actor             actors.ActorRuntime
 
 	nameResolver            nr.Resolver
 	hostAddress             string
@@ -590,7 +590,6 @@ func (a *DaprRuntime) appHealthReadyInit(ctx context.Context) error {
 
 	if cb := a.runtimeConfig.registry.ComponentsCallback(); cb != nil {
 		if err = cb(registry.ComponentRegistry{
-			Actors:          a.actor,
 			DirectMessaging: a.directMessaging,
 			CompStore:       a.compStore,
 		}); err != nil {

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -40,7 +40,7 @@ type WorkflowEngine struct {
 	workflowActor *workflowActor
 	activityActor *activityActor
 
-	actorRuntime   actors.Actors
+	actorRuntime   actors.ActorRuntime
 	startMutex     sync.Mutex
 	disconnectChan chan any
 	config         wfConfig
@@ -141,7 +141,7 @@ func (wfe *WorkflowEngine) SetExecutor(fn func(be backend.Backend) backend.Execu
 	wfe.executor = fn(wfe.backend)
 }
 
-func (wfe *WorkflowEngine) SetActorRuntime(actorRuntime actors.Actors) error {
+func (wfe *WorkflowEngine) SetActorRuntime(actorRuntime actors.ActorRuntime) error {
 	wfLogger.Info("Configuring workflow engine with actors backend")
 	wfe.actorRuntime = actorRuntime
 	wfe.backend.SetActorRuntime(actorRuntime)

--- a/pkg/runtime/wfengine/workflowstate_test.go
+++ b/pkg/runtime/wfengine/workflowstate_test.go
@@ -196,14 +196,13 @@ func getActorRuntime() actors.Actors {
 	})
 	compStore := compstore.New()
 	compStore.AddStateStore("workflowStore", store)
-	actors := actors.NewActors(actors.ActorsOpts{
+	return actors.NewActors(actors.ActorsOpts{
 		CompStore:      compStore,
 		Config:         cfg,
 		StateStoreName: "workflowStore",
 		MockPlacement:  NewMockPlacement(),
 		Resiliency:     resiliency.New(logger.NewLogger("test")),
 	})
-	return actors
 }
 
 func countOperations(t *testing.T, req *actors.TransactionalRequest) (upsertCount, deleteCount int) {


### PR DESCRIPTION
Related to #6538

Splits the Actors interface into two parts:

- `Actors` includes methods that actors can invoke only, such as calling actors, working with timers and reminders
- `ActorsRuntime` is the main actor runtime. It embeds `Actors` and it offers additional methods that are only used internally

This change makes it possible to expose to internal actors (such as workflow) a subset of methods. It will make it easier to create more internal actors (see #6538).

Otherwise, this PR doesn't include any changes in functionality. Changes can be considered mostly cosmetic.