### PR TITLE
Fix wrong service invocation type in http tracing

### DIFF
--- a/pkg/diagnostics/http_tracing.go
+++ b/pkg/diagnostics/http_tracing.go
@@ -206,9 +206,16 @@ func spanAttributesMapFromHTTPContext(rw responsewriter.ResponseWriter, r *http.
 	statusCode := rw.Status()
 
 	m := map[string]string{}
-	_, componentType := getAPIComponent(path)
 
 	var dbType string
+	var componentType string
+
+	appId := r.Header.Get("dapr-app-id")
+	if appId != "" {
+		componentType = "invoke"
+	} else {
+		_, componentType = getAPIComponent(path)
+	}
 	switch componentType {
 	case "state":
 		dbType = stateBuildingBlockType


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

If request contains header `dapr-app-id`, this PR will treat it as a service invocation.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[7085]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
