### PR TITLE
Integration: Reduce test output noise when focusing tests

### DIFF
--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -45,12 +45,19 @@ func RunIntegrationTests(t *testing.T) {
 	})
 	require.False(t, binFailed, "building binaries must succeed")
 
+	focusedTests := make(map[string]suite.Case)
 	for name, tcase := range suite.All(t) {
-		t.Run(name, func(t *testing.T) {
-			if !focus.MatchString(t.Name()) {
-				t.Skipf("skipping test case due to focus %s", t.Name())
-			}
+		// Continue rather than using `t.Skip` to reduce the noise in the test
+		// output.
+		if !focus.MatchString(name) {
+			t.Logf("skipping test case due to focus %s", name)
+			continue
+		}
+		focusedTests[name] = tcase
+	}
 
+	for name, tcase := range focusedTests {
+		t.Run(name, func(t *testing.T) {
 			t.Logf("setting up test case")
 			options := tcase.Setup(t)
 


### PR DESCRIPTION
In integration tests, ee currently use `t.Skip` when skipping tests that don't match on the given focus (`-focus`). This results in noisy test output which makes it difficult to parse results on tests which the developer cares about.

PR updates the integration test framework to not register focused tests at all and instead only print a test log line, greatly reducing the noise when running tests with `-focus` and allowing better human parsing of results.
