### PR TITLE
Trying large runners for Linux/Windows CI

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -103,7 +103,6 @@ jobs:
           make gen-proto check-proto-diff
   unit-tests:
     name: Unit tests
-    needs: lint
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
@@ -147,7 +146,6 @@ jobs:
 
   integration-tests:
     name: Integration tests
-    needs: lint
     runs-on: "${{ matrix.os }}"
     strategy:
       fail-fast: false
@@ -182,7 +180,7 @@ jobs:
   build:
     name: "Build artifacts on ${{ matrix.job_name }} - ${{ matrix.sidecar_flavor }}"
     runs-on: "${{ matrix.os }}"
-    needs: [unit-tests, integration-tests]
+    needs: [lint, unit-tests, integration-tests]
     env:
       GOOS: "${{ matrix.target_os }}"
       GOARCH: "${{ matrix.target_arch }}"

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -109,13 +109,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-latest-4-cores
             target_os: linux
             target_arch: amd64
-          - os: windows-2022
+          - os: windows-latest-8-cores
             target_os: windows
             target_arch: amd64
-            windows_version: ltsc2022
           - os: macOS-latest
             target_os: darwin
             target_arch: amd64
@@ -154,13 +153,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-latest-4-cores
             target_os: linux
             target_arch: amd64
-          - os: windows-2022
+          - os: windows-latest-8-cores
             target_os: windows
             target_arch: amd64
-            windows_version: ltsc2022
           - os: macOS-latest
             target_os: darwin
             target_arch: amd64

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -43,7 +43,7 @@ jobs:
   # workflows.
   e2e:
     name: e2e
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       REGISTRY_PORT: 5000
       REGISTRY_NAME: kind-registry


### PR DESCRIPTION
Uses larger Actions runners for:

- Linux unit and integration tests
- Windows unit and integration tests
- KIND tests

We cannot change the runners used on MacOS because STC doesn't have the option to enable larger MacOS runners.