### PR TITLE
Add DAPR_GO_BUILD_TAGS=wfbackendsqlite for e2e test

### DIFF
--- a/.github/workflows/dapr-perf-components.yml
+++ b/.github/workflows/dapr-perf-components.yml
@@ -258,6 +258,7 @@ jobs:
           echo "DAPR_TAG=${TEST_PREFIX}" >> $GITHUB_ENV
           echo "DAPR_TEST_TAG=${TEST_PREFIX}" >> $GITHUB_ENV
           echo "TEST_RESOURCE_GROUP=Dapr-Perf-${TEST_PREFIX}" >> $GITHUB_ENV
+          echo "DAPR_GO_BUILD_TAGS=wfbackendsqlite" >> $GITHUB_ENV
         shell: bash
       - name: Build dapr and its docker image
         if: env.TEST_PREFIX != ''

--- a/.github/workflows/dapr-perf.yml
+++ b/.github/workflows/dapr-perf.yml
@@ -280,6 +280,7 @@ jobs:
           echo "DAPR_TAG=${TEST_PREFIX}" >> $GITHUB_ENV
           echo "DAPR_TEST_TAG=${TEST_PREFIX}" >> $GITHUB_ENV
           echo "TEST_RESOURCE_GROUP=Dapr-Perf-${TEST_PREFIX}" >> $GITHUB_ENV
+          echo "DAPR_GO_BUILD_TAGS=wfbackendsqlite" >> $GITHUB_ENV
         shell: bash
       - name: Build dapr and its docker image
         if: env.TEST_PREFIX != ''

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -330,6 +330,7 @@ jobs:
           echo "DAPR_TEST_TAG=${TEST_PREFIX}" >> $GITHUB_ENV
           echo "TEST_RESOURCE_GROUP=Dapr-E2E-${TEST_PREFIX}" >> $GITHUB_ENV
           echo "WINDOWS_VERSION=${{ matrix.windows_version }}" >> $GITHUB_ENV
+          echo "DAPR_GO_BUILD_TAGS=wfbackendsqlite" >> $GITHUB_ENV
         shell: bash
       - name: Build Dapr and its Docker images
         if: env.TEST_PREFIX != ''


### PR DESCRIPTION
# Description

This PR adds DAPR_GO_BUILD_TAGS=wfbackendsqlite for e2e tests, where it is required to load sqlite backend component in dapr binaries for e2e tests related to sqlite backend.

This will fix the failing e2e tests [here](https://github.com/dapr/dapr/actions/runs/7498321229/job/20413628280#step:21:1726) for [this PR](https://github.com/dapr/dapr/pull/7283/files) related to configurable backend.
