### PR TITLE
Change default cardinality to low for metrics

### DIFF
--- a/charts/dapr/crds/configuration.yaml
+++ b/charts/dapr/crds/configuration.yaml
@@ -253,9 +253,8 @@ spec:
                       the HTTP server
                     properties:
                       increasedCardinality:
-                        description: 'If true, metrics for the HTTP server are collected
-                          with increased cardinality. The default is true in Dapr 1.13,
-                          but will be changed to false in 1.14+'
+                        description: |-
+                          If false (the default), metrics for the HTTP server are collected with increased cardinality.
                         type: boolean
                     type: object
                   rules:

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -219,9 +219,7 @@ type MetricSpec struct {
 
 // MetricHTTP defines configuration for metrics for the HTTP server
 type MetricHTTP struct {
-	// If false, metrics for the HTTP server are collected with increased cardinality.
-	// The default is true in Dapr 1.13, but will be changed to false in 1.14+
-	// TODO @ItalyPaleAle [MetricsCardinality] Change default in 1.14
+	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
 	// +optional
 	IncreasedCardinality *bool `json:"increasedCardinality,omitempty"`
 }

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -262,19 +262,15 @@ func (m MetricSpec) GetEnabled() bool {
 // GetHTTPIncreasedCardinality returns true if increased cardinality is enabled for HTTP metrics
 func (m MetricSpec) GetHTTPIncreasedCardinality(log logger.Logger) bool {
 	if m.HTTP == nil || m.HTTP.IncreasedCardinality == nil {
-		// The default is true in Dapr 1.13, but will be changed to false in 1.14+
-		// TODO @ItalyPaleAle [MetricsCardinality] Change default in 1.14
-		log.Warn("The default value for 'spec.metric.http.increasedCardinality' will change to 'false' in Dapr 1.14")
-		return true
+		// The default is false
+		return false
 	}
 	return *m.HTTP.IncreasedCardinality
 }
 
 // MetricHTTP defines configuration for metrics for the HTTP server
 type MetricHTTP struct {
-	// If false, metrics for the HTTP server are collected with increased cardinality.
-	// The default is true in Dapr 1.13, but will be changed to false in 1.14+
-	// TODO @ItalyPaleAle [MetricsCardinality] Change default in 1.14
+	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
 	IncreasedCardinality *bool `json:"increasedCardinality,omitempty" yaml:"increasedCardinality,omitempty"`
 }
 

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -596,20 +596,20 @@ func TestMetricsGetHTTPIncreasedCardinality(t *testing.T) {
 	log := logger.NewLogger("test")
 	log.SetOutput(io.Discard)
 
-	t.Run("no http configuration, returns true", func(t *testing.T) {
+	t.Run("no http configuration, returns false", func(t *testing.T) {
 		m := MetricSpec{
 			HTTP: nil,
 		}
-		assert.True(t, m.GetHTTPIncreasedCardinality(log))
+		assert.False(t, m.GetHTTPIncreasedCardinality(log))
 	})
 
-	t.Run("nil value, returns true", func(t *testing.T) {
+	t.Run("nil value, returns false", func(t *testing.T) {
 		m := MetricSpec{
 			HTTP: &MetricHTTP{
 				IncreasedCardinality: nil,
 			},
 		}
-		assert.True(t, m.GetHTTPIncreasedCardinality(log))
+		assert.False(t, m.GetHTTPIncreasedCardinality(log))
 	})
 
 	t.Run("value is set to true", func(t *testing.T) {

--- a/tests/integration/suite/daprd/metrics/httpserver_defaultcardinality.go
+++ b/tests/integration/suite/daprd/metrics/httpserver_defaultcardinality.go
@@ -32,8 +32,7 @@ func init() {
 	suite.Register(new(httpServerDefaultCardinality))
 }
 
-// httpServerDefaultCardinality tests daprd metrics for the HTTP server configured with the default cardinality
-// TODO @ItalyPaleAle [MetricsCardinality] Change default in 1.14 to be based on low cardinality
+// httpServerDefaultCardinality tests daprd metrics for the HTTP server configured with the default cardinality (low)
 type httpServerDefaultCardinality struct {
 	base
 }
@@ -56,7 +55,7 @@ func (m *httpServerDefaultCardinality) Run(t *testing.T, ctx context.Context) {
 
 		// Verify metrics
 		metrics := m.getMetrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/hi|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:InvokeService/myapp|status:200"]))
 	})
 
 	t.Run("state stores", func(t *testing.T) {
@@ -77,7 +76,7 @@ func (m *httpServerDefaultCardinality) Run(t *testing.T, ctx context.Context) {
 
 		// Verify metrics
 		metrics := m.getMetrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:/v1.0/state/mystore|status:204"]))
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/state/mystore|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:SaveState|status:204"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GetState|status:200"]))
 	})
 }


### PR DESCRIPTION
Sets the default to low for 1.14