### PR TITLE
Add metadata in binding response even in case of error

### DIFF
--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -571,6 +571,14 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 
 	diag.DefaultComponentMonitoring.OutputBindingEvent(context.Background(), name, req.Operation, err == nil, elapsed)
 
+	if resp != nil {
+		// Set the metadata in the response even in case of error.
+		// HTTP binding, for example, returns metadata even for error.
+		for k, v := range resp.Metadata {
+			reqCtx.Response.Header.Add(metadataPrefix+k, v)
+		}
+	}
+
 	if err != nil {
 		msg := NewErrorResponse("ERR_INVOKE_OUTPUT_BINDING", fmt.Sprintf(messages.ErrInvokeOutputBinding, name, err))
 		fasthttpRespond(reqCtx, fasthttpResponseWithError(nethttp.StatusInternalServerError, msg))
@@ -581,9 +589,6 @@ func (a *api) onOutputBindingMessage(reqCtx *fasthttp.RequestCtx) {
 	if resp == nil {
 		fasthttpRespond(reqCtx, fasthttpResponseWithEmpty())
 	} else {
-		for k, v := range resp.Metadata {
-			reqCtx.Response.Header.Add(metadataPrefix+k, v)
-		}
 		fasthttpRespond(reqCtx, fasthttpResponseWithJSON(nethttp.StatusOK, resp.Data, resp.Metadata))
 	}
 }

--- a/tests/integration/suite/daprd/binding/binding.go
+++ b/tests/integration/suite/daprd/binding/binding.go
@@ -15,4 +15,5 @@ package binding
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/binding/input"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/binding/output"
 )

--- a/tests/integration/suite/daprd/binding/output/errors.go
+++ b/tests/integration/suite/daprd/binding/output/errors.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	grpcMetadata "google.golang.org/grpc/metadata"
+
+	"github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(bindingerrors))
+}
+
+type bindingerrors struct {
+	srv   *prochttp.HTTP
+	daprd *daprd.Daprd
+}
+
+func (b *bindingerrors) Setup(t *testing.T) []framework.Option {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/error_404", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	b.srv = prochttp.New(t, prochttp.WithHandler(mux))
+	b.daprd = daprd.New(t,
+		daprd.WithResourceFiles(fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: github-http-binding-404
+spec:
+  type: bindings.http
+  version: v1
+  metadata:
+  - name: url
+    value: http://127.0.0.1:%d/error_404
+`, b.srv.Port())))
+
+	return []framework.Option{
+		framework.WithProcesses(b.srv, b.daprd),
+	}
+}
+
+func (b *bindingerrors) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	client := b.daprd.GRPCClient(t, ctx)
+	httpClient := util.HTTPClient(t)
+
+	assert.Eventually(t, func() bool {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/bindings/github-http-binding-404", b.daprd.HTTPPort())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer([]byte("{\"operation\":\"get\"}")))
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		return (resp.StatusCode == http.StatusInternalServerError) && (resp.Header.Get("Metadata.statuscode") == "404")
+	}, time.Second*5, 10*time.Millisecond)
+
+	assert.Eventually(t, func() bool {
+		req := runtime.InvokeBindingRequest{
+			Name:      "github-http-binding-404",
+			Operation: "get",
+		}
+		var header grpcMetadata.MD
+		resp, err := client.InvokeBinding(ctx, &req, grpc.Header(&header))
+		require.Error(t, err)
+		require.Nil(t, resp)
+		statusCodeArr := header.Get("metadata.statuscode")
+		require.Equal(t, 1, len(statusCodeArr))
+		return statusCodeArr[0] == "404"
+	}, time.Second*5, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/binding/output/errors.go
+++ b/tests/integration/suite/daprd/binding/output/errors.go
@@ -14,10 +14,10 @@ limitations under the License.
 package output
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -76,7 +76,7 @@ func (b *bindingerrors) Run(t *testing.T, ctx context.Context) {
 
 	assert.Eventually(t, func() bool {
 		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/bindings/github-http-binding-404", b.daprd.HTTPPort())
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer([]byte("{\"operation\":\"get\"}")))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader("{\"operation\":\"get\"}"))
 		require.NoError(t, err)
 		resp, err := httpClient.Do(req)
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func (b *bindingerrors) Run(t *testing.T, ctx context.Context) {
 		require.Error(t, err)
 		require.Nil(t, resp)
 		statusCodeArr := header.Get("metadata.statuscode")
-		require.Equal(t, 1, len(statusCodeArr))
+		require.Len(t, statusCodeArr, 1)
 		return statusCodeArr[0] == "404"
 	}, time.Second*5, 10*time.Millisecond)
 }


### PR DESCRIPTION
# Description

Adds binding metadata to HTTP headers and gRPC headers even when the response is an error. This is helpful because the HTTP binding (others might too) includes useful metadata (statusCode) even when it returns an error. The runtime was just dropping it to the floor.

## Issue reference

Discovered this while working on an issue for the Java SDK: https://github.com/dapr/java-sdk/issues/783

Please reference the issue this PR will close: https://github.com/dapr/java-sdk/issues/783

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
