### PR TITLE
Treat `duration` as `initialInterval` for exponential policies

### DIFF
--- a/charts/dapr/crds/resiliency.yaml
+++ b/charts/dapr/crds/resiliency.yaml
@@ -58,6 +58,8 @@ spec:
                       properties:
                         duration:
                           type: string
+                        initialInterval:
+                          type: string
                         maxInterval:
                           type: string
                         maxRetries:

--- a/pkg/apis/resiliency/v1alpha1/types.go
+++ b/pkg/apis/resiliency/v1alpha1/types.go
@@ -51,10 +51,11 @@ type Policies struct {
 }
 
 type Retry struct {
-	Policy      string `json:"policy,omitempty" yaml:"policy,omitempty"`
-	Duration    string `json:"duration,omitempty" yaml:"duration,omitempty"`
-	MaxInterval string `json:"maxInterval,omitempty" yaml:"maxInterval,omitempty"`
-	MaxRetries  *int   `json:"maxRetries,omitempty" yaml:"maxRetries,omitempty"`
+	Policy          string `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Duration        string `json:"duration,omitempty" yaml:"duration,omitempty"`
+	InitialInterval string `json:"initialInterval,omitempty" yaml:"initialInterval,omitempty"`
+	MaxInterval     string `json:"maxInterval,omitempty" yaml:"maxInterval,omitempty"`
+	MaxRetries      *int   `json:"maxRetries,omitempty" yaml:"maxRetries,omitempty"`
 }
 
 type CircuitBreaker struct {

--- a/pkg/resiliency/resiliency.go
+++ b/pkg/resiliency/resiliency.go
@@ -398,11 +398,17 @@ func (r *Resiliency) decodePolicies(c *resiliencyV1alpha.Resiliency) (err error)
 	}
 
 	for name, t := range policies.Retries {
+		// if the policy is exponential and "initialInterval" is not set use "duration" as "initialInterval"
+		if t.Policy == "exponential" && t.InitialInterval == "" {
+			t.InitialInterval = t.Duration
+		}
+
 		rc := retry.DefaultConfig()
 		m, err := toMap(t)
 		if err != nil {
 			return err
 		}
+
 		if err = retry.DecodeConfig(&rc, m); err != nil {
 			return fmt.Errorf("invalid retry configuration %q: %w", name, err)
 		}

--- a/pkg/resiliency/resiliency_test.go
+++ b/pkg/resiliency/resiliency_test.go
@@ -358,6 +358,26 @@ func TestBuiltInPoliciesAreCreated(t *testing.T) {
 	assert.Equal(t, time.Second, retry.Duration)
 }
 
+func TestResiliencyExponentialPolicyDurationUsedAsInitialInterval(t *testing.T) {
+	r := &resiliencyV1alpha.Resiliency{
+		Spec: resiliencyV1alpha.ResiliencySpec{
+			Policies: resiliencyV1alpha.Policies{
+				Retries: map[string]resiliencyV1alpha.Retry{
+					"myRetry": {
+						Policy:   "exponential",
+						Duration: "123s",
+					},
+				},
+			},
+		},
+	}
+	config := FromConfigurations(log, r)
+
+	assert.Equal(t, 123*time.Second, config.retries["myRetry"].InitialInterval)
+	assert.Equal(t, 123*time.Second, config.retries["myRetry"].Duration)
+	assert.Equal(t, "exponential", config.retries["myRetry"].Policy.String())
+}
+
 func TestResiliencyHasTargetDefined(t *testing.T) {
 	r := &resiliencyV1alpha.Resiliency{
 		Spec: resiliencyV1alpha.ResiliencySpec{


### PR DESCRIPTION
Temporary workaround because `initialInterval` is missing in CRDs.