### PR TITLE
Adds `--trust-anchors-file` to Daprd

### DIFF
--- a/cmd/daprd/app/app.go
+++ b/cmd/daprd/app/app.go
@@ -119,6 +119,7 @@ func Run() {
 		ControlPlaneTrustDomain: opts.ControlPlaneTrustDomain,
 		ControlPlaneNamespace:   opts.ControlPlaneNamespace,
 		TrustAnchors:            opts.TrustAnchors,
+		TrustAnchorsFile:        opts.TrustAnchorsFile,
 		AppID:                   opts.AppID,
 		MTLSEnabled:             opts.EnableMTLS,
 		Mode:                    modes.DaprMode(opts.Mode),

--- a/pkg/security/consts/consts.go
+++ b/pkg/security/consts/consts.go
@@ -32,7 +32,7 @@ const (
 
 	// TrustAnchorsFileEnvVar is the environment variable name for the trust anchors file in the sidecar.
 	// Superceeds TrustAnchorsEnvVar if set.
-	// TODO: @joshvanl: remove in v1.14 after this env var has been deprecated and removed in favour of just the CLI flag --trust-anchor-file.
+	// TODO: @joshvanl: remove in v1.15 after this env var has been deprecated and removed in favour of just the CLI flag --trust-anchor-file.
 	TrustAnchorsFileEnvVar = "DAPR_TRUST_ANCHORS_FILE"
 
 	// EnvKeysEnvVar is the variable injected in the daprd container with the list of injected env vars.

--- a/pkg/security/consts/consts.go
+++ b/pkg/security/consts/consts.go
@@ -30,6 +30,11 @@ const (
 	// TrustAnchorsEnvVar is the environment variable name for the trust anchors in the sidecar.
 	TrustAnchorsEnvVar = "DAPR_TRUST_ANCHORS"
 
+	// TrustAnchorsFileEnvVar is the environment variable name for the trust anchors file in the sidecar.
+	// Superceeds TrustAnchorsEnvVar if set.
+	// TODO: @joshvanl: remove in v1.14 after this env var has been deprecated and removed in favour of just the CLI flag --trust-anchor-file.
+	TrustAnchorsFileEnvVar = "DAPR_TRUST_ANCHORS_FILE"
+
 	// EnvKeysEnvVar is the variable injected in the daprd container with the list of injected env vars.
 	EnvKeysEnvVar = "DAPR_ENV_KEYS"
 

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -153,6 +153,9 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	if opts.controlPlaneTrustDomain != nil {
 		args = append(args, "--control-plane-trust-domain="+*opts.controlPlaneTrustDomain)
 	}
+	if opts.trustAnchorsFile != nil {
+		args = append(args, "--trust-anchors-file="+*opts.trustAnchorsFile)
+	}
 
 	ns := "default"
 	if opts.namespace != nil {

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -61,6 +61,7 @@ type options struct {
 	blockShutdownDuration   *string
 	controlPlaneTrustDomain *string
 	schedulerAddresses      []string
+	trustAnchorsFile        *string
 }
 
 func WithExecOptions(execOptions ...exec.Option) Option {
@@ -299,4 +300,10 @@ func WithAppAPIToken(t *testing.T, token string) Option {
 	return WithExecOptions(exec.WithEnvVars(t,
 		"APP_API_TOKEN", token,
 	))
+}
+
+func WithTrustAnchorsFile(file string) Option {
+	return func(o *options) {
+		o.trustAnchorsFile = &file
+	}
 }

--- a/tests/integration/framework/process/sentry/options.go
+++ b/tests/integration/framework/process/sentry/options.go
@@ -22,16 +22,17 @@ import (
 type options struct {
 	execOpts []exec.Option
 
-	bundle        *ca.Bundle
-	writeBundle   bool
-	port          int
-	healthzPort   int
-	metricsPort   int
-	configuration string
-	writeConfig   bool
-	kubeconfig    *string
-	trustDomain   *string
-	namespace     *string
+	bundle                *ca.Bundle
+	writeBundle           bool
+	port                  int
+	healthzPort           int
+	metricsPort           int
+	configuration         string
+	writeConfig           bool
+	kubeconfig            *string
+	trustDomain           *string
+	namespace             *string
+	issuerCredentialsPath *string
 }
 
 // Option is a function that configures the process.
@@ -100,5 +101,11 @@ func WithWriteConfig(write bool) Option {
 func WithNamespace(namespace string) Option {
 	return func(o *options) {
 		o.namespace = &namespace
+	}
+}
+
+func WithIssuerCredentialsPath(path string) Option {
+	return func(o *options) {
+		o.issuerCredentialsPath = &path
 	}
 }

--- a/tests/integration/suite/daprd/mtls/standalone/carotation/env.go
+++ b/tests/integration/suite/daprd/mtls/standalone/carotation/env.go
@@ -61,7 +61,7 @@ func (e *env) Setup(t *testing.T) []framework.Option {
 		daprd.WithMode("standalone"),
 		daprd.WithSentryAddress(e.sentry1.Address()),
 		daprd.WithEnableMTLS(true),
-		daprd.WithExecOptions(exec.WithEnvVars(
+		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS_FILE", e.taFile,
 		)),
 	)

--- a/tests/integration/suite/daprd/mtls/standalone/carotation/env.go
+++ b/tests/integration/suite/daprd/mtls/standalone/carotation/env.go
@@ -116,6 +116,7 @@ func (e *env) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
 			defer gcancel()
+			//nolint:staticcheck
 			_, err := grpc.DialContext(gctx, e.daprd.InternalGRPCAddress(),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithReturnConnectionError(),
@@ -130,6 +131,7 @@ func (e *env) Run(t *testing.T, ctx context.Context) {
 
 	t.Run("trying mTLS connection to Dapr API with same trust anchor should succeed", func(t *testing.T) {
 		sec := securityFromSentry(t, e.sentry1)
+		//nolint:staticcheck
 		conn, err := grpc.DialContext(ctx, e.daprd.InternalGRPCAddress(), sec.GRPCDialOptionMTLS(myAppID),
 			grpc.WithReturnConnectionError())
 		require.NoError(t, err)
@@ -144,6 +146,7 @@ func (e *env) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
 			defer gcancel()
+			//nolint:staticcheck
 			_, err := grpc.DialContext(gctx, e.daprd.InternalGRPCAddress(),
 				sec.GRPCDialOptionMTLS(myAppID),
 				grpc.WithReturnConnectionError(),
@@ -161,6 +164,7 @@ func (e *env) Run(t *testing.T, ctx context.Context) {
 		// Eventually, the connection should succeed because the target Daprd
 		// accepts the new CA.
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			//nolint:staticcheck
 			conn, err := grpc.DialContext(ctx, e.daprd.InternalGRPCAddress(),
 				sec.GRPCDialOptionMTLS(myAppID),
 				grpc.WithReturnConnectionError())

--- a/tests/integration/suite/daprd/mtls/standalone/carotation/env.go
+++ b/tests/integration/suite/daprd/mtls/standalone/carotation/env.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package carotation
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/dapr/dapr/pkg/security"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(env))
+}
+
+// env tests that Daprd will trust a new CA bundle when it is rotated on disk.
+// Sets trust anchor file with environment variable DAPR_TRUST_ANCHORS_FILE.
+// TODO: @joshvanl: remove in v1.14 when we remove the deprecated environment variable.
+type env struct {
+	daprd   *daprd.Daprd
+	sentry1 *sentry.Sentry
+	sentry2 *sentry.Sentry
+	taFile  string
+}
+
+func (e *env) Setup(t *testing.T) []framework.Option {
+	e.sentry1 = sentry.New(t)
+	e.sentry2 = sentry.New(t)
+
+	e.taFile = filepath.Join(t.TempDir(), "trust_anchors.pem")
+	require.NoError(t, os.WriteFile(e.taFile, e.sentry1.CABundle().TrustAnchors, 0o600))
+
+	e.daprd = daprd.New(t,
+		daprd.WithAppID("my-app"),
+		daprd.WithMode("standalone"),
+		daprd.WithSentryAddress(e.sentry1.Address()),
+		daprd.WithEnableMTLS(true),
+		daprd.WithExecOptions(exec.WithEnvVars(
+			"DAPR_TRUST_ANCHORS_FILE", e.taFile,
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(e.sentry1, e.sentry2, e.daprd),
+	}
+}
+
+func (e *env) Run(t *testing.T, ctx context.Context) {
+	e.sentry1.WaitUntilRunning(t, ctx)
+	e.sentry2.WaitUntilRunning(t, ctx)
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	securityFromSentry := func(t *testing.T, sentry *sentry.Sentry) security.Handler {
+		t.Helper()
+
+		sctx, cancel := context.WithCancel(ctx)
+
+		secProv, err := security.New(sctx, security.Options{
+			SentryAddress:           sentry.Address(),
+			ControlPlaneTrustDomain: "localhost",
+			ControlPlaneNamespace:   "default",
+			TrustAnchors:            append(e.sentry1.CABundle().TrustAnchors, e.sentry2.CABundle().TrustAnchors...),
+			AppID:                   "another-app",
+			MTLSEnabled:             true,
+		})
+		require.NoError(t, err)
+
+		secProvErr := make(chan error)
+		go func() {
+			secProvErr <- secProv.Run(sctx)
+		}()
+
+		t.Cleanup(func() {
+			cancel()
+			select {
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for security provider to stop")
+			case err = <-secProvErr:
+				require.NoError(t, err)
+			}
+		})
+
+		sec, err := secProv.Handler(sctx)
+		require.NoError(t, err)
+
+		return sec
+	}
+
+	t.Run("trying plain text connection to Dapr API should fail", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
+			defer gcancel()
+			_, err := grpc.DialContext(gctx, e.daprd.InternalGRPCAddress(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithReturnConnectionError(),
+			)
+			//nolint:testifylint
+			assert.ErrorContains(t, err, "error reading server preface:")
+		}, time.Second*5, 100*time.Millisecond)
+	})
+
+	myAppID, err := spiffeid.FromSegments(spiffeid.RequireTrustDomainFromString("public"), "ns", "default", "my-app")
+	require.NoError(t, err)
+
+	t.Run("trying mTLS connection to Dapr API with same trust anchor should succeed", func(t *testing.T) {
+		sec := securityFromSentry(t, e.sentry1)
+		conn, err := grpc.DialContext(ctx, e.daprd.InternalGRPCAddress(), sec.GRPCDialOptionMTLS(myAppID),
+			grpc.WithReturnConnectionError())
+		require.NoError(t, err)
+		conn.Connect()
+		assert.Equal(t, connectivity.Ready, conn.GetState())
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("trying mTLS connection to Dapr API with new trust domain should succeed when CA is updated on file", func(t *testing.T) {
+		sec := securityFromSentry(t, e.sentry2)
+
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
+			defer gcancel()
+			_, err := grpc.DialContext(gctx, e.daprd.InternalGRPCAddress(),
+				sec.GRPCDialOptionMTLS(myAppID),
+				grpc.WithReturnConnectionError(),
+			)
+			//nolint:testifylint
+			assert.ErrorContains(t, err, "error reading server preface:")
+		}, time.Second*5, time.Millisecond*100)
+
+		// Update CA file on disk
+		require.NoError(t, os.WriteFile(e.taFile,
+			append(e.sentry1.CABundle().TrustAnchors, e.sentry2.CABundle().TrustAnchors...),
+			0o600),
+		)
+
+		// Eventually, the connection should succeed because the target Daprd
+		// accepts the new CA.
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			conn, err := grpc.DialContext(ctx, e.daprd.InternalGRPCAddress(),
+				sec.GRPCDialOptionMTLS(myAppID),
+				grpc.WithReturnConnectionError())
+			//nolint:testifylint
+			if assert.NoError(t, err) {
+				conn.Connect()
+				assert.Equal(t, connectivity.Ready, conn.GetState())
+				require.NoError(t, conn.Close())
+			}
+		}, time.Second*5, time.Millisecond*100)
+	})
+}

--- a/tests/integration/suite/daprd/mtls/standalone/carotation/file.go
+++ b/tests/integration/suite/daprd/mtls/standalone/carotation/file.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package carotation
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/dapr/dapr/pkg/security"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(flag))
+}
+
+// flag tests that Daprd will trust a new CA bundle when it is rotated on disk.
+// Sets trust anchor file with --trust-anchor-file flag.
+type flag struct {
+	daprd   *daprd.Daprd
+	sentry1 *sentry.Sentry
+	sentry2 *sentry.Sentry
+	taFile  string
+}
+
+func (f *flag) Setup(t *testing.T) []framework.Option {
+	f.sentry1 = sentry.New(t)
+	f.sentry2 = sentry.New(t)
+
+	f.taFile = filepath.Join(t.TempDir(), "trust_anchors.pem")
+	require.NoError(t, os.WriteFile(f.taFile, f.sentry1.CABundle().TrustAnchors, 0o600))
+
+	f.daprd = daprd.New(t,
+		daprd.WithAppID("my-app"),
+		daprd.WithMode("standalone"),
+		daprd.WithSentryAddress(f.sentry1.Address()),
+		daprd.WithEnableMTLS(true),
+		daprd.WithTrustAnchorsFile(f.taFile),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(f.sentry1, f.sentry2, f.daprd),
+	}
+}
+
+func (f *flag) Run(t *testing.T, ctx context.Context) {
+	f.sentry1.WaitUntilRunning(t, ctx)
+	f.sentry2.WaitUntilRunning(t, ctx)
+	f.daprd.WaitUntilRunning(t, ctx)
+
+	securityFromSentry := func(t *testing.T, sentry *sentry.Sentry) security.Handler {
+		t.Helper()
+
+		sctx, cancel := context.WithCancel(ctx)
+
+		secProv, err := security.New(sctx, security.Options{
+			SentryAddress:           sentry.Address(),
+			ControlPlaneTrustDomain: "localhost",
+			ControlPlaneNamespace:   "default",
+			TrustAnchors:            append(f.sentry1.CABundle().TrustAnchors, f.sentry2.CABundle().TrustAnchors...),
+			AppID:                   "another-app",
+			MTLSEnabled:             true,
+		})
+		require.NoError(t, err)
+
+		secProvErr := make(chan error)
+		go func() {
+			secProvErr <- secProv.Run(sctx)
+		}()
+
+		t.Cleanup(func() {
+			cancel()
+			select {
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for security provider to stop")
+			case err = <-secProvErr:
+				require.NoError(t, err)
+			}
+		})
+
+		sec, err := secProv.Handler(sctx)
+		require.NoError(t, err)
+
+		return sec
+	}
+
+	t.Run("trying plain text connection to Dapr API should fail", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
+			defer gcancel()
+			_, err := grpc.DialContext(gctx, f.daprd.InternalGRPCAddress(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithReturnConnectionError(),
+			)
+			//nolint:testifylint
+			assert.ErrorContains(t, err, "error reading server preface:")
+		}, time.Second*5, 100*time.Millisecond)
+	})
+
+	myAppID, err := spiffeid.FromSegments(spiffeid.RequireTrustDomainFromString("public"), "ns", "default", "my-app")
+	require.NoError(t, err)
+
+	t.Run("trying mTLS connection to Dapr API with same trust anchor should succeed", func(t *testing.T) {
+		sec := securityFromSentry(t, f.sentry1)
+		conn, err := grpc.DialContext(ctx, f.daprd.InternalGRPCAddress(), sec.GRPCDialOptionMTLS(myAppID),
+			grpc.WithReturnConnectionError())
+		require.NoError(t, err)
+		conn.Connect()
+		assert.Equal(t, connectivity.Ready, conn.GetState())
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("trying mTLS connection to Dapr API with new trust domain should succeed when CA is updated on file", func(t *testing.T) {
+		sec := securityFromSentry(t, f.sentry2)
+
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
+			defer gcancel()
+			_, err := grpc.DialContext(gctx, f.daprd.InternalGRPCAddress(),
+				sec.GRPCDialOptionMTLS(myAppID),
+				grpc.WithReturnConnectionError(),
+			)
+			//nolint:testifylint
+			assert.ErrorContains(t, err, "error reading server preface:")
+		}, time.Second*5, time.Millisecond*100)
+
+		// Update CA file on disk
+		require.NoError(t, os.WriteFile(f.taFile,
+			append(f.sentry1.CABundle().TrustAnchors, f.sentry2.CABundle().TrustAnchors...),
+			0o600),
+		)
+
+		// Eventually, the connection should succeed because the target Daprd
+		// accepts the new CA.
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			conn, err := grpc.DialContext(ctx, f.daprd.InternalGRPCAddress(),
+				sec.GRPCDialOptionMTLS(myAppID),
+				grpc.WithReturnConnectionError())
+			//nolint:testifylint
+			if assert.NoError(t, err) {
+				conn.Connect()
+				assert.Equal(t, connectivity.Ready, conn.GetState())
+				require.NoError(t, conn.Close())
+			}
+		}, time.Second*5, time.Millisecond*100)
+	})
+}

--- a/tests/integration/suite/daprd/mtls/standalone/carotation/file.go
+++ b/tests/integration/suite/daprd/mtls/standalone/carotation/file.go
@@ -112,6 +112,7 @@ func (f *flag) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
 			defer gcancel()
+			//nolint:staticcheck
 			_, err := grpc.DialContext(gctx, f.daprd.InternalGRPCAddress(),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithReturnConnectionError(),
@@ -126,6 +127,7 @@ func (f *flag) Run(t *testing.T, ctx context.Context) {
 
 	t.Run("trying mTLS connection to Dapr API with same trust anchor should succeed", func(t *testing.T) {
 		sec := securityFromSentry(t, f.sentry1)
+		//nolint:staticcheck
 		conn, err := grpc.DialContext(ctx, f.daprd.InternalGRPCAddress(), sec.GRPCDialOptionMTLS(myAppID),
 			grpc.WithReturnConnectionError())
 		require.NoError(t, err)
@@ -140,6 +142,7 @@ func (f *flag) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			gctx, gcancel := context.WithTimeout(ctx, time.Second/4)
 			defer gcancel()
+			//nolint:staticcheck
 			_, err := grpc.DialContext(gctx, f.daprd.InternalGRPCAddress(),
 				sec.GRPCDialOptionMTLS(myAppID),
 				grpc.WithReturnConnectionError(),
@@ -157,6 +160,7 @@ func (f *flag) Run(t *testing.T, ctx context.Context) {
 		// Eventually, the connection should succeed because the target Daprd
 		// accepts the new CA.
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			//nolint:staticcheck
 			conn, err := grpc.DialContext(ctx, f.daprd.InternalGRPCAddress(),
 				sec.GRPCDialOptionMTLS(myAppID),
 				grpc.WithReturnConnectionError())

--- a/tests/integration/suite/daprd/mtls/standalone/standalone.go
+++ b/tests/integration/suite/daprd/mtls/standalone/standalone.go
@@ -6,15 +6,13 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sentry
+package standalone
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/sentry/ca"
-	_ "github.com/dapr/dapr/tests/integration/suite/sentry/metrics"
-	_ "github.com/dapr/dapr/tests/integration/suite/sentry/validator"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/mtls/standalone/carotation"
 )

--- a/tests/integration/suite/sentry/ca/rotation.go
+++ b/tests/integration/suite/sentry/ca/rotation.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffegrpc/grpccredentials"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/dapr/dapr/pkg/sentry/server/ca"
+	"github.com/dapr/dapr/tests/integration/framework"
+	sentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(rotation))
+}
+
+// rotation tests that sentry will rotate issuer certificates when they are updated on disk.
+type rotation struct {
+	sentry         *sentry.Sentry
+	issuerCredPath string
+	bundle1        ca.Bundle
+	bundle2        ca.Bundle
+}
+
+func (r *rotation) Setup(t *testing.T) []framework.Option {
+	pk1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	pk2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	bundle1, err := ca.GenerateBundle(pk1, "integration.test.dapr.io", time.Second*5, nil)
+	require.NoError(t, err)
+	bundle2, err := ca.GenerateBundle(pk2, "integration.test.dapr.io", time.Second*5, nil)
+	require.NoError(t, err)
+
+	r.issuerCredPath = t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(r.issuerCredPath, "issuer.crt"), bundle1.IssChainPEM, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(r.issuerCredPath, "issuer.key"), bundle1.IssKeyPEM, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(r.issuerCredPath, "ca.crt"), bundle1.TrustAnchors, 0o600))
+
+	r.sentry = sentry.New(t,
+		sentry.WithIssuerCredentialsPath(r.issuerCredPath),
+		sentry.WithTrustDomain("integration.test.dapr.io"),
+		sentry.WithWriteTrustBundle(false),
+	)
+	r.bundle1 = bundle1
+	r.bundle2 = bundle2
+
+	return []framework.Option{
+		framework.WithProcesses(r.sentry),
+	}
+}
+
+func (r *rotation) Run(t *testing.T, ctx context.Context) {
+	r.sentry.WaitUntilRunning(t, ctx)
+
+	sentryID, err := spiffeid.FromString("spiffe://integration.test.dapr.io/ns/default/dapr-sentry")
+	require.NoError(t, err)
+
+	t.Run("sentry should be serving on bundle 1 trust anchors", func(t *testing.T) {
+		x509bundle, err := x509bundle.Parse(sentryID.TrustDomain(), r.bundle1.TrustAnchors)
+		require.NoError(t, err)
+		conn, err := grpc.DialContext(ctx,
+			fmt.Sprintf("localhost:%d", r.sentry.Port()),
+			grpc.WithTransportCredentials(
+				grpccredentials.TLSClientCredentials(x509bundle, tlsconfig.AuthorizeID(sentryID)),
+			),
+			grpc.WithReturnConnectionError(), grpc.WithBlock(),
+		)
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	})
+
+	t.Run("sentry should begin to serve on the second bundle after writing", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(r.issuerCredPath, "issuer.crt"), r.bundle2.IssChainPEM, 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(r.issuerCredPath, "issuer.key"), r.bundle2.IssKeyPEM, 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(r.issuerCredPath, "ca.crt"), r.bundle2.TrustAnchors, 0o600))
+
+		x509bundle, err := x509bundle.Parse(sentryID.TrustDomain(), r.bundle2.TrustAnchors)
+		require.NoError(t, err)
+
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			sctx, cancel := context.WithTimeout(ctx, time.Second/4)
+			defer cancel()
+
+			conn, err := grpc.DialContext(sctx,
+				fmt.Sprintf("localhost:%d", r.sentry.Port()),
+				grpc.WithTransportCredentials(
+					grpccredentials.TLSClientCredentials(x509bundle, tlsconfig.AuthorizeID(sentryID)),
+				),
+				grpc.WithReturnConnectionError(), grpc.WithBlock(),
+			)
+			//nolint:testifylint
+			if assert.NoError(t, err) {
+				require.NoError(t, conn.Close())
+			}
+		}, time.Second*5, time.Millisecond*100)
+	})
+}

--- a/tests/integration/suite/sentry/ca/rotation.go
+++ b/tests/integration/suite/sentry/ca/rotation.go
@@ -88,6 +88,7 @@ func (r *rotation) Run(t *testing.T, ctx context.Context) {
 	t.Run("sentry should be serving on bundle 1 trust anchors", func(t *testing.T) {
 		x509bundle, err := x509bundle.Parse(sentryID.TrustDomain(), r.bundle1.TrustAnchors)
 		require.NoError(t, err)
+		//nolint:staticcheck
 		conn, err := grpc.DialContext(ctx,
 			fmt.Sprintf("localhost:%d", r.sentry.Port()),
 			grpc.WithTransportCredentials(
@@ -110,7 +111,7 @@ func (r *rotation) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			sctx, cancel := context.WithTimeout(ctx, time.Second/4)
 			defer cancel()
-
+			//nolint:staticcheck
 			conn, err := grpc.DialContext(sctx,
 				fmt.Sprintf("localhost:%d", r.sentry.Port()),
 				grpc.WithTransportCredentials(


### PR DESCRIPTION
Part of the joshvanl proposal trust distribution https://github.com/dapr/proposals/pull/42

PR updates kit to use the kit/fswatcher that uses the events/batcher to de-dupe file events.

Updates daprd with a new `--trust-anchors-file` flag and environment variable `DAPR_TRUST_ANCHORS_FILE` to allow users to specify a reference to a file containing the trust anchors bundle. This new flag supersedes the environment variable, which both supersede the existing static `DAPR_TRUST_ANCHORS` environment variable.

The trust anchor in security used by daprd will be updated to match the contents of the referenced file when the file changes. An environment variable is added so that backwards compatibility can be achieved when injector is updated to populate file reference, whilst still supporting patching older Daprds.

Integration tests have been added to validate the security CA bundle is updated when the file changes for both daprd when using the env var or flag, as well as sentry.

Draft until https://github.com/dapr/kit/pull/75 is merged into main.