### PR TITLE
[release-1.12] Run control plane services with `readOnlyRootFilesystem: true`

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -75,6 +75,7 @@ spec:
           capabilities:
             add: ["SYS_PTRACE"]
   {{- else }}
+          readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
   {{- end }}
@@ -110,6 +111,11 @@ spec:
         - name: dapr-identity-token
           mountPath: /var/run/secrets/dapr.io/sentrytoken
           readOnly: true
+      {{- end }}
+      {{- if eq .Values.debug.enabled false }}
+        # This is not needed in debug mode because the root FS is writable
+        - name: dapr-operator-tmp
+          mountPath: /tmp
       {{- end }}
       {{- with .Values.global.extraVolumeMounts.operator }}
         {{- toYaml . | nindent 8 }}
@@ -164,6 +170,10 @@ spec:
 {{- end }}
       serviceAccountName: dapr-operator
       volumes:
+        - name: dapr-operator-tmp
+          emptyDir:
+            sizeLimit: 2Mi
+            medium: Memory
         - name: dapr-trust-bundle
           configMap:
             name: dapr-trust-bundle

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
@@ -168,6 +168,7 @@ spec:
           capabilities:
             add: ["SYS_PTRACE"]
   {{- else }}
+          readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
   {{- end }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -106,6 +106,7 @@ spec:
           capabilities:
             add: ["SYS_PTRACE"]
   {{- else }}
+          readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
   {{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -84,6 +84,7 @@ spec:
           capabilities:
             add: ["SYS_PTRACE"]
   {{- else }}
+          readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
   {{- end }}


### PR DESCRIPTION
Fixes #6940

The root FS remains writable when Dapr runs in debug mode.

Due to the changes to Sentry, the Operator service needs to write a file (containing its SVID) to a temporary folder. For that reason, a very small `emptyDir` volume is mounted in `/tmp/` in the Operator's container.