### PR TITLE
add header to issue template for minor patch release

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor-patch-release.md
+++ b/.github/ISSUE_TEMPLATE/minor-patch-release.md
@@ -1,3 +1,11 @@
+---
+name: Minor Patch Release
+about: Minor Patch Release
+title: 'Minor Patch Release Checklist'
+labels: kind/bug
+assignees: ''
+---
+
 - [ ] Dapr maintainer(s) communicate out the discovery of issues that require a patch release and the reason why to the Discord Maintainers and Release channels. Patch releases are made for one of categories below:
     - [ ] Security vulnerability
         - <>


### PR DESCRIPTION
Adding header so that the minor patch release checklist shows up as an issue template. I didn't realize it was needed in order to show up.