### PR TITLE
add kit commented out in go.mod for easier uncommenting later

### DIFF
--- a/.github/scripts/check_go_mod.mjs
+++ b/.github/scripts/check_go_mod.mjs
@@ -2,10 +2,11 @@
 
 import { readFile } from 'node:fs/promises'
 
-const match = `// Uncomment for local development for testing with changes in the components-contrib repository.
+const match = `// Uncomment for local development for testing with changes in the components-contrib && kit repositories.
 // Don't commit with this uncommented!
 //
 // replace github.com/dapr/components-contrib => ../components-contrib
+// replace github.com/dapr/kit => ../kit
 //
 // Then, run \`make modtidy\` in this repository.
 // This ensures that go.mod and go.sum are up-to-date.`

--- a/.github/scripts/check_go_mod.mjs
+++ b/.github/scripts/check_go_mod.mjs
@@ -8,8 +8,8 @@ const match = `// Uncomment for local development for testing with changes in th
 // replace github.com/dapr/components-contrib => ../components-contrib
 // replace github.com/dapr/kit => ../kit
 //
-// Then, run \`make modtidy\` in this repository.
-// This ensures that go.mod and go.sum are up-to-date.`
+// Then, run \`make modtidy-all\` in this repository.
+// This ensures that go.mod and go.sum are up-to-date for each go.mod file.`
 
 const read = await readFile('go.mod', { encoding: 'utf8' })
 if (!read.includes(match)) {

--- a/go.mod
+++ b/go.mod
@@ -468,5 +468,5 @@ replace github.com/microcosm-cc/bluemonday => github.com/microcosm-cc/bluemonday
 // replace github.com/dapr/components-contrib => ../components-contrib
 // replace github.com/dapr/kit => ../kit
 //
-// Then, run `make modtidy` in this repository.
-// This ensures that go.mod and go.sum are up-to-date.
+// Then, run `make modtidy-all` in this repository.
+// This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.mod
+++ b/go.mod
@@ -462,10 +462,11 @@ replace (
 // check for retracted versions: go list -mod=mod -f '{{if .Retracted}}{{.}}{{end}}' -u -m all
 replace github.com/microcosm-cc/bluemonday => github.com/microcosm-cc/bluemonday v1.0.24
 
-// Uncomment for local development for testing with changes in the components-contrib repository.
+// Uncomment for local development for testing with changes in the components-contrib && kit repositories.
 // Don't commit with this uncommented!
 //
 // replace github.com/dapr/components-contrib => ../components-contrib
+// replace github.com/dapr/kit => ../kit
 //
 // Then, run `make modtidy` in this repository.
 // This ensures that go.mod and go.sum are up-to-date.


### PR DESCRIPTION
Adding kit uncommented out to go.mod for easier uncommenting later when working with local kit changes.
