### PR TITLE
Workflow backends: ignore on hot reloading

### DIFF
--- a/pkg/components/wfbackend/registry.go
+++ b/pkg/components/wfbackend/registry.go
@@ -26,7 +26,7 @@ import (
 // Registry is an interface for a component that returns registered workflow backend implementations.
 type Registry struct {
 	Logger                    logger.Logger
-	workflowBackendComponents map[string]WorkflowBackend
+	workflowBackendComponents map[string]workflowBackendFactory
 }
 
 // DefaultRegistry is the singleton with the registry.
@@ -35,12 +35,12 @@ var DefaultRegistry *Registry = NewRegistry()
 // NewRegistry is used to create workflow registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		workflowBackendComponents: make(map[string]WorkflowBackend),
+		workflowBackendComponents: make(map[string]workflowBackendFactory),
 	}
 }
 
 // RegisterComponent adds a new workflow to the registry.
-func (s *Registry) RegisterComponent(componentFactory WorkflowBackend, names ...string) {
+func (s *Registry) RegisterComponent(componentFactory workflowBackendFactory, names ...string) {
 	for _, name := range names {
 		s.workflowBackendComponents[createFullName(name)] = componentFactory
 	}
@@ -69,7 +69,7 @@ func (s *Registry) getWorkflowBackendComponent(name, version, logName string) (f
 	return nil, false
 }
 
-func (s *Registry) wrapFn(componentFactory WorkflowBackend, logName string) func(Metadata) (backend.Backend, error) {
+func (s *Registry) wrapFn(componentFactory workflowBackendFactory, logName string) func(Metadata) (backend.Backend, error) {
 	return func(m Metadata) (backend.Backend, error) {
 		l := s.Logger
 		if logName != "" && l != nil {

--- a/pkg/components/wfbackend/wfbackend.go
+++ b/pkg/components/wfbackend/wfbackend.go
@@ -19,5 +19,5 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
-// WorkflowBackend is a function that returns a workflow backend
-type WorkflowBackend = func(Metadata, logger.Logger) (backend.Backend, error)
+// workflowBackendFactory is a function that returns a workflow backend
+type workflowBackendFactory func(Metadata, logger.Logger) (backend.Backend, error)

--- a/pkg/runtime/compstore/compstore.go
+++ b/pkg/runtime/compstore/compstore.go
@@ -16,6 +16,8 @@ package compstore
 import (
 	"sync"
 
+	"github.com/microsoft/durabletask-go/backend"
+
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/components-contrib/configuration"
 	"github.com/dapr/components-contrib/crypto"
@@ -25,7 +27,6 @@ import (
 	"github.com/dapr/components-contrib/workflows"
 	compsv1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	httpEndpointV1alpha1 "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
-	wfbe "github.com/dapr/dapr/pkg/components/wfbackend"
 	"github.com/dapr/dapr/pkg/config"
 	rtpubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 )
@@ -48,7 +49,7 @@ type ComponentStore struct {
 	pubSubs                 map[string]PubsubItem
 	topicRoutes             map[string]TopicRoutes
 	workflowComponents      map[string]workflows.Workflow
-	workflowBackends        map[string]wfbe.WorkflowBackend
+	workflowBackends        map[string]backend.Backend
 	cryptoProviders         map[string]crypto.SubtleCrypto
 	components              []compsv1alpha1.Component
 	subscriptions           []rtpubsub.Subscription
@@ -71,7 +72,7 @@ func New() *ComponentStore {
 		locks:                   make(map[string]lock.Store),
 		pubSubs:                 make(map[string]PubsubItem),
 		workflowComponents:      make(map[string]workflows.Workflow),
-		workflowBackends:        make(map[string]wfbe.WorkflowBackend),
+		workflowBackends:        make(map[string]backend.Backend),
 		cryptoProviders:         make(map[string]crypto.SubtleCrypto),
 		topicRoutes:             make(map[string]TopicRoutes),
 	}

--- a/pkg/runtime/compstore/workflowbackend.go
+++ b/pkg/runtime/compstore/workflowbackend.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compstore
+
+import (
+	"github.com/microsoft/durabletask-go/backend"
+)
+
+func (c *ComponentStore) AddWorkflowBackend(name string, backend backend.Backend) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.workflowBackends[name] = backend
+}
+
+func (c *ComponentStore) GetWorkflowBackend(name string) (backend.Backend, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	backend, ok := c.workflowBackends[name]
+	return backend, ok
+}
+
+func (c *ComponentStore) ListWorkflowBackends() map[string]backend.Backend {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.workflowBackends
+}
+
+func (c *ComponentStore) DeleteWorkflowBackend(name string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.workflowBackends, name)
+}

--- a/pkg/runtime/hotreload/reconciler/component.go
+++ b/pkg/runtime/hotreload/reconciler/component.go
@@ -109,11 +109,6 @@ func (c *component) verify(vcomp componentsapi.Component) bool {
 		}
 	}
 
-	return true
-}
-
-//nolint:unused
-func (c *component) verify(vcomp componentsapi.Component) bool {
 	for backendName := range c.store.ListWorkflowBackends() {
 		if backendName == vcomp.Name {
 			log.Errorf("Aborting to hot-reload a workflowbackend component which is not supported: %s", vcomp.LogName())

--- a/pkg/runtime/hotreload/reconciler/component.go
+++ b/pkg/runtime/hotreload/reconciler/component.go
@@ -39,7 +39,7 @@ type component struct {
 //nolint:unused
 func (c *component) update(ctx context.Context, comp componentsapi.Component) error {
 	if strings.HasPrefix(comp.Spec.Type, "workflowbackend.") {
-		return fmt.Errorf("attempting to HotReload a workflowbackend component which is not supported: %s", comp.LogName())
+		return fmt.Errorf("aborting to hot-reload a workflowbackend component which is not supported: %s", comp.LogName())
 	}
 
 	oldComp, exists := c.store.GetComponent(comp.Name)
@@ -54,7 +54,7 @@ func (c *component) update(ctx context.Context, comp componentsapi.Component) er
 		log.Infof("Closing existing Component to reload: %s", oldComp.LogName())
 		// TODO: change close to accept pointer
 		if err := c.proc.Close(oldComp); err != nil {
-			log.Errorf("error closing old component: %w", err)
+			log.Errorf("error closing old component: %s", err)
 			return nil
 		}
 	}
@@ -76,11 +76,11 @@ func (c *component) update(ctx context.Context, comp componentsapi.Component) er
 //nolint:unused
 func (c *component) delete(comp componentsapi.Component) error {
 	if strings.HasPrefix(comp.Spec.Type, "workflowbackend.") {
-		return fmt.Errorf("attempting to HotReload a workflowbackend component which is not supported: %s", comp.LogName())
+		return fmt.Errorf("aborting to hot-reload a workflowbackend component which is not supported: %s", comp.LogName())
 	}
 
 	if err := c.proc.Close(comp); err != nil {
-		log.Errorf("error closing deleted component: %w", err)
+		log.Errorf("error closing deleted component: %s", err)
 	}
 
 	return nil

--- a/pkg/runtime/hotreload/reconciler/reconciler.go
+++ b/pkg/runtime/hotreload/reconciler/reconciler.go
@@ -15,6 +15,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -53,8 +54,8 @@ type Reconciler[T differ.Resource] struct {
 
 type manager[T differ.Resource] interface {
 	loader.Loader[T]
-	update(context.Context, T)
-	delete(T)
+	update(context.Context, T) error
+	delete(T) error
 }
 
 func NewComponent(opts Options[componentsapi.Component]) *Reconciler[componentsapi.Component] {
@@ -80,9 +81,7 @@ func (r *Reconciler[T]) Run(ctx context.Context) error {
 		return fmt.Errorf("error starting component stream: %w", err)
 	}
 
-	r.watchForEvents(ctx, stream)
-
-	return nil
+	return r.watchForEvents(ctx, stream)
 }
 
 func (r *Reconciler[T]) Close() error {
@@ -94,7 +93,7 @@ func (r *Reconciler[T]) Close() error {
 	return nil
 }
 
-func (r *Reconciler[T]) watchForEvents(ctx context.Context, stream <-chan *loader.Event[T]) {
+func (r *Reconciler[T]) watchForEvents(ctx context.Context, stream <-chan *loader.Event[T]) error {
 	log.Infof("Starting to watch %s updates", r.kind)
 
 	ticker := r.clock.NewTicker(time.Second * 60)
@@ -106,9 +105,9 @@ func (r *Reconciler[T]) watchForEvents(ctx context.Context, stream <-chan *loade
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-r.closeCh:
-			return
+			return nil
 		case <-ticker.C():
 			log.Debugf("Running scheduled %s reconcile", r.kind)
 			resources, err := r.manager.List(ctx)
@@ -118,10 +117,12 @@ func (r *Reconciler[T]) watchForEvents(ctx context.Context, stream <-chan *loade
 			}
 
 			if err := r.reconcile(ctx, differ.Diff(resources)); err != nil {
-				log.Errorf("Error reconciling %s: %s", r.kind, err)
+				return fmt.Errorf("error reconciling %s: %s", r.kind, err)
 			}
 		case event := <-stream:
-			r.handleEvent(ctx, event)
+			if err := r.handleEvent(ctx, event); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -131,7 +132,6 @@ func (r *Reconciler[T]) reconcile(ctx context.Context, result *differ.Result[T])
 		return nil
 	}
 
-	var wg sync.WaitGroup
 	for _, group := range []struct {
 		resources []T
 		eventType operatorpb.ResourceEventType
@@ -140,34 +140,42 @@ func (r *Reconciler[T]) reconcile(ctx context.Context, result *differ.Result[T])
 		{result.Updated, operatorpb.ResourceEventType_UPDATED},
 		{result.Created, operatorpb.ResourceEventType_CREATED},
 	} {
-		wg.Add(len(group.resources))
+		errCh := make(chan error)
 		for _, resource := range group.resources {
 			go func(resource T, eventType operatorpb.ResourceEventType) {
-				defer wg.Done()
-				r.handleEvent(ctx, &loader.Event[T]{
+				errCh <- r.handleEvent(ctx, &loader.Event[T]{
 					Type:     eventType,
 					Resource: resource,
 				})
 			}(resource, group.eventType)
 		}
-		wg.Wait()
+
+		errs := make([]error, 0, len(group.resources))
+		for range group.resources {
+			errs = append(errs, <-errCh)
+		}
+		if err := errors.Join(errs...); err != nil {
+			return fmt.Errorf("error reconciling %s: %w", r.kind, err)
+		}
 	}
 
 	return nil
 }
 
-func (r *Reconciler[T]) handleEvent(ctx context.Context, event *loader.Event[T]) {
+func (r *Reconciler[T]) handleEvent(ctx context.Context, event *loader.Event[T]) error {
 	log.Debugf("Received %s event %s: %s", event.Resource.Kind(), event.Type, event.Resource.LogName())
 
 	switch event.Type {
 	case operatorpb.ResourceEventType_CREATED:
 		log.Infof("Received %s creation: %s", r.kind, event.Resource.LogName())
-		r.manager.update(ctx, event.Resource)
+		return r.manager.update(ctx, event.Resource)
 	case operatorpb.ResourceEventType_UPDATED:
 		log.Infof("Received %s update: %s", r.kind, event.Resource.LogName())
-		r.manager.update(ctx, event.Resource)
+		return r.manager.update(ctx, event.Resource)
 	case operatorpb.ResourceEventType_DELETED:
 		log.Infof("Received %s deletion, closing: %s", r.kind, event.Resource.LogName())
-		r.manager.delete(event.Resource)
+		return r.manager.delete(event.Resource)
 	}
+
+	return nil
 }

--- a/pkg/runtime/hotreload/reconciler/reconciler_test.go
+++ b/pkg/runtime/hotreload/reconciler/reconciler_test.go
@@ -95,11 +95,13 @@ func Test_Run(t *testing.T) {
 		mngr.Loader = compLoader
 		updateCh := make(chan componentsapi.Component)
 		deleteCh := make(chan componentsapi.Component)
-		mngr.deleteFn = func(c componentsapi.Component) {
+		mngr.deleteFn = func(c componentsapi.Component) error {
 			deleteCh <- c
+			return nil
 		}
-		mngr.updateFn = func(_ context.Context, c componentsapi.Component) {
+		mngr.updateFn = func(_ context.Context, c componentsapi.Component) error {
 			updateCh <- c
+			return nil
 		}
 
 		r.manager = mngr
@@ -180,11 +182,13 @@ func Test_reconcile(t *testing.T) {
 
 	eventCh := make(chan componentsapi.Component)
 	mngr := newFakeManager()
-	mngr.deleteFn = func(c componentsapi.Component) {
+	mngr.deleteFn = func(c componentsapi.Component) error {
 		eventCh <- c
+		return nil
 	}
-	mngr.updateFn = func(_ context.Context, c componentsapi.Component) {
+	mngr.updateFn = func(_ context.Context, c componentsapi.Component) error {
 		eventCh <- c
+		return nil
 	}
 
 	r := &Reconciler[componentsapi.Component]{
@@ -249,13 +253,15 @@ func Test_handleEvent(t *testing.T) {
 	updateCalled, deleteCalled := 0, 0
 	comp1 := componentsapi.Component{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
-	mngr.deleteFn = func(c componentsapi.Component) {
+	mngr.deleteFn = func(c componentsapi.Component) error {
 		assert.Equal(t, comp1, c)
 		deleteCalled++
+		return nil
 	}
-	mngr.updateFn = func(_ context.Context, c componentsapi.Component) {
+	mngr.updateFn = func(_ context.Context, c componentsapi.Component) error {
 		assert.Equal(t, comp1, c)
 		updateCalled++
+		return nil
 	}
 
 	r := &Reconciler[componentsapi.Component]{manager: mngr}
@@ -287,25 +293,27 @@ func Test_handleEvent(t *testing.T) {
 
 type fakeManager struct {
 	loader.Loader[componentsapi.Component]
-	updateFn func(context.Context, componentsapi.Component)
-	deleteFn func(componentsapi.Component)
+	updateFn func(context.Context, componentsapi.Component) error
+	deleteFn func(componentsapi.Component) error
 }
 
 func newFakeManager() *fakeManager {
 	return &fakeManager{
-		updateFn: func(context.Context, componentsapi.Component) {
+		updateFn: func(context.Context, componentsapi.Component) error {
+			return nil
 		},
-		deleteFn: func(componentsapi.Component) {
+		deleteFn: func(componentsapi.Component) error {
+			return nil
 		},
 	}
 }
 
 //nolint:unused
-func (f *fakeManager) update(ctx context.Context, comp componentsapi.Component) {
-	f.updateFn(ctx, comp)
+func (f *fakeManager) update(ctx context.Context, comp componentsapi.Component) error {
+	return f.updateFn(ctx, comp)
 }
 
 //nolint:unused
-func (f *fakeManager) delete(comp componentsapi.Component) {
-	f.deleteFn(comp)
+func (f *fakeManager) delete(comp componentsapi.Component) error {
+	return f.deleteFn(comp)
 }

--- a/pkg/runtime/processor/manager.go
+++ b/pkg/runtime/processor/manager.go
@@ -61,7 +61,7 @@ type BindingManager interface {
 }
 
 type WorkflowBackendManager interface {
-	GetBackend() (backend.Backend, bool)
+	Backend() (backend.Backend, bool)
 }
 
 func (p *Processor) managerFromComp(comp componentsapi.Component) (manager, error) {

--- a/pkg/runtime/processor/wfbackend/wfbackend.go
+++ b/pkg/runtime/processor/wfbackend/wfbackend.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/microsoft/durabletask-go/backend"
 
@@ -56,18 +57,18 @@ func New(opts Options) *workflowBackend {
 	}
 }
 
-func (wfbe *workflowBackend) Init(ctx context.Context, comp compapi.Component) error {
-	wfbe.lock.Lock()
-	defer wfbe.lock.Unlock()
+func (w *workflowBackend) Init(ctx context.Context, comp compapi.Component) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
 
-	if wfbe.backend != nil {
+	if w.backend != nil {
 		// Can only have 1 workflow backend component
 		return errors.New("cannot create more than one workflow backend component")
 	}
 
 	// Create the component
 	fName := comp.LogName()
-	beFactory, err := wfbe.registry.Create(comp.Spec.Type, comp.Spec.Version, fName)
+	beFactory, err := w.registry.Create(comp.Spec.Type, comp.Spec.Version, fName)
 	if err != nil {
 		log.Errorf("Error creating workflow backend component (%s): %v", fName, err)
 		diag.DefaultMonitoring.ComponentInitFailed(comp.Spec.Type, "init", comp.ObjectMeta.Name)
@@ -79,14 +80,14 @@ func (wfbe *workflowBackend) Init(ctx context.Context, comp compapi.Component) e
 	}
 
 	// Initialization
-	baseMetadata, err := wfbe.meta.ToBaseMetadata(comp)
+	baseMetadata, err := w.meta.ToBaseMetadata(comp)
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(comp.Spec.Type, "init", comp.ObjectMeta.Name)
 		return rterrors.NewInit(rterrors.InitComponentFailure, fName, err)
 	}
 
 	be, err := beFactory(wfbeComp.Metadata{
-		AppID: wfbe.appID,
+		AppID: w.appID,
 		Base:  baseMetadata,
 	})
 	if err != nil {
@@ -96,21 +97,35 @@ func (wfbe *workflowBackend) Init(ctx context.Context, comp compapi.Component) e
 
 	log.Infof("Using %s as workflow backend", comp.Spec.Type)
 	diag.DefaultMonitoring.ComponentInitialized(comp.Spec.Type)
-	wfbe.backend = be
+	w.backend = be
+	w.compStore.AddWorkflowBackend(comp.Name, be)
 
 	return nil
 }
 
-func (wfbe *workflowBackend) Close(comp compapi.Component) error {
-	return nil
+func (w *workflowBackend) Close(comp compapi.Component) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	backend, ok := w.compStore.GetWorkflowBackend(comp.Name)
+	if !ok {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	defer w.compStore.DeleteWorkflowBackend(comp.Name)
+	w.backend = nil
+
+	return backend.Stop(ctx)
 }
 
-func (wfbe *workflowBackend) GetBackend() (backend.Backend, bool) {
-	wfbe.lock.Lock()
-	defer wfbe.lock.Unlock()
+func (w *workflowBackend) Backend() (backend.Backend, bool) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
 
-	if wfbe.backend == nil {
+	if w.backend == nil {
 		return nil, false
 	}
-	return wfbe.backend, true
+	return w.backend, true
 }

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -64,7 +64,7 @@ func NewWorkflowEngine(appID string, spec config.WorkflowSpec, backendManager pr
 
 	var ok bool
 	if backendManager != nil {
-		engine.Backend, ok = backendManager.GetBackend()
+		engine.Backend, ok = backendManager.Backend()
 	}
 	if !ok {
 		// If no backend was initialized by the manager, create a backend backed by actors

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -70,7 +70,7 @@ func Build(t *testing.T, name string) {
 
 		t.Logf("Root dir: %q", rootDir)
 		t.Logf("Compiling %q binary to: %q", name, binPath)
-		cmd := exec.Command("go", "build", "-tags=allcomponents", "-v", "-o", binPath, "./cmd/"+name)
+		cmd := exec.Command("go", "build", "-tags=allcomponents,wfbackendsqlite", "-v", "-o", binPath, "./cmd/"+name)
 		cmd.Dir = rootDir
 		cmd.Stdout = ioout
 		cmd.Stderr = ioerr

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -238,7 +238,7 @@ func (d *Daprd) WaitUntilAppHealth(t *testing.T, ctx context.Context) {
 	}
 }
 
-func (d *Daprd) GRPCClient(t *testing.T, ctx context.Context) rtv1.DaprClient {
+func (d *Daprd) GRPCConn(t *testing.T, ctx context.Context) *grpc.ClientConn {
 	conn, err := grpc.DialContext(ctx, fmt.Sprintf("localhost:%d", d.GRPCPort()),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
@@ -246,7 +246,11 @@ func (d *Daprd) GRPCClient(t *testing.T, ctx context.Context) rtv1.DaprClient {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
-	return rtv1.NewDaprClient(conn)
+	return conn
+}
+
+func (d *Daprd) GRPCClient(t *testing.T, ctx context.Context) rtv1.DaprClient {
+	return rtv1.NewDaprClient(d.GRPCConn(t, ctx))
 }
 
 func (d *Daprd) AppID() string {

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -144,7 +144,7 @@ func WithAppHealthProbeThreshold(threshold int) Option {
 
 func WithResourceFiles(files ...string) Option {
 	return func(o *options) {
-		o.resourceFiles = files
+		o.resourceFiles = append(o.resourceFiles, files...)
 	}
 }
 

--- a/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/dapr/pkg/apis/common"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/operator/api"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(workflowbackend))
+}
+
+type workflowbackend struct {
+	daprdCreate *daprd.Daprd
+	daprdUpdate *daprd.Daprd
+	daprdDelete *daprd.Daprd
+
+	operatorCreate *operator.Operator
+	operatorUpdate *operator.Operator
+	operatorDelete *operator.Operator
+
+	loglineCreate *logline.LogLine
+	loglineUpdate *logline.LogLine
+	loglineDelete *logline.LogLine
+}
+
+func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t)
+
+	w.loglineCreate = logline.New(t, logline.WithStdoutLineContains(
+		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+	))
+	w.loglineUpdate = logline.New(t, logline.WithStdoutLineContains(
+		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
+	))
+	w.loglineDelete = logline.New(t, logline.WithStdoutLineContains(
+		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+	))
+
+	w.operatorCreate = operator.New(t,
+		operator.WithSentry(sentry),
+		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
+			return &operatorv1.GetConfigurationResponse{
+				Configuration: []byte(
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
+				),
+			}, nil
+		}),
+	)
+	w.operatorUpdate = operator.New(t,
+		operator.WithSentry(sentry),
+		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
+			return &operatorv1.GetConfigurationResponse{
+				Configuration: []byte(
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
+				),
+			}, nil
+		}),
+	)
+	w.operatorDelete = operator.New(t,
+		operator.WithSentry(sentry),
+		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
+			return &operatorv1.GetConfigurationResponse{
+				Configuration: []byte(
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
+				),
+			}, nil
+		}),
+	)
+
+	inmemStore := compapi.Component{
+		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "mystore"},
+		Spec: compapi.ComponentSpec{
+			Type: "state.in-memory", Version: "v1",
+			Metadata: []common.NameValuePair{{Name: "actorStateStore", Value: common.DynamicValue{JSON: apiextv1.JSON{Raw: []byte(`"true"`)}}}},
+		},
+	}
+
+	w.operatorCreate.SetComponents(inmemStore)
+	w.operatorUpdate.SetComponents(inmemStore, compapi.Component{
+		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		Spec:       compapi.ComponentSpec{Type: "workflowbackend.actors", Version: "v1"},
+	})
+	w.operatorDelete.SetComponents(inmemStore, compapi.Component{
+		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		Spec:       compapi.ComponentSpec{Type: "workflowbackend.actors", Version: "v1"},
+	})
+
+	w.daprdCreate = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithConfigs("hotreloading"),
+		daprd.WithExecOptions(
+			exec.WithEnvVars("DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors)),
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(w.loglineCreate.Stdout()),
+		),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(w.operatorCreate.Address(t)),
+		daprd.WithDisableK8sSecretStore(true),
+	)
+	w.daprdUpdate = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithConfigs("hotreloading"),
+		daprd.WithExecOptions(
+			exec.WithEnvVars("DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors)),
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(w.loglineUpdate.Stdout()),
+		),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(w.operatorUpdate.Address(t)),
+		daprd.WithDisableK8sSecretStore(true),
+	)
+	w.daprdDelete = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithConfigs("hotreloading"),
+		daprd.WithExecOptions(
+			exec.WithEnvVars("DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors)),
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(w.loglineDelete.Stdout()),
+		),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(w.operatorDelete.Address(t)),
+		daprd.WithDisableK8sSecretStore(true),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry,
+			w.operatorCreate, w.operatorUpdate, w.operatorDelete,
+			w.loglineCreate, w.loglineUpdate, w.loglineDelete,
+			w.daprdCreate, w.daprdUpdate, w.daprdDelete,
+		),
+	}
+}
+
+func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
+	w.daprdCreate.WaitUntilRunning(t, ctx)
+	w.daprdUpdate.WaitUntilRunning(t, ctx)
+	w.daprdDelete.WaitUntilRunning(t, ctx)
+
+	httpClient := util.HTTPClient(t)
+
+	comps := util.GetMetaComponents(t, ctx, httpClient, w.daprdCreate.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{
+			Name: "mystore", Type: "state.in-memory", Version: "v1",
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+		},
+	}, comps)
+	actorsComp := compapi.Component{
+		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		Spec:       compapi.ComponentSpec{Type: "workflowbackend.actors", Version: "v1"},
+	}
+	w.operatorCreate.AddComponents(actorsComp)
+	w.operatorCreate.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &actorsComp, EventType: operatorv1.ResourceEventType_CREATED})
+	w.loglineCreate.EventuallyFoundAll(t)
+
+	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdUpdate.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
+		{
+			Name: "mystore", Type: "state.in-memory", Version: "v1",
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+		},
+	}, comps)
+	sqliteComp := compapi.Component{
+		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		Spec:       compapi.ComponentSpec{Type: "workflowbackend.sqlite", Version: "v1"},
+	}
+	w.operatorUpdate.SetComponents(sqliteComp)
+	w.operatorUpdate.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &sqliteComp, EventType: operatorv1.ResourceEventType_UPDATED})
+	w.loglineUpdate.EventuallyFoundAll(t)
+
+	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdDelete.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
+		{
+			Name: "mystore", Type: "state.in-memory", Version: "v1",
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+		},
+	}, comps)
+	w.operatorDelete.SetComponents()
+	w.operatorDelete.ComponentUpdateEvent(t, ctx, &api.ComponentUpdateEvent{Component: &actorsComp, EventType: operatorv1.ResourceEventType_DELETED})
+	w.loglineDelete.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
@@ -58,13 +58,13 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 	sentry := sentry.New(t)
 
 	w.loglineCreate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 	w.loglineUpdate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
+		"Aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
 	))
 	w.loglineDelete = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 
 	w.operatorCreate = operator.New(t,
@@ -126,10 +126,6 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 			exec.WithEnvVars(t,
 				"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 			),
-			exec.WithExitCode(1),
-			exec.WithRunError(func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "exit status 1")
-			}),
 			exec.WithStdout(w.loglineCreate.Stdout()),
 		),
 		daprd.WithSentryAddress(sentry.Address()),
@@ -143,10 +139,6 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 			exec.WithEnvVars(t,
 				"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 			),
-			exec.WithExitCode(1),
-			exec.WithRunError(func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "exit status 1")
-			}),
 			exec.WithStdout(w.loglineUpdate.Stdout()),
 		),
 		daprd.WithSentryAddress(sentry.Address()),
@@ -160,10 +152,6 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 			exec.WithEnvVars(t,
 				"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 			),
-			exec.WithExitCode(1),
-			exec.WithRunError(func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "exit status 1")
-			}),
 			exec.WithStdout(w.loglineDelete.Stdout()),
 		),
 		daprd.WithSentryAddress(sentry.Address()),

--- a/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
@@ -58,13 +58,13 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 	sentry := sentry.New(t)
 
 	w.loglineCreate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 	w.loglineUpdate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
+		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
 	))
 	w.loglineDelete = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 
 	w.operatorCreate = operator.New(t,

--- a/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
@@ -183,7 +183,6 @@ func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
 
 	comps := util.GetMetaComponents(t, ctx, httpClient, w.daprdCreate.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
 			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -200,7 +199,6 @@ func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
 
 	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdUpdate.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
@@ -218,7 +216,6 @@ func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
 
 	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdDelete.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",

--- a/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/operator/workflowbackend.go
@@ -100,7 +100,7 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 
 	inmemStore := compapi.Component{
 		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "mystore"},
+		ObjectMeta: metav1.ObjectMeta{Name: "mystore", Namespace: "default"},
 		Spec: compapi.ComponentSpec{
 			Type: "state.in-memory", Version: "v1",
 			Metadata: []common.NameValuePair{{Name: "actorStateStore", Value: common.DynamicValue{JSON: apiextv1.JSON{Raw: []byte(`"true"`)}}}},
@@ -110,12 +110,12 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 	w.operatorCreate.SetComponents(inmemStore)
 	w.operatorUpdate.SetComponents(inmemStore, compapi.Component{
 		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend", Namespace: "default"},
 		Spec:       compapi.ComponentSpec{Type: "workflowbackend.actors", Version: "v1"},
 	})
 	w.operatorDelete.SetComponents(inmemStore, compapi.Component{
 		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend", Namespace: "default"},
 		Spec:       compapi.ComponentSpec{Type: "workflowbackend.actors", Version: "v1"},
 	})
 
@@ -123,7 +123,9 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 		daprd.WithMode("kubernetes"),
 		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
-			exec.WithEnvVars("DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors)),
+			exec.WithEnvVars(t,
+				"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+			),
 			exec.WithExitCode(1),
 			exec.WithRunError(func(t *testing.T, err error) {
 				require.ErrorContains(t, err, "exit status 1")
@@ -138,7 +140,9 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 		daprd.WithMode("kubernetes"),
 		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
-			exec.WithEnvVars("DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors)),
+			exec.WithEnvVars(t,
+				"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+			),
 			exec.WithExitCode(1),
 			exec.WithRunError(func(t *testing.T, err error) {
 				require.ErrorContains(t, err, "exit status 1")
@@ -153,7 +157,9 @@ func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
 		daprd.WithMode("kubernetes"),
 		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
-			exec.WithEnvVars("DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors)),
+			exec.WithEnvVars(t,
+				"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+			),
 			exec.WithExitCode(1),
 			exec.WithRunError(func(t *testing.T, err error) {
 				require.ErrorContains(t, err, "exit status 1")
@@ -190,7 +196,7 @@ func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
 	}, comps)
 	actorsComp := compapi.Component{
 		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend", Namespace: "default"},
 		Spec:       compapi.ComponentSpec{Type: "workflowbackend.actors", Version: "v1"},
 	}
 	w.operatorCreate.AddComponents(actorsComp)
@@ -207,7 +213,7 @@ func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
 	}, comps)
 	sqliteComp := compapi.Component{
 		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend"},
+		ObjectMeta: metav1.ObjectMeta{Name: "wfbackend", Namespace: "default"},
 		Spec:       compapi.ComponentSpec{Type: "workflowbackend.sqlite", Version: "v1"},
 	}
 	w.operatorUpdate.SetComponents(sqliteComp)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfhosted
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(workflowbackend))
+}
+
+type workflowbackend struct {
+	daprdCreate *daprd.Daprd
+	daprdUpdate *daprd.Daprd
+	daprdDelete *daprd.Daprd
+
+	resDirCreate string
+	resDirUpdate string
+	resDirDelete string
+
+	loglineCreate *logline.LogLine
+	loglineUpdate *logline.LogLine
+	loglineDelete *logline.LogLine
+}
+
+func (w *workflowbackend) Setup(t *testing.T) []framework.Option {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: hotreloading
+spec:
+  features:
+  - name: HotReload
+    enabled: true`), 0o600))
+
+	w.loglineCreate = logline.New(t, logline.WithStdoutLineContains(
+		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+	))
+	w.loglineUpdate = logline.New(t, logline.WithStdoutLineContains(
+		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
+	))
+	w.loglineDelete = logline.New(t, logline.WithStdoutLineContains(
+		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+	))
+
+	w.resDirCreate = t.TempDir()
+	w.resDirUpdate = t.TempDir()
+	w.resDirDelete = t.TempDir()
+
+	place := placement.New(t)
+
+	w.daprdCreate = daprd.New(t,
+		daprd.WithConfigs(configFile),
+		daprd.WithResourcesDir(w.resDirCreate),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithExecOptions(
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(w.loglineCreate.Stdout()),
+		),
+	)
+
+	w.daprdUpdate = daprd.New(t,
+		daprd.WithConfigs(configFile),
+		daprd.WithResourcesDir(w.resDirUpdate),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithExecOptions(
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(w.loglineUpdate.Stdout()),
+		),
+	)
+
+	require.NoError(t, os.WriteFile(filepath.Join(w.resDirUpdate, "wf.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend
+spec:
+ type: workflowbackend.actors
+ version: v1
+`), 0o600))
+
+	w.daprdDelete = daprd.New(t,
+		daprd.WithConfigs(configFile),
+		daprd.WithResourcesDir(w.resDirDelete),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithExecOptions(
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(w.loglineDelete.Stdout()),
+		),
+	)
+
+	require.NoError(t, os.WriteFile(filepath.Join(w.resDirDelete, "wf.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend
+spec:
+ type: workflowbackend.actors
+ version: v1
+`), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(place,
+			w.loglineCreate, w.loglineUpdate, w.loglineDelete,
+			w.daprdCreate, w.daprdUpdate, w.daprdDelete,
+		),
+	}
+}
+
+func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
+	w.daprdCreate.WaitUntilRunning(t, ctx)
+	w.daprdUpdate.WaitUntilRunning(t, ctx)
+	w.daprdDelete.WaitUntilRunning(t, ctx)
+
+	httpClient := util.HTTPClient(t)
+
+	comps := util.GetMetaComponents(t, ctx, httpClient, w.daprdCreate.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{
+			Name: "mystore", Type: "state.in-memory", Version: "v1",
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+		},
+	}, comps)
+	require.NoError(t, os.WriteFile(filepath.Join(w.resDirCreate, "wf.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend
+spec:
+ type: workflowbackend.actors
+ version: v1
+`), 0o600))
+	w.loglineCreate.EventuallyFoundAll(t)
+
+	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdUpdate.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
+		{
+			Name: "mystore", Type: "state.in-memory", Version: "v1",
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+		},
+	}, comps)
+
+	require.NoError(t, os.WriteFile(filepath.Join(w.resDirUpdate, "wf.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend
+spec:
+ type: workflowbackend.sqlite
+ version: v1
+`), 0o600))
+	w.loglineUpdate.EventuallyFoundAll(t)
+
+	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdDelete.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
+		{
+			Name: "mystore", Type: "state.in-memory", Version: "v1",
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+		},
+	}, comps)
+
+	require.NoError(t, os.Remove(filepath.Join(w.resDirDelete, "wf.yaml")))
+	w.loglineDelete.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
@@ -62,13 +62,13 @@ spec:
     enabled: true`), 0o600))
 
 	w.loglineCreate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 	w.loglineUpdate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
+		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
 	))
 	w.loglineDelete = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: attempting to HotReload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 
 	w.resDirCreate = t.TempDir()

--- a/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
@@ -62,13 +62,13 @@ spec:
     enabled: true`), 0o600))
 
 	w.loglineCreate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 	w.loglineUpdate = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.sqlite/v1)",
+		"Aborting to hot-reload a workflowbackend component which is not supported: wfbackend (pubsub.in-memory/v1)",
 	))
 	w.loglineDelete = logline.New(t, logline.WithStdoutLineContains(
-		"Fatal error from runtime: aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
+		"Aborting to hot-reload a workflowbackend component which is not supported: wfbackend (workflowbackend.actors/v1)",
 	))
 
 	w.resDirCreate = t.TempDir()
@@ -83,10 +83,6 @@ spec:
 		daprd.WithPlacementAddresses(place.Address()),
 		daprd.WithInMemoryActorStateStore("mystore"),
 		daprd.WithExecOptions(
-			exec.WithExitCode(1),
-			exec.WithRunError(func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "exit status 1")
-			}),
 			exec.WithStdout(w.loglineCreate.Stdout()),
 		),
 	)
@@ -97,10 +93,6 @@ spec:
 		daprd.WithPlacementAddresses(place.Address()),
 		daprd.WithInMemoryActorStateStore("mystore"),
 		daprd.WithExecOptions(
-			exec.WithExitCode(1),
-			exec.WithRunError(func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "exit status 1")
-			}),
 			exec.WithStdout(w.loglineUpdate.Stdout()),
 		),
 	)
@@ -121,10 +113,6 @@ spec:
 		daprd.WithPlacementAddresses(place.Address()),
 		daprd.WithInMemoryActorStateStore("mystore"),
 		daprd.WithExecOptions(
-			exec.WithExitCode(1),
-			exec.WithRunError(func(t *testing.T, err error) {
-				require.ErrorContains(t, err, "exit status 1")
-			}),
 			exec.WithStdout(w.loglineDelete.Stdout()),
 		),
 	)
@@ -187,7 +175,7 @@ kind: Component
 metadata:
  name: wfbackend
 spec:
- type: workflowbackend.sqlite
+ type: pubsub.in-memory
  version: v1
 `), 0o600))
 	w.loglineUpdate.EventuallyFoundAll(t)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/workflowbackend.go
@@ -156,7 +156,6 @@ func (w *workflowbackend) Run(t *testing.T, ctx context.Context) {
 
 	comps := util.GetMetaComponents(t, ctx, httpClient, w.daprdCreate.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
 			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
@@ -175,7 +174,6 @@ spec:
 
 	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdUpdate.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
@@ -196,7 +194,6 @@ spec:
 
 	comps = util.GetMetaComponents(t, ctx, httpClient, w.daprdDelete.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",

--- a/tests/integration/suite/daprd/workflow/backend/actors.go
+++ b/tests/integration/suite/daprd/workflow/backend/actors.go
@@ -68,7 +68,6 @@ func (a *actors) Run(t *testing.T, ctx context.Context) {
 
 	comps := util.GetMetaComponents(t, ctx, util.HTTPClient(t), a.daprd.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",

--- a/tests/integration/suite/daprd/workflow/backend/actors.go
+++ b/tests/integration/suite/daprd/workflow/backend/actors.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	"github.com/microsoft/durabletask-go/client"
+	"github.com/microsoft/durabletask-go/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(actors))
+}
+
+type actors struct {
+	daprd *daprd.Daprd
+	place *placement.Placement
+}
+
+func (a *actors) Setup(t *testing.T) []framework.Option {
+	a.place = placement.New(t)
+	a.daprd = daprd.New(t,
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend
+spec:
+ type: workflowbackend.actors
+ version: v1
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.place, a.daprd),
+	}
+}
+
+func (a *actors) Run(t *testing.T, ctx context.Context) {
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	comps := util.GetMetaComponents(t, ctx, util.HTTPClient(t), a.daprd.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{Name: "wfbackend", Type: "workflowbackend.actors", Version: "v1"},
+		{
+			Name: "mystore", Type: "state.in-memory", Version: "v1",
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+		},
+	}, comps)
+
+	r := task.NewTaskRegistry()
+	r.AddOrchestratorN("SingleActivity", func(ctx *task.OrchestrationContext) (any, error) {
+		var input string
+		if err := ctx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		var output string
+		err := ctx.CallActivity("SayHello", task.WithActivityInput(input)).Await(&output)
+		return output, err
+	})
+	r.AddActivityN("SayHello", func(ctx task.ActivityContext) (any, error) {
+		var name string
+		if err := ctx.GetInput(&name); err != nil {
+			return nil, err
+		}
+		return fmt.Sprintf("Hello, %s!", name), nil
+	})
+	backendClient := client.NewTaskHubGrpcClient(a.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
+
+	resp, err := a.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "SingleActivity",
+		Input:             []byte(`"Dapr"`),
+		InstanceId:        "myinstance",
+	})
+	require.NoError(t, err)
+
+	id := api.InstanceID(resp.GetInstanceId())
+	metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.True(t, metadata.IsComplete())
+	assert.Equal(t, `"Hello, Dapr!"`, metadata.SerializedOutput)
+}

--- a/tests/integration/suite/daprd/workflow/backend/backend.go
+++ b/tests/integration/suite/daprd/workflow/backend/backend.go
@@ -11,8 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package workflow
+package backend
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/backend"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/backend/singular"
 )

--- a/tests/integration/suite/daprd/workflow/backend/singular/actors.go
+++ b/tests/integration/suite/daprd/workflow/backend/singular/actors.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package singular
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(actors))
+}
+
+// actors ensures that 2 actor workflow backends cannot be loaded at the same time.
+type actors struct {
+	logline *logline.LogLine
+	daprd   *daprd.Daprd
+}
+
+func (a *actors) Setup(t *testing.T) []framework.Option {
+	a.logline = logline.New(t,
+		logline.WithStdoutLineContains(
+			"Fatal error from runtime: process component wfbackend2 error: [INIT_COMPONENT_FAILURE]: initialization error occurred for wfbackend2 (workflowbackend.actors/v1): cannot create more than one workflow backend component",
+		),
+	)
+
+	a.daprd = daprd.New(t,
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend1
+spec:
+ type: workflowbackend.actors
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend2
+spec:
+ type: workflowbackend.actors
+ version: v1
+`),
+		daprd.WithExecOptions(
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(a.logline.Stdout()),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.logline, a.daprd),
+	}
+}
+
+func (a *actors) Run(t *testing.T, ctx context.Context) {
+	a.logline.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/workflow/backend/singular/sqlite.go
+++ b/tests/integration/suite/daprd/workflow/backend/singular/sqlite.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package singular
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(sqlite))
+}
+
+// sqlite ensures that 2 sqlite workflow backends cannot be loaded at the same time.
+type sqlite struct {
+	logline *logline.LogLine
+	daprd   *daprd.Daprd
+}
+
+func (s *sqlite) Setup(t *testing.T) []framework.Option {
+	s.logline = logline.New(t,
+		logline.WithStdoutLineContains(
+			"Fatal error from runtime: process component wfbackend2 error: [INIT_COMPONENT_FAILURE]: initialization error occurred for wfbackend2 (workflowbackend.sqlite/v1): cannot create more than one workflow backend component",
+		),
+	)
+
+	s.daprd = daprd.New(t,
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend1
+spec:
+ type: workflowbackend.sqlite
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend2
+spec:
+ type: workflowbackend.sqlite
+ version: v1
+`),
+		daprd.WithExecOptions(
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(s.logline.Stdout()),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.logline, s.daprd),
+	}
+}
+
+func (s *sqlite) Run(t *testing.T, ctx context.Context) {
+	s.logline.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/workflow/backend/singular/sqliteactors.go
+++ b/tests/integration/suite/daprd/workflow/backend/singular/sqliteactors.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package singular
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(sqliteactors))
+}
+
+// sqliteactors ensures that 2 workflow backends of different type cannot be
+// loaded at the same time.
+type sqliteactors struct {
+	logline *logline.LogLine
+	daprd   *daprd.Daprd
+}
+
+func (s *sqliteactors) Setup(t *testing.T) []framework.Option {
+	s.logline = logline.New(t,
+		logline.WithStdoutLineContains(
+			"Fatal error from runtime: process component wfbackend2 error: [INIT_COMPONENT_FAILURE]: initialization error occurred for wfbackend2 (workflowbackend.actors/v1): cannot create more than one workflow backend component",
+		),
+	)
+
+	s.daprd = daprd.New(t,
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend1
+spec:
+ type: workflowbackend.sqlite
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend2
+spec:
+ type: workflowbackend.actors
+ version: v1
+`),
+		daprd.WithExecOptions(
+			exec.WithExitCode(1),
+			exec.WithRunError(func(t *testing.T, err error) {
+				require.ErrorContains(t, err, "exit status 1")
+			}),
+			exec.WithStdout(s.logline.Stdout()),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.logline, s.daprd),
+	}
+}
+
+func (s *sqliteactors) Run(t *testing.T, ctx context.Context) {
+	s.logline.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/workflow/backend/sqlite.go
+++ b/tests/integration/suite/daprd/workflow/backend/sqlite.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	"github.com/microsoft/durabletask-go/client"
+	"github.com/microsoft/durabletask-go/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(sqlite))
+}
+
+type sqlite struct {
+	daprd *daprd.Daprd
+	dir   string
+}
+
+func (s *sqlite) Setup(t *testing.T) []framework.Option {
+	s.dir = filepath.Join(t.TempDir(), "wf.db")
+	s.daprd = daprd.New(t,
+		daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: wfbackend
+spec:
+ type: workflowbackend.sqlite
+ version: v1
+ metadata:
+ - name: connectionString
+   value: %s
+`, s.dir)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.daprd),
+	}
+}
+
+func (s *sqlite) Run(t *testing.T, ctx context.Context) {
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	comps := util.GetMetaComponents(t, ctx, util.HTTPClient(t), s.daprd.HTTPPort())
+	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
+		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
+		{Name: "wfbackend", Type: "workflowbackend.sqlite", Version: "v1"},
+	}, comps)
+
+	r := task.NewTaskRegistry()
+	r.AddOrchestratorN("SingleActivity", func(ctx *task.OrchestrationContext) (any, error) {
+		var input string
+		if err := ctx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		var output string
+		err := ctx.CallActivity("SayHello", task.WithActivityInput(input)).Await(&output)
+		return output, err
+	})
+	r.AddActivityN("SayHello", func(ctx task.ActivityContext) (any, error) {
+		var name string
+		if err := ctx.GetInput(&name); err != nil {
+			return nil, err
+		}
+		return fmt.Sprintf("Hello, %s!", name), nil
+	})
+	backendClient := client.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
+
+	resp, err := s.daprd.GRPCClient(t, ctx).
+		StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "SingleActivity",
+			Input:             []byte(`"Dapr"`),
+			InstanceId:        "myinstance",
+		})
+	require.NoError(t, err)
+
+	id := api.InstanceID(resp.GetInstanceId())
+	metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.True(t, metadata.IsComplete())
+	assert.Equal(t, `"Hello, Dapr!"`, metadata.SerializedOutput)
+}

--- a/tests/integration/suite/daprd/workflow/backend/sqlite.go
+++ b/tests/integration/suite/daprd/workflow/backend/sqlite.go
@@ -69,7 +69,6 @@ func (s *sqlite) Run(t *testing.T, ctx context.Context) {
 
 	comps := util.GetMetaComponents(t, ctx, util.HTTPClient(t), s.daprd.HTTPPort())
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
-		{Name: "dapr", Type: "workflow.dapr", Version: "v1"},
 		{Name: "wfbackend", Type: "workflowbackend.sqlite", Version: "v1"},
 	}, comps)
 

--- a/tests/integration/suite/daprd/workflow/basic.go
+++ b/tests/integration/suite/daprd/workflow/basic.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	"github.com/microsoft/durabletask-go/client"
+	"github.com/microsoft/durabletask-go/task"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+// metrics tests daprd metrics
+type basic struct {
+	daprd      *daprd.Daprd
+	place      *placement.Placement
+	httpClient *http.Client
+	grpcClient runtimev1pb.DaprClient
+}
+
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(""))
+	})
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	b.place = placement.New(t)
+	b.daprd = daprd.New(t,
+		daprd.WithAppID("myapp"),
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithPlacementAddresses(b.place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(b.place, srv, b.daprd),
+	}
+}
+
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.place.WaitUntilRunning(t, ctx)
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	b.httpClient = util.HTTPClient(t)
+
+	conn, err := grpc.DialContext(ctx,
+		b.daprd.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	b.grpcClient = runtimev1pb.NewDaprClient(conn)
+
+	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+
+	t.Run("basic", func(t *testing.T) {
+		r := task.NewTaskRegistry()
+		r.AddOrchestratorN("SingleActivity", func(ctx *task.OrchestrationContext) (any, error) {
+			var input string
+			if err := ctx.GetInput(&input); err != nil {
+				return nil, err
+			}
+			var output string
+			err := ctx.CallActivity("SayHello", task.WithActivityInput(input)).Await(&output)
+			return output, err
+		})
+		r.AddActivityN("SayHello", func(ctx task.ActivityContext) (any, error) {
+			var name string
+			if err := ctx.GetInput(&name); err != nil {
+				return nil, err
+			}
+			return fmt.Sprintf("Hello, %s!", name), nil
+		})
+		taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
+		backendClient.StartWorkItemListener(taskhubCtx, r)
+		defer cancelTaskhub()
+
+		id := api.InstanceID(b.startWorkflow(ctx, t, "SingleActivity", "Dapr"))
+		metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, id, api.WithFetchPayloads(true))
+		require.NoError(t, err)
+		assert.True(t, metadata.IsComplete())
+		assert.Equal(t, `"Hello, Dapr!"`, metadata.SerializedOutput)
+	})
+
+	t.Run("terminate", func(t *testing.T) {
+		delayTime := 4 * time.Second
+		var executedActivity atomic.Bool
+		r := task.NewTaskRegistry()
+		r.AddOrchestratorN("Root", func(ctx *task.OrchestrationContext) (any, error) {
+			tasks := []task.Task{}
+			for i := 0; i < 5; i++ {
+				task := ctx.CallSubOrchestrator("L1", task.WithSubOrchestrationInstanceID(string(ctx.ID)+"_L1_"+strconv.Itoa(i)))
+				tasks = append(tasks, task)
+			}
+			for _, task := range tasks {
+				task.Await(nil)
+			}
+			return nil, nil
+		})
+		r.AddOrchestratorN("L1", func(ctx *task.OrchestrationContext) (any, error) {
+			ctx.CallSubOrchestrator("L2", task.WithSubOrchestrationInstanceID(string(ctx.ID)+"_L2")).Await(nil)
+			return nil, nil
+		})
+		r.AddOrchestratorN("L2", func(ctx *task.OrchestrationContext) (any, error) {
+			ctx.CreateTimer(delayTime).Await(nil)
+			ctx.CallActivity("Fail").Await(nil)
+			return nil, nil
+		})
+		r.AddActivityN("Fail", func(ctx task.ActivityContext) (any, error) {
+			executedActivity.Store(true)
+			return nil, errors.New("failed: Should not have executed the activity")
+		})
+
+		taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
+		backendClient.StartWorkItemListener(taskhubCtx, r)
+		defer cancelTaskhub()
+
+		// Test terminating with and without recursion
+		for _, nonRecursive := range []string{"", "false", "true"} {
+			// `non_recursive` = "" means no query param, which should default to false
+			nonRecursiveBool := false
+			if nonRecursive == "true" {
+				nonRecursiveBool = true
+			}
+			t.Run(fmt.Sprintf("non_recursive = %v", nonRecursive), func(t *testing.T) {
+				id := api.InstanceID(b.startWorkflow(ctx, t, "Root", ""))
+
+				// Wait long enough to ensure all orchestrations have started (but not longer than the timer delay)
+				assert.Eventually(t, func() bool {
+					// List of all orchestrations created
+					orchestrationIDs := []string{string(id)}
+					for i := 0; i < 5; i++ {
+						orchestrationIDs = append(orchestrationIDs, string(id)+"_L1_"+strconv.Itoa(i), string(id)+"_L1_"+strconv.Itoa(i)+"_L2")
+					}
+					for _, orchID := range orchestrationIDs {
+						meta, err := backendClient.FetchOrchestrationMetadata(ctx, api.InstanceID(orchID))
+						require.NoError(t, err)
+						// All orchestrations should be running
+						if meta.RuntimeStatus != api.RUNTIME_STATUS_RUNNING {
+							return false
+						}
+					}
+					return true
+				}, 2*time.Second, 100*time.Millisecond)
+
+				// Terminate the root orchestration and mark whether a nonRecursive termination
+				b.terminateWorkflow(ctx, t, string(id), nonRecursive)
+
+				// Wait for the root orchestration to complete and verify its terminated status
+				metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, id)
+				require.NoError(t, err)
+				require.Equal(t, api.RUNTIME_STATUS_TERMINATED, metadata.RuntimeStatus)
+
+				// Wait for all L2 suborchestrations to complete
+				orchIDs := []string{}
+				for i := 0; i < 5; i++ {
+					orchIDs = append(orchIDs, string(id)+"_L1_"+strconv.Itoa(i)+"_L2")
+				}
+				for _, orchID := range orchIDs {
+					_, err := backendClient.WaitForOrchestrationCompletion(ctx, api.InstanceID(orchID))
+					require.NoError(t, err)
+				}
+
+				// Verify tht none of the L2 suborchestrations executed the activity in case of recursive termination
+				assert.Equal(t, nonRecursiveBool, executedActivity.Load())
+			})
+		}
+	})
+
+	t.Run("purge", func(t *testing.T) {
+		delayTime := 4 * time.Second
+		r := task.NewTaskRegistry()
+		r.AddOrchestratorN("Root", func(ctx *task.OrchestrationContext) (any, error) {
+			ctx.CallSubOrchestrator("L1", task.WithSubOrchestrationInstanceID(string(ctx.ID)+"_L1")).Await(nil)
+			return nil, nil
+		})
+		r.AddOrchestratorN("L1", func(ctx *task.OrchestrationContext) (any, error) {
+			ctx.CallSubOrchestrator("L2", task.WithSubOrchestrationInstanceID(string(ctx.ID)+"_L2")).Await(nil)
+			return nil, nil
+		})
+		r.AddOrchestratorN("L2", func(ctx *task.OrchestrationContext) (any, error) {
+			ctx.CreateTimer(delayTime).Await(nil)
+			return nil, nil
+		})
+		taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
+		backendClient.StartWorkItemListener(taskhubCtx, r)
+		defer cancelTaskhub()
+
+		// Test purging with and without recursion
+		for _, nonRecursive := range []string{"", "false", "true"} {
+			// `non_recursive` = "" means no query param, which should default to false
+			nonRecursiveBool := false
+			if nonRecursive == "true" {
+				nonRecursiveBool = true
+			}
+			t.Run(fmt.Sprintf("non_recursive = %v", nonRecursive), func(t *testing.T) {
+				// Run the orchestration, which will block waiting for external events
+				id := api.InstanceID(b.startWorkflow(ctx, t, "Root", ""))
+
+				metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, id)
+				require.NoError(t, err)
+				require.Equal(t, api.RUNTIME_STATUS_COMPLETED, metadata.RuntimeStatus)
+
+				// Purge the root orchestration
+				b.purgeWorkflow(ctx, t, string(id), nonRecursive)
+
+				// Verify that root Orchestration has been purged
+				_, err = backendClient.FetchOrchestrationMetadata(ctx, id)
+				assert.Contains(t, status.Convert(err).Message(), api.ErrInstanceNotFound.Error())
+
+				if nonRecursiveBool {
+					// Verify that L1 and L2 orchestrations are not purged
+					metadata, err = backendClient.FetchOrchestrationMetadata(ctx, id+"_L1")
+					require.NoError(t, err)
+					require.Equal(t, api.RUNTIME_STATUS_COMPLETED, metadata.RuntimeStatus)
+
+					_, err = backendClient.FetchOrchestrationMetadata(ctx, id+"_L1_L2")
+					require.NoError(t, err)
+					require.Equal(t, api.RUNTIME_STATUS_COMPLETED, metadata.RuntimeStatus)
+				} else {
+					// Verify that L1 and L2 orchestrations have been purged
+					_, err = backendClient.FetchOrchestrationMetadata(ctx, id+"_L1")
+					require.Contains(t, status.Convert(err).Message(), api.ErrInstanceNotFound.Error())
+
+					_, err = backendClient.FetchOrchestrationMetadata(ctx, id+"_L1_L2")
+					require.Contains(t, status.Convert(err).Message(), api.ErrInstanceNotFound.Error())
+				}
+			})
+		}
+	})
+
+	t.Run("child workflow", func(t *testing.T) {
+		r := task.NewTaskRegistry()
+		r.AddOrchestratorN("root", func(ctx *task.OrchestrationContext) (any, error) {
+			var input string
+			if err := ctx.GetInput(&input); err != nil {
+				return nil, err
+			}
+			var output string
+			err := ctx.CallSubOrchestrator("child", task.WithSubOrchestratorInput(input)).Await(&output)
+			return output, err
+		})
+		r.AddOrchestratorN("child", func(ctx *task.OrchestrationContext) (any, error) {
+			var input string
+			if err := ctx.GetInput(&input); err != nil {
+				return nil, err
+			}
+			return fmt.Sprintf("Hello, %s!", input), nil
+		})
+		taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
+		backendClient.StartWorkItemListener(taskhubCtx, r)
+		defer cancelTaskhub()
+
+		id := api.InstanceID(b.startWorkflow(ctx, t, "root", "Dapr"))
+		metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, id, api.WithFetchPayloads(true))
+		require.NoError(t, err)
+		assert.True(t, metadata.IsComplete())
+		assert.Equal(t, `"Hello, Dapr!"`, metadata.SerializedOutput)
+	})
+}
+
+func (b *basic) startWorkflow(ctx context.Context, t *testing.T, name string, input string) string {
+	// use http client to start the workflow
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0-beta1/workflows/dapr/%s/start", b.daprd.HTTPPort(), name)
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, reqURL, strings.NewReader(string(data)))
+	req.Header.Set("Content-Type", "application/json")
+	require.NoError(t, err)
+	resp, err := b.httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	var response struct {
+		InstanceID string `json:"instanceID"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	require.NoError(t, err)
+
+	return response.InstanceID
+}
+
+// terminate workflow
+func (b *basic) terminateWorkflow(ctx context.Context, t *testing.T, instanceID string, nonRecursive string) {
+	// use http client to terminate the workflow
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0-beta1/workflows/dapr/%s/terminate", b.daprd.HTTPPort(), instanceID)
+	if nonRecursive != "" {
+		reqURL += "?non_recursive=" + nonRecursive
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+	resp, err := b.httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+// purge workflow
+func (b *basic) purgeWorkflow(ctx context.Context, t *testing.T, instanceID string, nonRecursive string) {
+	// use http client to purge the workflow
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0-beta1/workflows/dapr/%s/purge", b.daprd.HTTPPort(), instanceID)
+	if nonRecursive != "" {
+		reqURL += "?non_recursive=" + nonRecursive
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+	resp, err := b.httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+}


### PR DESCRIPTION
Updates the hot reloading reconciler so that Daprd will log and error and ignore workflow backends when they are hot reloaded.

Adds integration tests for daprd ensuring workflow backends can be loaded on boot.

Adds tests to ensure daprd will log an error on a workflow backend being hot reloaded.

Adds tests to ensure multiple workflow backends cannot be loaded at once.

closes https://github.com/dapr/dapr/issues/7409