### PR TITLE
[release-1.12] Cherry-pick Fix: return HTTP status code in HTTP service invocation with resiliency enabled #7052

### DIFF
--- a/pkg/http/api_directmessaging_test.go
+++ b/pkg/http/api_directmessaging_test.go
@@ -925,6 +925,7 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.Equal(t, 1, failingDirectMessaging.Failure.CallCount("allgood"))
+		assert.Equal(t, fakeData, resp.RawBody)
 	})
 
 	t.Run("Test invoke direct message does not retry on 2xx", func(t *testing.T) {
@@ -941,6 +942,7 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 
 		assert.Equal(t, 201, resp.StatusCode)
 		assert.Equal(t, 1, failingDirectMessaging.Failure.CallCount("allgood2"))
+		assert.Equal(t, fakeData, resp.RawBody)
 	})
 
 	t.Run("Test invoke direct message retries with resiliency", func(t *testing.T) {
@@ -952,6 +954,24 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey"))
+	})
+
+	t.Run("Test invoke direct message retries on unsuccessful statuscode with resiliency", func(t *testing.T) {
+		failingDirectMessaging.SuccessStatusCode = 450
+		defer func() {
+			failingDirectMessaging.SuccessStatusCode = 0
+		}()
+		apiPath := "v1.0/invoke/failingApp/method/fakeMethod"
+		fakeData := []byte("failingKey2")
+
+		// act
+		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil, "header1", "val1")
+
+		assert.Equal(t, 450, resp.StatusCode)
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey2"))
+		assert.Equal(t, fakeData, resp.RawBody)
+		assert.Equal(t, "val1", resp.RawHeader.Get("header1"))
+		assert.Equal(t, "application/json", resp.ContentType)
 	})
 
 	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {

--- a/pkg/testing/directmessaging_mock.go
+++ b/pkg/testing/directmessaging_mock.go
@@ -85,9 +85,18 @@ func (_m *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
+	// Setting up the headers passed in request
+	md := r.GetMetadata()
+	headers := make(map[string][]string)
+	for k, v := range md {
+		headers[k] = v.GetValues()
+	}
+	contentType := r.Message.GetContentType()
 	resp := invokev1.
 		NewInvokeMethodResponse(int32(statusCode), http.StatusText(statusCode), nil).
-		WithRawDataBytes(r.Message.Data.Value)
+		WithRawDataBytes(r.Message.Data.Value).
+		WithHTTPHeaders(headers).
+		WithContentType(contentType)
 	return resp, nil
 }
 

--- a/tests/integration/suite/daprd/resiliency/apps/defaultretry.go
+++ b/tests/integration/suite/daprd/resiliency/apps/defaultretry.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaultretry))
+}
+
+type defaultretry struct {
+	daprd1    *daprd.Daprd
+	daprd2    *daprd.Daprd
+	callCount map[string]*atomic.Int32
+}
+
+func (d *defaultretry) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Method))
+	})
+
+	handler.HandleFunc("/retry", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		key := string(body)
+		if d.callCount[key] == nil {
+			d.callCount[key] = &atomic.Int32{}
+		}
+		d.callCount[key].Add(1)
+		w.Header().Set("x-method", r.Method)
+		w.Header().Set("content-type", "application/json")
+		if key == "success" {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		w.Write(body)
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+
+	resiliency := `
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: myresiliency
+spec:
+  policies:
+    retries:
+      DefaultAppRetryPolicy:
+        policy: constant
+        duration: 100ms
+        maxRetries: 3
+  targets: {}
+`
+	d.daprd1 = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithResourceFiles(resiliency),
+	)
+	d.daprd2 = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithResourceFiles(resiliency),
+	)
+	d.callCount = make(map[string]*atomic.Int32)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, d.daprd1, d.daprd2),
+	}
+}
+
+func (d *defaultretry) Run(t *testing.T, ctx context.Context) {
+	d.daprd1.WaitUntilRunning(t, ctx)
+	d.daprd2.WaitUntilRunning(t, ctx)
+
+	t.Run("no retry on successful statuscode", func(t *testing.T) {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/retry", d.daprd1.HTTPPort(), d.daprd2.AppID())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader("success"))
+		require.NoError(t, err)
+		resp, err := util.HTTPClient(t).Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "POST", resp.Header.Get("x-method"))
+		assert.Equal(t, "application/json", resp.Header.Get("content-type"))
+		assert.Equal(t, "success", string(body))
+		// CallCount["success"] should be 1 as there would be no retry on successful statuscode
+		assert.Equal(t, int32(1), d.callCount["success"].Load())
+	})
+
+	t.Run("retry on unsuccessful statuscode", func(t *testing.T) {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/retry", d.daprd1.HTTPPort(), d.daprd2.AppID())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader("fail"))
+		require.NoError(t, err)
+		resp, err := util.HTTPClient(t).Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "POST", resp.Header.Get("x-method"))
+		assert.Equal(t, "application/json", resp.Header.Get("content-type"))
+		assert.Equal(t, "fail", string(body))
+		// Callcount["fail"] should be 4 as there will be 3 retries(maxRetries=3)
+		assert.Equal(t, int32(4), d.callCount["fail"].Load())
+	})
+}


### PR DESCRIPTION
---------

# Description

Cherry-picks PR #7052 in release-1.12

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
