### PR TITLE
logging: sidecar injector - GetAppID

### DIFF
--- a/pkg/injector/patcher/sidecar_container.go
+++ b/pkg/injector/patcher/sidecar_container.go
@@ -38,6 +38,9 @@ type getSidecarContainerOpts struct {
 
 // getSidecarContainer returns the Container object for the sidecar.
 func (c *SidecarConfig) getSidecarContainer(opts getSidecarContainerOpts) (*corev1.Container, error) {
+	if c.GetAppID() == "" {
+		return nil, fmt.Errorf("app-id is not set empty")
+	}
 	// Ports for the daprd container
 	ports := []corev1.ContainerPort{
 		{

--- a/pkg/injector/patcher/sidecar_container.go
+++ b/pkg/injector/patcher/sidecar_container.go
@@ -411,10 +411,6 @@ func (c *SidecarConfig) getResourceRequirements() (*corev1.ResourceRequirements,
 
 // GetAppID returns the AppID property, fallinb back to the name of the pod.
 func (c *SidecarConfig) GetAppID() string {
-	if c.AppID == "" {
-		return c.pod.GetName()
-	}
-
 	return c.AppID
 }
 

--- a/pkg/injector/patcher/sidecar_container.go
+++ b/pkg/injector/patcher/sidecar_container.go
@@ -38,9 +38,6 @@ type getSidecarContainerOpts struct {
 
 // getSidecarContainer returns the Container object for the sidecar.
 func (c *SidecarConfig) getSidecarContainer(opts getSidecarContainerOpts) (*corev1.Container, error) {
-	if c.GetAppID() == "" {
-		return nil, fmt.Errorf("app-id is not set")
-	}
 	// Ports for the daprd container
 	ports := []corev1.ContainerPort{
 		{
@@ -411,6 +408,11 @@ func (c *SidecarConfig) getResourceRequirements() (*corev1.ResourceRequirements,
 
 // GetAppID returns the AppID property, fallinb back to the name of the pod.
 func (c *SidecarConfig) GetAppID() string {
+	if c.AppID == "" {
+		log.Warnf("app-id not set defaulting the app-id to: %s", c.pod.GetName())
+		return c.pod.GetName()
+	}
+
 	return c.AppID
 }
 

--- a/pkg/injector/patcher/sidecar_container.go
+++ b/pkg/injector/patcher/sidecar_container.go
@@ -39,7 +39,7 @@ type getSidecarContainerOpts struct {
 // getSidecarContainer returns the Container object for the sidecar.
 func (c *SidecarConfig) getSidecarContainer(opts getSidecarContainerOpts) (*corev1.Container, error) {
 	if c.GetAppID() == "" {
-		return nil, fmt.Errorf("app-id is not set empty")
+		return nil, fmt.Errorf("app-id is not set")
 	}
 	// Ports for the daprd container
 	ports := []corev1.ContainerPort{

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -294,6 +294,10 @@ func TestGetSidecarContainer(t *testing.T) {
 			container, err := c.getSidecarContainer(tc.getSidecarContainerOpts)
 			require.NoError(t, err)
 
+			c.AppID = ""
+			container, err = c.getSidecarContainer(tc.getSidecarContainerOpts)
+			require.Error(t, err)
+
 			tc.assertFn(t, container)
 		}
 	}

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -293,12 +293,11 @@ func TestGetSidecarContainer(t *testing.T) {
 
 			container, err := c.getSidecarContainer(tc.getSidecarContainerOpts)
 			require.NoError(t, err)
+			tc.assertFn(t, container)
 
 			c.AppID = ""
-			container, err = c.getSidecarContainer(tc.getSidecarContainerOpts)
+			_, err = c.getSidecarContainer(tc.getSidecarContainerOpts)
 			require.Error(t, err)
-
-			tc.assertFn(t, container)
 		}
 	}
 	testSuiteGenerator := func(tests []testCase) func(t *testing.T) {

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -293,11 +293,8 @@ func TestGetSidecarContainer(t *testing.T) {
 
 			container, err := c.getSidecarContainer(tc.getSidecarContainerOpts)
 			require.NoError(t, err)
-			tc.assertFn(t, container)
 
-			c.AppID = ""
-			_, err = c.getSidecarContainer(tc.getSidecarContainerOpts)
-			require.Error(t, err)
+			tc.assertFn(t, container)
 		}
 	}
 	testSuiteGenerator := func(tests []testCase) func(t *testing.T) {
@@ -829,7 +826,6 @@ func TestGetSidecarContainer(t *testing.T) {
 				},
 			})
 			c.IgnoreEntrypointTolerations = tc.ignoreEntrypointTolerations
-			c.AppID = "myapp"
 
 			container, err := c.getSidecarContainer(getSidecarContainerOpts{})
 			require.NoError(t, err)

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -829,6 +829,7 @@ func TestGetSidecarContainer(t *testing.T) {
 				},
 			})
 			c.IgnoreEntrypointTolerations = tc.ignoreEntrypointTolerations
+			c.AppID = "myapp"
 
 			container, err := c.getSidecarContainer(getSidecarContainerOpts{})
 			require.NoError(t, err)


### PR DESCRIPTION
# Description

sidecar injector - GetAppID will not default to any other name if not set and will fail the injection if not appID not set

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #5141 
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
