### PR TITLE
Update k6 dependency to fix perf test build

### DIFF
--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -1,8 +1,8 @@
 # Build the k6 binary with the extension
-FROM golang:1.21 as builder
+FROM golang:1.20 as builder
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest
-RUN xk6 build --output /k6 --with github.com/grafana/xk6-output-prometheus-remote@v0.1.0 --with github.com/grafana/xk6-disruptor@350f53204c65040e71757f98a330665a8f189f91
+RUN xk6 build --output /k6 --with github.com/grafana/xk6-output-prometheus-remote@v0.3.1 --with github.com/grafana/xk6-disruptor@350f53204c65040e71757f98a330665a8f189f91
 
 # Use the operator's base image and override the k6 binary
 FROM loadimpact/k6:latest

--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -1,5 +1,5 @@
 # Build the k6 binary with the extension
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest
 RUN xk6 build --output /k6 --with github.com/grafana/xk6-output-prometheus-remote@v0.3.1 --with github.com/grafana/xk6-disruptor@350f53204c65040e71757f98a330665a8f189f91


### PR DESCRIPTION
Perf tests on master branch fail to build due to an error with a k6 dependency. This is an attempt to upgrade to a version that doesn't have the issue.