### PR TITLE
Updates dapr/kit and dapr/components-contrib to HEAD

### DIFF
--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -128,11 +128,16 @@ func main() {
 	}
 
 	// Watch for changes in the watchDir
-	err = mngr.Add(func(ctx context.Context) error {
-		log.Infof("Starting watch on filesystem directory: %s", watchDir)
-		return fswatcher.Watch(ctx, watchDir, issuerEvent)
+	fs, err := fswatcher.New(fswatcher.Options{
+		Targets: []string{watchDir},
 	})
 	if err != nil {
+		log.Fatal(err)
+	}
+	if err = mngr.Add(func(ctx context.Context) error {
+		log.Infof("Starting watch on filesystem directory: %s", watchDir)
+		return fs.Run(ctx, issuerEvent)
+	}); err != nil {
 		log.Fatal(err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cloudevents/sdk-go/v2 v2.14.0
-	github.com/dapr/components-contrib v1.12.1-0.20231129042434-36a055ebd8d7
-	github.com/dapr/kit v0.12.2-0.20231031211530-0e1fd37fc4b3
+	github.com/dapr/components-contrib v1.12.1-0.20231204210358-79adc565c17a
+	github.com/dapr/kit v0.12.2-0.20231116003620-df64d3a144b3
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -405,10 +405,10 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.12.1-0.20231129042434-36a055ebd8d7 h1:f0n7cuFO2OTdeLwNDsdNs7eLwfIuhKCXi/Aeh/IbYXA=
-github.com/dapr/components-contrib v1.12.1-0.20231129042434-36a055ebd8d7/go.mod h1:s4vy1EFMh/9xMoeD0FvIH2D1LI3BHutzRwT1yKxGD+c=
-github.com/dapr/kit v0.12.2-0.20231031211530-0e1fd37fc4b3 h1:xsmVK3YOKRMOcaxqo50Ce0apQzq+LzAfWuFapQuu8Ro=
-github.com/dapr/kit v0.12.2-0.20231031211530-0e1fd37fc4b3/go.mod h1:c3Z78F+h7UYtb0LmpzJNC/ChT240ycDJFViRUztdpoo=
+github.com/dapr/components-contrib v1.12.1-0.20231204210358-79adc565c17a h1:4QIQrWZwcRQR11oUTcoLddxd85xdKG9+/0xpmGCDw1Y=
+github.com/dapr/components-contrib v1.12.1-0.20231204210358-79adc565c17a/go.mod h1:s4vy1EFMh/9xMoeD0FvIH2D1LI3BHutzRwT1yKxGD+c=
+github.com/dapr/kit v0.12.2-0.20231116003620-df64d3a144b3 h1:fqyFPfsGznKYlqR6jWHd9ZxcedgohkOY2IkLLO4h9pk=
+github.com/dapr/kit v0.12.2-0.20231116003620-df64d3a144b3/go.mod h1:c3Z78F+h7UYtb0LmpzJNC/ChT240ycDJFViRUztdpoo=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -101,6 +101,9 @@ func Test_Start(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		// Override the default of 500ms to 0 to speed up the test.
+		p.(*provider).fswatcherInterval = 0
+
 		ctx, cancel := context.WithCancel(context.Background())
 
 		providerStopped := make(chan struct{})


### PR DESCRIPTION
Updates dapr/kit and dapr/components-contrib to HEAD. This primarily includes updating the fswatcher from the old `fswatcher.Watch` to the new `fs, err := fswatcher.New(fswatcher.Options)` & `fs.Run` pattern.

`pkg/security` Provider now includes a `fswatcherInterval` option which is used as the trust bundle fswatcher interval duration. This is the interval to batch file events for the same file in fswatcher. This is always set to 500ms except for tests where it is set to 0 to speed up the test run. We want to keep this at 500ms as the live value to reduce CPU & IO usage on trust bundle file event churn which occurs on Kubernetes volumes or some text editors on "single" write events.

https://ahmet.im/blog/kubernetes-inotify/
https://www.extrema.is/blog/2022/03/04/vim-and-inotify

---

With these changes not in master, other developers wanting to make changes to dapr/dapr with an updated dapr/kit branch have to write these changes themself which is a pain & adds noise to PRs. I think moving forward, we should make an effort to ensure any updates to dapr/kit & dapr/components-contrib, particularly breaking changes, are updated in the dapr/dapr go.mod and merged into master as soon as possible. We can make the go.mod dapr/dapr PR a prereq like we do for docs PRs on new Dapr features.