### PR TITLE
Allow the injector control plane service to request any identity from sentry

### DIFF
--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -99,7 +99,7 @@ func (s *sentry) Start(parentCtx context.Context) error {
 				// authorizing the server based on the correct SPIFFE ID, and instead
 				// matched on the DNS SAN `cluster.local`(!).
 				DNS: []string{"cluster.local"},
-			})
+			}, false)
 			if csrErr != nil {
 				monitoring.ServerCertIssueFailed("ca_error")
 				return nil, csrErr

--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -18,6 +18,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/x509"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -58,7 +59,11 @@ type Signer interface {
 	// that this does not include the trust anchors, and does not perform _any_
 	// kind of validation on the request; authz should already have happened
 	// before this point.
-	SignIdentity(context.Context, *SignRequest) ([]*x509.Certificate, error)
+	// If given true, then the certificate duration will be given the largest
+	// possible according to the signing certificate.
+	// TODO: @joshvanl: Remove bool value in v1.13 as the inject no longer needs
+	// to request other identities.
+	SignIdentity(context.Context, *SignRequest, bool) ([]*x509.Certificate, error)
 
 	// TrustAnchors returns the trust anchors for the CA in PEM format.
 	TrustAnchors() []byte
@@ -132,7 +137,7 @@ func New(ctx context.Context, conf config.Config) (Signer, error) {
 	}, nil
 }
 
-func (c *ca) SignIdentity(ctx context.Context, req *SignRequest) ([]*x509.Certificate, error) {
+func (c *ca) SignIdentity(ctx context.Context, req *SignRequest, overrideDuration bool) ([]*x509.Certificate, error) {
 	spiffeID, err := (spiffe.Parsed{
 		TrustDomain: req.TrustDomain,
 		Namespace:   req.Namespace,
@@ -142,7 +147,12 @@ func (c *ca) SignIdentity(ctx context.Context, req *SignRequest) ([]*x509.Certif
 		return nil, err
 	}
 
-	tmpl, err := generateWorkloadCert(req.SignatureAlgorithm, c.config.WorkloadCertTTL, c.config.AllowedClockSkew, spiffeID)
+	dur := c.config.WorkloadCertTTL
+	if overrideDuration {
+		dur = time.Until(c.bundle.IssChain[0].NotAfter)
+	}
+
+	tmpl, err := generateWorkloadCert(req.SignatureAlgorithm, dur, c.config.AllowedClockSkew, spiffeID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/server/ca/ca_test.go
+++ b/pkg/sentry/server/ca/ca_test.go
@@ -171,7 +171,7 @@ func TestSignIdentity(t *testing.T) {
 			Namespace:          "my-test-namespace",
 			AppID:              "my-app-id",
 			DNS:                []string{"my-app-id.my-test-namespace.svc.cluster.local", "example.com"},
-		})
+		}, false)
 		require.NoError(t, err)
 
 		require.Len(t, clientCert, 3)

--- a/pkg/sentry/server/ca/fake/fake.go
+++ b/pkg/sentry/server/ca/fake/fake.go
@@ -24,13 +24,13 @@ import (
 )
 
 type Fake struct {
-	signIdentityFn func(context.Context, *ca.SignRequest) ([]*x509.Certificate, error)
+	signIdentityFn func(context.Context, *ca.SignRequest, bool) ([]*x509.Certificate, error)
 	trustAnchorsFn func() []byte
 }
 
 func New() *Fake {
 	return &Fake{
-		signIdentityFn: func(context.Context, *ca.SignRequest) ([]*x509.Certificate, error) {
+		signIdentityFn: func(context.Context, *ca.SignRequest, bool) ([]*x509.Certificate, error) {
 			return nil, nil
 		},
 		trustAnchorsFn: func() []byte {
@@ -39,7 +39,7 @@ func New() *Fake {
 	}
 }
 
-func (f *Fake) WithSignIdentity(fn func(context.Context, *ca.SignRequest) ([]*x509.Certificate, error)) *Fake {
+func (f *Fake) WithSignIdentity(fn func(context.Context, *ca.SignRequest, bool) ([]*x509.Certificate, error)) *Fake {
 	f.signIdentityFn = fn
 	return f
 }
@@ -49,8 +49,8 @@ func (f *Fake) WithTrustAnchors(fn func() []byte) *Fake {
 	return f
 }
 
-func (f *Fake) SignIdentity(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
-	return f.signIdentityFn(ctx, req)
+func (f *Fake) SignIdentity(ctx context.Context, req *ca.SignRequest, overrideDuration bool) ([]*x509.Certificate, error) {
+	return f.signIdentityFn(ctx, req, overrideDuration)
 }
 
 func (f *Fake) TrustAnchors() []byte {

--- a/pkg/sentry/server/server.go
+++ b/pkg/sentry/server/server.go
@@ -120,7 +120,7 @@ func (s *server) signCertificate(ctx context.Context, req *sentryv1pb.SignCertif
 
 	log.Debugf("Processing SignCertificate request for %s/%s (validator: %s)", req.Namespace, req.Id, validator.String())
 
-	trustDomain, err := s.vals[validator].Validate(ctx, req)
+	trustDomain, overrideDuration, err := s.vals[validator].Validate(ctx, req)
 	if err != nil {
 		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}
@@ -173,7 +173,7 @@ func (s *server) signCertificate(ctx context.Context, req *sentryv1pb.SignCertif
 		Namespace:          req.Namespace,
 		AppID:              req.Id,
 		DNS:                dns,
-	})
+	}, overrideDuration)
 	if err != nil {
 		log.Errorf("Error signing identity: %v", err)
 		return nil, status.Error(codes.Internal, "failed to sign certificate")

--- a/pkg/sentry/server/server_test.go
+++ b/pkg/sentry/server/server_test.go
@@ -82,10 +82,10 @@ func TestRun(t *testing.T) {
 			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
-			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.RequireTrustDomainFromString("test"), nil
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.RequireTrustDomainFromString("test"), false, nil
 			}),
-			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
 				return []*x509.Certificate{}, nil
 			}).WithTrustAnchors(func() []byte {
 				return []byte("my-trust-anchors")
@@ -106,10 +106,10 @@ func TestRun(t *testing.T) {
 			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
-			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.RequireTrustDomainFromString("test"), nil
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.RequireTrustDomainFromString("test"), false, nil
 			}),
-			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
 				return nil, fmt.Errorf("signing error")
 			}).WithTrustAnchors(func() []byte {
 				return []byte("my-trust-anchors")
@@ -130,10 +130,10 @@ func TestRun(t *testing.T) {
 			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
-			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), nil
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), false, nil
 			}),
-			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
 				return []*x509.Certificate{crtX509}, nil
 			}).WithTrustAnchors(func() []byte {
 				return []byte("my-trust-anchors")
@@ -154,10 +154,10 @@ func TestRun(t *testing.T) {
 			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
-			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.TrustDomain{}, fmt.Errorf("validation error")
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.TrustDomain{}, false, fmt.Errorf("validation error")
 			}),
-			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
 				return []*x509.Certificate{crtX509}, nil
 			}).WithTrustAnchors(func() []byte {
 				return []byte("my-trust-anchors")
@@ -178,10 +178,10 @@ func TestRun(t *testing.T) {
 			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
-			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), nil
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), false, nil
 			}),
-			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
 				return []*x509.Certificate{crtX509}, nil
 			}).WithTrustAnchors(func() []byte {
 				return []byte("my-trust-anchors")
@@ -206,10 +206,10 @@ func TestRun(t *testing.T) {
 			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
-			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), nil
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), false, nil
 			}),
-			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
 				assert.Equal(t, []string{"dapr-sidecar-injector.default.svc"}, req.DNS)
 				return []*x509.Certificate{crtX509}, nil
 			}).WithTrustAnchors(func() []byte {
@@ -235,17 +235,48 @@ func TestRun(t *testing.T) {
 			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
-			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), nil
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), false, nil
 			}),
-			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
 				assert.Equal(t, []string{"cluster.local", "dapr-webhook.default.svc"}, req.DNS)
+				assert.False(t, override)
 				return []*x509.Certificate{crtX509}, nil
 			}).WithTrustAnchors(func() []byte {
 				return []byte("my-trust-anchors")
 			}),
 			req: &sentryv1pb.SignCertificateRequest{
 				Id:                        "dapr-operator",
+				Token:                     "my-token",
+				TrustDomain:               "my-trust-domain",
+				Namespace:                 "default",
+				CertificateSigningRequest: csrPEM,
+				TokenValidator:            sentryv1pb.SignCertificateRequest_TokenValidator(-1),
+			},
+			expResp: &sentryv1pb.SignCertificateResponse{
+				WorkloadCertificate:    crtPEM,
+				TrustChainCertificates: [][]byte{[]byte("my-trust-anchors")},
+				ValidUntil:             timestamppb.New(time.Date(2023, 1, 1, 1, 1, 1, 0, time.UTC)),
+			},
+			expErr:  false,
+			expCode: codes.OK,
+		},
+		"if request has duration override, expect the cert duration to be max": {
+			sec: securityfake.New().WithGRPCServerOptionNoClientAuthFn(func() grpc.ServerOption {
+				return grpc.Creds(insecure.NewCredentials())
+			}),
+			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+				return spiffeid.RequireTrustDomainFromString("my-trust-domain"), true, nil
+			}),
+			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest, override bool) ([]*x509.Certificate, error) {
+				assert.Equal(t, []string{"dapr-sidecar-injector.default.svc"}, req.DNS)
+				assert.True(t, override)
+				return []*x509.Certificate{crtX509}, nil
+			}).WithTrustAnchors(func() []byte {
+				return []byte("my-trust-anchors")
+			}),
+			req: &sentryv1pb.SignCertificateRequest{
+				Id:                        "dapr-injector",
 				Token:                     "my-token",
 				TrustDomain:               "my-trust-domain",
 				Namespace:                 "default",

--- a/pkg/sentry/server/validator/fake/fake.go
+++ b/pkg/sentry/server/validator/fake/fake.go
@@ -26,7 +26,7 @@ import (
 
 // Fake implements the validator.Interface. It is used in tests.
 type Fake struct {
-	validateFn func(context.Context, *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error)
+	validateFn func(context.Context, *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error)
 	startFn    func(context.Context) error
 }
 
@@ -35,13 +35,13 @@ func New() *Fake {
 		startFn: func(context.Context) error {
 			return nil
 		},
-		validateFn: func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-			return spiffeid.TrustDomain{}, nil
+		validateFn: func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
+			return spiffeid.TrustDomain{}, false, nil
 		},
 	}
 }
 
-func (f *Fake) WithValidateFn(fn func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error)) *Fake {
+func (f *Fake) WithValidateFn(fn func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error)) *Fake {
 	f.validateFn = fn
 	return f
 }
@@ -51,7 +51,7 @@ func (f *Fake) WithStartFn(fn func(ctx context.Context) error) *Fake {
 	return f
 }
 
-func (f *Fake) Validate(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
+func (f *Fake) Validate(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
 	return f.validateFn(ctx, req)
 }
 

--- a/pkg/sentry/server/validator/insecure/insecure.go
+++ b/pkg/sentry/server/validator/insecure/insecure.go
@@ -36,6 +36,6 @@ func (s *insecure) Start(ctx context.Context) error {
 	return nil
 }
 
-func (s *insecure) Validate(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
+func (s *insecure) Validate(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
 	return internal.Validate(ctx, req)
 }

--- a/pkg/sentry/server/validator/internal/common.go
+++ b/pkg/sentry/server/validator/internal/common.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Validate validates the common rules for all requests.
-func Validate(_ context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
+func Validate(_ context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
 	err := errors.Join(
 		validation.ValidateSelfHostedAppID(req.Id),
 		appIDLessOrEqualTo64Characters(req.Id),
@@ -33,15 +33,18 @@ func Validate(_ context.Context, req *sentryv1pb.SignCertificateRequest) (spiffe
 		namespaceIsRequired(req.Namespace),
 	)
 	if err != nil {
-		return spiffeid.TrustDomain{}, fmt.Errorf("invalid request: %w", err)
+		return spiffeid.TrustDomain{}, false, fmt.Errorf("invalid request: %w", err)
 	}
 
+	var td spiffeid.TrustDomain
 	if req.GetTrustDomain() == "" {
 		// Default to public trust domain if not specified.
-		return spiffeid.TrustDomainFromString("public")
+		td, err = spiffeid.TrustDomainFromString("public")
+		return td, false, err
 	}
 
-	return spiffeid.TrustDomainFromString(req.GetTrustDomain())
+	td, err = spiffeid.TrustDomainFromString(req.GetTrustDomain())
+	return td, false, err
 }
 
 func appIDLessOrEqualTo64Characters(appID string) error {

--- a/pkg/sentry/server/validator/internal/common_test.go
+++ b/pkg/sentry/server/validator/internal/common_test.go
@@ -93,9 +93,10 @@ func TestValidate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			td, err := Validate(context.Background(), test.req)
+			td, overrideDuration, err := Validate(context.Background(), test.req)
 			assert.Equal(t, test.expTD, td)
 			assert.Equal(t, test.expErr, err)
+			assert.False(t, overrideDuration)
 		})
 	}
 }

--- a/pkg/sentry/server/validator/kubernetes/kubernetes.go
+++ b/pkg/sentry/server/validator/kubernetes/kubernetes.go
@@ -49,20 +49,10 @@ const (
 )
 
 var (
-	log    = logger.NewLogger("dapr.sentry.identity.kubernetes")
-	scheme = runtime.NewScheme()
+	log = logger.NewLogger("dapr.sentry.identity.kubernetes")
 
 	errMissingPodClaim = errors.New("kubernetes.io/pod/name claim is missing from Kubernetes token")
 )
-
-func init() {
-	if err := configv1alpha1.AddToScheme(scheme); err != nil {
-		panic(err)
-	}
-	if err := corev1.AddToScheme(scheme); err != nil {
-		panic(err)
-	}
-}
 
 type Options struct {
 	RestConfig     *rest.Config
@@ -84,6 +74,14 @@ type kubernetes struct {
 func New(ctx context.Context, opts Options) (validator.Validator, error) {
 	kubeClient, err := cl.NewForConfig(opts.RestConfig)
 	if err != nil {
+		return nil, err
+	}
+
+	scheme := runtime.NewScheme()
+	if err = configv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err = corev1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 
@@ -120,67 +118,72 @@ func (k *kubernetes) Start(ctx context.Context) error {
 	return nil
 }
 
-func (k *kubernetes) Validate(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
+func (k *kubernetes) Validate(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error) {
 	if !k.ready(ctx) {
-		return spiffeid.TrustDomain{}, errors.New("validator not ready")
+		return spiffeid.TrustDomain{}, false, errors.New("validator not ready")
 	}
 
 	// The TrustDomain field is ignored by the Kubernetes validator.
-	if _, err := internal.Validate(ctx, req); err != nil {
-		return spiffeid.TrustDomain{}, err
+	if _, _, err := internal.Validate(ctx, req); err != nil {
+		return spiffeid.TrustDomain{}, false, err
 	}
 
 	prts, err := k.executeTokenReview(ctx, req.GetToken(), LegacyServiceAccountAudience, k.sentryAudience)
 	if err != nil {
-		return spiffeid.TrustDomain{}, err
+		return spiffeid.TrustDomain{}, false, err
 	}
 
 	if len(prts) != 4 || prts[0] != "system" {
-		return spiffeid.TrustDomain{}, errors.New("provided token is not a properly structured service account token")
+		return spiffeid.TrustDomain{}, false, errors.New("provided token is not a properly structured service account token")
 	}
 
 	// We have already validated to the token against Kubernetes API server, so
 	// we do not need to supply a key.
 	ptoken, err := jwt.ParseInsecure([]byte(req.GetToken()), jwt.WithTypedClaim("kubernetes.io", new(k8sClaims)))
 	if err != nil {
-		return spiffeid.TrustDomain{}, fmt.Errorf("failed to parse Kubernetes token: %s", err)
+		return spiffeid.TrustDomain{}, false, fmt.Errorf("failed to parse Kubernetes token: %s", err)
 	}
 	claimsT, ok := ptoken.Get("kubernetes.io")
 	if !ok {
-		return spiffeid.TrustDomain{}, errMissingPodClaim
+		return spiffeid.TrustDomain{}, false, errMissingPodClaim
 	}
 	claims, ok := claimsT.(*k8sClaims)
 	if !ok || len(claims.Pod.Name) == 0 || len(claims.Pod.Namespace) == 0 {
-		return spiffeid.TrustDomain{}, errMissingPodClaim
+		return spiffeid.TrustDomain{}, false, errMissingPodClaim
 	}
 
 	var pod corev1.Pod
 	err = k.client.Get(ctx, types.NamespacedName{Namespace: claims.Pod.Namespace, Name: claims.Pod.Name}, &pod)
 	if err != nil {
 		log.Errorf("Failed to get pod %s/%s for requested identity: %s", claims.Pod.Namespace, claims.Pod.Name, err)
-		return spiffeid.TrustDomain{}, errors.New("failed to get pod of identity")
+		return spiffeid.TrustDomain{}, false, errors.New("failed to get pod of identity")
 	}
 
 	// TODO: @joshvanl: Remove is v1.13 when injector no longer needs to request
 	// daprd identities.
 	var injectorRequesting bool
+	var overrideDuration bool
 	if ctrlPlane, oka := pod.Annotations[consts.AnnotationKeyControlPlane]; oka && ctrlPlane == "injector" {
 		injectorRequesting = pod.Namespace == k.controlPlaneNS
 	}
 
-	if (prts[2] != req.Namespace || claims.Pod.Namespace != req.Namespace) && !injectorRequesting {
-		return spiffeid.TrustDomain{}, fmt.Errorf("namespace mismatch; received namespace: %s", req.Namespace)
+	if prts[2] != req.Namespace || claims.Pod.Namespace != req.Namespace {
+		if injectorRequesting {
+			overrideDuration = true
+		} else {
+			return spiffeid.TrustDomain{}, false, fmt.Errorf("namespace mismatch; received namespace: %s", req.Namespace)
+		}
 	}
 
 	if pod.Spec.ServiceAccountName != prts[3] {
 		log.Errorf("Service account on pod %s/%s does not match token", req.Namespace, claims.Pod.Name)
-		return spiffeid.TrustDomain{}, errors.New("pod service account mismatch")
+		return spiffeid.TrustDomain{}, false, errors.New("pod service account mismatch")
 	}
 
 	expID, isControlPlane, err := k.expectedID(&pod)
 	if err != nil {
 		log.Errorf("Failed to get expected ID for pod %s/%s: %s", req.Namespace, claims.Pod.Name, err)
-		return spiffeid.TrustDomain{}, err
+		return spiffeid.TrustDomain{}, false, err
 	}
 
 	// TODO: @joshvanl: Before v1.12, the injector instructed daprd to request
@@ -194,35 +197,39 @@ func (k *kubernetes) Validate(ctx context.Context, req *sentryv1pb.SignCertifica
 	// TODO: @joshvanl: Remove is v1.13 when injector no longer needs to request
 	// daprd identities.
 	if injectorRequesting {
+		if expID != req.Id {
+			overrideDuration = true
+		}
 		expID = req.Id
 	}
 
 	if expID != req.Id {
-		return spiffeid.TrustDomain{}, fmt.Errorf("app-id mismatch. expected: %s, received: %s", expID, req.Id)
+		return spiffeid.TrustDomain{}, false, fmt.Errorf("app-id mismatch. expected: %s, received: %s", expID, req.Id)
 	}
 
 	if isControlPlane {
-		return k.controlPlaneTD, nil
+		return k.controlPlaneTD, overrideDuration, nil
 	}
 
 	configName, ok := pod.GetAnnotations()[annotations.KeyConfig]
 	if !ok {
 		// Return early with default trust domain if no config annotation is found.
-		return spiffeid.RequireTrustDomainFromString("public"), nil
+		return spiffeid.RequireTrustDomainFromString("public"), overrideDuration, nil
 	}
 
 	var config configv1alpha1.Configuration
 	err = k.client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: configName}, &config)
 	if err != nil {
 		log.Errorf("Failed to get configuration %q: %v", configName, err)
-		return spiffeid.TrustDomain{}, errors.New("failed to get configuration")
+		return spiffeid.TrustDomain{}, false, errors.New("failed to get configuration")
 	}
 
 	if config.Spec.AccessControlSpec == nil || len(config.Spec.AccessControlSpec.TrustDomain) == 0 {
-		return spiffeid.RequireTrustDomainFromString("public"), nil
+		return spiffeid.RequireTrustDomainFromString("public"), overrideDuration, nil
 	}
 
-	return spiffeid.TrustDomainFromString(config.Spec.AccessControlSpec.TrustDomain)
+	td, err := spiffeid.TrustDomainFromString(config.Spec.AccessControlSpec.TrustDomain)
+	return td, overrideDuration, err
 }
 
 // expectedID returns the expected ID for the pod. If the pod is a control

--- a/pkg/sentry/server/validator/kubernetes/kubernetes.go
+++ b/pkg/sentry/server/validator/kubernetes/kubernetes.go
@@ -198,15 +198,12 @@ func (k *kubernetes) Validate(ctx context.Context, req *sentryv1pb.SignCertifica
 
 	// TODO: @joshvanl: Remove is v1.13 when injector no longer needs to request
 	// daprd identities.
-	if injectorRequesting {
-		if expID != req.Id {
-			overrideDuration = true
-		}
-		expID = req.Id
-	}
-
 	if expID != req.Id {
-		return spiffeid.TrustDomain{}, false, fmt.Errorf("app-id mismatch. expected: %s, received: %s", expID, req.Id)
+		if injectorRequesting {
+			overrideDuration = true
+		} else {
+			return spiffeid.TrustDomain{}, false, fmt.Errorf("app-id mismatch. expected: %s, received: %s", expID, req.Id)
+		}
 	}
 
 	if isControlPlane {

--- a/pkg/sentry/server/validator/kubernetes/kubernetes_test.go
+++ b/pkg/sentry/server/validator/kubernetes/kubernetes_test.go
@@ -31,7 +31,6 @@ import (
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
-	configv1alpha1 "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
 	sentryv1pb "github.com/dapr/dapr/pkg/proto/sentry/v1"
 )
 
@@ -1112,7 +1111,7 @@ func TestValidate(t *testing.T) {
 			kubeCl := kubefake.NewSimpleClientset(kobjs...)
 			kubeCl.Fake.PrependReactor("create", "tokenreviews", test.reactor(t))
 			scheme := runtime.NewScheme()
-			require.NoError(t, configv1alpha1.AddToScheme(scheme))
+			require.NoError(t, configapi.AddToScheme(scheme))
 			require.NoError(t, corev1.AddToScheme(scheme))
 			client := clientfake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(kobjs...).Build()
 

--- a/pkg/sentry/server/validator/kubernetes/kubernetes_test.go
+++ b/pkg/sentry/server/validator/kubernetes/kubernetes_test.go
@@ -470,40 +470,6 @@ func TestValidate(t *testing.T) {
 			expErr: true,
 			expTD:  spiffeid.TrustDomain{},
 		},
-		"if pod namespace is empty in kube token, expect error": {
-			sentryAudience: "spiffe://cluster.local/ns/dapr-test/dapr-sentry",
-			reactor: func(t *testing.T) core.ReactionFunc {
-				return func(action core.Action) (bool, runtime.Object, error) {
-					obj := action.(core.CreateAction).GetObject().(*kauthapi.TokenReview)
-					assert.Equal(t, []string{"dapr.io/sentry", "spiffe://cluster.local/ns/dapr-test/dapr-sentry"}, obj.Spec.Audiences)
-					return true, &kauthapi.TokenReview{Status: kauthapi.TokenReviewStatus{
-						Authenticated: true,
-						User: kauthapi.UserInfo{
-							Username: "system:serviceaccount:my-ns:my-sa",
-						},
-					}}, nil
-				}
-			},
-			req: &sentryv1pb.SignCertificateRequest{
-				CertificateSigningRequest: []byte("csr"),
-				Namespace:                 "my-ns",
-				Token:                     newToken(t, "", "my-pod"),
-				TrustDomain:               "example.test.dapr.io",
-				Id:                        "my-app-id",
-			},
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-pod",
-					Namespace: "my-ns",
-					Annotations: map[string]string{
-						"dapr.io/app-id": "my-app-id",
-					},
-				},
-				Spec: corev1.PodSpec{ServiceAccountName: "my-sa"},
-			},
-			expErr: true,
-			expTD:  spiffeid.TrustDomain{},
-		},
 		"valid authentication, no config annotation should be default trust domain": {
 			sentryAudience: "spiffe://cluster.local/ns/dapr-test/dapr-sentry",
 			reactor: func(t *testing.T) core.ReactionFunc {

--- a/pkg/sentry/server/validator/validator.go
+++ b/pkg/sentry/server/validator/validator.go
@@ -29,5 +29,10 @@ type Validator interface {
 	Start(context.Context) error
 
 	// Validate validates the identity of a certificate request.
-	Validate(context.Context, *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error)
+	// Returns the Trust Domain of the certificate requester, and whether the
+	// signed certificates duration should be overridden to the maximum time
+	// permitted by the singing certificate.
+	// TODO: @joshvanl remove the overrideDuration bool in v1.13 when injector no
+	// longer needs to request other identities.
+	Validate(context.Context, *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, bool, error)
 }


### PR DESCRIPTION
It is [required](https://github.com/dapr/dapr/issues/5756#issuecomment-1710610428) that we allow the injector to request any identity from sentry in Kubernetes mode so that it is able to inject the certificate and private key as environment variables for `v1.11` daprds.

PR updates sentry so it will accept the injector requesting any certificate identity. Adds an option so that the Kubernetes validator signals for this certificate to have the largest possible validity duration which is needed as these certificates will be used by daprds for its entire duration.

A follow-up PR will include the changes in injector to actually make use of this change.

/cc @mukundansundar