### PR TITLE
[1.10] Change injector and sentry to GET daprsystem Configuration

### DIFF
--- a/cmd/injector/main.go
+++ b/cmd/injector/main.go
@@ -62,7 +62,10 @@ func main() {
 		log.Fatalf("failed to get authentication uids from services accounts: %s", err)
 	}
 
-	inj := injector.NewInjector(uids, cfg, daprClient, kubeClient)
+	inj, err := injector.NewInjector(uids, cfg, daprClient, kubeClient)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Blocking call
 	inj.Run(ctx, func() {

--- a/pkg/injector/injector_test.go
+++ b/pkg/injector/injector_test.go
@@ -38,13 +38,15 @@ import (
 )
 
 func TestConfigCorrectValues(t *testing.T) {
-	i := NewInjector(nil, Config{
+	t.Setenv("NAMESPACE", "test")
+	i, err := NewInjector(nil, Config{
 		TLSCertFile:            "a",
 		TLSKeyFile:             "b",
 		SidecarImage:           "c",
 		SidecarImagePullPolicy: "d",
 		Namespace:              "e",
 	}, nil, nil)
+	assert.NoError(t, err)
 
 	injector := i.(*injector)
 	assert.Equal(t, "a", injector.config.TLSCertFile)
@@ -376,13 +378,15 @@ func TestGetAppIDFromRequest(t *testing.T) {
 
 func TestHandleRequest(t *testing.T) {
 	authID := "test-auth-id"
+	t.Setenv("NAMESPACE", "test")
 
-	i := NewInjector([]string{authID}, Config{
+	i, err := NewInjector([]string{authID}, Config{
 		TLSCertFile:  "test-cert",
 		TLSKeyFile:   "test-key",
 		SidecarImage: "test-image",
 		Namespace:    "test-ns",
 	}, fake.NewSimpleClientset(), kubernetesfake.NewSimpleClientset())
+	assert.NoError(t, err)
 	injector := i.(*injector)
 
 	podBytes, _ := json.Marshal(corev1.Pod{

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -20,7 +20,8 @@ import (
 
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
@@ -104,7 +105,7 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 		Identity:                     req.Namespace + ":" + pod.Spec.ServiceAccountName,
 		IgnoreEntrypointTolerations:  i.config.GetIgnoreEntrypointTolerations(),
 		ImagePullPolicy:              i.config.GetPullPolicy(),
-		MTLSEnabled:                  mTLSEnabled(daprClient),
+		MTLSEnabled:                  mTLSEnabled(i.namespace, daprClient),
 		Namespace:                    req.Namespace,
 		PlacementServiceAddress:      placementAddress,
 		SentryAddress:                sentryAddress,
@@ -149,18 +150,18 @@ func (i *injector) getPodPatchOperations(ar *v1.AdmissionReview,
 	return patchOps, nil
 }
 
-func mTLSEnabled(daprClient scheme.Interface) bool {
-	resp, err := daprClient.ConfigurationV1alpha1().Configurations(metaV1.NamespaceAll).List(metaV1.ListOptions{})
+func mTLSEnabled(controlPlaneNamespace string, daprClient scheme.Interface) bool {
+	resp, err := daprClient.ConfigurationV1alpha1().
+		Configurations(controlPlaneNamespace).
+		Get(defaultConfig, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		log.Infof("Dapr system configuration '%s' does not exist; using default value %t for mTLSEnabled", defaultConfig, defaultMtlsEnabled)
+		return defaultMtlsEnabled
+	}
 	if err != nil {
 		log.Errorf("Failed to load dapr configuration from k8s, use default value %t for mTLSEnabled: %s", defaultMtlsEnabled, err)
 		return defaultMtlsEnabled
 	}
 
-	for _, c := range resp.Items {
-		if c.GetName() == defaultConfig {
-			return c.Spec.MTLSSpec.Enabled
-		}
-	}
-	log.Infof("Dapr system configuration (%s) is not found, use default value %t for mTLSEnabled", defaultConfig, defaultMtlsEnabled)
-	return defaultMtlsEnabled
+	return resp.Spec.MTLSSpec.Enabled
 }

--- a/tests/config/ignore_daprsystem_config.yaml
+++ b/tests/config/ignore_daprsystem_config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aa
+---
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: daprsystem
+  namespace: aa
+spec:
+  metric:
+    enabled: true
+  metrics:
+    enabled: true
+  mtls:
+    allowedClockSkew: 0m
+    controlPlaneTrustDomain: cluster.local
+    enabled: false
+    sentryAddress: bad-address:1234
+    workloadCertTTL: 1ms

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -233,7 +233,7 @@ create-test-namespace:
 	kubectl create namespace $(DAPR_TEST_NAMESPACE)
 
 delete-test-namespace:
-	kubectl delete namespace $(DAPR_TEST_NAMESPACE)
+	kubectl delete namespace $(DAPR_TEST_NAMESPACE) aa
 
 setup-3rd-party: setup-helm-init setup-test-env-redis setup-test-env-kafka setup-test-env-mongodb setup-test-env-zipkin
 
@@ -494,6 +494,8 @@ setup-test-components: setup-app-configurations
 	$(KUBECTL) apply -f ./tests/config/dapr_cron_binding.yaml --namespace $(DAPR_TEST_NAMESPACE)
 	# TODO: Remove once AppHealthCheck feature is finalized
 	$(KUBECTL) apply -f ./tests/config/app_healthcheck.yaml --namespace $(DAPR_TEST_NAMESPACE)
+	# Don't set namespace as Namespace is defind in the yaml.
+	$(KUBECTL) apply -f ./tests/config/ignore_daprsystem_config.yaml
 
 	# Show the installed components
 	$(KUBECTL) get components --namespace $(DAPR_TEST_NAMESPACE)


### PR DESCRIPTION
In Kubernetes mode, when the Injector is patching a Pod to determine whether mTLS is enabled and Sentry on startup] fetches the global daprsystem Configuration, they do so by listing all Configurations in all namespaces and then match on the first Configuration with the name daprsystem. As Namespaces are sorted alphabetically when listed, the Configuration chosen by these services may not be the one located in the Dapr System namespace. This means that a malicious actor, or by accident a user of a Dapr enabled Kubernetes cluster, with write permissions to Configurations in a namespace which is alphabetically higher than the Dapr system namespace is able to override the global config for Sentry and Injector. We can expect that users of Dapr in Kubernertes would be able to have permissions to Configurations in order for them to control their Dapr deployment configuration.

PR updates the injector and sentry services to GET the daprsystem Configuration in the Dapr control plane namespace.

See: https://github.com/dapr/dapr/issues/7114