### PR TITLE
Fix: return HTTP status code in HTTP service invocation with resiliency enabled

### DIFF
--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -322,5 +322,5 @@ type codeError struct {
 }
 
 func (ce codeError) Error() string {
-	return fmt.Sprintf("received non-successful status code in response: statusCode='%d' msg='%v'", ce.statusCode, string(ce.msg))
+	return fmt.Sprintf("received non-successful status code in response: %d", ce.statusCode)
 }

--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -322,5 +322,5 @@ type codeError struct {
 }
 
 func (ce codeError) Error() string {
-	return fmt.Sprintf("CodeError: received non-successful status code (statusCode='%d') msg='%v'", ce.statusCode, string(ce.msg))
+	return fmt.Sprintf("received non-successful status code in response: statusCode='%d' msg='%v'", ce.statusCode, string(ce.msg))
 }

--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -322,5 +322,5 @@ type codeError struct {
 }
 
 func (ce codeError) Error() string {
-	return fmt.Sprintf("codeError (statusCode='%d') msg='%v'", ce.statusCode, string(ce.msg))
+	return fmt.Sprintf("CodeError: received non-successful status code (statusCode='%d') msg='%v'", ce.statusCode, string(ce.msg))
 }

--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -98,11 +98,8 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	defer req.Close()
 
-	policyRunner := resiliency.NewRunnerWithOptions(
+	policyRunner := resiliency.NewRunner[*invokev1.InvokeMethodResponse](
 		r.Context(), policyDef,
-		resiliency.RunnerOpts[*invokev1.InvokeMethodResponse]{
-			Disposer: resiliency.DisposerCloser[*invokev1.InvokeMethodResponse],
-		},
 	)
 	// Since we don't want to return the actual error, we have to extract several things in order to construct our response.
 	resp, err := policyRunner(func(ctx context.Context) (*invokev1.InvokeMethodResponse, error) {

--- a/pkg/http/api_directmessaging.go
+++ b/pkg/http/api_directmessaging.go
@@ -98,8 +98,11 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	defer req.Close()
 
-	policyRunner := resiliency.NewRunner[*invokev1.InvokeMethodResponse](
+	policyRunner := resiliency.NewRunnerWithOptions(
 		r.Context(), policyDef,
+		resiliency.RunnerOpts[*invokev1.InvokeMethodResponse]{
+			Disposer: resiliency.DisposerCloser[*invokev1.InvokeMethodResponse],
+		},
 	)
 	// Since we don't want to return the actual error, we have to extract several things in order to construct our response.
 	resp, err := policyRunner(func(ctx context.Context) (*invokev1.InvokeMethodResponse, error) {
@@ -140,9 +143,14 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 				resStatus.Code = statusCode
 			}
 		} else if resStatus.Code < 200 || resStatus.Code > 399 {
-			// We are not returning an `invokeError` here on purpose.
-			// Returning an error that is not an `invokeError` will cause Resiliency to retry the request (if retries are enabled), but if the request continues to fail, the response is sent to the user with whatever status code the app returned so the "received non-successful status code" is "swallowed" (will appear in logs but won't be returned to the app).
-			return rResp, fmt.Errorf("received non-successful status code: %d", resStatus.Code)
+			msg, _ := rResp.RawDataFull()
+			// Returning a `codeError` here will cause Resiliency to retry the request (if retries are enabled), but if the request continues to fail, the response is sent to the user with whatever status code the app returned.
+			return rResp, codeError{
+				headers:     rResp.Headers(),
+				statusCode:  int(resStatus.Code),
+				msg:         msg,
+				contentType: rResp.ContentType(),
+			}
 		}
 		return rResp, nil
 	})
@@ -150,6 +158,22 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 	// Special case for timeouts/circuit breakers since they won't go through the rest of the logic.
 	if errors.Is(err, context.DeadlineExceeded) || breaker.IsErrorPermanent(err) {
 		respondWithError(w, messages.ErrDirectInvoke.WithFormat(targetID, err))
+		return
+	}
+
+	var codeErr codeError
+	if errors.As(err, &codeErr) {
+		if len(codeErr.headers) > 0 {
+			invokev1.InternalMetadataToHTTPHeader(r.Context(), codeErr.headers, w.Header().Add)
+		}
+		respondWithHTTPRawResponse(w, &UniversalHTTPRawResponse{
+			Body:        codeErr.msg,
+			ContentType: codeErr.contentType,
+			StatusCode:  codeErr.statusCode,
+		}, codeErr.statusCode)
+		if resp != nil {
+			_ = resp.Close()
+		}
 		return
 	}
 
@@ -288,4 +312,15 @@ type invokeError struct {
 
 func (ie invokeError) Error() string {
 	return fmt.Sprintf("invokeError (statusCode='%d') msg='%v'", ie.statusCode, string(ie.msg))
+}
+
+type codeError struct {
+	statusCode  int
+	msg         []byte
+	headers     invokev1.DaprInternalMetadata
+	contentType string
+}
+
+func (ce codeError) Error() string {
+	return fmt.Sprintf("codeError (statusCode='%d') msg='%v'", ce.statusCode, string(ce.msg))
 }

--- a/pkg/http/api_directmessaging_test.go
+++ b/pkg/http/api_directmessaging_test.go
@@ -925,6 +925,7 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.Equal(t, 1, failingDirectMessaging.Failure.CallCount("allgood"))
+		assert.Equal(t, fakeData, resp.RawBody)
 	})
 
 	t.Run("Test invoke direct message does not retry on 2xx", func(t *testing.T) {
@@ -941,6 +942,7 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 
 		assert.Equal(t, 201, resp.StatusCode)
 		assert.Equal(t, 1, failingDirectMessaging.Failure.CallCount("allgood2"))
+		assert.Equal(t, fakeData, resp.RawBody)
 	})
 
 	t.Run("Test invoke direct message retries with resiliency", func(t *testing.T) {
@@ -963,10 +965,13 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		fakeData := []byte("failingKey2")
 
 		// act
-		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil)
+		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil, "header1", "val1")
 
 		assert.Equal(t, 450, resp.StatusCode)
 		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey2"))
+		assert.Equal(t, fakeData, resp.RawBody)
+		assert.Equal(t, "val1", resp.RawHeader.Get("header1"))
+		assert.Equal(t, "application/json", resp.ContentType)
 	})
 
 	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {

--- a/pkg/http/api_directmessaging_test.go
+++ b/pkg/http/api_directmessaging_test.go
@@ -954,6 +954,21 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey"))
 	})
 
+	t.Run("Test invoke direct message retries on unsuccessful statuscode with resiliency", func(t *testing.T) {
+		failingDirectMessaging.SuccessStatusCode = 450
+		defer func() {
+			failingDirectMessaging.SuccessStatusCode = 0
+		}()
+		apiPath := "v1.0/invoke/failingApp/method/fakeMethod"
+		fakeData := []byte("failingKey2")
+
+		// act
+		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil)
+
+		assert.Equal(t, 450, resp.StatusCode)
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey2"))
+	})
+
 	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {
 		apiPath := "v1.0/invoke/failingApp/method/fakeMethod"
 		fakeData := []byte("timeoutKey")

--- a/pkg/testing/directmessaging_mock.go
+++ b/pkg/testing/directmessaging_mock.go
@@ -85,7 +85,7 @@ func (_m *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
-	//Setting up the headers passed in request
+	// Setting up the headers passed in request
 	md := r.GetMetadata()
 	headers := make(map[string][]string)
 	for k, v := range md {

--- a/pkg/testing/directmessaging_mock.go
+++ b/pkg/testing/directmessaging_mock.go
@@ -85,9 +85,18 @@ func (_m *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
+	//Setting up the headers passed in request
+	md := r.GetMetadata()
+	headers := make(map[string][]string)
+	for k, v := range md {
+		headers[k] = v.GetValues()
+	}
+	contentType := r.Message.GetContentType()
 	resp := invokev1.
 		NewInvokeMethodResponse(int32(statusCode), http.StatusText(statusCode), nil).
-		WithRawDataBytes(r.Message.Data.Value)
+		WithRawDataBytes(r.Message.Data.Value).
+		WithHTTPHeaders(headers).
+		WithContentType(contentType)
 	return resp, nil
 }
 

--- a/tests/integration/suite/daprd/resiliency/apps/defaultretry.go
+++ b/tests/integration/suite/daprd/resiliency/apps/defaultretry.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaultretry))
+}
+
+type defaultretry struct {
+	daprd1    *daprd.Daprd
+	daprd2    *daprd.Daprd
+	callCount map[string]int
+}
+
+func (d *defaultretry) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Method))
+	})
+
+	handler.HandleFunc("/retry", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		key := string(body)
+		d.callCount[key]++
+
+		w.Header().Set("x-method", r.Method)
+		w.Header().Set("content-type", "application/json")
+		if key == "success" {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		w.Write(body)
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+
+	resiliency := `
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: myresiliency
+spec:
+  policies:
+    retries:
+      DefaultAppRetryPolicy:
+        policy: constant
+        duration: 100ms
+        maxRetries: 3
+  targets: {}
+`
+	d.daprd1 = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithResourceFiles(resiliency),
+		daprd.WithLogLevel("debug"),
+	)
+	d.daprd2 = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithResourceFiles(resiliency),
+	)
+	d.callCount = make(map[string]int)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, d.daprd1, d.daprd2),
+	}
+}
+
+func (d *defaultretry) Run(t *testing.T, ctx context.Context) {
+	d.daprd1.WaitUntilRunning(t, ctx)
+	d.daprd2.WaitUntilRunning(t, ctx)
+
+	t.Run("no retry on successful statuscode", func(t *testing.T) {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/retry", d.daprd1.HTTPPort(), d.daprd2.AppID())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader("success"))
+		require.NoError(t, err)
+		resp, err := util.HTTPClient(t).Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "POST", resp.Header.Get("x-method"))
+		assert.Equal(t, "application/json", resp.Header.Get("content-type"))
+		assert.Equal(t, "success", string(body))
+		// CallCount["success"] should be 1 as there would be no retry on successful statuscode
+		assert.Equal(t, 1, d.callCount["success"])
+	})
+
+	t.Run("retry on unsuccessful statuscode", func(t *testing.T) {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/retry", d.daprd1.HTTPPort(), d.daprd2.AppID())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader("fail"))
+		require.NoError(t, err)
+		resp, err := util.HTTPClient(t).Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "POST", resp.Header.Get("x-method"))
+		assert.Equal(t, "application/json", resp.Header.Get("content-type"))
+		assert.Equal(t, "fail", string(body))
+		// Callcount["fail"] should be 4 as there will be 3 retries(maxRetries=3)
+		assert.Equal(t, 4, d.callCount["fail"])
+	})
+}

--- a/tests/integration/suite/daprd/resiliency/apps/defaultretry.go
+++ b/tests/integration/suite/daprd/resiliency/apps/defaultretry.go
@@ -85,7 +85,6 @@ spec:
 	d.daprd1 = daprd.New(t,
 		daprd.WithAppPort(srv.Port()),
 		daprd.WithResourceFiles(resiliency),
-		daprd.WithLogLevel("debug"),
 	)
 	d.daprd2 = daprd.New(t,
 		daprd.WithAppPort(srv.Port()),


### PR DESCRIPTION
# Description

Currently With Resiliency enabled, in case of http service invocation, if one application sends error status codes (http code <200 or >399), Dapr instead of forwarding the received status code, converts it to 500(See #6840). This doesn't seem to be intended behavior as well(See the comment here: https://github.com/dapr/dapr/blob/725e7d6865e35726104b856208e2d60f1a583c75/pkg/http/api_directmessaging.go#L147). Also it makes dapr behave differently with and without resiliency enabled(#6840)

This PR adds a custom error object to handle the scenario for incorrect status codes. It also adds the unit test as well as integration test for the same.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #6840 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
