### PR TITLE
append app token to outgoing calls, if it is provided

### DIFF
--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -31,6 +31,8 @@ import (
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/proto/common/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/security"
+	securityConsts "github.com/dapr/dapr/pkg/security/consts"
 )
 
 // Proxy is the interface for a gRPC transparent proxy.
@@ -136,6 +138,11 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 	)
 	outCtx = p.telemetryFn(outCtx)
 	outCtx = metadata.AppendToOutgoingContext(outCtx, invokev1.CallerIDHeader, p.appID, invokev1.CalleeIDHeader, target.id)
+
+	var appMetadataToken = security.GetAppToken()
+	if appMetadataToken != "" {
+		outCtx = metadata.AppendToOutgoingContext(outCtx, securityConsts.APITokenHeader, appMetadataToken)
+	}
 
 	pt := &grpcProxy.ProxyTarget{
 		ID:        target.id,

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -139,7 +139,7 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 	outCtx = p.telemetryFn(outCtx)
 	outCtx = metadata.AppendToOutgoingContext(outCtx, invokev1.CallerIDHeader, p.appID, invokev1.CalleeIDHeader, target.id)
 
-	var appMetadataToken = security.GetAppToken()
+	appMetadataToken := security.GetAppToken()
 	if appMetadataToken != "" {
 		outCtx = metadata.AppendToOutgoingContext(outCtx, securityConsts.APITokenHeader, appMetadataToken)
 	}


### PR DESCRIPTION
# Description
This PR appends the App API Token to calls made using the transparent proxy functionality provided in grpc_proxy.go
It will only be appended if the environment variable exists

## Issue reference

#7344   

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
