### PR TITLE
[1.13] cherry pick: Fix daprd hotreload operator stream re-establishment causing tight loop

### DIFF
--- a/docs/release_notes/v1.13.1.md
+++ b/docs/release_notes/v1.13.1.md
@@ -1,0 +1,25 @@
+# Dapr 1.13.1
+
+This update includes bug fixes:
+
+- [(Hot-Reload) Fix operator client stream re-establishment causing tight loop](#hot-reload-fix-operator-client-stream-re-establishment-causing-tight-loop)
+
+## (Hot-Reload) Fix operator client stream re-establishment causing tight loop
+
+### Problem
+
+The operator becomes DDoSed by the Dapr runtime, and an extreme amount of logs are generated.
+Component hot-reloading no longer functions.
+
+### Impact
+
+Users running Dapr 1.13.0 that have the Component Hot-Reloading feature gate enabled.
+
+### Root cause
+
+A tight loop in the daprd operator client stream re-establishment causes runtime to constantly create new Component update streams.
+
+### Solution
+
+Fix the tight loop by correctly breaking out of retries after a successful re-establishment.
+Also ensures daprd will re-reconcile all Components in the event of a stream re-establishment, catching any Components which might have been deleted while the stream was down.

--- a/pkg/runtime/hotreload/loader/disk/resource_test.go
+++ b/pkg/runtime/hotreload/loader/disk/resource_test.go
@@ -102,7 +102,7 @@ func Test_Disk(t *testing.T) {
 	var events []*loader.Event[componentsapi.Component]
 	for i := 0; i < 3; i++ {
 		select {
-		case event := <-ch:
+		case event := <-ch.EventCh:
 			events = append(events, event)
 		case <-time.After(time.Second * 3):
 			assert.Fail(t, "expected to receive event")
@@ -174,7 +174,7 @@ func Test_Stream(t *testing.T) {
 		var events []*loader.Event[componentsapi.Component]
 		for i := 0; i < 3; i++ {
 			select {
-			case event := <-ch:
+			case event := <-ch.EventCh:
 				events = append(events, event)
 			case <-time.After(time.Second * 3):
 				assert.Fail(t, "expected to receive event")
@@ -249,7 +249,7 @@ func Test_Stream(t *testing.T) {
 		var events []*loader.Event[componentsapi.Component]
 		for i := 0; i < 2; i++ {
 			select {
-			case event := <-ch:
+			case event := <-ch.EventCh:
 				events = append(events, event)
 			case <-time.After(time.Second * 3):
 				assert.Fail(t, "expected to receive event")
@@ -325,7 +325,7 @@ func Test_Stream(t *testing.T) {
 		var events []*loader.Event[componentsapi.Component]
 		for i := 0; i < 3; i++ {
 			select {
-			case event := <-ch:
+			case event := <-ch.EventCh:
 				events = append(events, event)
 			case <-time.After(time.Second * 5):
 				assert.Fail(t, "expected to receive event")

--- a/pkg/runtime/hotreload/loader/fake/fake.go
+++ b/pkg/runtime/hotreload/loader/fake/fake.go
@@ -61,7 +61,7 @@ func (f *FakeT) WithRun(fn func(context.Context) error) *FakeT {
 
 type Fake[T differ.Resource] struct {
 	listFn   func(context.Context) (*differ.LocalRemoteResources[T], error)
-	streamFn func(context.Context) (<-chan *loader.Event[T], error)
+	streamFn func(context.Context) (*loader.StreamConn[T], error)
 }
 
 func NewFake[T differ.Resource]() *Fake[T] {
@@ -69,8 +69,11 @@ func NewFake[T differ.Resource]() *Fake[T] {
 		listFn: func(context.Context) (*differ.LocalRemoteResources[T], error) {
 			return nil, nil
 		},
-		streamFn: func(context.Context) (<-chan *loader.Event[T], error) {
-			return nil, nil
+		streamFn: func(context.Context) (*loader.StreamConn[T], error) {
+			return &loader.StreamConn[T]{
+				EventCh:     make(chan *loader.Event[T]),
+				ReconcileCh: make(chan struct{}),
+			}, nil
 		},
 	}
 }
@@ -80,7 +83,7 @@ func (f *Fake[T]) WithList(fn func(context.Context) (*differ.LocalRemoteResource
 	return f
 }
 
-func (f *Fake[T]) WithStream(fn func(context.Context) (<-chan *loader.Event[T], error)) *Fake[T] {
+func (f *Fake[T]) WithStream(fn func(context.Context) (*loader.StreamConn[T], error)) *Fake[T] {
 	f.streamFn = fn
 	return f
 }
@@ -89,6 +92,6 @@ func (f *Fake[T]) List(ctx context.Context) (*differ.LocalRemoteResources[T], er
 	return f.listFn(ctx)
 }
 
-func (f *Fake[T]) Stream(ctx context.Context) (<-chan *loader.Event[T], error) {
+func (f *Fake[T]) Stream(ctx context.Context) (*loader.StreamConn[T], error) {
 	return f.streamFn(ctx)
 }

--- a/pkg/runtime/hotreload/loader/loader.go
+++ b/pkg/runtime/hotreload/loader/loader.go
@@ -28,11 +28,16 @@ type Interface interface {
 	Components() Loader[componentsapi.Component]
 }
 
+type StreamConn[T differ.Resource] struct {
+	EventCh     chan *Event[T]
+	ReconcileCh chan struct{}
+}
+
 // Loader is an interface for loading and watching for changes to a resource
 // from a source.
 type Loader[T differ.Resource] interface {
 	List(context.Context) (*differ.LocalRemoteResources[T], error)
-	Stream(context.Context) (<-chan *Event[T], error)
+	Stream(context.Context) (*StreamConn[T], error)
 }
 
 // Event is a component event.

--- a/pkg/runtime/hotreload/loader/operator/resource_test.go
+++ b/pkg/runtime/hotreload/loader/operator/resource_test.go
@@ -91,7 +91,7 @@ func Test_generic(t *testing.T) {
 			}
 
 			select {
-			case got := <-ch:
+			case got := <-ch.EventCh:
 				assert.Same(t, comp, got)
 			case <-time.After(time.Second):
 				t.Error("expected to get event from on receive")
@@ -131,13 +131,19 @@ func Test_generic(t *testing.T) {
 			return nil, errors.New("recv error")
 		}
 
-		_, err := r.Stream(context.Background())
+		conn, err := r.Stream(context.Background())
 		require.NoError(t, err)
 
 		select {
 		case <-retried:
 		case <-time.After(time.Second * 3):
 			t.Error("expected generic to retry establishing stream after failure")
+		}
+
+		select {
+		case <-conn.ReconcileCh:
+		case <-time.After(time.Second * 3):
+			t.Error("expected reconcile channel to be sent")
 		}
 
 		require.NoError(t, r.close())

--- a/tests/integration/suite/daprd/hotreload/operator/informer/informer.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/informer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,11 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package operator
+package informer
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/binding"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/middleware"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/pubsub"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/reconnect"
 )

--- a/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/store"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(components))
+}
+
+type components struct {
+	daprd     *daprd.Daprd
+	store     *store.Store
+	kubeapi   *kubernetes.Kubernetes
+	operator1 *operator.Operator
+	operator2 *operator.Operator
+	operator3 *operator.Operator
+}
+
+func (c *components) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	c.store = store.New(metav1.GroupVersionKind{
+		Group:   "dapr.io",
+		Version: "v1alpha1",
+		Kind:    "Component",
+	})
+	c.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationList(t, &configapi.ConfigurationList{
+			Items: []configapi.Configuration{{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Configuration"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "daprsystem"},
+				Spec: configapi.ConfigurationSpec{
+					MTLSSpec: &configapi.MTLSSpec{
+						ControlPlaneTrustDomain: "integration.test.dapr.io",
+						SentryAddress:           sentry.Address(),
+					},
+					Features: []configapi.FeatureSpec{{
+						Name:    "HotReload",
+						Enabled: ptr.Of(true),
+					}},
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprComponentListFromStore(t, c.store),
+	)
+
+	opts := []operator.Option{
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(c.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	}
+	c.operator1 = operator.New(t, opts...)
+	c.operator2 = operator.New(t, append(opts,
+		operator.WithAPIPort(c.operator1.Port()),
+	)...)
+	c.operator3 = operator.New(t, append(opts,
+		operator.WithAPIPort(c.operator1.Port()),
+	)...)
+
+	c.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithConfigs("daprsystem"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(c.operator1.Address()),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, c.kubeapi, c.daprd),
+	}
+}
+
+func (c *components) Run(t *testing.T, ctx context.Context) {
+	c.operator1.Run(t, ctx)
+	c.operator1.WaitUntilRunning(t, ctx)
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	client := util.HTTPClient(t)
+
+	comp := compapi.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "default"},
+		Spec:       compapi.ComponentSpec{Type: "state.in-memory", Version: "v1"},
+	}
+	c.store.Add(&comp)
+	c.kubeapi.Informer().Add(t, &comp)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 1)
+	}, time.Second*10, time.Millisecond*10)
+
+	c.operator1.Cleanup(t)
+	c.store.Set()
+	c.kubeapi.Informer().Delete(t, &comp)
+	c.operator2.Run(t, ctx)
+	c.operator2.WaitUntilRunning(t, ctx)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()))
+	}, time.Second*10, time.Millisecond*10)
+
+	c.operator2.Cleanup(t)
+	c.store.Add(&comp)
+	c.kubeapi.Informer().Add(t, &comp)
+	c.operator3.Run(t, ctx)
+	c.operator3.WaitUntilRunning(t, ctx)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()))
+	}, time.Second*10, time.Millisecond*10)
+
+	c.operator3.Cleanup(t)
+}


### PR DESCRIPTION
When the HotReload feature is enabled in Kubernetes mode, daprd streams Component changes from the operator. In the event this stream failing (for example when the operator pod is restarted), daprd will attempt to re-establish the stream.

Due to a bug in the stream re-establishment logic, daprd would tight loop attempting to re-establish the stream. This results in component updates not being sent to daprd, as well as causing the operator to catastrophically print hundreds of connection logs a second. This completely locks up the operator process, and will produce GBs of logs unless all daprds are restarted.

sidecar connected for component updates

PR fixes the tight loop by correctly breaking out of retries after a successful re-establishment. Also ensures daprd will re-reconcile all Components in the event of a stream re-establishment, catching any Components which might have been deleted while the stream was down.

Adds integration tests operator stream re-establishment.

This PR must be back-ported to v1.13 and patch released.