### PR TITLE
Placement: Disseminate rate limiting

### DIFF
--- a/cmd/placement/app/app.go
+++ b/cmd/placement/app/app.go
@@ -93,7 +93,10 @@ func Run() {
 	if opts.MaxAPILevel >= 0 && opts.MaxAPILevel < math.MaxInt32 {
 		placementOpts.MaxAPILevel = ptr.Of(uint32(opts.MaxAPILevel))
 	}
-	apiServer := placement.NewPlacementService(placementOpts)
+	apiServer, err := placement.NewPlacementService(placementOpts)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	err = concurrency.NewRunnerManager(
 		func(ctx context.Context) error {

--- a/go.sum
+++ b/go.sum
@@ -1014,8 +1014,6 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/joshvanl/kit v0.0.0-20231021113046-e3ca28b9ef9f h1:5jG9awhZd+2gLeFSrrm1xROQbzRFXwnLrL+ev3T1eoM=
-github.com/joshvanl/kit v0.0.0-20231021113046-e3ca28b9ef9f/go.mod h1:orvgaWMtJ1tXl+soTWhQBIVqy20o1cHbO/QzJwrDvog=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -1014,6 +1014,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/kit v0.0.0-20231021113046-e3ca28b9ef9f h1:5jG9awhZd+2gLeFSrrm1xROQbzRFXwnLrL+ev3T1eoM=
+github.com/joshvanl/kit v0.0.0-20231021113046-e3ca28b9ef9f/go.mod h1:orvgaWMtJ1tXl+soTWhQBIVqy20o1cHbO/QzJwrDvog=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -170,8 +170,8 @@ func NewPlacementService(opts PlacementServiceOpts) (*Service, error) {
 	fhdd.Store(int64(faultyHostDetectInitialDuration))
 
 	disseminateRateLimiter, err := ratelimiting.NewCoalescing(ratelimiting.OptionsCoalescing{
-		InitialDelay:     ptr.Of(time.Millisecond * 500),
-		MaxDelay:         ptr.Of(time.Second * 5),
+		InitialDelay:     ptr.Of(time.Millisecond * 200),
+		MaxDelay:         ptr.Of(time.Second * 4),
 		MaxPendingEvents: ptr.Of(5),
 	})
 	if err != nil {

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -190,7 +190,7 @@ func NewPlacementService(opts PlacementServiceOpts) (*Service, error) {
 		clock:                    &clock.RealClock{},
 		closedCh:                 make(chan struct{}),
 		sec:                      opts.SecProvider,
-	}
+	}, nil
 }
 
 // Run starts the placement service gRPC server.

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -204,7 +204,7 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 
 		// assert
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
-			clock.Step(disseminateTimerInterval)
+			clock.Step(time.Second / 2)
 			select {
 			case memberChange := <-testServer.membershipCh:
 				assert.Equal(t, raft.MemberUpsert, memberChange.cmdType)

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -40,10 +40,11 @@ const testStreamSendLatency = time.Second
 func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Service, *clocktesting.FakeClock, context.CancelFunc) {
 	t.Helper()
 
-	testServer := NewPlacementService(PlacementServiceOpts{
+	testServer, err := NewPlacementService(PlacementServiceOpts{
 		RaftNode:    raftServer,
 		SecProvider: securityfake.New(),
 	})
+	require.NoError(t, err)
 	clock := clocktesting.NewFakeClock(time.Now())
 	testServer.clock = clock
 
@@ -155,7 +156,7 @@ func TestMemberRegistration_Leadership(t *testing.T) {
 
 		// assert
 		assert.Eventually(t, func() bool {
-			clock.Step(disseminateTimerInterval)
+			clock.Step(time.Second / 2)
 			select {
 			case memberChange := <-testServer.membershipCh:
 				assert.Equal(t, raft.MemberUpsert, memberChange.cmdType)

--- a/tests/integration/suite/actors/actors.go
+++ b/tests/integration/suite/actors/actors.go
@@ -15,9 +15,8 @@ package actors
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/healthz"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/invocation"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/matadatata"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/invoke"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/metadata"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/serialization"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/state"

--- a/tests/integration/suite/actors/actors.go
+++ b/tests/integration/suite/actors/actors.go
@@ -14,10 +14,11 @@ limitations under the License.
 package actors
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/grpc"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/healthz"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/metadata"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/invocation"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/matadatata"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/serialization"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/state"
 )

--- a/tests/integration/suite/actors/invoke/grpc.go
+++ b/tests/integration/suite/actors/invoke/grpc.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package invoke
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(igrpc))
+}
+
+type igrpc struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	daprd3 *daprd.Daprd
+	place  *placement.Placement
+}
+
+func (i *igrpc) Setup(t *testing.T) []framework.Option {
+	i.place = placement.New(t)
+
+	newHandler := func(id int) *prochttp.HTTP {
+		handler := http.NewServeMux()
+		handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{"entities": ["myactortype%d"]}`, id)
+		})
+		handler.HandleFunc(fmt.Sprintf("/actors/myactortype%d/myactorid/method/invoke", id), func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(strconv.Itoa(id)))
+		})
+		handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		})
+		handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		return prochttp.New(t, prochttp.WithHandler(handler))
+	}
+
+	daprdopts := func(srv *prochttp.HTTP) []daprd.Option {
+		return []daprd.Option{
+			daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: true
+`),
+			daprd.WithPlacementAddresses("localhost:" + strconv.Itoa(i.place.Port())),
+			daprd.WithAppProtocol("http"),
+			daprd.WithAppPort(srv.Port()),
+			daprd.WithAppHealthCheck(true),
+		}
+	}
+
+	srv1, srv2, srv3 := newHandler(0), newHandler(1), newHandler(2)
+	i.daprd1 = daprd.New(t, daprdopts(srv1)...)
+	i.daprd2 = daprd.New(t, daprdopts(srv2)...)
+	i.daprd3 = daprd.New(t, daprdopts(srv3)...)
+
+	return []framework.Option{
+		framework.WithProcesses(i.place, srv1, srv2, srv3, i.daprd1, i.daprd2, i.daprd3),
+	}
+}
+
+func (i *igrpc) Run(t *testing.T, ctx context.Context) {
+	i.place.WaitUntilRunning(t, ctx)
+	i.daprd1.WaitUntilRunning(t, ctx)
+	i.daprd2.WaitUntilRunning(t, ctx)
+	i.daprd3.WaitUntilRunning(t, ctx)
+
+	getClient := func(daprd *daprd.Daprd) rtv1.DaprClient {
+		conn, err := grpc.DialContext(ctx,
+			fmt.Sprintf("localhost:%d", daprd.GRPCPort()), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, conn.Close()) })
+		return rtv1.NewDaprClient(conn)
+	}
+
+	client1, client2, client3 := getClient(i.daprd1), getClient(i.daprd2), getClient(i.daprd3)
+
+	for i, client := range []rtv1.DaprClient{client1, client2, client3} {
+		i := i
+		client := client
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+				ActorType: "myactortype" + strconv.Itoa(i),
+				ActorId:   "myactorid",
+				Method:    "invoke",
+			})
+			assert.NoError(t, err)
+		}, time.Second*15, time.Millisecond*100)
+	}
+
+	for _, client := range []rtv1.DaprClient{client1, client2, client3} {
+		for target := 0; target < 3; target++ {
+			resp, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+				ActorType: "myactortype" + strconv.Itoa(target),
+				ActorId:   "myactorid",
+				Method:    "invoke",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, strconv.Itoa(target), string(resp.Data))
+		}
+	}
+}

--- a/tests/integration/suite/actors/invoke/grpc.go
+++ b/tests/integration/suite/actors/invoke/grpc.go
@@ -123,6 +123,7 @@ func (i *igrpc) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "invoke",
 			})
+			//nolint:testifylint
 			assert.NoError(t, err)
 		}, time.Second*15, time.Millisecond*100)
 	}
@@ -135,7 +136,7 @@ func (i *igrpc) Run(t *testing.T, ctx context.Context) {
 				Method:    "invoke",
 			})
 			require.NoError(t, err)
-			assert.Equal(t, strconv.Itoa(target), string(resp.Data))
+			assert.Equal(t, strconv.Itoa(target), string(resp.GetData()))
 		}
 	}
 }

--- a/tests/integration/suite/actors/invoke/http.go
+++ b/tests/integration/suite/actors/invoke/http.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package invoke
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(ihttp))
+}
+
+type ihttp struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	daprd3 *daprd.Daprd
+	place  *placement.Placement
+}
+
+func (i *ihttp) Setup(t *testing.T) []framework.Option {
+	i.place = placement.New(t)
+
+	newHandler := func(id int) *prochttp.HTTP {
+		handler := http.NewServeMux()
+		handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `{"entities": ["myactortype%d"]}`, id)
+		})
+		handler.HandleFunc(fmt.Sprintf("/actors/myactortype%d/myactorid/method/invoke", id), func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(strconv.Itoa(id)))
+		})
+		handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		})
+		handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		return prochttp.New(t, prochttp.WithHandler(handler))
+	}
+
+	daprdopts := func(srv *prochttp.HTTP) []daprd.Option {
+		return []daprd.Option{
+			daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: true
+`),
+			daprd.WithPlacementAddresses("localhost:" + strconv.Itoa(i.place.Port())),
+			daprd.WithAppProtocol("http"),
+			daprd.WithAppPort(srv.Port()),
+			daprd.WithAppHealthCheck(true),
+		}
+	}
+
+	srv1, srv2, srv3 := newHandler(0), newHandler(1), newHandler(2)
+	i.daprd1 = daprd.New(t, daprdopts(srv1)...)
+	i.daprd2 = daprd.New(t, daprdopts(srv2)...)
+	i.daprd3 = daprd.New(t, daprdopts(srv3)...)
+
+	return []framework.Option{
+		framework.WithProcesses(i.place, srv1, srv2, srv3, i.daprd1, i.daprd2, i.daprd3),
+	}
+}
+
+func (i *ihttp) Run(t *testing.T, ctx context.Context) {
+	i.place.WaitUntilRunning(t, ctx)
+	i.daprd1.WaitUntilRunning(t, ctx)
+	i.daprd2.WaitUntilRunning(t, ctx)
+	i.daprd3.WaitUntilRunning(t, ctx)
+
+	client := util.HTTPClient(t)
+
+	for i, daprd := range []*daprd.Daprd{i.daprd1, i.daprd2, i.daprd3} {
+		i := i
+		daprd := daprd
+		daprdURL := fmt.Sprintf("http://localhost:%s/v1.0/actors/myactortype%d/myactorid/method/invoke", strconv.Itoa(daprd.HTTPPort()), i)
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, daprdURL, nil)
+			require.NoError(t, err)
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
+			assert.Equal(t, strconv.Itoa(i), string(body))
+		}, time.Second*15, time.Millisecond*100)
+	}
+
+	for _, daprd := range []*daprd.Daprd{i.daprd1, i.daprd2, i.daprd3} {
+		for target := 0; target < 3; target++ {
+			daprdURL := fmt.Sprintf("http://localhost:%s/v1.0/actors/myactortype%d/myactorid/method/invoke", strconv.Itoa(daprd.HTTPPort()), target)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, daprdURL, nil)
+			require.NoError(t, err)
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
+			assert.Equal(t, strconv.Itoa(target), string(body))
+		}
+	}
+}

--- a/tests/integration/suite/actors/invoke/http.go
+++ b/tests/integration/suite/actors/invoke/http.go
@@ -117,7 +117,7 @@ func (i *ihttp) Run(t *testing.T, ctx context.Context) {
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			assert.NoError(t, resp.Body.Close())
+			require.NoError(t, resp.Body.Close())
 			assert.Equal(t, strconv.Itoa(i), string(body))
 		}, time.Second*15, time.Millisecond*100)
 	}
@@ -133,7 +133,7 @@ func (i *ihttp) Run(t *testing.T, ctx context.Context) {
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			assert.NoError(t, resp.Body.Close())
+			require.NoError(t, resp.Body.Close())
 			assert.Equal(t, strconv.Itoa(target), string(body))
 		}
 	}

--- a/tests/integration/suite/actors/state/state.go
+++ b/tests/integration/suite/actors/state/state.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/state/ttl"
+)


### PR DESCRIPTION
Currently, placement is using a [static 500ms](https://github.com/dapr/dapr/blob/a2270ea9baa1bcc8e9ea0773decf18a8d3ac5c1f/pkg/placement/placement.go#L64) interval to check whether it needs to update tables in the event that membership has changed. This is problematic because 1. continually checking every 500ms is wasteful whilst also slowing down a single instance joining placement, and 2. in the event of a large amount of churn in the Daprd cluster, results in a larger number of table writes which in itself is expensive.

PR updates the dissemination table channel to use a coalescing rate limiter. This has the benefit of both immediately joining new members if they join in isolation, as well as reducing the number of table updates in the event that there is a burst of members churning. The rate limit is exponential, starting at 200ms, maximum 4s. To prevent the table from ever being updated in the event of a large throughput, the maximum number of pending member updates is 5. If there are 5 pending membership updates the table is force updated regardless of the rate limiting status.

Adds actor invoke integration tests using 3 unique actor types on 3 daprds, in both HTTP and gRPC.

PR replaces kit with my personal fork which has the implementation of the rate limiter https://github.com/dapr/kit/pull/64. This PR should hold until that has been merged to `dapr/kit`.