### PR TITLE
Integration: flake on Windows (mtls standalone disable)

### DIFF
--- a/tests/integration/suite/daprd/mtls/standalone/disable.go
+++ b/tests/integration/suite/daprd/mtls/standalone/disable.go
@@ -15,6 +15,8 @@ package standalone
 
 import (
 	"context"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,10 +120,17 @@ func (e *disable) Run(t *testing.T, ctx context.Context) {
 		myAppID, err := spiffeid.FromSegments(spiffeid.RequireTrustDomainFromString("public"), "ns", "default", "my-app")
 		require.NoError(t, err)
 
-		gctx, gcancel := context.WithTimeout(ctx, time.Second)
-		t.Cleanup(gcancel)
-		_, err = grpc.DialContext(gctx, e.daprd.InternalGRPCAddress(), sec.GRPCDialOptionMTLS(myAppID),
-			grpc.WithReturnConnectionError())
+		assert.Eventually(t, func() bool {
+			gctx, gcancel := context.WithTimeout(ctx, time.Second)
+			t.Cleanup(gcancel)
+			_, err = grpc.DialContext(gctx, e.daprd.InternalGRPCAddress(), sec.GRPCDialOptionMTLS(myAppID),
+				grpc.WithReturnConnectionError())
+			require.Error(t, err)
+			if runtime.GOOS == "windows" {
+				return !strings.Contains(err.Error(), "An existing connection was forcibly closed by the remote host.")
+			}
+			return true
+		}, 5*time.Second, 100*time.Millisecond)
 		require.ErrorContains(t, err, "tls: first record does not look like a TLS handshake")
 	})
 }


### PR DESCRIPTION
Account for Windows specific host connection errors in the mtls standalone disable test. This makes parity with the kubernetes test.

https://github.com/dapr/dapr/blob/4bea8385796e097d14932d27a744a18b4dafe298/tests/integration/suite/daprd/mtls/kubernetes/disable.go#L140-L152