### PR TITLE
Integration: expand actor state TTL tests

### DIFF
--- a/tests/integration/suite/actors/grpc/ttl.go
+++ b/tests/integration/suite/actors/grpc/ttl.go
@@ -132,7 +132,8 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 
 	t.Run("ensure the state key returns a ttlExpireTime", func(t *testing.T) {
-		resp, err := client.GetActorState(ctx, &rtv1.GetActorStateRequest{
+		var resp *rtv1.GetActorStateResponse
+		resp, err = client.GetActorState(ctx, &rtv1.GetActorStateRequest{
 			ActorType: "myactortype", ActorId: "myactorid", Key: "mykey",
 		})
 		require.NoError(t, err)
@@ -140,7 +141,8 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(t, "myvalue", string(resp.Data))
 		ttlExpireTimeStr, ok := resp.Metadata["ttlExpireTime"]
 		require.True(t, ok)
-		ttlExpireTime, err := time.Parse(time.RFC3339, ttlExpireTimeStr)
+		var ttlExpireTime time.Time
+		ttlExpireTime, err = time.Parse(time.RFC3339, ttlExpireTimeStr)
 		require.NoError(t, err)
 		assert.InDelta(t, now.Add(2*time.Second).Unix(), ttlExpireTime.Unix(), 1)
 	})
@@ -155,16 +157,17 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 					Key:           "mykey",
 					Value:         &anypb.Any{Value: []byte("myvalue")},
 					Metadata: map[string]string{
-						"ttlInSeconds": "3",
+						"ttlInSeconds": "4",
 					},
 				},
 			},
 		})
 		require.NoError(t, err)
 
-		time.Sleep(time.Second * 2)
+		time.Sleep(time.Second * 3)
 
-		resp, err := client.GetActorState(ctx, &rtv1.GetActorStateRequest{
+		var resp *rtv1.GetActorStateResponse
+		resp, err = client.GetActorState(ctx, &rtv1.GetActorStateRequest{
 			ActorType: "myactortype", ActorId: "myactorid", Key: "mykey",
 		})
 		require.NoError(t, err)

--- a/tests/integration/suite/actors/http/ttl.go
+++ b/tests/integration/suite/actors/http/ttl.go
@@ -135,6 +135,27 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 		assert.InDelta(t, now.Add(2*time.Second).Unix(), ttlExpireTime.Unix(), 1)
 	})
 
+	t.Run("can update ttl with new value", func(t *testing.T) {
+		reqBody = `[{"operation":"upsert","request":{"key":"key1","value":"value1","metadata":{"ttlInSeconds":"3"}}}]`
+		req, err = http.NewRequest(http.MethodPost, daprdURL+"/v1.0/actors/myactortype/myactorid/state", strings.NewReader(reqBody))
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		assert.NoError(t, resp.Body.Close())
+
+		time.Sleep(time.Second * 2)
+
+		req, err = http.NewRequest(http.MethodGet, daprdURL+"/v1.0/actors/myactortype/myactorid/state/key1", nil)
+		require.NoError(t, err)
+		resp, err = client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.NoError(t, resp.Body.Close())
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, `"value1"`, string(body))
+	})
+
 	t.Run("ensure the state key is deleted after the ttl", func(t *testing.T) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			req, err := http.NewRequest(http.MethodGet, daprdURL+"/v1.0/actors/myactortype/myactorid/state/key1", nil)

--- a/tests/integration/suite/actors/http/ttl.go
+++ b/tests/integration/suite/actors/http/ttl.go
@@ -122,15 +122,18 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 	t.Run("ensure the state key returns a ttlExpireTime header", func(t *testing.T) {
 		req, err = http.NewRequest(http.MethodGet, daprdURL+"/v1.0/actors/myactortype/myactorid/state/key1", nil)
 		require.NoError(t, err)
-		resp, err := client.Do(req)
+		//nolint:bodyclose
+		resp, err = client.Do(req)
 		require.NoError(t, err)
-		body, err := io.ReadAll(resp.Body)
+		var body []byte
+		body, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.NoError(t, resp.Body.Close())
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, `"value1"`, string(body))
 		ttlExpireTimeStr := resp.Header.Get("metadata.ttlExpireTime")
-		ttlExpireTime, err := time.Parse(time.RFC3339, ttlExpireTimeStr)
+		var ttlExpireTime time.Time
+		ttlExpireTime, err = time.Parse(time.RFC3339, ttlExpireTimeStr)
 		require.NoError(t, err)
 		assert.InDelta(t, now.Add(2*time.Second).Unix(), ttlExpireTime.Unix(), 1)
 	})
@@ -139,7 +142,8 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 		reqBody = `[{"operation":"upsert","request":{"key":"key1","value":"value1","metadata":{"ttlInSeconds":"3"}}}]`
 		req, err = http.NewRequest(http.MethodPost, daprdURL+"/v1.0/actors/myactortype/myactorid/state", strings.NewReader(reqBody))
 		require.NoError(t, err)
-		resp, err := client.Do(req)
+		//nolint:bodyclose
+		resp, err = client.Do(req)
 		require.NoError(t, err)
 		assert.NoError(t, resp.Body.Close())
 
@@ -147,9 +151,11 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 
 		req, err = http.NewRequest(http.MethodGet, daprdURL+"/v1.0/actors/myactortype/myactorid/state/key1", nil)
 		require.NoError(t, err)
+		//nolint:bodyclose
 		resp, err = client.Do(req)
 		require.NoError(t, err)
-		body, err := io.ReadAll(resp.Body)
+		var body []byte
+		body, err = io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.NoError(t, resp.Body.Close())
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -158,11 +164,13 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 
 	t.Run("ensure the state key is deleted after the ttl", func(t *testing.T) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			req, err := http.NewRequest(http.MethodGet, daprdURL+"/v1.0/actors/myactortype/myactorid/state/key1", nil)
+			req, err = http.NewRequest(http.MethodGet, daprdURL+"/v1.0/actors/myactortype/myactorid/state/key1", nil)
 			require.NoError(c, err)
-			resp, err := client.Do(req)
+			//nolint:bodyclose
+			resp, err = client.Do(req)
 			require.NoError(c, err)
-			body, err := io.ReadAll(resp.Body)
+			var body []byte
+			body, err = io.ReadAll(resp.Body)
 			require.NoError(c, err)
 			assert.NoError(c, resp.Body.Close())
 			assert.Empty(c, string(body))


### PR DESCRIPTION
PR adds a check to ensure actor state key TTLs can be extended.