### PR TITLE
Updates Go version to 1.22

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -1,6 +1,6 @@
 module build-tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-containerregistry v0.11.1-0.20220802162123-c1f9836a4fa9

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ MODFILES := $(shell find . -name go.mod)
 define modtidy-target
 .PHONY: modtidy-$(1)
 modtidy-$(1):
-	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.21; cd -
+	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.22; cd -
 endef
 
 # Generate modtidy target action for each go.mod file

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,6 +1,6 @@
 # current directory must be ./dist
 
-FROM golang:1.21
+FROM golang:1.22
 
 ARG PKG_FILES
 RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,7 +1,7 @@
 # Based on https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/go/.devcontainer/base.Dockerfile
 
-# [Choice] Go version: 1, 1.21, etc
-ARG GOVERSION=1.21
+# [Choice] Go version: 1, 1.22, etc
+ARG GOVERSION=1.22
 FROM golang:${GOVERSION}-bullseye
 
 # [Option] Install zsh

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ This includes dockerfiles to build Dapr release and debug images and development
 
 The Dev Container can be rebuilt with custom options. Relevant args (and their default values) include:
 
-* `GOVERSION` (default: `1.21`)
+* `GOVERSION` (default: `1.22`)
 * `INSTALL_ZSH` (default: `true`)
 * `KUBECTL_VERSION` (default: `latest`)
 * `HELM_VERSION` (default: `latest`)

--- a/docs/development/setup-dapr-development-env.md
+++ b/docs/development/setup-dapr-development-env.md
@@ -23,7 +23,7 @@ This document helps you get started developing Dapr. If you find any problems wh
 
 ## Go (Golang)
 
-1. Download and install [Go 1.21 or later](https://golang.org/doc/install#tarball).
+1. Download and install [Go 1.22 or later](https://golang.org/doc/install#tarball).
 
 2. Install [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation) for Go debugging, if desired.
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/dapr/dapr
 
-go 1.21
-
-toolchain go1.21.4
+go 1.22
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
@@ -178,7 +176,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chebyrash/promise v0.0.0-20230709133807-42ec49ba1459 // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
-	github.com/choleraehyq/pid v0.0.17 // indirect
+	github.com/choleraehyq/pid v0.0.18 // indirect
 	github.com/clbanning/mxj/v2 v2.5.6 // indirect
 	github.com/cloudevents/sdk-go/binding/format/protobuf/v2 v2.14.0 // indirect
 	github.com/cloudwego/fastpb v0.0.4-0.20230131074846-6fc453d58b96 // indirect

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLI
 github.com/choleraehyq/pid v0.0.16/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/choleraehyq/pid v0.0.17 h1:BLBfHTllp2nRRbZ/cOFHKlx9oWJuMwKmp7GqB5d58Hk=
 github.com/choleraehyq/pid v0.0.17/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
+github.com/choleraehyq/pid v0.0.18 h1:O7LLxPoOyt3YtonlCC8BmNrF9P6Hc8B509UOqlPSVhw=
+github.com/choleraehyq/pid v0.0.18/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=

--- a/tests/apps/actorload/Dockerfile
+++ b/tests/apps/actorload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 WORKDIR /actorload/
 COPY . .
 RUN make build

--- a/tests/apps/actorload/go.mod
+++ b/tests/apps/actorload/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/actorload
 
-go 1.21
+go 1.22
 
 require (
 	fortio.org/fortio v1.6.8

--- a/tests/apps/crypto/Dockerfile
+++ b/tests/apps/crypto/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.21 as build_env
+FROM golang:1.22 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/crypto/go.mod
+++ b/tests/apps/crypto/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/crypto
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dapr/go-sdk v1.8.0

--- a/tests/apps/perf/actor-activation-locker/Dockerfile
+++ b/tests/apps/perf/actor-activation-locker/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.21 as build_env
+FROM golang:1.22 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/actor-activation-locker/go.mod
+++ b/tests/apps/perf/actor-activation-locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/actor-activation-locker
 
-go 1.21
+go 1.22
 
 require (
 	github.com/bsm/redislock v0.8.2

--- a/tests/apps/perf/actorfeatures/Dockerfile
+++ b/tests/apps/perf/actorfeatures/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.21-bullseye as build_env
+FROM golang:1.22-bullseye as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod go.sum ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.21-bullseye as fortio_build_env
+FROM golang:1.22-bullseye as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/actorfeatures/go.mod
+++ b/tests/apps/perf/actorfeatures/go.mod
@@ -1,5 +1,5 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.21
+go 1.22
 
 require github.com/go-chi/chi/v5 v5.0.10

--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -1,5 +1,5 @@
 # Build the k6 binary with the extension
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest
 RUN xk6 build --output /k6 --with github.com/grafana/xk6-output-prometheus-remote@latest --with github.com/grafana/xk6-disruptor@350f53204c65040e71757f98a330665a8f189f91

--- a/tests/apps/perf/service_invocation_grpc/Dockerfile
+++ b/tests/apps/perf/service_invocation_grpc/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.21 as build_env
+FROM golang:1.22 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_grpc/go.mod
+++ b/tests/apps/perf/service_invocation_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_grpc
 
-go 1.21
+go 1.22
 
 require github.com/dapr/go-sdk v1.8.0
 

--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.21 as build_env
+FROM golang:1.22 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_http/go.mod
+++ b/tests/apps/perf/service_invocation_http/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_http
 
-go 1.21
+go 1.22

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.21-bullseye as build_env
+FROM golang:1.22-bullseye as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.21-bullseye as fortio_build_env
+FROM golang:1.22-bullseye as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/tester/go.mod
+++ b/tests/apps/perf/tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.21
+go 1.22

--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/kafka-bindings
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-pubsub/go.mod
+++ b/tests/apps/pluggable_redis-pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-pubsub
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-statestore/go.mod
+++ b/tests/apps/pluggable_redis-statestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-statestore
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/resiliencyapp/go.mod
+++ b/tests/apps/resiliencyapp/go.mod
@@ -1,6 +1,8 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0
 
 require (
 	github.com/dapr/dapr v0.0.0

--- a/tests/apps/resiliencyapp_grpc/go.mod
+++ b/tests/apps/resiliencyapp_grpc/go.mod
@@ -1,6 +1,8 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp_grpc
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0
 
 require (
 	github.com/dapr/dapr v1.7.4

--- a/tests/apps/service_invocation_grpc_proxy_client/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_client/go.mod
@@ -1,6 +1,8 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_client
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0
 
 require (
 	github.com/dapr/dapr v0.0.0-00010101000000-000000000000

--- a/tests/apps/service_invocation_grpc_proxy_server/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_server/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_server
 
-go 1.21
+go 1.22
 
 require (
 	google.golang.org/grpc v1.54.0

--- a/tests/integration/suite/daprd/pubsub/http/fuzz.go
+++ b/tests/integration/suite/daprd/pubsub/http/fuzz.go
@@ -131,6 +131,7 @@ func (f *fuzzpubsub) Setup(t *testing.T) []framework.Option {
 			strings.HasPrefix(*s, ".") || strings.Contains(*s, "?") ||
 			strings.Contains(*s, "#") || strings.Contains(*s, "%") ||
 			strings.Contains(*s, " ") || strings.Contains(*s, "\t") ||
+			strings.Contains(*s, "{") || strings.Contains(*s, "}") ||
 			strings.Contains(*s, "\n") || strings.Contains(*s, "\r") {
 			*s = "/" + c.RandString()
 		}


### PR DESCRIPTION
Updates Go to version 1.22 for Dapr 1.14 release.

pubsub fuzz integration test has been updated to account for the new HTTP route parsing functionality [introduced in 1.22](https://tip.golang.org/doc/go1.22#library). Without this, the test would panic!