### PR TITLE
[1.11] Change injector webhook config template to source caBundle from Secret

### DIFF
--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_webhook_config.yaml
@@ -1,6 +1,5 @@
 {{- if eq .Values.enabled true }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "dapr-sidecar-injector-cert"}}
-{{- $existingWebHookConfig := lookup "admissionregistration.k8s.io/v1" "MutatingWebhookConfiguration" .Release.Namespace "dapr-sidecar-injector"}}
 {{- $ca := genCA "dapr-sidecar-injector-ca" 3650 }}
 {{- $cn := printf "dapr-sidecar-injector" }}
 {{- $altName1 := printf "dapr-sidecar-injector.%s" .Release.Namespace }}
@@ -43,7 +42,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       name: dapr-sidecar-injector
       path: "/mutate"
-    caBundle: {{ if $existingWebHookConfig }}{{ (index $existingWebHookConfig.webhooks 0).clientConfig.caBundle }}{{ else }}{{ b64enc $ca.Cert }}{{ end }}
+    caBundle: {{ if $existingSecret }}{{ index $existingSecret.data "tls.crt" }}{{ else }}{{ b64enc $ca.Cert }}{{ end }}
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
Source injector webhook CA bundle from webhook certificate secret, rather than existing webhook configuration to allow downgrades from 1.12.

The CA Bundle will change from the root CA to the injector serving certificate on subsequent runs of helm install, which doesn't have any impact on functionality or security.

See: https://github.com/dapr/dapr/issues/7055#issuecomment-1768573741