### PR TITLE
e2e: Fix version-skew patch release directory env name

### DIFF
--- a/.github/workflows/version-skew-e2e.yaml
+++ b/.github/workflows/version-skew-e2e.yaml
@@ -118,7 +118,7 @@ jobs:
     - name: Apply patches to latest release
       run: |
         export DAPR_LATEST_MAJOR_MINOR=$(echo ${{ env.DAPR_PREV_VERSION }} | cut -d. -f1-2)
-        export DAPR_PATCH_DIR="$(pwd)/.github/scripts/version-skew-test-patches/release-${{ env.DAPR_LATEST_MAJOR_MINOR }}"
+        export DAPR_PATCH_DIR="$(pwd)/.github/scripts/version-skew-test-patches/release-$DAPR_LATEST_MAJOR_MINOR"
         if [ -d "$DAPR_PATCH_DIR" ]; then
           echo "Applying patches from $DAPR_PATCH_DIR"
           cd latest-release && git apply --ignore-space-change --ignore-whitespace $DAPR_PATCH_DIR/*.patch


### PR DESCRIPTION
Fixes the Version Skew GitHub action which is currently not correctly applying the patch because it is attempting to use a GitHub environment variable, rather than local.

You can see the patches being correctly applied in [this](https://github.com/JoshVanL/dapr/actions/runs/6596672204/job/17922962000) github action and the `rename reminder` test being skipped. The other failing tests look to be real version skew failures.