### PR TITLE
Actor Reminders: Default JSON serialization.

### DIFF
--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -198,10 +198,14 @@ func (b *runtimeBuilder) buildActorRuntime(t *testing.T) *actorsRuntime {
 	compStore := compstore.New()
 	compStore.AddStateStore(storeName, store)
 	a, err := newActorsWithClock(ActorsOpts{
-		CompStore:      compStore,
-		AppChannel:     b.appChannel,
-		Config:         *b.config,
-		TracingSpec:    config.TracingSpec{SamplingRate: "1"},
+		CompStore:  compStore,
+		AppChannel: b.appChannel,
+		Config:     *b.config,
+		GlobalConfig: &config.Configuration{
+			Spec: config.ConfigurationSpec{
+				TracingSpec: &config.TracingSpec{SamplingRate: "1"},
+			},
+		},
 		Resiliency:     resiliency.FromConfigurations(log, testResiliency),
 		StateStoreName: storeName,
 	}, clock)
@@ -226,10 +230,14 @@ func newTestActorsRuntimeWithMock(t *testing.T, appChannel channel.AppChannel) *
 	compStore := compstore.New()
 	compStore.AddStateStore("actorStore", fakeStore())
 	a, err := newActorsWithClock(ActorsOpts{
-		CompStore:      compStore,
-		AppChannel:     appChannel,
-		Config:         conf,
-		TracingSpec:    config.TracingSpec{SamplingRate: "1"},
+		CompStore:  compStore,
+		AppChannel: appChannel,
+		Config:     conf,
+		GlobalConfig: &config.Configuration{
+			Spec: config.ConfigurationSpec{
+				TracingSpec: &config.TracingSpec{SamplingRate: "1"},
+			},
+		},
 		Resiliency:     resiliency.New(log),
 		StateStoreName: "actorStore",
 		MockPlacement:  NewMockPlacement(TestAppID),
@@ -249,10 +257,14 @@ func newTestActorsRuntimeWithMockWithoutPlacement(t *testing.T, appChannel chann
 	clock := clocktesting.NewFakeClock(startOfTime)
 
 	a, err := newActorsWithClock(ActorsOpts{
-		CompStore:      compstore.New(),
-		AppChannel:     appChannel,
-		Config:         conf,
-		TracingSpec:    config.TracingSpec{SamplingRate: "1"},
+		CompStore:  compstore.New(),
+		AppChannel: appChannel,
+		Config:     conf,
+		GlobalConfig: &config.Configuration{
+			Spec: config.ConfigurationSpec{
+				TracingSpec: &config.TracingSpec{SamplingRate: "1"},
+			},
+		},
 		Resiliency:     resiliency.New(log),
 		StateStoreName: "actorStore",
 	}, clock)
@@ -271,10 +283,14 @@ func newTestActorsRuntimeWithMockAndNoStore(t *testing.T, appChannel channel.App
 	clock := clocktesting.NewFakeClock(startOfTime)
 
 	a, err := newActorsWithClock(ActorsOpts{
-		CompStore:      compstore.New(),
-		AppChannel:     appChannel,
-		Config:         conf,
-		TracingSpec:    config.TracingSpec{SamplingRate: "1"},
+		CompStore:  compstore.New(),
+		AppChannel: appChannel,
+		Config:     conf,
+		GlobalConfig: &config.Configuration{
+			Spec: config.ConfigurationSpec{
+				TracingSpec: &config.TracingSpec{SamplingRate: "1"},
+			},
+		},
 		Resiliency:     resiliency.New(log),
 		StateStoreName: "actorStore",
 	}, clock)

--- a/pkg/actors/internal/api_level.go
+++ b/pkg/actors/internal/api_level.go
@@ -20,8 +20,9 @@ package internal
 // API levels per Dapr version:
 // - 1.11.x and older = unset (equivalent to 0)
 // - 1.12.x = 10
-// - 1.13.x = 20
-const ActorAPILevel = 20
+// - 1.13.x = 10
+// - 1.14.x = 20
+const ActorAPILevel = 10
 
 // Features that can be enabled depending on the API level
 type apiLevelFeature uint32

--- a/pkg/actors/internal/options.go
+++ b/pkg/actors/internal/options.go
@@ -37,5 +37,7 @@ type ActorsProviderOptions struct {
 	// Pointer to the API level object
 	APILevel *atomic.Uint32
 
+	InitialAPILevel uint32
+
 	Clock kclock.WithTicker
 }

--- a/pkg/actors/internal_actor_test.go
+++ b/pkg/actors/internal_actor_test.go
@@ -87,7 +87,7 @@ func (*mockInternalActor) InvokeTimer(ctx context.Context, timer InternalActorRe
 func newTestActorsRuntimeWithInternalActors(internalActors map[string]InternalActorFactory) (*actorsRuntime, error) {
 	spec := config.TracingSpec{SamplingRate: "1"}
 	store := fakeStore()
-	config := NewConfig(ConfigOpts{
+	cfg := NewConfig(ConfigOpts{
 		AppID:         TestAppID,
 		ActorsService: "placement:placement:5050",
 		HostAddress:   "localhost",
@@ -97,9 +97,13 @@ func newTestActorsRuntimeWithInternalActors(internalActors map[string]InternalAc
 	compStore := compstore.New()
 	compStore.AddStateStore("actorStore", store)
 	a, err := NewActors(ActorsOpts{
-		CompStore:      compStore,
-		Config:         config,
-		TracingSpec:    spec,
+		CompStore: compStore,
+		Config:    cfg,
+		GlobalConfig: &config.Configuration{
+			Spec: config.ConfigurationSpec{
+				TracingSpec: &spec,
+			},
+		},
 		Resiliency:     resiliency.New(log),
 		StateStoreName: "actorStore",
 		Security:       fake.New(),

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -43,8 +43,12 @@ type Feature string
 const (
 	// Enables support for setting TTL on Actor state keys.
 	ActorStateTTL Feature = "ActorStateTTL"
-	// Enables support for hot reloading of Daprd Components and HTTPEndpoints.
+
+	// Enables support for hot reloading of Daprd Components.
 	HotReload Feature = "HotReload"
+
+	// Enables support for Actor Reminder storage format to Protobuf.
+	ActorReminderStorageProtobuf Feature = "ActorReminderStorageProtobuf"
 )
 
 // end feature flags section

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -967,7 +967,7 @@ func (a *DaprRuntime) initActors(ctx context.Context) error {
 		AppChannel:       a.channels.AppChannel(),
 		GRPCConnectionFn: a.grpc.GetGRPCConnection,
 		Config:           actorConfig,
-		TracingSpec:      a.globalConfig.GetTracingSpec(),
+		GlobalConfig:     a.globalConfig,
 		Resiliency:       a.resiliency,
 		StateStoreName:   actorStateStoreName,
 		CompStore:        a.compStore,

--- a/pkg/runtime/wfengine/backends/actors/backend_test.go
+++ b/pkg/runtime/wfengine/backends/actors/backend_test.go
@@ -220,6 +220,7 @@ func getActorRuntime(t *testing.T) actors.Actors {
 	act, err := actors.NewActors(actors.ActorsOpts{
 		CompStore:      compStore,
 		Config:         cfg,
+		GlobalConfig:   new(config.Configuration),
 		StateStoreName: "workflowStore",
 		MockPlacement:  actors.NewMockPlacement(testAppID),
 		Resiliency:     resiliency.New(logger.NewLogger("test")),

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -941,6 +941,7 @@ func getEngine(t *testing.T, ctx context.Context) *wfengine.WorkflowEngine {
 	actors, err := actors.NewActors(actors.ActorsOpts{
 		CompStore:      compStore,
 		Config:         cfg,
+		GlobalConfig:   new(config.Configuration),
 		StateStoreName: "workflowStore",
 		MockPlacement:  actors.NewMockPlacement(testAppID),
 		Resiliency:     resiliency.New(logger.NewLogger("test")),
@@ -976,6 +977,7 @@ func getEngineAndStateStore(t *testing.T, ctx context.Context) (*wfengine.Workfl
 	actors, err := actors.NewActors(actors.ActorsOpts{
 		CompStore:      compStore,
 		Config:         cfg,
+		GlobalConfig:   new(config.Configuration),
 		StateStoreName: "workflowStore",
 		MockPlacement:  actors.NewMockPlacement(testAppID),
 		Resiliency:     resiliency.New(logger.NewLogger("test")),

--- a/tests/integration/suite/actors/reminders/serialization/default.go
+++ b/tests/integration/suite/actors/reminders/serialization/default.go
@@ -35,12 +35,11 @@ import (
 )
 
 func init() {
-	suite.Register(new(jsonFormat))
+	suite.Register(new(defaultS))
 }
 
-// jsonFormat tests:
-// - That reminders are serialized to JSON when the Actors API level in the cluster is < 20
-type jsonFormat struct {
+// defaultS ensures that reminders are stored as JSON by default.
+type defaultS struct {
 	daprd   *daprd.Daprd
 	srv     *prochttp.HTTP
 	handler *httpServer
@@ -48,62 +47,46 @@ type jsonFormat struct {
 	db      *sqlite.SQLite
 }
 
-func (j *jsonFormat) Setup(t *testing.T) []framework.Option {
+func (d *defaultS) Setup(t *testing.T) []framework.Option {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows due to SQLite limitations")
 	}
 
-	// Init placement with a maximum API level of 10
-	// We need to set the max API level to 10, because levels 20 and up with serialise as protobuf
-	j.place = placement.New(t,
-		placement.WithMaxAPILevel(10),
-	)
+	d.place = placement.New(t)
 
-	// Create a SQLite database
-	j.db = sqlite.New(t, sqlite.WithActorStateStore(true))
+	d.db = sqlite.New(t, sqlite.WithActorStateStore(true))
 
-	// Init daprd and the HTTP server
-	j.handler = &httpServer{}
-	j.srv = prochttp.New(t, prochttp.WithHandler(j.handler.NewHandler()))
-	j.daprd = daprd.New(t,
-		daprd.WithResourceFiles(j.db.GetComponent(t)),
-		daprd.WithPlacementAddresses("127.0.0.1:"+strconv.Itoa(j.place.Port())),
-		daprd.WithAppPort(j.srv.Port()),
+	d.handler = new(httpServer)
+	d.srv = prochttp.New(t, prochttp.WithHandler(d.handler.NewHandler()))
+	d.daprd = daprd.New(t,
+		daprd.WithResourceFiles(d.db.GetComponent(t)),
+		daprd.WithPlacementAddresses("127.0.0.1:"+strconv.Itoa(d.place.Port())),
+		daprd.WithAppPort(d.srv.Port()),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(j.db, j.place, j.srv, j.daprd),
+		framework.WithProcesses(d.db, d.place, d.srv, d.daprd),
 	}
 }
 
-func (j *jsonFormat) Run(t *testing.T, ctx context.Context) {
-	// Wait for placement to be ready
-	j.place.WaitUntilRunning(t, ctx)
-
-	// Wait for daprd to be ready
-	j.daprd.WaitUntilRunning(t, ctx)
-
-	// Wait for actors to be ready
-	err := j.handler.WaitForActorsReady(ctx)
-	require.NoError(t, err)
+func (d *defaultS) Run(t *testing.T, ctx context.Context) {
+	d.place.WaitUntilRunning(t, ctx)
+	d.daprd.WaitUntilRunning(t, ctx)
+	require.NoError(t, d.handler.WaitForActorsReady(ctx))
 
 	client := util.HTTPClient(t)
-	baseURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactortype/myactorid", j.daprd.HTTPPort())
+	baseURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactortype/myactorid", d.daprd.HTTPPort())
 
-	// Invoke an actor to confirm everything is ready to go
 	invokeActor(t, ctx, baseURL, client)
 
-	// Store a reminder
-	// This causes the data in the state store to be updated
 	storeReminder(t, ctx, baseURL, client)
 
 	// Check the data in the SQLite database
 	// The value must begin with `[{`, which indicates it was serialized as JSON
-	storedVal := loadRemindersFromDB(t, ctx, j.db.GetConnection(t))
+	storedVal := loadRemindersFromDB(t, ctx, d.db.GetConnection(t))
 	assert.Truef(t, strings.HasPrefix(storedVal, "[{"), "Prefix not found in value: '%v'", storedVal)
 
-	// Ensure the reminder was invoked at least once
 	assert.Eventually(t, func() bool {
-		return j.handler.remindersInvokeCount.Load() > 0
+		return d.handler.remindersInvokeCount.Load() > 0
 	}, 5*time.Second, 10*time.Millisecond, "Reminder was not invoked at least once")
 }


### PR DESCRIPTION
To support downgrades to 1.12 from 1.13, this PR changes the reminder serialization storage format back to JSON by default. This means a 1.12 actor reminder client can read reminders written by 1.13 actors.

1.13 will continue to understand both JSON and protobuf. Protobuf serialization can be enabled with the `ActorReminderStorageProtobuf` feature gate. The actor "API Level" has been changed back to 10.

Adds test to ensure the default serialization is JSON.