### PR TITLE
Increase Sentry retry to 30s from Sidecar Injector

### DIFF
--- a/cmd/injector/app/app.go
+++ b/cmd/injector/app/app.go
@@ -122,12 +122,11 @@ func Run() {
 			if err != nil {
 				return rerr
 			}
-			requester := sentry.New(sentry.Options{
+			requester, derr := sentry.New(ctx, sentry.Options{
 				SentryAddress: cfg.SentryAddress,
 				SentryID:      sentryID,
 				Security:      sec,
 			})
-			derr := requester.DialSentryConnection(ctx)
 			if derr != nil {
 				return derr
 			}


### PR DESCRIPTION
Follow up to https://github.com/dapr/dapr/pull/7507

Increases retries to `30s` which is the maximum mutation request allowed duration when the K8s API server calls an admission webhook.

Also moves connection init to `New` to encapsulate the logic in the requester.
