### PR TITLE
Increase unit test timeout to 20m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ test: test-deps
 			--format pkgname-and-test-fails \
 			-- \
 				./pkg/... ./utils/... ./cmd/... \
-				$(COVERAGE_OPTS) --tags=unit,allcomponents
+				$(COVERAGE_OPTS) -timeout=20m --tags=unit,allcomponents
 	CGO_ENABLED=$(CGO) \
 		go test --tags=allcomponents ./tests/...
 


### PR DESCRIPTION
# Description

I found sometimes unit tests would take more than 10min(default timeout) to run, and failed which could be recovered from retry. 
Suggest increasing the unit test timeout to 20 minutes. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
