### PR TITLE
Remove duplicate log entry from sentry

### DIFF
--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -36,8 +36,6 @@ import (
 var log = logger.NewLogger("dapr.sentry")
 
 func main() {
-	log.Infof("Starting sentry certificate authority -- version %s -- commit %s", buildinfo.Version(), buildinfo.Commit())
-
 	opts := options.New()
 
 	// Apply options to all loggers
@@ -57,7 +55,7 @@ func main() {
 	if err := utils.SetEnvVariables(map[string]string{
 		utils.KubeConfigVar: opts.Kubeconfig,
 	}); err != nil {
-		log.Fatalf("error set env failed:  %s", err.Error())
+		log.Fatalf("Error setting env: %v", err)
 	}
 
 	if err := monitoring.InitMetrics(); err != nil {
@@ -99,14 +97,14 @@ func main() {
 
 				case <-issuerEvent:
 					monitoring.IssuerCertChanged()
-					log.Debug("received issuer credentials changed signal")
+					log.Debug("Received issuer credentials changed signal")
 
 					select {
 					case <-ctx.Done():
 						return nil
 					// Batch all signals within 2s of each other
 					case <-time.After(2 * time.Second):
-						log.Warn("issuer credentials changed; reloading")
+						log.Warn("Issuer credentials changed; reloading")
 						return nil
 					}
 				}


### PR DESCRIPTION
Sentry was logging the "Starting Dapr Sentry" message twice. The first log was also before the call to `logger.ApplyOptionsToAllLogger`, so it would have not been JSON-formatted if that's what users wish.