### PR TITLE
[1.11] Fix injector mTLS enabled

### DIFF
--- a/docs/release_notes/v1.11.6.md
+++ b/docs/release_notes/v1.11.6.md
@@ -1,0 +1,23 @@
+# Dapr 1.11.6
+
+This patch release contains bug fixes:
+
+- [Fixed mTLS configuration](#fixed-mtls-configuration)
+
+## Fixed mTLS configuration
+
+### Problem
+
+The mTLS configuration was always enabled for Dapr sidecards in Kubernetes, regardless of the `daprsystem` configuration.
+
+### Impact
+
+Users on Dapr 1.11.5 could not disable mTLS for Dapr sidecars in Kubernetes.
+
+### Root cause
+
+The `daprsystem` configuration was not being read correctly by the sidecar injector.
+
+### Solution
+
+The `daprsystem` configuration is now read correctly by the sidecar injector and the mTLS option is correctly set for Dapr sidecars in Kubernetes.

--- a/pkg/injector/pod_patch.go
+++ b/pkg/injector/pod_patch.go
@@ -166,7 +166,7 @@ func mTLSEnabled(controlPlaneNamespace string, daprClient scheme.Interface) bool
 	resp, err := daprClient.ConfigurationV1alpha1().
 		Configurations(controlPlaneNamespace).
 		Get(defaultConfig, metav1.GetOptions{})
-	if !apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		log.Infof("Dapr system configuration '%s' does not exist; using default value %t for mTLSEnabled", defaultConfig, defaultMtlsEnabled)
 		return defaultMtlsEnabled
 	}

--- a/pkg/injector/pod_patch_test.go
+++ b/pkg/injector/pod_patch_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	clientfake "github.com/dapr/dapr/pkg/client/clientset/versioned/fake"
+)
+
+func Test_mtlsEnabled(t *testing.T) {
+	t.Run("if configuration doesn't exist, return true", func(t *testing.T) {
+		cl := clientfake.NewSimpleClientset()
+		assert.True(t, mTLSEnabled("test-ns", cl))
+	})
+
+	t.Run("if configuration exists and is false, return false", func(t *testing.T) {
+		cl := clientfake.NewSimpleClientset()
+		cl.ConfigurationV1alpha1().Configurations("test-ns").Create(
+			&configapi.Configuration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "daprsystem",
+					Namespace: "test-ns",
+				},
+				Spec: configapi.ConfigurationSpec{MTLSSpec: configapi.MTLSSpec{Enabled: false}},
+			},
+		)
+		assert.False(t, mTLSEnabled("test-ns", cl))
+	})
+
+	t.Run("if configuration exists and is true, return true", func(t *testing.T) {
+		cl := clientfake.NewSimpleClientset()
+		cl.ConfigurationV1alpha1().Configurations("test-ns").Create(
+			&configapi.Configuration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "daprsystem",
+					Namespace: "test-ns",
+				},
+				Spec: configapi.ConfigurationSpec{MTLSSpec: configapi.MTLSSpec{Enabled: true}},
+			},
+		)
+		assert.True(t, mTLSEnabled("test-ns", cl))
+	})
+}


### PR DESCRIPTION
Fix bug in injector pod patcher where mTLS would always be enabled on patched sidecards regardless of the value of the `spec.mtls.enabled` option in the `daprsystem` global Configuration.

Adds 1.11.6 release notes.
