### PR TITLE
[1.11] Change injector and sentry to GET daprsystem Configuration

### DIFF
--- a/charts/dapr/charts/dapr_rbac/templates/injector.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/injector.yaml
@@ -21,7 +21,7 @@ rules:
     verbs: ["get", "list"]
 {{- if not .Values.global.rbac.namespaced }}
   - apiGroups: ["dapr.io"]
-    resources: ["configurations", "components"]
+    resources: ["components"]
     verbs: [ "get", "list"]
 {{- end }}
 ---
@@ -57,9 +57,12 @@ rules:
     resourceNames: ["dapr-trust-bundle"]
 {{- if eq .Values.global.rbac.namespaced true }}
   - apiGroups: ["dapr.io"]
-    resources: ["configurations", "components"]
+    resources: ["components"]
     verbs: [ "get", "list"]
 {{- end }}
+  - apiGroups: ["dapr.io"]
+    resources: ["configurations"]
+    verbs: [ "get" ]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
+++ b/charts/dapr/charts/dapr_rbac/templates/sentry.yaml
@@ -19,11 +19,6 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-{{- if not .Values.global.rbac.namespaced }}
-  - apiGroups: ["dapr.io"]
-    resources: ["configurations"]
-    verbs: ["list"]
-{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -55,11 +50,9 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "update"]
     resourceNames: ["dapr-trust-bundle"]
-{{- if eq .Values.global.rbac.namespaced true }}
   - apiGroups: ["dapr.io"]
     resources: ["configurations"]
-    verbs: ["list"]
-{{- end }}
+    verbs: ["get"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/injector/injector.go
+++ b/pkg/injector/injector.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -113,9 +112,9 @@ func getAppIDFromRequest(req *v1.AdmissionRequest) string {
 func NewInjector(authUIDs []string, config Config, daprClient scheme.Interface, kubeClient kubernetes.Interface) (Injector, error) {
 	mux := http.NewServeMux()
 
-	namespace, ok := os.LookupEnv("NAMESPACE")
-	if !ok {
-		return nil, errors.New("'NAMESPACE' environment variable not found")
+	namespace, err := utils.CurrentNamespaceOrError()
+	if err != nil {
+		return nil, err
 	}
 
 	i := &injector{

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 func TestConfigCorrectValues(t *testing.T) {
+	t.Setenv("NAMESPACE", "test")
 	i, err := NewInjector(nil, Config{
 		TLSCertFile:                       "a",
 		TLSKeyFile:                        "b",
@@ -402,6 +403,7 @@ func TestGetAppIDFromRequest(t *testing.T) {
 
 func TestHandleRequest(t *testing.T) {
 	authID := "test-auth-id"
+	t.Setenv("NAMESPACE", "test")
 
 	i, err := NewInjector([]string{authID}, Config{
 		TLSCertFile:                       "test-cert",

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -2,13 +2,13 @@ package operator
 
 import (
 	"context"
-	"os"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
 	"github.com/dapr/dapr/pkg/credentials"
+	"github.com/dapr/dapr/utils"
 )
 
 // Config returns an operator config options.
@@ -17,16 +17,16 @@ type Config struct {
 	Credentials credentials.TLSCredentials
 }
 
-// GetNamespace returns the namespace for Dapr.
-func GetNamespace() string {
-	return os.Getenv("NAMESPACE")
-}
-
 // LoadConfiguration loads the Kubernetes configuration and returns an Operator Config.
 func LoadConfiguration(name string, client client.Client) (*Config, error) {
+	namespace, err := utils.CurrentNamespaceOrError()
+	if err != nil {
+		return nil, err
+	}
+
 	var conf v1alpha1.Configuration
 	key := types.NamespacedName{
-		Namespace: GetNamespace(),
+		Namespace: namespace,
 		Name:      name,
 	}
 	if err := client.Get(context.Background(), key, &conf); err != nil {

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -110,9 +110,9 @@ func getKubernetesConfig(configName string) (SentryConfig, error) {
 		return defaultConfig, err
 	}
 
-	namespace, ok := os.LookupEnv("NAMESPACE")
-	if !ok {
-		return defaultConfig, errors.New("'NAMESPACE' environment variable not found")
+	namespace, err := utils.CurrentNamespaceOrError()
+	if err != nil {
+		return defaultConfig, err
 	}
 
 	if configName == "" {

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
@@ -109,29 +110,37 @@ func getKubernetesConfig(configName string) (SentryConfig, error) {
 		return defaultConfig, err
 	}
 
-	list, err := daprClient.ConfigurationV1alpha1().Configurations(metaV1.NamespaceAll).List(metaV1.ListOptions{})
-	if err != nil {
-		return defaultConfig, err
+	namespace, ok := os.LookupEnv("NAMESPACE")
+	if !ok {
+		return defaultConfig, errors.New("'NAMESPACE' environment variable not found")
 	}
 
 	if configName == "" {
 		configName = defaultDaprSystemConfigName
 	}
 
-	for _, i := range list.Items {
-		if i.GetName() == configName {
-			spec, _ := json.Marshal(i.Spec)
-
-			var configSpec daprGlobalConfig.ConfigurationSpec
-			json.Unmarshal(spec, &configSpec)
-
-			conf := daprGlobalConfig.Configuration{
-				Spec: configSpec,
-			}
-			return parseConfiguration(defaultConfig, &conf)
-		}
+	cfg, err := daprClient.ConfigurationV1alpha1().Configurations(namespace).Get(configName, metaV1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return defaultConfig, errors.New("config CRD not found")
 	}
-	return defaultConfig, errors.New("config CRD not found")
+
+	if err != nil {
+		return defaultConfig, err
+	}
+
+	spec, err := json.Marshal(cfg.Spec)
+	if err != nil {
+		return defaultConfig, err
+	}
+
+	var configSpec daprGlobalConfig.ConfigurationSpec
+	if err := json.Unmarshal(spec, &configSpec); err != nil {
+		return defaultConfig, err
+	}
+
+	return parseConfiguration(defaultConfig, &daprGlobalConfig.Configuration{
+		Spec: configSpec,
+	})
 }
 
 func getSelfhostedConfig(configName string) (SentryConfig, error) {

--- a/tests/config/ignore_daprsystem_config.yaml
+++ b/tests/config/ignore_daprsystem_config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aa
+---
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: daprsystem
+  namespace: aa
+spec:
+  metric:
+    enabled: true
+  metrics:
+    enabled: true
+  mtls:
+    allowedClockSkew: 0m
+    controlPlaneTrustDomain: cluster.local
+    enabled: false
+    sentryAddress: bad-address:1234
+    workloadCertTTL: 1ms

--- a/tests/config/ignore_daprsystem_config.yaml
+++ b/tests/config/ignore_daprsystem_config.yaml
@@ -15,7 +15,5 @@ spec:
     enabled: true
   mtls:
     allowedClockSkew: 0m
-    controlPlaneTrustDomain: cluster.local
     enabled: false
-    sentryAddress: bad-address:1234
     workloadCertTTL: 1ms

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -250,7 +250,7 @@ create-test-namespace:
 	kubectl create namespace $(DAPR_TEST_NAMESPACE)
 
 delete-test-namespace:
-	kubectl delete namespace $(DAPR_TEST_NAMESPACE)
+	kubectl delete namespace $(DAPR_TEST_NAMESPACE) aa
 
 setup-3rd-party: setup-helm-init setup-test-env-redis setup-test-env-kafka setup-test-env-mongodb setup-test-env-zipkin setup-test-env-postgres
 
@@ -595,6 +595,8 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/grpcproxyserverexternal_service.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/externalinvocationcrd.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	$(KUBECTL) apply -f ./tests/config/omithealthchecks_config.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	# Don't set namespace as Namespace is defind in the yaml.
+	$(KUBECTL) apply -f ./tests/config/ignore_daprsystem_config.yaml
 
 	# Show the installed components
 	$(KUBECTL) get components --namespace $(DAPR_TEST_NAMESPACE)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,6 +14,7 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -210,4 +211,19 @@ func GetNamespaceOrDefault(defaultNamespace string) string {
 		namespace = defaultNamespace
 	}
 	return namespace
+}
+
+// CurrentNamespaceOrError returns the namespace of this workload. If current
+// Namespace is not found, error.
+func CurrentNamespaceOrError() (string, error) {
+	namespace, ok := os.LookupEnv("NAMESPACE")
+	if !ok {
+		return "", errors.New("'NAMESPACE' environment variable not set")
+	}
+
+	if len(namespace) == 0 {
+		return "", errors.New("'NAMESPACE' environment variable is empty")
+	}
+
+	return namespace, nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -283,3 +283,32 @@ func TestGetNamespaceOrDefault(t *testing.T) {
 		assert.Equal(t, "testNs", ns)
 	})
 }
+
+func TestCurrentNamespace(t *testing.T) {
+	t.Run("error is namespace is not set", func(t *testing.T) {
+		osns, ok := os.LookupEnv("NAMESPACE")
+		os.Unsetenv("NAMESPACE")
+		t.Cleanup(func() {
+			if ok {
+				os.Setenv("NAMESPACE", osns)
+			}
+		})
+		ns, err := CurrentNamespaceOrError()
+		assert.Error(t, err)
+		assert.Empty(t, ns)
+	})
+
+	t.Run("error if namespace is set but empty", func(t *testing.T) {
+		t.Setenv("NAMESPACE", "")
+		ns, err := CurrentNamespaceOrError()
+		assert.Error(t, err)
+		assert.Empty(t, ns)
+	})
+
+	t.Run("returns namespace if set", func(t *testing.T) {
+		t.Setenv("NAMESPACE", "foo")
+		ns, err := CurrentNamespaceOrError()
+		assert.NoError(t, err)
+		assert.Equal(t, "foo", ns)
+	})
+}


### PR DESCRIPTION
In Kubernetes mode, when the Injector is patching a Pod to determine whether mTLS is enabled and Sentry on startup] fetches the global daprsystem Configuration, they do so by listing all Configurations in all namespaces and then match on the first Configuration with the name daprsystem. As Namespaces are sorted alphabetically when listed, the Configuration chosen by these services may not be the one located in the Dapr System namespace. This means that a malicious actor, or by accident a user of a Dapr enabled Kubernetes cluster, with write permissions to Configurations in a namespace which is alphabetically higher than the Dapr system namespace is able to override the global config for Sentry and Injector. We can expect that users of Dapr in Kubernertes would be able to have permissions to Configurations in order for them to control their Dapr deployment configuration.

PR updates the injector and sentry services to GET the daprsystem Configuration in the Dapr control plane namespace.

See: https://github.com/dapr/dapr/issues/7114