### PR TITLE
[1.12] integration: Change daprd default log level to info

### DIFF
--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -69,7 +69,7 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 		publicPort:       fp.Port(t, 3),
 		metricsPort:      fp.Port(t, 4),
 		profilePort:      fp.Port(t, 5),
-		logLevel:         "debug",
+		logLevel:         "info",
 		mode:             "standalone",
 	}
 


### PR DESCRIPTION
Using debug as the default log level for daprd is not ideal as it is quite noisy, and causes issues on slow CI runners which are not able to handle the volume of IO. Should improve the stability of the integration tests on slow CI runners.

