### PR TITLE
Integration test optimization 115s -> 80s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ test-integration: test-deps
 			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
 			--format testname \
 			-- \
-			./tests/integration -count=1 -v -tags="integration"
+			./tests/integration -timeout=20m -count=1 -v -tags="integration"
 
 ################################################################################
 # Target: lint                                                                 #

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -65,7 +65,7 @@ func Build(t *testing.T, name string) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		// Ensure CGO is disabled to avoid linking against system libraries.
-		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 		require.NoError(t, cmd.Run())
 
 		require.NoError(t, os.Setenv(EnvKey(name), binPath))

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -60,7 +60,7 @@ func Build(t *testing.T, name string) {
 
 		t.Logf("Root dir: %q", rootDir)
 		t.Logf("Compiling %q binary to: %q", name, binPath)
-		cmd := exec.Command("go", "build", "-tags=allcomponents", "-v", "-o", binPath, filepath.Join(rootDir, "cmd/"+name))
+		cmd := exec.Command("go", "build", "-tags=allcomponents", "-v", "-o", binPath, "./cmd/"+name)
 		cmd.Dir = rootDir
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -58,15 +58,14 @@ func Build(t *testing.T, name string) {
 			binPath += ".exe"
 		}
 
-		// Ensure CGO is disabled to avoid linking against system libraries.
-		require.NoError(t, os.Setenv("CGO_ENABLED", "0"))
-
 		t.Logf("Root dir: %q", rootDir)
 		t.Logf("Compiling %q binary to: %q", name, binPath)
 		cmd := exec.Command("go", "build", "-tags=allcomponents", "-v", "-o", binPath, filepath.Join(rootDir, "cmd/"+name))
 		cmd.Dir = rootDir
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		// Ensure CGO is disabled to avoid linking against system libraries.
+		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
 		require.NoError(t, cmd.Run())
 
 		require.NoError(t, os.Setenv(EnvKey(name), binPath))

--- a/tests/integration/framework/process/exec/exec.go
+++ b/tests/integration/framework/process/exec/exec.go
@@ -112,9 +112,6 @@ func (e *exec) Cleanup(t *testing.T) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
-	assert.NoError(t, e.stderrpipe.Close())
-	assert.NoError(t, e.stdoutpipe.Close())
-
 	kill.Kill(t, e.cmd)
 	e.checkExit(t)
 }

--- a/tests/integration/framework/process/exec/exec.go
+++ b/tests/integration/framework/process/exec/exec.go
@@ -112,6 +112,9 @@ func (e *exec) Cleanup(t *testing.T) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
+	assert.NoError(t, e.stderrpipe.Close())
+	assert.NoError(t, e.stdoutpipe.Close())
+
 	kill.Kill(t, e.cmd)
 	e.checkExit(t)
 }

--- a/tests/integration/framework/process/exec/iowriter/iowriter_test.go
+++ b/tests/integration/framework/process/exec/iowriter/iowriter_test.go
@@ -15,6 +15,7 @@ package iowriter
 
 import (
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 
 type mockLogger struct {
 	msgs []string
+	t    *testing.T
 }
 
 func (m *mockLogger) Log(args ...any) {
@@ -34,9 +36,13 @@ func (m mockLogger) Name() string {
 	return "TestLogger"
 }
 
+func (m mockLogger) Cleanup(fn func()) {
+	m.t.Cleanup(fn)
+}
+
 func TestNew(t *testing.T) {
 	t.Run("should return new stdwriter", func(t *testing.T) {
-		writer := New(new(mockLogger), "proc")
+		writer := New(&mockLogger{t: t}, "proc")
 		_, ok := writer.(*stdwriter)
 		assert.True(t, ok)
 	})
@@ -44,7 +50,7 @@ func TestNew(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	t.Run("should write to buffer", func(t *testing.T) {
-		logger := new(mockLogger)
+		logger := &mockLogger{t: t}
 		writer := New(logger, "proc").(*stdwriter)
 
 		_, err := writer.Write([]byte("test"))
@@ -52,31 +58,35 @@ func TestWrite(t *testing.T) {
 		assert.Equal(t, "test", writer.buf.String())
 	})
 
-	t.Run("should flush on newline", func(t *testing.T) {
-		logger := new(mockLogger)
+	t.Run("should not flush on newline but on close", func(t *testing.T) {
+		logger := &mockLogger{t: t}
 		writer := New(logger, "proc").(*stdwriter)
 
 		_, err := writer.Write([]byte("test\n"))
 		require.NoError(t, err)
 
-		assert.Equal(t, 0, writer.buf.Len())
+		assert.Equal(t, 5, writer.buf.Len())
+
+		assert.Len(t, logger.msgs, 0)
+
+		assert.NoError(t, writer.Close())
 
 		_ = assert.Len(t, logger.msgs, 1) && assert.Equal(t, "TestLogger/proc: test", logger.msgs[0])
 	})
 
-	t.Run("should return error when closed", func(t *testing.T) {
-		writer := New(new(mockLogger), "proc").(*stdwriter)
-		writer.Close()
+	t.Run("should return error on write when closed", func(t *testing.T) {
+		writer := New(&mockLogger{t: t}, "proc").(*stdwriter)
+		assert.NoError(t, writer.Close())
 
 		_, err := writer.Write([]byte("test\n"))
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, io.ErrClosedPipe)
 		assert.Empty(t, writer.buf.String())
 	})
 }
 
 func TestClose(t *testing.T) {
 	t.Run("should flush and close", func(t *testing.T) {
-		logger := new(mockLogger)
+		logger := &mockLogger{t: t}
 		writer := New(logger, "proc").(*stdwriter)
 		writer.Write([]byte("test"))
 		writer.Close()
@@ -88,7 +98,7 @@ func TestClose(t *testing.T) {
 
 func TestConcurrency(t *testing.T) {
 	t.Run("should handle concurrent writes", func(t *testing.T) {
-		logger := new(mockLogger)
+		logger := &mockLogger{t: t}
 		writer := New(logger, "proc").(*stdwriter)
 		wg := sync.WaitGroup{}
 		wg.Add(2)
@@ -108,6 +118,8 @@ func TestConcurrency(t *testing.T) {
 		}()
 
 		wg.Wait()
+
+		assert.NoError(t, writer.Close())
 
 		assert.Equal(t, 0, writer.buf.Len())
 		assert.Len(t, logger.msgs, 2000)

--- a/tests/integration/framework/process/exec/iowriter/iowriter_test.go
+++ b/tests/integration/framework/process/exec/iowriter/iowriter_test.go
@@ -74,13 +74,13 @@ func TestWrite(t *testing.T) {
 		_ = assert.Len(t, logger.msgs, 1) && assert.Equal(t, "TestLogger/proc: test", logger.msgs[0])
 	})
 
-	t.Run("should return error on write when closed", func(t *testing.T) {
+	t.Run("should not return error on write when closed", func(t *testing.T) {
 		writer := New(&mockLogger{t: t}, "proc").(*stdwriter)
 		assert.NoError(t, writer.Close())
 
 		_, err := writer.Write([]byte("test\n"))
-		assert.ErrorIs(t, err, io.ErrClosedPipe)
-		assert.Empty(t, writer.buf.String())
+		assert.NoError(t, err, io.ErrClosedPipe)
+		assert.Equal(t, "test\n", writer.buf.String())
 	})
 }
 

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -64,7 +64,7 @@ func New(t *testing.T, fopts ...Option) *Placement {
 	}
 
 	args := []string{
-		"--log-level=" + "debug",
+		"--log-level=" + "info",
 		"--id=" + opts.id,
 		"--port=" + strconv.Itoa(opts.port),
 		"--healthz-port=" + strconv.Itoa(opts.healthzPort),

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -91,7 +91,7 @@ func New(t *testing.T, fopts ...Option) *Sentry {
 	}
 
 	args := []string{
-		"-log-level=" + "debug",
+		"-log-level=" + "info",
 		"-port=" + strconv.Itoa(opts.port),
 		"-config=" + configPath,
 		"-issuer-ca-filename=ca.crt",

--- a/tests/integration/framework/util/parallel.go
+++ b/tests/integration/framework/util/parallel.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ParallelTest is a helper for running tests in parallel without having to
+// create new Go test functions.
+type ParallelTest struct {
+	lock sync.Mutex
+	fns  []func(*assert.CollectT)
+}
+
+// NewParallel creates a new ParallelTest.
+// Tests are executed during given test's cleanup.
+func NewParallel(t *testing.T, fns ...func(*assert.CollectT)) *ParallelTest {
+	p := &ParallelTest{
+		fns: fns,
+	}
+	t.Cleanup(func() {
+		p.lock.Lock()
+		defer p.lock.Unlock()
+		t.Helper()
+
+		ch := make(chan any)
+		collects := make([]*assert.CollectT, len(p.fns))
+		for i, fn := range p.fns {
+			collects[i] = new(assert.CollectT)
+			go func(i int, fn func(*assert.CollectT)) {
+				defer func() {
+					if r := recover(); r != nil {
+						ch <- r
+					}
+				}()
+
+				fn(collects[i])
+				ch <- nil
+			}(i, fn)
+		}
+
+		for i := 0; i < len(p.fns); i++ {
+			assert.Nil(t, <-ch)
+		}
+
+		for _, collect := range collects {
+			collect.Copy(t)
+		}
+	})
+
+	return p
+}
+
+// Add adds a test function to be executed in parallel.
+func (p *ParallelTest) Add(fn func(*assert.CollectT)) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.fns = append(p.fns, fn)
+}

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -39,10 +39,10 @@ func RunIntegrationTests(t *testing.T) {
 			t.Logf("setting up test case")
 			options := tcase.Setup(t)
 
-			f := framework.Run(t, ctx, options...)
-
 			ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 			t.Cleanup(cancel)
+
+			f := framework.Run(t, ctx, options...)
 
 			t.Run("run", func(t *testing.T) {
 				t.Log("running test case")

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -39,10 +39,10 @@ func RunIntegrationTests(t *testing.T) {
 			t.Logf("setting up test case")
 			options := tcase.Setup(t)
 
+			f := framework.Run(t, ctx, options...)
+
 			ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 			t.Cleanup(cancel)
-
-			f := framework.Run(t, ctx, options...)
 
 			t.Run("run", func(t *testing.T) {
 				t.Log("running test case")

--- a/tests/integration/suite/actors/healthz/healthz.go
+++ b/tests/integration/suite/actors/healthz/healthz.go
@@ -106,11 +106,11 @@ func (h *healthz) Run(t *testing.T, ctx context.Context) {
 
 	client := util.HTTPClient(t)
 
-	rctx, cancel := context.WithTimeout(ctx, time.Second*2)
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	t.Cleanup(cancel)
 	daprdURL := "http://localhost:" + strconv.Itoa(h.daprd.HTTPPort()) + "/v1.0/actors/myactortype/myactorid/method/foo"
 
-	req, err := http.NewRequestWithContext(rctx, http.MethodPost, daprdURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, daprdURL, nil)
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)

--- a/tests/integration/suite/actors/http/ttl.go
+++ b/tests/integration/suite/actors/http/ttl.go
@@ -112,7 +112,7 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 
 	now := time.Now()
 
-	reqBody := `[{"operation":"upsert","request":{"key":"key1","value":"value1","metadata":{"ttlInSeconds":"3"}}}]`
+	reqBody := `[{"operation":"upsert","request":{"key":"key1","value":"value1","metadata":{"ttlInSeconds":"2"}}}]`
 	req, err = http.NewRequest(http.MethodPost, daprdURL+"/v1.0/actors/myactortype/myactorid/state", strings.NewReader(reqBody))
 	require.NoError(t, err)
 	resp, err := client.Do(req)
@@ -132,7 +132,7 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 		ttlExpireTimeStr := resp.Header.Get("metadata.ttlExpireTime")
 		ttlExpireTime, err := time.Parse(time.RFC3339, ttlExpireTimeStr)
 		require.NoError(t, err)
-		assert.InDelta(t, now.Add(3*time.Second).Unix(), ttlExpireTime.Unix(), 1)
+		assert.InDelta(t, now.Add(2*time.Second).Unix(), ttlExpireTime.Unix(), 1)
 	})
 
 	t.Run("ensure the state key is deleted after the ttl", func(t *testing.T) {

--- a/tests/integration/suite/actors/reminders/rebalancing.go
+++ b/tests/integration/suite/actors/reminders/rebalancing.go
@@ -195,7 +195,7 @@ func (i *rebalancing) Run(t *testing.T, ctx context.Context) {
 	// Also invoke the same actors using actor invocation
 	for j := 0; j < iterations; j++ {
 		go func(j int) {
-			rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
 			daprdURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactortype/myactorid-%d/method/foo", i.daprd[0].HTTPPort(), j)
 			req, rErr := http.NewRequestWithContext(rctx, http.MethodPost, daprdURL, nil)

--- a/tests/integration/suite/daprd/mtls/kubernetes/disable.go
+++ b/tests/integration/suite/daprd/mtls/kubernetes/disable.go
@@ -136,7 +136,7 @@ func (e *disable) Run(t *testing.T, ctx context.Context) {
 		myAppID, err := spiffeid.FromSegments(spiffeid.RequireTrustDomainFromString("public"), "ns", "default", "my-app")
 		require.NoError(t, err)
 
-		gctx, gcancel := context.WithTimeout(ctx, time.Second*2)
+		gctx, gcancel := context.WithTimeout(ctx, time.Second)
 		t.Cleanup(gcancel)
 		_, err = grpc.DialContext(gctx, "localhost:"+strconv.Itoa(e.daprd.InternalGRPCPort()), sec.GRPCDialOptionMTLS(myAppID),
 			grpc.WithReturnConnectionError())

--- a/tests/integration/suite/daprd/mtls/kubernetes/enable.go
+++ b/tests/integration/suite/daprd/mtls/kubernetes/enable.go
@@ -92,7 +92,7 @@ func (e *enable) Run(t *testing.T, ctx context.Context) {
 	e.daprd.WaitUntilRunning(t, ctx)
 
 	t.Run("trying plain text connection to Dapr API should fail", func(t *testing.T) {
-		gctx, gcancel := context.WithTimeout(ctx, time.Second*2)
+		gctx, gcancel := context.WithTimeout(ctx, time.Second)
 		t.Cleanup(gcancel)
 		_, err := grpc.DialContext(gctx, "localhost:"+strconv.Itoa(e.daprd.InternalGRPCPort()),
 			grpc.WithReturnConnectionError(),

--- a/tests/integration/suite/daprd/mtls/standalone/disable.go
+++ b/tests/integration/suite/daprd/mtls/standalone/disable.go
@@ -119,7 +119,7 @@ func (e *disable) Run(t *testing.T, ctx context.Context) {
 		myAppID, err := spiffeid.FromSegments(spiffeid.RequireTrustDomainFromString("public"), "ns", "default", "my-app")
 		require.NoError(t, err)
 
-		gctx, gcancel := context.WithTimeout(ctx, time.Second*5)
+		gctx, gcancel := context.WithTimeout(ctx, time.Second)
 		t.Cleanup(gcancel)
 		_, err = grpc.DialContext(gctx, "localhost:"+strconv.Itoa(e.daprd.InternalGRPCPort()), sec.GRPCDialOptionMTLS(myAppID),
 			grpc.WithReturnConnectionError())

--- a/tests/integration/suite/daprd/mtls/standalone/enable.go
+++ b/tests/integration/suite/daprd/mtls/standalone/enable.go
@@ -86,11 +86,11 @@ func (e *enable) Run(t *testing.T, ctx context.Context) {
 	e.daprd.WaitUntilRunning(t, ctx)
 
 	t.Run("trying plain text connection to Dapr API should fail", func(t *testing.T) {
-		gctx, gcancel := context.WithTimeout(ctx, time.Second*5)
+		gctx, gcancel := context.WithTimeout(ctx, time.Second)
 		t.Cleanup(gcancel)
 		_, err := grpc.DialContext(gctx, "localhost:"+strconv.Itoa(e.daprd.InternalGRPCPort()),
-			grpc.WithReturnConnectionError(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithReturnConnectionError(),
 		)
 		require.ErrorContains(t, err, "error reading server preface:")
 	})

--- a/tests/integration/suite/daprd/pubsub/http/compname.go
+++ b/tests/integration/suite/daprd/pubsub/http/compname.go
@@ -94,12 +94,11 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := util.HTTPClient(t)
 
+	pt := util.NewParallel(t)
 	for i := range c.pubsubNames {
 		pubsubName := c.pubsubNames[i]
 		topicName := c.topicNames[i]
-		t.Run(pubsubName, func(t *testing.T) {
-			t.Parallel()
-
+		pt.Add(func(t *assert.CollectT) {
 			reqURL := fmt.Sprintf("http://127.0.0.1:%d/v1.0/publish/%s/%s", c.daprd.HTTPPort(), url.QueryEscape(pubsubName), url.QueryEscape(topicName))
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(`{"status": "completed"}`))
 			require.NoError(t, err)

--- a/tests/integration/suite/daprd/secret/http/compname.go
+++ b/tests/integration/suite/daprd/secret/http/compname.go
@@ -100,14 +100,16 @@ spec:
 func (c *componentName) Run(t *testing.T, ctx context.Context) {
 	c.daprd.WaitUntilRunning(t, ctx)
 
+	client := util.HTTPClient(t)
+
+	pt := util.NewParallel(t)
 	for _, secretStoreName := range c.secretStoreNames {
 		secretStoreName := secretStoreName
-		t.Run(secretStoreName, func(t *testing.T) {
-			t.Parallel()
+		pt.Add(func(t *assert.CollectT) {
 			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/key1", c.daprd.HTTPPort(), url.QueryEscape(secretStoreName))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 			require.NoError(t, err)
-			resp, err := util.HTTPClient(t).Do(req)
+			resp, err := client.Do(req)
 			require.NoError(t, err)
 			// TODO: @joshvanl: 500 is obviously the wrong status code here and
 			// should be changed.

--- a/tests/integration/suite/daprd/secret/http/fuzz.go
+++ b/tests/integration/suite/daprd/secret/http/fuzz.go
@@ -117,15 +117,17 @@ spec:
 func (f *fuzzsecret) Run(t *testing.T, ctx context.Context) {
 	f.daprd.WaitUntilRunning(t, ctx)
 
+	client := util.HTTPClient(t)
+
+	pt := util.NewParallel(t)
 	for key, value := range f.values {
 		key := key
 		value := value
-		t.Run(key+":"+value, func(t *testing.T) {
-			t.Parallel()
+		pt.Add(func(t *assert.CollectT) {
 			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.secretStoreName), url.QueryEscape(key))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 			require.NoError(t, err)
-			resp, err := util.HTTPClient(t).Do(req)
+			resp, err := client.Do(req)
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			respBody, err := io.ReadAll(resp.Body)

--- a/tests/integration/suite/daprd/serviceinvocation/http/httpendpoints.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/httpendpoints.go
@@ -156,6 +156,7 @@ func (h *httpendpoints) Run(t *testing.T, ctx context.Context) {
 
 				body := make(map[string]any)
 				require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+				require.NoError(t, resp.Body.Close())
 				endpoints, ok := body["httpEndpoints"]
 				_ = assert.True(t, ok) && assert.Len(t, endpoints.([]any), 2)
 			}, time.Second*5, time.Millisecond*100)

--- a/tests/integration/suite/daprd/serviceinvocation/http/httpendpoints.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/httpendpoints.go
@@ -15,11 +15,13 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -140,6 +142,25 @@ func (h *httpendpoints) Run(t *testing.T, ctx context.Context) {
 	httpClient := util.HTTPClient(t)
 
 	invokeTests := func(t *testing.T, expTLSCode int, assertBody func(t *testing.T, body string), daprd *procdaprd.Daprd) {
+		for _, port := range []int{
+			h.daprd1.HTTPPort(),
+			h.daprd2.HTTPPort(),
+		} {
+			assert.EventuallyWithT(t, func(t *assert.CollectT) {
+				url := fmt.Sprintf("http://localhost:%d/v1.0/metadata", port)
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				require.NoError(t, err)
+
+				resp, err := httpClient.Do(req)
+				require.NoError(t, err)
+
+				body := make(map[string]any)
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+				endpoints, ok := body["httpEndpoints"]
+				_ = assert.True(t, ok) && assert.Len(t, endpoints.([]any), 2)
+			}, time.Second*5, time.Millisecond*100)
+		}
+
 		t.Run("invoke http endpoint", func(t *testing.T) {
 			doReq := func(method, url string, headers map[string]string) (int, string) {
 				req, err := http.NewRequestWithContext(ctx, method, url, nil)

--- a/tests/integration/suite/daprd/state/grpc/basic.go
+++ b/tests/integration/suite/daprd/state/grpc/basic.go
@@ -68,10 +68,8 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			{StoreName: "mystore", States: []*commonv1.StateItem{{}}},
 			{StoreName: "mystore", States: []*commonv1.StateItem{{Value: []byte("value1")}}},
 		} {
-			t.Run(fmt.Sprintf("%+v", req), func(t *testing.T) {
-				_, err = client.SaveState(ctx, req)
-				require.Error(t, err)
-			})
+			_, err = client.SaveState(ctx, req)
+			require.Error(t, err)
 		}
 	})
 
@@ -89,10 +87,8 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 				{Key: "key2", Value: []byte("value2")},
 			}},
 		} {
-			t.Run(fmt.Sprintf("%v", req), func(t *testing.T) {
-				_, err = client.SaveState(ctx, req)
-				require.NoError(t, err)
-			})
+			_, err = client.SaveState(ctx, req)
+			require.NoError(t, err)
 		}
 	})
 }

--- a/tests/integration/suite/daprd/state/grpc/compname.go
+++ b/tests/integration/suite/daprd/state/grpc/compname.go
@@ -31,6 +31,7 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/util"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -89,13 +90,12 @@ spec:
 func (c *componentName) Run(t *testing.T, ctx context.Context) {
 	c.daprd.WaitUntilRunning(t, ctx)
 
+	pt := util.NewParallel(t)
 	for _, storeName := range c.storeNames {
 		storeName := storeName
-		t.Run(storeName, func(t *testing.T) {
-			t.Parallel()
-
+		pt.Add(func(col *assert.CollectT) {
 			conn, err := grpc.DialContext(ctx, fmt.Sprintf("localhost:%d", c.daprd.GRPCPort()), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-			require.NoError(t, err)
+			require.NoError(col, err)
 			t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
 			client := rtv1.NewDaprClient(conn)
@@ -107,7 +107,7 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 					{Key: "key2", Value: []byte("value2")},
 				},
 			})
-			require.NoError(t, err)
+			require.NoError(col, err)
 
 			_, err = client.SaveState(ctx, &rtv1.SaveStateRequest{
 				StoreName: storeName,
@@ -116,21 +116,21 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 					{Key: "key2", Value: []byte("value2")},
 				},
 			})
-			require.NoError(t, err)
+			require.NoError(col, err)
 
 			resp, err := client.GetState(ctx, &rtv1.GetStateRequest{
 				StoreName: storeName,
 				Key:       "key1",
 			})
-			require.NoError(t, err)
-			assert.Equal(t, "value1", string(resp.Data))
+			require.NoError(col, err)
+			assert.Equal(col, "value1", string(resp.Data))
 
 			resp, err = client.GetState(ctx, &rtv1.GetStateRequest{
 				StoreName: storeName,
 				Key:       "key2",
 			})
-			require.NoError(t, err)
-			assert.Equal(t, "value2", string(resp.Data))
+			require.NoError(col, err)
+			assert.Equal(col, "value2", string(resp.Data))
 		})
 	}
 }

--- a/tests/integration/suite/daprd/state/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/state/grpc/fuzz.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -176,23 +175,25 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	client := rtv1.NewDaprClient(conn)
 
 	t.Run("get", func(t *testing.T) {
-		t.Parallel()
+		pt := util.NewParallel(t)
 		for i := range f.getFuzzKeys {
-			resp, err := client.GetState(ctx, &rtv1.GetStateRequest{
-				StoreName: f.storeName,
-				Key:       f.getFuzzKeys[i],
+			pt.Add(func(t *assert.CollectT) {
+				resp, err := client.GetState(ctx, &rtv1.GetStateRequest{
+					StoreName: f.storeName,
+					Key:       f.getFuzzKeys[i],
+				})
+				require.NoError(t, err)
+				assert.Empty(t, resp.Data, "key: %s", f.getFuzzKeys[i])
 			})
-			require.NoError(t, err)
-			assert.Empty(t, resp.Data, "key: %s", f.getFuzzKeys[i])
 		}
 	})
 
 	httpClient := util.HTTPClient(t)
 
+	pt := util.NewParallel(t)
 	for i := 0; i < len(f.getFuzzKeys); i++ {
 		i := i
-		t.Run("save "+strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
+		pt.Add(func(t *assert.CollectT) {
 			for _, req := range [][]*commonv1.StateItem{f.saveReqBinaries[i], f.saveReqStrings[i]} {
 				_, err := client.SaveState(ctx, &rtv1.SaveStateRequest{
 					StoreName: f.storeName,

--- a/tests/integration/suite/daprd/state/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/state/grpc/fuzz.go
@@ -177,6 +177,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	t.Run("get", func(t *testing.T) {
 		pt := util.NewParallel(t)
 		for i := range f.getFuzzKeys {
+			i := i
 			pt.Add(func(t *assert.CollectT) {
 				resp, err := client.GetState(ctx, &rtv1.GetStateRequest{
 					StoreName: f.storeName,

--- a/tests/integration/suite/daprd/state/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/state/grpc/fuzz.go
@@ -66,7 +66,7 @@ type fuzzstate struct {
 }
 
 func (f *fuzzstate) Setup(t *testing.T) []framework.Option {
-	const numTests = 5000
+	const numTests = 1000
 
 	var takenKeys sync.Map
 

--- a/tests/integration/suite/daprd/state/http/basic.go
+++ b/tests/integration/suite/daprd/state/http/basic.go
@@ -73,17 +73,15 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			`[{"key": "key1", "value": "value1", "etag": 123}]`,
 			`[{"ey": "key0", "value": "value1"}]`,
 		} {
-			t.Run(body, func(t *testing.T) {
-				req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, strings.NewReader(body))
-				require.NoError(t, err)
-				resp, err := httpClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				require.NoError(t, resp.Body.Close())
-				assert.Contains(t, string(body), "ERR_MALFORMED_REQUEST")
-			})
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, strings.NewReader(body))
+			require.NoError(t, err)
+			resp, err := httpClient.Do(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			assert.Contains(t, string(body), "ERR_MALFORMED_REQUEST")
 		}
 	})
 
@@ -95,17 +93,15 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			`[{"key": "key1", "value": "value1"},{"key": "key2", "value": "value1"}]`,
 			`[{"key": "key1", "value": "value1"},{"key": "key2", "value": "value1"},  {"key": "key1", "value": "value1"},{"key": "key2", "value": "value1"}]`,
 		} {
-			t.Run(body, func(t *testing.T) {
-				req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, strings.NewReader(body))
-				require.NoError(t, err)
-				resp, err := httpClient.Do(req)
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-				body, err := io.ReadAll(resp.Body)
-				require.NoError(t, err)
-				require.NoError(t, resp.Body.Close())
-				assert.Empty(t, string(body))
-			})
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, strings.NewReader(body))
+			require.NoError(t, err)
+			resp, err := httpClient.Do(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			assert.Empty(t, string(body))
 		}
 	})
 }

--- a/tests/integration/suite/daprd/state/http/compname.go
+++ b/tests/integration/suite/daprd/state/http/compname.go
@@ -91,10 +91,10 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := util.HTTPClient(t)
 
+	pt := util.NewParallel(t)
 	for _, storeName := range c.storeNames {
 		storeName := storeName
-		t.Run(storeName, func(t *testing.T) {
-			t.Parallel()
+		pt.Add(func(t *assert.CollectT) {
 			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", c.daprd.HTTPPort(), url.QueryEscape(storeName))
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(`[{"key": "key1", "value": "value1"}]`))
 			require.NoError(t, err)

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -156,6 +156,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	t.Run("get", func(t *testing.T) {
 		pt := util.NewParallel(t)
 		for i := range f.getFuzzKeys {
+			i := i
 			pt.Add(func(t *assert.CollectT) {
 				getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName), url.QueryEscape(f.getFuzzKeys[i]))
 				// t.Log("URL", getURL)

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -155,28 +154,30 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	httpClient := util.HTTPClient(t)
 
 	t.Run("get", func(t *testing.T) {
-		t.Parallel()
+		pt := util.NewParallel(t)
 		for i := range f.getFuzzKeys {
-			getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName), url.QueryEscape(f.getFuzzKeys[i]))
-			// t.Log("URL", getURL)
-			// t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
-			// t.Log("Key", f.getFuzzKeys[i], printRunes(f.getFuzzKeys[i]))
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
-			require.NoError(t, err)
-			resp, err := httpClient.Do(req)
-			require.NoError(t, err)
-			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-			respBody, err := io.ReadAll(resp.Body)
-			require.NoError(t, err)
-			require.NoError(t, resp.Body.Close())
-			assert.Empty(t, string(respBody), "key: %s", f.getFuzzKeys[i])
+			pt.Add(func(t *assert.CollectT) {
+				getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName), url.QueryEscape(f.getFuzzKeys[i]))
+				// t.Log("URL", getURL)
+				// t.Log("State store name", f.storeName, hex.EncodeToString([]byte(f.storeName)), printRunes(f.storeName))
+				// t.Log("Key", f.getFuzzKeys[i], printRunes(f.getFuzzKeys[i]))
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
+				require.NoError(t, err)
+				resp, err := httpClient.Do(req)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+				respBody, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				require.NoError(t, resp.Body.Close())
+				assert.Empty(t, string(respBody), "key: %s", f.getFuzzKeys[i])
+			})
 		}
 	})
 
+	pt := util.NewParallel(t)
 	for i := 0; i < len(f.getFuzzKeys); i++ {
 		i := i
-		t.Run("save "+strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
+		pt.Add(func(t *assert.CollectT) {
 			for _, req := range []any{f.saveReqBinaries[i], f.saveReqStrings[i]} {
 				postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName))
 				b := new(bytes.Buffer)


### PR DESCRIPTION
Adds ParallelTest test helper. This can be used by integration tests as
an alternative to Go's `t.Parallel()` which requires spawning a new test
func which can make test result output noisy.

Updates iowriter to print exec output all at once at end of test
execution, rather than line by line.

Change placement and sentry integration processes to log at info level
rather than debug by default. This is to reduce the amount of logs
generated by the integration tests.

Updates the integration test suite to use the ParallelTest
rather than `t.Parallel()` to reduce test case number.
