### PR TITLE
[1.12] Fix invoke remote stream from closing stream before EOF

### DIFF
--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -440,11 +440,6 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 			readErr   error
 		)
 		for {
-			if ctx.Err() != nil {
-				pw.CloseWithError(ctx.Err())
-				return
-			}
-
 			// Get the payload from the chunk that was previously read
 			payload = chunk.GetPayload()
 			if payload != nil {

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -187,8 +186,6 @@ func TestInvokeRemote(t *testing.T) {
 	}
 
 	t.Run("streaming with no data", func(t *testing.T) {
-		routines := runtime.NumGoroutine()
-
 		messaging, teardown := prepareEnvironment(t, true, nil)
 		defer teardown()
 
@@ -206,12 +203,9 @@ func TestInvokeRemote(t *testing.T) {
 			return
 		}
 		assert.True(t, pd.Message.Data == nil || len(pd.Message.Data.Value) == 0)
-		assert.Equal(t, routines, runtime.NumGoroutine())
 	})
 
 	t.Run("streaming with single chunk", func(t *testing.T) {
-		routines := runtime.NumGoroutine()
-
 		messaging, teardown := prepareEnvironment(t, true, []string{"🐱"})
 		defer teardown()
 
@@ -227,11 +221,9 @@ func TestInvokeRemote(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "🐱", string(pd.Message.Data.Value))
-		assert.Equal(t, routines, runtime.NumGoroutine())
 	})
 
 	t.Run("streaming with multiple chunks", func(t *testing.T) {
-		routines := runtime.NumGoroutine()
 		chunks := []string{
 			"Sempre caro mi fu quest'ermo colle ",
 			"e questa siepe, che da tanta parte ",
@@ -254,11 +246,9 @@ func TestInvokeRemote(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "Sempre caro mi fu quest'ermo colle e questa siepe, che da tanta parte dell'ultimo orizzonte il guardo esclude. … E il naufragar m'è dolce in questo mare.", string(pd.Message.Data.Value))
-		assert.Equal(t, routines, runtime.NumGoroutine())
 	})
 
 	t.Run("target does not support streaming - request is not replayable", func(t *testing.T) {
-		routines := runtime.NumGoroutine()
 		messaging, teardown := prepareEnvironment(t, false, nil)
 		defer teardown()
 
@@ -271,11 +261,9 @@ func TestInvokeRemote(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, fmt.Sprintf(streamingUnsupportedErr, "app1"), err.Error())
 		assert.Nil(t, res)
-		assert.Equal(t, routines, runtime.NumGoroutine())
 	})
 
 	t.Run("target does not support streaming - request is replayable", func(t *testing.T) {
-		routines := runtime.NumGoroutine()
 		messaging, teardown := prepareEnvironment(t, false, nil)
 		defer teardown()
 
@@ -292,11 +280,9 @@ func TestInvokeRemote(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "🐶", string(pd.Message.Data.Value))
-		assert.Equal(t, routines, runtime.NumGoroutine())
 	})
 
 	t.Run("target does not support streaming - request has data in-memory", func(t *testing.T) {
-		routines := runtime.NumGoroutine()
 		messaging, teardown := prepareEnvironment(t, false, nil)
 		defer teardown()
 
@@ -318,7 +304,6 @@ func TestInvokeRemote(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "🐶", string(pd.Message.Data.Value))
-		assert.Equal(t, routines, runtime.NumGoroutine())
 	})
 }
 

--- a/tests/integration/suite/daprd/daprd.go
+++ b/tests/integration/suite/daprd/daprd.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/multipleconfigs"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/outbox"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resources"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/secret"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation"

--- a/tests/integration/suite/daprd/resiliency/apps/defaulttimeout.go
+++ b/tests/integration/suite/daprd/resiliency/apps/defaulttimeout.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaulttimeout))
+}
+
+type defaulttimeout struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+}
+
+func (d *defaulttimeout) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Method))
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+
+	resiliency := `
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: myresiliency
+spec:
+  policies:
+    timeouts:
+      DefaultAppTimeoutPolicy: 30s
+  targets: {}
+`
+	d.daprd1 = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithResourceFiles(resiliency),
+		daprd.WithLogLevel("debug"),
+	)
+	d.daprd2 = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithResourceFiles(resiliency),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, d.daprd1, d.daprd2),
+	}
+}
+
+func (d *defaulttimeout) Run(t *testing.T, ctx context.Context) {
+	d.daprd1.WaitUntilRunning(t, ctx)
+	d.daprd2.WaitUntilRunning(t, ctx)
+
+	client := util.HTTPClient(t)
+
+	url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/test", d.daprd1.HTTPPort(), d.daprd2.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+	assert.Equal(t, "GET", string(body))
+}

--- a/tests/integration/suite/daprd/resiliency/resiliency.go
+++ b/tests/integration/suite/daprd/resiliency/resiliency.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resiliency
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/apps"
+)


### PR DESCRIPTION
Closes #6997

The invoke remote stream go routine data handler will exit early and write the context's error in the event that the context is cancelled. Importantly, it will react to the context being cancelled, before the actual connection has an EOF or graceful close.
This scenario happens specifically when a timeout resiliency policy is used for service invocation (though there could be other scenarios where this happens I didn't find). With resiliency, regardless of whether a timeout is reached or not, the context is always (correctly) cancelled after the operation is finished, but since the stream data routine would still be sending data or before an EOF, it catches the context cancelled and sends that instead.

https://github.com/dapr/dapr/blob/5d8f6de1b6affb78e393e634f2b9cdf36d7ad254/pkg/resiliency/policy.go#L118-L128

https://github.com/dapr/dapr/blob/master/pkg/messaging/direct_messaging.go#L344-L346

This PR updates this behaviour so that the go routine will continue to attempt to read and write data on the line until there is a error such as in the event of a graceful close of the sender (because the stream is complete or because the context was cancelled!). This ensures the entire message is sent over the stream.

This error is also present in v1.11 and should be back ported.