### PR TITLE
Fix vnode calculation in placement clients.

### DIFF
--- a/cmd/placement/app/app.go
+++ b/cmd/placement/app/app.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dapr/dapr/pkg/metrics"
 	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/placement"
-	"github.com/dapr/dapr/pkg/placement/hashing"
 	"github.com/dapr/dapr/pkg/placement/monitoring"
 	"github.com/dapr/dapr/pkg/placement/raft"
 	"github.com/dapr/dapr/pkg/security"
@@ -58,10 +57,11 @@ func Run() {
 
 	// Start Raft cluster.
 	raftServer := raft.New(raft.Options{
-		ID:           opts.RaftID,
-		InMem:        opts.RaftInMemEnabled,
-		Peers:        opts.RaftPeers,
-		LogStorePath: opts.RaftLogStorePath,
+		ID:                opts.RaftID,
+		InMem:             opts.RaftInMemEnabled,
+		Peers:             opts.RaftPeers,
+		LogStorePath:      opts.RaftLogStorePath,
+		ReplicationFactor: int64(opts.ReplicationFactor),
 	})
 	if raftServer == nil {
 		log.Fatal("Failed to create raft server.")
@@ -80,8 +80,6 @@ func Run() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	hashing.SetReplicationFactor(opts.ReplicationFactor)
 
 	placementOpts := placement.PlacementServiceOpts{
 		RaftNode:    raftServer,

--- a/pkg/actors/placement/client.go
+++ b/pkg/actors/placement/client.go
@@ -15,13 +15,10 @@ package placement
 
 import (
 	"context"
-	"strconv"
 	"sync"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 
-	"github.com/dapr/dapr/pkg/placement"
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 )
 
@@ -66,7 +63,6 @@ func (c *placementClient) connectToServer(ctx context.Context, serverAddr string
 	}
 
 	client := v1pb.NewPlacementClient(conn)
-	ctx = metadata.AppendToOutgoingContext(ctx, placement.GRPCContextKeyAPILevel, strconv.Itoa(int(apiLevel)))
 	stream, err := client.ReportDaprStatus(ctx)
 	if err != nil {
 		if conn != nil {

--- a/pkg/actors/placement/client_test.go
+++ b/pkg/actors/placement/client_test.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 	"testing"
 
-	"google.golang.org/grpc/metadata"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -88,18 +86,6 @@ func TestConnectToServer(t *testing.T) {
 
 		err := client.connectToServer(context.Background(), conn, 10)
 		require.NoError(t, err)
-
-		// Extract the "dapr-placement-api-level" value from the context's metadata
-		md, ok := metadata.FromOutgoingContext(client.clientStream.Context())
-		require.True(t, ok)
-
-		// All keys in the returned MD are lowercase, as per the http spec for header fields
-		// https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2
-		apiLevelValues := md["dapr-placement-api-level"]
-		require.Len(t, apiLevelValues, 1)
-
-		apiLevelStr := apiLevelValues[0]
-		require.Equal(t, "10", apiLevelStr)
 	})
 }
 

--- a/pkg/placement/hashing/consistent_hash_test.go
+++ b/pkg/placement/hashing/consistent_hash_test.go
@@ -34,9 +34,7 @@ func TestReplicationFactor(t *testing.T) {
 		factors := []int{1, 100, 1000, 10000}
 
 		for _, f := range factors {
-			SetReplicationFactor(f)
-
-			h := NewConsistentHash()
+			h := NewConsistentHash(f)
 			for _, n := range nodes {
 				s := h.Add(n, n, 1)
 				assert.False(t, s)
@@ -65,13 +63,6 @@ func TestReplicationFactor(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestSetReplicationFactor(t *testing.T) {
-	f := 10
-	SetReplicationFactor(f)
-
-	assert.Equal(t, f, replicationFactor)
 }
 
 func TestGetAndSetVirtualNodeCacheHashes(t *testing.T) {

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -282,7 +282,7 @@ func TestPerformTableUpdate(t *testing.T) {
 	testServer.streamConnPoolLock.RUnlock()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	require.NoError(t, testServer.performTablesUpdate(ctx, streamConnPool, nil, nil))
+	require.NoError(t, testServer.performTablesUpdate(ctx, streamConnPool, nil))
 
 	// assert
 	for i := 0; i < testClients; i++ {

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -250,19 +250,9 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 				registeredMemberID = req.GetName()
 				p.addStreamConn(stream)
 				// We need to use a background context here so dissemination isn't tied to the context of this stream
-				// TODO: If each sidecar can report table version, then placement
-				// doesn't need to disseminate tables to each sidecar.
+				placementTable := p.raftNode.FSM().PlacementState(p.minAPILevel < NoVirtualNodesInPlacementTablesAPILevel)
 
-				placementTable := &placementv1pb.PlacementTables{}
-				placementTableWithVirtualNodes := &placementv1pb.PlacementTables{}
-				apiLevel := req.GetApiLevel()
-				if apiLevel >= NoVirtualNodesInPlacementTablesAPILevel {
-					placementTable = p.raftNode.FSM().PlacementState(false)
-				} else {
-					placementTableWithVirtualNodes = p.raftNode.FSM().PlacementState(true)
-				}
-
-				err = p.performTablesUpdate(context.Background(), []placementGRPCStream{stream}, placementTable, placementTableWithVirtualNodes)
+				err = p.performTablesUpdate(context.Background(), []placementGRPCStream{stream}, placementTable)
 				if err != nil {
 					return err
 				}

--- a/pkg/placement/raft/fsm_test.go
+++ b/pkg/placement/raft/fsm_test.go
@@ -18,15 +18,13 @@ import (
 	"io"
 	"testing"
 
-	"github.com/dapr/dapr/pkg/placement/hashing"
-
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFSMApply(t *testing.T) {
-	fsm := newFSM()
+	fsm := newFSM(100)
 
 	t.Run("upsertMember", func(t *testing.T) {
 		cmdLog, err := makeRaftLogCommand(MemberUpsert, DaprHostMember{
@@ -79,9 +77,9 @@ func TestFSMApply(t *testing.T) {
 
 func TestRestore(t *testing.T) {
 	// arrange
-	fsm := newFSM()
+	fsm := newFSM(100)
 
-	s := newDaprHostMemberState()
+	s := newDaprHostMemberState(100)
 	s.upsertMember(&DaprHostMember{
 		Name:     "127.0.0.1:8080",
 		AppID:    "FakeID",
@@ -101,9 +99,7 @@ func TestRestore(t *testing.T) {
 }
 
 func TestPlacementStateWithVirtualNodes(t *testing.T) {
-	hashing.SetReplicationFactor(100)
-
-	fsm := newFSM()
+	fsm := newFSM(100)
 	m := DaprHostMember{
 		Name:     "127.0.0.1:3030",
 		AppID:    "fakeAppID",
@@ -134,9 +130,7 @@ func TestPlacementStateWithVirtualNodes(t *testing.T) {
 }
 
 func TestPlacementState(t *testing.T) {
-	hashing.SetReplicationFactor(100)
-
-	fsm := newFSM()
+	fsm := newFSM(100)
 	m := DaprHostMember{
 		Name:     "127.0.0.1:3030",
 		AppID:    "fakeAppID",

--- a/pkg/placement/raft/server.go
+++ b/pkg/placement/raft/server.go
@@ -77,11 +77,12 @@ type Server struct {
 }
 
 type Options struct {
-	ID           string
-	InMem        bool
-	Peers        []PeerInfo
-	LogStorePath string
-	Clock        clock.Clock
+	ID                string
+	InMem             bool
+	Peers             []PeerInfo
+	LogStorePath      string
+	Clock             clock.Clock
+	ReplicationFactor int64
 }
 
 // New creates Raft server node.
@@ -104,6 +105,7 @@ func New(opts Options) *Server {
 		raftLogStorePath: opts.LogStorePath,
 		clock:            cl,
 		raftReady:        make(chan struct{}),
+		fsm:              newFSM(opts.ReplicationFactor),
 	}
 }
 
@@ -152,8 +154,6 @@ func (s *Server) StartRaft(ctx context.Context, sec security.Handler, config *ra
 			}
 		}
 	}()
-
-	s.fsm = newFSM()
 
 	addr, err := s.tryResolveRaftAdvertiseAddr(ctx, s.raftBind)
 	if err != nil {

--- a/pkg/placement/raft/snapshot_test.go
+++ b/pkg/placement/raft/snapshot_test.go
@@ -42,7 +42,7 @@ func (m *MockSnapShotSink) Close() error {
 
 func TestPersist(t *testing.T) {
 	// arrange
-	fsm := newFSM()
+	fsm := newFSM(10)
 	testMember := DaprHostMember{
 		Name:     "127.0.0.1:3030",
 		AppID:    "fakeAppID",
@@ -65,7 +65,7 @@ func TestPersist(t *testing.T) {
 	snap.Persist(fakeSink)
 
 	// assert
-	restoredState := newDaprHostMemberState()
+	restoredState := newDaprHostMemberState(10)
 	err = restoredState.restore(buf)
 	require.NoError(t, err)
 

--- a/pkg/placement/raft/state_test.go
+++ b/pkg/placement/raft/state_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestNewDaprHostMemberState(t *testing.T) {
 	// act
-	s := newDaprHostMemberState()
+	s := newDaprHostMemberState(10)
 
 	// assert
 	assert.Equal(t, uint64(0), s.Index())
@@ -31,7 +31,7 @@ func TestNewDaprHostMemberState(t *testing.T) {
 
 func TestClone(t *testing.T) {
 	// arrange
-	s := newDaprHostMemberState()
+	s := newDaprHostMemberState(10)
 	s.upsertMember(&DaprHostMember{
 		Name:     "127.0.0.1:8080",
 		AppID:    "FakeID",
@@ -50,7 +50,7 @@ func TestClone(t *testing.T) {
 
 func TestUpsertMember(t *testing.T) {
 	// arrange
-	s := newDaprHostMemberState()
+	s := newDaprHostMemberState(10)
 
 	t.Run("add new actor member", func(t *testing.T) {
 		// act
@@ -131,7 +131,7 @@ func TestUpsertMember(t *testing.T) {
 
 func TestRemoveMember(t *testing.T) {
 	// arrange
-	s := newDaprHostMemberState()
+	s := newDaprHostMemberState(10)
 
 	t.Run("remove member and clean up consistent hashing table", func(t *testing.T) {
 		// act
@@ -174,7 +174,7 @@ func TestUpdateHashingTable(t *testing.T) {
 	// each subtest has dependency on the state
 
 	// arrange
-	s := newDaprHostMemberState()
+	s := newDaprHostMemberState(10)
 
 	t.Run("add new hashing table per actor types", func(t *testing.T) {
 		testMember := &DaprHostMember{
@@ -227,7 +227,7 @@ func TestRemoveHashingTable(t *testing.T) {
 		{"127.0.0.1:8081", 0},
 	}
 
-	s := newDaprHostMemberState()
+	s := newDaprHostMemberState(10)
 	for _, tc := range testcases {
 		testMember.Name = tc.name
 		s.updateHashingTables(testMember)

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/slowappstartup.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/slowappstartup.go
@@ -105,7 +105,7 @@ func (s *slowappstartup) Run(t *testing.T, ctx context.Context) {
 		resp, err = client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
 			Id: s.daprd.AppID(),
 			Message: &commonv1.InvokeRequest{
-				Method: "Ping",
+				Method: "TiggerCallbBack",
 				Data:   req,
 			},
 		})

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/slowappstartup.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/slowappstartup.go
@@ -105,7 +105,7 @@ func (s *slowappstartup) Run(t *testing.T, ctx context.Context) {
 		resp, err = client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
 			Id: s.daprd.AppID(),
 			Message: &commonv1.InvokeRequest{
-				Method: "TiggerCallbBack",
+				Method: "Ping",
 				Data:   req,
 			},
 		})

--- a/tests/integration/suite/placement/apilevel/shared.go
+++ b/tests/integration/suite/placement/apilevel/shared.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/metadata"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -59,7 +57,6 @@ func registerHost(t *testing.T, ctx context.Context, conn *grpc.ClientConn, name
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		client := placementv1pb.NewPlacementClient(conn)
-		ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(apiLevel))
 
 		stream, rErr := client.ReportDaprStatus(ctx)
 		//nolint:testifylint

--- a/tests/integration/suite/placement/authz/mtls.go
+++ b/tests/integration/suite/placement/authz/mtls.go
@@ -17,11 +17,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
-
-	"google.golang.org/grpc/metadata"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
@@ -98,7 +95,6 @@ func (m *mtls) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	client := v1pb.NewPlacementClient(conn)
-	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(m.place.CurrentActorsAPILevel()))
 
 	// Can only create hosts where the app ID match.
 	stream := establishStream(t, ctx, client)

--- a/tests/integration/suite/placement/authz/nomtls.go
+++ b/tests/integration/suite/placement/authz/nomtls.go
@@ -15,10 +15,7 @@ package authz
 
 import (
 	"context"
-	"strconv"
 	"testing"
-
-	"google.golang.org/grpc/metadata"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -58,7 +55,6 @@ func (n *nomtls) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
 	client := v1pb.NewPlacementClient(conn)
-	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(n.place.CurrentActorsAPILevel()))
 
 	// Can create hosts with any appIDs or namespaces.
 	stream := establishStream(t, ctx, client)

--- a/tests/integration/suite/placement/quorum/jwks.go
+++ b/tests/integration/suite/placement/quorum/jwks.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/metadata"
-
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -167,7 +165,6 @@ func (j *jwks) Run(t *testing.T, ctx context.Context) {
 		}
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 		client := v1pb.NewPlacementClient(conn)
-		ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(j.places[i].CurrentActorsAPILevel()))
 
 		stream, err = client.ReportDaprStatus(ctx)
 		if err != nil {

--- a/tests/integration/suite/placement/quorum/notls.go
+++ b/tests/integration/suite/placement/quorum/notls.go
@@ -16,11 +16,8 @@ package quorum
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
-
-	"google.golang.org/grpc/metadata"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,7 +80,6 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		}
 		t.Cleanup(func() { require.NoError(t, conn.Close()) })
 		client := v1pb.NewPlacementClient(conn)
-		ctx = metadata.AppendToOutgoingContext(ctx, "dapr-placement-api-level", strconv.Itoa(n.places[j].CurrentActorsAPILevel()))
 
 		stream, err = client.ReportDaprStatus(ctx)
 		if err != nil {


### PR DESCRIPTION
Fixes vnode response to placement clients to be backwards compatible. Makes the API level check based on cluster level, rather than on a per request basis. Remove placement API level gRPC context metadata.

Fix piping the replication factor config to consistent hashing.

Use local hashing in daprd based on the placement API level of the cluster.

We still need to add integration tests which check the contents on the placement decimation response for the expected presence of vnodes, and the current expected API level.
