### PR TITLE
[1.12] Use Namespace from AdmissionReview rather than Pod

### DIFF
--- a/pkg/injector/service/pod_patch.go
+++ b/pkg/injector/service/pod_patch.go
@@ -55,7 +55,7 @@ func (i *injector) getPodPatchOperations(ctx context.Context, ar *admissionv1.Ad
 	if err != nil {
 		return nil, err
 	}
-	daprdCert, daprdPrivateKey, err := i.signDaprdCertificate(ctx, pod.Namespace)
+	daprdCert, daprdPrivateKey, err := i.signDaprdCertificate(ctx, ar.Request.Namespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It is not always the case that the `metadata.Nameapace` of a submitted object to an admission review is populated, and so the injector must use the namespace of the admission request itself when requesting for the Pod's identity certificate from sentry.

See https://github.com/kubernetes/website/issues/30574
