### PR TITLE
Use official dapr-ext-workflow release instead of dev

### DIFF
--- a/tests/apps/perf/workflowsapp/requirements.txt
+++ b/tests/apps/perf/workflowsapp/requirements.txt
@@ -1,3 +1,3 @@
-dapr-ext-workflow-dev>=0.0.1rc1.dev
+dapr-ext-workflow
 dapr
 flask


### PR DESCRIPTION
# Description

We have been using dev release of dapr-ext-workflow extension instead of stable one. The PR fixes it.
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
