### PR TITLE
Update GitHub verison-skew workflow to use 1.12 setup components

### DIFF
--- a/.github/workflows/version-skew-e2e.yaml
+++ b/.github/workflows/version-skew-e2e.yaml
@@ -219,9 +219,8 @@ jobs:
         make setup-helm-init
         make setup-test-env-redis
         make setup-test-env-kafka
-        make setup-test-env-mongodb
         make setup-test-env-zipkin
-        helm upgrade --install dapr-kafka bitnami/kafka --version 23.0.7 -f ./tests/config/kafka_override.yaml --namespace ${{ env.DAPR_NAMESPACE }} --timeout 10m0s
+        make setup-test-env-postgres
         make setup-test-components
 
     - name: Free up some diskspace


### PR DESCRIPTION
Updates version skew workflow to use `1.12` setup components targets.

This unblocks running version skew tests on master which is currently broken because we are using setup components for `1.11`.

Demo of PR working on my fork: https://github.com/JoshVanL/dapr/actions/runs/6526229680
Looks like we have a failing backwards compat with Dapr in master