### PR TITLE
Nit: reserving folder for local dev in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage.txt
 
 # Go Workspaces (introduced in Go 1.18+)
 go.work
+
+# Directory reserved for local dev files: config files, scripts, anything for individual local dev.
+.local/


### PR DESCRIPTION
# Description

This is handy for people working on multiple fronts in runtime and want to keep a folder with config files, components, docker compose YAMLs or anything that expedites local development of a feature.

## Issue reference


Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
