### PR TITLE
Integration Tests: Subscriptions

### DIFF
--- a/tests/integration/framework/process/grpc/app/app.go
+++ b/tests/integration/framework/process/grpc/app/app.go
@@ -14,6 +14,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -27,7 +28,7 @@ type Option func(*options)
 
 // App is a wrapper around a grpc.Server that implements a Dapr App.
 type App struct {
-	*procgrpc.GRPC
+	grpc *procgrpc.GRPC
 }
 
 func New(t *testing.T, fopts ...Option) *App {
@@ -39,7 +40,7 @@ func New(t *testing.T, fopts ...Option) *App {
 	}
 
 	return &App{
-		GRPC: procgrpc.New(t, append(opts.grpcopts, procgrpc.WithRegister(func(s *grpc.Server) {
+		grpc: procgrpc.New(t, append(opts.grpcopts, procgrpc.WithRegister(func(s *grpc.Server) {
 			srv := &server{
 				onInvokeFn:         opts.onInvokeFn,
 				onTopicEventFn:     opts.onTopicEventFn,
@@ -57,4 +58,16 @@ func New(t *testing.T, fopts ...Option) *App {
 			}
 		}))...),
 	}
+}
+
+func (a *App) Run(t *testing.T, ctx context.Context) {
+	a.grpc.Run(t, ctx)
+}
+
+func (a *App) Cleanup(t *testing.T) {
+	a.grpc.Cleanup(t)
+}
+
+func (a *App) Port(t *testing.T) int {
+	return a.grpc.Port(t)
 }

--- a/tests/integration/framework/process/grpc/app/options.go
+++ b/tests/integration/framework/process/grpc/app/options.go
@@ -24,7 +24,8 @@ import (
 	procgrpc "github.com/dapr/dapr/tests/integration/framework/process/grpc"
 )
 
-// options contains the options for running a GRPC server in integration tests.
+// options contains the options for running a GRPC server app in integration
+// tests.
 type options struct {
 	grpcopts           []procgrpc.Option
 	withRegister       func(s *grpc.Server)

--- a/tests/integration/framework/process/http/subscriber/json.go
+++ b/tests/integration/framework/process/http/subscriber/json.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriber
+
+type (
+	SubscriptionJSON struct {
+		PubsubName      string            `json:"pubsubname"`
+		Topic           string            `json:"topic"`
+		DeadLetterTopic string            `json:"deadLetterTopic"`
+		Metadata        map[string]string `json:"metadata,omitempty"`
+		Route           string            `json:"route"`  // Single route from v1alpha1
+		Routes          RoutesJSON        `json:"routes"` // Multiple routes from v2alpha1
+		BulkSubscribe   BulkSubscribeJSON `json:"bulkSubscribe,omitempty"`
+	}
+
+	RoutesJSON struct {
+		Rules   []*RuleJSON `json:"rules,omitempty"`
+		Default string      `json:"default,omitempty"`
+	}
+
+	BulkSubscribeJSON struct {
+		Enabled            bool  `json:"enabled"`
+		MaxMessagesCount   int32 `json:"maxMessagesCount,omitempty"`
+		MaxAwaitDurationMs int32 `json:"maxAwaitDurationMs,omitempty"`
+	}
+
+	RuleJSON struct {
+		Match string `json:"match"`
+		Path  string `json:"path"`
+	}
+)

--- a/tests/integration/framework/process/http/subscriber/options.go
+++ b/tests/integration/framework/process/http/subscriber/options.go
@@ -23,6 +23,7 @@ type options struct {
 	routes       []string
 	bulkRoutes   []string
 	handlerFuncs []app.Option
+	progSubs     *[]SubscriptionJSON
 }
 
 func WithRoutes(routes ...string) Option {
@@ -40,5 +41,14 @@ func WithBulkRoutes(routes ...string) Option {
 func WithHandlerFunc(path string, fn http.HandlerFunc) Option {
 	return func(o *options) {
 		o.handlerFuncs = append(o.handlerFuncs, app.WithHandlerFunc(path, fn))
+	}
+}
+
+func WithProgrammaticSubscriptions(subs ...SubscriptionJSON) Option {
+	return func(o *options) {
+		if o.progSubs == nil {
+			o.progSubs = new([]SubscriptionJSON)
+		}
+		*o.progSubs = append(*o.progSubs, subs...)
 	}
 }

--- a/tests/integration/framework/process/http/subscriber/subscriber.go
+++ b/tests/integration/framework/process/http/subscriber/subscriber.go
@@ -119,6 +119,12 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 		}))
 	}
 
+	if opts.progSubs != nil {
+		appOpts = append(appOpts, app.WithHandlerFunc("/dapr/subscribe", func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(*opts.progSubs))
+		}))
+	}
+
 	appOpts = append(appOpts, opts.handlerFuncs...)
 
 	return &Subscriber{

--- a/tests/integration/framework/process/kubernetes/options.go
+++ b/tests/integration/framework/process/kubernetes/options.go
@@ -31,7 +31,8 @@ import (
 	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
 	httpendapi "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
 	resapi "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
-	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	subv1api "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	subv2api "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/store"
 )
 
@@ -54,7 +55,17 @@ func WithClusterDaprResiliencyList(t *testing.T, res *resapi.ResiliencyList) Opt
 	return handleClusterListResource(t, "/apis/dapr.io/v1alpha1/resiliencies", res)
 }
 
-func WithClusterDaprSubscriptionList(t *testing.T, subs *subapi.SubscriptionList) Option {
+func WithClusterDaprSubscriptionList(t *testing.T, subs *subv1api.SubscriptionList) Option {
+	subv2List := new(subv2api.SubscriptionList)
+	for _, s := range subs.Items {
+		subv2 := new(subv2api.Subscription)
+		require.NoError(t, subv2.ConvertFrom(s.DeepCopy()))
+		subv2List.Items = append(subv2List.Items, *subv2)
+	}
+	return handleClusterListResource(t, "/apis/dapr.io/v2alpha1/subscriptions", subv2List)
+}
+
+func WithClusterDaprSubscriptionListV2(t *testing.T, subs *subv2api.SubscriptionList) Option {
 	return handleClusterListResource(t, "/apis/dapr.io/v2alpha1/subscriptions", subs)
 }
 
@@ -64,6 +75,10 @@ func WithClusterDaprComponentList(t *testing.T, comps *compapi.ComponentList) Op
 
 func WithClusterDaprComponentListFromStore(t *testing.T, store *store.Store) Option {
 	return handleClusterListResourceFromStore(t, "/apis/dapr.io/v1alpha1/components", store)
+}
+
+func WithClusterDaprSubscriptionListFromStore(t *testing.T, store *store.Store) Option {
+	return handleClusterListResourceFromStore(t, "/apis/dapr.io/v1alpha1/subscriptions", store)
 }
 
 func WithClusterDaprHTTPEndpointList(t *testing.T, endpoints *httpendapi.HTTPEndpointList) Option {

--- a/tests/integration/suite/daprd/daprd.go
+++ b/tests/integration/suite/daprd/daprd.go
@@ -31,5 +31,6 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/state"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow"
 )

--- a/tests/integration/suite/daprd/pubsub/scopes/allowedtopics.go
+++ b/tests/integration/suite/daprd/pubsub/scopes/allowedtopics.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(allowedtopics))
+}
+
+type allowedtopics struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	daprd3 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (a *allowedtopics) Setup(t *testing.T) []framework.Option {
+	a.sub = subscriber.New(t)
+
+	resDir := t.TempDir()
+
+	a.daprd1 = daprd.New(t,
+		daprd.WithAppPort(a.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	a.daprd2 = daprd.New(t,
+		daprd.WithAppPort(a.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	a.daprd3 = daprd.New(t,
+		daprd.WithAppPort(a.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+
+	var subYaml string
+	for i, sub := range []struct {
+		pubsub string
+		topic  string
+	}{
+		{"topic12", "topic0"},
+		{"topic12", "topic1"},
+		{"topic12", "topic2"},
+		{"topic34-publishing", "topic3"},
+		{"topic34-publishing", "topic4"},
+		{"topic56-subscribing", "topic5"},
+		{"topic56-subscribing", "topic6"},
+		{"topic789-publishing-subscribing", "topic7"},
+		{"topic789-publishing-subscribing", "topic8"},
+		{"topic789-publishing-subscribing", "topic9"},
+	} {
+		subYaml += fmt.Sprintf(`
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub%d
+spec:
+ pubsubname: %s
+ topic: %s
+ route: /a
+`, i+1, sub.pubsub, sub.topic)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"), []byte(subYaml), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "pubsub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic12
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: allowedTopics
+   value: "topic1,topic2"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic34-publishing
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: allowedTopics
+   value: "topic3,topic4"
+ - name: publishingScopes
+   value: "%[1]s=topic3;%[2]s=topic4"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic56-subscribing
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: allowedTopics
+   value: "topic5,topic6"
+ - name: subscriptionScopes
+   value: "%[1]s=topic5;%[2]s=topic6"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic789-publishing-subscribing
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: allowedTopics
+   value: "topic7,topic8,topic9"
+ - name: subscriptionScopes
+   value: "%[1]s=topic7,topic9;%[2]s=topic8,topic9"
+ - name: publishingScopes
+   value: "%[1]s=topic8,topic9;%[2]s=topic7,topic9"
+`, a.daprd1.AppID(), a.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(a.sub, a.daprd1, a.daprd2, a.daprd3),
+	}
+}
+
+func (a *allowedtopics) Run(t *testing.T, ctx context.Context) {
+	a.daprd1.WaitUntilRunning(t, ctx)
+	a.daprd2.WaitUntilRunning(t, ctx)
+	a.daprd3.WaitUntilRunning(t, ctx)
+
+	for _, daprd := range []*daprd.Daprd{a.daprd1, a.daprd2, a.daprd3} {
+		meta, err := daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		require.NoError(t, err)
+		assert.Len(t, meta.GetRegisteredComponents(), 4)
+		assert.Len(t, meta.GetSubscriptions(), 10)
+	}
+
+	newReq := func(pubsub, topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: pubsub, Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	req := newReq("topic12", "topic0")
+	a.sub.ExpectPublishError(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishError(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishError(t, ctx, a.daprd3, req)
+	req = newReq("topic12", "topic1")
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+	req = newReq("topic12", "topic2")
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+	req = newReq("topic12", "topic3")
+	a.sub.ExpectPublishError(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishError(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishError(t, ctx, a.daprd3, req)
+
+	req = newReq("topic34-publishing", "topic3")
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishError(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+	req = newReq("topic34-publishing", "topic4")
+	a.sub.ExpectPublishError(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+
+	req = newReq("topic56-subscribing", "topic5")
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishNoReceive(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+	req = newReq("topic56-subscribing", "topic6")
+	a.sub.ExpectPublishNoReceive(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+
+	req = newReq("topic789-publishing-subscribing", "topic7")
+	a.sub.ExpectPublishError(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishNoReceive(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+	req = newReq("topic789-publishing-subscribing", "topic8")
+	a.sub.ExpectPublishNoReceive(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishError(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+	req = newReq("topic789-publishing-subscribing", "topic9")
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd1, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd2, req)
+	a.sub.ExpectPublishReceive(t, ctx, a.daprd3, req)
+}

--- a/tests/integration/suite/daprd/pubsub/scopes/protectedtopics.go
+++ b/tests/integration/suite/daprd/pubsub/scopes/protectedtopics.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(protectedtopics))
+}
+
+type protectedtopics struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	daprd3 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (p *protectedtopics) Setup(t *testing.T) []framework.Option {
+	p.sub = subscriber.New(t)
+
+	resDir := t.TempDir()
+
+	p.daprd1 = daprd.New(t,
+		daprd.WithAppPort(p.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+		daprd.WithAppID("app1"),
+	)
+	p.daprd2 = daprd.New(t,
+		daprd.WithAppPort(p.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+		daprd.WithAppID("app2"),
+	)
+	p.daprd3 = daprd.New(t,
+		daprd.WithAppPort(p.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+		daprd.WithAppID("app3"),
+	)
+
+	var subYaml string
+	for i, sub := range []struct {
+		pubsub string
+		topic  string
+	}{
+		{"topic12", "topic0"},
+		{"topic12", "topic1"},
+		{"topic12", "topic2"},
+		{"topic34-publishing", "topic3"},
+		{"topic34-publishing", "topic4"},
+		{"topic56-subscribing", "topic5"},
+		{"topic56-subscribing", "topic6"},
+		{"topic789-publishing-subscribing", "topic7"},
+		{"topic789-publishing-subscribing", "topic8"},
+		{"topic789-publishing-subscribing", "topic9"},
+		{"topic789-publishing-subscribing", "topic10"},
+	} {
+		subYaml += fmt.Sprintf(`
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub%d
+spec:
+ pubsubname: %s
+ topic: %s
+ route: /a
+`, i+1, sub.pubsub, sub.topic)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"), []byte(subYaml), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "pubsub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic12
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: protectedTopics
+   value: "topic1,topic2"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic34-publishing
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: protectedTopics
+   value: "topic3,topic4"
+ - name: publishingScopes
+   value: "%[1]s=topic3;%[2]s=topic4"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic56-subscribing
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: protectedTopics
+   value: "topic5,topic6"
+ - name: subscriptionScopes
+   value: "%[1]s=topic5;%[2]s=topic6"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: topic789-publishing-subscribing
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: protectedTopics
+   value: "topic7,topic8,topic9,topic10"
+ - name: allowedTopics
+   value: "topic7,topic8,topic9,topic10"
+ - name: subscriptionScopes
+   value: "%[1]s=topic7,topic9;%[2]s=topic8,topic9"
+ - name: publishingScopes
+   value: "%[1]s=topic8,topic9;%[2]s=topic7,topic9"
+`, p.daprd1.AppID(), p.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(p.sub, p.daprd1, p.daprd2, p.daprd3),
+	}
+}
+
+func (p *protectedtopics) Run(t *testing.T, ctx context.Context) {
+	p.daprd1.WaitUntilRunning(t, ctx)
+	p.daprd2.WaitUntilRunning(t, ctx)
+	p.daprd3.WaitUntilRunning(t, ctx)
+
+	for _, daprd := range []*daprd.Daprd{p.daprd1, p.daprd2, p.daprd3} {
+		meta, err := daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		require.NoError(t, err)
+		assert.Len(t, meta.GetRegisteredComponents(), 4)
+		assert.Len(t, meta.GetSubscriptions(), 11)
+	}
+
+	newReq := func(pubsub, topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: pubsub, Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	req := newReq("topic12", "topic0")
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd3, req)
+	req = newReq("topic12", "topic1")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+	req = newReq("topic12", "topic2")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+
+	req = newReq("topic34-publishing", "topic3")
+	p.sub.ExpectPublishNoReceive(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+	req = newReq("topic34-publishing", "topic4")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishNoReceive(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+
+	req = newReq("topic56-subscribing", "topic5")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+	req = newReq("topic56-subscribing", "topic6")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+
+	req = newReq("topic789-publishing-subscribing", "topic7")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishNoReceive(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+	req = newReq("topic789-publishing-subscribing", "topic8")
+	p.sub.ExpectPublishNoReceive(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+	req = newReq("topic789-publishing-subscribing", "topic9")
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+	req = newReq("topic789-publishing-subscribing", "topic10")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd3, req)
+}

--- a/tests/integration/suite/daprd/pubsub/scopes/publishing.go
+++ b/tests/integration/suite/daprd/pubsub/scopes/publishing.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(publishing))
+}
+
+type publishing struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	daprd3 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (p *publishing) Setup(t *testing.T) []framework.Option {
+	p.sub = subscriber.New(t)
+
+	resDir := t.TempDir()
+
+	p.daprd1 = daprd.New(t,
+		daprd.WithAppPort(p.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	p.daprd2 = daprd.New(t,
+		daprd.WithAppPort(p.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	p.daprd3 = daprd.New(t,
+		daprd.WithAppPort(p.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+
+	var subYaml string
+	for i, sub := range []struct {
+		pubsub string
+		topic  string
+	}{
+		{"all", "topic1"},
+		{"allempty", "topic2"},
+		{"app1-topic34", "topic3"},
+		{"app1-topic34", "topic4"},
+		{"app2-topic56", "topic5"},
+		{"app2-topic56", "topic6"},
+		{"app1-topic7-app2-topic8", "topic7"},
+		{"app1-topic7-app2-topic8", "topic8"},
+		{"app1-nil-app2-topic910", "topic9"},
+		{"app1-nil-app2-topic910", "topic10"},
+	} {
+		subYaml += fmt.Sprintf(`
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub%d
+spec:
+ pubsubname: %s
+ topic: %s
+ route: /a
+`, i+1, sub.pubsub, sub.topic)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"), []byte(subYaml), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "pubsub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: all
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: allempty
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: publishingScopes
+   value: ""
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app1-topic34
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: publishingScopes
+   value: "%[1]s=topic3,topic4"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app2-topic56
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: publishingScopes
+   value: "%[2]s=topic5,topic6"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app1-topic7-app2-topic8
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: publishingScopes
+   value: "%[1]s=topic7;%[2]s=topic8"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app1-nil-app2-topic910
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: publishingScopes
+   value: "%[1]s=;%[2]s=topic9,topic10"
+`, p.daprd1.AppID(), p.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(p.sub, p.daprd1, p.daprd2, p.daprd3),
+	}
+}
+
+func (p *publishing) Run(t *testing.T, ctx context.Context) {
+	p.daprd1.WaitUntilRunning(t, ctx)
+	p.daprd2.WaitUntilRunning(t, ctx)
+	p.daprd3.WaitUntilRunning(t, ctx)
+
+	for _, daprd := range []*daprd.Daprd{p.daprd1, p.daprd2, p.daprd3} {
+		meta, err := daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		require.NoError(t, err)
+		assert.Len(t, meta.GetRegisteredComponents(), 6)
+		assert.Len(t, meta.GetSubscriptions(), 10)
+	}
+
+	newReq := func(pubsub, topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: pubsub, Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	for _, req := range []*rtv1.PublishEventRequest{
+		newReq("all", "topic1"),
+		newReq("allempty", "topic2"),
+		newReq("app1-topic34", "topic3"),
+		newReq("app1-topic34", "topic4"),
+		newReq("app2-topic56", "topic5"),
+		newReq("app2-topic56", "topic6"),
+	} {
+		t.Run("pubsub="+req.GetPubsubName()+",topic="+req.GetTopic(), func(t *testing.T) {
+			p.sub.ExpectPublishReceive(t, ctx, p.daprd1, req)
+			p.sub.ExpectPublishReceive(t, ctx, p.daprd2, req)
+			p.sub.ExpectPublishReceive(t, ctx, p.daprd3, req)
+		})
+	}
+
+	req := newReq("app1-topic7-app2-topic8", "topic7")
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishError(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd3, req)
+
+	req = newReq("app1-topic7-app2-topic8", "topic8")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd3, req)
+
+	req = newReq("app1-nil-app2-topic910", "topic9")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd3, req)
+
+	req = newReq("app1-nil-app2-topic910", "topic10")
+	p.sub.ExpectPublishError(t, ctx, p.daprd1, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd2, req)
+	p.sub.ExpectPublishReceive(t, ctx, p.daprd3, req)
+}

--- a/tests/integration/suite/daprd/pubsub/scopes/subscription.go
+++ b/tests/integration/suite/daprd/pubsub/scopes/subscription.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(subscription))
+}
+
+type subscription struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	daprd3 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (s *subscription) Setup(t *testing.T) []framework.Option {
+	s.sub = subscriber.New(t)
+
+	resDir := t.TempDir()
+
+	s.daprd1 = daprd.New(t,
+		daprd.WithAppPort(s.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	s.daprd2 = daprd.New(t,
+		daprd.WithAppPort(s.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	s.daprd3 = daprd.New(t,
+		daprd.WithAppPort(s.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+
+	var subYaml string
+	for i, sub := range []struct {
+		pubsub string
+		topic  string
+	}{
+		{"all", "topic1"},
+		{"allempty", "topic2"},
+		{"app1-topic34", "topic3"},
+		{"app1-topic34", "topic4"},
+		{"app2-topic56", "topic5"},
+		{"app2-topic56", "topic6"},
+		{"app1-topic7-app2-topic8", "topic7"},
+		{"app1-topic7-app2-topic8", "topic8"},
+		{"app1-nil-app2-topic910", "topic9"},
+		{"app1-nil-app2-topic910", "topic10"},
+	} {
+		subYaml += fmt.Sprintf(`
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub%d
+spec:
+ pubsubname: %s
+ topic: %s
+ route: /a
+`, i+1, sub.pubsub, sub.topic)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"), []byte(subYaml), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "pubsub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: all
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: allempty
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: subscriptionScopes
+   value: ""
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app1-topic34
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: subscriptionScopes
+   value: "%[1]s=topic3,topic4"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app2-topic56
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: subscriptionScopes
+   value: "%[2]s=topic5,topic6"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app1-topic7-app2-topic8
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: subscriptionScopes
+   value: "%[1]s=topic7;%[2]s=topic8"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: app1-nil-app2-topic910
+spec:
+ type: pubsub.in-memory
+ version: v1
+ metadata:
+ - name: subscriptionScopes
+   value: "%[1]s=;%[2]s=topic9,topic10"
+`, s.daprd1.AppID(), s.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(s.sub, s.daprd1, s.daprd2, s.daprd3),
+	}
+}
+
+func (s *subscription) Run(t *testing.T, ctx context.Context) {
+	s.daprd1.WaitUntilRunning(t, ctx)
+	s.daprd2.WaitUntilRunning(t, ctx)
+	s.daprd3.WaitUntilRunning(t, ctx)
+
+	for _, daprd := range []*daprd.Daprd{s.daprd1, s.daprd2, s.daprd3} {
+		meta, err := daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		require.NoError(t, err)
+		assert.Len(t, meta.GetRegisteredComponents(), 6)
+		assert.Len(t, meta.GetSubscriptions(), 10)
+	}
+
+	newReq := func(pubsub, topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: pubsub, Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	for _, req := range []*rtv1.PublishEventRequest{
+		newReq("all", "topic1"),
+		newReq("allempty", "topic2"),
+		newReq("app1-topic34", "topic3"),
+		newReq("app1-topic34", "topic4"),
+		newReq("app2-topic56", "topic5"),
+		newReq("app2-topic56", "topic6"),
+	} {
+		t.Run("pubsub="+req.GetPubsubName()+",topic="+req.GetTopic(), func(t *testing.T) {
+			s.sub.ExpectPublishReceive(t, ctx, s.daprd1, req)
+			s.sub.ExpectPublishReceive(t, ctx, s.daprd2, req)
+			s.sub.ExpectPublishReceive(t, ctx, s.daprd3, req)
+		})
+	}
+
+	req := newReq("app1-topic7-app2-topic8", "topic7")
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd1, req)
+	s.sub.ExpectPublishNoReceive(t, ctx, s.daprd2, req)
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd3, req)
+
+	req = newReq("app1-topic7-app2-topic8", "topic8")
+	s.sub.ExpectPublishNoReceive(t, ctx, s.daprd1, req)
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd2, req)
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd3, req)
+
+	req = newReq("app1-nil-app2-topic910", "topic9")
+	s.sub.ExpectPublishNoReceive(t, ctx, s.daprd1, req)
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd2, req)
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd3, req)
+
+	req = newReq("app1-nil-app2-topic910", "topic10")
+	s.sub.ExpectPublishNoReceive(t, ctx, s.daprd1, req)
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd2, req)
+	s.sub.ExpectPublishReceive(t, ctx, s.daprd3, req)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/declarative.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/declarative.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/declarative.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/declarative.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pubsub
+package declarative
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/operator.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/operator.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/operator.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/operator.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pubsub
+package operator
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/grpc.go
@@ -91,6 +91,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic/http.go
@@ -90,6 +90,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/grpc.go
@@ -106,6 +106,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/http.go
@@ -103,6 +103,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/grpc.go
@@ -115,6 +115,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/http.go
@@ -107,6 +107,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter/http.go
@@ -11,24 +11,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package informer
+package deadletter
 
 import (
 	"context"
+	nethttp "net/http"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
-	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
-	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
 	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
 	"github.com/dapr/dapr/tests/integration/framework/process/operator"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
@@ -36,21 +35,26 @@ import (
 )
 
 func init() {
-	suite.Register(new(grpc))
+	suite.Register(new(http))
 }
 
-type grpc struct {
+type http struct {
 	daprd    *daprd.Daprd
 	kubeapi  *kubernetes.Kubernetes
 	operator *operator.Operator
 	sub      *subscriber.Subscriber
 }
 
-func (g *grpc) Setup(t *testing.T) []framework.Option {
-	g.sub = subscriber.New(t)
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t,
+		subscriber.WithRoutes("/b"),
+		subscriber.WithHandlerFunc("/a", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			w.WriteHeader(nethttp.StatusServiceUnavailable)
+		}),
+	)
 	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
 
-	g.kubeapi = kubernetes.New(t,
+	h.kubeapi = kubernetes.New(t,
 		kubernetes.WithBaseOperatorAPI(t,
 			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
 			"default",
@@ -58,36 +62,48 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		),
 		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
 			Items: []compapi.Component{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
 				Spec: compapi.ComponentSpec{
 					Type: "pubsub.in-memory", Version: "v1",
 				},
 			}},
 		}),
 		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
-			Items: []subapi.Subscription{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
-				Spec: subapi.SubscriptionSpec{
-					Pubsubname: "mypubsub",
-					Topic:      "a",
-					Route:      "/a",
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname:      "mypub",
+						Topic:           "a",
+						Route:           "/a",
+						DeadLetterTopic: "mydead",
+					},
 				},
-			}},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "anothersub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname:      "mypub",
+						Topic:           "mydead",
+						Route:           "/b",
+						DeadLetterTopic: "mydead",
+					},
+				},
+			},
 		}),
 	)
 
-	g.operator = operator.New(t,
+	h.operator = operator.New(t,
 		operator.WithNamespace("default"),
-		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithKubeconfigPath(h.kubeapi.KubeconfigPath(t)),
 		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
 	)
 
-	g.daprd = daprd.New(t,
+	h.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
 		daprd.WithSentryAddress(sentry.Address()),
-		daprd.WithControlPlaneAddress(g.operator.Address()),
-		daprd.WithAppPort(g.sub.Port(t)),
-		daprd.WithAppProtocol("grpc"),
+		daprd.WithControlPlaneAddress(h.operator.Address()),
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
@@ -97,29 +113,22 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+		framework.WithProcesses(sentry, h.sub, h.kubeapi, h.operator, h.daprd),
 	}
 }
 
-func (g *grpc) Run(t *testing.T, ctx context.Context) {
-	g.operator.WaitUntilRunning(t, ctx)
-	g.daprd.WaitUntilRunning(t, ctx)
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
 
-	client := g.daprd.GRPCClient(t, ctx)
-
-	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-	require.NoError(t, err)
-	require.Len(t, meta.GetSubscriptions(), 1)
-
-	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
-		PubsubName: "mypubsub", Topic: "a", Data: []byte(`{"status": "completed"}`),
-		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
 	})
-	require.NoError(t, err)
-	resp := g.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.GetPath())
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
-	assert.Equal(t, "1.0", resp.GetSpecVersion())
-	assert.Equal(t, "mypubsub", resp.GetPubsubName())
-	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/b", resp.Route)
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, `{"status": "completed"}`, string(resp.Data()))
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/grpc.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+				Spec: subapi.SubscriptionSpec{
+					Pubsubname: "mypubsub",
+					Topic:      "a",
+					Route:      "/a",
+				},
+			}},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	require.Len(t, meta.GetSubscriptions(), 1)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypubsub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypubsub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/grpc.go
@@ -91,6 +91,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/http.go
@@ -89,6 +89,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer/http.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes("/a"))
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	h.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+				Spec: subapi.SubscriptionSpec{
+					Pubsubname: "mypubsub",
+					Topic:      "a",
+					Route:      "/a",
+				},
+			}},
+		}),
+	)
+
+	h.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(h.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(h.operator.Address()),
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, h.sub, h.kubeapi, h.operator, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.operator.WaitUntilRunning(t, ctx)
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypubsub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/grpc.go
@@ -101,6 +101,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing/http.go
@@ -101,6 +101,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/grpc.go
@@ -99,6 +99,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/grpc.go
@@ -11,10 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package informer
+package rawpayload
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -22,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/dapr/components-contrib/pubsub"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -47,8 +50,8 @@ type grpc struct {
 }
 
 func (g *grpc) Setup(t *testing.T) []framework.Option {
-	g.sub = subscriber.New(t)
 	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+	g.sub = subscriber.New(t)
 
 	g.kubeapi = kubernetes.New(t,
 		kubernetes.WithBaseOperatorAPI(t,
@@ -58,21 +61,26 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		),
 		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
 			Items: []compapi.Component{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
 				Spec: compapi.ComponentSpec{
 					Type: "pubsub.in-memory", Version: "v1",
 				},
 			}},
 		}),
 		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
-			Items: []subapi.Subscription{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
-				Spec: subapi.SubscriptionSpec{
-					Pubsubname: "mypubsub",
-					Topic:      "a",
-					Route:      "/a",
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Route:      "/a",
+						Metadata: map[string]string{
+							"rawPayload": "true",
+						},
+					},
 				},
-			}},
+			},
 		}),
 	)
 
@@ -107,19 +115,66 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 
 	client := g.daprd.GRPCClient(t, ctx)
 
-	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-	require.NoError(t, err)
-	require.Len(t, meta.GetSubscriptions(), 1)
-
-	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
-		PubsubName: "mypubsub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
 		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
 	})
 	require.NoError(t, err)
 	resp := g.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.GetPath())
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
 	assert.Equal(t, "1.0", resp.GetSpecVersion())
-	assert.Equal(t, "mypubsub", resp.GetPubsubName())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
 	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["datacontenttype"] = "foo/bar"
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/http.go
@@ -99,6 +99,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload/http.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rawpayload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/components-contrib/pubsub"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes("/a"))
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	h.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Route:      "/a",
+						Metadata: map[string]string{
+							"rawPayload": "true",
+						},
+					},
+				},
+			},
+		}),
+	)
+
+	h.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(h.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(h.operator.Address()),
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, h.sub, h.kubeapi, h.operator, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "text/plain", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("application/json"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("foo/bar"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "foo/bar"
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       "foo",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
@@ -151,7 +151,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 	resp := g.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/a/b/c/d"}, []string{resp.GetPath()})
+	assert.Contains(t, []string{"/a", "/a/b/c/d"}, resp.GetPath())
 	assert.Empty(t, resp.GetData())
 
 	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
@@ -160,6 +160,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 	resp = g.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/a/b/c/d", "/d/c/b/a"}, []string{resp.GetPath()})
+	assert.Contains(t, []string{"/a", "/a/b/c/d", "/d/c/b/a"}, resp.GetPath())
 	assert.Empty(t, resp.GetData())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
@@ -125,6 +125,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/grpc.go
@@ -160,6 +160,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 	resp = g.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/d/c/b/a"}, []string{resp.GetPath()})
+	assert.Subset(t, []string{"/a", "/a/b/c/d", "/d/c/b/a"}, []string{resp.GetPath()})
 	assert.Empty(t, resp.GetData())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
@@ -131,6 +131,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
@@ -150,7 +150,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		Topic:      "a",
 	})
 	resp := h.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/a/b/c/d"}, []string{resp.Route})
+	assert.Contains(t, []string{"/a", "/a/b/c/d"}, resp.Route)
 	assert.Empty(t, resp.Data())
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
@@ -159,6 +159,6 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		Topic:      "b",
 	})
 	resp = h.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/a/b/c/d", "/d/c/b/a"}, []string{resp.Route})
+	assert.Contains(t, []string{"/a", "/a/b/c/d", "/d/c/b/a"}, resp.Route)
 	assert.Empty(t, resp.Data())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route/http.go
@@ -159,6 +159,6 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		Topic:      "b",
 	})
 	resp = h.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/d/c/b/a"}, []string{resp.Route})
+	assert.Subset(t, []string{"/a", "/a/b/c/d", "/d/c/b/a"}, []string{resp.Route})
 	assert.Empty(t, resp.Data())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
@@ -135,6 +135,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+	g.sub = subscriber.New(t)
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub1", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "anotherpub",
+						Topic:      "a",
+						Route:      "/a",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "c",
+						Route:      "/c",
+					},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	g.sub.ExpectPublishError(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "anotherpub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "b", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "c", Data: []byte(`{"status": "completed"}`),
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/grpc.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,15 +41,19 @@ func init() {
 }
 
 type grpc struct {
-	daprd    *daprd.Daprd
 	kubeapi  *kubernetes.Kubernetes
 	operator *operator.Operator
 	sub      *subscriber.Subscriber
+	daprd1   *daprd.Daprd
+	daprd2   *daprd.Daprd
 }
 
 func (g *grpc) Setup(t *testing.T) []framework.Option {
 	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
 	g.sub = subscriber.New(t)
+
+	appid1 := uuid.New().String()
+	appid2 := uuid.New().String()
 
 	g.kubeapi = kubernetes.New(t,
 		kubernetes.WithBaseOperatorAPI(t,
@@ -67,20 +72,49 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
 			Items: []subapi.Subscription{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "mysub1", Namespace: "default"},
-					Spec: subapi.SubscriptionSpec{
-						Pubsubname: "anotherpub",
-						Topic:      "a",
-						Route:      "/a",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "mysub2", Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{Name: "sub1", Namespace: "default"},
 					Spec: subapi.SubscriptionSpec{
 						Pubsubname: "mypub",
-						Topic:      "c",
-						Route:      "/c",
+						Topic:      "all",
+						Route:      "/all",
 					},
+					Scopes: nil,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "allempty",
+						Route:      "/allempty",
+					},
+					Scopes: []string{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub3", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "only1",
+						Route:      "/only1",
+					},
+					Scopes: []string{appid1},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub4", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "only2",
+						Route:      "/only2",
+					},
+					Scopes: []string{appid2},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub5", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "both",
+						Route:      "/both",
+					},
+					Scopes: []string{appid1, appid2},
 				},
 			},
 		}),
@@ -92,7 +126,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
 	)
 
-	g.daprd = daprd.New(t,
+	daprdOpts := []daprd.Option{
 		daprd.WithMode("kubernetes"),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(g.operator.Address()),
@@ -104,31 +138,78 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),
-	)
+	}
+	g.daprd1 = daprd.New(t, append(daprdOpts, daprd.WithAppID(appid1))...)
+	g.daprd2 = daprd.New(t, append(daprdOpts, daprd.WithAppID(appid2))...)
 
 	return []framework.Option{
-		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd1, g.daprd2),
 	}
 }
 
 func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	g.operator.WaitUntilRunning(t, ctx)
-	g.daprd.WaitUntilRunning(t, ctx)
+	g.daprd1.WaitUntilRunning(t, ctx)
+	g.daprd2.WaitUntilRunning(t, ctx)
 
-	client := g.daprd.GRPCClient(t, ctx)
+	client1 := g.daprd1.GRPCClient(t, ctx)
+	client2 := g.daprd2.GRPCClient(t, ctx)
 
-	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	meta, err := client1.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 	require.NoError(t, err)
-	assert.Len(t, meta.GetRegisteredComponents(), 1)
-	assert.Len(t, meta.GetSubscriptions(), 2)
+	assert.ElementsMatch(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only1", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only1"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
 
-	g.sub.ExpectPublishError(t, ctx, g.daprd, &rtv1.PublishEventRequest{
-		PubsubName: "anotherpub", Topic: "a", Data: []byte(`{"status": "completed"}`),
-	})
-	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
-		PubsubName: "mypub", Topic: "b", Data: []byte(`{"status": "completed"}`),
-	})
-	g.sub.ExpectPublishReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
-		PubsubName: "mypub", Topic: "c", Data: []byte(`{"status": "completed"}`),
-	})
+	meta, err = client2.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only2", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only2"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	newReq := func(topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: "mypub", Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	reqAll := newReq("all")
+	reqEmpty := newReq("allempty")
+	reqOnly1 := newReq("only1")
+	reqOnly2 := newReq("only2")
+	reqBoth := newReq("both")
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqEmpty)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqOnly1)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd1, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqBoth)
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqEmpty)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd2, reqOnly1)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqBoth)
+
+	g.sub.AssertEventChanLen(t, 0)
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/http.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes("/a", "/b", "/c"))
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	h.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub1", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "anotherpub",
+						Topic:      "a",
+						Route:      "/a",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "c",
+						Route:      "/c",
+					},
+				},
+			},
+		}),
+	)
+
+	h.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(h.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(h.operator.Address()),
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, h.sub, h.kubeapi, h.operator, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	meta, err := h.daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	h.sub.ExpectPublishError(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "anotherpub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+
+	h.sub.ExpectPublishNoReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+		Data:       `{"status": "completed"}`,
+	})
+
+	h.sub.ExpectPublishReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "c",
+		Data:       `{"status": "completed"}`,
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes/http.go
@@ -138,6 +138,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
@@ -21,4 +21,5 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/scopes"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pubsub
+package v1alpha1
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/v1alpha1.go
@@ -14,5 +14,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/basic"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/deadletter"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/informer"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/missing"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/rawpayload"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/route"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/grpc.go
@@ -93,6 +93,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/grpc.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+				Spec: subapi.SubscriptionSpec{
+					Pubsubname: "mypubsub",
+					Topic:      "a",
+					Routes: subapi.Routes{
+						Default: "/a",
+					},
+				},
+			}},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	require.Len(t, meta.GetSubscriptions(), 1)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypubsub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypubsub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypubsub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypubsub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "foo/bar", resp.GetDataContentType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypubsub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "foo", string(resp.GetData()))
+	assert.Equal(t, "text/plain", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypubsub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/http.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
-	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -63,13 +63,15 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 				},
 			}},
 		}),
-		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
 			Items: []subapi.Subscription{{
 				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
 				Spec: subapi.SubscriptionSpec{
 					Pubsubname: "mypubsub",
 					Topic:      "a",
-					Route:      "/a",
+					Routes: subapi.Routes{
+						Default: "/a",
+					},
 				},
 			}},
 		}),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic/http.go
@@ -92,6 +92,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
@@ -110,6 +110,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bulk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+						BulkSubscribe: subapi.BulkSubscribe{
+							Enabled:            true,
+							MaxMessagesCount:   100,
+							MaxAwaitDurationMs: 40,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "nobulk", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/b",
+						},
+					},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	resp, err := client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.AssertBulkEventChanLen(t, 0)
+
+	resp, err = client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	g.sub.AssertBulkEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/http.go
@@ -107,6 +107,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/http.go
@@ -11,18 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package basic
+package bulk
 
 import (
 	"context"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
-	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -31,7 +30,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/operator"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/suite"
-	"github.com/dapr/kit/ptr"
 )
 
 func init() {
@@ -46,7 +44,7 @@ type http struct {
 }
 
 func (h *http) Setup(t *testing.T) []framework.Option {
-	h.sub = subscriber.New(t, subscriber.WithRoutes("/a"))
+	h.sub = subscriber.New(t, subscriber.WithBulkRoutes("/a", "/b"))
 	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
 
 	h.kubeapi = kubernetes.New(t,
@@ -57,21 +55,40 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		),
 		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
 			Items: []compapi.Component{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
 				Spec: compapi.ComponentSpec{
 					Type: "pubsub.in-memory", Version: "v1",
 				},
 			}},
 		}),
-		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
-			Items: []subapi.Subscription{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
-				Spec: subapi.SubscriptionSpec{
-					Pubsubname: "mypubsub",
-					Topic:      "a",
-					Route:      "/a",
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+						BulkSubscribe: subapi.BulkSubscribe{
+							Enabled:            true,
+							MaxMessagesCount:   100,
+							MaxAwaitDurationMs: 40,
+						},
+					},
 				},
-			}},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "nobulk", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/b",
+						},
+					},
+				},
+			},
 		}),
 	)
 
@@ -101,68 +118,40 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 }
 
 func (h *http) Run(t *testing.T, ctx context.Context) {
-	h.operator.WaitUntilRunning(t, ctx)
 	h.daprd.WaitUntilRunning(t, ctx)
 
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	h.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
 		Daprd:      h.daprd,
-		PubSubName: "mypubsub",
+		PubSubName: "mypub",
 		Topic:      "a",
-		Data:       `{"status": "completed"}`,
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
 	})
-	resp := h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "text/plain", resp.DataContentType())
 
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:           h.daprd,
-		PubSubName:      "mypubsub",
-		Topic:           "a",
-		Data:            `{"status": "completed"}`,
-		DataContentType: ptr.Of("application/json"),
-	})
-	resp = h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "application/json", resp.DataContentType())
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
 
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:           h.daprd,
-		PubSubName:      "mypubsub",
-		Topic:           "a",
-		Data:            `{"status": "completed"}`,
-		DataContentType: ptr.Of("foo/bar"),
-	})
-	resp = h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "foo/bar", resp.DataContentType())
-
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+	h.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
 		Daprd:      h.daprd,
-		PubSubName: "mypubsub",
-		Topic:      "a",
-		Data:       "foo",
+		PubSubName: "mypub",
+		Topic:      "b",
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
 	})
-	resp = h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.Equal(t, "foo", string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "text/plain", resp.DataContentType())
+
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/grpc.go
@@ -119,6 +119,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/grpc.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deadletter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	app      *app.App
+	inCh     chan *rtv1.TopicEventRequest
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+	g.inCh = make(chan *rtv1.TopicEventRequest)
+	g.app = app.New(t,
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			if in.GetTopic() == "a" {
+				return nil, errors.New("my error")
+			}
+			g.inCh <- in
+			return new(rtv1.TopicEventResponse), nil
+		}),
+	)
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+						DeadLetterTopic: "mydead",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "anothersub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "mydead",
+						Routes: subapi.Routes{
+							Default: "/b",
+						},
+						DeadLetterTopic: "mydead",
+					},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.app, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	t.Cleanup(cancel)
+	select {
+	case <-ctx.Done():
+		assert.Fail(t, "timeout waiting for event")
+	case in := <-g.inCh:
+		assert.Equal(t, "mydead", in.GetTopic())
+		assert.Equal(t, "/b", in.GetPath())
+	}
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter/http.go
@@ -111,6 +111,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/grpc.go
@@ -93,6 +93,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/grpc.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+				Spec: subapi.SubscriptionSpec{
+					Pubsubname: "mypubsub",
+					Topic:      "a",
+					Routes: subapi.Routes{
+						Default: "/a",
+					},
+				},
+			}},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	require.Len(t, meta.GetSubscriptions(), 1)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypubsub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypubsub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/http.go
@@ -91,6 +91,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer/http.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes("/a"))
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	h.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+				Spec: subapi.SubscriptionSpec{
+					Pubsubname: "mypubsub",
+					Topic:      "a",
+					Routes: subapi.Routes{
+						Default: "/a",
+					},
+				},
+			}},
+		}),
+	)
+
+	h.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(h.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(h.operator.Address()),
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, h.sub, h.kubeapi, h.operator, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.operator.WaitUntilRunning(t, ctx)
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypubsub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/grpc.go
@@ -105,6 +105,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/grpc.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package missing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+	g.sub = subscriber.New(t)
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub1", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "anotherpub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "c",
+						Routes: subapi.Routes{
+							Default: "/c",
+						},
+					},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	g.sub.ExpectPublishError(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "anotherpub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "b", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "c", Data: []byte(`{"status": "completed"}`),
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing/http.go
@@ -105,6 +105,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/grpc.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rawpayload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/components-contrib/pubsub"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+	g.sub = subscriber.New(t)
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+						Metadata: map[string]string{
+							"rawPayload": "true",
+						},
+					},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["datacontenttype"] = "foo/bar"
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/grpc.go
@@ -101,6 +101,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/http.go
@@ -101,6 +101,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload/http.go
@@ -11,18 +11,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package basic
+package rawpayload
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/dapr/components-contrib/pubsub"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
-	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -57,21 +61,28 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		),
 		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
 			Items: []compapi.Component{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
 				Spec: compapi.ComponentSpec{
 					Type: "pubsub.in-memory", Version: "v1",
 				},
 			}},
 		}),
-		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
-			Items: []subapi.Subscription{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
-				Spec: subapi.SubscriptionSpec{
-					Pubsubname: "mypubsub",
-					Topic:      "a",
-					Route:      "/a",
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+						Metadata: map[string]string{
+							"rawPayload": "true",
+						},
+					},
 				},
-			}},
+			},
 		}),
 	)
 
@@ -101,68 +112,99 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 }
 
 func (h *http) Run(t *testing.T, ctx context.Context) {
-	h.operator.WaitUntilRunning(t, ctx)
 	h.daprd.WaitUntilRunning(t, ctx)
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
 		Daprd:      h.daprd,
-		PubSubName: "mypubsub",
+		PubSubName: "mypub",
 		Topic:      "a",
 		Data:       `{"status": "completed"}`,
 	})
 	resp := h.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
 	assert.Equal(t, "a", resp.Extensions()["topic"])
 	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "text/plain", resp.DataContentType())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "text/plain", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
 		Daprd:           h.daprd,
-		PubSubName:      "mypubsub",
+		PubSubName:      "mypub",
 		Topic:           "a",
 		Data:            `{"status": "completed"}`,
 		DataContentType: ptr.Of("application/json"),
 	})
 	resp = h.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
 	assert.Equal(t, "a", resp.Extensions()["topic"])
 	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "application/json", resp.DataContentType())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
 		Daprd:           h.daprd,
-		PubSubName:      "mypubsub",
+		PubSubName:      "mypub",
 		Topic:           "a",
 		Data:            `{"status": "completed"}`,
 		DataContentType: ptr.Of("foo/bar"),
 	})
 	resp = h.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
 	assert.Equal(t, "a", resp.Extensions()["topic"])
 	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "foo/bar", resp.DataContentType())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "foo/bar"
+	assert.Equal(t, exp, ce)
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
 		Daprd:      h.daprd,
-		PubSubName: "mypubsub",
+		PubSubName: "mypub",
 		Topic:      "a",
 		Data:       "foo",
 	})
 	resp = h.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
-	assert.Equal(t, "foo", string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
 	assert.Equal(t, "a", resp.Extensions()["topic"])
 	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "text/plain", resp.DataContentType())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultroute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub1", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a/b/c/d",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub3", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub4", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/a/b/c/d",
+						},
+					},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a/b/c/d", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
@@ -125,6 +125,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/grpc.go
@@ -147,7 +147,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 	resp := g.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/a/b/c/d"}, []string{resp.GetPath()})
+	assert.Contains(t, []string{"/a", "/a/b/c/d"}, resp.GetPath())
 	assert.Empty(t, resp.GetData())
 
 	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
@@ -156,6 +156,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 	resp = g.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/b", "/a/b/c/d"}, []string{resp.GetPath()})
+	assert.Contains(t, []string{"/b", "/a/b/c/d"}, resp.GetPath())
 	assert.Empty(t, resp.GetData())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
@@ -145,7 +145,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		Topic:      "a",
 	})
 	resp := h.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/a", "/a/b/c/d"}, []string{resp.Route})
+	assert.Contains(t, []string{"/a", "/a/b/c/d"}, resp.Route)
 	assert.Empty(t, resp.Data())
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
@@ -154,6 +154,6 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		Topic:      "b",
 	})
 	resp = h.sub.Receive(t, ctx)
-	assert.Subset(t, []string{"/b", "/a/b/c/d"}, []string{resp.Route})
+	assert.Contains(t, []string{"/b", "/a/b/c/d"}, resp.Route)
 	assert.Empty(t, resp.Data())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
@@ -92,7 +92,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 						Pubsubname: "mypub",
 						Topic:      "b",
 						Routes: subapi.Routes{
-							Default: "/a",
+							Default: "/b",
 						},
 					},
 				},
@@ -145,7 +145,7 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		Topic:      "a",
 	})
 	resp := h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a/b/c/d", resp.Route)
+	assert.Subset(t, []string{"/a", "/a/b/c/d"}, []string{resp.Route})
 	assert.Empty(t, resp.Data())
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
@@ -154,6 +154,6 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 		Topic:      "b",
 	})
 	resp = h.sub.Receive(t, ctx)
-	assert.Equal(t, "/b", resp.Route)
+	assert.Subset(t, []string{"/b", "/a/b/c/d"}, []string{resp.Route})
 	assert.Empty(t, resp.Data())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute/http.go
@@ -125,6 +125,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/grpc.go
@@ -139,6 +139,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/grpc.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package emptymatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd    *daprd.Daprd
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "justpath", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "justpath",
+						Routes: subapi.Routes{
+
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub3", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub4", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/a/b/c/d",
+						},
+					},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a/b/c/d", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/http.go
@@ -140,6 +140,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch/http.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package basic
+package emptymatch
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
-	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -31,7 +31,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/operator"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/suite"
-	"github.com/dapr/kit/ptr"
 )
 
 func init() {
@@ -46,7 +45,9 @@ type http struct {
 }
 
 func (h *http) Setup(t *testing.T) []framework.Option {
-	h.sub = subscriber.New(t, subscriber.WithRoutes("/a"))
+	h.sub = subscriber.New(t, subscriber.WithRoutes(
+		"/a/b/c/d", "/a", "/b", "/d/c/b/a",
+	))
 	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
 
 	h.kubeapi = kubernetes.New(t,
@@ -57,21 +58,55 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		),
 		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
 			Items: []compapi.Component{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
 				Spec: compapi.ComponentSpec{
 					Type: "pubsub.in-memory", Version: "v1",
 				},
 			}},
 		}),
-		kubernetes.WithClusterDaprSubscriptionList(t, &subapi.SubscriptionList{
-			Items: []subapi.Subscription{{
-				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
-				Spec: subapi.SubscriptionSpec{
-					Pubsubname: "mypubsub",
-					Topic:      "a",
-					Route:      "/a",
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub1", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a/b/c/d",
+						},
+					},
 				},
-			}},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "a",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub3", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/a",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "mysub4", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "b",
+						Routes: subapi.Routes{
+							Default: "/a/b/c/d",
+						},
+					},
+				},
+			},
 		}),
 	)
 
@@ -106,63 +141,19 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
 		Daprd:      h.daprd,
-		PubSubName: "mypubsub",
+		PubSubName: "mypub",
 		Topic:      "a",
-		Data:       `{"status": "completed"}`,
 	})
 	resp := h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "text/plain", resp.DataContentType())
-
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:           h.daprd,
-		PubSubName:      "mypubsub",
-		Topic:           "a",
-		Data:            `{"status": "completed"}`,
-		DataContentType: ptr.Of("application/json"),
-	})
-	resp = h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "application/json", resp.DataContentType())
-
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:           h.daprd,
-		PubSubName:      "mypubsub",
-		Topic:           "a",
-		Data:            `{"status": "completed"}`,
-		DataContentType: ptr.Of("foo/bar"),
-	})
-	resp = h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "foo/bar", resp.DataContentType())
+	assert.Equal(t, "/a/b/c/d", resp.Route)
+	assert.Empty(t, resp.Data())
 
 	h.sub.Publish(t, ctx, subscriber.PublishRequest{
 		Daprd:      h.daprd,
-		PubSubName: "mypubsub",
-		Topic:      "a",
-		Data:       "foo",
+		PubSubName: "mypub",
+		Topic:      "b",
 	})
 	resp = h.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.Equal(t, "foo", string(resp.Data()))
-	assert.Equal(t, "1.0", resp.SpecVersion())
-	assert.Equal(t, "mypubsub", resp.Extensions()["pubsubname"])
-	assert.Equal(t, "a", resp.Extensions()["topic"])
-	assert.Equal(t, "com.dapr.event.sent", resp.Type())
-	assert.Equal(t, "text/plain", resp.DataContentType())
+	assert.Equal(t, "/b", resp.Route)
+	assert.Empty(t, resp.Data())
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/grpc.go
@@ -168,6 +168,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match/http.go
@@ -170,6 +170,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/routes.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/routes.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/routes.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/routes.go
@@ -11,9 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package operator
+package v2alpha1
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/emptymatch"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes/match"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/grpc.go
@@ -145,6 +145,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/grpc.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+	daprd1   *daprd.Daprd
+	daprd2   *daprd.Daprd
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+	g.sub = subscriber.New(t)
+
+	appid1 := uuid.New().String()
+	appid2 := uuid.New().String()
+
+	g.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub1", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "all",
+						Routes: subapi.Routes{
+							Default: "/all",
+						},
+					},
+					Scopes: nil,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "allempty",
+						Routes: subapi.Routes{
+							Default: "/allempty",
+						},
+					},
+					Scopes: []string{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub3", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "only1",
+						Routes: subapi.Routes{
+							Default: "/only1",
+						},
+					},
+					Scopes: []string{appid1},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub4", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "only2",
+						Routes: subapi.Routes{
+							Default: "/only2",
+						},
+					},
+					Scopes: []string{appid2},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub5", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "both",
+						Routes: subapi.Routes{
+							Default: "/both",
+						},
+					},
+					Scopes: []string{appid1, appid2},
+				},
+			},
+		}),
+	)
+
+	g.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(g.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	daprdOpts := []daprd.Option{
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(g.operator.Address()),
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	}
+	g.daprd1 = daprd.New(t, append(daprdOpts, daprd.WithAppID(appid1))...)
+	g.daprd2 = daprd.New(t, append(daprdOpts, daprd.WithAppID(appid2))...)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, g.sub, g.kubeapi, g.operator, g.daprd1, g.daprd2),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.operator.WaitUntilRunning(t, ctx)
+	g.daprd1.WaitUntilRunning(t, ctx)
+	g.daprd2.WaitUntilRunning(t, ctx)
+
+	client1 := g.daprd1.GRPCClient(t, ctx)
+	client2 := g.daprd2.GRPCClient(t, ctx)
+
+	meta, err := client1.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only1", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only1"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	meta, err = client2.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only2", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only2"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	newReq := func(topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: "mypub", Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	reqAll := newReq("all")
+	reqEmpty := newReq("allempty")
+	reqOnly1 := newReq("only1")
+	reqOnly2 := newReq("only2")
+	reqBoth := newReq("both")
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqEmpty)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqOnly1)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd1, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqBoth)
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqEmpty)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd2, reqOnly1)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqBoth)
+
+	g.sub.AssertEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/http.go
@@ -148,6 +148,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes/http.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+	sub      *subscriber.Subscriber
+	daprd1   *daprd.Daprd
+	daprd2   *daprd.Daprd
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes(
+		"/all", "/allempty", "/only1", "/only2", "/both",
+	))
+
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	appid1 := uuid.New().String()
+	appid2 := uuid.New().String()
+
+	h.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub1", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "all",
+						Routes: subapi.Routes{
+							Default: "/all",
+						},
+					},
+					Scopes: nil,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub2", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "allempty",
+						Routes: subapi.Routes{
+							Default: "/allempty",
+						},
+					},
+					Scopes: []string{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub3", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "only1",
+						Routes: subapi.Routes{
+							Default: "/only1",
+						},
+					},
+					Scopes: []string{appid1},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub4", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "only2",
+						Routes: subapi.Routes{
+							Default: "/only2",
+						},
+					},
+					Scopes: []string{appid2},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "sub5", Namespace: "default"},
+					Spec: subapi.SubscriptionSpec{
+						Pubsubname: "mypub",
+						Topic:      "both",
+						Routes: subapi.Routes{
+							Default: "/both",
+						},
+					},
+					Scopes: []string{appid1, appid2},
+				},
+			},
+		}),
+	)
+
+	h.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(h.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	daprdOpts := []daprd.Option{
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(h.operator.Address()),
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	}
+	h.daprd1 = daprd.New(t, append(daprdOpts, daprd.WithAppID(appid1))...)
+	h.daprd2 = daprd.New(t, append(daprdOpts, daprd.WithAppID(appid2))...)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, h.sub, h.kubeapi, h.operator, h.daprd1, h.daprd2),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd1.WaitUntilRunning(t, ctx)
+	h.daprd2.WaitUntilRunning(t, ctx)
+
+	client1 := h.daprd1.GRPCClient(t, ctx)
+	client2 := h.daprd2.GRPCClient(t, ctx)
+
+	meta, err := client1.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only1", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only1"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	meta, err = client2.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only2", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only2"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	newReq := func(daprd *daprd.Daprd, topic string) subscriber.PublishRequest {
+		return subscriber.PublishRequest{
+			Daprd:      daprd,
+			PubSubName: "mypub",
+			Topic:      topic,
+			Data:       `{"status": "completed"}`,
+		}
+	}
+
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "all"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "allempty"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "only1"))
+	h.sub.ExpectPublishNoReceive(t, ctx, newReq(h.daprd1, "only2"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "both"))
+
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "all"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "allempty"))
+	h.sub.ExpectPublishNoReceive(t, ctx, newReq(h.daprd2, "only1"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "only2"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "both"))
+
+	h.sub.AssertEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/v2alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/v2alpha1.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/v2alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/v2alpha1.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pubsub
+package v2alpha1
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/v2alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/v2alpha1.go
@@ -14,5 +14,12 @@ limitations under the License.
 package v2alpha1
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/basic"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/deadletter"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/informer"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/missing"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/rawpayload"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/routes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/scopes"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/mixed/defaultroute.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/mixed/defaultroute.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mixed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaultroute))
+}
+
+type defaultroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (d *defaultroute) Setup(t *testing.T) []framework.Option {
+	d.sub = subscriber.New(t, subscriber.WithRoutes("/123", "/456", "/zyx", "/xyz"))
+
+	d.daprd = daprd.New(t,
+		daprd.WithAppPort(d.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /123
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /456
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub3
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  default: /xyz
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub4
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /zyx
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(d.sub, d.daprd),
+	}
+}
+
+func (d *defaultroute) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	d.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      d.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	assert.Equal(t, "/123", d.sub.Receive(t, ctx).Route)
+
+	d.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      d.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	assert.Equal(t, "/xyz", d.sub.Receive(t, ctx).Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/mixed/emptyroute.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/mixed/emptyroute.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mixed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptyroute))
+}
+
+type emptyroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *emptyroute) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t, subscriber.WithRoutes("/a/b/c/d", "/123"))
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port()),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a/b/c/d
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+  - path: /123
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub3
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  rules:
+  - path: /123
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub4
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *emptyroute) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	assert.Equal(t, "/a/b/c/d", e.sub.Receive(t, ctx).Route)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	assert.Equal(t, "/123", e.sub.Receive(t, ctx).Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/mixed/match.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/mixed/match.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mixed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(match))
+}
+
+type match struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (m *match) Setup(t *testing.T) []framework.Option {
+	m.sub = subscriber.New(t, subscriber.WithRoutes("/a/b/c/d", "/123"))
+	m.daprd = daprd.New(t,
+		daprd.WithAppPort(m.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a/b/c/d
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+  - path: /123
+    match: event.topic == "a"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: sub3
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  rules:
+  - path: /123
+    match: event.topic == "b"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub4
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(m.sub, m.daprd),
+	}
+}
+
+func (m *match) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	m.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	assert.Equal(t, "/a/b/c/d", m.sub.Receive(t, ctx).Route)
+
+	m.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	assert.Equal(t, "/123", m.sub.Receive(t, ctx).Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/selfhosted.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/selfhosted.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/selfhosted.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/selfhosted.go
@@ -14,6 +14,7 @@ limitations under the License.
 package selfhosted
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/mixed"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/selfhosted.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/selfhosted.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pubsub
+package selfhosted
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/basic/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/basic/grpc.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  route: /a
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "foo/bar", resp.GetDataContentType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "foo", string(resp.GetData()))
+	assert.Equal(t, "text/plain", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/basic/http.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a"),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  route: /a
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("application/json"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/json", resp.DataContentType())
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("foo/bar"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "foo/bar", resp.DataContentType())
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       "foo",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "foo", string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/grpc.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bulk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a
+ bulkSubscribe:
+  enabled: true
+  maxMessagesCount: 100
+  maxAwaitDurationMs: 40
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: nobulk
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /b
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	resp, err := client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.AssertBulkEventChanLen(t, 0)
+
+	resp, err = client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	g.sub.AssertBulkEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/http.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bulk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithBulkRoutes("/a", "/b"))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a
+ bulkSubscribe:
+  enabled: true
+  maxMessagesCount: 100
+  maxAwaitDurationMs: 40
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: nobulk
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /b
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	h.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
+	})
+
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+
+	h.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
+	})
+
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/grpc.go
@@ -75,7 +75,7 @@ spec:
 apiVersion: dapr.io/v1alpha1
 kind: Subscription
 metadata:
- name: mysub
+ name: anothermysub
 spec:
  pubsubname: mypub
  topic: mydead

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/grpc.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deadletter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	app   *app.App
+	inCh  chan *rtv1.TopicEventRequest
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.inCh = make(chan *rtv1.TopicEventRequest)
+	g.app = app.New(t,
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			if in.GetTopic() == "a" {
+				return nil, errors.New("my error")
+			}
+			g.inCh <- in
+			return new(rtv1.TopicEventResponse), nil
+		}),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a
+ deadLetterTopic: mydead
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: mydead
+ route: /b
+ deadLetterTopic: mydead
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.app, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	t.Cleanup(cancel)
+	select {
+	case <-ctx.Done():
+		assert.Fail(t, "timeout waiting for event")
+	case in := <-g.inCh:
+		assert.Equal(t, "mydead", in.GetTopic())
+		assert.Equal(t, "/b", in.GetPath())
+	}
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter/http.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deadletter
+
+import (
+	"context"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t,
+		subscriber.WithRoutes("/b"),
+		subscriber.WithHandlerFunc("/a", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			w.WriteHeader(nethttp.StatusServiceUnavailable)
+		}),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a
+ deadLetterTopic: mydead
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: mydead
+ route: /b
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/b", resp.Route)
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, `{"status": "completed"}`, string(resp.Data()))
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/grpc.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package missing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub1
+spec:
+ pubsubname: anotherpub
+ topic: a
+ route: /a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub2
+spec:
+ pubsubname: mypub
+ topic: c
+ route: /c
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	g.sub.ExpectPublishError(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "anotherpub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "b", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "c", Data: []byte(`{"status": "completed"}`),
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing/http.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package missing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes("/a", "/b", "/c"))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub1
+spec:
+ pubsubname: anotherpub
+ topic: a
+ route: /a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub2
+spec:
+ pubsubname: mypub
+ topic: c
+ route: /c
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	meta, err := h.daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	h.sub.ExpectPublishError(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "anotherpub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+
+	h.sub.ExpectPublishNoReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+		Data:       `{"status": "completed"}`,
+	})
+
+	h.sub.ExpectPublishReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "c",
+		Data:       `{"status": "completed"}`,
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/grpc.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rawpayload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/pubsub"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a
+ metadata:
+  rawPayload: "true"
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["datacontenttype"] = "foo/bar"
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload/http.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rawpayload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a"),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ route: /a
+ metadata:
+  rawPayload: "true"
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "text/plain", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("application/json"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("foo/bar"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "foo/bar"
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       "foo",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/grpc.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub1
+spec:
+  pubsubname: mypub
+  topic: a
+  route: /a/b/c/d
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub2
+spec:
+  pubsubname: mypub
+  topic: a
+  route: /a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub3
+spec:
+  pubsubname: mypub
+  topic: b
+  route: /a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub4
+spec:
+  pubsubname: mypub
+  topic: b
+  route: /d/c/b/a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub5
+spec:
+  pubsubname: mypub
+  topic: b
+  route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a/b/c/d", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+
+	// Uses the first defined route for a topic when two declared routes match
+	// the topic.
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route/http.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes("/a", "/d/c/b/a", "/a/b/c/d"))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub1
+spec:
+  pubsubname: mypub
+  topic: a
+  route: /a/b/c/d
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub2
+spec:
+  pubsubname: mypub
+  topic: a
+  route: /a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub3
+spec:
+  pubsubname: mypub
+  topic: b
+  route: /a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub5
+spec:
+  pubsubname: mypub
+  topic: b
+  route: /d/c/b/a
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: mysub6
+spec:
+  pubsubname: mypub
+  topic: b
+  route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a/b/c/d", resp.Route)
+	assert.Empty(t, resp.Data())
+
+	// Uses the first defined route for a topic when two declared routes match
+	// the topic.
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Empty(t, resp.Data())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/grpc.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	resDir := t.TempDir()
+
+	g.daprd1 = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	g.daprd2 = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub1
+spec:
+  pubsubname: mypub
+  topic: all
+  route: /all
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub2
+spec:
+  pubsubname: mypub
+  topic: allempty
+  route: /allempty
+scopes: []
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub3
+spec:
+  pubsubname: mypub
+  topic: only1
+  route: /only1
+scopes:
+- %[1]s
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub4
+spec:
+  pubsubname: mypub
+  topic: only2
+  route: /only2
+scopes:
+- %[2]s
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub5
+spec:
+  pubsubname: mypub
+  topic: both
+  route: /both
+scopes:
+- %[1]s
+- %[2]s
+`, g.daprd1.AppID(), g.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd1, g.daprd2),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd1.WaitUntilRunning(t, ctx)
+	g.daprd2.WaitUntilRunning(t, ctx)
+
+	client1 := g.daprd1.GRPCClient(t, ctx)
+	client2 := g.daprd2.GRPCClient(t, ctx)
+
+	meta, err := client1.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only1", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only1"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	meta, err = client2.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only2", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only2"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	newReq := func(topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: "mypub", Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	reqAll := newReq("all")
+	reqEmpty := newReq("allempty")
+	reqOnly1 := newReq("only1")
+	reqOnly2 := newReq("only2")
+	reqBoth := newReq("both")
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqEmpty)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqOnly1)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd1, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqBoth)
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqEmpty)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd2, reqOnly1)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqBoth)
+
+	g.sub.AssertEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes/http.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes(
+		"/all", "/allempty", "/only1", "/only2", "/both",
+	))
+
+	resDir := t.TempDir()
+
+	h.daprd1 = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourcesDir(resDir),
+	)
+	h.daprd2 = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourcesDir(resDir),
+	)
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub1
+spec:
+  pubsubname: mypub
+  topic: all
+  route: /all
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub2
+spec:
+  pubsubname: mypub
+  topic: allempty
+  route: /allempty
+scopes: []
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub3
+spec:
+  pubsubname: mypub
+  topic: only1
+  route: /only1
+scopes:
+- %[1]s
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub4
+spec:
+  pubsubname: mypub
+  topic: only2
+  route: /only2
+scopes:
+- %[2]s
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+  name: sub5
+spec:
+  pubsubname: mypub
+  topic: both
+  route: /both
+scopes:
+- %[1]s
+- %[2]s
+`, h.daprd1.AppID(), h.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd1, h.daprd2),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd1.WaitUntilRunning(t, ctx)
+	h.daprd2.WaitUntilRunning(t, ctx)
+
+	client1 := h.daprd1.GRPCClient(t, ctx)
+	client2 := h.daprd2.GRPCClient(t, ctx)
+
+	meta, err := client1.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only1", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only1"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	meta, err = client2.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only2", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only2"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	newReq := func(daprd *daprd.Daprd, topic string) subscriber.PublishRequest {
+		return subscriber.PublishRequest{
+			Daprd:      daprd,
+			PubSubName: "mypub",
+			Topic:      topic,
+			Data:       `{"status": "completed"}`,
+		}
+	}
+
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "all"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "allempty"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "only1"))
+	h.sub.ExpectPublishNoReceive(t, ctx, newReq(h.daprd1, "only2"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "both"))
+
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "all"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "allempty"))
+	h.sub.ExpectPublishNoReceive(t, ctx, newReq(h.daprd2, "only1"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "only2"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "both"))
+
+	h.sub.AssertEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/v1alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/v1alpha1.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/v1alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/v1alpha1.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/basic"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/deadletter"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/missing"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/rawpayload"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/route"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/scopes"
+)

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/grpc.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  routes:
+    default: /a
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "foo/bar", resp.GetDataContentType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "foo", string(resp.GetData()))
+	assert.Equal(t, "text/plain", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic/http.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a"),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  routes:
+    default: /a
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("application/json"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/json", resp.DataContentType())
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("foo/bar"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "foo/bar", resp.DataContentType())
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       "foo",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "foo", string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/grpc.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bulk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+ bulkSubscribe:
+  enabled: true
+  maxMessagesCount: 100
+  maxAwaitDurationMs: 40
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: nobulk
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  default: /b
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	resp, err := client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.ReceiveBulk(t, ctx)
+	g.sub.AssertBulkEventChanLen(t, 0)
+
+	resp, err = client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	g.sub.AssertBulkEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/http.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bulk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithBulkRoutes("/a", "/b"))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+ bulkSubscribe:
+  enabled: true
+  maxMessagesCount: 100
+  maxAwaitDurationMs: 40
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: nobulk
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  default: /b
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	h.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
+	})
+
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+
+	h.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
+	})
+
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+	h.sub.ReceiveBulk(t, ctx)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/grpc.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deadletter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	app   *app.App
+	inCh  chan *rtv1.TopicEventRequest
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.inCh = make(chan *rtv1.TopicEventRequest)
+	g.app = app.New(t,
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			if in.GetTopic() == "a" {
+				return nil, errors.New("my error")
+			}
+			g.inCh <- in
+			return new(rtv1.TopicEventResponse), nil
+		}),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+ deadLetterTopic: mydead
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: mydead
+ routes:
+  default: /b
+ deadLetterTopic: mydead
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.app, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	t.Cleanup(cancel)
+	select {
+	case <-ctx.Done():
+		assert.Fail(t, "timeout waiting for event")
+	case in := <-g.inCh:
+		assert.Equal(t, "mydead", in.GetTopic())
+		assert.Equal(t, "/b", in.GetPath())
+	}
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter/http.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deadletter
+
+import (
+	"context"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t,
+		subscriber.WithRoutes("/b"),
+		subscriber.WithHandlerFunc("/a", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			w.WriteHeader(nethttp.StatusServiceUnavailable)
+		}),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+ deadLetterTopic: mydead
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: mydead
+ routes:
+  default: /b
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/b", resp.Route)
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, `{"status": "completed"}`, string(resp.Data()))
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/grpc.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package missing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub1
+spec:
+ pubsubname: anotherpub
+ topic: a
+ routes:
+  default: /a
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub2
+spec:
+ pubsubname: mypub
+ topic: c
+ routes:
+  default: /c
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	g.sub.ExpectPublishError(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "anotherpub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "b", Data: []byte(`{"status": "completed"}`),
+	})
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "c", Data: []byte(`{"status": "completed"}`),
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing/http.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package missing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes("/a", "/b", "/c"))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub1
+spec:
+ pubsubname: anotherpub
+ topic: a
+ routes:
+  default: /a
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub2
+spec:
+ pubsubname: mypub
+ topic: c
+ routes:
+  default: /c
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	meta, err := h.daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	h.sub.ExpectPublishError(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "anotherpub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+
+	h.sub.ExpectPublishNoReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+		Data:       `{"status": "completed"}`,
+	})
+
+	h.sub.ExpectPublishReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "c",
+		Data:       `{"status": "completed"}`,
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/rawpayload/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/rawpayload/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/rawpayload/grpc.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rawpayload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/pubsub"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+ metadata:
+  rawPayload: "true"
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["datacontenttype"] = "foo/bar"
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/rawpayload/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/rawpayload/http.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rawpayload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a"),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+ metadata:
+  rawPayload: "true"
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "text/plain", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("application/json"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           h.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("foo/bar"),
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "foo/bar"
+	assert.Equal(t, exp, ce)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       "foo",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/grpc.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultroute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a/b/c/d
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub2
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub3
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  default: /a
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub4
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  default: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a/b/c/d", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute/http.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultroute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes(
+		"/a/b/c/d", "/a", "/b", "/d/c/b/a",
+	))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a/b/c/d
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub2
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /a
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub3
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  default: /b
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: mysub4
+spec:
+ pubsubname: mypub
+ topic: b
+ routes:
+  default: /d/c/b/a
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/a/b/c/d", resp.Route)
+	assert.Empty(t, resp.Data())
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/b", resp.Route)
+	assert.Empty(t, resp.Data())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/grpc.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package emptymatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: justpath
+spec:
+ pubsubname: mypub
+ topic: justpath
+ routes:
+  rules:
+  - path: /justpath
+    match: ""
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: defaultandpath
+spec:
+ pubsubname: mypub
+ topic: defaultandpath
+ routes:
+  default: /abc
+  rules:
+  - path: /123
+    match: ""
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: multipaths
+spec:
+ pubsubname: mypub
+ topic: multipaths
+ routes:
+  rules:
+  - path: /xyz
+    match: ""
+  - path: /456
+    match: ""
+  - path: /789
+    match: ""
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: defaultandpaths
+spec:
+ pubsubname: mypub
+ topic: defaultandpaths
+ routes:
+  default: /def
+  rules:
+  - path: /zyz
+    match: ""
+  - path: /aaa
+    match: ""
+  - path: /bbb
+    match: ""
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "justpath",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/justpath", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "defaultandpath",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "multipaths",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/xyz", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "defaultandpaths",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/zyz", resp.GetPath())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch/http.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package emptymatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes(
+		"/justpath", "/abc", "/123", "/def", "/zyz",
+		"/aaa", "/bbb", "/xyz", "/456", "/789",
+	))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: justpath
+spec:
+ pubsubname: mypub
+ topic: justpath
+ routes:
+  rules:
+  - path: /justpath
+    match: ""
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: defaultandpath
+spec:
+ pubsubname: mypub
+ topic: defaultandpath
+ routes:
+  default: /abc
+  rules:
+  - path: /123
+    match: ""
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: multipaths
+spec:
+ pubsubname: mypub
+ topic: multipaths
+ routes:
+  rules:
+  - path: /xyz
+    match: ""
+  - path: /456
+    match: ""
+  - path: /789
+    match: ""
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: defaultandpaths
+spec:
+ pubsubname: mypub
+ topic: defaultandpaths
+ routes:
+  default: /def
+  rules:
+  - path: /zyz
+    match: ""
+  - path: /aaa
+    match: ""
+  - path: /bbb
+    match: ""
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "justpath",
+	})
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/justpath", resp.Route)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "defaultandpath",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.Route)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "multipaths",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/xyz", resp.Route)
+
+	h.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "defaultandpaths",
+	})
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/zyz", resp.Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/grpc.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package match
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: type
+spec:
+ pubsubname: mypub
+ topic: type
+ routes:
+  default: /aaa
+  rules:
+  - path: /type
+    match: event.type == "com.dapr.event.sent"
+  - path: /foo
+    match: ""
+  - path: /bar
+    match: event.type == "com.dapr.event.recv"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order1
+spec:
+ pubsubname: mypub
+ topic: order1
+ routes:
+  default: /aaa
+  rules:
+  - path: /type
+    match: event.type == "com.dapr.event.sent"
+  - path: /topic
+    match: event.topic == "order1"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order2
+spec:
+ pubsubname: mypub
+ topic: order2
+ routes:
+  default: /aaa
+  rules:
+  - path: /topic
+    match: event.topic == "order2"
+  - path: /type
+    match: event.type == "com.dapr.event.sent"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order3
+spec:
+ pubsubname: mypub
+ topic: order3
+ routes:
+  default: /aaa
+  rules:
+  - path: /123
+    match: event.topic == "order3"
+  - path: /456
+    match: event.topic == "order3"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order4
+spec:
+ pubsubname: mypub
+ topic: order4
+ routes:
+  rules:
+  - path: /123
+    match: event.topic == "order5"
+  - path: /456
+    match: event.topic == "order6"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order7
+spec:
+ pubsubname: mypub
+ topic: order7
+ default: /order7def
+ routes:
+  rules:
+  - path: /order7rule
+    match: ""
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+	client := g.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "type",
+	})
+	require.NoError(t, err)
+	resp := g.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order1",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order2",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/topic", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order3",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.GetPath())
+
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order4",
+	})
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order7",
+	})
+	require.NoError(t, err)
+	resp = g.sub.Receive(t, ctx)
+	assert.Equal(t, "/order7rule", resp.GetPath())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
@@ -38,7 +38,8 @@ type http struct {
 
 func (h *http) Setup(t *testing.T) []framework.Option {
 	h.sub = subscriber.New(t, subscriber.WithRoutes(
-		"/aaa", "/type", "/foo", "/bar", "/topic", "/123", "/456", "/order7def", "/order7rule",
+		"/aaa", "/type", "/foo", "/bar", "/topic",
+		"/123", "/456", "/order7def", "/order7rule",
 	))
 
 	h.daprd = daprd.New(t,

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match/http.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package match
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes(
+		"/aaa", "/type", "/foo", "/bar", "/topic", "/123", "/456", "/order7def", "/order7rule",
+	))
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: type
+spec:
+ pubsubname: mypub
+ topic: type
+ routes:
+  default: /aaa
+  rules:
+  - path: /type
+    match: event.type == "com.dapr.event.sent"
+  - path: /foo
+    match: ""
+  - path: /bar
+    match: event.type == "com.dapr.event.recv"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order1
+spec:
+ pubsubname: mypub
+ topic: order1
+ routes:
+  default: /aaa
+  rules:
+  - path: /type
+    match: event.type == "com.dapr.event.sent"
+  - path: /topic
+    match: event.topic == "order1"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order2
+spec:
+ pubsubname: mypub
+ topic: order2
+ routes:
+  default: /aaa
+  rules:
+  - path: /topic
+    match: event.topic == "order2"
+  - path: /type
+    match: event.type == "com.dapr.event.sent"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order3
+spec:
+ pubsubname: mypub
+ topic: order3
+ routes:
+  default: /aaa
+  rules:
+  - path: /123
+    match: event.topic == "order3"
+  - path: /456
+    match: event.topic == "order3"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order4
+spec:
+ pubsubname: mypub
+ topic: order4
+ routes:
+  rules:
+  - path: /123
+    match: event.topic == "order5"
+  - path: /456
+    match: event.topic == "order6"
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: order7
+spec:
+ pubsubname: mypub
+ topic: order7
+ default: /order7def
+ routes:
+  rules:
+  - path: /order7rule
+    match: ""
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+	client := h.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "type",
+	})
+	require.NoError(t, err)
+	resp := h.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.Route)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order1",
+	})
+	require.NoError(t, err)
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.Route)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order2",
+	})
+	require.NoError(t, err)
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/topic", resp.Route)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order3",
+	})
+	require.NoError(t, err)
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.Route)
+
+	h.sub.ExpectPublishNoReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      h.daprd,
+		PubSubName: "mypub",
+		Topic:      "order4",
+	})
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order7",
+	})
+	require.NoError(t, err)
+	resp = h.sub.Receive(t, ctx)
+	assert.Equal(t, "/order7rule", resp.Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/routes.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/routes.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/routes.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/routes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pubsub
+package v2alpha1
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/defaultroute"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/emptymatch"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes/match"
 )

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/grpc.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.sub = subscriber.New(t)
+
+	resDir := t.TempDir()
+
+	g.daprd1 = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+	g.daprd2 = daprd.New(t,
+		daprd.WithAppPort(g.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(resDir),
+	)
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub1
+spec:
+  pubsubname: mypub
+  topic: all
+  routes:
+    default: /all
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub2
+spec:
+  pubsubname: mypub
+  topic: allempty
+  routes:
+    default: /allempty
+scopes: []
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub3
+spec:
+  pubsubname: mypub
+  topic: only1
+  routes:
+    default: /only1
+scopes:
+- %[1]s
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub4
+spec:
+  pubsubname: mypub
+  topic: only2
+  routes:
+    default: /only2
+scopes:
+- %[2]s
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub5
+spec:
+  pubsubname: mypub
+  topic: both
+  routes:
+    default: /both
+scopes:
+- %[1]s
+- %[2]s
+`, g.daprd1.AppID(), g.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(g.sub, g.daprd1, g.daprd2),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd1.WaitUntilRunning(t, ctx)
+	g.daprd2.WaitUntilRunning(t, ctx)
+
+	client1 := g.daprd1.GRPCClient(t, ctx)
+	client2 := g.daprd2.GRPCClient(t, ctx)
+
+	meta, err := client1.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only1", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only1"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	meta, err = client2.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only2", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only2"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	newReq := func(topic string) *rtv1.PublishEventRequest {
+		return &rtv1.PublishEventRequest{PubsubName: "mypub", Topic: topic, Data: []byte(`{"status": "completed"}`)}
+	}
+
+	reqAll := newReq("all")
+	reqEmpty := newReq("allempty")
+	reqOnly1 := newReq("only1")
+	reqOnly2 := newReq("only2")
+	reqBoth := newReq("both")
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqEmpty)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqOnly1)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd1, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd1, reqBoth)
+
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqAll)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqEmpty)
+	g.sub.ExpectPublishNoReceive(t, ctx, g.daprd2, reqOnly1)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqOnly2)
+	g.sub.ExpectPublishReceive(t, ctx, g.daprd2, reqBoth)
+
+	g.sub.AssertEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/http.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/http.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes/http.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	sub    *subscriber.Subscriber
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.sub = subscriber.New(t, subscriber.WithRoutes(
+		"/all", "/allempty", "/only1", "/only2", "/both",
+	))
+
+	resDir := t.TempDir()
+
+	h.daprd1 = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourcesDir(resDir),
+	)
+	h.daprd2 = daprd.New(t,
+		daprd.WithAppPort(h.sub.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourcesDir(resDir),
+	)
+
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "sub.yaml"),
+		[]byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub1
+spec:
+  pubsubname: mypub
+  topic: all
+  routes:
+    default: /all
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub2
+spec:
+  pubsubname: mypub
+  topic: allempty
+  routes:
+    default: /allempty
+scopes: []
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub3
+spec:
+  pubsubname: mypub
+  topic: only1
+  routes:
+    default: /only1
+scopes:
+- %[1]s
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub4
+spec:
+  pubsubname: mypub
+  topic: only2
+  routes:
+    default: /only2
+scopes:
+- %[2]s
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: sub5
+spec:
+  pubsubname: mypub
+  topic: both
+  routes:
+    default: /both
+scopes:
+- %[1]s
+- %[2]s
+`, h.daprd1.AppID(), h.daprd2.AppID())), 0o600))
+
+	return []framework.Option{
+		framework.WithProcesses(h.sub, h.daprd1, h.daprd2),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd1.WaitUntilRunning(t, ctx)
+	h.daprd2.WaitUntilRunning(t, ctx)
+
+	client1 := h.daprd1.GRPCClient(t, ctx)
+	client2 := h.daprd2.GRPCClient(t, ctx)
+
+	meta, err := client1.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only1", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only1"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	meta, err = client2.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, []*rtv1.PubsubSubscription{
+		{PubsubName: "mypub", Topic: "all", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/all"}},
+		}},
+		{PubsubName: "mypub", Topic: "allempty", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/allempty"}},
+		}},
+		{PubsubName: "mypub", Topic: "only2", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/only2"}},
+		}},
+		{PubsubName: "mypub", Topic: "both", Rules: &rtv1.PubsubSubscriptionRules{
+			Rules: []*rtv1.PubsubSubscriptionRule{{Path: "/both"}},
+		}},
+	}, meta.GetSubscriptions())
+
+	newReq := func(daprd *daprd.Daprd, topic string) subscriber.PublishRequest {
+		return subscriber.PublishRequest{
+			Daprd:      daprd,
+			PubSubName: "mypub",
+			Topic:      topic,
+			Data:       `{"status": "completed"}`,
+		}
+	}
+
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "all"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "allempty"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "only1"))
+	h.sub.ExpectPublishNoReceive(t, ctx, newReq(h.daprd1, "only2"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd1, "both"))
+
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "all"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "allempty"))
+	h.sub.ExpectPublishNoReceive(t, ctx, newReq(h.daprd2, "only1"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "only2"))
+	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd2, "both"))
+
+	h.sub.AssertEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/v2alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/v2alpha1.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/v2alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/v2alpha1.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/basic"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/deadletter"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/missing"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/rawpayload"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/routes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/scopes"
+)

--- a/tests/integration/suite/daprd/subscriptions/mixed/grpc/defaultroute.go
+++ b/tests/integration/suite/daprd/subscriptions/mixed/grpc/defaultroute.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaultroute))
+}
+
+type defaultroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (d *defaultroute) Setup(t *testing.T) []framework.Option {
+	d.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/123",
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "b",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/xyz",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	d.daprd = daprd.New(t,
+		daprd.WithAppPort(d.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /456
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /zyx
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(d.sub, d.daprd),
+	}
+}
+
+func (d *defaultroute) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	client := d.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/123", d.sub.Receive(t, ctx).GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/123", d.sub.Receive(t, ctx).GetPath())
+}

--- a/tests/integration/suite/daprd/subscriptions/mixed/grpc/emptyroute.go
+++ b/tests/integration/suite/daprd/subscriptions/mixed/grpc/emptyroute.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptyroute))
+}
+
+type emptyroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *emptyroute) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a/b/c/d",
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "b",
+						Routes: &rtv1.TopicRoutes{
+							Rules: []*rtv1.TopicRule{
+								{Path: "/123"},
+							},
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+  - path: /123
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *emptyroute) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	client := e.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/a/b/c/d", e.sub.Receive(t, ctx).GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/a/b/c/d", e.sub.Receive(t, ctx).GetPath())
+}

--- a/tests/integration/suite/daprd/subscriptions/mixed/grpc/match.go
+++ b/tests/integration/suite/daprd/subscriptions/mixed/grpc/match.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(match))
+}
+
+type match struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *match) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a/b/c/d",
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "b",
+						Routes: &rtv1.TopicRoutes{
+							Rules: []*rtv1.TopicRule{
+								{Path: "/123", Match: `event.topic == "b"`},
+							},
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+  - path: /123
+    match: event.topic == "a"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *match) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	client := e.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/a/b/c/d", e.sub.Receive(t, ctx).GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/a/b/c/d", e.sub.Receive(t, ctx).GetPath())
+}

--- a/tests/integration/suite/daprd/subscriptions/mixed/http/defaultroute.go
+++ b/tests/integration/suite/daprd/subscriptions/mixed/http/defaultroute.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaultroute))
+}
+
+type defaultroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (d *defaultroute) Setup(t *testing.T) []framework.Option {
+	d.sub = subscriber.New(t,
+		subscriber.WithRoutes("/123", "/456", "/zyx", "/xyz"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Route:      "/123",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Routes: subscriber.RoutesJSON{
+					Default: "/xyz",
+				},
+			},
+		),
+	)
+
+	d.daprd = daprd.New(t,
+		daprd.WithAppPort(d.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  default: /456
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /zyx
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(d.sub, d.daprd),
+	}
+}
+
+func (d *defaultroute) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	d.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      d.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	assert.Equal(t, "/123", d.sub.Receive(t, ctx).Route)
+
+	d.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      d.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	assert.Equal(t, "/xyz", d.sub.Receive(t, ctx).Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/mixed/http/emptyroute.go
+++ b/tests/integration/suite/daprd/subscriptions/mixed/http/emptyroute.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptyroute))
+}
+
+type emptyroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *emptyroute) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a/b/c/d", "/123"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Route:      "/a/b/c/d",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Routes: subscriber.RoutesJSON{
+					Rules: []*subscriber.RuleJSON{
+						{Path: "/123"},
+					},
+				},
+			},
+		),
+	)
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port()),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: mypub
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+Kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+  - path: /123
+---
+apiVersion: dapr.io/v1alpha1
+Kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *emptyroute) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	assert.Equal(t, "/a/b/c/d", e.sub.Receive(t, ctx).Route)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	assert.Equal(t, "/123", e.sub.Receive(t, ctx).Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/mixed/http/match.go
+++ b/tests/integration/suite/daprd/subscriptions/mixed/http/match.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(match))
+}
+
+type match struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (m *match) Setup(t *testing.T) []framework.Option {
+	m.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a/b/c/d", "/123"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Route:      "/a/b/c/d",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Routes: subscriber.RoutesJSON{
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/123",
+							Match: `event.topic == "b"`,
+						},
+					},
+				},
+			},
+		),
+	)
+
+	m.daprd = daprd.New(t,
+		daprd.WithAppPort(m.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: mypub
+ topic: a
+ routes:
+  rules:
+  - path: /123
+    match: event.topic == "a"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: sub2
+spec:
+ pubsubname: mypub
+ topic: b
+ route: /a/b/c/d
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(m.sub, m.daprd),
+	}
+}
+
+func (m *match) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	m.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	assert.Equal(t, "/a/b/c/d", m.sub.Receive(t, ctx).Route)
+
+	m.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	assert.Equal(t, "/123", m.sub.Receive(t, ctx).Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/mixed/mixed.go
+++ b/tests/integration/suite/daprd/subscriptions/mixed/mixed.go
@@ -14,7 +14,6 @@ limitations under the License.
 package subscriptions
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/mixed"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/mixed/grpc"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/mixed/http"
 )

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/basic.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/basic.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/basic.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/basic.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+type basic struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	b.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	b.daprd = daprd.New(t,
+		daprd.WithAppPort(b.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(b.sub, b.daprd),
+	}
+}
+
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	client := b.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := b.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.GetData()))
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = b.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "foo/bar", resp.GetDataContentType())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = b.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "foo", string(resp.GetData()))
+	assert.Equal(t, "text/plain", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/bulk.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/bulk.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/bulk.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/bulk.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(bulk))
+}
+
+type bulk struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (b *bulk) Setup(t *testing.T) []framework.Option {
+	b.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+						BulkSubscribe: &rtv1.BulkSubscribeConfig{
+							Enabled:            true,
+							MaxMessagesCount:   100,
+							MaxAwaitDurationMs: 40,
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "b",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/b",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	b.daprd = daprd.New(t,
+		daprd.WithAppPort(b.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(b.sub, b.daprd),
+	}
+}
+
+func (b *bulk) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	client := b.daprd.GRPCClient(t, ctx)
+
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	resp, err := client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.AssertBulkEventChanLen(t, 0)
+
+	resp, err = client.BulkPublishEventAlpha1(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"id": 1}`), ContentType: "application/json"},
+			{EntryId: "2", Event: []byte(`{"id": 2}`), ContentType: "application/json"},
+			{EntryId: "3", Event: []byte(`{"id": 3}`), ContentType: "application/json"},
+			{EntryId: "4", Event: []byte(`{"id": 4}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, len(resp.GetFailedEntries()))
+	b.sub.AssertBulkEventChanLen(t, 0)
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/deadletter.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/deadletter.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/deadletter.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/deadletter.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(deadletter))
+}
+
+type deadletter struct {
+	daprd *daprd.Daprd
+	app   *app.App
+	inCh  chan *rtv1.TopicEventRequest
+}
+
+func (d *deadletter) Setup(t *testing.T) []framework.Option {
+	d.inCh = make(chan *rtv1.TopicEventRequest)
+	d.app = app.New(t,
+		app.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+						DeadLetterTopic: "mydead",
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "mydead",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/b",
+						},
+						DeadLetterTopic: "mydead",
+					},
+				},
+			}, nil
+		}),
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			if in.GetTopic() == "a" {
+				return nil, errors.New("my error")
+			}
+			d.inCh <- in
+			return new(rtv1.TopicEventResponse), nil
+		}),
+	)
+
+	d.daprd = daprd.New(t,
+		daprd.WithAppPort(d.app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(d.app, d.daprd),
+	}
+}
+
+func (d *deadletter) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	client := d.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	t.Cleanup(cancel)
+	select {
+	case <-ctx.Done():
+		assert.Fail(t, "timeout waiting for event")
+	case in := <-d.inCh:
+		assert.Equal(t, "mydead", in.GetTopic())
+		assert.Equal(t, "/b", in.GetPath())
+	}
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/grpc.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/grpc.go
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package subscriptions
+package grpc
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes"
 )

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/missing.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/missing.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(missing))
+}
+
+type missing struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (m *missing) Setup(t *testing.T) []framework.Option {
+	m.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "anotherpub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "c",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/c",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	m.daprd = daprd.New(t,
+		daprd.WithAppPort(m.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(m.sub, m.daprd),
+	}
+}
+
+func (m *missing) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	client := m.daprd.GRPCClient(t, ctx)
+
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	m.sub.ExpectPublishError(t, ctx, m.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "anotherpub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	m.sub.ExpectPublishNoReceive(t, ctx, m.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "b", Data: []byte(`{"status": "completed"}`),
+	})
+	m.sub.ExpectPublishReceive(t, ctx, m.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "c", Data: []byte(`{"status": "completed"}`),
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/rawpayload.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/rawpayload.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/rawpayload.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/rawpayload.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/dapr/components-contrib/pubsub"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(rawpayload))
+}
+
+type rawpayload struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (r *rawpayload) Setup(t *testing.T) []framework.Option {
+	r.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+						Metadata: map[string]string{
+							"rawPayload": "true",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(r.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(r.sub, r.daprd),
+	}
+}
+
+func (r *rawpayload) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	client := r.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+		Metadata: map[string]string{"foo": "bar"}, DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+	resp := r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data: []byte(`{"status": "completed"}`), DataContentType: "foo/bar",
+	})
+	require.NoError(t, err)
+	resp = r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["datacontenttype"] = "foo/bar"
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte("foo"),
+	})
+	require.NoError(t, err)
+	resp = r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Equal(t, "application/octet-stream", resp.GetDataContentType())
+	assert.Equal(t, "1.0", resp.GetSpecVersion())
+	assert.Equal(t, "mypub", resp.GetPubsubName())
+	assert.Equal(t, "com.dapr.event.sent", resp.GetType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.GetData())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/defaultroute.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/defaultroute.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaultroute))
+}
+
+type defaultroute struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (d *defaultroute) Setup(t *testing.T) []framework.Option {
+	d.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a/b/c/d",
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "b",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/b",
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "b",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/d/c/b/a",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	d.daprd = daprd.New(t,
+		daprd.WithAppPort(d.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(d.sub, d.daprd),
+	}
+}
+
+func (d *defaultroute) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	client := d.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "a",
+	})
+	require.NoError(t, err)
+	resp := d.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "b",
+	})
+	require.NoError(t, err)
+	resp = d.sub.Receive(t, ctx)
+	assert.Equal(t, "/d/c/b/a", resp.GetPath())
+	assert.Empty(t, resp.GetData())
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/emptymatch.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/emptymatch.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/emptymatch.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/emptymatch.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptymatch))
+}
+
+type emptymatch struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *emptymatch) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "justpath",
+						Routes: &rtv1.TopicRoutes{
+							Rules: []*rtv1.TopicRule{
+								{Path: "/justpath", Match: ""},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "defaultandpath",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/abc",
+							Rules: []*rtv1.TopicRule{
+								{Path: "/123", Match: ""},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "multipaths",
+						Routes: &rtv1.TopicRoutes{
+							Rules: []*rtv1.TopicRule{
+								{Path: "/xyz", Match: ""},
+								{Path: "/456", Match: ""},
+								{Path: "/789", Match: ""},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "defaultandpaths",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/def",
+							Rules: []*rtv1.TopicRule{
+								{Path: "/zyz", Match: ""},
+								{Path: "/aaa", Match: ""},
+								{Path: "/bbb", Match: ""},
+							},
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *emptymatch) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	client := e.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "justpath",
+	})
+	require.NoError(t, err)
+	resp := e.sub.Receive(t, ctx)
+	assert.Equal(t, "/justpath", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "defaultandpath",
+	})
+	require.NoError(t, err)
+	resp = e.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "multipaths",
+	})
+	require.NoError(t, err)
+	resp = e.sub.Receive(t, ctx)
+	assert.Equal(t, "/xyz", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "defaultandpaths",
+	})
+	require.NoError(t, err)
+	resp = e.sub.Receive(t, ctx)
+	assert.Equal(t, "/zyz", resp.GetPath())
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/match.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/match.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/match.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/routes/match.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(match))
+}
+
+type match struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (m *match) Setup(t *testing.T) []framework.Option {
+	m.sub = subscriber.New(t,
+		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "type",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/aaa",
+							Rules: []*rtv1.TopicRule{
+								{Path: "/type", Match: `event.type == "com.dapr.event.sent"`},
+								{Path: "/foo", Match: ""},
+								{Path: "/bar", Match: `event.type == "com.dapr.event.recv"`},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "order1",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/aaa",
+							Rules: []*rtv1.TopicRule{
+								{Path: "/type", Match: `event.type == "com.dapr.event.sent"`},
+								{Path: "/topic", Match: `event.topic == "order1"`},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "order2",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/aaa",
+							Rules: []*rtv1.TopicRule{
+								{Path: "/topic", Match: `event.topic == "order2"`},
+								{Path: "/type", Match: `event.type == "com.dapr.event.sent"`},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "order3",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/aaa",
+							Rules: []*rtv1.TopicRule{
+								{Path: "/123", Match: `event.topic == "order3"`},
+								{Path: "/456", Match: `event.topic == "order3"`},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "order4",
+						Routes: &rtv1.TopicRoutes{
+							Rules: []*rtv1.TopicRule{
+								{Path: "/123", Match: `event.topic == "order5"`},
+								{Path: "/456", Match: `event.topic == "order6"`},
+							},
+						},
+					},
+					{
+						PubsubName: "mypub",
+						Topic:      "order7",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/order7def",
+							Rules: []*rtv1.TopicRule{
+								{Path: "/order7rule", Match: ""},
+							},
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	m.daprd = daprd.New(t,
+		daprd.WithAppPort(m.sub.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(m.sub, m.daprd),
+	}
+}
+
+func (m *match) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	client := m.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "type",
+	})
+	require.NoError(t, err)
+	resp := m.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order1",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order2",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/topic", resp.GetPath())
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order3",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.GetPath())
+
+	m.sub.ExpectPublishNoReceive(t, ctx, m.daprd, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order4",
+	})
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order7",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/order7rule", resp.GetPath())
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/http.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/http.go
@@ -14,6 +14,7 @@ limitations under the License.
 package http
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http/mixed"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1"
 )

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/http.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/http.go
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package programmatic
+package http
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1"
 )

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/mixed/match.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/mixed/match.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package routes
+package mixed
 
 import (
 	"context"
@@ -26,51 +26,72 @@ import (
 )
 
 func init() {
-	suite.Register(new(defaultroute))
+	suite.Register(new(match))
 }
 
-type defaultroute struct {
+type match struct {
 	daprd *daprd.Daprd
 	sub   *subscriber.Subscriber
 }
 
-func (d *defaultroute) Setup(t *testing.T) []framework.Option {
-	d.sub = subscriber.New(t,
-		subscriber.WithRoutes("/a/b/c/d", "/a", "/b", "/d/c/b/a"),
+func (m *match) Setup(t *testing.T) []framework.Option {
+	m.sub = subscriber.New(t,
+		subscriber.WithRoutes(
+			"/a/b/c/d", "/123",
+		),
 		subscriber.WithProgrammaticSubscriptions(
 			subscriber.SubscriptionJSON{
 				PubsubName: "mypub",
 				Topic:      "a",
+				Route:      "/a/b/c/d",
 				Routes: subscriber.RoutesJSON{
-					Default: "/a/b/c/d",
-				},
-			},
-			subscriber.SubscriptionJSON{
-				PubsubName: "mypub",
-				Topic:      "a",
-				Routes: subscriber.RoutesJSON{
-					Default: "/a",
-				},
-			},
-			subscriber.SubscriptionJSON{
-				PubsubName: "mypub",
-				Topic:      "b",
-				Routes: subscriber.RoutesJSON{
-					Default: "/b",
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/123",
+							Match: `event.topic == "a"`,
+						},
+					},
 				},
 			},
 			subscriber.SubscriptionJSON{
 				PubsubName: "mypub",
 				Topic:      "b",
+				Route:      "/a/b/c/d",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
 				Routes: subscriber.RoutesJSON{
-					Default: "/d/c/b/a",
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/123",
+							Match: `event.topic == "b"`,
+						},
+					},
 				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "c",
+				Routes: subscriber.RoutesJSON{
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/123",
+							Match: `event.topic == "c"`,
+						},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "c",
+				Route:      "/a/b/c/d",
 			},
 		),
 	)
 
-	d.daprd = daprd.New(t,
-		daprd.WithAppPort(d.sub.Port()),
+	m.daprd = daprd.New(t,
+		daprd.WithAppPort(m.sub.Port()),
 		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -81,28 +102,31 @@ spec:
 `))
 
 	return []framework.Option{
-		framework.WithProcesses(d.sub, d.daprd),
+		framework.WithProcesses(m.sub, m.daprd),
 	}
 }
 
-func (d *defaultroute) Run(t *testing.T, ctx context.Context) {
-	d.daprd.WaitUntilRunning(t, ctx)
+func (m *match) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
 
-	d.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:      d.daprd,
+	m.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
 		PubSubName: "mypub",
 		Topic:      "a",
 	})
-	resp := d.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.Route)
-	assert.Empty(t, resp.Data())
+	assert.Equal(t, "/123", m.sub.Receive(t, ctx).Route)
 
-	d.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:      d.daprd,
+	m.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
 		PubSubName: "mypub",
 		Topic:      "b",
 	})
-	resp = d.sub.Receive(t, ctx)
-	assert.Equal(t, "/d/c/b/a", resp.Route)
-	assert.Empty(t, resp.Data())
+	assert.Equal(t, "/123", m.sub.Receive(t, ctx).Route)
+
+	m.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "c",
+	})
+	assert.Equal(t, "/a/b/c/d", m.sub.Receive(t, ctx).Route)
 }

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/basic.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/basic.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+type basic struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	b.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a"),
+		subscriber.WithProgrammaticSubscriptions(subscriber.SubscriptionJSON{
+			PubsubName: "mypub",
+			Topic:      "a",
+			Route:      "/a",
+		}),
+	)
+
+	b.daprd = daprd.New(t,
+		daprd.WithAppPort(b.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(b.sub, b.daprd),
+	}
+}
+
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      b.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := b.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           b.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("application/json"),
+	})
+	resp = b.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/json", resp.DataContentType())
+
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           b.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("foo/bar"),
+	})
+	resp = b.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "foo/bar", resp.DataContentType())
+
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      b.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       "foo",
+	})
+	resp = b.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "foo", string(resp.Data()))
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "text/plain", resp.DataContentType())
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/bulk.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/bulk.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(bulk))
+}
+
+type bulk struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (b *bulk) Setup(t *testing.T) []framework.Option {
+	b.sub = subscriber.New(t,
+		subscriber.WithBulkRoutes("/a", "/b"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Route:      "/a",
+				BulkSubscribe: subscriber.BulkSubscribeJSON{
+					Enabled:            true,
+					MaxMessagesCount:   100,
+					MaxAwaitDurationMs: 40,
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Route:      "/b",
+			},
+		),
+	)
+
+	b.daprd = daprd.New(t,
+		daprd.WithAppPort(b.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(b.sub, b.daprd),
+	}
+}
+
+func (b *bulk) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	// TODO: @joshvanl: add support for bulk publish to in-memory pubsub.
+	b.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
+		Daprd:      b.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
+	})
+
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+
+	b.sub.PublishBulk(t, ctx, subscriber.PublishBulkRequest{
+		Daprd:      b.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+		Entries: []subscriber.PublishBulkRequestEntry{
+			{EntryID: "1", Event: `{"id": 1}`, ContentType: "application/json"},
+			{EntryID: "2", Event: `{"id": 2}`, ContentType: "application/json"},
+			{EntryID: "3", Event: `{"id": 3}`, ContentType: "application/json"},
+			{EntryID: "4", Event: `{"id": 4}`, ContentType: "application/json"},
+		},
+	})
+
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+	b.sub.ReceiveBulk(t, ctx)
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/deadletter.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/deadletter.go
@@ -18,11 +18,12 @@ import (
 	nethttp "net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
 	"github.com/dapr/dapr/tests/integration/suite"
-	"github.com/stretchr/testify/assert"
 )
 
 func init() {

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/deadletter.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/deadletter.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	suite.Register(new(deadletter))
+}
+
+type deadletter struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (d *deadletter) Setup(t *testing.T) []framework.Option {
+	d.sub = subscriber.New(t,
+		subscriber.WithHandlerFunc("/a", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			w.WriteHeader(nethttp.StatusServiceUnavailable)
+		}),
+		subscriber.WithRoutes("/b"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName:      "mypub",
+				Topic:           "a",
+				Route:           "/a",
+				DeadLetterTopic: "mydead",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "mydead",
+				Route:      "/b",
+			},
+		),
+	)
+
+	d.daprd = daprd.New(t,
+		daprd.WithAppPort(d.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(d.sub, d.daprd),
+	}
+}
+
+func (d *deadletter) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	d.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      d.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+
+	resp := d.sub.Receive(t, ctx)
+	assert.Equal(t, "/b", resp.Route)
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, `{"status": "completed"}`, string(resp.Data()))
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/missing.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/missing.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(missing))
+}
+
+type missing struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (m *missing) Setup(t *testing.T) []framework.Option {
+	m.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a", "/b", "/c"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "anotherpub",
+				Topic:      "a",
+				Route:      "/a",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "c",
+				Route:      "/c",
+			},
+		),
+	)
+
+	m.daprd = daprd.New(t,
+		daprd.WithAppPort(m.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(m.sub, m.daprd),
+	}
+}
+
+func (m *missing) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	meta, err := m.daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Len(t, meta.GetRegisteredComponents(), 1)
+	assert.Len(t, meta.GetSubscriptions(), 2)
+
+	m.sub.ExpectPublishError(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "anotherpub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+
+	m.sub.ExpectPublishNoReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+		Data:       `{"status": "completed"}`,
+	})
+
+	m.sub.ExpectPublishReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "c",
+		Data:       `{"status": "completed"}`,
+	})
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/rawpayload.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/rawpayload.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(rawpayload))
+}
+
+type rawpayload struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (r *rawpayload) Setup(t *testing.T) []framework.Option {
+	r.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Route:      "/a",
+				Metadata: map[string]string{
+					"rawPayload": "true",
+				},
+			},
+		),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(r.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(r.sub, r.daprd),
+	}
+}
+
+func (r *rawpayload) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	r.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      r.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       `{"status": "completed"}`,
+	})
+	resp := r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	var ce map[string]any
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp := pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "text/plain", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	r.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           r.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("application/json"),
+	})
+	resp = r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte(`{"status": "completed"}`), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	assert.Equal(t, exp, ce)
+
+	r.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           r.daprd,
+		PubSubName:      "mypub",
+		Topic:           "a",
+		Data:            `{"status": "completed"}`,
+		DataContentType: ptr.Of("foo/bar"),
+	})
+	resp = r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", nil, "", "")
+	exp["id"] = ce["id"]
+	exp["data"] = `{"status": "completed"}`
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "foo/bar"
+	assert.Equal(t, exp, ce)
+
+	r.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      r.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+		Data:       "foo",
+	})
+	resp = r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Equal(t, "1.0", resp.SpecVersion())
+	assert.Equal(t, "mypub", resp.Extensions()["pubsubname"])
+	assert.Equal(t, "a", resp.Extensions()["topic"])
+	assert.Equal(t, "com.dapr.event.sent", resp.Type())
+	assert.Equal(t, "application/octet-stream", resp.DataContentType())
+	require.NoError(t, json.NewDecoder(bytes.NewReader(resp.Data())).Decode(&ce))
+	exp = pubsub.NewCloudEventsEnvelope("", "", "com.dapr.event.sent", "", "a", "mypub", "application/json", []byte("foo"), "", "")
+	exp["id"] = ce["id"]
+	exp["source"] = ce["source"]
+	exp["time"] = ce["time"]
+	exp["traceid"] = ce["traceid"]
+	exp["traceparent"] = ce["traceparent"]
+	exp["datacontenttype"] = "text/plain"
+	assert.Equal(t, exp, ce)
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/route.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1/route.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(route))
+}
+
+type route struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (r *route) Setup(t *testing.T) []framework.Option {
+	r.sub = subscriber.New(t,
+		subscriber.WithRoutes("/a", "/a/b/c/d", "/d/c/b/a"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Route:      "/a/b/c/d",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Route:      "/a",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Route:      "/a",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Route:      "/d/c/b/a",
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Route:      "/a/b/c/d",
+			},
+		),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(r.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(r.sub, r.daprd),
+	}
+}
+
+func (r *route) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	r.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      r.daprd,
+		PubSubName: "mypub",
+		Topic:      "a",
+	})
+	resp := r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a", resp.Route)
+	assert.Empty(t, resp.Data())
+
+	// Uses the first defined route for a topic when two declared routes match
+	// the topic.
+	r.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      r.daprd,
+		PubSubName: "mypub",
+		Topic:      "b",
+	})
+	resp = r.sub.Receive(t, ctx)
+	assert.Equal(t, "/a/b/c/d", resp.Route)
+	assert.Empty(t, resp.Data())
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/basic.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/basic.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package basic
+package v2alpha1
 
 import (
 	"context"
@@ -27,22 +27,28 @@ import (
 )
 
 func init() {
-	suite.Register(new(http))
+	suite.Register(new(basic))
 }
 
-type http struct {
+type basic struct {
 	daprd *daprd.Daprd
 	sub   *subscriber.Subscriber
 }
 
-func (h *http) Setup(t *testing.T) []framework.Option {
-	h.sub = subscriber.New(t,
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	b.sub = subscriber.New(t,
 		subscriber.WithRoutes("/a"),
+		subscriber.WithProgrammaticSubscriptions(subscriber.SubscriptionJSON{
+			PubsubName: "mypub",
+			Topic:      "a",
+			Routes: subscriber.RoutesJSON{
+				Default: "/a",
+			},
+		}),
 	)
 
-	h.daprd = daprd.New(t,
-		daprd.WithAppPort(h.sub.Port()),
-		daprd.WithAppProtocol("http"),
+	b.daprd = daprd.New(t,
+		daprd.WithAppPort(b.sub.Port()),
 		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -50,32 +56,23 @@ metadata:
 spec:
   type: pubsub.in-memory
   version: v1
----
-apiVersion: dapr.io/v1alpha1
-kind: Subscription
-metadata:
-  name: mysub
-spec:
-  pubsubname: mypub
-  topic: a
-  route: /a
 `))
 
 	return []framework.Option{
-		framework.WithProcesses(h.sub, h.daprd),
+		framework.WithProcesses(b.sub, b.daprd),
 	}
 }
 
-func (h *http) Run(t *testing.T, ctx context.Context) {
-	h.daprd.WaitUntilRunning(t, ctx)
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
 
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:      h.daprd,
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      b.daprd,
 		PubSubName: "mypub",
 		Topic:      "a",
 		Data:       `{"status": "completed"}`,
 	})
-	resp := h.sub.Receive(t, ctx)
+	resp := b.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
 	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())
@@ -84,14 +81,14 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	assert.Equal(t, "com.dapr.event.sent", resp.Type())
 	assert.Equal(t, "text/plain", resp.DataContentType())
 
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:           h.daprd,
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           b.daprd,
 		PubSubName:      "mypub",
 		Topic:           "a",
 		Data:            `{"status": "completed"}`,
 		DataContentType: ptr.Of("application/json"),
 	})
-	resp = h.sub.Receive(t, ctx)
+	resp = b.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
 	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())
@@ -100,14 +97,14 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	assert.Equal(t, "com.dapr.event.sent", resp.Type())
 	assert.Equal(t, "application/json", resp.DataContentType())
 
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:           h.daprd,
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:           b.daprd,
 		PubSubName:      "mypub",
 		Topic:           "a",
 		Data:            `{"status": "completed"}`,
 		DataContentType: ptr.Of("foo/bar"),
 	})
-	resp = h.sub.Receive(t, ctx)
+	resp = b.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
 	assert.JSONEq(t, `{"status": "completed"}`, string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())
@@ -116,13 +113,13 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	assert.Equal(t, "com.dapr.event.sent", resp.Type())
 	assert.Equal(t, "foo/bar", resp.DataContentType())
 
-	h.sub.Publish(t, ctx, subscriber.PublishRequest{
-		Daprd:      h.daprd,
+	b.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      b.daprd,
 		PubSubName: "mypub",
 		Topic:      "a",
 		Data:       "foo",
 	})
-	resp = h.sub.Receive(t, ctx)
+	resp = b.sub.Receive(t, ctx)
 	assert.Equal(t, "/a", resp.Route)
 	assert.Equal(t, "foo", string(resp.Data()))
 	assert.Equal(t, "1.0", resp.SpecVersion())

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/routes/defaultroute.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/routes/defaultroute.go
@@ -18,13 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/emptypb"
 
-	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -39,45 +36,41 @@ type defaultroute struct {
 
 func (d *defaultroute) Setup(t *testing.T) []framework.Option {
 	d.sub = subscriber.New(t,
-		subscriber.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
-			return &rtv1.ListTopicSubscriptionsResponse{
-				Subscriptions: []*rtv1.TopicSubscription{
-					{
-						PubsubName: "mypub",
-						Topic:      "a",
-						Routes: &rtv1.TopicRoutes{
-							Default: "/a/b/c/d",
-						},
-					},
-					{
-						PubsubName: "mypub",
-						Topic:      "a",
-						Routes: &rtv1.TopicRoutes{
-							Default: "/a",
-						},
-					},
-					{
-						PubsubName: "mypub",
-						Topic:      "b",
-						Routes: &rtv1.TopicRoutes{
-							Default: "/b",
-						},
-					},
-					{
-						PubsubName: "mypub",
-						Topic:      "b",
-						Routes: &rtv1.TopicRoutes{
-							Default: "/d/c/b/a",
-						},
-					},
+		subscriber.WithRoutes("a/b/c/d", "/a", "/b", "/d/c/b/a"),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Routes: subscriber.RoutesJSON{
+					Default: "/a/b/c/d",
 				},
-			}, nil
-		}),
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "a",
+				Routes: subscriber.RoutesJSON{
+					Default: "/a",
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Routes: subscriber.RoutesJSON{
+					Default: "/b",
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "b",
+				Routes: subscriber.RoutesJSON{
+					Default: "/d/c/b/a",
+				},
+			},
+		),
 	)
 
 	d.daprd = daprd.New(t,
-		daprd.WithAppPort(d.sub.Port(t)),
-		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppPort(d.sub.Port()),
 		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -95,23 +88,21 @@ spec:
 func (d *defaultroute) Run(t *testing.T, ctx context.Context) {
 	d.daprd.WaitUntilRunning(t, ctx)
 
-	client := d.daprd.GRPCClient(t, ctx)
-
-	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
-		PubsubName: "mypub",
+	d.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      d.daprd,
+		PubSubName: "mypub",
 		Topic:      "a",
 	})
-	require.NoError(t, err)
 	resp := d.sub.Receive(t, ctx)
-	assert.Equal(t, "/a", resp.GetPath())
-	assert.Empty(t, resp.GetData())
+	assert.Equal(t, "/a", resp.Route)
+	assert.Empty(t, resp.Data())
 
-	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
-		PubsubName: "mypub",
+	d.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      d.daprd,
+		PubSubName: "mypub",
 		Topic:      "b",
 	})
-	require.NoError(t, err)
 	resp = d.sub.Receive(t, ctx)
-	assert.Equal(t, "/d/c/b/a", resp.GetPath())
-	assert.Empty(t, resp.GetData())
+	assert.Equal(t, "/d/c/b/a", resp.Route)
+	assert.Empty(t, resp.Data())
 }

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/routes/emptymatch.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/routes/emptymatch.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptymatch))
+}
+
+type emptymatch struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (e *emptymatch) Setup(t *testing.T) []framework.Option {
+	e.sub = subscriber.New(t,
+		subscriber.WithRoutes(
+			"/justpath", "/abc", "/123", "/def", "/zyz",
+			"/aaa", "/bbb", "/xyz", "/456", "/789",
+		),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "justpath",
+				Routes: subscriber.RoutesJSON{
+					Rules: []*subscriber.RuleJSON{
+						{Path: "/justpath", Match: ""},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "defaultandpath",
+				Routes: subscriber.RoutesJSON{
+					Default: "/abc",
+					Rules: []*subscriber.RuleJSON{
+						{Path: "/123", Match: ""},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "multipaths",
+				Routes: subscriber.RoutesJSON{
+					Rules: []*subscriber.RuleJSON{
+						{Path: "/xyz", Match: ""},
+						{Path: "/456", Match: ""},
+						{Path: "/789", Match: ""},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "defaultandpaths",
+				Routes: subscriber.RoutesJSON{
+					Default: "/def",
+					Rules: []*subscriber.RuleJSON{
+						{Path: "/zyz", Match: ""},
+						{Path: "/aaa", Match: ""},
+						{Path: "/bbb", Match: ""},
+					},
+				},
+			},
+		),
+	)
+
+	e.daprd = daprd.New(t,
+		daprd.WithAppPort(e.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(e.sub, e.daprd),
+	}
+}
+
+func (e *emptymatch) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "justpath",
+	})
+	resp := e.sub.Receive(t, ctx)
+	assert.Equal(t, "/justpath", resp.Route)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "defaultandpath",
+	})
+	resp = e.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.Route)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "multipaths",
+	})
+	resp = e.sub.Receive(t, ctx)
+	assert.Equal(t, "/xyz", resp.Route)
+
+	e.sub.Publish(t, ctx, subscriber.PublishRequest{
+		Daprd:      e.daprd,
+		PubSubName: "mypub",
+		Topic:      "defaultandpaths",
+	})
+	resp = e.sub.Receive(t, ctx)
+	assert.Equal(t, "/zyz", resp.Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/routes/match.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/routes/match.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(match))
+}
+
+type match struct {
+	daprd *daprd.Daprd
+	sub   *subscriber.Subscriber
+}
+
+func (m *match) Setup(t *testing.T) []framework.Option {
+	m.sub = subscriber.New(t,
+		subscriber.WithRoutes(
+			"/aaa", "/type", "/foo", "/bar", "/topic",
+			"/123", "/456", "/order7def", "/order7rule",
+		),
+		subscriber.WithProgrammaticSubscriptions(
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "type",
+				Routes: subscriber.RoutesJSON{
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/type",
+							Match: `event.type == "com.dapr.event.sent"`,
+						},
+						{Path: "/foo", Match: ""},
+						{
+							Path:  "/bar",
+							Match: `event.type == "com.dapr.event.recv"`,
+						},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "order1",
+				Routes: subscriber.RoutesJSON{
+					Default: "/aaa",
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/type",
+							Match: `event.type == "com.dapr.event.sent"`,
+						},
+						{
+							Path:  "/topic",
+							Match: `event.topic == "order1"`,
+						},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "order2",
+				Routes: subscriber.RoutesJSON{
+					Default: "/aaa",
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/topic",
+							Match: `event.topic == "order2"`,
+						},
+						{
+							Path:  "/type",
+							Match: `event.type == "com.dapr.event.sent"`,
+						},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "order3",
+				Routes: subscriber.RoutesJSON{
+					Default: "/aaa",
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/123",
+							Match: `event.topic == "order3"`,
+						},
+						{
+							Path:  "/456",
+							Match: `event.topic == "order3"`,
+						},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "order4",
+				Routes: subscriber.RoutesJSON{
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/123",
+							Match: `event.topic == "order5"`,
+						},
+						{
+							Path:  "/456",
+							Match: `event.topic == "order6"`,
+						},
+					},
+				},
+			},
+			subscriber.SubscriptionJSON{
+				PubsubName: "mypub",
+				Topic:      "order7",
+				Routes: subscriber.RoutesJSON{
+					Default: "/order7def",
+					Rules: []*subscriber.RuleJSON{
+						{
+							Path:  "/order7rule",
+							Match: "",
+						},
+					},
+				},
+			},
+		),
+	)
+
+	m.daprd = daprd.New(t,
+		daprd.WithAppPort(m.sub.Port()),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(m.sub, m.daprd),
+	}
+}
+
+func (m *match) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+	client := m.daprd.GRPCClient(t, ctx)
+
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "type",
+	})
+	require.NoError(t, err)
+	resp := m.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.Route)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order1",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/type", resp.Route)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order2",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/topic", resp.Route)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order3",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/123", resp.Route)
+
+	m.sub.ExpectPublishNoReceive(t, ctx, subscriber.PublishRequest{
+		Daprd:      m.daprd,
+		PubSubName: "mypub",
+		Topic:      "order4",
+	})
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub",
+		Topic:      "order7",
+	})
+	require.NoError(t, err)
+	resp = m.sub.Receive(t, ctx)
+	assert.Equal(t, "/order7rule", resp.Route)
+}

--- a/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/v2alpha1.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/v2alpha1.go
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package http
+package v2alpha1
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http/v1alpha1"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/http/v2alpha1/routes"
 )

--- a/tests/integration/suite/daprd/subscriptions/programmatic/programmatic.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/programmatic.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/programmatic/programmatic.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/programmatic.go
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package subscriptions
+package programmatic
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/programmatic/grpc"
 )

--- a/tests/integration/suite/daprd/subscriptions/subscriptions.go
+++ b/tests/integration/suite/daprd/subscriptions/subscriptions.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/subscriptions/subscriptions.go
+++ b/tests/integration/suite/daprd/subscriptions/subscriptions.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pubsub
+package daprd
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/subscriptions/declarative"
 )


### PR DESCRIPTION
PR includes integration tests to gain test coverage for both programmatic and declarative Subscriptions, and the matrix of both types, v1/v2 versions, and http/grpc app protocols.

These tests are required for making progress on Subscription hot reloading since it will both change the Subscription parsing machinery and Subscription execution. These tests ensure backwards compatibility.

Notice that no implementation code has changed (besides cherry picking https://github.com/dapr/dapr/pull/7539). The intention of this PR is to encode the _current behaviour_, regardless of whether that behaviour should be considered bugged or not. 