### PR TITLE
Split up runtime resource handler into processor manager

### DIFF
--- a/pkg/runtime/authorizer/authorizer.go
+++ b/pkg/runtime/authorizer/authorizer.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"reflect"
+
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	httpendpointsapi "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
+	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/kit/logger"
+)
+
+var log = logger.NewLogger("dapr.runtime.authorizer")
+
+// Type of function that determines if a component is authorized.
+// The function receives the component and must return true if the component is authorized.
+type ComponentAuthorizer func(component componentsapi.Component) bool
+
+// Type of function that determines if an http endpoint is authorized.
+// The function receives the http endpoint and must return true if the http endpoint is authorized.
+type HTTPEndpointAuthorizer func(endpoint httpendpointsapi.HTTPEndpoint) bool
+
+type Options struct {
+	ID           string
+	Namespace    string
+	GlobalConfig *config.Configuration
+}
+
+type Authorizer struct {
+	id        string
+	namespace string
+
+	componentAuthorizers    []ComponentAuthorizer
+	httpEndpointAuthorizers []HTTPEndpointAuthorizer
+}
+
+func New(opts Options) *Authorizer {
+	r := &Authorizer{
+		id:        opts.ID,
+		namespace: opts.Namespace,
+	}
+
+	r.componentAuthorizers = []ComponentAuthorizer{r.namespaceComponentAuthorizer}
+	if opts.GlobalConfig != nil && opts.GlobalConfig.Spec.ComponentsSpec != nil && len(opts.GlobalConfig.Spec.ComponentsSpec.Deny) > 0 {
+		dl := newComponentDenyList(opts.GlobalConfig.Spec.ComponentsSpec.Deny)
+		r.componentAuthorizers = append(r.componentAuthorizers, dl.IsAllowed)
+	}
+
+	r.httpEndpointAuthorizers = []HTTPEndpointAuthorizer{r.namespaceHTTPEndpointAuthorizer}
+
+	return r
+}
+
+func (a *Authorizer) GetAuthorizedObjects(objects any, authorizer func(any) bool) any {
+	reflectValue := reflect.ValueOf(objects)
+	authorized := reflect.MakeSlice(reflectValue.Type(), 0, reflectValue.Len())
+	for i := 0; i < reflectValue.Len(); i++ {
+		object := reflectValue.Index(i).Interface()
+		if authorizer(object) {
+			authorized = reflect.Append(authorized, reflect.ValueOf(object))
+		}
+	}
+	return authorized.Interface()
+}
+
+func (a *Authorizer) IsObjectAuthorized(object any) bool {
+	switch obj := object.(type) {
+	case httpendpointsapi.HTTPEndpoint:
+		for _, auth := range a.httpEndpointAuthorizers {
+			if !auth(obj) {
+				return false
+			}
+		}
+	case componentsapi.Component:
+		for _, auth := range a.componentAuthorizers {
+			if !auth(obj) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (a *Authorizer) namespaceHTTPEndpointAuthorizer(endpoint httpendpointsapi.HTTPEndpoint) bool {
+	switch {
+	case a.namespace == "",
+		endpoint.ObjectMeta.Namespace == "",
+		(a.namespace != "" && endpoint.ObjectMeta.Namespace == a.namespace):
+		return endpoint.IsAppScoped(a.id)
+	default:
+		return false
+	}
+}
+
+func (a *Authorizer) namespaceComponentAuthorizer(comp componentsapi.Component) bool {
+	if a.namespace == "" || comp.ObjectMeta.Namespace == "" || (a.namespace != "" && comp.ObjectMeta.Namespace == a.namespace) {
+		return comp.IsAppScoped(a.id)
+	}
+
+	return false
+}

--- a/pkg/runtime/authorizer/authorizer_test.go
+++ b/pkg/runtime/authorizer/authorizer_test.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	componentsV1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	httpEndpointV1alpha1 "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
+	"github.com/dapr/dapr/pkg/config"
+	daprt "github.com/dapr/dapr/pkg/testing"
+)
+
+func TestAuthorizedComponents(t *testing.T) {
+	testCompName := "fakeComponent"
+
+	t.Run("standalone mode, no namespce", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "default",
+			GlobalConfig: &config.Configuration{},
+		})
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Len(t, components, 1)
+		assert.Equal(t, testCompName, components[0].Name)
+	})
+
+	t.Run("namespace mismatch", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+		component.ObjectMeta.Namespace = "b"
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Empty(t, components)
+	})
+
+	t.Run("namespace match", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+		component.ObjectMeta.Namespace = "a"
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Len(t, components, 1)
+	})
+
+	t.Run("in scope, namespace match", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+		component.ObjectMeta.Namespace = "a"
+		component.Scopes = []string{daprt.TestRuntimeConfigID}
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Len(t, components, 1)
+	})
+
+	t.Run("not in scope, namespace match", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+		component.ObjectMeta.Namespace = "a"
+		component.Scopes = []string{"other"}
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Empty(t, components)
+	})
+
+	t.Run("in scope, namespace mismatch", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+		component.ObjectMeta.Namespace = "b"
+		component.Scopes = []string{daprt.TestRuntimeConfigID}
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Empty(t, components)
+	})
+
+	t.Run("not in scope, namespace mismatch", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+		component.ObjectMeta.Namespace = "b"
+		component.Scopes = []string{"other"}
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Empty(t, components)
+	})
+
+	t.Run("no authorizers", func(t *testing.T) {
+		auth := New(Options{
+			ID: "test",
+			// Namespace mismatch, should be accepted anyways
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+		auth.componentAuthorizers = []ComponentAuthorizer{}
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+		component.ObjectMeta.Namespace = "b"
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Len(t, components, 1)
+		assert.Equal(t, testCompName, components[0].Name)
+	})
+
+	t.Run("only deny all", func(t *testing.T) {
+		auth := New(Options{
+			ID:           daprt.TestRuntimeConfigID,
+			Namespace:    "a",
+			GlobalConfig: &config.Configuration{},
+		})
+		auth.componentAuthorizers = []ComponentAuthorizer{
+			func(component componentsV1alpha1.Component) bool {
+				return false
+			},
+		}
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Empty(t, components)
+	})
+
+	t.Run("additional authorizer denies all", func(t *testing.T) {
+		auth := New(Options{
+			ID:        "test",
+			Namespace: "a",
+			GlobalConfig: &config.Configuration{
+				Spec: config.ConfigurationSpec{},
+			},
+		})
+
+		auth.componentAuthorizers = append(auth.componentAuthorizers, func(component componentsV1alpha1.Component) bool {
+			return false
+		})
+
+		component := componentsV1alpha1.Component{}
+		component.ObjectMeta.Name = testCompName
+
+		componentObj := auth.GetAuthorizedObjects([]componentsV1alpha1.Component{component}, auth.IsObjectAuthorized)
+		components, ok := componentObj.([]componentsV1alpha1.Component)
+		assert.True(t, ok)
+		assert.Empty(t, components)
+	})
+}
+
+func TestAuthorizedHTTPEndpoints(t *testing.T) {
+	auth := New(Options{
+		ID:        daprt.TestRuntimeConfigID,
+		Namespace: "a",
+		GlobalConfig: &config.Configuration{
+			Spec: config.ConfigurationSpec{},
+		},
+	})
+	endpoint := httpEndpointV1alpha1.HTTPEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testEndpoint",
+		},
+		Spec: httpEndpointV1alpha1.HTTPEndpointSpec{
+			BaseURL: "http://api.test.com",
+		},
+	}
+
+	t.Run("standalone mode, no namespace", func(t *testing.T) {
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Len(t, endpoints, 1)
+		assert.Equal(t, endpoint.Name, endpoints[0].Name)
+	})
+
+	t.Run("namespace mismatch", func(t *testing.T) {
+		auth.namespace = "a"
+		endpoint.ObjectMeta.Namespace = "b"
+
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Empty(t, endpoints)
+	})
+
+	t.Run("namespace match", func(t *testing.T) {
+		auth.namespace = "a"
+		endpoint.ObjectMeta.Namespace = "a"
+
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Len(t, endpoints, 1)
+	})
+
+	t.Run("in scope, namespace match", func(t *testing.T) {
+		auth.namespace = "a"
+		endpoint.ObjectMeta.Namespace = "a"
+		endpoint.Scopes = []string{daprt.TestRuntimeConfigID}
+
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Len(t, endpoints, 1)
+	})
+
+	t.Run("not in scope, namespace match", func(t *testing.T) {
+		auth.namespace = "a"
+		endpoint.ObjectMeta.Namespace = "a"
+		endpoint.Scopes = []string{"other"}
+
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Empty(t, endpoints)
+	})
+
+	t.Run("in scope, namespace mismatch", func(t *testing.T) {
+		auth.namespace = "a"
+		endpoint.ObjectMeta.Namespace = "b"
+		endpoint.Scopes = []string{daprt.TestRuntimeConfigID}
+
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Empty(t, endpoints)
+	})
+
+	t.Run("not in scope, namespace mismatch", func(t *testing.T) {
+		auth.namespace = "a"
+		endpoint.ObjectMeta.Namespace = "b"
+		endpoint.Scopes = []string{"other"}
+
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Empty(t, endpoints)
+	})
+
+	t.Run("no authorizers", func(t *testing.T) {
+		auth.httpEndpointAuthorizers = []HTTPEndpointAuthorizer{}
+		// Namespace mismatch, should be accepted anyways
+		auth.namespace = "a"
+		endpoint.ObjectMeta.Namespace = "b"
+
+		endpointObjs := auth.GetAuthorizedObjects([]httpEndpointV1alpha1.HTTPEndpoint{endpoint}, auth.IsObjectAuthorized)
+		endpoints, ok := endpointObjs.([]httpEndpointV1alpha1.HTTPEndpoint)
+		assert.True(t, ok)
+		assert.Len(t, endpoints, 1)
+		assert.Equal(t, endpoint.Name, endpoints[0].ObjectMeta.Name)
+	})
+}

--- a/pkg/runtime/authorizer/component.go
+++ b/pkg/runtime/authorizer/component.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Dapr Authors
+Copyright 2023 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runtime
+package authorizer
 
 import (
 	"strings"

--- a/pkg/runtime/authorizer/component_test.go
+++ b/pkg/runtime/authorizer/component_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Dapr Authors
+Copyright 2023 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runtime
+package authorizer
 
 import (
 	"reflect"

--- a/pkg/runtime/authorizer/unit.go
+++ b/pkg/runtime/authorizer/unit.go
@@ -1,0 +1,37 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+func (a *Authorizer) WithComponentAuthorizers(authorizers []ComponentAuthorizer) *Authorizer {
+	a.componentAuthorizers = authorizers
+	return a
+}
+
+func (a *Authorizer) WithAppendComponentAuthorizers(authorizers ...ComponentAuthorizer) *Authorizer {
+	a.componentAuthorizers = append(a.componentAuthorizers, authorizers...)
+	return a
+}
+
+func (a *Authorizer) WithHTTPEndpointAuthorizers(authorizers []HTTPEndpointAuthorizer) *Authorizer {
+	a.httpEndpointAuthorizers = authorizers
+	return a
+}
+
+func (a *Authorizer) WithAppendHTTPEndpointAuthorizers(authorizers ...HTTPEndpointAuthorizer) *Authorizer {
+	a.httpEndpointAuthorizers = append(a.httpEndpointAuthorizers, authorizers...)
+	return a
+}

--- a/pkg/runtime/meta/meta.go
+++ b/pkg/runtime/meta/meta.go
@@ -50,6 +50,7 @@ func New(options Options) *Meta {
 		namespace:     options.Namespace,
 		strictSandbox: options.StrictSandbox,
 		id:            options.ID,
+		mode:          options.Mode,
 	}
 }
 

--- a/pkg/runtime/mock/mock.go
+++ b/pkg/runtime/mock/mock.go
@@ -90,3 +90,60 @@ func (b *Binding) Invoke(ctx context.Context, req *bindings.InvokeRequest) (*bin
 func (b *Binding) Close() error {
 	return b.CloseErr
 }
+
+type MockKubernetesStateStore struct {
+	Callback func(context.Context) error
+	CloseFn  func() error
+}
+
+func (m *MockKubernetesStateStore) Init(ctx context.Context, metadata secretstores.Metadata) error {
+	if m.Callback != nil {
+		return m.Callback(ctx)
+	}
+	return nil
+}
+
+func (m *MockKubernetesStateStore) GetSecret(ctx context.Context, req secretstores.GetSecretRequest) (secretstores.GetSecretResponse, error) {
+	return secretstores.GetSecretResponse{
+		Data: map[string]string{
+			"key1":   "value1",
+			"_value": "_value_data",
+			"name1":  "value1",
+		},
+	}, nil
+}
+
+func (m *MockKubernetesStateStore) BulkGetSecret(ctx context.Context, req secretstores.BulkGetSecretRequest) (secretstores.BulkGetSecretResponse, error) {
+	response := map[string]map[string]string{}
+	response["k8s-secret"] = map[string]string{
+		"key1":   "value1",
+		"_value": "_value_data",
+		"name1":  "value1",
+	}
+	return secretstores.BulkGetSecretResponse{
+		Data: response,
+	}, nil
+}
+
+func (m *MockKubernetesStateStore) Close() error {
+	if m.CloseFn != nil {
+		return m.CloseFn()
+	}
+	return nil
+}
+
+func (m *MockKubernetesStateStore) Features() []secretstores.Feature {
+	return []secretstores.Feature{}
+}
+
+func NewMockKubernetesStore() secretstores.SecretStore {
+	return &MockKubernetesStateStore{}
+}
+
+func NewMockKubernetesStoreWithInitCallback(cb func(context.Context) error) secretstores.SecretStore {
+	return &MockKubernetesStateStore{Callback: cb}
+}
+
+func NewMockKubernetesStoreWithClose(closeFn func() error) secretstores.SecretStore {
+	return &MockKubernetesStateStore{CloseFn: closeFn}
+}

--- a/pkg/runtime/processor/manager.go
+++ b/pkg/runtime/processor/manager.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package processor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dapr/components-contrib/bindings"
+	contribpubsub "github.com/dapr/components-contrib/pubsub"
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/outbox"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+)
+
+// manager implements the life cycle events of a component category.
+type manager interface {
+	Init(context.Context, componentsapi.Component) error
+	Close(componentsapi.Component) error
+}
+
+type StateManager interface {
+	ActorStateStoreName() (string, bool)
+	manager
+}
+
+type SecretManager interface {
+	ProcessResource(context.Context, meta.Resource) (bool, string)
+	manager
+}
+
+type PubsubManager interface {
+	Publish(context.Context, *contribpubsub.PublishRequest) error
+	BulkPublish(context.Context, *contribpubsub.BulkPublishRequest) (contribpubsub.BulkPublishResponse, error)
+
+	StartSubscriptions(context.Context) error
+	StopSubscriptions()
+	Outbox() outbox.Outbox
+	manager
+}
+
+type BindingManager interface {
+	SendToOutputBinding(context.Context, string, *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
+
+	StartReadingFromBindings(context.Context) error
+	StopReadingFromBindings()
+	manager
+}
+
+func (p *Processor) managerFromComp(comp componentsapi.Component) (manager, error) {
+	category := p.category(comp)
+	m, ok := p.managers[category]
+	if !ok {
+		return nil, fmt.Errorf("unknown component category: %q", category)
+	}
+	return m, nil
+}
+
+func (p *Processor) State() StateManager {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.state
+}
+
+func (p *Processor) Secret() SecretManager {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.secret
+}
+
+func (p *Processor) PubSub() PubsubManager {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.pubsub
+}
+
+func (p *Processor) Binding() BindingManager {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.binding
+}

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -19,22 +19,28 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
-	"github.com/dapr/components-contrib/bindings"
-	contribpubsub "github.com/dapr/components-contrib/pubsub"
+	apiextapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	httpendapi "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
 	"github.com/dapr/dapr/pkg/components"
 	"github.com/dapr/dapr/pkg/config"
 	configmodes "github.com/dapr/dapr/pkg/config/modes"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
+	grpcmanager "github.com/dapr/dapr/pkg/grpc/manager"
+	"github.com/dapr/dapr/pkg/internal/apis"
 	"github.com/dapr/dapr/pkg/modes"
-	"github.com/dapr/dapr/pkg/outbox"
 	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/channels"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
+	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/meta"
-
-	grpcmanager "github.com/dapr/dapr/pkg/grpc/manager"
 	"github.com/dapr/dapr/pkg/runtime/processor/binding"
 	"github.com/dapr/dapr/pkg/runtime/processor/configuration"
 	"github.com/dapr/dapr/pkg/runtime/processor/crypto"
@@ -45,7 +51,15 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/processor/state"
 	"github.com/dapr/dapr/pkg/runtime/processor/workflow"
 	"github.com/dapr/dapr/pkg/runtime/registry"
+	"github.com/dapr/kit/concurrency"
+	"github.com/dapr/kit/logger"
 )
+
+const (
+	defaultComponentInitTimeout = time.Second * 5
+)
+
+var log = logger.NewLogger("dapr.runtime.processor")
 
 type Options struct {
 	// ID is the ID of this Dapr instance.
@@ -91,44 +105,24 @@ type Options struct {
 	OperatorClient operatorv1.OperatorClient
 }
 
-// manager implements the life cycle events of a component category.
-type manager interface {
-	Init(context.Context, compapi.Component) error
-	Close(compapi.Component) error
-}
-
-type StateManager interface {
-	ActorStateStoreName() (string, bool)
-	manager
-}
-
-type PubsubManager interface {
-	Publish(context.Context, *contribpubsub.PublishRequest) error
-	BulkPublish(context.Context, *contribpubsub.BulkPublishRequest) (contribpubsub.BulkPublishResponse, error)
-
-	StartSubscriptions(context.Context) error
-	StopSubscriptions()
-	Outbox() outbox.Outbox
-	manager
-}
-
-type BindingManager interface {
-	SendToOutputBinding(context.Context, string, *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-
-	StartReadingFromBindings(context.Context) error
-	StopReadingFromBindings()
-	manager
-}
-
 // Processor manages the lifecycle of all components categories.
 type Processor struct {
 	compStore *compstore.ComponentStore
 	managers  map[components.Category]manager
 	state     StateManager
+	secret    SecretManager
 	pubsub    PubsubManager
 	binding   BindingManager
 
-	lock sync.RWMutex
+	pendingHTTPEndpoints       chan httpendapi.HTTPEndpoint
+	pendingComponents          chan compapi.Component
+	pendingComponentDependents map[string][]compapi.Component
+
+	lock     sync.RWMutex
+	chlock   sync.RWMutex
+	running  atomic.Bool
+	shutdown atomic.Bool
+	closedCh chan struct{}
 }
 
 func New(opts Options) *Processor {
@@ -157,6 +151,13 @@ func New(opts Options) *Processor {
 		Outbox:           ps.Outbox(),
 	})
 
+	secret := secret.New(secret.Options{
+		Registry:       opts.Registry.SecretStores(),
+		ComponentStore: opts.ComponentStore,
+		Meta:           opts.Meta,
+		OperatorClient: opts.OperatorClient,
+	})
+
 	binding := binding.New(binding.Options{
 		Registry:       opts.Registry.Bindings(),
 		ComponentStore: opts.ComponentStore,
@@ -169,10 +170,15 @@ func New(opts Options) *Processor {
 	})
 
 	return &Processor{
-		compStore: opts.ComponentStore,
-		state:     state,
-		pubsub:    ps,
-		binding:   binding,
+		pendingHTTPEndpoints:       make(chan httpendapi.HTTPEndpoint),
+		pendingComponents:          make(chan componentsapi.Component),
+		pendingComponentDependents: make(map[string][]componentsapi.Component),
+		closedCh:                   make(chan struct{}),
+		compStore:                  opts.ComponentStore,
+		state:                      state,
+		pubsub:                     ps,
+		binding:                    binding,
+		secret:                     secret,
 		managers: map[components.Category]manager{
 			components.CategoryBindings: binding,
 			components.CategoryConfiguration: configuration.New(configuration.Options{
@@ -190,13 +196,9 @@ func New(opts Options) *Processor {
 				ComponentStore: opts.ComponentStore,
 				Meta:           opts.Meta,
 			}),
-			components.CategoryPubSub: ps,
-			components.CategorySecretStore: secret.New(secret.Options{
-				Registry:       opts.Registry.SecretStores(),
-				ComponentStore: opts.ComponentStore,
-				Meta:           opts.Meta,
-			}),
-			components.CategoryStateStore: state,
+			components.CategoryPubSub:      ps,
+			components.CategorySecretStore: secret,
+			components.CategoryStateStore:  state,
 			components.CategoryWorkflow: workflow.New(workflow.Options{
 				Registry:       opts.Registry.Workflows(),
 				ComponentStore: opts.ComponentStore,
@@ -247,16 +249,230 @@ func (p *Processor) Close(comp compapi.Component) error {
 	return nil
 }
 
-func (p *Processor) managerFromComp(comp compapi.Component) (manager, error) {
-	category := p.Category(comp)
-	m, ok := p.managers[category]
-	if !ok {
-		return nil, fmt.Errorf("unknown component category: %q", category)
-	}
-	return m, nil
+type componentPreprocessRes struct {
+	unreadyDependency string
 }
 
-func (p *Processor) Category(comp compapi.Component) components.Category {
+func (p *Processor) Process(ctx context.Context) error {
+	if !p.running.CompareAndSwap(false, true) {
+		return errors.New("processor is already running")
+	}
+
+	return concurrency.NewRunnerManager(
+		p.processComponents,
+		p.processHTTPEndpoints,
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			close(p.closedCh)
+			p.chlock.Lock()
+			defer p.chlock.Unlock()
+			p.shutdown.Store(true)
+			close(p.pendingComponents)
+			close(p.pendingHTTPEndpoints)
+			return nil
+		},
+	).Run(ctx)
+}
+
+func (p *Processor) AddPendingComponent(ctx context.Context, comp componentsapi.Component) bool {
+	p.chlock.RLock()
+	defer p.chlock.RUnlock()
+	if p.shutdown.Load() {
+		return false
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-p.closedCh:
+		return false
+	case p.pendingComponents <- comp:
+		return true
+	}
+}
+
+func (p *Processor) AddPendingEndpoint(ctx context.Context, endpoint httpendapi.HTTPEndpoint) bool {
+	p.chlock.RLock()
+	defer p.chlock.RUnlock()
+	if p.shutdown.Load() {
+		return false
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-p.closedCh:
+		return false
+	case p.pendingHTTPEndpoints <- endpoint:
+		return true
+	}
+}
+
+func (p *Processor) processComponents(ctx context.Context) error {
+	for comp := range p.pendingComponents {
+		if comp.Name == "" {
+			continue
+		}
+
+		err := p.processComponentAndDependents(ctx, comp)
+		if err != nil {
+			err = fmt.Errorf("process component %s error: %s", comp.Name, err)
+			if !comp.Spec.IgnoreErrors {
+				log.Warnf("Error processing component, daprd will exit gracefully")
+				return err
+			}
+			log.Error(err)
+		}
+	}
+
+	return nil
+}
+
+func (p *Processor) processHTTPEndpoints(ctx context.Context) error {
+	for endpoint := range p.pendingHTTPEndpoints {
+		if endpoint.Name == "" {
+			continue
+		}
+		p.processHTTPEndpointSecrets(ctx, &endpoint)
+		p.compStore.AddHTTPEndpoint(endpoint)
+	}
+
+	return nil
+}
+
+func (p *Processor) processComponentAndDependents(ctx context.Context, comp componentsapi.Component) error {
+	log.Debug("Loading component: " + comp.LogName())
+	res := p.preprocessOneComponent(ctx, &comp)
+	if res.unreadyDependency != "" {
+		p.pendingComponentDependents[res.unreadyDependency] = append(p.pendingComponentDependents[res.unreadyDependency], comp)
+		return nil
+	}
+
+	compCategory := p.category(comp)
+	if compCategory == "" {
+		// the category entered is incorrect, return error
+		return fmt.Errorf("incorrect type %s", comp.Spec.Type)
+	}
+
+	timeout, err := time.ParseDuration(comp.Spec.InitTimeout)
+	if err != nil {
+		timeout = defaultComponentInitTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	err = p.Init(ctx, comp)
+	// If the context is canceled, we want  to return an init error.
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		err = fmt.Errorf("init timeout for component %s exceeded after %s", comp.LogName(), timeout.String())
+	}
+	if err != nil {
+		log.Errorf("Failed to init component %s: %s", comp.Name, err)
+		diag.DefaultMonitoring.ComponentInitFailed(comp.Spec.Type, "init", comp.ObjectMeta.Name)
+		return rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), err)
+	}
+
+	log.Info("Component loaded: " + comp.LogName())
+	diag.DefaultMonitoring.ComponentLoaded()
+
+	dependency := componentDependency(compCategory, comp.Name)
+	if deps, ok := p.pendingComponentDependents[dependency]; ok {
+		delete(p.pendingComponentDependents, dependency)
+		for _, dependent := range deps {
+			if err := p.processComponentAndDependents(ctx, dependent); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *Processor) processHTTPEndpointSecrets(ctx context.Context, endpoint *httpendapi.HTTPEndpoint) {
+	_, _ = p.secret.ProcessResource(ctx, endpoint)
+
+	tlsResource := apis.GenericNameValueResource{
+		Name:        endpoint.ObjectMeta.Name,
+		Namespace:   endpoint.ObjectMeta.Namespace,
+		SecretStore: endpoint.Auth.SecretStore,
+		Pairs:       []commonapi.NameValuePair{},
+	}
+
+	root, clientCert, clientKey := "root", "clientCert", "clientKey"
+
+	ca := commonapi.NameValuePair{
+		Name: root,
+	}
+
+	if endpoint.HasTLSRootCA() {
+		ca.Value = *endpoint.Spec.ClientTLS.RootCA.Value
+	}
+
+	if endpoint.HasTLSRootCASecret() {
+		ca.SecretKeyRef = *endpoint.Spec.ClientTLS.RootCA.SecretKeyRef
+	}
+	tlsResource.Pairs = append(tlsResource.Pairs, ca)
+
+	cCert := commonapi.NameValuePair{
+		Name: clientCert,
+	}
+
+	if endpoint.HasTLSClientCert() {
+		cCert.Value = *endpoint.Spec.ClientTLS.Certificate.Value
+	}
+
+	if endpoint.HasTLSClientCertSecret() {
+		cCert.SecretKeyRef = *endpoint.Spec.ClientTLS.Certificate.SecretKeyRef
+	}
+	tlsResource.Pairs = append(tlsResource.Pairs, cCert)
+
+	cKey := commonapi.NameValuePair{
+		Name: clientKey,
+	}
+
+	if endpoint.HasTLSPrivateKey() {
+		cKey.Value = *endpoint.Spec.ClientTLS.PrivateKey.Value
+	}
+
+	if endpoint.HasTLSPrivateKeySecret() {
+		cKey.SecretKeyRef = *endpoint.Spec.ClientTLS.PrivateKey.SecretKeyRef
+	}
+
+	tlsResource.Pairs = append(tlsResource.Pairs, cKey)
+
+	updated, _ := p.secret.ProcessResource(ctx, tlsResource)
+	if updated {
+		for _, np := range tlsResource.Pairs {
+			dv := &commonapi.DynamicValue{
+				JSON: apiextapi.JSON{
+					Raw: np.Value.Raw,
+				},
+			}
+
+			switch np.Name {
+			case root:
+				endpoint.Spec.ClientTLS.RootCA.Value = dv
+			case clientCert:
+				endpoint.Spec.ClientTLS.Certificate.Value = dv
+			case clientKey:
+				endpoint.Spec.ClientTLS.PrivateKey.Value = dv
+			}
+		}
+	}
+}
+
+func (p *Processor) preprocessOneComponent(ctx context.Context, comp *componentsapi.Component) componentPreprocessRes {
+	_, unreadySecretsStore := p.secret.ProcessResource(ctx, comp)
+	if unreadySecretsStore != "" {
+		return componentPreprocessRes{
+			unreadyDependency: componentDependency(components.CategorySecretStore, unreadySecretsStore),
+		}
+	}
+	return componentPreprocessRes{}
+}
+
+func (p *Processor) category(comp componentsapi.Component) components.Category {
 	for category := range p.managers {
 		if strings.HasPrefix(comp.Spec.Type, string(category)+".") {
 			return category
@@ -265,20 +481,6 @@ func (p *Processor) Category(comp compapi.Component) components.Category {
 	return ""
 }
 
-func (p *Processor) State() StateManager {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	return p.state
-}
-
-func (p *Processor) PubSub() PubsubManager {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	return p.pubsub
-}
-
-func (p *Processor) Binding() BindingManager {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	return p.binding
+func componentDependency(compCategory components.Category, name string) string {
+	return string(compCategory) + ":" + name
 }

--- a/pkg/runtime/processor/processor_test.go
+++ b/pkg/runtime/processor/processor_test.go
@@ -14,14 +14,152 @@ limitations under the License.
 package processor
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/components-contrib/secretstores"
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/modes"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+	rtmock "github.com/dapr/dapr/pkg/runtime/mock"
 	"github.com/dapr/dapr/pkg/runtime/registry"
+	daprt "github.com/dapr/dapr/pkg/testing"
+	"github.com/dapr/kit/logger"
 )
+
+func newTestProcWithID(id string) (*Processor, *registry.Registry) {
+	reg := registry.New(registry.NewOptions())
+	return New(Options{
+		ID:             id,
+		Namespace:      "test",
+		Registry:       reg,
+		ComponentStore: compstore.New(),
+		Meta: meta.New(meta.Options{
+			ID:        id,
+			PodName:   "testPodName",
+			Namespace: "test",
+			Mode:      modes.StandaloneMode,
+		}),
+		Resiliency:     resiliency.New(log),
+		Mode:           modes.StandaloneMode,
+		PodName:        "testPodName",
+		OperatorClient: nil,
+		GRPC:           nil,
+		Channels:       nil,
+		GlobalConfig:   new(config.Configuration),
+	}), reg
+}
+
+func newTestProc() (*Processor, *registry.Registry) {
+	return newTestProcWithID("id")
+}
+
+func TestProcessComponentsAndDependents(t *testing.T) {
+	proc, _ := newTestProc()
+	incorrectComponentType := componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpubsub",
+		},
+		Spec: componentsapi.ComponentSpec{
+			Type:     "pubsubs.mockPubSub",
+			Version:  "v1",
+			Metadata: daprt.GetFakeMetadataItems(),
+		},
+	}
+
+	t.Run("test incorrect type", func(t *testing.T) {
+		err := proc.processComponentAndDependents(context.Background(), incorrectComponentType)
+		assert.Error(t, err, "expected an error")
+		assert.Equal(t, "incorrect type pubsubs.mockPubSub", err.Error(), "expected error strings to match")
+	})
+}
+
+func TestInitSecretStores(t *testing.T) {
+	t.Run("init with store", func(t *testing.T) {
+		proc, reg := newTestProc()
+		m := rtmock.NewMockKubernetesStore()
+		reg.SecretStores().RegisterComponent(
+			func(_ logger.Logger) secretstores.SecretStore {
+				return m
+			},
+			"kubernetesMock",
+		)
+
+		err := proc.processComponentAndDependents(context.Background(), componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kubernetesMock",
+			},
+			Spec: componentsapi.ComponentSpec{
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("secret store is registered", func(t *testing.T) {
+		proc, reg := newTestProc()
+		m := rtmock.NewMockKubernetesStore()
+		reg.SecretStores().RegisterComponent(
+			func(_ logger.Logger) secretstores.SecretStore {
+				return m
+			},
+			"kubernetesMock",
+		)
+
+		err := proc.processComponentAndDependents(context.Background(), componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kubernetesMock",
+			},
+			Spec: componentsapi.ComponentSpec{
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
+			},
+		})
+		assert.NoError(t, err)
+		store, ok := proc.compStore.GetSecretStore("kubernetesMock")
+		assert.True(t, ok)
+		assert.NotNil(t, store)
+	})
+
+	t.Run("get secret store", func(t *testing.T) {
+		proc, reg := newTestProc()
+		m := rtmock.NewMockKubernetesStore()
+		reg.SecretStores().RegisterComponent(
+			func(_ logger.Logger) secretstores.SecretStore {
+				return m
+			},
+			"kubernetesMock",
+		)
+
+		proc.processComponentAndDependents(context.Background(), componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kubernetesMock",
+			},
+			Spec: componentsapi.ComponentSpec{
+				Type:    "secretstores.kubernetesMock",
+				Version: "v1",
+			},
+		})
+
+		s, ok := proc.compStore.GetSecretStore("kubernetesMock")
+		assert.True(t, ok)
+		assert.NotNil(t, s)
+	})
+}
 
 func TestExtractComponentCategory(t *testing.T) {
 	compCategoryTests := []struct {
@@ -46,13 +184,270 @@ func TestExtractComponentCategory(t *testing.T) {
 
 	for _, tt := range compCategoryTests {
 		t.Run(tt.specType, func(t *testing.T) {
-			fakeComp := compapi.Component{
-				Spec: compapi.ComponentSpec{
+			fakeComp := componentsapi.Component{
+				Spec: componentsapi.ComponentSpec{
 					Type:    tt.specType,
 					Version: "v1",
 				},
 			}
-			assert.Equal(t, string(p.Category(fakeComp)), tt.category)
+			assert.Equal(t, string(p.category(fakeComp)), tt.category)
 		})
 	}
+}
+
+func TestMetadataUUID(t *testing.T) {
+	pubsubComponent := componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpubsub",
+		},
+		Spec: componentsapi.ComponentSpec{
+			Type:     "pubsub.mockPubSub",
+			Version:  "v1",
+			Metadata: daprt.GetFakeMetadataItems(),
+		},
+	}
+
+	pubsubComponent.Spec.Metadata = append(
+		pubsubComponent.Spec.Metadata,
+		commonapi.NameValuePair{
+			Name: "consumerID",
+			Value: commonapi.DynamicValue{
+				JSON: v1.JSON{
+					Raw: []byte("{uuid}"),
+				},
+			},
+		}, commonapi.NameValuePair{
+			Name: "twoUUIDs",
+			Value: commonapi.DynamicValue{
+				JSON: v1.JSON{
+					Raw: []byte("{uuid} {uuid}"),
+				},
+			},
+		})
+	proc, reg := newTestProc()
+	mockPubSub := new(daprt.MockPubSub)
+
+	reg.PubSubs().RegisterComponent(
+		func(_ logger.Logger) pubsub.PubSub {
+			return mockPubSub
+		},
+		"mockPubSub",
+	)
+
+	mockPubSub.On("Init", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		metadata := args.Get(0).(pubsub.Metadata)
+		consumerID := metadata.Properties["consumerID"]
+		var uuid0, uuid1, uuid2 uuid.UUID
+		uuid0, err := uuid.Parse(consumerID)
+		assert.NoError(t, err)
+
+		twoUUIDs := metadata.Properties["twoUUIDs"]
+		uuids := strings.Split(twoUUIDs, " ")
+		assert.Equal(t, 2, len(uuids))
+		uuid1, err = uuid.Parse(uuids[0])
+		assert.NoError(t, err)
+		uuid2, err = uuid.Parse(uuids[1])
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, uuid0, uuid1)
+		assert.NotEqual(t, uuid0, uuid2)
+		assert.NotEqual(t, uuid1, uuid2)
+	})
+
+	err := proc.processComponentAndDependents(context.Background(), pubsubComponent)
+	assert.NoError(t, err)
+}
+
+func TestMetadataPodName(t *testing.T) {
+	t.Setenv("POD_NAME", "testPodName")
+
+	pubsubComponent := componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpubsub",
+		},
+		Spec: componentsapi.ComponentSpec{
+			Type:     "pubsub.mockPubSub",
+			Version:  "v1",
+			Metadata: daprt.GetFakeMetadataItems(),
+		},
+	}
+
+	pubsubComponent.Spec.Metadata = append(
+		pubsubComponent.Spec.Metadata,
+		commonapi.NameValuePair{
+			Name: "consumerID",
+			Value: commonapi.DynamicValue{
+				JSON: v1.JSON{
+					Raw: []byte("{podName}"),
+				},
+			},
+		})
+	proc, reg := newTestProc()
+	mockPubSub := new(daprt.MockPubSub)
+
+	reg.PubSubs().RegisterComponent(
+		func(_ logger.Logger) pubsub.PubSub {
+			return mockPubSub
+		},
+		"mockPubSub",
+	)
+
+	mockPubSub.On("Init", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		metadata := args.Get(0).(pubsub.Metadata)
+		consumerID := metadata.Properties["consumerID"]
+
+		assert.Equal(t, "testPodName", consumerID)
+	})
+
+	err := proc.processComponentAndDependents(context.Background(), pubsubComponent)
+	assert.NoError(t, err)
+}
+
+func TestMetadataNamespace(t *testing.T) {
+	t.Setenv("NAMESPACE", "test")
+
+	pubsubComponent := componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpubsub",
+		},
+		Spec: componentsapi.ComponentSpec{
+			Type:     "pubsub.mockPubSub",
+			Version:  "v1",
+			Metadata: daprt.GetFakeMetadataItems(),
+		},
+	}
+
+	pubsubComponent.Spec.Metadata = append(
+		pubsubComponent.Spec.Metadata,
+		commonapi.NameValuePair{
+			Name: "consumerID",
+			Value: commonapi.DynamicValue{
+				JSON: v1.JSON{
+					Raw: []byte("{namespace}"),
+				},
+			},
+		})
+
+	proc, reg := newTestProcWithID("app1")
+	mockPubSub := new(daprt.MockPubSub)
+
+	reg.PubSubs().RegisterComponent(
+		func(_ logger.Logger) pubsub.PubSub {
+			return mockPubSub
+		},
+		"mockPubSub",
+	)
+
+	mockPubSub.On("Init", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		metadata := args.Get(0).(pubsub.Metadata)
+		consumerID := metadata.Properties["consumerID"]
+
+		assert.Equal(t, "test.app1", consumerID)
+	})
+
+	err := proc.processComponentAndDependents(context.Background(), pubsubComponent)
+	assert.NoError(t, err)
+}
+
+func TestMetadataClientID(t *testing.T) {
+	pubsubComponent := componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpubsub",
+		},
+		Spec: componentsapi.ComponentSpec{
+			Type:     "pubsub.mockPubSub",
+			Version:  "v1",
+			Metadata: daprt.GetFakeMetadataItems(),
+		},
+	}
+
+	// ClientID should be namespace.AppID for Kubernetes
+	t.Run("Kubernetes Mode AppID", func(t *testing.T) {
+		t.Setenv("NAMESPACE", "test")
+		pubsubComponent.Spec.Metadata = append(
+			pubsubComponent.Spec.Metadata,
+			commonapi.NameValuePair{
+				Name: "clientID",
+				Value: commonapi.DynamicValue{
+					JSON: v1.JSON{
+						Raw: []byte("{namespace}"),
+					},
+				},
+			})
+
+		proc, reg := newTestProcWithID("myApp")
+		mockPubSub := new(daprt.MockPubSub)
+
+		reg.PubSubs().RegisterComponent(
+			func(_ logger.Logger) pubsub.PubSub {
+				return mockPubSub
+			},
+			"mockPubSub",
+		)
+
+		var k8sClientID string
+		clientIDChan := make(chan string, 1)
+		mockPubSub.On("Init", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			metadata := args.Get(0).(pubsub.Metadata)
+			k8sClientID = metadata.Properties["clientID"]
+			clientIDChan <- k8sClientID
+		})
+
+		err := proc.processComponentAndDependents(context.Background(), pubsubComponent)
+		assert.NoError(t, err)
+
+		select {
+		case clientID := <-clientIDChan:
+			assert.Equal(t, "test.myApp", clientID)
+		case <-time.After(20 * time.Second):
+			t.Error("Timed out waiting for clientID for Kubernetes Mode test")
+		}
+	})
+
+	// ClientID should be AppID for Self-Hosted
+	t.Run("Standalone Mode AppID", func(t *testing.T) {
+		pubsubComponent.Spec.Metadata = append(
+			pubsubComponent.Spec.Metadata,
+			commonapi.NameValuePair{
+				Name: "clientID",
+				Value: commonapi.DynamicValue{
+					JSON: v1.JSON{
+						Raw: []byte("{appID} {appID}"),
+					},
+				},
+			})
+
+		proc, reg := newTestProcWithID(daprt.TestRuntimeConfigID)
+		mockPubSub := new(daprt.MockPubSub)
+
+		reg.PubSubs().RegisterComponent(
+			func(_ logger.Logger) pubsub.PubSub {
+				return mockPubSub
+			},
+			"mockPubSub",
+		)
+
+		var standAloneClientID string
+		clientIDChan := make(chan string, 1)
+		mockPubSub.On("Init", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			metadata := args.Get(0).(pubsub.Metadata)
+			standAloneClientID = metadata.Properties["clientID"]
+			clientIDChan <- standAloneClientID
+		})
+
+		err := proc.processComponentAndDependents(context.Background(), pubsubComponent)
+		assert.NoError(t, err)
+		appIds := strings.Split(standAloneClientID, " ")
+		assert.Equal(t, 2, len(appIds))
+		for _, appID := range appIds {
+			assert.Equal(t, daprt.TestRuntimeConfigID, appID)
+		}
+
+		select {
+		case clientID := <-clientIDChan:
+			assert.Equal(t, standAloneClientID, clientID)
+		case <-time.After(20 * time.Second):
+			t.Error("Timed out waiting for clientID for Standalone Mode test")
+		}
+	})
 }

--- a/pkg/runtime/processor/secret/secret.go
+++ b/pkg/runtime/processor/secret/secret.go
@@ -15,29 +15,41 @@ package secret
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"io"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/dapr/components-contrib/secretstores"
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	compsecret "github.com/dapr/dapr/pkg/components/secretstores"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/meta"
+	"github.com/dapr/dapr/pkg/security/consts"
+	"github.com/dapr/kit/logger"
 )
+
+var log = logger.NewLogger("dapr.runtime.processor.secret")
 
 type Options struct {
 	Registry       *compsecret.Registry
 	ComponentStore *compstore.ComponentStore
 	Meta           *meta.Meta
+	OperatorClient operatorv1pb.OperatorClient
 }
 
 type secret struct {
-	registry  *compsecret.Registry
-	compStore *compstore.ComponentStore
-	meta      *meta.Meta
-	lock      sync.Mutex
+	registry       *compsecret.Registry
+	compStore      *compstore.ComponentStore
+	meta           *meta.Meta
+	operatorClient operatorv1pb.OperatorClient
+	lock           sync.Mutex
 }
 
 func New(opts Options) *secret {
@@ -95,4 +107,120 @@ func (s *secret) Close(comp compapi.Component) error {
 
 	s.compStore.DeleteSecretStore(comp.Name)
 	return nil
+}
+
+// Returns the component or HTTP endpoint updated with the secrets applied.
+// If the resource references a secret store that hasn't been loaded yet, it returns the name of the secret store component as second returned value.
+func (s *secret) ProcessResource(ctx context.Context, resource meta.Resource) (updated bool, secretStoreName string) {
+	cache := map[string]secretstores.GetSecretResponse{}
+
+	secretStoreName = s.meta.AuthSecretStoreOrDefault(resource)
+
+	metadata := resource.NameValuePairs()
+	for i, m := range metadata {
+		// If there's an env var and no value, use that
+		if !m.HasValue() && m.EnvRef != "" {
+			if isEnvVarAllowed(m.EnvRef) {
+				metadata[i].SetValue([]byte(os.Getenv(m.EnvRef)))
+			} else {
+				log.Warnf("%s %s references an env variable that isn't allowed: %s", resource.Kind(), resource.GetName(), m.EnvRef)
+			}
+			metadata[i].EnvRef = ""
+			updated = true
+			continue
+		}
+
+		if m.SecretKeyRef.Name == "" {
+			continue
+		}
+
+		// If running in Kubernetes and have an operator client, do not fetch secrets from the Kubernetes secret store as they will be populated by the operator.
+		// Instead, base64 decode the secret values into their real self.
+		if s.operatorClient != nil && secretStoreName == compsecret.BuiltinKubernetesSecretStore {
+			var jsonVal string
+			err := json.Unmarshal(m.Value.Raw, &jsonVal)
+			if err != nil {
+				log.Errorf("Error decoding secret: %v", err)
+				continue
+			}
+
+			dec, err := base64.StdEncoding.DecodeString(jsonVal)
+			if err != nil {
+				log.Errorf("Error decoding secret: %v", err)
+				continue
+			}
+
+			metadata[i].SetValue(dec)
+			metadata[i].SecretKeyRef = commonapi.SecretKeyRef{}
+			updated = true
+			continue
+		}
+
+		secretStore, ok := s.compStore.GetSecretStore(secretStoreName)
+		if !ok {
+			log.Warnf("%s %s references a secret store that isn't loaded: %s", resource.Kind(), resource.GetName(), secretStoreName)
+			return updated, secretStoreName
+		}
+
+		resp, ok := cache[m.SecretKeyRef.Name]
+		if !ok {
+			r, err := secretStore.GetSecret(ctx, secretstores.GetSecretRequest{
+				Name: m.SecretKeyRef.Name,
+				Metadata: map[string]string{
+					"namespace": resource.GetNamespace(),
+				},
+			})
+			if err != nil {
+				log.Errorf("Error getting secret: %v", err)
+				continue
+			}
+			resp = r
+		}
+
+		// Use the SecretKeyRef.Name key if SecretKeyRef.Key is not given
+		secretKeyName := m.SecretKeyRef.Key
+		if secretKeyName == "" {
+			secretKeyName = m.SecretKeyRef.Name
+		}
+
+		val, ok := resp.Data[secretKeyName]
+		if ok && val != "" {
+			metadata[i].SetValue([]byte(val))
+			metadata[i].SecretKeyRef = commonapi.SecretKeyRef{}
+			updated = true
+		}
+
+		cache[m.SecretKeyRef.Name] = resp
+	}
+	return updated, ""
+}
+
+func isEnvVarAllowed(key string) bool {
+	// First, apply a denylist that blocks access to sensitive env vars
+	key = strings.ToUpper(key)
+	switch {
+	case key == "":
+		return false
+	case key == "APP_API_TOKEN":
+		return false
+	case strings.HasPrefix(key, "DAPR_"):
+		return false
+	case strings.Contains(key, " "):
+		return false
+	}
+
+	// If we have a `DAPR_ENV_KEYS` env var (which is added by the Dapr Injector in Kubernetes mode), use that as allowlist too
+	allowlist := os.Getenv(consts.EnvKeysEnvVar)
+	if allowlist == "" {
+		return true
+	}
+
+	// Need to check for the full var, so there must be a space after OR it must be the end of the string, and there must be a space before OR it must be at the beginning of the string
+	idx := strings.Index(allowlist, key)
+	if idx >= 0 &&
+		(idx+len(key) == len(allowlist) || allowlist[idx+len(key)] == ' ') &&
+		(idx == 0 || allowlist[idx-1] == ' ') {
+		return true
+	}
+	return false
 }

--- a/pkg/runtime/processor/secret/secret.go
+++ b/pkg/runtime/processor/secret/secret.go
@@ -54,9 +54,10 @@ type secret struct {
 
 func New(opts Options) *secret {
 	return &secret{
-		registry:  opts.Registry,
-		compStore: opts.ComponentStore,
-		meta:      opts.Meta,
+		registry:       opts.Registry,
+		compStore:      opts.ComponentStore,
+		meta:           opts.Meta,
+		operatorClient: opts.OperatorClient,
 	}
 }
 

--- a/pkg/runtime/processor/secret/secret_test.go
+++ b/pkg/runtime/processor/secret/secret_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/components-contrib/secretstores"
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	compsecret "github.com/dapr/dapr/pkg/components/secretstores"
+	"github.com/dapr/dapr/pkg/modes"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+	"github.com/dapr/dapr/pkg/runtime/mock"
+	"github.com/dapr/dapr/pkg/runtime/registry"
+	"github.com/dapr/dapr/pkg/security/consts"
+	"github.com/dapr/kit/logger"
+)
+
+func TestProcessResourceSecrets(t *testing.T) {
+	createMockBinding := func() *componentsapi.Component {
+		return &componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mockBinding",
+			},
+			Spec: componentsapi.ComponentSpec{
+				Type:     "bindings.mock",
+				Version:  "v1",
+				Metadata: []commonapi.NameValuePair{},
+			},
+		}
+	}
+
+	t.Run("Standalone Mode", func(t *testing.T) {
+		mockBinding := createMockBinding()
+		mockBinding.Spec.Metadata = append(mockBinding.Spec.Metadata, commonapi.NameValuePair{
+			Name: "a",
+			SecretKeyRef: commonapi.SecretKeyRef{
+				Key:  "key1",
+				Name: "name1",
+			},
+		})
+		mockBinding.Auth.SecretStore = compsecret.BuiltinKubernetesSecretStore
+
+		sec := New(Options{
+			Registry:       registry.New(registry.NewOptions()).SecretStores(),
+			ComponentStore: compstore.New(),
+			Meta: meta.New(meta.Options{
+				ID:   "test",
+				Mode: modes.StandaloneMode,
+			}),
+		})
+
+		m := mock.NewMockKubernetesStore()
+		sec.registry.RegisterComponent(
+			func(_ logger.Logger) secretstores.SecretStore {
+				return m
+			},
+			compsecret.BuiltinKubernetesSecretStore,
+		)
+
+		// add Kubernetes component manually
+		assert.NoError(t, sec.Init(context.Background(), componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: compsecret.BuiltinKubernetesSecretStore,
+			},
+			Spec: componentsapi.ComponentSpec{
+				Type:    "secretstores.kubernetes",
+				Version: "v1",
+			},
+		}))
+
+		updated, unready := sec.ProcessResource(context.Background(), mockBinding)
+		assert.True(t, updated)
+		assert.Equal(t, "value1", mockBinding.Spec.Metadata[0].Value.String())
+		assert.Empty(t, unready)
+	})
+
+	t.Run("Look up name only", func(t *testing.T) {
+		mockBinding := createMockBinding()
+		mockBinding.Spec.Metadata = append(mockBinding.Spec.Metadata, commonapi.NameValuePair{
+			Name: "a",
+			SecretKeyRef: commonapi.SecretKeyRef{
+				Name: "name1",
+			},
+		})
+		mockBinding.Auth.SecretStore = "mock"
+
+		sec := New(Options{
+			Registry:       registry.New(registry.NewOptions()).SecretStores(),
+			ComponentStore: compstore.New(),
+			Meta: meta.New(meta.Options{
+				ID:   "test",
+				Mode: modes.KubernetesMode,
+			}),
+		})
+
+		sec.registry.RegisterComponent(
+			func(_ logger.Logger) secretstores.SecretStore {
+				return &mock.SecretStore{}
+			},
+			"mock",
+		)
+
+		// initSecretStore appends Kubernetes component even if kubernetes component is not added
+		err := sec.Init(context.Background(), componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mock",
+			},
+			Spec: componentsapi.ComponentSpec{
+				Type:    "secretstores.mock",
+				Version: "v1",
+			},
+		})
+		assert.NoError(t, err)
+
+		updated, unready := sec.ProcessResource(context.Background(), mockBinding)
+		assert.True(t, updated)
+		assert.Equal(t, "value1", mockBinding.Spec.Metadata[0].Value.String())
+		assert.Empty(t, unready)
+	})
+
+	t.Run("Secret from env", func(t *testing.T) {
+		t.Setenv("MY_ENV_VAR", "ciao mondo")
+
+		mockBinding := createMockBinding()
+		mockBinding.Spec.Metadata = append(mockBinding.Spec.Metadata, commonapi.NameValuePair{
+			Name:   "a",
+			EnvRef: "MY_ENV_VAR",
+		})
+
+		sec := New(Options{
+			Registry:       registry.New(registry.NewOptions()).SecretStores(),
+			ComponentStore: compstore.New(),
+			Meta: meta.New(meta.Options{
+				ID:   "test",
+				Mode: modes.StandaloneMode,
+			}),
+		})
+
+		updated, unready := sec.ProcessResource(context.Background(), mockBinding)
+		assert.True(t, updated)
+		assert.Equal(t, "ciao mondo", mockBinding.Spec.Metadata[0].Value.String())
+		assert.Empty(t, unready)
+	})
+
+	t.Run("Disallowed env var", func(t *testing.T) {
+		t.Setenv("APP_API_TOKEN", "test")
+		t.Setenv("DAPR_KEY", "test")
+
+		mockBinding := createMockBinding()
+		mockBinding.Spec.Metadata = append(mockBinding.Spec.Metadata,
+			commonapi.NameValuePair{
+				Name:   "a",
+				EnvRef: "DAPR_KEY",
+			},
+			commonapi.NameValuePair{
+				Name:   "b",
+				EnvRef: "APP_API_TOKEN",
+			},
+		)
+
+		sec := New(Options{
+			Registry:       registry.New(registry.NewOptions()).SecretStores(),
+			ComponentStore: compstore.New(),
+			Meta: meta.New(meta.Options{
+				ID:   "test",
+				Mode: modes.StandaloneMode,
+			}),
+		})
+
+		updated, unready := sec.ProcessResource(context.Background(), mockBinding)
+		assert.True(t, updated)
+		assert.Equal(t, "", mockBinding.Spec.Metadata[0].Value.String())
+		assert.Equal(t, "", mockBinding.Spec.Metadata[1].Value.String())
+		assert.Empty(t, unready)
+	})
+}
+
+func TestIsEnvVarAllowed(t *testing.T) {
+	t.Run("no allowlist", func(t *testing.T) {
+		tests := []struct {
+			name string
+			key  string
+			want bool
+		}{
+			{name: "empty string is not allowed", key: "", want: false},
+			{name: "key is allowed", key: "FOO", want: true},
+			{name: "keys starting with DAPR_ are denied", key: "DAPR_TEST", want: false},
+			{name: "APP_API_TOKEN is denied", key: "APP_API_TOKEN", want: false},
+			{name: "keys with a space are denied", key: "FOO BAR", want: false},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := isEnvVarAllowed(tt.key); got != tt.want {
+					t.Errorf("isEnvVarAllowed(%q) = %v, want %v", tt.key, got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("with allowlist", func(t *testing.T) {
+		t.Setenv(consts.EnvKeysEnvVar, "FOO BAR TEST")
+
+		tests := []struct {
+			name string
+			key  string
+			want bool
+		}{
+			{name: "FOO is allowed", key: "FOO", want: true},
+			{name: "BAR is allowed", key: "BAR", want: true},
+			{name: "TEST is allowed", key: "TEST", want: true},
+			{name: "FO is not allowed", key: "FO", want: false},
+			{name: "EST is not allowed", key: "EST", want: false},
+			{name: "BA is not allowed", key: "BA", want: false},
+			{name: "AR is not allowed", key: "AR", want: false},
+			{name: "keys starting with DAPR_ are denied", key: "DAPR_TEST", want: false},
+			{name: "APP_API_TOKEN is denied", key: "APP_API_TOKEN", want: false},
+			{name: "keys with a space are denied", key: "FOO BAR", want: false},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := isEnvVarAllowed(tt.key); got != tt.want {
+					t.Errorf("isEnvVarAllowed(%q) = %v, want %v", tt.key, got, tt.want)
+				}
+			})
+		}
+	})
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -16,8 +16,6 @@ package runtime
 import (
 	"context"
 	"crypto/tls"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	otlptracegrpc "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otlptracehttp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -38,14 +35,11 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
-	apiextensionsV1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nr "github.com/dapr/components-contrib/nameresolution"
-	"github.com/dapr/components-contrib/secretstores"
 	"github.com/dapr/components-contrib/state"
 	"github.com/dapr/dapr/pkg/actors"
-	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	componentsV1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	httpEndpointV1alpha1 "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
 	"github.com/dapr/dapr/pkg/apphealth"
@@ -61,7 +55,6 @@ import (
 	"github.com/dapr/dapr/pkg/grpc/universalapi"
 	"github.com/dapr/dapr/pkg/http"
 	"github.com/dapr/dapr/pkg/httpendpoint"
-	"github.com/dapr/dapr/pkg/internal/apis"
 	"github.com/dapr/dapr/pkg/messaging"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	httpMiddleware "github.com/dapr/dapr/pkg/middleware/http"
@@ -69,6 +62,7 @@ import (
 	"github.com/dapr/dapr/pkg/operator/client"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/authorizer"
 	"github.com/dapr/dapr/pkg/runtime/channels"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
@@ -77,31 +71,12 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/registry"
 	"github.com/dapr/dapr/pkg/runtime/wfengine"
 	"github.com/dapr/dapr/pkg/security"
-	securityConsts "github.com/dapr/dapr/pkg/security/consts"
 	"github.com/dapr/dapr/utils"
 	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/logger"
 )
 
-const (
-
-	// hot reloading is currently unsupported, but
-	// setting this environment variable restores the
-	// partial hot reloading support for k8s.
-	hotReloadingEnvVar = "DAPR_ENABLE_HOT_RELOADING"
-
-	defaultComponentInitTimeout = time.Second * 5
-)
-
 var log = logger.NewLogger("dapr.runtime")
-
-// Type of function that determines if a component is authorized.
-// The function receives the component and must return true if the component is authorized.
-type ComponentAuthorizer func(component componentsV1alpha1.Component) bool
-
-// Type of function that determines if an http endpoint is authorized.
-// The function receives the http endpoint and must return true if the http endpoint is authorized.
-type HTTPEndpointAuthorizer func(endpoint httpEndpointV1alpha1.HTTPEndpoint) bool
 
 // DaprRuntime holds all the core components of the runtime.
 type DaprRuntime struct {
@@ -114,29 +89,26 @@ type DaprRuntime struct {
 	directMessaging   invokev1.DirectMessaging
 	actor             actors.ActorRuntime
 
-	nameResolver            nr.Resolver
-	hostAddress             string
-	actorStateStoreLock     sync.RWMutex
-	namespace               string
-	podName                 string
-	daprUniversalAPI        *universalapi.UniversalAPI
-	daprHTTPAPI             http.API
-	daprGRPCAPI             grpc.API
-	operatorClient          operatorv1pb.OperatorClient
-	componentAuthorizers    []ComponentAuthorizer
-	httpEndpointAuthorizers []HTTPEndpointAuthorizer
-	appHealth               *apphealth.AppHealth
-	appHealthReady          func(context.Context) error // Invoked the first time the app health becomes ready
-	appHealthLock           sync.Mutex
-	compStore               *compstore.ComponentStore
-	processor               *processor.Processor
-	meta                    *meta.Meta
-	sec                     security.Handler
-	runnerCloser            *concurrency.RunnerCloserManager
-
-	pendingHTTPEndpoints       chan httpEndpointV1alpha1.HTTPEndpoint
-	pendingComponents          chan componentsV1alpha1.Component
-	pendingComponentDependents map[string][]componentsV1alpha1.Component
+	nameResolver        nr.Resolver
+	hostAddress         string
+	actorStateStoreLock sync.RWMutex
+	namespace           string
+	podName             string
+	daprUniversalAPI    *universalapi.UniversalAPI
+	daprHTTPAPI         http.API
+	daprGRPCAPI         grpc.API
+	operatorClient      operatorv1pb.OperatorClient
+	appHealth           *apphealth.AppHealth
+	appHealthReady      func(context.Context) error // Invoked the first time the app health becomes ready
+	appHealthLock       sync.Mutex
+	compStore           *compstore.ComponentStore
+	meta                *meta.Meta
+	processor           *processor.Processor
+	authz               *authorizer.Authorizer
+	sec                 security.Handler
+	runnerCloser        *concurrency.RunnerCloserManager
+	// Used for testing.
+	initComplete chan struct{}
 
 	proxy messaging.Proxy
 
@@ -149,10 +121,6 @@ type DaprRuntime struct {
 	wg sync.WaitGroup
 }
 
-type componentPreprocessRes struct {
-	unreadyDependency string
-}
-
 // newDaprRuntime returns a new runtime with the given runtime config and global config.
 func newDaprRuntime(ctx context.Context,
 	sec security.Handler,
@@ -162,10 +130,14 @@ func newDaprRuntime(ctx context.Context,
 	resiliencyProvider resiliency.Provider,
 ) (*DaprRuntime, error) {
 	compStore := compstore.New()
+
+	namespace := getNamespace()
+	podName := getPodName()
+
 	meta := meta.New(meta.Options{
 		ID:            runtimeConfig.id,
-		PodName:       getPodName(),
-		Namespace:     getNamespace(),
+		PodName:       podName,
+		Namespace:     namespace,
 		StrictSandbox: globalConfig.Spec.WasmSpec.GetStrictSandbox(),
 		Mode:          runtimeConfig.mode,
 	})
@@ -180,6 +152,12 @@ func newDaprRuntime(ctx context.Context,
 	wfe := wfengine.NewWorkflowEngine(runtimeConfig.id, globalConfig.GetWorkflowSpec())
 	wfe.ConfigureGrpcExecutor()
 
+	authz := authorizer.New(authorizer.Options{
+		ID:           runtimeConfig.id,
+		Namespace:    namespace,
+		GlobalConfig: globalConfig,
+	})
+
 	channels := channels.New(channels.Options{
 		Registry:            runtimeConfig.registry,
 		ComponentStore:      compStore,
@@ -191,49 +169,44 @@ func newDaprRuntime(ctx context.Context,
 		GRPC:                grpc,
 	})
 
+	processor := processor.New(processor.Options{
+		ID:               runtimeConfig.id,
+		Namespace:        namespace,
+		IsHTTP:           runtimeConfig.appConnectionConfig.Protocol.IsHTTP(),
+		PlacementEnabled: len(runtimeConfig.placementAddresses) > 0,
+		Registry:         runtimeConfig.registry,
+		ComponentStore:   compStore,
+		Meta:             meta,
+		GlobalConfig:     globalConfig,
+		Resiliency:       resiliencyProvider,
+		Mode:             runtimeConfig.mode,
+		PodName:          podName,
+		Standalone:       runtimeConfig.standalone,
+		OperatorClient:   operatorClient,
+		GRPC:             grpc,
+		Channels:         channels,
+	})
+
 	rt := &DaprRuntime{
-		runtimeConfig:              runtimeConfig,
-		globalConfig:               globalConfig,
-		accessControlList:          accessControlList,
-		grpc:                       grpc,
-		pendingHTTPEndpoints:       make(chan httpEndpointV1alpha1.HTTPEndpoint),
-		pendingComponents:          make(chan componentsV1alpha1.Component),
-		pendingComponentDependents: map[string][]componentsV1alpha1.Component{},
-		tracerProvider:             nil,
-		resiliency:                 resiliencyProvider,
-		workflowEngine:             wfe,
-		appHealthReady:             nil,
-		compStore:                  compStore,
-		meta:                       meta,
-		operatorClient:             operatorClient,
-		channels:                   channels,
-		sec:                        sec,
-		processor: processor.New(processor.Options{
-			ID:               runtimeConfig.id,
-			Namespace:        getNamespace(),
-			IsHTTP:           runtimeConfig.appConnectionConfig.Protocol.IsHTTP(),
-			PlacementEnabled: len(runtimeConfig.placementAddresses) > 0,
-			Registry:         runtimeConfig.registry,
-			ComponentStore:   compStore,
-			Meta:             meta,
-			GlobalConfig:     globalConfig,
-			Resiliency:       resiliencyProvider,
-			Mode:             runtimeConfig.mode,
-			PodName:          getPodName(),
-			Standalone:       runtimeConfig.standalone,
-			OperatorClient:   operatorClient,
-			GRPC:             grpc,
-			Channels:         channels,
-		}),
+		runtimeConfig:     runtimeConfig,
+		globalConfig:      globalConfig,
+		accessControlList: accessControlList,
+		grpc:              grpc,
+		tracerProvider:    nil,
+		resiliency:        resiliencyProvider,
+		workflowEngine:    wfe,
+		appHealthReady:    nil,
+		compStore:         compStore,
+		meta:              meta,
+		operatorClient:    operatorClient,
+		channels:          channels,
+		sec:               sec,
+		processor:         processor,
+		authz:             authz,
+		namespace:         namespace,
+		podName:           podName,
+		initComplete:      make(chan struct{}),
 	}
-
-	rt.componentAuthorizers = []ComponentAuthorizer{rt.namespaceComponentAuthorizer}
-	if globalConfig != nil && globalConfig.Spec.ComponentsSpec != nil && len(globalConfig.Spec.ComponentsSpec.Deny) > 0 {
-		dl := newComponentDenyList(globalConfig.Spec.ComponentsSpec.Deny)
-		rt.componentAuthorizers = append(rt.componentAuthorizers, dl.IsAllowed)
-	}
-
-	rt.httpEndpointAuthorizers = []HTTPEndpointAuthorizer{rt.namespaceHTTPEndpointAuthorizer}
 
 	var gracePeriod *time.Duration
 	if duration := runtimeConfig.gracefulShutdownDuration; duration > 0 {
@@ -242,14 +215,8 @@ func newDaprRuntime(ctx context.Context,
 
 	rt.runnerCloser = concurrency.NewRunnerCloserManager(gracePeriod,
 		rt.runtimeConfig.metricsExporter.Run,
-		rt.processComponents,
-		rt.processHTTPEndpoints,
+		rt.processor.Process,
 		func(ctx context.Context) error {
-			defer func() {
-				close(rt.pendingComponents)
-				close(rt.pendingHTTPEndpoints)
-			}()
-
 			start := time.Now()
 			log.Infof("%s mode configured", rt.runtimeConfig.mode)
 			log.Infof("app id: %s", rt.runtimeConfig.id)
@@ -266,6 +233,7 @@ func newDaprRuntime(ctx context.Context,
 				rt.daprHTTPAPI.MarkStatusAsReady()
 			}
 
+			close(rt.initComplete)
 			<-ctx.Done()
 
 			return nil
@@ -403,9 +371,6 @@ func (a *DaprRuntime) setupTracing(ctx context.Context, hostAddress string, tpSt
 }
 
 func (a *DaprRuntime) initRuntime(ctx context.Context) error {
-	a.namespace = getNamespace()
-	a.podName = getPodName()
-
 	var err error
 	if a.hostAddress, err = utils.GetHostAddress(); err != nil {
 		return fmt.Errorf("failed to determine host address: %w", err)
@@ -425,20 +390,6 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	a.initDirectMessaging(a.nameResolver)
 
 	a.initPluggableComponents(ctx)
-
-	if _, ok := os.LookupEnv(hotReloadingEnvVar); ok {
-		log.Debug("starting to watch component updates")
-		err = a.beginComponentsUpdates(ctx)
-		if err != nil {
-			log.Warnf("failed to watch component updates: %s", err)
-		}
-
-		log.Debug("starting to watch http endpoint updates")
-		err = a.beginHTTPEndpointsUpdates(ctx)
-		if err != nil {
-			log.Warnf("failed to watch http endpoint updates: %s", err)
-		}
-	}
 
 	a.appendBuiltinSecretStore(ctx)
 	err = a.loadComponents(ctx)
@@ -704,275 +655,6 @@ func (a *DaprRuntime) initProxy() {
 	})
 }
 
-// begin components updates for kubernetes mode.
-func (a *DaprRuntime) beginComponentsUpdates(ctx context.Context) error {
-	if a.operatorClient == nil {
-		return nil
-	}
-
-	a.wg.Add(1)
-	go func() {
-		defer a.wg.Done()
-		parseAndUpdate := func(compRaw []byte) {
-			var component componentsV1alpha1.Component
-			if err := json.Unmarshal(compRaw, &component); err != nil {
-				log.Warnf("error deserializing component: %s", err)
-				return
-			}
-
-			if !a.isObjectAuthorized(component) {
-				log.Debugf("received unauthorized component update, ignored. name: %s, type: %s", component.ObjectMeta.Name, component.LogName())
-				return
-			}
-
-			log.Debugf("received component update. name: %s, type: %s", component.ObjectMeta.Name, component.LogName())
-			updated := a.onComponentUpdated(ctx, component)
-			if !updated {
-				log.Info("component update skipped: .spec field unchanged")
-			}
-		}
-
-		needList := false
-		for {
-			var stream operatorv1pb.Operator_ComponentUpdateClient //nolint:nosnakecase
-
-			// Retry on stream error.
-			backoff.Retry(func() error {
-				var err error
-				stream, err = a.operatorClient.ComponentUpdate(ctx, &operatorv1pb.ComponentUpdateRequest{
-					Namespace: a.namespace,
-					PodName:   a.podName,
-				})
-				if err != nil {
-					log.Errorf("error from operator stream: %s", err)
-					return err
-				}
-				return nil
-			}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
-
-			if needList {
-				// We should get all components again to avoid missing any updates during the failure time.
-				backoff.Retry(func() error {
-					resp, err := a.operatorClient.ListComponents(ctx, &operatorv1pb.ListComponentsRequest{
-						Namespace: a.namespace,
-					})
-					if err != nil {
-						log.Errorf("error listing components: %s", err)
-						return err
-					}
-
-					comps := resp.GetComponents()
-					a.wg.Add(len(comps))
-					for i := 0; i < len(comps); i++ {
-						// avoid missing any updates during the init component time.
-						go func(comp []byte) {
-							defer a.wg.Done()
-							parseAndUpdate(comp)
-						}(comps[i])
-					}
-
-					return nil
-				}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
-			}
-
-			for {
-				c, err := stream.Recv()
-				if err != nil {
-					// Retry on stream error.
-					needList = true
-					log.Errorf("error from operator stream: %s", err)
-					break
-				}
-
-				parseAndUpdate(c.GetComponent())
-			}
-		}
-	}()
-	return nil
-}
-
-func (a *DaprRuntime) onComponentUpdated(ctx context.Context, component componentsV1alpha1.Component) bool {
-	oldComp, exists := a.compStore.GetComponent(component.Name)
-	_, _ = a.processResourceSecrets(ctx, &component)
-
-	if exists && reflect.DeepEqual(oldComp.Spec, component.Spec) {
-		return false
-	}
-
-	return a.addPendingComponent(ctx, component)
-}
-
-// begin http endpoint updates for kubernetes mode.
-func (a *DaprRuntime) beginHTTPEndpointsUpdates(ctx context.Context) error {
-	if a.operatorClient == nil {
-		return nil
-	}
-
-	a.wg.Add(1)
-	go func() {
-		defer a.wg.Done()
-		parseAndUpdate := func(endpointRaw []byte) {
-			var endpoint httpEndpointV1alpha1.HTTPEndpoint
-			if err := json.Unmarshal(endpointRaw, &endpoint); err != nil {
-				log.Warnf("error deserializing http endpoint: %s", err)
-				return
-			}
-
-			log.Debugf("received http endpoint update for name: %s", endpoint.ObjectMeta.Name)
-			updated := a.onHTTPEndpointUpdated(ctx, endpoint)
-			if !updated {
-				log.Info("http endpoint update skipped: .spec field unchanged")
-			}
-		}
-
-		needList := false
-		for ctx.Err() == nil {
-			var stream operatorv1pb.Operator_HTTPEndpointUpdateClient //nolint:nosnakecase
-			streamData, err := backoff.RetryWithData(func() (interface{}, error) {
-				var err error
-				stream, err = a.operatorClient.HTTPEndpointUpdate(ctx, &operatorv1pb.HTTPEndpointUpdateRequest{
-					Namespace: a.namespace,
-					PodName:   a.podName,
-				})
-				if err != nil {
-					log.Errorf("error from operator stream: %s", err)
-					return nil, err
-				}
-				return stream, nil
-			}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
-			if err != nil {
-				// Retry on stream error.
-				needList = true
-				log.Errorf("error from operator stream: %s", err)
-				continue
-			}
-			stream = streamData.(operatorv1pb.Operator_HTTPEndpointUpdateClient)
-
-			if needList {
-				// We should get all http endpoints again to avoid missing any updates during the failure time.
-				streamData, err := backoff.RetryWithData(func() (interface{}, error) {
-					resp, err := a.operatorClient.ListHTTPEndpoints(ctx, &operatorv1pb.ListHTTPEndpointsRequest{
-						Namespace: a.namespace,
-					})
-					if err != nil {
-						log.Errorf("error listing http endpoints: %s", err)
-						return nil, err
-					}
-
-					return resp.GetHttpEndpoints(), nil
-				}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
-				if err != nil {
-					// Retry on stream error.
-					log.Errorf("persistent error from operator stream: %s", err)
-					continue
-				}
-
-				endpointsToUpdate := streamData.([][]byte)
-				for i := 0; i < len(endpointsToUpdate); i++ {
-					parseAndUpdate(endpointsToUpdate[i])
-				}
-			}
-
-			for {
-				e, err := stream.Recv()
-				if err != nil {
-					// Retry on stream error.
-					needList = true
-					log.Errorf("error from operator stream: %s", err)
-					break
-				}
-
-				parseAndUpdate(e.GetHttpEndpoints())
-			}
-		}
-	}()
-	return nil
-}
-
-func (a *DaprRuntime) onHTTPEndpointUpdated(ctx context.Context, endpoint httpEndpointV1alpha1.HTTPEndpoint) bool {
-	oldEndpoint, exists := a.compStore.GetHTTPEndpoint(endpoint.Name)
-	_, _ = a.processResourceSecrets(ctx, &endpoint)
-
-	if exists && reflect.DeepEqual(oldEndpoint.Spec, endpoint.Spec) {
-		return false
-	}
-
-	return a.addPendingEndpoint(ctx, endpoint)
-}
-
-func (a *DaprRuntime) processHTTPEndpointSecrets(ctx context.Context, endpoint *httpEndpointV1alpha1.HTTPEndpoint) {
-	_, _ = a.processResourceSecrets(ctx, endpoint)
-
-	tlsResource := apis.GenericNameValueResource{
-		Name:        endpoint.ObjectMeta.Name,
-		Namespace:   endpoint.ObjectMeta.Namespace,
-		SecretStore: endpoint.Auth.SecretStore,
-		Pairs:       []commonapi.NameValuePair{},
-	}
-
-	root, clientCert, clientKey := "root", "clientCert", "clientKey"
-
-	ca := commonapi.NameValuePair{
-		Name: root,
-	}
-
-	if endpoint.HasTLSRootCA() {
-		ca.Value = *endpoint.Spec.ClientTLS.RootCA.Value
-	}
-
-	if endpoint.HasTLSRootCASecret() {
-		ca.SecretKeyRef = *endpoint.Spec.ClientTLS.RootCA.SecretKeyRef
-	}
-	tlsResource.Pairs = append(tlsResource.Pairs, ca)
-
-	cCert := commonapi.NameValuePair{
-		Name: clientCert,
-	}
-
-	if endpoint.HasTLSClientCert() {
-		cCert.Value = *endpoint.Spec.ClientTLS.Certificate.Value
-	}
-
-	if endpoint.HasTLSClientCertSecret() {
-		cCert.SecretKeyRef = *endpoint.Spec.ClientTLS.Certificate.SecretKeyRef
-	}
-	tlsResource.Pairs = append(tlsResource.Pairs, cCert)
-
-	cKey := commonapi.NameValuePair{
-		Name: clientKey,
-	}
-
-	if endpoint.HasTLSPrivateKey() {
-		cKey.Value = *endpoint.Spec.ClientTLS.PrivateKey.Value
-	}
-
-	if endpoint.HasTLSPrivateKeySecret() {
-		cKey.SecretKeyRef = *endpoint.Spec.ClientTLS.PrivateKey.SecretKeyRef
-	}
-
-	tlsResource.Pairs = append(tlsResource.Pairs, cKey)
-
-	updated, _ := a.processResourceSecrets(ctx, &tlsResource)
-	if updated {
-		for _, np := range tlsResource.Pairs {
-			dv := &commonapi.DynamicValue{
-				JSON: apiextensionsV1.JSON{
-					Raw: np.Value.Raw,
-				},
-			}
-
-			switch np.Name {
-			case root:
-				endpoint.Spec.ClientTLS.RootCA.Value = dv
-			case clientCert:
-				endpoint.Spec.ClientTLS.Certificate.Value = dv
-			case clientKey:
-				endpoint.Spec.ClientTLS.PrivateKey.Value = dv
-			}
-		}
-	}
-}
-
 func (a *DaprRuntime) startHTTPServer(port int, publicPort *int, profilePort int, allowedOrigins string, pipeline httpMiddleware.Pipeline) error {
 	a.daprHTTPAPI = http.NewAPI(http.APIOpts{
 		UniversalAPI:          a.daprUniversalAPI,
@@ -1179,55 +861,6 @@ func (a *DaprRuntime) initActors(ctx context.Context) error {
 	return rterrors.NewInit(rterrors.InitFailure, "actors", err)
 }
 
-func (a *DaprRuntime) namespaceComponentAuthorizer(component componentsV1alpha1.Component) bool {
-	if a.namespace == "" || component.ObjectMeta.Namespace == "" || (a.namespace != "" && component.ObjectMeta.Namespace == a.namespace) {
-		return component.IsAppScoped(a.runtimeConfig.id)
-	}
-
-	return false
-}
-
-func (a *DaprRuntime) getAuthorizedObjects(objects interface{}, authorizer func(interface{}) bool) interface{} {
-	reflectValue := reflect.ValueOf(objects)
-	authorized := reflect.MakeSlice(reflectValue.Type(), 0, reflectValue.Len())
-	for i := 0; i < reflectValue.Len(); i++ {
-		object := reflectValue.Index(i).Interface()
-		if authorizer(object) {
-			authorized = reflect.Append(authorized, reflect.ValueOf(object))
-		}
-	}
-	return authorized.Interface()
-}
-
-func (a *DaprRuntime) isObjectAuthorized(object interface{}) bool {
-	switch obj := object.(type) {
-	case httpEndpointV1alpha1.HTTPEndpoint:
-		for _, auth := range a.httpEndpointAuthorizers {
-			if !auth(obj) {
-				return false
-			}
-		}
-	case componentsV1alpha1.Component:
-		for _, auth := range a.componentAuthorizers {
-			if !auth(obj) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func (a *DaprRuntime) namespaceHTTPEndpointAuthorizer(endpoint httpEndpointV1alpha1.HTTPEndpoint) bool {
-	switch {
-	case a.namespace == "",
-		endpoint.ObjectMeta.Namespace == "",
-		(a.namespace != "" && endpoint.ObjectMeta.Namespace == a.namespace):
-		return endpoint.IsAppScoped(a.runtimeConfig.id)
-	default:
-		return false
-	}
-}
-
 func (a *DaprRuntime) loadComponents(ctx context.Context) error {
 	var loader components.ComponentLoader
 
@@ -1246,7 +879,7 @@ func (a *DaprRuntime) loadComponents(ctx context.Context) error {
 		return err
 	}
 
-	authorizedComps := a.getAuthorizedObjects(comps, a.isObjectAuthorized).([]componentsV1alpha1.Component)
+	authorizedComps := a.authz.GetAuthorizedObjects(comps, a.authz.IsObjectAuthorized).([]componentsV1alpha1.Component)
 
 	// Iterate through the list twice
 	// First, we look for secret stores and load those, then all other components
@@ -1254,7 +887,7 @@ func (a *DaprRuntime) loadComponents(ctx context.Context) error {
 	for _, comp := range authorizedComps {
 		if strings.HasPrefix(comp.Spec.Type, string(components.CategorySecretStore)+".") {
 			log.Debug("Found component: " + comp.LogName())
-			if !a.addPendingComponent(ctx, comp) {
+			if !a.processor.AddPendingComponent(ctx, comp) {
 				return nil
 			}
 		}
@@ -1262,42 +895,10 @@ func (a *DaprRuntime) loadComponents(ctx context.Context) error {
 	for _, comp := range authorizedComps {
 		if !strings.HasPrefix(comp.Spec.Type, string(components.CategorySecretStore)+".") {
 			log.Debug("Found component: " + comp.LogName())
-			if !a.addPendingComponent(ctx, comp) {
+			if !a.processor.AddPendingComponent(ctx, comp) {
 				return nil
 			}
 		}
-	}
-
-	return nil
-}
-
-func (a *DaprRuntime) processComponents(ctx context.Context) error {
-	for comp := range a.pendingComponents {
-		if comp.Name == "" {
-			continue
-		}
-
-		err := a.processComponentAndDependents(ctx, comp)
-		if err != nil {
-			err = fmt.Errorf("process component %s error: %s", comp.Name, err)
-			if !comp.Spec.IgnoreErrors {
-				log.Warnf("Error processing component, daprd process will exit gracefully")
-				return err
-			}
-			log.Error(err)
-		}
-	}
-
-	return nil
-}
-
-func (a *DaprRuntime) processHTTPEndpoints(ctx context.Context) error {
-	for endpoint := range a.pendingHTTPEndpoints {
-		if endpoint.Name == "" {
-			continue
-		}
-		a.processHTTPEndpointSecrets(ctx, &endpoint)
-		a.compStore.AddHTTPEndpoint(endpoint)
 	}
 
 	return nil
@@ -1307,7 +908,7 @@ func (a *DaprRuntime) flushOutstandingHTTPEndpoints(ctx context.Context) {
 	log.Info("Waiting for all outstanding http endpoints to be processed…")
 	// We flush by sending a no-op http endpoint. Since the processHTTPEndpoints goroutine only reads one http endpoint at a time,
 	// We know that once the no-op http endpoint is read from the channel, all previous http endpoints will have been fully processed.
-	if a.addPendingEndpoint(ctx, httpEndpointV1alpha1.HTTPEndpoint{}) {
+	if a.processor.AddPendingEndpoint(ctx, httpEndpointV1alpha1.HTTPEndpoint{}) {
 		log.Info("All outstanding http endpoints processed")
 	}
 }
@@ -1316,68 +917,9 @@ func (a *DaprRuntime) flushOutstandingComponents(ctx context.Context) {
 	log.Info("Waiting for all outstanding components to be processed…")
 	// We flush by sending a no-op component. Since the processComponents goroutine only reads one component at a time,
 	// We know that once the no-op component is read from the channel, all previous components will have been fully processed.
-	if a.addPendingComponent(ctx, componentsV1alpha1.Component{}) {
+	if a.processor.AddPendingComponent(ctx, componentsV1alpha1.Component{}) {
 		log.Info("All outstanding components processed")
 	}
-}
-
-func (a *DaprRuntime) processComponentAndDependents(ctx context.Context, comp componentsV1alpha1.Component) error {
-	log.Debug("Loading component: " + comp.LogName())
-	res := a.preprocessOneComponent(ctx, &comp)
-	if res.unreadyDependency != "" {
-		a.pendingComponentDependents[res.unreadyDependency] = append(a.pendingComponentDependents[res.unreadyDependency], comp)
-		return nil
-	}
-
-	compCategory := a.processor.Category(comp)
-	if compCategory == "" {
-		// the category entered is incorrect, return error
-		return fmt.Errorf("incorrect type %s", comp.Spec.Type)
-	}
-
-	timeout, err := time.ParseDuration(comp.Spec.InitTimeout)
-	if err != nil {
-		timeout = defaultComponentInitTimeout
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	err = a.processor.Init(ctx, comp)
-	// If the context is canceled, we want  to return an init error.
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		err = fmt.Errorf("init timeout for component %s exceeded after %s", comp.LogName(), timeout.String())
-	}
-	if err != nil {
-		log.Errorf("Failed to init component %s: %s", comp.Name, err)
-		diag.DefaultMonitoring.ComponentInitFailed(comp.Spec.Type, "init", comp.ObjectMeta.Name)
-		return rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), err)
-	}
-
-	log.Info("Component loaded: " + comp.LogName())
-	diag.DefaultMonitoring.ComponentLoaded()
-
-	dependency := componentDependency(compCategory, comp.Name)
-	if deps, ok := a.pendingComponentDependents[dependency]; ok {
-		delete(a.pendingComponentDependents, dependency)
-		for _, dependent := range deps {
-			if err := a.processComponentAndDependents(ctx, dependent); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (a *DaprRuntime) preprocessOneComponent(ctx context.Context, comp *componentsV1alpha1.Component) componentPreprocessRes {
-	_, unreadySecretsStore := a.processResourceSecrets(ctx, comp)
-	if unreadySecretsStore != "" {
-		return componentPreprocessRes{
-			unreadyDependency: componentDependency(components.CategorySecretStore, unreadySecretsStore),
-		}
-	}
-	return componentPreprocessRes{}
 }
 
 func (a *DaprRuntime) loadHTTPEndpoints(ctx context.Context) error {
@@ -1398,11 +940,11 @@ func (a *DaprRuntime) loadHTTPEndpoints(ctx context.Context) error {
 		return err
 	}
 
-	authorizedHTTPEndpoints := a.getAuthorizedObjects(endpoints, a.isObjectAuthorized).([]httpEndpointV1alpha1.HTTPEndpoint)
+	authorizedHTTPEndpoints := a.authz.GetAuthorizedObjects(endpoints, a.authz.IsObjectAuthorized).([]httpEndpointV1alpha1.HTTPEndpoint)
 
 	for _, e := range authorizedHTTPEndpoints {
 		log.Infof("Found http endpoint: %s", e.Name)
-		if !a.addPendingEndpoint(ctx, e) {
+		if !a.processor.AddPendingEndpoint(ctx, e) {
 			return nil
 		}
 	}
@@ -1449,133 +991,6 @@ func (a *DaprRuntime) cleanSockets() error {
 		}
 	}
 	return errors.Join(errs...)
-}
-
-func isEnvVarAllowed(key string) bool {
-	// First, apply a denylist that blocks access to sensitive env vars
-	key = strings.ToUpper(key)
-	switch {
-	case key == "":
-		return false
-	case key == "APP_API_TOKEN":
-		return false
-	case strings.HasPrefix(key, "DAPR_"):
-		return false
-	case strings.Contains(key, " "):
-		return false
-	}
-
-	// If we have a `DAPR_ENV_KEYS` env var (which is added by the Dapr Injector in Kubernetes mode), use that as allowlist too
-	allowlist := strings.ToUpper(os.Getenv(securityConsts.EnvKeysEnvVar))
-	if allowlist == "" {
-		return true
-	}
-
-	// Need to check for the full var, so there must be a space after OR it must be the end of the string, and there must be a space before OR it must be at the beginning of the string
-	idx := strings.Index(allowlist, key)
-	if idx >= 0 &&
-		(idx+len(key) == len(allowlist) || allowlist[idx+len(key)] == ' ') &&
-		(idx == 0 || allowlist[idx-1] == ' ') {
-		return true
-	}
-	return false
-}
-
-// Returns the component or HTTP endpoint updated with the secrets applied.
-// If the resource references a secret store that hasn't been loaded yet, it returns the name of the secret store component as second returned value.
-func (a *DaprRuntime) processResourceSecrets(ctx context.Context, resource meta.Resource) (updated bool, secretStoreName string) {
-	cache := map[string]secretstores.GetSecretResponse{}
-
-	secretStoreName = a.authSecretStoreOrDefault(resource)
-
-	metadata := resource.NameValuePairs()
-	for i, m := range metadata {
-		// If there's an env var and no value, use that
-		if !m.HasValue() && m.EnvRef != "" {
-			if isEnvVarAllowed(m.EnvRef) {
-				metadata[i].SetValue([]byte(os.Getenv(m.EnvRef)))
-			} else {
-				log.Warnf("%s %s references an env variable that isn't allowed: %s", resource.Kind(), resource.GetName(), m.EnvRef)
-			}
-			metadata[i].EnvRef = ""
-			updated = true
-			continue
-		}
-
-		if m.SecretKeyRef.Name == "" {
-			continue
-		}
-
-		// If running in Kubernetes and have an operator client, do not fetch secrets from the Kubernetes secret store as they will be populated by the operator.
-		// Instead, base64 decode the secret values into their real self.
-		if a.operatorClient != nil && secretStoreName == secretstoresLoader.BuiltinKubernetesSecretStore {
-			var jsonVal string
-			err := json.Unmarshal(m.Value.Raw, &jsonVal)
-			if err != nil {
-				log.Errorf("Error decoding secret: %v", err)
-				continue
-			}
-
-			dec, err := base64.StdEncoding.DecodeString(jsonVal)
-			if err != nil {
-				log.Errorf("Error decoding secret: %v", err)
-				continue
-			}
-
-			metadata[i].SetValue(dec)
-			metadata[i].SecretKeyRef = commonapi.SecretKeyRef{}
-			updated = true
-			continue
-		}
-
-		secretStore, ok := a.compStore.GetSecretStore(secretStoreName)
-		if !ok {
-			log.Warnf("%s %s references a secret store that isn't loaded: %s", resource.Kind(), resource.GetName(), secretStoreName)
-			return updated, secretStoreName
-		}
-
-		resp, ok := cache[m.SecretKeyRef.Name]
-		if !ok {
-			r, err := secretStore.GetSecret(ctx, secretstores.GetSecretRequest{
-				Name: m.SecretKeyRef.Name,
-				Metadata: map[string]string{
-					"namespace": resource.GetNamespace(),
-				},
-			})
-			if err != nil {
-				log.Errorf("Error getting secret: %v", err)
-				continue
-			}
-			resp = r
-		}
-
-		// Use the SecretKeyRef.Name key if SecretKeyRef.Key is not given
-		secretKeyName := m.SecretKeyRef.Key
-		if secretKeyName == "" {
-			secretKeyName = m.SecretKeyRef.Name
-		}
-
-		val, ok := resp.Data[secretKeyName]
-		if ok && val != "" {
-			metadata[i].SetValue([]byte(val))
-			metadata[i].SecretKeyRef = commonapi.SecretKeyRef{}
-			updated = true
-		}
-
-		cache[m.SecretKeyRef.Name] = resp
-	}
-	return updated, ""
-}
-
-func (a *DaprRuntime) authSecretStoreOrDefault(resource meta.Resource) string {
-	secretStore := resource.GetSecretStore()
-	if secretStore == "" {
-		switch a.runtimeConfig.mode {
-		case modes.KubernetesMode:
-			return "kubernetes"
-		}
-	}
-	return secretStore
 }
 
 func (a *DaprRuntime) blockUntilAppIsReady(ctx context.Context) error {
@@ -1645,7 +1060,7 @@ func (a *DaprRuntime) appendBuiltinSecretStore(ctx context.Context) {
 	switch a.runtimeConfig.mode {
 	case modes.KubernetesMode:
 		// Preload Kubernetes secretstore
-		a.addPendingComponent(ctx, componentsV1alpha1.Component{
+		a.processor.AddPendingComponent(ctx, componentsV1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: secretstoresLoader.BuiltinKubernetesSecretStore,
 			},
@@ -1654,24 +1069,6 @@ func (a *DaprRuntime) appendBuiltinSecretStore(ctx context.Context) {
 				Version: components.FirstStableVersion,
 			},
 		})
-	}
-}
-
-func (a *DaprRuntime) addPendingComponent(ctx context.Context, comp componentsV1alpha1.Component) bool {
-	select {
-	case <-ctx.Done():
-		return false
-	case a.pendingComponents <- comp:
-		return true
-	}
-}
-
-func (a *DaprRuntime) addPendingEndpoint(ctx context.Context, endpoint httpEndpointV1alpha1.HTTPEndpoint) bool {
-	select {
-	case <-ctx.Done():
-		return false
-	case a.pendingHTTPEndpoints <- endpoint:
-		return true
 	}
 }
 
@@ -1717,10 +1114,6 @@ func featureTypeToString(features interface{}) []string {
 		}
 	}
 	return featureStr
-}
-
-func componentDependency(compCategory components.Category, name string) string {
-	return fmt.Sprintf("%s:%s", compCategory, name)
 }
 
 func createGRPCManager(sec security.Handler, runtimeConfig *internalConfig, globalConfig *config.Configuration) *manager.Manager {


### PR DESCRIPTION
PR splits out the runtime authorizer and resource processor into a dedicated authorizer package, and a manager in the processor package. This de-couples the main runtime package from the processor so that hot reloading (not implemented here) can also make use of the processor manager.

Components are no longer indexed in the ComponentStore by both their name _and_ type. This is because the hot reloader would not be able to determine "which" Component it should delete on delete events. No two Components with the same type but different names can co-exist anyway.

Removes the existing hot reloading functionality as it is being replaced with the more robust implementation in a follow-up PR.

Part of #1172 
Spun out of https://github.com/dapr/dapr/pull/6845 to have separation of concerns and make reviewing easier.