### PR TITLE
[release-1.12] Ensure sentry certificate expiry metric is served when provided

### DIFF
--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -134,10 +134,10 @@ func New(ctx context.Context, conf config.Config) (Signer, error) {
 
 		log.Info("Self-signed certs generated and persisted successfully")
 		monitoring.IssuerCertChanged()
-		monitoring.IssuerCertExpiry(bundle.IssChain[0].NotAfter)
 	} else {
 		log.Info("Root and issuer certs found: using existing certs")
 	}
+	monitoring.IssuerCertExpiry(bundle.IssChain[0].NotAfter)
 
 	return &ca{
 		bundle: bundle,

--- a/tests/integration/framework/process/sentry/options.go
+++ b/tests/integration/framework/process/sentry/options.go
@@ -22,11 +22,12 @@ import (
 type options struct {
 	execOpts []exec.Option
 
-	bundle        ca.Bundle
-	port          int
-	healthzPort   int
-	metricsPort   int
-	configuration string
+	bundle         ca.Bundle
+	dontGiveBundle bool
+	port           int
+	healthzPort    int
+	metricsPort    int
+	configuration  string
 }
 
 // Option is a function that configures the process.
@@ -65,5 +66,11 @@ func WithCABundle(bundle ca.Bundle) Option {
 func WithConfiguration(config string) Option {
 	return func(o *options) {
 		o.configuration = config
+	}
+}
+
+func WithDontGiveBundle(dontGiveBundle bool) Option {
+	return func(o *options) {
+		o.dontGiveBundle = dontGiveBundle
 	}
 }

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -99,7 +99,12 @@ func New(t *testing.T, fopts ...Option) *Sentry {
 		"-issuer-key-filename=issuer.key",
 		"-metrics-port=" + strconv.Itoa(opts.metricsPort),
 		"-healthz-port=" + strconv.Itoa(opts.healthzPort),
-		"-issuer-credentials=" + tmpDir,
+	}
+
+	if opts.dontGiveBundle {
+		args = append(args, "-issuer-credentials="+t.TempDir())
+	} else {
+		args = append(args, "-issuer-credentials="+tmpDir)
 	}
 
 	return &Sentry{

--- a/tests/integration/suite/sentry/metrics/metrics.go
+++ b/tests/integration/suite/sentry/metrics/metrics.go
@@ -77,6 +77,7 @@ func (e *expiry) Run(t *testing.T, ctx context.Context) {
 
 		respBody, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
+		assert.NoError(t, resp.Body.Close())
 
 		t.Run(name+": test `dapr_sentry_issuercert_expiry_timestamp` metric is present with correct date", func(t *testing.T) {
 			for _, line := range bytes.Split(respBody, []byte("\n")) {

--- a/tests/integration/suite/sentry/metrics/metrics.go
+++ b/tests/integration/suite/sentry/metrics/metrics.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/sentry/server/ca"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(sentry))
+}
+
+// sentry tests Sentry with the insecure validator.
+type sentry struct {
+	notGiven *procsentry.Sentry
+	given    *procsentry.Sentry
+}
+
+func (s *sentry) Setup(t *testing.T) []framework.Option {
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	onemonth := time.Hour * 24 * 30
+	bundle, err := ca.GenerateBundle(rootKey, "integration.test.dapr.io", time.Second*5, &onemonth)
+	require.NoError(t, err)
+
+	s.notGiven = procsentry.New(t, procsentry.WithDontGiveBundle(true))
+	s.given = procsentry.New(t, procsentry.WithCABundle(bundle))
+
+	return []framework.Option{
+		framework.WithProcesses(s.notGiven, s.given),
+	}
+}
+
+func (s *sentry) Run(t *testing.T, ctx context.Context) {
+	s.notGiven.WaitUntilRunning(t, ctx)
+	s.given.WaitUntilRunning(t, ctx)
+
+	time.Sleep(time.Second)
+	client := util.HTTPClient(t)
+
+	testExiry := func(name string, proc *procsentry.Sentry, expTime time.Time) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/metrics", proc.MetricsPort()), nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		t.Run(name+": test `dapr_sentry_issuercert_expiry_timestamp` metric is present with correct date", func(t *testing.T) {
+			for _, line := range bytes.Split(respBody, []byte("\n")) {
+				if len(line) == 0 || line[0] == '#' {
+					continue
+				}
+
+				split := bytes.Split(line, []byte(" "))
+				if len(split) != 2 {
+					continue
+				}
+
+				if string(split[0]) != "dapr_sentry_issuercert_expiry_timestamp" {
+					continue
+				}
+
+				timestamp, err := strconv.ParseFloat(string(split[1]), 64)
+				require.NoError(t, err)
+
+				tsTime := time.Unix(int64(timestamp), 0)
+				assert.InDelta(t, expTime.Unix(), tsTime.Unix(), 20)
+				return
+			}
+			assert.Fail(t, "metric not found")
+		})
+	}
+
+	testExiry("certificate not given", s.notGiven, time.Now().Add(time.Hour*24*365))
+	testExiry("certificate given", s.given, time.Now().Add(time.Hour*24*30))
+}

--- a/tests/integration/suite/sentry/metrics/metrics.go
+++ b/tests/integration/suite/sentry/metrics/metrics.go
@@ -68,7 +68,7 @@ func (s *sentry) Run(t *testing.T, ctx context.Context) {
 	time.Sleep(time.Second)
 	client := util.HTTPClient(t)
 
-	testExiry := func(name string, proc *procsentry.Sentry, expTime time.Time) {
+	testExpiry := func(name string, proc *procsentry.Sentry, expTime time.Time) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/metrics", proc.MetricsPort()), nil)
 		require.NoError(t, err)
 
@@ -104,6 +104,6 @@ func (s *sentry) Run(t *testing.T, ctx context.Context) {
 		})
 	}
 
-	testExiry("certificate not given", s.notGiven, time.Now().Add(time.Hour*24*365))
-	testExiry("certificate given", s.given, time.Now().Add(time.Hour*24*30))
+	testExpiry("certificate not given", s.notGiven, time.Now().Add(time.Hour*24*365))
+	testExpiry("certificate given", s.given, time.Now().Add(time.Hour*24*30))
 }

--- a/tests/integration/suite/sentry/sentry.go
+++ b/tests/integration/suite/sentry/sentry.go
@@ -14,5 +14,6 @@ limitations under the License.
 package sentry
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/sentry/metrics"
 	_ "github.com/dapr/dapr/tests/integration/suite/sentry/validator"
 )


### PR DESCRIPTION
Fixes #6971 

Ensure the `dapr_sentry_issuercert_expiry_timestamp` metric is set and served by sentry when the intermediate certificate bundle is provided, rather than just when sentry self generates.

When sentry self generates the certificate, we check that the expiry is 1 year in the future (the default). When given, we check is matches the 1 month expiry which is provided.

/cc @filintod 