### PR TITLE
[release-1.12] Fix race condition in app health and actors/workflow initialization

### DIFF
--- a/pkg/grpc/api_actor_test.go
+++ b/pkg/grpc/api_actor_test.go
@@ -56,11 +56,14 @@ var testActorResiliency = &v1alpha1.Resiliency{
 
 func TestRegisterActorReminder(t *testing.T) {
 	t.Run("actors not initialized", func(t *testing.T) {
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -74,11 +77,14 @@ func TestRegisterActorReminder(t *testing.T) {
 
 func TestUnregisterActorTimer(t *testing.T) {
 	t.Run("actors not initialized", func(t *testing.T) {
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -92,11 +98,14 @@ func TestUnregisterActorTimer(t *testing.T) {
 
 func TestRegisterActorTimer(t *testing.T) {
 	t.Run("actors not initialized", func(t *testing.T) {
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -110,11 +119,14 @@ func TestRegisterActorTimer(t *testing.T) {
 
 func TestGetActorState(t *testing.T) {
 	t.Run("actors not initialized", func(t *testing.T) {
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -144,12 +156,15 @@ func TestGetActorState(t *testing.T) {
 			ActorType: "fakeActorType",
 		}).Return(true)
 
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
-				AppID:  "fakeAPI",
-				Actors: mockActors,
+				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorRuntime(mockActors)
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -176,11 +191,14 @@ func TestGetActorState(t *testing.T) {
 
 func TestExecuteActorStateTransaction(t *testing.T) {
 	t.Run("actors not initialized", func(t *testing.T) {
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -222,12 +240,15 @@ func TestExecuteActorStateTransaction(t *testing.T) {
 			ActorType: "fakeActorType",
 		}).Return(true)
 
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
-				AppID:  "fakeAPI",
-				Actors: mockActors,
+				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorRuntime(mockActors)
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -258,7 +279,7 @@ func TestExecuteActorStateTransaction(t *testing.T) {
 			})
 
 		// assert
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		mockActors.AssertNumberOfCalls(t, "TransactionalStateOperation", 1)
 	})
@@ -266,11 +287,14 @@ func TestExecuteActorStateTransaction(t *testing.T) {
 
 func TestUnregisterActorReminder(t *testing.T) {
 	t.Run("actors not initialized", func(t *testing.T) {
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -284,11 +308,14 @@ func TestUnregisterActorReminder(t *testing.T) {
 
 func TestInvokeActor(t *testing.T) {
 	t.Run("actors not initialized", func(t *testing.T) {
-		server, lis := startDaprAPIServer(&api{
+		api := &api{
 			UniversalAPI: &universalapi.UniversalAPI{
 				AppID: "fakeAPI",
 			},
-		}, "")
+		}
+		api.InitUniversalAPI()
+		api.SetActorsInitDone()
+		server, lis := startDaprAPIServer(api, "")
 		defer server.Stop()
 
 		clientConn := createTestClient(lis)
@@ -301,7 +328,7 @@ func TestInvokeActor(t *testing.T) {
 }
 
 func TestInvokeActorWithResiliency(t *testing.T) {
-	failingActors := actors.FailingActors{
+	failingActors := &actors.FailingActors{
 		Failure: daprt.NewFailure(
 			map[string]int{
 				"failingActor": 1,
@@ -312,13 +339,16 @@ func TestInvokeActorWithResiliency(t *testing.T) {
 	}
 
 	rs := resiliency.FromConfigurations(logger.NewLogger("grpc.api.test"), testActorResiliency)
-	server, lis := startDaprAPIServer(&api{
+	api := &api{
 		UniversalAPI: &universalapi.UniversalAPI{
 			AppID:      "fakeAPI",
-			Actors:     &failingActors,
 			Resiliency: rs,
 		},
-	}, "")
+	}
+	api.InitUniversalAPI()
+	api.SetActorRuntime(failingActors)
+	api.SetActorsInitDone()
+	server, lis := startDaprAPIServer(api, "")
 	defer server.Stop()
 
 	t.Run("actors recover from error with resiliency", func(t *testing.T) {

--- a/pkg/grpc/universalapi/api_actors.go
+++ b/pkg/grpc/universalapi/api_actors.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package universalapi
+
+import (
+	"context"
+	"time"
+
+	"github.com/dapr/dapr/pkg/actors"
+)
+
+func (a *UniversalAPI) SetActorRuntime(actor actors.ActorRuntime) {
+	a.Actors = actor
+}
+
+// SetActorsInitDone indicates that the actors runtime has been initialized, whether actors are available or not
+func (a *UniversalAPI) SetActorsInitDone() {
+	if a.actorsReady.CompareAndSwap(false, true) {
+		close(a.actorsReadyCh)
+	}
+}
+
+// WaitForActorsReady blocks until the actor runtime is set in the object (or until the context is canceled).
+func (a *UniversalAPI) WaitForActorsReady(ctx context.Context) {
+	// Quick check to avoid allocating a timer if the actors are ready
+	if a.actorsReady.Load() {
+		return
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer waitCancel()
+
+	// In both cases, it's a no-op as we check for the actors runtime to be ready below
+	select {
+	case <-waitCtx.Done():
+	case <-a.actorsReadyCh:
+	}
+}

--- a/pkg/grpc/universalapi/api_workflow.go
+++ b/pkg/grpc/universalapi/api_workflow.go
@@ -34,6 +34,9 @@ func (a *UniversalAPI) GetWorkflowBeta1(ctx context.Context, in *runtimev1pb.Get
 		return &runtimev1pb.GetWorkflowResponse{}, err
 	}
 
+	// Workflow requires actors to be ready
+	a.WaitForActorsReady(ctx)
+
 	workflowComponent, err := a.getWorkflowComponent(in.WorkflowComponent)
 	if err != nil {
 		a.Logger.Debug(err)
@@ -78,6 +81,9 @@ func (a *UniversalAPI) StartWorkflowBeta1(ctx context.Context, in *runtimev1pb.S
 		return &runtimev1pb.StartWorkflowResponse{}, err
 	}
 
+	// Workflow requires actors to be ready
+	a.WaitForActorsReady(ctx)
+
 	workflowComponent, err := a.getWorkflowComponent(in.WorkflowComponent)
 	if err != nil {
 		a.Logger.Debug(err)
@@ -110,6 +116,9 @@ func (a *UniversalAPI) TerminateWorkflowBeta1(ctx context.Context, in *runtimev1
 		a.Logger.Debug(err)
 		return emptyResponse, err
 	}
+
+	// Workflow requires actors to be ready
+	a.WaitForActorsReady(ctx)
 
 	workflowComponent, err := a.getWorkflowComponent(in.WorkflowComponent)
 	if err != nil {
@@ -146,6 +155,9 @@ func (a *UniversalAPI) RaiseEventWorkflowBeta1(ctx context.Context, in *runtimev
 		return emptyResponse, err
 	}
 
+	// Workflow requires actors to be ready
+	a.WaitForActorsReady(ctx)
+
 	workflowComponent, err := a.getWorkflowComponent(in.WorkflowComponent)
 	if err != nil {
 		a.Logger.Debug(err)
@@ -175,6 +187,9 @@ func (a *UniversalAPI) PauseWorkflowBeta1(ctx context.Context, in *runtimev1pb.P
 		return emptyResponse, err
 	}
 
+	// Workflow requires actors to be ready
+	a.WaitForActorsReady(ctx)
+
 	workflowComponent, err := a.getWorkflowComponent(in.WorkflowComponent)
 	if err != nil {
 		a.Logger.Debug(err)
@@ -200,6 +215,9 @@ func (a *UniversalAPI) ResumeWorkflowBeta1(ctx context.Context, in *runtimev1pb.
 		return emptyResponse, err
 	}
 
+	// Workflow requires actors to be ready
+	a.WaitForActorsReady(ctx)
+
 	workflowComponent, err := a.getWorkflowComponent(in.WorkflowComponent)
 	if err != nil {
 		a.Logger.Debug(err)
@@ -224,6 +242,9 @@ func (a *UniversalAPI) PurgeWorkflowBeta1(ctx context.Context, in *runtimev1pb.P
 		a.Logger.Debug(err)
 		return emptyResponse, err
 	}
+
+	// Workflow requires actors to be ready
+	a.WaitForActorsReady(ctx)
 
 	workflowComponent, err := a.getWorkflowComponent(in.WorkflowComponent)
 	if err != nil {

--- a/pkg/grpc/universalapi/api_workflow_test.go
+++ b/pkg/grpc/universalapi/api_workflow_test.go
@@ -115,6 +115,8 @@ func TestStartWorkflowBeta1API(t *testing.T) {
 		Resiliency: resiliency.New(nil),
 		CompStore:  compStore,
 	}
+	fakeAPI.InitUniversalAPI()
+	fakeAPI.SetActorsInitDone()
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -187,6 +189,8 @@ func TestGetWorkflowBeta1API(t *testing.T) {
 		Resiliency: resiliency.New(nil),
 		CompStore:  compStore,
 	}
+	fakeAPI.InitUniversalAPI()
+	fakeAPI.SetActorsInitDone()
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -258,6 +262,8 @@ func TestTerminateWorkflowBeta1API(t *testing.T) {
 		Resiliency: resiliency.New(nil),
 		CompStore:  compStore,
 	}
+	fakeAPI.InitUniversalAPI()
+	fakeAPI.SetActorsInitDone()
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -344,6 +350,8 @@ func TestRaiseEventWorkflowBeta1Api(t *testing.T) {
 		Resiliency: resiliency.New(nil),
 		CompStore:  compStore,
 	}
+	fakeAPI.InitUniversalAPI()
+	fakeAPI.SetActorsInitDone()
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -417,6 +425,8 @@ func TestPauseWorkflowBeta1Api(t *testing.T) {
 		Resiliency: resiliency.New(nil),
 		CompStore:  compStore,
 	}
+	fakeAPI.InitUniversalAPI()
+	fakeAPI.SetActorsInitDone()
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -488,6 +498,8 @@ func TestResumeWorkflowBeta1Api(t *testing.T) {
 		Resiliency: resiliency.New(nil),
 		CompStore:  compStore,
 	}
+	fakeAPI.InitUniversalAPI()
+	fakeAPI.SetActorsInitDone()
 
 	for _, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/grpc/universalapi/universalapi.go
+++ b/pkg/grpc/universalapi/universalapi.go
@@ -17,6 +17,7 @@ package universalapi
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/dapr/dapr/pkg/actors"
 	"github.com/dapr/dapr/pkg/config"
@@ -39,4 +40,16 @@ type UniversalAPI struct {
 	GlobalConfig                *config.Configuration
 
 	extendedMetadataLock sync.RWMutex
+	actorsReady          atomic.Bool
+	actorsReadyCh        chan struct{}
+	initDone             atomic.Bool
+}
+
+// InitUniversalAPI completes the initialization of the UniversalAPI object.
+func (a *UniversalAPI) InitUniversalAPI() {
+	if !a.initDone.CompareAndSwap(false, true) {
+		return
+	}
+
+	a.actorsReadyCh = make(chan struct{})
 }

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -1002,9 +1002,10 @@ func TestV1ActorEndpoints(t *testing.T) {
 		universal: &universalapi.UniversalAPI{
 			AppID:      "fakeAPI",
 			Resiliency: rc,
-			Actors:     nil,
 		},
 	}
+	testAPI.universal.InitUniversalAPI()
+	testAPI.universal.SetActorsInitDone()
 
 	fakeServer.StartServer(testAPI.constructActorEndpoints(), nil)
 
@@ -1910,7 +1911,6 @@ func TestV1MetadataEndpoint(t *testing.T) {
 	testAPI := &api{
 		universal: &universalapi.UniversalAPI{
 			AppID:     "xyz",
-			Actors:    mockActors,
 			CompStore: compStore,
 			GetComponentsCapabilitiesFn: func() map[string][]string {
 				capsMap := make(map[string][]string)
@@ -1925,6 +1925,9 @@ func TestV1MetadataEndpoint(t *testing.T) {
 			GlobalConfig:        &config.Configuration{},
 		},
 	}
+	testAPI.universal.InitUniversalAPI()
+	testAPI.universal.SetActorRuntime(mockActors)
+	testAPI.universal.SetActorsInitDone()
 
 	fakeServer.StartServer(testAPI.constructMetadataEndpoints(), nil)
 
@@ -1977,11 +1980,12 @@ func TestV1ActorEndpointsWithTracer(t *testing.T) {
 
 	testAPI := &api{
 		universal: &universalapi.UniversalAPI{
-			Actors:     nil,
 			Resiliency: resiliency.New(nil),
 		},
 		tracingSpec: spec,
 	}
+	testAPI.universal.InitUniversalAPI()
+	testAPI.universal.SetActorsInitDone()
 
 	fakeServer.StartServer(testAPI.constructActorEndpoints(), &fakeHTTPServerOptions{
 		spec: &spec,

--- a/pkg/messages/predefined.go
+++ b/pkg/messages/predefined.go
@@ -61,7 +61,6 @@ const (
 	ErrAppUnhealthy = "app is not in a healthy state"
 
 	// Actor.
-	ErrActorRuntimeNotFound      = "the state store is not configured to use the actor runtime. Have you set the - name: actorStateStore value: \"true\" in your state store component file?"
 	ErrActorInstanceMissing      = "actor instance is missing"
 	ErrActorInvoke               = "error invoke actor method: %s"
 	ErrActorReminderCreate       = "error creating actor reminder: %s"
@@ -125,6 +124,7 @@ var (
 
 	// Actor.
 	ErrActorReminderOpActorNotHosted = APIError{"operations on actor reminders are only possible on hosted actor types", "ERR_ACTOR_REMINDER_NON_HOSTED", http.StatusForbidden, grpcCodes.PermissionDenied}
+	ErrActorRuntimeNotFound          = APIError{`the state store is not configured to use the actor runtime. Have you set the - name: actorStateStore value: "true" in your state store component file?`, "ERR_ACTOR_RUNTIME_NOT_FOUND", http.StatusInternalServerError, grpcCodes.Internal}
 
 	// Lock.
 	ErrLockStoresNotConfigured    = APIError{"lock store is not configured", "ERR_LOCK_STORE_NOT_CONFIGURED", http.StatusInternalServerError, grpcCodes.FailedPrecondition}

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -135,6 +135,10 @@ type internalConfig struct {
 	metricsExporter              metrics.Exporter
 }
 
+func (i internalConfig) ActorsEnabled() bool {
+	return len(i.placementAddresses) > 0
+}
+
 // FromConfig creates a new Dapr Runtime from a configuration.
 func FromConfig(ctx context.Context, cfg *Config) (*DaprRuntime, error) {
 	intc, err := cfg.toInternal()

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -121,6 +121,7 @@ type DaprRuntime struct {
 	actorStateStoreLock     sync.RWMutex
 	namespace               string
 	podName                 string
+	daprUniversalAPI        *universalapi.UniversalAPI
 	daprHTTPAPI             http.API
 	daprGRPCAPI             grpc.API
 	operatorClient          operatorv1pb.OperatorClient
@@ -469,7 +470,7 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	a.populateSecretsConfiguration()
 
 	// Create and start the external gRPC server
-	univAPI := &universalapi.UniversalAPI{
+	a.daprUniversalAPI = &universalapi.UniversalAPI{
 		AppID:                       a.runtimeConfig.id,
 		Logger:                      logger.NewLogger("dapr.api"),
 		CompStore:                   a.compStore,
@@ -483,7 +484,7 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 
 	// Create and start internal and external gRPC servers
 	a.daprGRPCAPI = grpc.NewAPI(grpc.APIOpts{
-		UniversalAPI:          univAPI,
+		UniversalAPI:          a.daprUniversalAPI,
 		Channels:              a.channels,
 		PubsubAdapter:         a.processor.PubSub(),
 		DirectMessaging:       a.directMessaging,
@@ -507,7 +508,7 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	}
 
 	// Start HTTP Server
-	err = a.startHTTPServer(a.runtimeConfig.httpPort, a.runtimeConfig.publicPort, a.runtimeConfig.profilePort, a.runtimeConfig.allowedOrigins, pipeline, univAPI)
+	err = a.startHTTPServer(a.runtimeConfig.httpPort, a.runtimeConfig.publicPort, a.runtimeConfig.profilePort, a.runtimeConfig.allowedOrigins, pipeline)
 	if err != nil {
 		return fmt.Errorf("failed to start HTTP server: %w", err)
 	}
@@ -573,18 +574,24 @@ func (a *DaprRuntime) appHealthReadyInit(ctx context.Context) error {
 	// Load app configuration (for actors) and init actors
 	a.loadAppConfiguration(ctx)
 
-	if len(a.runtimeConfig.placementAddresses) != 0 {
+	if a.runtimeConfig.ActorsEnabled() {
 		err = a.initActors(ctx)
 		if err != nil {
 			log.Warn(err)
 		} else {
-			a.daprHTTPAPI.SetActorRuntime(a.actor)
-			a.daprGRPCAPI.SetActorRuntime(a.actor)
-
 			// Workflow engine depends on actor runtime being initialized
+			// This needs to be called before "SetActorsInitDone" on the universal API object to prevent a race condition in workflow methods
 			a.initWorkflowEngine(ctx)
+
+			a.daprUniversalAPI.SetActorRuntime(a.actor)
 		}
+	} else {
+		// If actors are not enabled, still invoke SetActorRuntime on the workflow engine with `nil` to unblock the goroutine
+		a.workflowEngine.SetActorRuntime(a.actor)
 	}
+
+	// We set actors as initialized whether we have an actors runtime or not
+	a.daprUniversalAPI.SetActorsInitDone()
 
 	if cb := a.runtimeConfig.registry.ComponentsCallback(); cb != nil {
 		if err = cb(registry.ComponentRegistry{
@@ -601,18 +608,15 @@ func (a *DaprRuntime) appHealthReadyInit(ctx context.Context) error {
 func (a *DaprRuntime) initWorkflowEngine(ctx context.Context) {
 	wfComponentFactory := wfengine.BuiltinWorkflowFactory(a.workflowEngine)
 
-	if wfInitErr := a.workflowEngine.SetActorRuntime(a.actor); wfInitErr != nil {
-		log.Warnf("Failed to set actor runtime for Dapr workflow engine - workflow engine will not start: %w", wfInitErr)
-	} else {
-		if reg := a.runtimeConfig.registry.Workflows(); reg != nil {
-			log.Infof("Registering component for dapr workflow engine...")
-			reg.RegisterComponent(wfComponentFactory, "dapr")
-			if componentInitErr := a.processor.Init(ctx, wfengine.ComponentDefinition); componentInitErr != nil {
-				log.Warnf("Failed to initialize Dapr workflow component: %v", componentInitErr)
-			}
-		} else {
-			log.Infof("No workflow registry available, not registering Dapr workflow component...")
+	a.workflowEngine.SetActorRuntime(a.actor)
+	if reg := a.runtimeConfig.registry.Workflows(); reg != nil {
+		log.Infof("Registering component for dapr workflow engine...")
+		reg.RegisterComponent(wfComponentFactory, "dapr")
+		if componentInitErr := a.processor.Init(ctx, wfengine.ComponentDefinition); componentInitErr != nil {
+			log.Warnf("Failed to initialize Dapr workflow component: %v", componentInitErr)
 		}
+	} else {
+		log.Infof("No workflow registry available, not registering Dapr workflow component...")
 	}
 }
 
@@ -971,9 +975,9 @@ func (a *DaprRuntime) processHTTPEndpointSecrets(ctx context.Context, endpoint *
 	}
 }
 
-func (a *DaprRuntime) startHTTPServer(port int, publicPort *int, profilePort int, allowedOrigins string, pipeline httpMiddleware.Pipeline, univAPI *universalapi.UniversalAPI) error {
+func (a *DaprRuntime) startHTTPServer(port int, publicPort *int, profilePort int, allowedOrigins string, pipeline httpMiddleware.Pipeline) error {
 	a.daprHTTPAPI = http.NewAPI(http.APIOpts{
-		UniversalAPI:          univAPI,
+		UniversalAPI:          a.daprUniversalAPI,
 		Channels:              a.channels,
 		DirectMessaging:       a.directMessaging,
 		PubsubAdapter:         a.processor.PubSub(),

--- a/tests/integration/suite/actors/actors.go
+++ b/tests/integration/suite/actors/actors.go
@@ -15,5 +15,6 @@ package actors
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/grpc"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/healthz"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/http"
 )

--- a/tests/integration/suite/actors/healthz/healthz.go
+++ b/tests/integration/suite/actors/healthz/healthz.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliei.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(initerror))
+}
+
+// initerror tests that Daprd will block actor calls until actors have been
+// initialized.
+type initerror struct {
+	daprd        *daprd.Daprd
+	place        *placement.Placement
+	configCalled chan struct{}
+	blockConfig  chan struct{}
+}
+
+func (i *initerror) Setup(t *testing.T) []framework.Option {
+	i.configCalled = make(chan struct{})
+	i.blockConfig = make(chan struct{})
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+		close(i.configCalled)
+		<-i.blockConfig
+		w.Write([]byte(`{"entities": ["myactortype"]}`))
+	})
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`OK`))
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	i.place = placement.New(t)
+	i.daprd = daprd.New(t, daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: true
+`),
+		daprd.WithPlacementAddresses("localhost:"+strconv.Itoa(i.place.Port())),
+		daprd.WithAppPort(srv.Port()),
+		// Daprd is super noisy in debug mode when connecting to placement.
+		daprd.WithLogLevel("info"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(i.place, srv, i.daprd),
+	}
+}
+
+func (i *initerror) Run(t *testing.T, ctx context.Context) {
+	i.place.WaitUntilRunning(t, ctx)
+
+	assert.Eventually(t, func() bool {
+		dialer := net.Dialer{Timeout: time.Second}
+		net, err := dialer.DialContext(ctx, "tcp", "localhost:"+strconv.Itoa(i.daprd.HTTPPort()))
+		if err != nil {
+			return false
+		}
+		net.Close()
+		return true
+	}, time.Second*5, time.Millisecond*100)
+
+	client := util.HTTPClient(t)
+
+	select {
+	case <-i.configCalled:
+	case <-time.After(time.Second * 5):
+		t.Fatal("timed out waiting for config call")
+	}
+
+	rctx, cancel := context.WithTimeout(ctx, time.Second*2)
+	t.Cleanup(cancel)
+	daprdURL := "http://localhost:" + strconv.Itoa(i.daprd.HTTPPort()) + "/v1.0/actors/myactortype/myactorid/method/foo"
+
+	req, err := http.NewRequestWithContext(rctx, http.MethodPost, daprdURL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	if resp != nil && resp.Body != nil {
+		assert.NoError(t, resp.Body.Close())
+	}
+
+	close(i.blockConfig)
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, daprdURL, nil)
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NoError(t, resp.Body.Close())
+}


### PR DESCRIPTION
Fixes the issue discovered in https://github.com/dapr/dapr/pull/6968#issuecomment-1736563355

Dapr reports in /healthz (and /healthz/outbound) a ready status when the API servers are ready, but the actor runtime (and thus workflow) is initialized asynchronously.

This means that apps that try to invoke actors or use workflow fail. We've experienced this error in E2E tests in #6968, where a refactoring on unrelated things made the race condition appear.

This PR fixes the issue by making all actor and workflow APIs (including those managed by the WF engine) block while the actor runtime is initialized (successfully or not).

I validated this fix by adding a `time.Sleep(10 * time.Second)` at the start of `runtime.appHealthReadyInit`