### PR TITLE
[1.13] Subscriptions: Fix panic when match rule is empty

### DIFF
--- a/pkg/runtime/processor/pubsub/pubsub.go
+++ b/pkg/runtime/processor/pubsub/pubsub.go
@@ -236,7 +236,7 @@ func findMatchingRoute(rules []*rtpubsub.Rule, cloudEvent interface{}) (path str
 
 func matchRoutingRule(rules []*rtpubsub.Rule, data map[string]interface{}) (*rtpubsub.Rule, error) {
 	for _, rule := range rules {
-		if rule.Match == nil {
+		if rule.Match == nil || len(rule.Match.String()) == 0 {
 			return rule, nil
 		}
 		iResult, err := rule.Match.Eval(data)

--- a/tests/integration/framework/process/grpc/subscriber/options.go
+++ b/tests/integration/framework/process/grpc/subscriber/options.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+// options contains the options for running a pubsub subscriber gRPC server app.
+type options struct{}

--- a/tests/integration/framework/process/grpc/subscriber/subscriber.go
+++ b/tests/integration/framework/process/grpc/subscriber/subscriber.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+)
+
+type Option func(*options)
+
+type Subscriber struct {
+	app     *app.App
+	inCh    chan *rtv1.TopicEventRequest
+	closeCh chan struct{}
+}
+
+func New(t *testing.T, fopts ...Option) *Subscriber {
+	t.Helper()
+
+	var opts options
+	for _, fopt := range fopts {
+		fopt(&opts)
+	}
+
+	inCh := make(chan *rtv1.TopicEventRequest, 100)
+	closeCh := make(chan struct{})
+
+	return &Subscriber{
+		inCh:    inCh,
+		closeCh: closeCh,
+		app: app.New(t,
+			app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+				select {
+				case inCh <- in:
+				case <-ctx.Done():
+				case <-closeCh:
+				}
+				return new(rtv1.TopicEventResponse), nil
+			}),
+		),
+	}
+}
+
+func (s *Subscriber) Run(t *testing.T, ctx context.Context) {
+	t.Helper()
+	s.app.Run(t, ctx)
+}
+
+func (s *Subscriber) Cleanup(t *testing.T) {
+	t.Helper()
+	close(s.closeCh)
+	s.app.Cleanup(t)
+}
+
+func (s *Subscriber) Port(t *testing.T) int {
+	t.Helper()
+	return s.app.Port(t)
+}
+
+func (s *Subscriber) Receive(t *testing.T, ctx context.Context) *rtv1.TopicEventRequest {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timed out waiting for event response")
+		return nil
+	case in := <-s.inCh:
+		return in
+	}
+}
+
+func (s *Subscriber) AssertEventChanLen(t *testing.T, l int) {
+	t.Helper()
+	assert.Len(t, s.inCh, l)
+}
+
+func (s *Subscriber) ExpectPublishReceive(t *testing.T, ctx context.Context, daprd *daprd.Daprd, req *rtv1.PublishEventRequest) {
+	t.Helper()
+	_, err := daprd.GRPCClient(t, ctx).PublishEvent(ctx, req)
+	require.NoError(t, err)
+	s.Receive(t, ctx)
+	s.AssertEventChanLen(t, 0)
+}
+
+func (s *Subscriber) ExpectPublishError(t *testing.T, ctx context.Context, daprd *daprd.Daprd, req *rtv1.PublishEventRequest) {
+	t.Helper()
+	_, err := daprd.GRPCClient(t, ctx).PublishEvent(ctx, req)
+	require.Error(t, err)
+}
+
+func (s *Subscriber) ExpectPublishNoReceive(t *testing.T, ctx context.Context, daprd *daprd.Daprd, req *rtv1.PublishEventRequest) {
+	t.Helper()
+	_, err := daprd.GRPCClient(t, ctx).PublishEvent(ctx, req)
+	require.NoError(t, err)
+	s.AssertEventChanLen(t, 0)
+}

--- a/tests/integration/framework/process/http/app/app.go
+++ b/tests/integration/framework/process/http/app/app.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/http"
+)
+
+type Option func(*options)
+
+type App struct {
+	http    *http.HTTP
+	healthz *atomic.Bool
+}
+
+func New(t *testing.T, fopts ...Option) *App {
+	t.Helper()
+
+	opts := options{
+		subscribe:     "[]",
+		config:        "{}",
+		initialHealth: true,
+	}
+	for _, fopt := range fopts {
+		fopt(&opts)
+	}
+
+	var healthz atomic.Bool
+	healthz.Store(opts.initialHealth)
+
+	httpopts := []http.Option{
+		http.WithHandlerFunc("/dapr/config", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			w.Write([]byte(opts.config))
+		}),
+		http.WithHandlerFunc("/dapr/subscribe", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			w.Write([]byte(opts.subscribe))
+		}),
+		http.WithHandlerFunc("/healthz", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			if healthz.Load() {
+				w.WriteHeader(nethttp.StatusOK)
+			} else {
+				w.WriteHeader(nethttp.StatusServiceUnavailable)
+			}
+		}),
+	}
+	httpopts = append(httpopts, opts.handlerFuncs...)
+
+	return &App{
+		http:    http.New(t, httpopts...),
+		healthz: &healthz,
+	}
+}
+
+func (a *App) Run(t *testing.T, ctx context.Context) {
+	a.http.Run(t, ctx)
+}
+
+func (a *App) Cleanup(t *testing.T) {
+	a.http.Cleanup(t)
+}
+
+func (a *App) Port() int {
+	return a.http.Port()
+}

--- a/tests/integration/framework/process/http/app/options.go
+++ b/tests/integration/framework/process/http/app/options.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	nethttp "net/http"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/http"
+)
+
+type options struct {
+	subscribe     string
+	config        string
+	initialHealth bool
+	handlerFuncs  []http.Option
+}
+
+func WithSubscribe(subscribe string) Option {
+	return func(o *options) {
+		o.subscribe = subscribe
+	}
+}
+
+func WithConfig(config string) Option {
+	return func(o *options) {
+		o.config = config
+	}
+}
+
+func WithHandlerFunc(path string, fn nethttp.HandlerFunc) Option {
+	return func(o *options) {
+		o.handlerFuncs = append(o.handlerFuncs, http.WithHandlerFunc(path, fn))
+	}
+}
+
+func WithInitialHealth(initialHealth bool) Option {
+	return func(o *options) {
+		o.initialHealth = initialHealth
+	}
+}

--- a/tests/integration/framework/process/http/subscriber/options.go
+++ b/tests/integration/framework/process/http/subscriber/options.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+import (
+	"net/http"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+)
+
+type options struct {
+	routes       []string
+	bulkRoutes   []string
+	handlerFuncs []app.Option
+}
+
+func WithRoutes(routes ...string) Option {
+	return func(o *options) {
+		o.routes = append(o.routes, routes...)
+	}
+}
+
+func WithBulkRoutes(routes ...string) Option {
+	return func(o *options) {
+		o.bulkRoutes = append(o.bulkRoutes, routes...)
+	}
+}
+
+func WithHandlerFunc(path string, fn http.HandlerFunc) Option {
+	return func(o *options) {
+		o.handlerFuncs = append(o.handlerFuncs, app.WithHandlerFunc(path, fn))
+	}
+}

--- a/tests/integration/framework/process/http/subscriber/subscriber.go
+++ b/tests/integration/framework/process/http/subscriber/subscriber.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+)
+
+type Option func(*options)
+
+type RouteEvent struct {
+	Route string
+	*event.Event
+}
+
+type PublishRequest struct {
+	Daprd           *daprd.Daprd
+	PubSubName      string
+	Topic           string
+	Data            string
+	DataContentType *string
+}
+
+type Subscriber struct {
+	app     *app.App
+	client  *http.Client
+	inCh    chan *RouteEvent
+	closeCh chan struct{}
+}
+
+func New(t *testing.T, fopts ...Option) *Subscriber {
+	t.Helper()
+
+	var opts options
+	for _, fopt := range fopts {
+		fopt(&opts)
+	}
+
+	inCh := make(chan *RouteEvent, 100)
+	closeCh := make(chan struct{})
+
+	appOpts := make([]app.Option, 0, len(opts.routes)+len(opts.handlerFuncs))
+	for _, route := range opts.routes {
+		appOpts = append(appOpts, app.WithHandlerFunc(route, func(w http.ResponseWriter, r *http.Request) {
+			var ce event.Event
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&ce))
+			select {
+			case inCh <- &RouteEvent{Route: r.URL.Path, Event: &ce}:
+			case <-closeCh:
+			case <-r.Context().Done():
+			}
+		}))
+	}
+
+	appOpts = append(appOpts, opts.handlerFuncs...)
+
+	return &Subscriber{
+		app:     app.New(t, appOpts...),
+		client:  util.HTTPClient(t),
+		inCh:    inCh,
+		closeCh: closeCh,
+	}
+}
+
+func (s *Subscriber) Run(t *testing.T, ctx context.Context) {
+	t.Helper()
+	s.app.Run(t, ctx)
+}
+
+func (s *Subscriber) Cleanup(t *testing.T) {
+	t.Helper()
+	close(s.closeCh)
+	s.app.Cleanup(t)
+}
+
+func (s *Subscriber) Port() int {
+	return s.app.Port()
+}
+
+func (s *Subscriber) Receive(t *testing.T, ctx context.Context) *RouteEvent {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timed out waiting for event response")
+		return nil
+	case in := <-s.inCh:
+		return in
+	}
+}
+
+func (s *Subscriber) AssertEventChanLen(t *testing.T, l int) {
+	t.Helper()
+	assert.Len(t, s.inCh, l)
+}
+
+func (s *Subscriber) ExpectPublishReceive(t *testing.T, ctx context.Context, req PublishRequest) {
+	t.Helper()
+
+	s.Publish(t, ctx, req)
+	s.Receive(t, ctx)
+	s.AssertEventChanLen(t, 0)
+}
+
+func (s *Subscriber) ExpectPublishError(t *testing.T, ctx context.Context, req PublishRequest) {
+	t.Helper()
+	//nolint:bodyclose
+	resp := s.publish(t, ctx, req)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	s.AssertEventChanLen(t, 0)
+}
+
+func (s *Subscriber) ExpectPublishNoReceive(t *testing.T, ctx context.Context, req PublishRequest) {
+	t.Helper()
+	s.Publish(t, ctx, req)
+	s.AssertEventChanLen(t, 0)
+}
+
+func (s *Subscriber) Publish(t *testing.T, ctx context.Context, req PublishRequest) {
+	t.Helper()
+	//nolint:bodyclose
+	resp := s.publish(t, ctx, req)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func (s *Subscriber) publish(t *testing.T, ctx context.Context, req PublishRequest) *http.Response {
+	t.Helper()
+	reqURL := fmt.Sprintf("http://%s/v1.0/publish/%s/%s", req.Daprd.HTTPAddress(), req.PubSubName, req.Topic)
+	hreq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(req.Data))
+	require.NoError(t, err)
+	if req.DataContentType != nil {
+		hreq.Header.Add("Content-Type", *req.DataContentType)
+	}
+	resp, err := s.client.Do(hreq)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	return resp
+}

--- a/tests/integration/suite/daprd/pubsub/grpc/emptymatch.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/emptymatch.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptyroute))
+}
+
+type emptyroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *emptyroute) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t)
+
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+   - path: "/a"
+     match: ""
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *emptyroute) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	client := e.daprd.GRPCClient(t, ctx)
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+		Data:       []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+
+	resp := e.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+}

--- a/tests/integration/suite/daprd/pubsub/http/emptymatch.go
+++ b/tests/integration/suite/daprd/pubsub/http/emptymatch.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptyroute))
+}
+
+type emptyroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *emptyroute) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a"),
+	)
+
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+  - path: /a
+    match: ""
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *emptyroute) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := e.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+}


### PR DESCRIPTION
Prevents a panic resulting when a subscription route rule match (`spec.routes.rules.match`) is empty. An empty match rule is valid and is considered "default". Error occurs because of Go interface vs implementation struct pointer nil check foot-gun.

Adds integration tests for both HTTP and gRPC subscribers.