### PR TITLE
docs: Update Helm Chart README

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -103,7 +103,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `global.daprControlPlaneOs`               | Operating System for Dapr control plane                                 | `linux`                 |
 | `global.daprControlPlaneArch`             | CPU Architecture for Dapr control plane                                 | `amd64`                 |
 | `global.nodeSelector`                     | Pods will be scheduled onto a node node whose labels match the nodeSelector        | `{}`         |
-| `global.tolerations`                      | Pods will be allowed to schedule onto a node whose taints match the tolerations    | `{}`         |
+| `global.tolerations`                      | Pods will be allowed to schedule onto a node whose taints match the tolerations    | `[]`         |
 | `global.labels`                           | Custom pod labels                                                                  | `{}`         |
 | `global.k8sLabels`                        | Custom metadata labels                                                             | `{}`         |
 | `global.issuerFilenames.ca`               | Custom name of the file containing the root CA certificate inside the container    | `ca.crt`     |


### PR DESCRIPTION
# Description

Helm chart showed default value for `global.tolerations` as object, `{}` when it is actually array `[]` which might confuse readers who are expecting to supply an array into the Helm chart. 

## Issue reference

Please reference the issue this PR will close: #7499

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
