### PR TITLE
Adds cluster.local top level domain to default sentry address in dapr system config

### DIFF
--- a/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
+++ b/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
@@ -14,5 +14,5 @@ spec:
     workloadCertTTL: {{ .Values.global.mtls.workloadCertTTL }}
     allowedClockSkew: {{ .Values.global.mtls.allowedClockSkew }}
     controlPlaneTrustDomain: {{ .Values.global.mtls.controlPlaneTrustDomain }}
-    sentryAddress: {{ if .Values.global.mtls.sentryAddress }}{{ .Values.global.mtls.sentryAddress }}{{ else }}dapr-sentry.{{ .Release.Namespace }}.svc:443{{ end }}
+    sentryAddress: {{ if .Values.global.mtls.sentryAddress }}{{ .Values.global.mtls.sentryAddress }}{{ else }}dapr-sentry.{{ .Release.Namespace }}.svc.cluster.local:443{{ end }}
 {{- end }}

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -39,7 +39,7 @@ global:
     workloadCertTTL: 24h
     allowedClockSkew: 15m
     controlPlaneTrustDomain: "cluster.local"
-    # Used to override `dapr-sentry.{{ .Release.Namespace }}.svc:443`
+    # Used to override `dapr-sentry.{{ .Release.Namespace }}.svc.cluster.local:443`
     #sentryAddress:
   actors:
     enabled: true

--- a/pkg/security/x509source.go
+++ b/pkg/security/x509source.go
@@ -406,21 +406,16 @@ func atomicWrite(clock clock.Clock, dir string, data map[string][]byte) error {
 		}
 	}
 
-	if err := os.Symlink(newDir, dir+"-new"); err != nil {
-		return err
-	}
-
+	// Symlinks are typically not available on Windows, so we use a rename
+	// instead and don't save history.
 	if runtime.GOOS == "windows" {
-		if err := os.Remove(dir); err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		if err := os.Symlink(newDir, dir); err != nil {
-			return err
-		}
-		if err := os.Remove(dir + "-new"); err != nil {
+		if err := os.Rename(newDir, dir); err != nil {
 			return err
 		}
 	} else {
+		if err := os.Symlink(newDir, dir+"-new"); err != nil {
+			return err
+		}
 		if err := os.Rename(dir+"-new", dir); err != nil {
 			return err
 		}

--- a/pkg/security/x509source.go
+++ b/pkg/security/x509source.go
@@ -427,8 +427,10 @@ func atomicWrite(clock clock.Clock, dir string, data map[string][]byte) error {
 				return err
 			}
 		}
+		// You can't rename a directory over an existing directory.
+		os.RemoveAll(dir)
 		if err := os.Rename(dir+"-new", dir); err != nil {
-			return err
+			return fmt.Errorf("failed to rename %s to %s: %w", dir+"-new", dir, err)
 		}
 	} else {
 		if err := os.Symlink(newDir, dir+"-new"); err != nil {

--- a/pkg/security/x509source_test.go
+++ b/pkg/security/x509source_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/x509"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -229,12 +230,14 @@ func Test_atomicWrite(t *testing.T) {
 
 			f, err = os.Lstat(dir)
 			require.NoError(t, err)
-			assert.False(t, f.IsDir())
-			assert.Equal(t, os.ModeSymlink.Type().String(), f.Mode().Type().String())
-
-			target, err := os.Readlink(dir)
-			require.NoError(t, err)
-			assert.Equal(t, newDir, target)
+			if runtime.GOOS == "windows" {
+				assert.Equal(t, os.ModeDir.Type().String(), f.Mode().Type().String())
+			} else {
+				assert.Equal(t, os.ModeSymlink.Type().String(), f.Mode().Type().String())
+				target, err := os.Readlink(dir)
+				require.NoError(t, err)
+				assert.Equal(t, newDir, target)
+			}
 
 			walkDir, err := os.ReadDir(newDir)
 			require.NoError(t, err)

--- a/pkg/security/x509source_test.go
+++ b/pkg/security/x509source_test.go
@@ -234,8 +234,8 @@ func Test_atomicWrite(t *testing.T) {
 				assert.Equal(t, os.ModeDir.Type().String(), f.Mode().Type().String())
 			} else {
 				assert.Equal(t, os.ModeSymlink.Type().String(), f.Mode().Type().String())
-				target, err := os.Readlink(dir)
-				require.NoError(t, err)
+				target, lerr := os.Readlink(dir)
+				require.NoError(t, lerr)
 				assert.Equal(t, newDir, target)
 			}
 


### PR DESCRIPTION
Changes the default sentry address top level domain in dapr helm chart config to include `cluster.local`. This is to be consistent elsewhere and support cases where this is required.

Changes the security atomic writer to not use system links on Windows. It is often the case that Windows containers do not have permissions to create system links.