### PR TITLE
workflows HTTP - obfuscate metrics

### DIFF
--- a/pkg/diagnostics/http_monitoring.go
+++ b/pkg/diagnostics/http_monitoring.go
@@ -278,6 +278,29 @@ func (h *httpMetrics) convertPathToMetricLabel(path string) string {
 		parsedPath[3] = "{id}"
 		// Concat 5 items(v1, actors, DemoActor, {id}, timer) in /v1/actors/DemoActor/1/timer/name
 		return "/" + strings.Join(parsedPath[0:5], "/")
+	case "workflows":
+		// v1.0-alpha1/workflows/<workflowComponentName>/<instanceId>
+		if len(parsedPath) == 4 {
+			parsedPath[3] = "{instanceId}"
+			return "/" + strings.Join(parsedPath[0:4], "/")
+		}
+		// v1.0-alpha1/workflows/<workflowComponentName>/<workflowName>/start[?instanceID=<instanceID>]
+		if parsedPath[4] != "" && strings.HasPrefix(parsedPath[4], "start") {
+			// not obfuscating the workflow name, just the possible instanceID
+			return "/" + strings.Join(parsedPath[0:4], "/") + "/start"
+		} else {
+			// v1.0-alpha1/workflows/<workflowComponentName>/<instanceId>/terminate
+			// v1.0-alpha1/workflows/<workflowComponentName>/<instanceId>/pause
+			// v1.0-alpha1/workflows/<workflowComponentName>/<instanceId>/resume
+			// v1.0-alpha1/workflows/<workflowComponentName>/<instanceId>/purge
+			parsedPath[3] = "{instanceId}"
+			// v1.0-alpha1/workflows/<workflowComponentName>/<instanceID>/raiseEvent/<eventName>
+			if len(parsedPath) == 6 && parsedPath[4] == "raiseEvent" && parsedPath[5] != "" {
+				parsedPath[5] = "{eventName}"
+				return "/" + strings.Join(parsedPath[0:6], "/")
+			}
+		}
+		return "/" + strings.Join(parsedPath[0:5], "/")
 	}
 
 	return path

--- a/pkg/diagnostics/http_monitoring_test.go
+++ b/pkg/diagnostics/http_monitoring_test.go
@@ -107,6 +107,14 @@ func TestConvertPathToMethodName(t *testing.T) {
 		{"actors/DemoActor/1/method/method1", "actors/DemoActor/{id}/method/method1"},
 		{"actors/DemoActor/1/method/timer/timer1", "actors/DemoActor/{id}/method/timer/timer1"},
 		{"actors/DemoActor/1/method/remind/reminder1", "actors/DemoActor/{id}/method/remind/reminder1"},
+		{"/v1.0-alpha1/workflows/dapr/mywf/start?instanceID=1234", "/v1.0-alpha1/workflows/dapr/mywf/start"},
+		{"/v1.0-alpha1/workflows/dapr/mywf/start", "/v1.0-alpha1/workflows/dapr/mywf/start"},
+		{"/v1.0-alpha1/workflows/dapr/1234/terminate", "/v1.0-alpha1/workflows/dapr/{instanceId}/terminate"},
+		{"/v1.0-alpha1/workflows/dapr/1234/raiseEvent/foobaz", "/v1.0-alpha1/workflows/dapr/{instanceId}/raiseEvent/{eventName}"},
+		{"/v1.0-alpha1/workflows/dapr/1234/pause", "/v1.0-alpha1/workflows/dapr/{instanceId}/pause"},
+		{"/v1.0-alpha1/workflows/dapr/1234/resume", "/v1.0-alpha1/workflows/dapr/{instanceId}/resume"},
+		{"/v1.0-alpha1/workflows/dapr/1234/purge", "/v1.0-alpha1/workflows/dapr/{instanceId}/purge"},
+		{"/v1.0-alpha1/workflows/dapr/1234", "/v1.0-alpha1/workflows/dapr/{instanceId}"},
 		{"", ""},
 	}
 


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
Implementation for https://github.com/dapr/dapr/issues/6903

Adds logic to `convertPathToMetricLabel` to handle the workflows http API

NOTE: I decided to not obfuscate `workflowComponentName` which will be `dapr` in all cases for some time and also I haven't obfuscated `workflowName` because I think the workflow name is useful for observability and I think likely users may not use a huge amount of different workflow names but if there are different opinions I'm happy to change this.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #6903 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
