### PR TITLE
[release-1.11]Fix: return HTTP status code in HTTP service invocation with resiliency enabled

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -1303,6 +1303,17 @@ func (a *api) getStateStoreName(reqCtx *fasthttp.RequestCtx) string {
 	return reqCtx.UserValue(storeNameParam).(string)
 }
 
+type codeError struct {
+	statusCode  int
+	msg         []byte
+	headers     invokev1.DaprInternalMetadata
+	contentType string
+}
+
+func (ce codeError) Error() string {
+	return fmt.Sprintf("received non-successful status code in response: %d", ce.statusCode)
+}
+
 type invokeError struct {
 	statusCode int
 	msg        ErrorResponse
@@ -1458,9 +1469,14 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 				resStatus.Code = statusCode
 			}
 		} else if resStatus.Code < 200 || resStatus.Code > 399 {
-			// We are not returning an `invokeError` here on purpose.
-			// Returning an error that is not an `invokeError` will cause Resiliency to retry the request (if retries are enabled), but if the request continues to fail, the response is sent to the user with whatever status code the app returned so the "received non-successful status code" is "swallowed" (will appear in logs but won't be returned to the app).
-			return rResp, fmt.Errorf("received non-successful status code: %d", resStatus.Code)
+			msg, _ := rResp.RawDataFull()
+			// Returning a `codeError` here will cause Resiliency to retry the request (if retries are enabled), but if the request continues to fail, the response is sent to the user with whatever status code the app returned.
+			return rResp, codeError{
+				headers:     rResp.Headers(),
+				statusCode:  int(resStatus.Code),
+				msg:         msg,
+				contentType: rResp.ContentType(),
+			}
 		}
 		return rResp, nil
 	})
@@ -1469,6 +1485,19 @@ func (a *api) onDirectMessage(reqCtx *fasthttp.RequestCtx) {
 	if errors.Is(err, context.DeadlineExceeded) || breaker.IsErrorPermanent(err) {
 		respond(reqCtx, withError(fasthttp.StatusInternalServerError, NewErrorResponse("ERR_DIRECT_INVOKE", err.Error())))
 		cancel()
+		return
+	}
+	var codeErr codeError
+	if errors.As(err, &codeErr) {
+		if len(codeErr.headers) > 0 {
+			invokev1.InternalMetadataToHTTPHeader(reqCtx, codeErr.headers, reqCtx.Response.Header.Add)
+		}
+		reqCtx.Response.Header.SetContentType(codeErr.contentType)
+		respond(reqCtx, with(codeErr.statusCode, codeErr.msg))
+		cancel()
+		if resp != nil {
+			_ = resp.Close()
+		}
 		return
 	}
 

--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -1831,6 +1831,24 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey"))
 	})
 
+	t.Run("Test invoke direct message retries on unsuccessful statuscode with resiliency", func(t *testing.T) {
+		failingDirectMessaging.SuccessStatusCode = 450
+		defer func() {
+			failingDirectMessaging.SuccessStatusCode = 0
+		}()
+		apiPath := "v1.0/invoke/failingApp/method/fakeMethod"
+		fakeData := []byte("failingKey2")
+
+		// act
+		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil, "header1", "val1")
+
+		assert.Equal(t, 450, resp.StatusCode)
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey2"))
+		assert.Equal(t, fakeData, resp.RawBody)
+		assert.Equal(t, "val1", resp.RawHeader.Get("header1"))
+		assert.Equal(t, "application/json", resp.ContentType)
+	})
+
 	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {
 		apiPath := "v1.0/invoke/failingApp/method/fakeMethod"
 		fakeData := []byte("timeoutKey")

--- a/pkg/testing/directmessaging_mock.go
+++ b/pkg/testing/directmessaging_mock.go
@@ -85,9 +85,18 @@ func (_m *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
+	// Setting up the headers passed in request
+	md := r.GetMetadata()
+	headers := make(map[string][]string)
+	for k, v := range md {
+		headers[k] = v.GetValues()
+	}
+	contentType := r.Message.GetContentType()
 	resp := invokev1.
 		NewInvokeMethodResponse(int32(statusCode), http.StatusText(statusCode), nil).
-		WithRawDataBytes(r.Message.Data.Value)
+		WithRawDataBytes(r.Message.Data.Value).
+		WithHTTPHeaders(headers).
+		WithContentType(contentType)
 	return resp, nil
 }
 


### PR DESCRIPTION
…cy enabled

# Description

This PR brings the same change as done in #7052 to release-1.11. Can't do a direct cherry-pick due to several merge conflicts as code is changed a lot. Also integration test is missing since there is no framework in 1.11. 
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
