### PR TITLE
Operator: Add discard logger to controller manager

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	argov1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/go-logr/logr"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -122,6 +123,7 @@ func NewOperator(ctx context.Context, opts Options) (Operator, error) {
 	}
 
 	mgr, err := ctrl.NewManager(conf, ctrl.Options{
+		Logger: logr.Discard(),
 		Scheme: scheme,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: opts.WebhookServerPort,


### PR DESCRIPTION
Adds discard logger to controller manager to prevent garbage log trace output.

Fixes https://github.com/dapr/dapr/issues/7607