### PR TITLE
[release-1.10] Cherry-pick Fix: return HTTP status code in HTTP service invocation with resiliency enabled #7068

### DIFF
--- a/pkg/http/api_test.go
+++ b/pkg/http/api_test.go
@@ -1462,6 +1462,24 @@ func TestV1DirectMessagingEndpointsWithResiliency(t *testing.T) {
 		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey"))
 	})
 
+	t.Run("Test invoke direct message retries on unsuccessful statuscode with resiliency", func(t *testing.T) {
+		failingDirectMessaging.SuccessStatusCode = 450
+		defer func() {
+			failingDirectMessaging.SuccessStatusCode = 0
+		}()
+		apiPath := "v1.0/invoke/failingApp/method/fakeMethod"
+		fakeData := []byte("failingKey2")
+
+		// act
+		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil, "header1", "val1")
+
+		assert.Equal(t, 450, resp.StatusCode)
+		assert.Equal(t, 2, failingDirectMessaging.Failure.CallCount("failingKey2"))
+		assert.Equal(t, fakeData, resp.RawBody)
+		assert.Equal(t, "val1", resp.RawHeader.Get("header1"))
+		assert.Equal(t, "application/json", resp.ContentType)
+	})
+
 	t.Run("Test invoke direct message fails with timeout", func(t *testing.T) {
 		apiPath := "v1.0/invoke/failingApp/method/fakeMethod"
 		fakeData := []byte("timeoutKey")

--- a/pkg/testing/directmessaging_mock.go
+++ b/pkg/testing/directmessaging_mock.go
@@ -75,9 +75,18 @@ func (f *FailingDirectMessaging) Invoke(ctx context.Context, targetAppID string,
 	if statusCode == 0 {
 		statusCode = http.StatusOK
 	}
+	// Setting up the headers passed in request
+	md := r.GetMetadata()
+	headers := make(map[string][]string)
+	for k, v := range md {
+		headers[k] = v.GetValues()
+	}
+	contentType := r.Message.GetContentType()
 	resp := invokev1.
 		NewInvokeMethodResponse(int32(statusCode), http.StatusText(statusCode), nil).
-		WithRawDataBytes(r.Message.Data.Value)
+		WithRawDataBytes(r.Message.Data.Value).
+		WithHTTPHeaders(headers).
+		WithContentType(contentType)
 	return resp, nil
 }
 


### PR DESCRIPTION
# Description

This is the cherry-pick PR of #7068 to release-1.10.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
