### PR TITLE
Updates github.com/dapr/kit.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cloudevents/sdk-go/v2 v2.14.0
 	github.com/dapr/components-contrib v1.11.3-0.20230905221417-0c2ce324b2bf
-	github.com/dapr/kit v0.11.4-0.20230807225040-b6b141aa3e32
+	github.com/dapr/kit v0.11.4-0.20230907165049-f08dc3ff1671
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.11.3-0.20230905221417-0c2ce324b2bf h1:dszfRm7WTZuLz0/lfEqvfJjstZEbTx2GgL9Re38UY7M=
 github.com/dapr/components-contrib v1.11.3-0.20230905221417-0c2ce324b2bf/go.mod h1:jgo1jGXsi+ikW/g/qDXZMMRTUYz8+i3+HmvVVhMqcIU=
-github.com/dapr/kit v0.11.4-0.20230807225040-b6b141aa3e32 h1:ctqg12Eqd9SE88pwlJTupsIJowtaQcyH4s5xRMoweUU=
-github.com/dapr/kit v0.11.4-0.20230807225040-b6b141aa3e32/go.mod h1:bRyy09hwD03VEJ6b4weVNZWDjC5K3XY1+oGI5JCdZnU=
+github.com/dapr/kit v0.11.4-0.20230907165049-f08dc3ff1671 h1:G+bO4jojjphyGgPWwDlgXCROSMk4U+yfDCMHGshduck=
+github.com/dapr/kit v0.11.4-0.20230907165049-f08dc3ff1671/go.mod h1:eNYjsudq3Ij0x8CLWsPturHor56sZRNu5tk2hUiJT80=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/actors/timers/timers.go
+++ b/pkg/actors/timers/timers.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/actors/internal"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
-	"github.com/dapr/kit/eventqueue"
+	"github.com/dapr/kit/events/queue"
 	"github.com/dapr/kit/logger"
 )
 
@@ -42,7 +42,7 @@ type timers struct {
 	activeTimersCountLock sync.RWMutex
 	metricsCollector      timersMetricsCollector
 	runningCh             chan struct{}
-	processor             *eventqueue.Processor[*internal.Reminder]
+	processor             *queue.Processor[*internal.Reminder]
 }
 
 // NewTimersProvider returns a TimerProvider.
@@ -54,7 +54,7 @@ func NewTimersProvider(clock clock.WithTicker) internal.TimersProvider {
 		metricsCollector:  diag.DefaultMonitoring.ActorTimers,
 		runningCh:         make(chan struct{}),
 	}
-	t.processor = eventqueue.NewProcessor[*internal.Reminder](t.processorExecuteFn, t.clock)
+	t.processor = queue.NewProcessor[*internal.Reminder](t.processorExecuteFn)
 	return t
 }
 

--- a/pkg/actors/timers/timers_test.go
+++ b/pkg/actors/timers/timers_test.go
@@ -36,8 +36,9 @@ const TestAppID = "fakeAppID"
 
 func newTestTimers() *timers {
 	clock := clocktesting.NewFakeClock(startOfTime)
-	r := NewTimersProvider(clock)
-	return r.(*timers)
+	r := NewTimersProvider(clock).(*timers)
+	r.processor.WithClock(clock)
+	return r
 }
 
 // testRequest is the request object that encapsulates the `data` field of a request.
@@ -49,6 +50,7 @@ func TestCreateTimerDueTimes(t *testing.T) {
 	t.Run("create timer with positive DueTime", func(t *testing.T) {
 		clock := clocktesting.NewFakeClock(startOfTime)
 		provider := NewTimersProvider(clock).(*timers)
+		provider.processor.WithClock(clock)
 		defer provider.Close()
 
 		executed := make(chan string, 1)
@@ -86,6 +88,7 @@ func TestCreateTimerDueTimes(t *testing.T) {
 	t.Run("create timer with 0 DueTime", func(t *testing.T) {
 		clock := clocktesting.NewFakeClock(startOfTime)
 		provider := NewTimersProvider(clock).(*timers)
+		provider.processor.WithClock(clock)
 		defer provider.Close()
 
 		executed := make(chan string, 1)
@@ -123,6 +126,7 @@ func TestCreateTimerDueTimes(t *testing.T) {
 	t.Run("create timer with no DueTime", func(t *testing.T) {
 		clock := clocktesting.NewFakeClock(startOfTime)
 		provider := NewTimersProvider(clock).(*timers)
+		provider.processor.WithClock(clock)
 		defer provider.Close()
 
 		executed := make(chan string, 1)
@@ -575,6 +579,7 @@ func TestTimerValidation(t *testing.T) {
 func TestOverrideTimer(t *testing.T) {
 	clock := clocktesting.NewFakeClock(startOfTime)
 	provider := NewTimersProvider(clock).(*timers)
+	provider.processor.WithClock(clock)
 	defer provider.Close()
 
 	executed := make(chan string, 1)
@@ -648,6 +653,7 @@ func TestTimerCounter(t *testing.T) {
 
 	clock := clocktesting.NewFakeClock(startOfTime)
 	provider := NewTimersProvider(clock).(*timers)
+	provider.processor.WithClock(clock)
 	defer provider.Close()
 
 	// Init a mock metrics collector
@@ -774,6 +780,7 @@ func TestTimerCounter(t *testing.T) {
 func TestCreateTimerGoroutineLeak(t *testing.T) {
 	clock := clocktesting.NewFakeClock(startOfTime)
 	provider := NewTimersProvider(clock).(*timers)
+	provider.processor.WithClock(clock)
 	defer provider.Close()
 	require.NoError(t, provider.Init(context.Background()))
 


### PR DESCRIPTION
Update actor timers to use new kit events queue package which sets clock in tests.

/cc @berndverst 