### PR TITLE
ensure clientID is properly set & add test for pubsub.kafka && bindings.kafka

### DIFF
--- a/pkg/runtime/metadata_helper/metadata_helper.go
+++ b/pkg/runtime/metadata_helper/metadata_helper.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadatahelper
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dapr/dapr/pkg/modes"
+)
+
+// Shared helper func for metadata on pubsub.kafka && bindings.kafka to properly set the ClientID
+func SetKafkaClientID(properties map[string]string, id string, namespace string, mode modes.DaprMode) {
+	clientID := strings.TrimSpace(properties["clientID"])
+	if clientID == "" || clientID == "sarama" {
+		switch mode {
+		case modes.KubernetesMode:
+			clientID = fmt.Sprintf("%s.%s", namespace, id)
+		case modes.StandaloneMode:
+			clientID = id
+		}
+		properties["clientID"] = clientID
+	}
+}

--- a/pkg/runtime/processor/pubsub/pubsub.go
+++ b/pkg/runtime/processor/pubsub/pubsub.go
@@ -39,6 +39,7 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/meta"
+	metadatahelper "github.com/dapr/dapr/pkg/runtime/metadata_helper"
 	rtpubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/pkg/scopes"
 	"github.com/dapr/kit/logger"
@@ -158,6 +159,10 @@ func (p *pubsub) Init(ctx context.Context, comp compapi.Component) error {
 		consumerID = p.id
 	}
 	properties["consumerID"] = consumerID
+
+	if comp.Spec.Type == "pubsub.kafka" {
+		metadatahelper.SetKafkaClientID(properties, p.id, p.namespace, p.mode)
+	}
 
 	err = pubSub.Init(ctx, contribpubsub.Metadata{Base: baseMetadata})
 	if err != nil {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1329,7 +1329,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			select {
 			case clientID := <-clientIDChan:
 				assert.Equal(t, standAloneClientID, clientID)
-			case <-time.After(20 * time.Second):
+			case <-time.After(5 * time.Second):
 				t.Error("Timed out waiting for clientID for Standalone Mode test")
 			}
 		})
@@ -1347,7 +1347,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 						},
 					},
 				})
-			//only func to accept k8s mode
+
 			rt, err := NewTestDaprRuntime(t, modes.KubernetesMode)
 			require.NoError(t, err)
 			defer stopRuntime(t, rt)
@@ -1369,7 +1369,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			case <-testOk:
 				return
 			case <-time.After(5 * time.Second):
-				t.Fatalf("test failed")
+				t.Fatalf("PubSub Generic test failed")
 			}
 
 			var k8sClientID string
@@ -1382,7 +1382,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			select {
 			case clientID := <-clientIDChan:
 				assert.Equal(t, "test.myApp", clientID)
-			case <-time.After(20 * time.Second):
+			case <-time.After(5 * time.Second):
 				t.Error("Timed out waiting for clientID for Kubernetes Mode test")
 			}
 			err = rt.processComponentAndDependents(context.Background(), pubsubComponent)
@@ -1449,7 +1449,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			select {
 			case clientID := <-clientIDChan:
 				assert.Equal(t, standAloneClientID, clientID)
-			case <-time.After(20 * time.Second):
+			case <-time.After(5 * time.Second):
 				t.Error("Timed out waiting for clientID for Standalone Mode test")
 			}
 		})
@@ -1465,7 +1465,6 @@ func TestKafkaMetadataClientID(t *testing.T) {
 					Value: commonapi.DynamicValue{
 						JSON: v1.JSON{
 							Raw: []byte(""),
-							// Raw: []byte("{namespace}"),
 						},
 					},
 				})
@@ -1491,7 +1490,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			case <-testOk:
 				return
 			case <-time.After(5 * time.Second):
-				t.Fatalf("test failed")
+				t.Fatalf("PubSub Kafka test failed")
 			}
 
 			var k8sClientID string
@@ -1508,7 +1507,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			select {
 			case clientID := <-clientIDChan:
 				assert.Equal(t, fmt.Sprintf("%s.%s", rt.namespace, rt.runtimeConfig.id), clientID)
-			case <-time.After(20 * time.Second):
+			case <-time.After(5 * time.Second):
 				t.Error("Timed out waiting for clientID for Kubernetes Mode test")
 			}
 		})
@@ -1559,7 +1558,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			case <-testOk:
 				return
 			case <-time.After(5 * time.Second):
-				t.Fatalf("test failed")
+				t.Fatalf("Bindings Kafka test failed")
 			}
 
 			var standAloneClientID string
@@ -1581,7 +1580,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			select {
 			case clientID := <-clientIDChan:
 				assert.Equal(t, standAloneClientID, clientID)
-			case <-time.After(20 * time.Second):
+			case <-time.After(5 * time.Second):
 				t.Error("Timed out waiting for clientID for Standalone Mode test")
 			}
 		})
@@ -1639,7 +1638,7 @@ func TestKafkaMetadataClientID(t *testing.T) {
 			select {
 			case clientID := <-clientIDChan:
 				assert.Equal(t, "test.myApp", clientID)
-			case <-time.After(20 * time.Second):
+			case <-time.After(5 * time.Second):
 				t.Error("Timed out waiting for clientID for Kubernetes Mode test")
 			}
 		})


### PR DESCRIPTION
Added a metadata_helper func to update the `ClientID` value that is shared btw both `bindings.kafka` && `pubsub.kafka`. I added to the tests to test both standalone and k8s mode. Since the value depends on the mode: self hosted or kubernetes, I put the logic here.

## Issue reference

Will close: https://github.com/dapr/components-contrib/issues/2397

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] Extended the documentation / https://github.com/dapr/docs/pull/3713
