### PR TITLE
Change target qps for actor reminder test

### DIFF
--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -39,7 +39,7 @@ const (
 	appName         = "perf-actor-reminder-service"
 
 	// Target for the QPS
-	targetQPS = 50
+	targetQPS = 36
 )
 
 var tr *runner.TestRunner


### PR DESCRIPTION
The move to PostgreSQL for actor tests reduced the actual QPS from +50 to ~38. This PR changes the target QPS accordingly so performance tests can run to completion again.
