### PR TITLE
add to clientID tests to test both k8s and standalone mode

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1332,7 +1332,7 @@ func TestMetadataClientID(t *testing.T) {
 		select {
 		case clientID := <-clientIDChan:
 			assert.Equal(t, "test.myApp", clientID)
-		case <-time.After(2 * time.Second):
+		case <-time.After(20 * time.Second):
 			t.Error("Timed out waiting for clientID for Kubernetes Mode test")
 		}
 	})
@@ -1383,7 +1383,7 @@ func TestMetadataClientID(t *testing.T) {
 		select {
 		case clientID := <-clientIDChan:
 			assert.Equal(t, standAloneClientID, clientID)
-		case <-time.After(2 * time.Second):
+		case <-time.After(20 * time.Second):
 			t.Error("Timed out waiting for clientID for Standalone Mode test")
 		}
 	})


### PR DESCRIPTION
# Description

Made sure that both the standalone and kubernetes modes are being tested for clientID. 

## Issue reference

Will close this issue: [validating Kafka](https://github.com/dapr/components-contrib/issues/2397)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
