### PR TITLE
Add content-length to http channel

### DIFF
--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -233,9 +233,7 @@ func InternalMetadataToHTTPHeader(ctx context.Context, internalMD DaprInternalMe
 			continue
 		}
 
-		if strings.HasSuffix(keyName, gRPCBinaryMetadataSuffix) ||
-			keyName == ContentTypeHeader ||
-			keyName == ContentLengthHeader {
+		if strings.HasSuffix(keyName, gRPCBinaryMetadataSuffix) || keyName == ContentTypeHeader {
 			continue
 		}
 

--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -278,12 +278,7 @@ func testPublish(t *testing.T, publisherExternalURL string, protocol string) rec
 	require.NoError(t, err)
 	offset += numberOfMessagesToPublish + 1
 
-	// Test bug where content-length metadata conflict makes message undeliverable in grpc subscriber.
-	// We set an arbitrarily large number that it is unlikely to match the size of the payload daprd delivers.
-	metadataContentLengthConflict := map[string]string{
-		"content-length": "9999999",
-	}
-	sentTopicAMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-a-topic", protocol, metadataContentLengthConflict, "")
+	sentTopicAMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-a-topic", protocol, nil, "")
 	require.NoError(t, err)
 	offset += numberOfMessagesToPublish + 1
 
@@ -295,10 +290,10 @@ func testPublish(t *testing.T, publisherExternalURL string, protocol string) rec
 	require.NoError(t, err)
 	offset += numberOfMessagesToPublish + 1
 
-	metadataRawPayload := map[string]string{
+	metadata := map[string]string{
 		"rawPayload": "true",
 	}
-	sentTopicRawMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-raw-topic", protocol, metadataRawPayload, "")
+	sentTopicRawMessages, err := sendToPublisher(t, publisherExternalURL, "pubsub-raw-topic", protocol, metadata, "")
 	require.NoError(t, err)
 	offset += numberOfMessagesToPublish + 1
 


### PR DESCRIPTION
For 1.13 we removed the content-length metadata from gRPC calls based on grpc-go's recommendation. The content-length header was also removed from HTTP calls between Dapr and the app, and that causes some webservers to abruptly close connections. This PR returns the content-length header to HTTP calls which is essential.