### PR TITLE
Fix subscription match nil format.

### DIFF
--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -82,6 +82,9 @@ func (e *Expr) Expr() string {
 }
 
 func (e *Expr) String() string {
+	if e == nil {
+		return ""
+	}
 	return e.expr
 }
 

--- a/pkg/grpc/universalapi/api_metadata.go
+++ b/pkg/grpc/universalapi/api_metadata.go
@@ -139,17 +139,15 @@ func metadataGetOrDefaultCapabilities(dict map[string][]string, key string) []st
 
 func metadataConvertPubSubSubscriptionRules(rules []*runtimePubsub.Rule) *runtimev1pb.PubsubSubscriptionRules {
 	out := &runtimev1pb.PubsubSubscriptionRules{
-		Rules: make([]*runtimev1pb.PubsubSubscriptionRule, 0),
+		Rules: make([]*runtimev1pb.PubsubSubscriptionRule, len(rules)),
 	}
-	for _, r := range rules {
-		match := ""
-		if r.Match != nil {
-			match = r.Match.String()
+	for i, r := range rules {
+		out.Rules[i] = &runtimev1pb.PubsubSubscriptionRule{
+			Path: r.Path,
 		}
-		out.Rules = append(out.Rules, &runtimev1pb.PubsubSubscriptionRule{
-			Match: match,
-			Path:  r.Path,
-		})
+		if r.Match != nil {
+			out.Rules[i].Match = r.Match.String()
+		}
 	}
 	return out
 }

--- a/pkg/grpc/universalapi/api_metadata.go
+++ b/pkg/grpc/universalapi/api_metadata.go
@@ -15,7 +15,6 @@ package universalapi
 
 import (
 	"context"
-	"fmt"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -143,9 +142,12 @@ func metadataConvertPubSubSubscriptionRules(rules []*runtimePubsub.Rule) *runtim
 		Rules: make([]*runtimev1pb.PubsubSubscriptionRule, 0),
 	}
 	for _, r := range rules {
+		match := ""
+		if r.Match != nil {
+			match = r.Match.String()
+		}
 		out.Rules = append(out.Rules, &runtimev1pb.PubsubSubscriptionRule{
-			// TODO avoid using fmt.Sprintf
-			Match: fmt.Sprintf("%s", r.Match),
+			Match: match,
 			Path:  r.Path,
 		})
 	}

--- a/pkg/runtime/pubsub/subscription.go
+++ b/pkg/runtime/pubsub/subscription.go
@@ -23,4 +23,5 @@ type Rule struct {
 
 type Expr interface {
 	Eval(variables map[string]interface{}) (interface{}, error)
+	String() string
 }

--- a/pkg/runtime/pubsub/subscription.go
+++ b/pkg/runtime/pubsub/subscription.go
@@ -1,5 +1,7 @@
 package pubsub
 
+import "fmt"
+
 type Subscription struct {
 	PubsubName      string            `json:"pubsubname"`
 	Topic           string            `json:"topic"`
@@ -22,6 +24,7 @@ type Rule struct {
 }
 
 type Expr interface {
+	fmt.Stringer
+
 	Eval(variables map[string]interface{}) (interface{}, error)
-	String() string
 }

--- a/pkg/runtime/pubsub/subscriptions_test.go
+++ b/pkg/runtime/pubsub/subscriptions_test.go
@@ -800,7 +800,7 @@ func TestK8sSubscriptions(t *testing.T) {
 }
 
 func TestGetRuleMatchString(t *testing.T) {
-	var cases = []subscriptionsapiV2alpha1.Rule{
+	cases := []subscriptionsapiV2alpha1.Rule{
 		{
 			Match: `event.type == "myevent.v3"`,
 			Path:  "myroute.v3",

--- a/pkg/runtime/pubsub/subscriptions_test.go
+++ b/pkg/runtime/pubsub/subscriptions_test.go
@@ -798,3 +798,26 @@ func TestK8sSubscriptions(t *testing.T) {
 		assert.Equal(t, "testValue", subs[0].Metadata["testName"])
 	}
 }
+
+func TestGetRuleMatchString(t *testing.T) {
+	var cases = []subscriptionsapiV2alpha1.Rule{
+		{
+			Match: `event.type == "myevent.v3"`,
+			Path:  "myroute.v3",
+		},
+		{
+			Match: `event.type == "myevent.v2"`,
+			Path:  "myroute.v2",
+		},
+		{
+			Match: "",
+			Path:  "myroute.v1",
+		},
+	}
+
+	for _, v := range cases {
+		rule, err := createRoutingRule(v.Match, v.Path)
+		assert.NoError(t, err)
+		assert.Equal(t, v.Match, rule.Match.String())
+	}
+}

--- a/tests/integration/suite/daprd/metadata/metadata.go
+++ b/tests/integration/suite/daprd/metadata/metadata.go
@@ -123,6 +123,7 @@ func validateResponse(t *testing.T, appID string, appPort int, body io.Reader) {
 	rules, ok := subscription["rules"].([]interface{})
 	require.True(t, ok)
 	rule, ok := rules[0].(map[string]interface{})
+	require.True(t, ok)
 	require.Empty(t, rule["match"])
 	require.Equal(t, "/B", rule["path"])
 }

--- a/tests/integration/suite/daprd/metadata/metadata.go
+++ b/tests/integration/suite/daprd/metadata/metadata.go
@@ -40,7 +40,25 @@ type metadata struct {
 }
 
 func (m *metadata) Setup(t *testing.T) []framework.Option {
-	m.proc = procdaprd.New(t)
+	subComponentAndConfiguration := `
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub
+spec:
+  topic: B
+  route: /B
+  pubsubname: pubsub
+`
+	m.proc = procdaprd.New(t, procdaprd.WithResourceFiles(subComponentAndConfiguration))
 	return []framework.Option{
 		framework.WithProcesses(m.proc),
 	}
@@ -95,4 +113,16 @@ func validateResponse(t *testing.T, appID string, appPort int, body io.Reader) {
 	require.Equal(t, appPort, int(port))
 	require.Equal(t, "http", appConnectionProperties["protocol"])
 	require.Equal(t, "127.0.0.1", appConnectionProperties["channelAddress"])
+
+	// validate that the metadata contains correct format of subscription.
+	// The http response struct is private, so we use assert here.
+	subscriptions, ok := bodyMap["subscriptions"].([]interface{})
+	require.True(t, ok)
+	subscription, ok := subscriptions[0].(map[string]interface{})
+	require.True(t, ok)
+	rules, ok := subscription["rules"].([]interface{})
+	require.True(t, ok)
+	rule, ok := rules[0].(map[string]interface{})
+	require.Empty(t, rule["match"])
+	require.Equal(t, "/B", rule["path"])
 }


### PR DESCRIPTION
# Description

Metadata API returns rule match value to be empty when it is not defined.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #7049

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
