### PR TITLE
Bug fixes and test stabilization to unblock 1.13 release - keeping "localhost"

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -179,6 +179,10 @@ jobs:
           go-version-file: "go.mod"
       - name: Build binaries
         run: make build
+      - name: Override DAPR_HOST_IP for MacOS
+        if: matrix.target_os == 'darwin'
+        run: |
+          echo "DAPR_HOST_IP=127.0.0.1" >>${GITHUB_ENV}
       - name: Run make test-integration
         run: make test-integration
   build:

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -822,8 +822,18 @@ func (a *actorsRuntime) callRemoteActor(
 }
 
 func (a *actorsRuntime) isActorLocal(targetActorAddress, hostAddress string, grpcPort int) bool {
-	return strings.Contains(targetActorAddress, "localhost") || strings.Contains(targetActorAddress, "127.0.0.1") ||
-		targetActorAddress == hostAddress+":"+strconv.Itoa(grpcPort)
+	if targetActorAddress == hostAddress+":"+strconv.Itoa(grpcPort) {
+		// Easy case when there is a perfect match
+		return true
+	}
+
+	if hostAddress == "localhost" || hostAddress == "127.0.0.1" || hostAddress == "[::1]" || hostAddress == "::1" {
+		return targetActorAddress == "localhost:"+strconv.Itoa(grpcPort) ||
+			targetActorAddress == "127.0.0.1:"+strconv.Itoa(grpcPort) ||
+			targetActorAddress == "[::1]:"+strconv.Itoa(grpcPort)
+	}
+
+	return false
 }
 
 func (a *actorsRuntime) GetState(ctx context.Context, req *GetStateRequest) (*StateResponse, error) {

--- a/pkg/actors/actors_mock.go
+++ b/pkg/actors/actors_mock.go
@@ -71,7 +71,7 @@ func (p *MockPlacement) LookupActor(ctx context.Context, req internal.LookupActo
 	}
 
 	return internal.LookupActorResponse{
-		Address: "localhost",
+		Address: "localhost:5000",
 		AppID:   p.testAppID,
 	}, nil
 }

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -217,6 +217,8 @@ func newTestActorsRuntimeWithMock(t *testing.T, appChannel channel.AppChannel) *
 		AppConfig: config.ApplicationConfig{
 			Entities: []string{"cat", "dog", "actor2"},
 		},
+		HostAddress: "localhost",
+		Port:        Port,
 	})
 
 	clock := clocktesting.NewFakeClock(startOfTime)

--- a/pkg/actors/internal_actor_test.go
+++ b/pkg/actors/internal_actor_test.go
@@ -90,6 +90,8 @@ func newTestActorsRuntimeWithInternalActors(internalActors map[string]InternalAc
 	config := NewConfig(ConfigOpts{
 		AppID:         TestAppID,
 		ActorsService: "placement:placement:5050",
+		HostAddress:   "localhost",
+		Port:          Port,
 	})
 
 	compStore := compstore.New()

--- a/pkg/placement/ha_test.go
+++ b/pkg/placement/ha_test.go
@@ -368,7 +368,7 @@ func findLeader(t *testing.T, raftServers []*raft.Server) int {
 		}
 
 		return true
-	}, time.Second*10, time.Second, "no leader elected")
+	}, time.Second*30, time.Second, "no leader elected")
 	return n
 }
 

--- a/pkg/placement/hashing/consistent_hash.go
+++ b/pkg/placement/hashing/consistent_hash.go
@@ -449,10 +449,7 @@ func (c *Consistent) SortedSet() (sortedSet []uint64) {
 	c.RLock()
 	defer c.RUnlock()
 
-	for k := range c.sortedSet {
-		sortedSet = append(sortedSet, uint64(k))
-	}
-	return sortedSet
+	return c.sortedSet
 }
 
 func hash(key string) uint64 {

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -967,6 +967,8 @@ func getEngineAndStateStore(t *testing.T, ctx context.Context) (*wfengine.Workfl
 		AppID:         testAppID,
 		ActorsService: "placement:placement:5050",
 		AppConfig:     config.ApplicationConfig{},
+		HostAddress:   "localhost",
+		Port:          5000, // port for unit tests to pass IsLocalActor
 	})
 	compStore := compstore.New()
 	compStore.AddStateStore("workflowStore", store)


### PR DESCRIPTION
# Description

* Use of DAPR_HOST_IP to force sidecar to advertise itself as "127.0.0.1" in integration-tests
* Fix IsActorLocal() to also compare port in case of localhost
* Fix reminder rebalance bug (by @elena-kolevska)

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: endgame

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
