### PR TITLE
Make injector resilient to sentry unavailability

### DIFF
--- a/cmd/injector/app/app.go
+++ b/cmd/injector/app/app.go
@@ -127,6 +127,11 @@ func Run() {
 				SentryID:      sentryID,
 				Security:      sec,
 			})
+			derr := requester.DialSentryConnection(ctx)
+			if derr != nil {
+				return derr
+			}
+
 			return inj.Run(ctx,
 				sec.TLSServerConfigNoClientAuth(),
 				sentryID,

--- a/pkg/injector/sentry/sentry.go
+++ b/pkg/injector/sentry/sentry.go
@@ -55,14 +55,12 @@ type Requester struct {
 // New returns a new instance of the Requester.
 func New(opts Options) *Requester {
 	_, kubeMode := os.LookupEnv("KUBERNETES_SERVICE_HOST")
-	r := &Requester{
+	return &Requester{
 		sentryAddress:  opts.SentryAddress,
 		sentryID:       opts.SentryID,
 		sec:            opts.Security,
 		kubernetesMode: kubeMode,
 	}
-
-	return r
 }
 
 // DialSentryConnection creates the gRPC connection to the Sentry service and blocks for 1 minute.

--- a/pkg/injector/sentry/sentry.go
+++ b/pkg/injector/sentry/sentry.go
@@ -23,7 +23,9 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"time"
 
+	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"google.golang.org/grpc"
 
@@ -47,17 +49,34 @@ type Requester struct {
 	sentryID       spiffeid.ID
 	sec            security.Handler
 	kubernetesMode bool
+	sentryConn     *grpc.ClientConn
 }
 
 // New returns a new instance of the Requester.
 func New(opts Options) *Requester {
 	_, kubeMode := os.LookupEnv("KUBERNETES_SERVICE_HOST")
-	return &Requester{
+	r := &Requester{
 		sentryAddress:  opts.SentryAddress,
 		sentryID:       opts.SentryID,
 		sec:            opts.Security,
 		kubernetesMode: kubeMode,
 	}
+
+	return r
+}
+
+// DialSentryConnection creates the gRPC connection to the Sentry service and blocks for 1 minute.
+func (r *Requester) DialSentryConnection(ctx context.Context) error {
+	connCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	conn, err := grpc.DialContext(connCtx, r.sentryAddress, r.sec.GRPCDialOptionMTLS(r.sentryID), grpc.WithBlock())
+	if err != nil {
+		return fmt.Errorf("error establishing connection to sentry: %w", err)
+	}
+	r.sentryConn = conn
+
+	return nil
 }
 
 // RequestCertificateFromSentry requests a certificate from sentry for a
@@ -78,18 +97,12 @@ func (r *Requester) RequestCertificateFromSentry(ctx context.Context, namespace 
 		return nil, nil, fmt.Errorf("failed to create sidecar csr: %w", err)
 	}
 
-	conn, err := grpc.DialContext(ctx, r.sentryAddress, r.sec.GRPCDialOptionMTLS(r.sentryID))
-	if err != nil {
-		return nil, nil, fmt.Errorf("error establishing connection to sentry: %w", err)
-	}
-	defer conn.Close()
-
 	token, tokenValidator, err := securitytoken.GetSentryToken(r.kubernetesMode)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error obtaining token: %w", err)
 	}
 
-	resp, err := sentryv1pb.NewCAClient(conn).SignCertificate(ctx,
+	resp, err := sentryv1pb.NewCAClient(r.sentryConn).SignCertificate(ctx,
 		&sentryv1pb.SignCertificateRequest{
 			CertificateSigningRequest: pem.EncodeToMemory(&pem.Block{
 				Type: "CERTIFICATE REQUEST", Bytes: csrDER,
@@ -98,7 +111,7 @@ func (r *Requester) RequestCertificateFromSentry(ctx context.Context, namespace 
 			Token:          token,
 			Namespace:      namespace,
 			TokenValidator: tokenValidator,
-		})
+		}, grpcRetry.WithMax(3), grpcRetry.WithPerRetryTimeout(time.Second*3))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error from sentry SignCertificate: %w", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/dapr/dapr/issues/7479

Reported by multiple users: In case Sentry becomes temporarily unavailable for any reason or a signing certificate fails, A pod mutation request causes a pod to be deployed without sidecars. In addition, we were opening a new gRPC connection per signing request which can lead to performance issues at scale.

This PR uses a single connection through the lifecycle of the injector and adds gRPC retries when calling Sentry for certificate signing requests.
