### PR TITLE
Fix placement and CallLocalStream unit test

### DIFF
--- a/pkg/grpc/api_daprinternal.go
+++ b/pkg/grpc/api_daprinternal.go
@@ -245,7 +245,7 @@ func (a *api) CallLocalStream(stream internalv1pb.ServiceInvocation_CallLocalStr
 
 		if r != nil {
 			n, err = r.Read(*buf)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				done = true
 			} else if err != nil {
 				return err

--- a/pkg/grpc/api_daprinternal_test.go
+++ b/pkg/grpc/api_daprinternal_test.go
@@ -15,6 +15,8 @@ package grpc
 
 import (
 	"context"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -122,7 +124,7 @@ func TestCallLocalStream(t *testing.T) {
 		err = st.Send(&internalv1pb.InternalInvokeRequestStream{
 			Request: request.Proto(),
 		})
-		require.NoError(t, err)
+		require.True(t, err == nil || errors.Is(err, io.EOF))
 		err = st.CloseSend()
 		require.NoError(t, err)
 


### PR DESCRIPTION
The placement test is failing almost 100% of times lately.

The CallLocalStream test is another one that fails frequently