### PR TITLE
[1.12] Ignore error when attempting to delete a socket which does not exist

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1433,6 +1433,9 @@ func (a *DaprRuntime) cleanSockets() error {
 	if a.runtimeConfig.unixDomainSocket != "" {
 		for _, s := range []string{"http", "grpc"} {
 			err := os.Remove(fmt.Sprintf("%s/dapr-%s-%s.socket", a.runtimeConfig.unixDomainSocket, a.runtimeConfig.id, s))
+			if os.IsNotExist(err) {
+				continue
+			}
 			if err != nil {
 				errs = append(errs, fmt.Errorf("error removing socket file: %w", err))
 			}


### PR DESCRIPTION
Ignore errors in runtime when attempting to delete a socket file which does not exist. This prevents daprd needlessly erroring and  exiting non-zero if the file does not exist which can be safely ignored.

This error surfaces in dapr/cli e2e tests https://github.com/dapr/cli/actions/runs/6233455455/job/16918723431?pr=1342