### PR TITLE
Update placement API Level gRPC context key to `dapr-placement-api-level`

### DIFF
--- a/pkg/actors/placement/client.go
+++ b/pkg/actors/placement/client.go
@@ -18,10 +18,10 @@ import (
 	"strconv"
 	"sync"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	"google.golang.org/grpc"
-
+	"github.com/dapr/dapr/pkg/placement"
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 )
 
@@ -66,7 +66,7 @@ func (c *placementClient) connectToServer(ctx context.Context, serverAddr string
 	}
 
 	client := v1pb.NewPlacementClient(conn)
-	ctx = metadata.AppendToOutgoingContext(ctx, "ApiLevel", strconv.Itoa(int(apiLevel)))
+	ctx = metadata.AppendToOutgoingContext(ctx, placement.GRPCContextKeyAPILevel, strconv.Itoa(int(apiLevel)))
 	stream, err := client.ReportDaprStatus(ctx)
 	if err != nil {
 		if conn != nil {

--- a/pkg/actors/placement/client_test.go
+++ b/pkg/actors/placement/client_test.go
@@ -89,13 +89,13 @@ func TestConnectToServer(t *testing.T) {
 		err := client.connectToServer(context.Background(), conn, 10)
 		require.NoError(t, err)
 
-		// Extract the "ApiLevel" value from the context's metadata
+		// Extract the "dapr-placement-api-level" value from the context's metadata
 		md, ok := metadata.FromOutgoingContext(client.clientStream.Context())
 		require.True(t, ok)
 
 		// All keys in the returned MD are lowercase, as per the http spec for header fields
 		// https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
-		apiLevelValues := md["apilevel"]
+		apiLevelValues := md["dapr-placement-api-level"]
 		require.Len(t, apiLevelValues, 1)
 
 		apiLevelStr := apiLevelValues[0]

--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -37,6 +37,7 @@ const (
 	raftApplyCommandMaxConcurrency          = 10
 	barrierWriteTimeout                     = 2 * time.Minute
 	NoVirtualNodesInPlacementTablesAPILevel = 20
+	GRPCContextKeyAPILevel                  = "dapr-placement-api-level"
 )
 
 // MonitorLeadership is used to monitor if we acquire or lose our role
@@ -480,7 +481,7 @@ func getHostAPILevel(stream placementGRPCStream) int {
 	}
 
 	// Extract apiLevel from metadata
-	apiLevel := md.Get("ApiLevel")
+	apiLevel := md.Get(GRPCContextKeyAPILevel)
 	if len(apiLevel) == 0 {
 		return 0
 	}

--- a/tests/integration/suite/placement/apilevel/shared.go
+++ b/tests/integration/suite/placement/apilevel/shared.go
@@ -59,7 +59,7 @@ func registerHost(t *testing.T, ctx context.Context, conn *grpc.ClientConn, name
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		client := placementv1pb.NewPlacementClient(conn)
-		ctx = metadata.AppendToOutgoingContext(ctx, "ApiLevel", strconv.Itoa(apiLevel))
+		ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(apiLevel))
 
 		stream, rErr := client.ReportDaprStatus(ctx)
 		//nolint:testifylint

--- a/tests/integration/suite/placement/authz/mtls.go
+++ b/tests/integration/suite/placement/authz/mtls.go
@@ -98,7 +98,7 @@ func (m *mtls) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	client := v1pb.NewPlacementClient(conn)
-	ctx = metadata.AppendToOutgoingContext(ctx, "ApiLevel", strconv.Itoa(m.place.CurrentActorsAPILevel()))
+	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(m.place.CurrentActorsAPILevel()))
 
 	// Can only create hosts where the app ID match.
 	stream := establishStream(t, ctx, client)

--- a/tests/integration/suite/placement/authz/nomtls.go
+++ b/tests/integration/suite/placement/authz/nomtls.go
@@ -58,7 +58,7 @@ func (n *nomtls) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
 	client := v1pb.NewPlacementClient(conn)
-	ctx = metadata.AppendToOutgoingContext(ctx, "ApiLevel", strconv.Itoa(n.place.CurrentActorsAPILevel()))
+	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(n.place.CurrentActorsAPILevel()))
 
 	// Can create hosts with any appIDs or namespaces.
 	stream := establishStream(t, ctx, client)

--- a/tests/integration/suite/placement/quorum/insecure.go
+++ b/tests/integration/suite/placement/quorum/insecure.go
@@ -122,7 +122,7 @@ func (i *insecure) Run(t *testing.T, ctx context.Context) {
 		}
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 		client := v1pb.NewPlacementClient(conn)
-		ctx = metadata.AppendToOutgoingContext(ctx, "ApiLevel", strconv.Itoa(i.places[j].CurrentActorsAPILevel()))
+		ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(i.places[j].CurrentActorsAPILevel()))
 
 		stream, err = client.ReportDaprStatus(ctx)
 		if err != nil {

--- a/tests/integration/suite/placement/quorum/jwks.go
+++ b/tests/integration/suite/placement/quorum/jwks.go
@@ -167,7 +167,7 @@ func (j *jwks) Run(t *testing.T, ctx context.Context) {
 		}
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 		client := v1pb.NewPlacementClient(conn)
-		ctx = metadata.AppendToOutgoingContext(ctx, "ApiLevel", strconv.Itoa(j.places[i].CurrentActorsAPILevel()))
+		ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(j.places[i].CurrentActorsAPILevel()))
 
 		stream, err = client.ReportDaprStatus(ctx)
 		if err != nil {

--- a/tests/integration/suite/placement/quorum/notls.go
+++ b/tests/integration/suite/placement/quorum/notls.go
@@ -83,7 +83,7 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		}
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 		client := v1pb.NewPlacementClient(conn)
-		ctx = metadata.AppendToOutgoingContext(ctx, "ApiLevel", strconv.Itoa(n.places[j].CurrentActorsAPILevel()))
+		ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(n.places[j].CurrentActorsAPILevel()))
 
 		stream, err = client.ReportDaprStatus(ctx)
 		if err != nil {


### PR DESCRIPTION
Updates the placement API Level gRPC context key from `ApiLevel` to `dapr-placement-api-level`. Although collisions are highly unlikely, it could be considered more "correct" and best practice to namespace our application specific metadata keys. It could also help in downstream tracers and metric consumers debugging RPCs.

This isn't a breaking change as this key hasn't been part of a release yet.

cc @elena-kolevska 