### PR TITLE
Integration: Only write process logs on failure

### DIFF
--- a/tests/docs/writing-integration-test.md
+++ b/tests/docs/writing-integration-test.md
@@ -15,9 +15,7 @@ always built from source within the test.
 go test -v -race -count -tags="integration" ./tests/integration` -run="Test_Integration/daprd/pubsub/http/fuzzpubsubNoRaw"
 ```
 
-Rather than building from source, you can also set a custom daprd, sentry, or
-placement binary path
-with the environment variables
+Rather than building from source, you can also set a custom daprd, sentry, or placement binary path with the environment variables:
 - `DAPR_INTEGRATION_DAPRD_PATH`
 - `DAPR_INTEGRATION_PLACEMENT_PATH`
 - `DAPR_INTEGRATION_SENTRY_PATH`

--- a/tests/docs/writing-integration-test.md
+++ b/tests/docs/writing-integration-test.md
@@ -15,8 +15,16 @@ always built from source within the test.
 go test -v -race -count -tags="integration" ./tests/integration` -run="Test_Integration/daprd/pubsub/http/fuzzpubsubNoRaw"
 ```
 
-Rather than building from source, you can also set a custom daprd binary path
-with the environment variable `DAPR_INTEGRATION_DAPRD_PATH`.
+Rather than building from source, you can also set a custom daprd, sentry, or
+placement binary path
+with the environment variables
+- `DAPR_INTEGRATION_DAPRD_PATH`
+- `DAPR_INTEGRATION_PLACEMENT_PATH`
+- `DAPR_INTEGRATION_SENTRY_PATH`
+
+By default, binary logs will not be printed unless the test fails. You can force
+logs to always be printed with the environment variable
+`DAPR_INTEGRATION_LOGS=true`.
 
 ## Adding a new test
 


### PR DESCRIPTION
PR updates the integration test io writer to by default, only write the exec process logs on test failure. This is in an effort to reduce the amount of IO done by the test runners. If a test fails, the processes logs will be output at the end. Logs can be enabled for all tests by setting the `DAPR_INTEGRATION_LOGS` environment variable to `true`.