### PR TITLE
Make Workflow `dapr` Component internal

### DIFF
--- a/pkg/runtime/hotreload/differ/differ.go
+++ b/pkg/runtime/hotreload/differ/differ.go
@@ -24,6 +24,8 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/wfengine"
 )
 
+var wfengineComp = wfengine.ComponentDefinition()
+
 // Resource is a generic type constraint.
 type Resource interface {
 	componentsapi.Component
@@ -63,8 +65,8 @@ func Diff[T Resource](resources *LocalRemoteResources[T]) *Result[T] {
 				return true
 			}
 
-			if comp.Name == wfengine.ComponentDefinition.Name &&
-				comp.Spec.Type == wfengine.ComponentDefinition.Spec.Type {
+			if comp.Name == wfengineComp.Name &&
+				comp.Spec.Type == wfengineComp.Spec.Type {
 				return true
 			}
 		}

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -48,8 +48,7 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/processor/pubsub"
 	"github.com/dapr/dapr/pkg/runtime/processor/secret"
 	"github.com/dapr/dapr/pkg/runtime/processor/state"
-	wfbeProcessor "github.com/dapr/dapr/pkg/runtime/processor/wfbackend"
-	"github.com/dapr/dapr/pkg/runtime/processor/workflow"
+	"github.com/dapr/dapr/pkg/runtime/processor/wfbackend"
 	"github.com/dapr/dapr/pkg/runtime/registry"
 	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/logger"
@@ -170,7 +169,7 @@ func New(opts Options) *Processor {
 		Channels:       opts.Channels,
 	})
 
-	wfbe := wfbeProcessor.New(wfbeProcessor.Options{
+	wfbe := wfbackend.New(wfbackend.Options{
 		AppID:          opts.ID,
 		Registry:       opts.Registry.WorkflowBackends(),
 		ComponentStore: opts.ComponentStore,
@@ -209,12 +208,7 @@ func New(opts Options) *Processor {
 			components.CategorySecretStore:     secret,
 			components.CategoryStateStore:      state,
 			components.CategoryWorkflowBackend: wfbe,
-			components.CategoryWorkflow: workflow.New(workflow.Options{
-				Registry:       opts.Registry.Workflows(),
-				ComponentStore: opts.ComponentStore,
-				Meta:           opts.Meta,
-			}),
-			components.CategoryMiddleware: middleware.New(),
+			components.CategoryMiddleware:      middleware.New(),
 		},
 	}
 }

--- a/pkg/runtime/processor/processor_test.go
+++ b/pkg/runtime/processor/processor_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dapr/components-contrib/secretstores"
 	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/components"
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/resiliency"
@@ -452,4 +453,10 @@ func TestMetadataClientID(t *testing.T) {
 			t.Error("Timed out waiting for clientID for Standalone Mode test")
 		}
 	})
+}
+
+func TestProcessNoWorkflow(t *testing.T) {
+	proc, _ := newTestProc()
+	_, ok := proc.managers[components.CategoryWorkflow]
+	require.False(t, ok, "workflow cannot be registered as user facing component")
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -70,6 +70,7 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/hotreload"
 	"github.com/dapr/dapr/pkg/runtime/meta"
 	"github.com/dapr/dapr/pkg/runtime/processor"
+	"github.com/dapr/dapr/pkg/runtime/processor/workflow"
 	"github.com/dapr/dapr/pkg/runtime/registry"
 	"github.com/dapr/dapr/pkg/runtime/wfengine"
 	"github.com/dapr/dapr/pkg/security"
@@ -644,12 +645,22 @@ func (a *DaprRuntime) initWorkflowEngine(ctx context.Context) error {
 		return nil
 	}
 
-	log.Infof("Registering component for dapr workflow engine...")
+	log.Info("Registering component for dapr workflow engine...")
 	reg.RegisterComponent(wfComponentFactory, "dapr")
-	if !a.processor.AddPendingComponent(ctx, wfengine.ComponentDefinition) {
-		log.Warn("failed to initialize Dapr workflow component")
+	wfe := workflow.New(workflow.Options{
+		Registry:       a.runtimeConfig.registry.Workflows(),
+		ComponentStore: a.compStore,
+		Meta:           a.meta,
+	})
+	if err := wfe.Init(ctx, wfengine.ComponentDefinition()); err != nil {
+		return fmt.Errorf("failed to initialize Dapr workflow component: %w", err)
 	}
-	return nil
+
+	log.Info("Workflow engine initialized.")
+
+	return a.runnerCloser.AddCloser(func() error {
+		return wfe.Close(wfengine.ComponentDefinition())
+	})
 }
 
 // initPluggableComponents discover pluggable components and initialize with their respective registries.

--- a/pkg/runtime/wfengine/component.go
+++ b/pkg/runtime/wfengine/component.go
@@ -25,24 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/dapr/components-contrib/workflows"
-	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	componentsV1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1" // This will be removed
 	"github.com/dapr/kit/logger"
 )
-
-var ComponentDefinition = componentsV1alpha1.Component{
-	TypeMeta: metav1.TypeMeta{
-		Kind: "Component",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "dapr",
-	},
-	Spec: componentsV1alpha1.ComponentSpec{
-		Type:     "workflow.dapr",
-		Version:  "v1",
-		Metadata: []commonapi.NameValuePair{},
-	},
-}
 
 // Status values are defined at: https://github.com/microsoft/durabletask-go/blob/119b361079c45e368f83b223888d56a436ac59b9/internal/protos/orchestrator_service.pb.go#L42-L64
 var statusMap = map[int32]string{
@@ -260,4 +245,12 @@ func getStatusString(status int32) string {
 		return statusStr
 	}
 	return "UNKNOWN"
+}
+
+func ComponentDefinition() componentsV1alpha1.Component {
+	return componentsV1alpha1.Component{
+		TypeMeta:   metav1.TypeMeta{Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Name: "dapr"},
+		Spec:       componentsV1alpha1.ComponentSpec{Type: "workflow.dapr", Version: "v1"},
+	}
 }

--- a/tests/integration/framework/process/logline/logline.go
+++ b/tests/integration/framework/process/logline/logline.go
@@ -19,8 +19,10 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,12 +85,10 @@ func New(t *testing.T, fopts ...Option) *LogLine {
 func (l *LogLine) Run(t *testing.T, ctx context.Context) {
 	go func() {
 		res := l.checkOut(t, ctx, l.stdoutLineContains, l.stdoutExp, l.stdout)
-		l.done.Add(1)
 		l.outCheck <- res
 	}()
 	go func() {
 		res := l.checkOut(t, ctx, l.stderrLinContains, l.stderrExp, l.stderr)
-		l.done.Add(1)
 		l.outCheck <- res
 	}()
 }
@@ -109,6 +109,11 @@ func (l *LogLine) Cleanup(t *testing.T) {
 func (l *LogLine) checkOut(t *testing.T, ctx context.Context, expLines map[string]bool, closer io.WriteCloser, reader io.Reader) map[string]bool {
 	t.Helper()
 
+	if len(expLines) == 0 {
+		l.done.Add(1)
+		return expLines
+	}
+
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -117,10 +122,12 @@ func (l *LogLine) checkOut(t *testing.T, ctx context.Context, expLines map[strin
 		}
 	}()
 
+	var once sync.Once
+
 	breader := bufio.NewReader(reader)
 	for {
 		if len(expLines) == 0 {
-			break
+			once.Do(func() { l.done.Add(1) })
 		}
 
 		line, _, err := breader.ReadLine()
@@ -145,4 +152,8 @@ func (l *LogLine) Stdout() io.WriteCloser {
 
 func (l *LogLine) Stderr() io.WriteCloser {
 	return l.stderrExp
+}
+
+func (l *LogLine) EventuallyFoundAll(t *testing.T) {
+	assert.Eventually(t, l.FoundAll, time.Second*5, time.Millisecond*100)
 }

--- a/tests/integration/suite/daprd/hotreload/operator/binding/intput/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/intput/grpc.go
@@ -151,7 +151,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			//nolint:testifylint
 			assert.NoError(c, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*20, time.Millisecond*100)
 		g.expectBinding(t, 0, "binding1")
 	})
@@ -183,7 +183,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -217,7 +217,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 4)
+			assert.Len(c, resp.GetRegisteredComponents(), 3)
 		}, time.Second*5, time.Millisecond*100)
 		g.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -233,7 +233,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.registered[0].Store(false)
 		g.expectBindings(t, []bindingPair{
@@ -251,7 +251,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(c, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 1)
+			assert.Empty(c, resp.GetRegisteredComponents())
 		}, time.Second*5, time.Millisecond*100)
 		g.registered[1].Store(false)
 		g.registered[2].Store(false)
@@ -285,7 +285,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*5, time.Millisecond*100)
 		g.expectBinding(t, 0, "binding1")
 	})

--- a/tests/integration/suite/daprd/hotreload/operator/binding/intput/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/intput/http.go
@@ -144,7 +144,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 2)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 1)
 		h.expectBinding(t, 0, "binding1")
 	})
 
@@ -173,7 +173,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -205,7 +205,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		h.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -220,7 +220,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_DELETED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.registered[0].Store(false)
 		h.expectBindings(t, []bindingPair{
@@ -236,7 +236,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp1, EventType: operatorv1.ResourceEventType_DELETED})
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp2, EventType: operatorv1.ResourceEventType_DELETED})
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
+			assert.Empty(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()))
 		}, time.Second*5, time.Millisecond*100)
 		h.registered[1].Store(false)
 		h.registered[2].Store(false)
@@ -268,7 +268,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		h.expectBinding(t, 0, "binding1")
 	})

--- a/tests/integration/suite/daprd/hotreload/operator/binding/output.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/output.go
@@ -105,7 +105,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 
 	client := util.HTTPClient(t)
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, o.daprd.HTTPPort()), 1)
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, o.daprd.HTTPPort()))
 	})
 
 	t.Run("adding a component should become available", func(t *testing.T) {
@@ -126,7 +126,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 		o.operator.SetComponents(comp)
 		o.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 1)
 		}, time.Second*10, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding1", "file1", "data1")
 		o.postBindingFail(t, ctx, client, "binding2")
@@ -153,7 +153,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 		o.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
 		}, time.Second*10, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding1", "file2", "data2")
 		o.postBinding(t, ctx, client, "binding2", "file1", "data1")
@@ -180,7 +180,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 		o.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 3)
 		}, time.Second*10, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding1", "file3", "data3")
 		o.postBinding(t, ctx, client, "binding2", "file2", "data2")
@@ -196,7 +196,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 		o.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_DELETED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
 		}, time.Second*10, time.Millisecond*100)
 
 		o.postBindingFail(t, ctx, client, "binding1")
@@ -215,7 +215,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 		o.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp2, EventType: operatorv1.ResourceEventType_DELETED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 1)
+			assert.Empty(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()))
 		}, time.Second*10, time.Millisecond*100)
 		o.postBindingFail(t, ctx, client, "binding1")
 		o.postBindingFail(t, ctx, client, "binding2")
@@ -239,7 +239,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 		o.operator.AddComponents(comp)
 		o.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 1)
 		}, time.Second*10, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding2", "file5", "data5")
 		o.postBindingFail(t, ctx, client, "binding1")

--- a/tests/integration/suite/daprd/hotreload/operator/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/operator/crypto.go
@@ -102,7 +102,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 		require.NoError(t, err)
-		assert.Len(t, resp.GetRegisteredComponents(), 1)
+		assert.Empty(t, resp.GetRegisteredComponents())
 		c.encryptDecryptFail(t, ctx, client, "crypto1")
 		c.encryptDecryptFail(t, ctx, client, "crypto2")
 	})
@@ -130,7 +130,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			//nolint:testifylint
 			assert.NoError(c, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*10, time.Millisecond*100)
 
 		c.encryptDecrypt(t, ctx, client, "crypto1")
@@ -161,7 +161,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			//nolint:testifylint
 			assert.NoError(c, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*10, time.Millisecond*100)
 
 		c.encryptDecrypt(t, ctx, client, "crypto1")
@@ -192,7 +192,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			//nolint:testifylint
 			assert.NoError(c, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 4)
+			assert.Len(c, resp.GetRegisteredComponents(), 3)
 		}, time.Second*10, time.Millisecond*100)
 
 		c.encryptDecrypt(t, ctx, client, "crypto1")
@@ -217,7 +217,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "crypto1", Type: "crypto.dapr.localstorage", Version: "v1"},
 				{Name: "crypto3", Type: "crypto.dapr.localstorage", Version: "v1"},
 				{
@@ -241,7 +240,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			//nolint:testifylint
 			assert.NoError(c, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*10, time.Millisecond*100)
 
 		delComp = c.operator.Components()[0]
@@ -260,7 +259,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "crypto3", Type: "state.in-memory", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -290,7 +288,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			//nolint:testifylint
 			assert.NoError(c, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*10, time.Millisecond*100)
 
 		c.encryptDecryptFail(t, ctx, client, "crypto1")

--- a/tests/integration/suite/daprd/hotreload/operator/informer.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer.go
@@ -119,7 +119,7 @@ func (i *informer) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort()), 1)
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort()))
 	})
 
 	t.Run("adding a component should become available", func(t *testing.T) {
@@ -135,11 +135,10 @@ func (i *informer) Run(t *testing.T, ctx context.Context) {
 		i.kubeapi.Informer().Add(t, &comp)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort()), 1)
 		}, time.Second*10, time.Millisecond*100)
 		metaComponents := util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort())
 		assert.ElementsMatch(t, metaComponents, []*rtv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
 				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -169,17 +168,12 @@ func (i *informer) Run(t *testing.T, ctx context.Context) {
 		i.kubeapi.Informer().Modify(t, &comp)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			// Assert here, as we might catch the component in the middle of being
-			// updated, i.e. between closed and re-inited.
-			if assert.Len(c, util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort()), 2) {
-				assert.ElementsMatch(c, util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort()), []*rtv1.RegisteredComponents{
-					{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
-					{
-						Name: "abc", Type: "state.sqlite", Version: "v1",
-						Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
-					},
-				})
-			}
+			assert.ElementsMatch(c, util.GetMetaComponents(t, ctx, client, i.daprd.HTTPPort()), []*rtv1.RegisteredComponents{
+				{
+					Name: "abc", Type: "state.sqlite", Version: "v1",
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				},
+			})
 		}, time.Second*10, time.Millisecond*100)
 	})
 
@@ -188,7 +182,7 @@ func (i *informer) Run(t *testing.T, ctx context.Context) {
 		i.kubeapi.Informer().Delete(t, &comp)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, i.daprd.HTTPPort()), 1)
+			assert.Empty(c, util.GetMetaComponents(c, ctx, client, i.daprd.HTTPPort()))
 		}, time.Second*20, time.Millisecond*100)
 	})
 }

--- a/tests/integration/suite/daprd/hotreload/operator/middleware.go
+++ b/tests/integration/suite/daprd/hotreload/operator/middleware.go
@@ -119,7 +119,7 @@ func (m *middleware) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(cancel)
 
 	t.Run("expect middleware to be loaded", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, m.daprd.HTTPPort()), 2)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, m.daprd.HTTPPort()), 1)
 	})
 
 	t.Run("middleware hot reloading doesn't work yet", func(t *testing.T) {
@@ -155,7 +155,7 @@ func (m *middleware) Run(t *testing.T, ctx context.Context) {
 		)
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, m.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, m.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100, "expected component to be loaded")
 		m.doReq(t, ctx, client, "/helloworld", http.StatusNotFound)
 	})

--- a/tests/integration/suite/daprd/hotreload/operator/pubsub/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/pubsub/grpc.go
@@ -114,7 +114,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 		require.NoError(t, err)
-		assert.Len(t, resp.GetRegisteredComponents(), 2)
+		assert.Len(t, resp.GetRegisteredComponents(), 1)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
 		g.publishMessageFails(t, ctx, client, "pubsub3", "topic3")
@@ -137,7 +137,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -160,7 +160,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 4)
+			assert.Len(c, resp.GetRegisteredComponents(), 3)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -175,7 +175,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -190,7 +190,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -205,7 +205,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 1)
+			assert.Empty(c, resp.GetRegisteredComponents())
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -229,7 +229,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		g.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")

--- a/tests/integration/suite/daprd/hotreload/operator/pubsub/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/pubsub/http.go
@@ -128,7 +128,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 2)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 1)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 	})
 
@@ -147,7 +147,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		h.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -168,7 +168,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		h.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -181,7 +181,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_DELETED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		h.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -193,7 +193,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.SetComponents(h.operator.Components()[1])
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_DELETED})
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		h.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -205,7 +205,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.SetComponents()
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_DELETED})
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
+			assert.Empty(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()))
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		h.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -226,7 +226,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		h.operator.AddComponents(comp)
 		h.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		h.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")

--- a/tests/integration/suite/daprd/hotreload/operator/secret.go
+++ b/tests/integration/suite/daprd/hotreload/operator/secret.go
@@ -104,7 +104,7 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 1)
+		assert.Empty(t, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()))
 		s.readExpectError(t, ctx, "123", "SEC_1", http.StatusInternalServerError)
 	})
 
@@ -125,13 +125,12 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 		s.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &newComp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		resp := util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort())
-		require.Len(t, resp, 2)
+		require.Len(t, resp, 1)
 
 		assert.ElementsMatch(t, resp, []*rtpbv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{Name: "123", Type: "secretstores.local.env", Version: "v1"},
 		})
 
@@ -190,13 +189,12 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 		s.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &newComp2, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		resp := util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort())
-		require.Len(t, resp, 4)
+		require.Len(t, resp, 3)
 
 		assert.ElementsMatch(t, []*rtpbv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{Name: "123", Type: "secretstores.local.env", Version: "v1"},
 			{Name: "abc", Type: "secretstores.local.file", Version: "v1"},
 			{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -233,7 +231,6 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "123", Type: "secretstores.local.env", Version: "v1"},
 				{Name: "abc", Type: "secretstores.local.env", Version: "v1"},
 				{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -315,7 +312,6 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "123", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "abc", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -363,7 +359,6 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "123", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -403,7 +398,6 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c,
 				[]*rtpbv1.RegisteredComponents{
-					{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 					{Name: "123", Type: "secretstores.local.file", Version: "v1"},
 					{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
 					{Name: "foo", Type: "secretstores.local.env", Version: "v1"},
@@ -440,9 +434,8 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
-			assert.Len(c, resp, 2)
+			assert.Len(c, resp, 1)
 			assert.ElementsMatch(c, resp, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -473,7 +466,7 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 		s.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp1, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 
 		s.read(t, ctx, "123", "SEC_1", "bar1")

--- a/tests/integration/suite/daprd/hotreload/operator/state.go
+++ b/tests/integration/suite/daprd/hotreload/operator/state.go
@@ -88,7 +88,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()), 1)
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()))
 		s.writeExpectError(t, ctx, client, "123", http.StatusInternalServerError)
 	})
 
@@ -104,13 +104,12 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		s.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &newComp, EventType: operatorv1.ResourceEventType_CREATED})
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		resp := util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort())
-		require.Len(t, resp, 2)
+		require.Len(t, resp, 1)
 
 		assert.ElementsMatch(t, resp, []*rtv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{
 				Name:    "123",
 				Type:    "state.in-memory",
@@ -154,14 +153,13 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		s.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &newComp1, EventType: operatorv1.ResourceEventType_CREATED})
 		s.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &newComp2, EventType: operatorv1.ResourceEventType_CREATED})
 
+		var resp []*rtv1.RegisteredComponents
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()), 4)
+			resp = util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort())
+			assert.Len(c, resp, 3)
 		}, time.Second*5, time.Millisecond*100)
-		resp := util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort())
-		require.Len(t, resp, 4)
 
 		assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
 				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -209,7 +207,6 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "123", Type: "state.in-memory", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -283,7 +280,6 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -346,7 +342,6 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -401,7 +396,6 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
@@ -441,7 +435,6 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 			}, resp)
 		}, time.Second*10, time.Millisecond*100)
@@ -463,7 +456,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		s.operator.AddComponents(comp)
 		s.operator.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &comp, EventType: operatorv1.ResourceEventType_CREATED})
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		s.writeRead(t, ctx, client, "123")
 	})

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/grpc.go
@@ -134,7 +134,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 		require.NoError(t, err)
-		assert.Len(t, resp.GetRegisteredComponents(), 2)
+		assert.Len(t, resp.GetRegisteredComponents(), 1)
 		g.expectBinding(t, 0, "binding1")
 	})
 
@@ -157,7 +157,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -197,7 +197,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 4)
+			assert.Len(c, resp.GetRegisteredComponents(), 3)
 		}, time.Second*5, time.Millisecond*100)
 		g.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -224,7 +224,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.registered[0].Store(false)
 		g.expectBindings(t, []bindingPair{
@@ -239,7 +239,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 1)
+			assert.Empty(c, resp.GetRegisteredComponents())
 		}, time.Second*5, time.Millisecond*100)
 		g.registered[1].Store(false)
 		g.registered[2].Store(false)
@@ -266,7 +266,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*5, time.Millisecond*100)
 		g.expectBinding(t, 0, "binding1")
 	})

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/http.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/http.go
@@ -129,7 +129,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 2)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 1)
 		h.expectBinding(t, 0, "binding1")
 	})
 
@@ -150,7 +150,7 @@ spec:
     value: "input"
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -188,7 +188,7 @@ spec:
     value: "input"
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		h.expectBindings(t, []bindingPair{
 			{0, "binding1"},
@@ -213,7 +213,7 @@ spec:
     value: "input"
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.registered[0].Store(false)
 		h.expectBindings(t, []bindingPair{
@@ -226,7 +226,7 @@ spec:
 		require.NoError(t, os.Remove(filepath.Join(h.resDir, "1.yaml")))
 		require.NoError(t, os.Remove(filepath.Join(h.resDir, "2.yaml")))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
+			assert.Empty(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()))
 		}, time.Second*5, time.Millisecond*100)
 		h.registered[1].Store(false)
 		h.registered[2].Store(false)
@@ -251,7 +251,7 @@ spec:
     value: "input"
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		h.expectBinding(t, 0, "binding1")
 	})

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/output.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/output.go
@@ -76,7 +76,7 @@ func (o *output) Run(t *testing.T, ctx context.Context) {
 
 	client := util.HTTPClient(t)
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, o.daprd.HTTPPort()), 1)
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, o.daprd.HTTPPort()))
 	})
 
 	t.Run("adding a component should become available", func(t *testing.T) {
@@ -94,7 +94,7 @@ spec:
    value: '%s'
 `, o.bindingDir1)), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding1", "file1", "data1")
 		o.postBindingFail(t, ctx, client, "binding2")
@@ -128,7 +128,7 @@ spec:
    value: '%s'
 `, o.bindingDir1, o.bindingDir2)), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding1", "file2", "data2")
 		o.postBinding(t, ctx, client, "binding2", "file1", "data1")
@@ -152,7 +152,7 @@ spec:
    value: '%s'
 `, o.bindingDir3)), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding1", "file3", "data3")
 		o.postBinding(t, ctx, client, "binding2", "file2", "data2")
@@ -177,7 +177,7 @@ spec:
    value: '%s'
 `, o.bindingDir2)), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		o.postBindingFail(t, ctx, client, "binding1")
 		assert.NoFileExists(t, filepath.Join(o.bindingDir1, "file4"))
@@ -191,7 +191,7 @@ spec:
 		require.NoError(t, os.Remove(filepath.Join(o.resDir, "1.yaml")))
 		require.NoError(t, os.Remove(filepath.Join(o.resDir, "2.yaml")))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 1)
+			assert.Empty(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()))
 		}, time.Second*5, time.Millisecond*100)
 		o.postBindingFail(t, ctx, client, "binding1")
 		o.postBindingFail(t, ctx, client, "binding2")
@@ -213,7 +213,7 @@ spec:
    value: '%s'
 `, o.bindingDir2)), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, o.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		o.postBinding(t, ctx, client, "binding2", "file5", "data5")
 		o.postBindingFail(t, ctx, client, "binding1")

--- a/tests/integration/suite/daprd/hotreload/selfhosted/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/crypto.go
@@ -79,7 +79,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 		require.NoError(t, err)
-		assert.Len(t, resp.GetRegisteredComponents(), 1)
+		assert.Empty(t, resp.GetRegisteredComponents())
 		c.encryptDecryptFail(t, ctx, client, "crypto1")
 		c.encryptDecryptFail(t, ctx, client, "crypto2")
 	})
@@ -105,7 +105,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*5, time.Millisecond*100)
 
 		c.encryptDecrypt(t, ctx, client, "crypto1")
@@ -134,7 +134,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 
 		c.encryptDecrypt(t, ctx, client, "crypto1")
@@ -173,7 +173,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 4)
+			assert.Len(c, resp.GetRegisteredComponents(), 3)
 		}, time.Second*5, time.Millisecond*100)
 
 		c.encryptDecrypt(t, ctx, client, "crypto1")
@@ -206,7 +206,6 @@ spec:
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "crypto1", Type: "crypto.dapr.localstorage", Version: "v1"},
 				{Name: "crypto3", Type: "crypto.dapr.localstorage", Version: "v1"},
 				{
@@ -226,7 +225,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		require.NoError(t, os.WriteFile(filepath.Join(c.resDir, "2.yaml"), []byte(`
 apiVersion: dapr.io/v1alpha1
@@ -242,7 +241,6 @@ spec:
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "crypto1", Type: "state.in-memory", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -271,7 +269,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 
 		c.encryptDecryptFail(t, ctx, client, "crypto1")

--- a/tests/integration/suite/daprd/hotreload/selfhosted/middleware.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/middleware.go
@@ -124,7 +124,7 @@ func (m *middleware) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(cancel)
 
 	t.Run("expect middleware to be loaded", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, m.daprd1.HTTPPort()), 2)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, m.daprd1.HTTPPort()), 1)
 	})
 
 	t.Run("middleware hot reloading doesn't work yet", func(t *testing.T) {
@@ -153,7 +153,7 @@ spec:
   version: v1
 `), 0o600))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, m.daprd1.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, m.daprd1.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100, "expected component to be loaded")
 		m.doReq(t, ctx, client, "/helloworld", http.StatusNotFound)
 	})

--- a/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/grpc.go
@@ -104,7 +104,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 		require.NoError(t, err)
-		assert.Len(t, resp.GetRegisteredComponents(), 2)
+		assert.Len(t, resp.GetRegisteredComponents(), 1)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
 		g.publishMessageFails(t, ctx, client, "pubsub3", "topic3")
@@ -124,7 +124,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -152,7 +152,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 4)
+			assert.Len(c, resp.GetRegisteredComponents(), 3)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -173,7 +173,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 3)
+			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -185,7 +185,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -197,7 +197,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 1)
+			assert.Empty(c, resp.GetRegisteredComponents())
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		g.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -218,7 +218,7 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 			require.NoError(t, err)
-			assert.Len(c, resp.GetRegisteredComponents(), 2)
+			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*5, time.Millisecond*100)
 		g.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		g.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")

--- a/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/http.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/http.go
@@ -118,7 +118,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 2)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, h.daprd.HTTPPort()), 1)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 	})
 
@@ -133,7 +133,7 @@ spec:
   version: v1
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		h.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -158,7 +158,7 @@ spec:
   version: v1
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		h.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")
@@ -176,7 +176,7 @@ spec:
   version: v1
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessage(t, ctx, client, "pubsub1", "topic1", "/route1")
 		h.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -186,7 +186,7 @@ spec:
 	t.Run("delete another component", func(t *testing.T) {
 		require.NoError(t, os.Remove(filepath.Join(h.resDir, "1.yaml")))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		h.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -196,7 +196,7 @@ spec:
 	t.Run("delete last component", func(t *testing.T) {
 		require.NoError(t, os.Remove(filepath.Join(h.resDir, "2.yaml")))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
+			assert.Empty(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()))
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		h.publishMessageFails(t, ctx, client, "pubsub2", "topic2")
@@ -214,7 +214,7 @@ spec:
   version: v1
 `), 0o600))
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, h.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		h.publishMessageFails(t, ctx, client, "pubsub1", "topic1")
 		h.publishMessage(t, ctx, client, "pubsub2", "topic2", "/route2")

--- a/tests/integration/suite/daprd/hotreload/selfhosted/secret.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/secret.go
@@ -88,7 +88,7 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()), 1)
+		assert.Empty(t, util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort()))
 		s.readExpectError(t, ctx, "123", "SEC_1", http.StatusInternalServerError)
 	})
 
@@ -107,13 +107,12 @@ spec:
 `), 0o600))
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		resp := util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort())
-		require.Len(t, resp, 2)
+		require.Len(t, resp, 1)
 
 		assert.ElementsMatch(t, resp, []*rtpbv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{Name: "123", Type: "secretstores.local.env", Version: "v1"},
 		})
 
@@ -164,13 +163,12 @@ spec:
 `), 0o600))
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		resp := util.GetMetaComponents(t, ctx, s.client, s.daprd.HTTPPort())
-		require.Len(t, resp, 4)
+		require.Len(t, resp, 3)
 
 		assert.ElementsMatch(t, []*rtpbv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{Name: "123", Type: "secretstores.local.env", Version: "v1"},
 			{Name: "abc", Type: "secretstores.local.file", Version: "v1"},
 			{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -203,7 +201,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "123", Type: "secretstores.local.env", Version: "v1"},
 				{Name: "abc", Type: "secretstores.local.env", Version: "v1"},
 				{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -270,7 +267,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "123", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "abc", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -309,7 +305,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "123", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
@@ -346,7 +341,6 @@ spec:
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c,
 				[]*rtpbv1.RegisteredComponents{
-					{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 					{Name: "123", Type: "secretstores.local.file", Version: "v1"},
 					{Name: "xyz", Type: "secretstores.local.env", Version: "v1"},
 					{Name: "foo", Type: "secretstores.local.env", Version: "v1"},
@@ -378,7 +372,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -407,7 +400,7 @@ spec:
 `), 0o600))
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, s.client, s.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 
 		s.read(t, ctx, "123", "SEC_1", "bar1")

--- a/tests/integration/suite/daprd/hotreload/selfhosted/state.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/state.go
@@ -77,7 +77,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()), 1)
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort()))
 		s.writeExpectError(t, ctx, client, "123", http.StatusInternalServerError)
 	})
 
@@ -94,11 +94,10 @@ spec:
 `), 0o600))
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort()), 2)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort()), 1)
 		}, time.Second*5, time.Millisecond*100)
 		resp := util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort())
 		assert.ElementsMatch(t, []*rtpbv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
 				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -138,11 +137,10 @@ spec:
  `), 0o600))
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort()), 4)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort()), 3)
 		}, time.Second*5, time.Millisecond*100)
 		resp := util.GetMetaComponents(t, ctx, client, s.daprd.HTTPPort())
 		assert.ElementsMatch(t, []*rtpbv1.RegisteredComponents{
-			{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
 				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -184,7 +182,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "123", Type: "state.in-memory", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -247,7 +244,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -293,7 +289,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -344,7 +339,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
@@ -379,7 +373,6 @@ spec:
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp := util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort())
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
-				{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 			}, resp)
 		}, time.Second*10, time.Millisecond*100)
@@ -403,7 +396,7 @@ spec:
 `), 0o600))
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Len(c, util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort()), 3)
+			assert.Len(c, util.GetMetaComponents(c, ctx, client, s.daprd.HTTPPort()), 2)
 		}, time.Second*5, time.Millisecond*100)
 
 		s.writeRead(t, ctx, client, "123")

--- a/tests/integration/suite/daprd/metrics/metrics.go
+++ b/tests/integration/suite/daprd/metrics/metrics.go
@@ -209,8 +209,6 @@ func (m *metrics) Run(t *testing.T, ctx context.Context) {
 		taskhubClient.StartWorkItemListener(taskhubCtx, r)
 		defer cancelTaskhub()
 
-		time.Sleep(5 * time.Second)
-
 		t.Run("successful workflow execution", func(t *testing.T) {
 			id, err := taskhubClient.ScheduleNewOrchestration(ctx, "workflow", api.WithInput("activity_success"))
 			require.NoError(t, err)

--- a/tests/integration/suite/daprd/resources/dapr.go
+++ b/tests/integration/suite/daprd/resources/dapr.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(dapr))
+}
+
+// dapr ensures that a component with the name `dapr` can be loaded.
+type dapr struct {
+	daprd   *daprd.Daprd
+	logline *logline.LogLine
+}
+
+func (d *dapr) Setup(t *testing.T) []framework.Option {
+	d.logline = logline.New(t,
+		logline.WithStdoutLineContains(
+			"Component loaded: dapr (state.in-memory/v1)",
+			"Workflow engine initialized.",
+		),
+	)
+
+	d.daprd = daprd.New(t, daprd.WithResourceFiles(
+		`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: dapr
+spec:
+  type: state.in-memory
+  version: v1
+`),
+		daprd.WithExecOptions(
+			exec.WithStdout(d.logline.Stdout()),
+		),
+	)
+	return []framework.Option{
+		framework.WithProcesses(d.logline, d.daprd),
+	}
+}
+
+func (d *dapr) Run(t *testing.T, ctx context.Context) {
+	d.logline.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/resources/namespace.go
+++ b/tests/integration/suite/daprd/resources/namespace.go
@@ -101,7 +101,6 @@ func (n *namespace) Run(t *testing.T, ctx context.Context) {
 	resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{
 			Name: "abc", Type: "state.in-memory", Version: "v1",
 			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},

--- a/tests/integration/suite/daprd/resources/workflow.go
+++ b/tests/integration/suite/daprd/resources/workflow.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(workflow))
+}
+
+// workflow ensures a Component with type `dapr.workflow` cannot be loaded.
+type workflow struct {
+	daprd   *daprd.Daprd
+	logline *logline.LogLine
+}
+
+func (w *workflow) Setup(t *testing.T) []framework.Option {
+	w.logline = logline.New(t,
+		logline.WithStdoutLineContains(
+			"process component myworkflow error: incorrect type workflow.dapr",
+		),
+	)
+
+	w.daprd = daprd.New(t, daprd.WithResourceFiles(
+		`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: myworkflow
+spec:
+  type: workflow.dapr
+  version: v1
+`),
+		daprd.WithExecOptions(
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(w.logline.Stdout()),
+		),
+	)
+	return []framework.Option{
+		framework.WithProcesses(w.logline, w.daprd),
+	}
+}
+
+func (w *workflow) Run(t *testing.T, ctx context.Context) {
+	w.logline.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/secret/http/fuzz.go
+++ b/tests/integration/suite/daprd/secret/http/fuzz.go
@@ -121,7 +121,7 @@ func (f *fuzzsecret) Run(t *testing.T, ctx context.Context) {
 	client := util.HTTPClient(t)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, util.GetMetaComponents(c, ctx, client, f.daprd.HTTPPort()), 2)
+		assert.Len(c, util.GetMetaComponents(c, ctx, client, f.daprd.HTTPPort()), 1)
 	}, time.Second*20, time.Millisecond*100)
 
 	pt := util.NewParallel(t)

--- a/tests/integration/suite/daprd/state/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/state/grpc/fuzz.go
@@ -169,7 +169,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	f.daprd.WaitUntilRunning(t, ctx)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, util.GetMetaComponents(c, ctx, util.HTTPClient(t), f.daprd.HTTPPort()), 2)
+		assert.Len(c, util.GetMetaComponents(c, ctx, util.HTTPClient(t), f.daprd.HTTPPort()), 1)
 	}, time.Second*20, time.Millisecond*100)
 
 	client := f.daprd.GRPCClient(t, ctx)

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -155,7 +155,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	httpClient := util.HTTPClient(t)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, util.GetMetaComponents(c, ctx, httpClient, f.daprd.HTTPPort()), 2)
+		assert.Len(c, util.GetMetaComponents(c, ctx, httpClient, f.daprd.HTTPPort()), 1)
 	}, time.Second*20, time.Millisecond*100)
 
 	t.Run("get", func(t *testing.T) {


### PR DESCRIPTION
The internal workflow engine `dapr` component is currently being registered in the processor component store, making it visible to the user via the metadata registered component list and preventing the user creating a Component of the same name.

PR updates the workflow engine machinery to `Init` the component manually, bypassing the processor and preventing it being committed to the component store.

Adds integration test to ensure a `dapr` named component can be created by the user.

Updates tests that previously expected the workflow engine component to be registered in the component store.

closes https://github.com/dapr/dapr/issues/7411

/cc @mukundansundar @ASHIQUEMD 