### PR TITLE
Resiliency: add `GetAttempt` method for policy function

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -456,9 +456,8 @@ func (a *actorsRuntime) callRemoteActorWithRetry(
 				Disposer: resiliency.DisposerCloser[*invokev1.InvokeMethodResponse],
 			},
 		)
-		attempts := atomic.Int32{}
 		return policyRunner(func(ctx context.Context) (*invokev1.InvokeMethodResponse, error) {
-			attempt := attempts.Add(1)
+			attempt := resiliency.GetAttempt(ctx)
 			rResp, teardown, rErr := fn(ctx, targetAddress, targetID, req)
 			if rErr == nil {
 				teardown(false)

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -196,9 +195,8 @@ func (d *directMessaging) invokeWithRetry(
 				Disposer: resiliency.DisposerCloser[*invokev1.InvokeMethodResponse],
 			},
 		)
-		attempts := atomic.Int32{}
 		return policyRunner(func(ctx context.Context) (*invokev1.InvokeMethodResponse, error) {
-			attempt := attempts.Add(1)
+			attempt := resiliency.GetAttempt(ctx)
 			rResp, teardown, rErr := fn(ctx, app.id, app.namespace, app.address, req)
 			if rErr == nil {
 				teardown(false)


### PR DESCRIPTION
Quick change that makes it easier for a resiliency policy function to get the current attempt number (safely also for concurrent use by multiple goroutines).

Inside a policy runner function, it's now possible to call `resiliency.GetAttempt` with the context to get the current attempt number, for example:

```go
val, err := policyRunner(func(ctx context.Context) (any, error) {
	attempt := resiliency.GetAttempt(ctx)
})
```

There were already 2 instances in the codebase where this could be used. I have also expanded the logs to return the number of attempts before the operation was successful, to improve debugging.

Unit tests are included.