### PR TITLE
Placement: Adds authorization to ReportDaprStatus

### DIFF
--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	hashing.SetReplicationFactor(opts.ReplicationFactor)
-	apiServer := placement.NewPlacementService(raftServer)
+	apiServer := placement.NewPlacementService(raftServer, secProvider)
 
 	err = concurrency.NewRunnerManager(
 		func(ctx context.Context) error {
@@ -105,11 +105,7 @@ func main() {
 			return nil
 		},
 		func(ctx context.Context) error {
-			sec, sErr := secProvider.Handler(ctx)
-			if sErr != nil {
-				return sErr
-			}
-			return apiServer.Run(ctx, strconv.Itoa(opts.PlacementPort), sec)
+			return apiServer.Run(ctx, strconv.Itoa(opts.PlacementPort))
 		},
 	).Run(ctx)
 	if err != nil {

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -39,7 +39,7 @@ const testStreamSendLatency = time.Second
 func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Service, *clocktesting.FakeClock, context.CancelFunc) {
 	t.Helper()
 
-	testServer := NewPlacementService(raftServer)
+	testServer := NewPlacementService(raftServer, securityfake.New())
 	clock := clocktesting.NewFakeClock(time.Now())
 	testServer.clock = clock
 
@@ -50,7 +50,7 @@ func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Ser
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		defer close(serverStopped)
-		require.NoError(t, testServer.Run(ctx, strconv.Itoa(port), securityfake.New()))
+		require.NoError(t, testServer.Run(ctx, strconv.Itoa(port)))
 	}()
 
 	assert.Eventually(t, func() bool {

--- a/pkg/security/fake/fake_test.go
+++ b/pkg/security/fake/fake_test.go
@@ -24,4 +24,5 @@ import (
 
 func TestFake(t *testing.T) {
 	var _ security.Handler = New()
+	var _ security.Provider = New()
 }

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -62,6 +62,7 @@ type Handler interface {
 	ControlPlaneNamespace() string
 	CurrentTrustAnchors() ([]byte, error)
 
+	MTLSEnabled() bool
 	WatchTrustAnchors(context.Context, chan<- []byte)
 }
 
@@ -391,6 +392,11 @@ func (s *security) NetDialerID(ctx context.Context, spiffeID spiffeid.ID, timeou
 		NetDialer: (&net.Dialer{Timeout: timeout, Cancel: ctx.Done()}),
 		Config:    tlsconfig.MTLSClientConfig(s.source, s.source, tlsconfig.AuthorizeID(spiffeID)),
 	}).Dial
+}
+
+// MTLSEnabled returns true if mTLS is enabled.
+func (s *security) MTLSEnabled() bool {
+	return s.mtls
 }
 
 // CurrentNamespace returns the namespace of this workload.

--- a/tests/integration/suite/placement/authz/mtls.go
+++ b/tests/integration/suite/placement/authz/mtls.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authz
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/pkg/security"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(mtls))
+}
+
+// mtls tests placement can find quorum with tls disabled.
+type mtls struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+}
+
+func (m *mtls) Setup(t *testing.T) []framework.Option {
+	m.sentry = sentry.New(t)
+
+	taFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(taFile, m.sentry.CABundle().TrustAnchors, 0o600))
+	m.place = placement.New(t,
+		placement.WithEnableTLS(true),
+		placement.WithSentryAddress("localhost:"+strconv.Itoa(m.sentry.Port())),
+		placement.WithTrustAnchorsFile(taFile),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.sentry, m.place),
+	}
+}
+
+func (m *mtls) Run(t *testing.T, ctx context.Context) {
+	m.sentry.WaitUntilRunning(t, ctx)
+	m.place.WaitUntilRunning(t, ctx)
+
+	secProv, err := security.New(ctx, security.Options{
+		SentryAddress:           "localhost:" + strconv.Itoa(m.sentry.Port()),
+		ControlPlaneTrustDomain: "localhost",
+		ControlPlaneNamespace:   "default",
+		TrustAnchors:            m.sentry.CABundle().TrustAnchors,
+		AppID:                   "app-1",
+		MTLSEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- secProv.Run(ctx)
+	}()
+	t.Cleanup(func() { cancel(); require.NoError(t, <-errCh) })
+
+	sec, err := secProv.Handler(ctx)
+	require.NoError(t, err)
+
+	placeID, err := spiffeid.FromSegments(sec.ControlPlaneTrustDomain(), "ns", "default", "dapr-placement")
+	require.NoError(t, err)
+
+	host := "localhost:" + strconv.Itoa(m.place.Port())
+
+	conn, err := grpc.DialContext(ctx, host, grpc.WithBlock(), sec.GRPCDialOptionMTLS(placeID))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := v1pb.NewPlacementClient(conn)
+
+	// Can only create hosts where the app ID match.
+	stream := establishStream(t, ctx, client)
+	assert.NoError(t, stream.Send(&v1pb.Host{
+		Id: "app-1",
+	}))
+	waitForUnlock(t, stream)
+	_, err = stream.Recv()
+	assert.NoError(t, err)
+
+	stream = establishStream(t, ctx, client)
+	assert.NoError(t, stream.Send(&v1pb.Host{
+		Id: "app-2",
+	}))
+	waitForUnlock(t, stream)
+	_, err = stream.Recv()
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func waitForUnlock(t *testing.T, stream v1pb.Placement_ReportDaprStatusClient) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := stream.Recv()
+		if assert.NoError(c, err) {
+			assert.Equal(c, "unlock", resp.Operation)
+		}
+	}, time.Second*5, time.Millisecond*100)
+}
+
+func establishStream(t *testing.T, ctx context.Context, client v1pb.PlacementClient) v1pb.Placement_ReportDaprStatusClient {
+	t.Helper()
+	var stream v1pb.Placement_ReportDaprStatusClient
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		stream, err = client.ReportDaprStatus(ctx)
+		if !assert.NoError(c, err) {
+			return
+		}
+		if assert.NoError(c, stream.Send(&v1pb.Host{
+			Id: "app-1",
+		})) {
+			_, err = stream.Recv()
+			assert.NoError(c, err)
+		}
+	}, time.Second*5, time.Millisecond*100)
+	return stream
+}

--- a/tests/integration/suite/placement/authz/nomtls.go
+++ b/tests/integration/suite/placement/authz/nomtls.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authz
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	grpcinsecure "google.golang.org/grpc/credentials/insecure"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(nomtls))
+}
+
+// nomtls tests placement can find quorum with tls disabled.
+type nomtls struct {
+	place *placement.Placement
+}
+
+func (n *nomtls) Setup(t *testing.T) []framework.Option {
+	n.place = placement.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(n.place),
+	}
+}
+
+func (n *nomtls) Run(t *testing.T, ctx context.Context) {
+	n.place.WaitUntilRunning(t, ctx)
+
+	host := "localhost:" + strconv.Itoa(n.place.Port())
+	conn, err := grpc.DialContext(ctx, host, grpc.WithBlock(), grpc.WithReturnConnectionError(),
+		grpc.WithTransportCredentials(grpcinsecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	client := v1pb.NewPlacementClient(conn)
+
+	// Can create hosts with any appIDs or namespaces.
+	stream := establishStream(t, ctx, client)
+	assert.NoError(t, stream.Send(new(v1pb.Host)))
+	waitForUnlock(t, stream)
+	_, err = stream.Recv()
+	assert.NoError(t, err)
+
+	stream = establishStream(t, ctx, client)
+	assert.NoError(t, stream.Send(&v1pb.Host{Name: "bar"}))
+	waitForUnlock(t, stream)
+	_, err = stream.Recv()
+	assert.NoError(t, err)
+}

--- a/tests/integration/suite/placement/placement.go
+++ b/tests/integration/suite/placement/placement.go
@@ -14,5 +14,6 @@ limitations under the License.
 package placement
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/placement/authz"
 	_ "github.com/dapr/dapr/tests/integration/suite/placement/quorum"
 )

--- a/tests/integration/suite/placement/quorum/insecure.go
+++ b/tests/integration/suite/placement/quorum/insecure.go
@@ -124,7 +124,7 @@ func (i *insecure) Run(t *testing.T, ctx context.Context) {
 		if err != nil {
 			return false
 		}
-		err = stream.Send(new(v1pb.Host))
+		err = stream.Send(&v1pb.Host{Id: "app-1"})
 		if err != nil {
 			return false
 		}

--- a/tests/integration/suite/placement/quorum/jwks.go
+++ b/tests/integration/suite/placement/quorum/jwks.go
@@ -169,7 +169,7 @@ func (j *jwks) Run(t *testing.T, ctx context.Context) {
 		if err != nil {
 			return false
 		}
-		err = stream.Send(new(v1pb.Host))
+		err = stream.Send(&v1pb.Host{Id: "app-1"})
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
PR updates the placement server to authorize ReportDaprStatus client requests when in mTLS mode. In mTLS mode, placement will verify that the requested host update has the same app ID as the client's identity.

There is currently no concept of namespacing in placement, so apps across namespaces with the same app ID are considered to have the same identity, so different identities can share the same host pool across namespaces. Though today the actor subsystem is public across the cluster, and actors cannot invoke across namespaces.