### PR TITLE
Injector: Change daprd projected token audience to sentry SPIFFE ID

### DIFF
--- a/cmd/injector/app/app.go
+++ b/cmd/injector/app/app.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,7 +40,7 @@ import (
 var log = logger.NewLogger("dapr.injector")
 
 func Run() {
-	opts := options.New()
+	opts := options.New(os.Args[1:])
 
 	// Apply options to all loggers
 	err := logger.ApplyOptionsToLoggers(&opts.Logger)
@@ -107,7 +108,7 @@ func Run() {
 		log.Fatalf("Error creating injector: %v", err)
 	}
 
-	healthzServer := health.NewServer(log)
+	healthzServer := health.NewServer(health.Options{Log: log})
 	caBundleCh := make(chan []byte)
 	mngr := concurrency.NewRunnerManager(
 		metricsExporter.Run,

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cast"
-	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	corev1 "k8s.io/api/core/v1"
 
 	injectorConsts "github.com/dapr/dapr/pkg/injector/consts"
@@ -54,7 +53,7 @@ type SidecarConfig struct {
 	ControlPlaneTrustDomain     string
 	ActorsService               string
 	RemindersService            string
-	SentrySPIFFEID              spiffeid.ID
+	SentrySPIFFEID              string
 	SidecarHTTPPort             int32 `default:"3500"`
 	SidecarAPIGRPCPort          int32 `default:"50001"`
 	SidecarInternalGRPCPort     int32 `default:"50002"`

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cast"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	corev1 "k8s.io/api/core/v1"
 
 	injectorConsts "github.com/dapr/dapr/pkg/injector/consts"
@@ -53,6 +54,7 @@ type SidecarConfig struct {
 	ControlPlaneTrustDomain     string
 	ActorsService               string
 	RemindersService            string
+	SentrySPIFFEID              spiffeid.ID
 	SidecarHTTPPort             int32 `default:"3500"`
 	SidecarAPIGRPCPort          int32 `default:"50001"`
 	SidecarInternalGRPCPort     int32 `default:"50002"`

--- a/pkg/injector/patcher/sidecar_patcher_test.go
+++ b/pkg/injector/patcher/sidecar_patcher_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -270,10 +269,7 @@ func TestPatching(t *testing.T) {
 			c.Identity = "pod:identity"
 			c.CertChain = "certchain"
 			c.CertKey = "certkey"
-			td, err := spiffeid.TrustDomainFromString("foo.bar")
-			require.NoError(t, err)
-			c.SentrySPIFFEID, err = spiffeid.FromSegments(td, "ns", "example", "dapr-sentry")
-			require.NoError(t, err)
+			c.SentrySPIFFEID = "spiffe://foo.bar/ns/example/dapr-sentry"
 
 			if tc.sidecarConfigModifierFn != nil {
 				tc.sidecarConfigModifierFn(c)

--- a/pkg/injector/patcher/sidecar_volumes.go
+++ b/pkg/injector/patcher/sidecar_volumes.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	injectorConsts "github.com/dapr/dapr/pkg/injector/consts"
-	securityConsts "github.com/dapr/dapr/pkg/security/consts"
 	"github.com/dapr/kit/ptr"
 )
 
@@ -78,7 +77,7 @@ func (c *SidecarConfig) getTokenVolume() corev1.Volume {
 				DefaultMode: ptr.Of(int32(420)),
 				Sources: []corev1.VolumeProjection{{
 					ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-						Audience:          securityConsts.ServiceAccountTokenAudience,
+						Audience:          c.SentrySPIFFEID.String(),
 						ExpirationSeconds: ptr.Of(int64(7200)),
 						Path:              "token",
 					},

--- a/pkg/injector/patcher/sidecar_volumes.go
+++ b/pkg/injector/patcher/sidecar_volumes.go
@@ -77,7 +77,7 @@ func (c *SidecarConfig) getTokenVolume() corev1.Volume {
 				DefaultMode: ptr.Of(int32(420)),
 				Sources: []corev1.VolumeProjection{{
 					ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-						Audience:          c.SentrySPIFFEID.String(),
+						Audience:          c.SentrySPIFFEID,
 						ExpirationSeconds: ptr.Of(int64(7200)),
 						Path:              "token",
 					},

--- a/pkg/injector/service/injector.go
+++ b/pkg/injector/service/injector.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dapr/dapr/pkg/injector/annotations"
 	"github.com/dapr/dapr/pkg/injector/namespacednamematcher"
 	"github.com/dapr/kit/logger"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 )
 
 const (
@@ -62,7 +63,7 @@ type (
 
 // Injector is the interface for the Dapr runtime sidecar injection component.
 type Injector interface {
-	Run(context.Context, *tls.Config, signDaprdCertificateFn, currentTrustAnchorsFn) error
+	Run(context.Context, *tls.Config, spiffeid.ID, signDaprdCertificateFn, currentTrustAnchorsFn) error
 	Ready(context.Context) error
 }
 
@@ -87,6 +88,7 @@ type injector struct {
 	controlPlaneNamespace   string
 	controlPlaneTrustDomain string
 	currentTrustAnchors     currentTrustAnchorsFn
+	sentrySPIFFEID          spiffeid.ID
 	signDaprdCertificate    signDaprdCertificateFn
 
 	namespaceNameMatcher *namespacednamematcher.EqualPrefixNameNamespaceMatcher
@@ -213,7 +215,7 @@ func getServiceAccount(ctx context.Context, kubeClient kubernetes.Interface, all
 	return allowedUids, nil
 }
 
-func (i *injector) Run(ctx context.Context, tlsConfig *tls.Config, signDaprdFn signDaprdCertificateFn, currentTrustAnchors currentTrustAnchorsFn) error {
+func (i *injector) Run(ctx context.Context, tlsConfig *tls.Config, sentryID spiffeid.ID, signDaprdFn signDaprdCertificateFn, currentTrustAnchors currentTrustAnchorsFn) error {
 	select {
 	case <-i.ready:
 		return errors.New("injector already running")
@@ -225,6 +227,7 @@ func (i *injector) Run(ctx context.Context, tlsConfig *tls.Config, signDaprdFn s
 
 	i.currentTrustAnchors = currentTrustAnchors
 	i.signDaprdCertificate = signDaprdFn
+	i.sentrySPIFFEID = sentryID
 	i.server.TLSConfig = tlsConfig
 
 	errCh := make(chan error, 1)

--- a/pkg/injector/service/injector.go
+++ b/pkg/injector/service/injector.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +35,6 @@ import (
 	"github.com/dapr/dapr/pkg/injector/annotations"
 	"github.com/dapr/dapr/pkg/injector/namespacednamematcher"
 	"github.com/dapr/kit/logger"
-	"github.com/spiffe/go-spiffe/v2/spiffeid"
 )
 
 const (

--- a/pkg/injector/service/pod_patch.go
+++ b/pkg/injector/service/pod_patch.go
@@ -76,7 +76,7 @@ func (i *injector) getPodPatchOperations(ctx context.Context, ar *admissionv1.Ad
 	sidecar.SidecarDropALLCapabilities = i.config.GetDropCapabilities()
 	sidecar.ControlPlaneNamespace = i.controlPlaneNamespace
 	sidecar.ControlPlaneTrustDomain = i.controlPlaneTrustDomain
-	sidecar.SentrySPIFFEID = i.sentrySPIFFEID
+	sidecar.SentrySPIFFEID = i.sentrySPIFFEID.String()
 	sidecar.CurrentTrustAnchors = trustAnchors
 	sidecar.CertChain = string(daprdCert)
 	sidecar.CertKey = string(daprdPrivateKey)

--- a/pkg/injector/service/pod_patch.go
+++ b/pkg/injector/service/pod_patch.go
@@ -76,6 +76,7 @@ func (i *injector) getPodPatchOperations(ctx context.Context, ar *admissionv1.Ad
 	sidecar.SidecarDropALLCapabilities = i.config.GetDropCapabilities()
 	sidecar.ControlPlaneNamespace = i.controlPlaneNamespace
 	sidecar.ControlPlaneTrustDomain = i.controlPlaneTrustDomain
+	sidecar.SentrySPIFFEID = i.sentrySPIFFEID
 	sidecar.CurrentTrustAnchors = trustAnchors
 	sidecar.CertChain = string(daprdCert)
 	sidecar.CertKey = string(daprdPrivateKey)

--- a/pkg/security/consts/consts.go
+++ b/pkg/security/consts/consts.go
@@ -27,9 +27,6 @@ const (
 	// TrustBundleK8sSecretName is the name of the kubernetes secret that holds the trust bundle.
 	TrustBundleK8sSecretName = "dapr-trust-bundle" /* #nosec */
 
-	// ServiceAccountTokenAudience is the audience for the service account token.
-	ServiceAccountTokenAudience = "dapr.io/sentry" /* #nosec */
-
 	// TrustAnchorsEnvVar is the environment variable name for the trust anchors in the sidecar.
 	TrustAnchorsEnvVar = "DAPR_TRUST_ANCHORS"
 	// CertChainEnvVar is the environment variable name for the cert chain in the sidecar.


### PR DESCRIPTION
Inject the SPIFFE ID of sentry as the daprd sentry token audience over the legacy `dapr.io/sentry`. More secure as it is more specific to the dapr cluster installation control plane trust domain and control plane namespace. The control plane components are already using the sentry SPIFFE ID of sentry as their identity token audience.

The legacy `dapr.io/sentry` audience continues to be accepted by sentry for backwards compatibility. 

Part of #5756 