### PR TITLE
[v1.12] Helm: Don't base64 encode root certificate to dapr-trust-bundle ConfigMap

### DIFF
--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -26,7 +26,7 @@ metadata:
     {{- end }}
 {{ if .Values.tls.root.certPEM }}
 data:
-  ca.crt: {{ b64enc .Values.tls.root.certPEM | trim }}
+  ca.crt: {{- .Values.tls.root.certPEM | toYaml | indent 1}}
 {{end}}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Previously, if a custom `.Values.tls.root.certPEM` Helm value was given, the `dapr-trust-bundle` ConfigMap was populated with the `base64` encoded value. This is wrong, as the file is expected to be written as is.

PR removes the base 64 encoding of the value.
