### PR TITLE
Fix operator when healthz when running without webhooks

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -271,6 +271,8 @@ func (o *operator) Run(ctx context.Context) error {
 		},
 		func(ctx context.Context) error {
 			if !enableConversionWebhooks {
+				healthzServer.Ready()
+				<-ctx.Done()
 				return nil
 			}
 
@@ -283,6 +285,8 @@ func (o *operator) Run(ctx context.Context) error {
 		},
 		func(ctx context.Context) error {
 			if !enableConversionWebhooks {
+				healthzServer.Ready()
+				<-ctx.Done()
 				return nil
 			}
 


### PR DESCRIPTION
Operator will currently always fail healthz check and exit error when webhooks are disabled.

PR correctly sets healthz and prevents the concurrency manager from exiting early.