### PR TITLE
[1.12] Pin contrib 1.12.9, add release notes, fix CI

### DIFF
--- a/.github/workflows/dapr-standalone-validation.yml
+++ b/.github/workflows/dapr-standalone-validation.yml
@@ -47,26 +47,29 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.CHECKOUT_REPO }}
-          ref: ${{ env.CHECKOUT_REF }}
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
       - name: Set up Go
         id: setup-go
         uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - name: Build Dapr's sidecar
-        run: make ./dist/${GOOS}_${GOARCH}/release/daprd
-      - name: Check out code at master branch for PR validation
+        run: |
+          git status
+          make ./dist/${GOOS}_${GOARCH}/release/daprd
+      - name: "Check out code at ${{ github.base_ref }} for PR validation"
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.CHECKOUT_REPO }}
-          ref: master
-          path: .master
-      - name: Build and override daprd with master version
+          repository: ${{ github.repository }}
+          ref: ${{ github.base_ref }}
+          path: .baseline
+      - name: "Build and override daprd from ${{ github.base_ref }}"
         if: github.event_name == 'pull_request'
         run: |
-          cd .master
+          cd .baseline
+          git status
           make ./dist/${GOOS}_${GOARCH}/release/daprd
           mkdir -p $HOME/.dapr/bin/
           cp dist/${GOOS}_${GOARCH}/release/daprd $HOME/.dapr/bin/daprd

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -53,9 +53,7 @@ jobs:
         id: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20.11'
-          # temporarily hard code version to accelerate release due to a Go CVE
-          # go-version-file: "go.mod"
+          go-version-file: "go.mod"
       - name: Check white space in .md files
         if: github.event_name == 'pull_request'
         run: |

--- a/docs/release_notes/v1.12.5.md
+++ b/docs/release_notes/v1.12.5.md
@@ -1,0 +1,19 @@
+# Dapr 1.12.5
+
+## Azure Event Hubs bindings and pubsub silently fail to recover subscriptions during event processor failures
+
+### Problem
+
+The Azure Event Hubs bindings and pubsub components may fail in such a way that for one or multiple subscribed topics no further events will be received.
+
+### Impact
+
+Impacts users running Dapr 1.12.4 or earlier that use Azure EventHubs bindings or pubsub components. The dapr sidecar error message `Error from event processor` indicates that this problem has been encountered.
+
+### Root cause
+
+Under certain failure scenarios (including networking interruption) the Event Hubs event processor for a particular subscription topic can return an error. When this occurs the error is logged once, existing partition clients will terminate with errors and no further partition clients will be allocated. At this point the subscription for this topic effectively ends with no attempt to restart the subscription. This however does not impact other sidecar functionality and the sidecar continues to report healthy status.
+
+### Solution
+
+Added error handling for the topic event processor host to restart the entire subscription loop for this topic 5 seconds after an error is encountered.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cloudevents/sdk-go/v2 v2.14.0
-	github.com/dapr/components-contrib v1.12.9-0.20240108194428-ba865c5ed734
+	github.com/dapr/components-contrib v1.12.9
 	github.com/dapr/kit v0.12.2-0.20231227152556-77f7f031c92a
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.12.9-0.20240108194428-ba865c5ed734 h1:W1J+3HqcKFeIQhxsqhrn90xCcUhnQQ/erC8QytRf3xE=
-github.com/dapr/components-contrib v1.12.9-0.20240108194428-ba865c5ed734/go.mod h1:jZk9XuSOI6k2wG9v9n0WAG168m4E46yvChfL0DrpCog=
+github.com/dapr/components-contrib v1.12.9 h1:yoj7iLaklOVwFjBqAUw/DG35BIToVdT7JXRjYCzSvio=
+github.com/dapr/components-contrib v1.12.9/go.mod h1:jZk9XuSOI6k2wG9v9n0WAG168m4E46yvChfL0DrpCog=
 github.com/dapr/kit v0.12.2-0.20231227152556-77f7f031c92a h1:KXwxHwO6DWSOFRTeuohyYVmqEN062u+Ml70rdWOsIw8=
 github.com/dapr/kit v0.12.2-0.20231227152556-77f7f031c92a/go.mod h1:VyHrelNXPbtS/VcQX0Y/uzW0lfEVuveJ+1E5bDys8mo=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
# Description

Release 1.12: Pin contrib 1.12.9

Fixes an issue where Event Hubs Bindings and PubSub subscriptions encounter an error and never recover - causing the sidecar to silently end the subscriptions with no way to recover.

Also cherry-picks ed125cc from @artursouza to fix standalone validation workflow.
