### PR TITLE
[Release 1.12] Updates contrib to 1.12.0-rc.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cloudevents/sdk-go/v2 v2.14.0
-	github.com/dapr/components-contrib v1.12.0-rc.3
+	github.com/dapr/components-contrib v1.12.0-rc.4
 	github.com/dapr/kit v0.12.1
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.12.0-rc.3 h1:S1xDKvUyhxbIYR3wwtj2C0cAiVUNc8+1/efpEupaOTY=
-github.com/dapr/components-contrib v1.12.0-rc.3/go.mod h1:2jRaZ7FEm+u12lsmfnCFASlTMu5nUn0gtsirAtueBe4=
+github.com/dapr/components-contrib v1.12.0-rc.4 h1:8EH7sRjgb4uNpvEkOkUNNb1VGuecJ9Ux3QOwSq0Szwo=
+github.com/dapr/components-contrib v1.12.0-rc.4/go.mod h1:2jRaZ7FEm+u12lsmfnCFASlTMu5nUn0gtsirAtueBe4=
 github.com/dapr/kit v0.12.1 h1:XT0CJQQaKRYSzIzZo15O1PAHGUrMGoAavdFRcNVZ+UE=
 github.com/dapr/kit v0.12.1/go.mod h1:eNYjsudq3Ij0x8CLWsPturHor56sZRNu5tk2hUiJT80=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
Updates contrib to 1.12.0-rc.4 for fixes to the two GCP components that were failing to authenticate