### PR TITLE
update maven3 java base image to eclipse-temurin

### DIFF
--- a/tests/apps/actorjava/Dockerfile
+++ b/tests/apps/actorjava/Dockerfile
@@ -1,5 +1,5 @@
 # build stage build the jar with all our resources
-FROM maven:3-openjdk-11 as build
+FROM maven:3-eclipse-temurin-11 as build
 
 VOLUME /tmp
 WORKDIR /build
@@ -11,7 +11,7 @@ ADD src/ /build/src/
 RUN mvn package
 
 # package stage
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 
 ARG JAR_FILE
 COPY --from=build /build/target/app.jar /opt/app.jar

--- a/tests/apps/perf/actorjava/Dockerfile
+++ b/tests/apps/perf/actorjava/Dockerfile
@@ -1,5 +1,5 @@
 # build stage build the jar with all our resources
-FROM maven:3-openjdk-11 as build
+FROM maven:3-eclipse-temurin-11 as build
 
 VOLUME /tmp
 WORKDIR /build
@@ -11,7 +11,7 @@ ADD src/ /build/src/
 RUN mvn package
 
 # package stage
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 
 ARG JAR_FILE
 COPY --from=build /build/target/app.jar /opt/app.jar


### PR DESCRIPTION
# Description

Update Maven3 Java base images from OpenJDK (deprecated) to Eclipse-Temurin

https://hub.docker.com/_/openjdk
https://hub.docker.com/_/eclipse-temurin

## Issue reference

N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
