### PR TITLE
[release-1.12] Fix service invocation error due to slow app start up.

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -525,8 +525,6 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	}
 	log.Infof("Internal gRPC server is running on port %v", a.runtimeConfig.internalGRPCPort)
 
-	a.initDirectMessaging(a.nameResolver)
-
 	if a.daprHTTPAPI != nil {
 		a.daprHTTPAPI.MarkStatusAsOutboundReady()
 	}
@@ -563,6 +561,8 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 		a.appHealthChanged(ctx, apphealth.AppStatusHealthy)
 	}
 
+	// Service invocation is a special case because it requires app's endpoint to be up.
+	a.initDirectMessaging(a.nameResolver)
 	return nil
 }
 


### PR DESCRIPTION
# Description

Fix to avoid race condition in 1.12 (not present in 1.11) between service invocation and app's health.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
