### PR TITLE
[1.12] Preserve TypeURL in gRPC->gRPC service invocation 

### DIFF
--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -136,12 +136,10 @@ func (g *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 		WithTrailers(trailer).
 		WithMessage(resp)
 
-	// If the data has a type_url, set protobuf as content type
-	// This is necessary to support the HTTP->gRPC service invocation path correctly
-	typeURL := resp.GetData().GetTypeUrl()
-	if typeURL != "" {
-		rsp.WithContentType(invokev1.ProtobufContentType)
-	}
+	// If the data has a type_url, set that in the object too
+	// This is necessary to support the HTTP->gRPC and gRPC->gRPC service invocation (legacy, non-proxy) paths correctly
+	// (Note that GetTypeUrl could return an empty value, so this call becomes a no-op)
+	rsp.WithDataTypeURL(resp.GetData().GetTypeUrl())
 
 	return rsp, nil
 }

--- a/pkg/grpc/api_daprinternal.go
+++ b/pkg/grpc/api_daprinternal.go
@@ -109,6 +109,11 @@ func (a *api) CallLocalStream(stream internalv1pb.ServiceInvocation_CallLocalStr
 		WithContentType(chunk.Request.Message.ContentType)
 	defer req.Close()
 
+	// If the data has a type_url, set that in the object too
+	// This is necessary to support the gRPC->gRPC service invocation (legacy, non-proxy) path correctly
+	// (Note that GetTypeUrl could return an empty value, so this call becomes a no-op)
+	req.WithDataTypeURL(chunk.Request.Message.GetData().GetTypeUrl())
+
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 

--- a/pkg/grpc/api_daprinternal.go
+++ b/pkg/grpc/api_daprinternal.go
@@ -210,6 +210,13 @@ func (a *api) CallLocalStream(stream internalv1pb.ServiceInvocation_CallLocalStr
 	}()
 	r := res.RawData()
 	resProto := res.Proto()
+
+	// If there's a message in the proto, we remove it from the message we send to avoid sending it twice
+	messageData := resProto.GetMessage().GetData()
+	if messageData != nil {
+		messageData.Value = nil
+	}
+
 	proto := &internalv1pb.InternalInvokeResponseStream{}
 	var (
 		n    int

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -376,6 +376,10 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 
 		// Send the chunk if there's anything to send
 		if proto.Request != nil || proto.Payload != nil {
+			// Avoid sending the data in the message too
+			if md := proto.GetRequest().GetMessage().GetData(); md != nil {
+				md.Value = nil
+			}
 			err = stream.SendMsg(proto)
 			if errors.Is(err, io.EOF) {
 				// If SendMsg returns an io.EOF error, it usually means that there's a transport-level error

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -442,10 +442,11 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 	if err != nil {
 		return nil, err
 	}
-	res.WithRawData(pr)
 	if chunk.Response.Message != nil {
 		res.WithContentType(chunk.Response.Message.ContentType)
+		res.WithDataTypeURL(chunk.Response.Message.GetData().GetTypeUrl()) // Could be empty
 	}
+	res.WithRawData(pr)
 
 	// Read the response into the stream in the background
 	go func() {

--- a/pkg/messaging/v1/invoke_method_response.go
+++ b/pkg/messaging/v1/invoke_method_response.go
@@ -32,7 +32,8 @@ import (
 // and provides the helpers to manage it.
 type InvokeMethodResponse struct {
 	replayableRequest
-	r *internalv1pb.InternalInvokeResponse
+	r           *internalv1pb.InternalInvokeResponse
+	dataTypeURL string
 }
 
 // NewInvokeMethodResponse returns new InvokeMethodResponse object with status.
@@ -84,6 +85,13 @@ func (imr *InvokeMethodResponse) WithRawDataString(data string) *InvokeMethodRes
 // WithContentType sets the content type.
 func (imr *InvokeMethodResponse) WithContentType(contentType string) *InvokeMethodResponse {
 	imr.r.Message.ContentType = contentType
+	return imr
+}
+
+// WithDataTypeURL sets the type_url property for the data.
+// When a type_url is set, the Content-Type automatically becomes the protobuf one.
+func (imr *InvokeMethodResponse) WithDataTypeURL(val string) *InvokeMethodResponse {
+	imr.dataTypeURL = val
 	return imr
 }
 
@@ -176,7 +184,8 @@ func (imr *InvokeMethodResponse) ProtoWithData() (*internalv1pb.InternalInvokeRe
 		return m, err
 	}
 	m.Message.Data = &anypb.Any{
-		Value: data,
+		Value:   data,
+		TypeUrl: imr.dataTypeURL, // Could be empty
 	}
 
 	return m, nil
@@ -230,8 +239,9 @@ func (imr *InvokeMethodResponse) ContentType() string {
 
 	contentType := m.ContentType
 
-	if m.GetData().GetTypeUrl() != "" {
-		contentType = ProtobufContentType
+	// If there's a proto data and that has a type URL, or if we have a dataTypeUrl in the object, then the content type is the protobuf one
+	if imr.dataTypeURL != "" || m.GetData().GetTypeUrl() != "" {
+		return ProtobufContentType
 	}
 
 	return contentType

--- a/pkg/messaging/v1/invoke_method_response.go
+++ b/pkg/messaging/v1/invoke_method_response.go
@@ -209,7 +209,7 @@ func (imr *InvokeMethodResponse) Message() *commonv1pb.InvokeResponse {
 // HasMessageData returns true if the message object contains a slice of data buffered.
 func (imr *InvokeMethodResponse) HasMessageData() bool {
 	m := imr.r.Message
-	return m != nil && m.Data != nil && len(m.Data.Value) > 0
+	return len(m.GetData().GetValue()) > 0
 }
 
 // ResetMessageData resets the data inside the message object if present.
@@ -230,7 +230,7 @@ func (imr *InvokeMethodResponse) ContentType() string {
 
 	contentType := m.ContentType
 
-	if m.Data != nil && m.Data.TypeUrl != "" {
+	if m.GetData().GetTypeUrl() != "" {
 		contentType = ProtobufContentType
 	}
 

--- a/tests/apps/resiliencyapp_grpc/app.go
+++ b/tests/apps/resiliencyapp_grpc/app.go
@@ -88,14 +88,14 @@ func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloRe
 
 // gRPC server definitions.
 func (s *server) OnInvoke(ctx context.Context, in *commonv1pb.InvokeRequest) (*commonv1pb.InvokeResponse, error) {
-	log.Printf("Got invoked method %s and data: %s\n", in.Method, string(in.GetData().Value))
+	log.Printf("Got invoked method %s and data: %s", in.Method, string(in.GetData().Value))
 
 	resp := &commonv1pb.InvokeResponse{}
 
 	if in.Method == "GetCallCount" {
 		log.Println("Getting call counts")
 		for key, val := range s.callTracking {
-			log.Printf("\t%s - Called %d times.\n", key, len(val))
+			log.Printf("\t%s - Called %d times.", key, len(val))
 		}
 		b, err := json.Marshal(s.callTracking)
 

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/basic.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/basic.go
@@ -91,7 +91,6 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 		default:
 			return nil, errors.New("invalid method")
 		}
-
 	}
 
 	srv1 := newGRPCServer(t, onInvoke)
@@ -115,7 +114,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	b.daprd2.WaitUntilRunning(t, ctx)
 
 	t.Run("invoke host", func(t *testing.T) {
-		t.Skip()
 		doReq := func(host, hostID string, verb commonv1.HTTPExtension_Verb) ([]byte, string) {
 			conn, err := grpc.DialContext(ctx, host,
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -168,7 +166,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("method doesn't exist", func(t *testing.T) {
-		t.Skip()
 		host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
 		conn, err := grpc.DialContext(ctx, host,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -192,7 +189,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("no method", func(t *testing.T) {
-		t.Skip()
 		host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
 		conn, err := grpc.DialContext(ctx, host,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -216,7 +212,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("multiple segments", func(t *testing.T) {
-		t.Skip()
 		host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
 		conn, err := grpc.DialContext(ctx, host,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -238,8 +233,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("parallel requests", func(t *testing.T) {
-		t.Skip()
-
 		errCh := make(chan error)
 		for i := 0; i < 100; i++ {
 			go func(i int) {

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/basic.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/basic.go
@@ -47,7 +47,8 @@ type basic struct {
 
 func (b *basic) Setup(t *testing.T) []framework.Option {
 	onInvoke := func(ctx context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
-		if in.Method == "foo" {
+		switch in.GetMethod() {
+		case "foo":
 			var verb int
 			var data []byte
 			switch in.HttpExtension.Verb {
@@ -71,22 +72,38 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 				Data:        &anypb.Any{Value: data},
 				ContentType: strconv.Itoa(verb),
 			}, nil
-		}
 
-		if in.Method == "multiple/segments" {
+		case "typed":
+			return &commonv1.InvokeResponse{
+				Data: &anypb.Any{
+					Value:   []byte(fmt.Sprintf("%s/%s", string(in.GetData().GetValue()), in.GetData().GetTypeUrl())),
+					TypeUrl: "mytype",
+				},
+				ContentType: "application/json",
+			}, nil
+
+		case "multiple/segments":
 			return &commonv1.InvokeResponse{
 				Data:        &anypb.Any{Value: []byte("multiple/segments")},
 				ContentType: "application/json",
 			}, nil
+
+		default:
+			return nil, errors.New("invalid method")
 		}
 
-		return nil, errors.New("invalid method")
 	}
 
 	srv1 := newGRPCServer(t, onInvoke)
 	srv2 := newGRPCServer(t, onInvoke)
-	b.daprd1 = procdaprd.New(t, procdaprd.WithAppProtocol("grpc"), procdaprd.WithAppPort(srv1.Port(t)))
-	b.daprd2 = procdaprd.New(t, procdaprd.WithAppProtocol("grpc"), procdaprd.WithAppPort(srv2.Port(t)))
+	b.daprd1 = procdaprd.New(t,
+		procdaprd.WithAppProtocol("grpc"),
+		procdaprd.WithAppPort(srv1.Port(t)),
+	)
+	b.daprd2 = procdaprd.New(t,
+		procdaprd.WithAppProtocol("grpc"),
+		procdaprd.WithAppPort(srv2.Port(t)),
+	)
 
 	return []framework.Option{
 		framework.WithProcesses(srv1, srv2, b.daprd1, b.daprd2),
@@ -98,8 +115,12 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	b.daprd2.WaitUntilRunning(t, ctx)
 
 	t.Run("invoke host", func(t *testing.T) {
+		t.Skip()
 		doReq := func(host, hostID string, verb commonv1.HTTPExtension_Verb) ([]byte, string) {
-			conn, err := grpc.DialContext(ctx, host, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+			conn, err := grpc.DialContext(ctx, host,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithBlock(),
+			)
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
@@ -147,8 +168,12 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("method doesn't exist", func(t *testing.T) {
+		t.Skip()
 		host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
-		conn, err := grpc.DialContext(ctx, host, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+		conn, err := grpc.DialContext(ctx, host,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+		)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
@@ -167,8 +192,12 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("no method", func(t *testing.T) {
+		t.Skip()
 		host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
-		conn, err := grpc.DialContext(ctx, host, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+		conn, err := grpc.DialContext(ctx, host,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+		)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
@@ -187,8 +216,12 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("multiple segments", func(t *testing.T) {
+		t.Skip()
 		host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
-		conn, err := grpc.DialContext(ctx, host, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+		conn, err := grpc.DialContext(ctx, host,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+		)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
@@ -204,24 +237,72 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(t, "application/json", resp.ContentType)
 	})
 
-	for i := 0; i < 100; i++ {
-		t.Run("parallel requests", func(t *testing.T) {
-			t.Parallel()
-			host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
-			conn, err := grpc.DialContext(ctx, host, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	t.Run("parallel requests", func(t *testing.T) {
+		t.Skip()
 
-			resp, err := rtv1.NewDaprClient(conn).InvokeService(ctx, &rtv1.InvokeServiceRequest{
-				Id: b.daprd2.AppID(),
-				Message: &commonv1.InvokeRequest{
-					Method:        "foo",
-					HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_POST},
+		errCh := make(chan error)
+		for i := 0; i < 100; i++ {
+			go func(i int) {
+				host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
+				conn, err := grpc.DialContext(ctx, host,
+					grpc.WithTransportCredentials(insecure.NewCredentials()),
+					grpc.WithBlock(),
+				)
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				resp, err := rtv1.NewDaprClient(conn).InvokeService(ctx, &rtv1.InvokeServiceRequest{
+					Id: b.daprd2.AppID(),
+					Message: &commonv1.InvokeRequest{
+						Method:        "foo",
+						HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_POST},
+					},
+				})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if string(resp.Data.Value) != "POST" {
+					errCh <- fmt.Errorf("value is '%s', expected 'POST'", string(resp.Data.Value))
+					return
+				}
+				if resp.ContentType != "201" {
+					errCh <- fmt.Errorf("content type is '%s', expected '201'", resp.ContentType)
+					return
+				}
+				errCh <- conn.Close()
+			}(i)
+		}
+
+		for i := 0; i < 100; i++ {
+			require.NoError(t, <-errCh)
+		}
+	})
+
+	t.Run("type URL", func(t *testing.T) {
+		host := fmt.Sprintf("localhost:%d", b.daprd1.GRPCPort())
+		conn, err := grpc.DialContext(ctx, host,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+		resp, err := rtv1.NewDaprClient(conn).InvokeService(ctx, &rtv1.InvokeServiceRequest{
+			Id: b.daprd2.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method: "typed",
+				Data: &anypb.Any{
+					Value:   []byte("emozioni di settembre"),
+					TypeUrl: "pfm",
 				},
-			})
-			require.NoError(t, err)
-			assert.Equal(t, "POST", string(resp.Data.Value))
-			assert.Equal(t, "201", resp.ContentType)
+			},
 		})
-	}
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetData())
+		assert.Equal(t, "emozioni di settembre/pfm", string(resp.Data.Value))
+		assert.Equal(t, "mytype", resp.Data.TypeUrl)
+	})
 }


### PR DESCRIPTION
Fixes #7012

Also fixes: in gRPC->gRPC/HTTP service invocation, data in the first chunk was included twice