### PR TITLE
Version Skew test- patching previous release

### DIFF
--- a/.github/scripts/version-skew-test-patches/release-1.12/0001-remove-actor-reminder-rename.patch
+++ b/.github/scripts/version-skew-test-patches/release-1.12/0001-remove-actor-reminder-rename.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/e2e/actor_reminder/actor_reminder_test.go b/tests/e2e/actor_reminder/actor_reminder_test.go
+index 45047f423..fbcfd8321 100644
+--- a/tests/e2e/actor_reminder/actor_reminder_test.go
++++ b/tests/e2e/actor_reminder/actor_reminder_test.go
+@@ -375,6 +375,8 @@ func TestActorReminder(t *testing.T) {
+ 	})
+ 
+ 	t.Run("Actor reminder rename should succeed.", func(t *testing.T) {
++		t.Skip("Actor reminder rename is no longer supported in 1.13")
++
+ 		var wg sync.WaitGroup
+ 		for iteration := 1; iteration <= numIterations; iteration++ {
+ 			wg.Add(1)

--- a/.github/workflows/version-skew-e2e.yaml
+++ b/.github/workflows/version-skew-e2e.yaml
@@ -115,6 +115,14 @@ jobs:
         repository: dapr/dapr
         path: latest-release
         ref: v${{ env.DAPR_PREV_VERSION }}
+    - name: Apply patches to latest release
+      run: |
+        export DAPR_LATEST_MAJOR_MINOR=$(echo ${{ env.DAPR_PREV_VERSION }} | cut -d. -f1-2)
+        export DAPR_PATCH_DIR="$(pwd)/.github/scripts/version-skew-test-patches/release-${{ env.DAPR_LATEST_MAJOR_MINOR }}"
+        if [ -d "$DAPR_PATCH_DIR" ]; then
+          echo "Applying patches from $DAPR_PATCH_DIR"
+          cd latest-release && git apply --ignore-space-change --ignore-whitespace $DAPR_PATCH_DIR/*.patch
+        fi
     - name: Set up Go
       id: setup-go
       uses: actions/setup-go@v4


### PR DESCRIPTION
Sometimes version skew tests will fail because an API has been removed and is no longer available in master, or for example a test string matches an error string which has been changed. These tests need to be edited in the previous release in order for the version skew tests to correctly pass and not cause failure noise.

PR adds a mechanism to add patches to the latest Dapr release in the version skew workflow. Note that this patching mechanism should not be misused in order to hide true backwards compatibility breakages.

Also adds a patch which skips running the reminder rename tests as the rename API has been removed [here](https://github.com/dapr/dapr/commit/a16df5eed42fd8f72b47a39095577fcb025c6cde).