### PR TITLE
Operator: Component server side scope filtering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -472,8 +472,7 @@ replace github.com/microcosm-cc/bluemonday => github.com/microcosm-cc/bluemonday
 // Don't commit with this uncommented!
 //
 // replace github.com/dapr/components-contrib => ../components-contrib
-replace github.com/dapr/kit => github.com/joshvanl/kit v0.0.0-20240311144338-09c44f2190ef
-
+// replace github.com/dapr/kit => ../kit
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.mod
+++ b/go.mod
@@ -472,7 +472,8 @@ replace github.com/microcosm-cc/bluemonday => github.com/microcosm-cc/bluemonday
 // Don't commit with this uncommented!
 //
 // replace github.com/dapr/components-contrib => ../components-contrib
-// replace github.com/dapr/kit => ../kit
+replace github.com/dapr/kit => github.com/joshvanl/kit v0.0.0-20240311144338-09c44f2190ef
+
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.sum
+++ b/go.sum
@@ -1014,8 +1014,6 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/joshvanl/kit v0.0.0-20240311144338-09c44f2190ef h1:lFxkZ6/Z5F1YYeTHjqRDfFv8J/t6plop7fhxshPXVOY=
-github.com/joshvanl/kit v0.0.0-20240311144338-09c44f2190ef/go.mod h1:dons8V2bF6MPR2yFdxtTa86PfaE7EJtKAOkZ9hOavBQ=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -1014,6 +1014,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/kit v0.0.0-20240311144338-09c44f2190ef h1:lFxkZ6/Z5F1YYeTHjqRDfFv8J/t6plop7fhxshPXVOY=
+github.com/joshvanl/kit v0.0.0-20240311144338-09c44f2190ef/go.mod h1:dons8V2bF6MPR2yFdxtTa86PfaE7EJtKAOkZ9hOavBQ=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/apis/components/v1alpha1/types.go
+++ b/pkg/apis/components/v1alpha1/types.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/common"
 	"github.com/dapr/dapr/pkg/apis/components"
@@ -74,6 +75,14 @@ func (c Component) GetSecretStore() string {
 // NameValuePairs returns the component's metadata as name/value pairs
 func (c Component) NameValuePairs() []common.NameValuePair {
 	return c.Spec.Metadata
+}
+
+func (c Component) ClientObject() client.Object {
+	return &c
+}
+
+func (c Component) GetScopes() []string {
+	return c.Scopes
 }
 
 // EmptyMetaDeepCopy returns a new instance of the component type with the

--- a/pkg/apis/httpEndpoint/v1alpha1/types.go
+++ b/pkg/apis/httpEndpoint/v1alpha1/types.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/common"
 	httpendpoint "github.com/dapr/dapr/pkg/apis/httpEndpoint"
@@ -106,6 +107,14 @@ func (h HTTPEndpoint) HasTLSClientCert() bool {
 // HasTLSPrivateKey returns a bool indicating if the HTTP endpoint contains a tls client key
 func (h HTTPEndpoint) HasTLSPrivateKey() bool {
 	return h.Spec.ClientTLS != nil && h.Spec.ClientTLS.PrivateKey != nil && h.Spec.ClientTLS.PrivateKey.Value != nil
+}
+
+func (h HTTPEndpoint) ClientObject() client.Object {
+	return &h
+}
+
+func (h HTTPEndpoint) GetScopes() []string {
+	return h.Scopes
 }
 
 // EmptyMetaDeepCopy returns a new instance of the component type with the

--- a/pkg/apis/subscriptions/v1alpha1/types.go
+++ b/pkg/apis/subscriptions/v1alpha1/types.go
@@ -15,6 +15,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/common"
 	"github.com/dapr/dapr/pkg/apis/subscriptions"
@@ -106,4 +107,12 @@ func (s Subscription) LogName() string {
 
 func (s Subscription) NameValuePairs() []common.NameValuePair {
 	return nil
+}
+
+func (s Subscription) ClientObject() client.Object {
+	return &s
+}
+
+func (s Subscription) GetScopes() []string {
+	return s.Scopes
 }

--- a/pkg/apis/subscriptions/v2alpha1/types.go
+++ b/pkg/apis/subscriptions/v2alpha1/types.go
@@ -15,6 +15,7 @@ package v2alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/common"
 	"github.com/dapr/dapr/pkg/apis/subscriptions"
@@ -137,4 +138,12 @@ func (s Subscription) LogName() string {
 
 func (s Subscription) NameValuePairs() []common.NameValuePair {
 	return nil
+}
+
+func (s Subscription) ClientObject() client.Object {
+	return &s
+}
+
+func (s Subscription) GetScopes() []string {
+	return s.Scopes
 }

--- a/pkg/internal/apis/namevaluepair.go
+++ b/pkg/internal/apis/namevaluepair.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/common"
 )
@@ -60,4 +61,12 @@ func (g GenericNameValueResource) LogName() string {
 
 func (g GenericNameValueResource) EmptyMetaDeepCopy() metav1.Object {
 	return &metav1.ObjectMeta{Name: g.Name}
+}
+
+func (g GenericNameValueResource) ClientObject() client.Object {
+	return nil
+}
+
+func (g GenericNameValueResource) GetScopes() []string {
+	return nil
 }

--- a/pkg/operator/api/authz/authz.go
+++ b/pkg/operator/api/authz/authz.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package authz
 
 import (
 	"context"
@@ -22,17 +22,17 @@ import (
 	"github.com/dapr/dapr/pkg/security/spiffe"
 )
 
-// authzRequest ensures that the requesting identity resides in the same
+// Request ensures that the requesting identity resides in the same
 // namespace as that of the requested namespace.
-func (a *apiServer) authzRequest(ctx context.Context, namespace string) error {
-	spiffeID, ok, err := spiffe.FromGRPCContext(ctx)
+func Request(ctx context.Context, namespace string) (*spiffe.Parsed, error) {
+	id, ok, err := spiffe.FromGRPCContext(ctx)
 	if err != nil || !ok {
-		return status.New(codes.PermissionDenied, "failed to determine identity").Err()
+		return nil, status.New(codes.PermissionDenied, "failed to determine identity").Err()
 	}
 
-	if len(namespace) == 0 || spiffeID.Namespace() != namespace {
-		return status.New(codes.PermissionDenied, "identity does not match requested namespace").Err()
+	if len(namespace) == 0 || id.Namespace() != namespace {
+		return nil, status.New(codes.PermissionDenied, "identity does not match requested namespace").Err()
 	}
 
-	return nil
+	return id, nil
 }

--- a/pkg/operator/api/authz/authz_test.go
+++ b/pkg/operator/api/authz/authz_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Dapr Authors
+Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package authz
 
 import (
 	"context"
@@ -23,42 +23,53 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/dapr/dapr/pkg/security/spiffe"
 	"github.com/dapr/dapr/tests/util"
 )
 
-func Test_authzRequest(t *testing.T) {
+func Test_Request(t *testing.T) {
 	appID := spiffeid.RequireFromString("spiffe://example.org/ns/ns1/app1")
 	serverID := spiffeid.RequireFromString("spiffe://example.org/ns/dapr-system/dapr-operator")
 	pki := util.GenPKI(t, util.PKIOptions{LeafID: serverID, ClientID: appID})
 
 	t.Run("no auth context should error", func(t *testing.T) {
-		err := new(apiServer).authzRequest(context.Background(), "ns1")
+		id, err := Request(context.Background(), "ns1")
 		require.Error(t, err)
 		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.Nil(t, id)
 	})
 
 	t.Run("different namespace should error", func(t *testing.T) {
-		err := new(apiServer).authzRequest(pki.ClientGRPCCtx(t), "ns2")
+		id, err := Request(pki.ClientGRPCCtx(t), "ns2")
 		require.Error(t, err)
 		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.Nil(t, id)
 	})
 
 	t.Run("empty namespace should error", func(t *testing.T) {
-		err := new(apiServer).authzRequest(pki.ClientGRPCCtx(t), "")
+		id, err := Request(pki.ClientGRPCCtx(t), "")
 		require.Error(t, err)
 		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.Nil(t, id)
 	})
 
 	t.Run("invalid SPIFFE path should error", func(t *testing.T) {
 		appID := spiffeid.RequireFromString("spiffe://example.org/foo/bar")
 		pki2 := util.GenPKI(t, util.PKIOptions{LeafID: serverID, ClientID: appID})
-		err := new(apiServer).authzRequest(pki2.ClientGRPCCtx(t), "ns1")
+		id, err := Request(pki2.ClientGRPCCtx(t), "ns1")
 		require.Error(t, err)
 		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.Nil(t, id)
 	})
 
 	t.Run("same namespace should no error", func(t *testing.T) {
-		err := new(apiServer).authzRequest(pki.ClientGRPCCtx(t), "ns1")
+		ctx := pki.ClientGRPCCtx(t)
+		id, err := Request(ctx, "ns1")
 		require.NoError(t, err)
+		expID, err := spiffe.FromStrings(
+			spiffeid.RequireTrustDomainFromString("example.org"),
+			"ns1", "app1")
+		require.NoError(t, err)
+		assert.Equal(t, expID, id)
 	})
 }

--- a/pkg/operator/api/configurations.go
+++ b/pkg/operator/api/configurations.go
@@ -21,12 +21,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	configurationapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	"github.com/dapr/dapr/pkg/operator/api/authz"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 )
 
 // GetConfiguration returns a Dapr configuration.
 func (a *apiServer) GetConfiguration(ctx context.Context, in *operatorv1pb.GetConfigurationRequest) (*operatorv1pb.GetConfigurationResponse, error) {
-	if err := a.authzRequest(ctx, in.GetNamespace()); err != nil {
+	if _, err := authz.Request(ctx, in.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operator/api/httpendpoints.go
+++ b/pkg/operator/api/httpendpoints.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	httpendpointsapi "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
+	"github.com/dapr/dapr/pkg/operator/api/authz"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 )
 
@@ -81,7 +82,7 @@ func processHTTPEndpointSecrets(ctx context.Context, endpoint *httpendpointsapi.
 
 // GetHTTPEndpoint returns a specified http endpoint object.
 func (a *apiServer) GetHTTPEndpoint(ctx context.Context, in *operatorv1pb.GetResiliencyRequest) (*operatorv1pb.GetHTTPEndpointResponse, error) {
-	if err := a.authzRequest(ctx, in.GetNamespace()); err != nil {
+	if _, err := authz.Request(ctx, in.GetNamespace()); err != nil {
 		return nil, err
 	}
 
@@ -101,7 +102,7 @@ func (a *apiServer) GetHTTPEndpoint(ctx context.Context, in *operatorv1pb.GetRes
 
 // ListHTTPEndpoints gets the list of applied http endpoints.
 func (a *apiServer) ListHTTPEndpoints(ctx context.Context, in *operatorv1pb.ListHTTPEndpointsRequest) (*operatorv1pb.ListHTTPEndpointsResponse, error) {
-	if err := a.authzRequest(ctx, in.GetNamespace()); err != nil {
+	if _, err := authz.Request(ctx, in.GetNamespace()); err != nil {
 		return nil, err
 	}
 
@@ -137,7 +138,7 @@ func (a *apiServer) ListHTTPEndpoints(ctx context.Context, in *operatorv1pb.List
 
 // HTTPEndpointUpdate updates Dapr sidecars whenever an http endpoint in the cluster is modified.
 func (a *apiServer) HTTPEndpointUpdate(in *operatorv1pb.HTTPEndpointUpdateRequest, srv operatorv1pb.Operator_HTTPEndpointUpdateServer) error { //nolint:nosnakecase
-	if err := a.authzRequest(srv.Context(), in.GetNamespace()); err != nil {
+	if _, err := authz.Request(srv.Context(), in.GetNamespace()); err != nil {
 		return err
 	}
 

--- a/pkg/operator/api/informer/fake/fake.go
+++ b/pkg/operator/api/informer/fake/fake.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/dapr/dapr/pkg/operator/api/informer"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+)
+
+type Fake[T meta.Resource] struct {
+	runFn          func(context.Context) error
+	watchUpdatesFn func(context.Context, string) (<-chan *informer.Event[T], error)
+}
+
+func New[T meta.Resource]() *Fake[T] {
+	return &Fake[T]{
+		runFn: func(context.Context) error {
+			return nil
+		},
+		watchUpdatesFn: func(context.Context, string) (<-chan *informer.Event[T], error) {
+			return nil, nil
+		},
+	}
+}
+
+func (f *Fake[T]) WithRun(fn func(context.Context) error) *Fake[T] {
+	f.runFn = fn
+	return f
+}
+
+func (f *Fake[T]) WithWatchUpdates(fn func(context.Context, string) (<-chan *informer.Event[T], error)) *Fake[T] {
+	f.watchUpdatesFn = fn
+	return f
+}
+
+func (f *Fake[T]) Run(ctx context.Context) error {
+	return f.runFn(ctx)
+}
+
+func (f *Fake[T]) WatchUpdates(ctx context.Context, namespace string) (<-chan *informer.Event[T], error) {
+	return f.watchUpdatesFn(ctx, namespace)
+}

--- a/pkg/operator/api/informer/fake/fake_test.go
+++ b/pkg/operator/api/informer/fake/fake_test.go
@@ -6,14 +6,20 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package informer
+package fake
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/reconnect"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/scopes"
+	"testing"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/operator/api/informer"
 )
+
+func Test_Fake(t *testing.T) {
+	var _ informer.Interface[compapi.Component] = New[compapi.Component]()
+}

--- a/pkg/operator/api/informer/handler.go
+++ b/pkg/operator/api/informer/handler.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+	"github.com/dapr/dapr/pkg/security/spiffe"
+	"github.com/dapr/dapr/utils"
+)
+
+type handler[T meta.Resource] struct {
+	i       *informer[T]
+	batchCh <-chan *informerEvent[T]
+	appCh   chan<- *Event[T]
+	id      *spiffe.Parsed
+}
+
+func (h *handler[T]) loop(ctx context.Context) {
+	defer close(h.appCh)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-h.i.closeCh:
+			return
+		case event := <-h.batchCh:
+			env, ok := h.appEventFromEvent(event)
+			if !ok {
+				continue
+			}
+
+			select {
+			case <-ctx.Done():
+			case <-h.i.closeCh:
+			case h.appCh <- env:
+			}
+		}
+	}
+}
+
+func (h *handler[T]) appEventFromEvent(event *informerEvent[T]) (*Event[T], bool) {
+	if event.newObj.Manifest.GetNamespace() != h.id.Namespace() {
+		return nil, false
+	}
+
+	// Handle case where scope is removed from manifest through update.
+	var appInOld bool
+	if event.oldObj != nil {
+		manifest := *event.oldObj
+		appInOld = len(manifest.GetScopes()) == 0 || utils.Contains(manifest.GetScopes(), h.id.AppID())
+	}
+
+	newManifest := event.newObj.Manifest
+	var appInNew bool
+	if len(newManifest.GetScopes()) == 0 || utils.Contains(newManifest.GetScopes(), h.id.AppID()) {
+		appInNew = true
+	}
+
+	if !appInNew {
+		if !appInOld {
+			return nil, false
+		}
+
+		return &Event[T]{
+			Manifest: *event.oldObj,
+			Type:     operatorv1.ResourceEventType_DELETED,
+		}, true
+	}
+
+	env := event.newObj
+	if !appInOld && env.Type == operatorv1.ResourceEventType_UPDATED {
+		env.Type = operatorv1.ResourceEventType_CREATED
+	}
+
+	return env, true
+}

--- a/pkg/operator/api/informer/handler_test.go
+++ b/pkg/operator/api/informer/handler_test.go
@@ -1,0 +1,436 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/dapr/pkg/apis/common"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/pkg/security/spiffe"
+)
+
+func Test_loop(t *testing.T) {
+	t.Run("if context is done, return", func(t *testing.T) {
+		done := make(chan struct{})
+		h := &handler[compapi.Component]{
+			i:       &informer[compapi.Component]{closeCh: make(chan struct{})},
+			batchCh: make(chan *informerEvent[compapi.Component]),
+			appCh:   make(chan *Event[compapi.Component]),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			h.loop(ctx)
+			close(done)
+		}()
+
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			assert.Fail(t, "expected loop to return")
+		}
+	})
+
+	t.Run("if closeCh is closed, return", func(t *testing.T) {
+		done := make(chan struct{})
+		closeCh := make(chan struct{})
+		h := &handler[compapi.Component]{
+			i:       &informer[compapi.Component]{closeCh: closeCh},
+			batchCh: make(chan *informerEvent[compapi.Component]),
+			appCh:   make(chan *Event[compapi.Component]),
+		}
+
+		go func() {
+			h.loop(context.Background())
+			close(done)
+		}()
+
+		close(closeCh)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			assert.Fail(t, "expected loop to return")
+		}
+	})
+
+	t.Run("expect to receive events in order until close", func(t *testing.T) {
+		done := make(chan struct{})
+		closeCh := make(chan struct{})
+		batchCh := make(chan *informerEvent[compapi.Component], 10)
+		appCh := make(chan *Event[compapi.Component], 10)
+
+		td, err := spiffeid.TrustDomainFromString("example.org")
+		require.NoError(t, err)
+		id, err := spiffe.FromStrings(td, "myns", "myapp")
+		require.NoError(t, err)
+
+		h := &handler[compapi.Component]{
+			i:       &informer[compapi.Component]{closeCh: closeCh},
+			batchCh: batchCh,
+			appCh:   appCh,
+			id:      id,
+		}
+
+		go func() {
+			h.loop(context.Background())
+			close(done)
+		}()
+
+		batchCh <- &informerEvent[compapi.Component]{
+			newObj: &Event[compapi.Component]{
+				Manifest: compapi.Component{ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"}},
+				Type:     operatorv1.ResourceEventType_CREATED,
+			},
+		}
+		batchCh <- &informerEvent[compapi.Component]{
+			newObj: &Event[compapi.Component]{
+				Manifest: compapi.Component{ObjectMeta: metav1.ObjectMeta{Name: "comp2", Namespace: "notmyns"}},
+				Type:     operatorv1.ResourceEventType_CREATED,
+			},
+		}
+		batchCh <- &informerEvent[compapi.Component]{
+			newObj: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp3", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+				},
+				Type: operatorv1.ResourceEventType_CREATED,
+			},
+		}
+		batchCh <- &informerEvent[compapi.Component]{
+			oldObj: &compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+			},
+			newObj: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_UPDATED,
+			},
+		}
+		batchCh <- &informerEvent[compapi.Component]{
+			oldObj: &compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+				Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+			},
+			newObj: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+				},
+				Type: operatorv1.ResourceEventType_UPDATED,
+			},
+		}
+		batchCh <- &informerEvent[compapi.Component]{
+			oldObj: &compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+				Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+			},
+			newObj: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_UPDATED,
+			},
+		}
+		batchCh <- &informerEvent[compapi.Component]{
+			newObj: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_DELETED,
+			},
+		}
+
+		for _, exp := range []*Event[compapi.Component]{
+			{
+				Manifest: compapi.Component{ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"}},
+				Type:     operatorv1.ResourceEventType_CREATED,
+			},
+			{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_UPDATED,
+			},
+			{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_DELETED,
+			},
+			{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_CREATED,
+			},
+			{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_DELETED,
+			},
+		} {
+			select {
+			case actual := <-appCh:
+				assert.Equal(t, exp, actual)
+			case <-time.After(time.Second):
+				assert.Fail(t, "expected to receive event")
+			}
+		}
+
+		close(closeCh)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			assert.Fail(t, "expected loop to return")
+		}
+	})
+}
+
+func Test_appEventFromEvent(t *testing.T) {
+	tests := map[string]struct {
+		event    *informerEvent[compapi.Component]
+		expEvent *Event[compapi.Component]
+		expOK    bool
+	}{
+		"if manifest in different namespace, return false": {
+			event: &informerEvent[compapi.Component]{
+				oldObj: &compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+				},
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "notmyns"},
+					},
+					Type: operatorv1.ResourceEventType_UPDATED,
+				},
+			},
+			expEvent: nil,
+			expOK:    false,
+		},
+		"if manifest in same namespace, return event": {
+			event: &informerEvent[compapi.Component]{
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"}},
+					Type:     operatorv1.ResourceEventType_CREATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"}},
+				Type:     operatorv1.ResourceEventType_CREATED,
+			},
+			expOK: true,
+		},
+		"if manifest in scope, return event": {
+			event: &informerEvent[compapi.Component]{
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+						Scoped:     common.Scoped{Scopes: []string{"anotherappid", "myapp"}},
+					},
+					Type: operatorv1.ResourceEventType_CREATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"anotherappid", "myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_CREATED,
+			},
+			expOK: true,
+		},
+		"if manifest not in scope, don't return event": {
+			event: &informerEvent[compapi.Component]{
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+						Scoped:     common.Scoped{Scopes: []string{"anotherappid", "notmyapp"}},
+					},
+					Type: operatorv1.ResourceEventType_CREATED,
+				},
+			},
+			expEvent: nil,
+			expOK:    false,
+		},
+		"if manifest in both manifests, return new object": {
+			event: &informerEvent[compapi.Component]{
+				oldObj: &compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"myapp"}},
+				},
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+						Scoped:     common.Scoped{Scopes: []string{"myapp", "notmyapp"}},
+					},
+					Type: operatorv1.ResourceEventType_UPDATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"myapp", "notmyapp"}},
+				},
+				Type: operatorv1.ResourceEventType_UPDATED,
+			},
+			expOK: true,
+		},
+		"if manifest in old scope but not new, return delete event": {
+			event: &informerEvent[compapi.Component]{
+				oldObj: &compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"myapp"}},
+				},
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+						Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+					},
+					Type: operatorv1.ResourceEventType_UPDATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"myapp"}},
+				},
+				Type: operatorv1.ResourceEventType_DELETED,
+			},
+			expOK: true,
+		},
+		"if manifest in both manifests (empty), return new object": {
+			event: &informerEvent[compapi.Component]{
+				oldObj: &compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"myapp"}},
+				},
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					},
+					Type: operatorv1.ResourceEventType_UPDATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+				},
+				Type: operatorv1.ResourceEventType_UPDATED,
+			},
+			expOK: true,
+		},
+		"if manifest in old scope but not new (empty), return delete event": {
+			event: &informerEvent[compapi.Component]{
+				oldObj: &compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+				},
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+						Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+					},
+					Type: operatorv1.ResourceEventType_UPDATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+				},
+				Type: operatorv1.ResourceEventType_DELETED,
+			},
+			expOK: true,
+		},
+		"if manifest not in old but in new scope, return created": {
+			event: &informerEvent[compapi.Component]{
+				oldObj: &compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+				},
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+						Scoped:     common.Scoped{Scopes: []string{"myapp", "notmyapp"}},
+					},
+					Type: operatorv1.ResourceEventType_UPDATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"myapp", "notmyapp"}},
+				},
+				Type: operatorv1.ResourceEventType_CREATED,
+			},
+			expOK: true,
+		},
+		"if manifest not in old but in new scope (empty), return created": {
+			event: &informerEvent[compapi.Component]{
+				oldObj: &compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					Scoped:     common.Scoped{Scopes: []string{"notmyapp"}},
+				},
+				newObj: &Event[compapi.Component]{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+					},
+					Type: operatorv1.ResourceEventType_UPDATED,
+				},
+			},
+			expEvent: &Event[compapi.Component]{
+				Manifest: compapi.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "myns"},
+				},
+				Type: operatorv1.ResourceEventType_CREATED,
+			},
+			expOK: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			td, err := spiffeid.TrustDomainFromString("example.org")
+			require.NoError(t, err)
+			id, err := spiffe.FromStrings(td, "myns", "myapp")
+			require.NoError(t, err)
+
+			h := &handler[compapi.Component]{
+				id: id,
+			}
+			actual, ok := h.appEventFromEvent(test.event)
+			assert.Equal(t, test.expOK, ok)
+			assert.Equal(t, test.expEvent, actual)
+		})
+	}
+}

--- a/pkg/operator/api/informer/informer.go
+++ b/pkg/operator/api/informer/informer.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/dapr/dapr/pkg/operator/api/authz"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+	"github.com/dapr/kit/events/batcher"
+	"github.com/dapr/kit/logger"
+)
+
+type Options struct {
+	Cache ctrlcache.Cache
+}
+
+// Interface is an interface for syncing Kubernetes manifests.
+type Interface[T meta.Resource] interface {
+	Run(context.Context) error
+	WatchUpdates(context.Context, string) (<-chan *Event[T], error)
+}
+
+// Event is a Kubernetes manifest event, containing the manifest and the event
+// type.
+type Event[T meta.Resource] struct {
+	Manifest T
+	Type     operatorv1.ResourceEventType
+}
+
+type informer[T meta.Resource] struct {
+	cache   ctrlcache.Cache
+	lock    sync.Mutex
+	batcher *batcher.Batcher[int, *informerEvent[T]]
+	batchID int
+
+	log     logger.Logger
+	closeCh chan struct{}
+	wg      sync.WaitGroup
+}
+
+type informerEvent[T meta.Resource] struct {
+	newObj *Event[T]
+	oldObj *T
+}
+
+func New[T meta.Resource](opts Options) Interface[T] {
+	var zero T
+	return &informer[T]{
+		log:     logger.NewLogger("dapr.operator.informer." + strings.ToLower(zero.Kind())),
+		batcher: batcher.New[int, *informerEvent[T]](0),
+		cache:   opts.Cache,
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (i *informer[T]) Run(ctx context.Context) error {
+	var zero T
+	informer, err := i.cache.GetInformer(ctx, zero.ClientObject())
+	if err != nil {
+		return fmt.Errorf("unable to get setup %s informer: %w", zero.Kind(), err)
+	}
+
+	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			i.handleEvent(ctx, nil, obj, operatorv1.ResourceEventType_CREATED)
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			i.handleEvent(ctx, oldObj, newObj, operatorv1.ResourceEventType_UPDATED)
+		},
+		DeleteFunc: func(obj any) {
+			i.handleEvent(ctx, nil, obj, operatorv1.ResourceEventType_DELETED)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("unable to add %s informer event handler: %w", zero.Kind(), err)
+	}
+
+	<-ctx.Done()
+	close(i.closeCh)
+	i.batcher.Close()
+	i.wg.Wait()
+	return nil
+}
+
+func (i *informer[T]) WatchUpdates(ctx context.Context, ns string) (<-chan *Event[T], error) {
+	id, err := authz.Request(ctx, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	batchCh := make(chan *informerEvent[T], 10)
+	appCh := make(chan *Event[T], 10)
+
+	i.batcher.Subscribe(ctx, batchCh)
+	i.wg.Add(1)
+	go func() {
+		defer i.wg.Done()
+		(&handler[T]{
+			i:       i,
+			appCh:   appCh,
+			batchCh: batchCh,
+			id:      id,
+		}).loop(ctx)
+	}()
+
+	return appCh, nil
+}
+
+func (i *informer[T]) handleEvent(ctx context.Context, oldObj, newObj any, eventType operatorv1.ResourceEventType) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	newT, ok := i.anyToT(newObj)
+	if !ok {
+		return
+	}
+
+	event := &informerEvent[T]{
+		newObj: &Event[T]{
+			Manifest: newT,
+			Type:     eventType,
+		},
+	}
+	if oldObj != nil {
+		oldT, ok := i.anyToT(oldObj)
+		if !ok {
+			return
+		}
+
+		event.oldObj = &oldT
+	}
+
+	i.batcher.Batch(i.batchID, event)
+	i.batchID++
+}
+
+func (i *informer[T]) anyToT(obj any) (T, bool) {
+	switch objT := obj.(type) {
+	case *T:
+		return *objT, true
+	case T:
+		return objT, true
+	case cache.DeletedFinalStateUnknown:
+		return i.anyToT(obj.(cache.DeletedFinalStateUnknown).Obj)
+	default:
+		i.log.Errorf("unexpected type %T", obj)
+		var zero T
+		return zero, false
+	}
+}

--- a/pkg/operator/api/informer/informer_test.go
+++ b/pkg/operator/api/informer/informer_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/dapr/dapr/pkg/apis/common"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	"github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/util"
+)
+
+func Test_WatchUpdates(t *testing.T) {
+	t.Run("bad authz should error", func(t *testing.T) {
+		appID := spiffeid.RequireFromString("spiffe://example.org/ns/ns1/app1")
+		serverID := spiffeid.RequireFromString("spiffe://example.org/ns/dapr-system/dapr-operator")
+		pki := util.GenPKI(t, util.PKIOptions{LeafID: serverID, ClientID: appID})
+
+		i := New[compapi.Component](Options{}).(*informer[compapi.Component])
+
+		appCh, err := i.WatchUpdates(pki.ClientGRPCCtx(t), "ns2")
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.Nil(t, appCh)
+
+		appCh, err = i.WatchUpdates(context.Background(), "ns2")
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+		assert.Nil(t, appCh)
+	})
+
+	t.Run("should receive app events on batch events in order", func(t *testing.T) {
+		appID := spiffeid.RequireFromString("spiffe://example.org/ns/ns1/app1")
+		serverID := spiffeid.RequireFromString("spiffe://example.org/ns/dapr-system/dapr-operator")
+		pki := util.GenPKI(t, util.PKIOptions{LeafID: serverID, ClientID: appID})
+
+		i := New[compapi.Component](Options{}).(*informer[compapi.Component])
+		t.Cleanup(func() { close(i.closeCh) })
+
+		appCh1, err := i.WatchUpdates(pki.ClientGRPCCtx(t), "ns1")
+		require.NoError(t, err)
+		appCh2, err := i.WatchUpdates(pki.ClientGRPCCtx(t), "ns1")
+		require.NoError(t, err)
+
+		i.handleEvent(context.Background(),
+			&compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+			},
+			&compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec:       compapi.ComponentSpec{Type: "bindings.redis"},
+			},
+			operator.ResourceEventType_UPDATED,
+		)
+		i.handleEvent(context.Background(),
+			&compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Spec:       compapi.ComponentSpec{Type: "bindings.redis"},
+			},
+			&compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+				Scoped:     common.Scoped{Scopes: []string{"notapp1"}},
+			},
+			operator.ResourceEventType_UPDATED,
+		)
+		i.handleEvent(context.Background(),
+			nil,
+			&compapi.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp2", Namespace: "ns1"},
+			},
+			operator.ResourceEventType_CREATED,
+		)
+
+		for _, appCh := range []<-chan *Event[compapi.Component]{appCh1, appCh2} {
+			for _, exp := range []*Event[compapi.Component]{
+				{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+						Spec:       compapi.ComponentSpec{Type: "bindings.redis"},
+					},
+					Type: operator.ResourceEventType_UPDATED,
+				},
+				{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1"},
+						Spec:       compapi.ComponentSpec{Type: "bindings.redis"},
+					},
+					Type: operator.ResourceEventType_DELETED,
+				},
+				{
+					Manifest: compapi.Component{
+						ObjectMeta: metav1.ObjectMeta{Name: "comp2", Namespace: "ns1"},
+					},
+					Type: operator.ResourceEventType_CREATED,
+				},
+			} {
+				select {
+				case event := <-appCh:
+					assert.Equal(t, exp, event)
+				case <-time.After(time.Second):
+					assert.Fail(t, "timeout waiting for app event")
+				}
+			}
+		}
+	})
+}
+
+func Test_anyToT(t *testing.T) {
+	tests := map[string]struct {
+		obj   any
+		expT  compapi.Component
+		expOK bool
+	}{
+		"type *T ok": {
+			obj:   new(compapi.Component),
+			expT:  compapi.Component{},
+			expOK: true,
+		},
+		"type T ok": {
+			obj:   compapi.Component{},
+			expT:  compapi.Component{},
+			expOK: true,
+		},
+		"type cache.DeletedFinalStateUnknown(*T) ok": {
+			obj:   cache.DeletedFinalStateUnknown{Obj: new(compapi.Component)},
+			expT:  compapi.Component{},
+			expOK: true,
+		},
+		"type cache.DeletedFinalStateUnknown(T) ok": {
+			obj:   cache.DeletedFinalStateUnknown{Obj: compapi.Component{}},
+			expT:  compapi.Component{},
+			expOK: true,
+		},
+		"type cache.DeletedFinalStateUnknown(not_T) not ok": {
+			obj:   cache.DeletedFinalStateUnknown{Obj: new(subapi.Subscription)},
+			expT:  compapi.Component{},
+			expOK: false,
+		},
+		"type different, not ok": {
+			obj:   new(subapi.Subscription),
+			expT:  compapi.Component{},
+			expOK: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			i := New[compapi.Component](Options{}).(*informer[compapi.Component])
+
+			got, ok := i.anyToT(test.obj)
+			assert.Equal(t, test.expOK, ok)
+			assert.Equal(t, test.expT, got)
+		})
+	}
+}

--- a/pkg/operator/api/resiliencies.go
+++ b/pkg/operator/api/resiliencies.go
@@ -22,12 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	resiliencyapi "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
+	"github.com/dapr/dapr/pkg/operator/api/authz"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 )
 
 // GetResiliency returns a specified resiliency object.
 func (a *apiServer) GetResiliency(ctx context.Context, in *operatorv1pb.GetResiliencyRequest) (*operatorv1pb.GetResiliencyResponse, error) {
-	if err := a.authzRequest(ctx, in.GetNamespace()); err != nil {
+	if _, err := authz.Request(ctx, in.GetNamespace()); err != nil {
 		return nil, err
 	}
 
@@ -47,7 +48,7 @@ func (a *apiServer) GetResiliency(ctx context.Context, in *operatorv1pb.GetResil
 
 // ListResiliency gets the list of applied resiliencies.
 func (a *apiServer) ListResiliency(ctx context.Context, in *operatorv1pb.ListResiliencyRequest) (*operatorv1pb.ListResiliencyResponse, error) {
-	if err := a.authzRequest(ctx, in.GetNamespace()); err != nil {
+	if _, err := authz.Request(ctx, in.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operator/api/subscriptions.go
+++ b/pkg/operator/api/subscriptions.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	"github.com/dapr/dapr/pkg/operator/api/authz"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 )
 
@@ -59,7 +60,7 @@ func (a *apiServer) ListSubscriptions(ctx context.Context, in *emptypb.Empty) (*
 
 // ListSubscriptionsV2 returns a list of Dapr pub/sub subscriptions. Use ListSubscriptionsRequest to expose pod info.
 func (a *apiServer) ListSubscriptionsV2(ctx context.Context, in *operatorv1pb.ListSubscriptionsRequest) (*operatorv1pb.ListSubscriptionsResponse, error) {
-	if err := a.authzRequest(ctx, in.GetNamespace()); err != nil {
+	if _, err := authz.Request(ctx, in.GetNamespace()); err != nil {
 		return nil, err
 	}
 
@@ -91,7 +92,7 @@ func (a *apiServer) ListSubscriptionsV2(ctx context.Context, in *operatorv1pb.Li
 }
 
 func (a *apiServer) SubscriptionUpdate(in *operatorv1pb.SubscriptionUpdateRequest, srv operatorv1pb.Operator_SubscriptionUpdateServer) error { //nolint:nosnakecase
-	if err := a.authzRequest(srv.Context(), in.GetNamespace()); err != nil {
+	if _, err := authz.Request(srv.Context(), in.GetNamespace()); err != nil {
 		return err
 	}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -222,7 +222,7 @@ func (o *operator) Run(ctx context.Context) error {
 	log.Info("Dapr Operator is starting")
 	healthzServer := health.NewServer(health.Options{
 		Log:     log,
-		Targets: ptr.Of(6),
+		Targets: ptr.Of(5),
 	})
 
 	/*

--- a/pkg/runtime/meta/resource.go
+++ b/pkg/runtime/meta/resource.go
@@ -15,6 +15,7 @@ package meta
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/common"
 )
@@ -28,7 +29,9 @@ type Resource interface {
 	GetNamespace() string
 	LogName() string
 	GetSecretStore() string
+	GetScopes() []string
 	NameValuePairs() []common.NameValuePair
+	ClientObject() client.Object
 
 	// Returns a deep copy of the resource, with the object meta set only with
 	// Name and Namespace.

--- a/tests/integration/framework/process/operator/operator.go
+++ b/tests/integration/framework/process/operator/operator.go
@@ -142,13 +142,13 @@ func (o *Operator) HealthzPort() int {
 	return o.healthzPort
 }
 
-func (o *Operator) Dial(t *testing.T, ctx context.Context, ns string, sentry *sentry.Sentry) operatorv1pb.OperatorClient {
+func (o *Operator) Dial(t *testing.T, ctx context.Context, sentry *sentry.Sentry, appID string) operatorv1pb.OperatorClient {
 	sec, err := security.New(ctx, security.Options{
 		SentryAddress:           "localhost:" + strconv.Itoa(sentry.Port()),
 		ControlPlaneTrustDomain: "integration.test.dapr.io",
-		ControlPlaneNamespace:   ns,
+		ControlPlaneNamespace:   o.namespace,
 		TrustAnchorsFile:        sentry.TrustAnchorsFile(t),
-		AppID:                   "myapp",
+		AppID:                   appID,
 		Mode:                    modes.StandaloneMode,
 		MTLSEnabled:             true,
 	})

--- a/tests/integration/suite/daprd/hotreload/operator/informer/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/components.go
@@ -46,10 +46,11 @@ func init() {
 	suite.Register(new(components))
 }
 
-// components tests operator Comoponent hot reloading with a live operator and
-// daprd, using the process kubernetes informer.
+// components tests operator hot reloading with a live operator and daprd,
+// using the process kubernetes informer.
 type components struct {
-	daprd    *daprd.Daprd
+	daprd1   *daprd.Daprd
+	daprd2   *daprd.Daprd
 	store    *store.Store
 	kubeapi  *kubernetes.Kubernetes
 	operator *operator.Operator
@@ -94,7 +95,7 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
 	)
 
-	c.daprd = daprd.New(t,
+	opts := []daprd.Option{
 		daprd.WithMode("kubernetes"),
 		daprd.WithConfigs("daprsystem"),
 		daprd.WithSentryAddress(sentry.Address()),
@@ -106,21 +107,25 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),
 		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
-	)
+	}
+
+	c.daprd1 = daprd.New(t, opts...)
+	c.daprd2 = daprd.New(t, opts...)
 
 	return []framework.Option{
-		framework.WithProcesses(sentry, c.kubeapi, c.operator, c.daprd),
+		framework.WithProcesses(sentry, c.kubeapi, c.operator, c.daprd1, c.daprd2),
 	}
 }
 
 func (c *components) Run(t *testing.T, ctx context.Context) {
 	c.operator.WaitUntilRunning(t, ctx)
-	c.daprd.WaitUntilRunning(t, ctx)
+	c.daprd1.WaitUntilRunning(t, ctx)
 
 	client := util.HTTPClient(t)
 
 	t.Run("expect no components to be loaded yet", func(t *testing.T) {
-		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()))
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd1.HTTPPort()))
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd2.HTTPPort()))
 	})
 
 	t.Run("adding a component should become available", func(t *testing.T) {
@@ -136,29 +141,36 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 		c.kubeapi.Informer().Add(t, &comp)
 
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			assert.Len(ct, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 1)
+			assert.Len(ct, util.GetMetaComponents(ct, ctx, client, c.daprd1.HTTPPort()), 1)
+			assert.Len(ct, util.GetMetaComponents(ct, ctx, client, c.daprd2.HTTPPort()), 1)
 		}, time.Second*10, time.Millisecond*10)
-		metaComponents := util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort())
-		assert.ElementsMatch(t, metaComponents, []*rtv1.RegisteredComponents{
+
+		exp := []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
 				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
 			},
-		})
+		}
+		assert.ElementsMatch(t, exp, util.GetMetaComponents(t, ctx, client, c.daprd1.HTTPPort()))
+		assert.ElementsMatch(t, exp, util.GetMetaComponents(t, ctx, client, c.daprd2.HTTPPort()))
 	})
 
-	dir := filepath.Join(t.TempDir(), "dc.sqlite")
+	dir := filepath.Join(t.TempDir(), "db.sqlite")
 	dirJSON, err := json.Marshal(dir)
 	require.NoError(t, err)
 	comp := compapi.Component{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Component"},
 		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "default"},
 		Spec: compapi.ComponentSpec{
-			Type:    "state.sqlite",
-			Version: "v1",
+			Type:         "state.sqlite",
+			Version:      "v1",
+			IgnoreErrors: true,
 			Metadata: []common.NameValuePair{
 				{Name: "connectionString", Value: common.DynamicValue{
 					JSON: apiextv1.JSON{Raw: dirJSON},
+				}},
+				{Name: "busyTimeout", Value: common.DynamicValue{
+					JSON: apiextv1.JSON{Raw: []byte(`"10s"`)},
 				}},
 			},
 		},
@@ -169,13 +181,15 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 		c.kubeapi.Informer().Modify(t, &comp)
 
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			assert.ElementsMatch(ct, util.GetMetaComponents(ct, ctx, client, c.daprd.HTTPPort()), []*rtv1.RegisteredComponents{
+			exp := []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
 					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
 				},
-			})
-		}, time.Second*10, time.Millisecond*10)
+			}
+			assert.ElementsMatch(ct, exp, util.GetMetaComponents(ct, ctx, client, c.daprd1.HTTPPort()))
+			assert.ElementsMatch(ct, exp, util.GetMetaComponents(ct, ctx, client, c.daprd2.HTTPPort()))
+		}, time.Second*20, time.Millisecond*10)
 	})
 
 	t.Run("deleting a component should delete the component", func(t *testing.T) {
@@ -183,7 +197,8 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 		c.kubeapi.Informer().Delete(t, &comp)
 
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			assert.Empty(ct, util.GetMetaComponents(ct, ctx, client, c.daprd.HTTPPort()))
+			assert.Empty(ct, util.GetMetaComponents(ct, ctx, client, c.daprd1.HTTPPort()))
+			assert.Empty(ct, util.GetMetaComponents(ct, ctx, client, c.daprd2.HTTPPort()))
 		}, time.Second*20, time.Millisecond*10)
 	})
 }

--- a/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
@@ -42,7 +42,8 @@ func init() {
 }
 
 type components struct {
-	daprd     *daprd.Daprd
+	daprd1    *daprd.Daprd
+	daprd2    *daprd.Daprd
 	store     *store.Store
 	kubeapi   *kubernetes.Kubernetes
 	operator1 *operator.Operator
@@ -83,20 +84,20 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 		kubernetes.WithClusterDaprComponentListFromStore(t, c.store),
 	)
 
-	opts := []operator.Option{
+	oopts := []operator.Option{
 		operator.WithNamespace("default"),
 		operator.WithKubeconfigPath(c.kubeapi.KubeconfigPath(t)),
 		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
 	}
-	c.operator1 = operator.New(t, opts...)
-	c.operator2 = operator.New(t, append(opts,
+	c.operator1 = operator.New(t, oopts...)
+	c.operator2 = operator.New(t, append(oopts,
 		operator.WithAPIPort(c.operator1.Port()),
 	)...)
-	c.operator3 = operator.New(t, append(opts,
+	c.operator3 = operator.New(t, append(oopts,
 		operator.WithAPIPort(c.operator1.Port()),
 	)...)
 
-	c.daprd = daprd.New(t,
+	dopts := []daprd.Option{
 		daprd.WithMode("kubernetes"),
 		daprd.WithConfigs("daprsystem"),
 		daprd.WithSentryAddress(sentry.Address()),
@@ -108,17 +109,20 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),
-	)
+	}
+	c.daprd1 = daprd.New(t, dopts...)
+	c.daprd2 = daprd.New(t, dopts...)
 
 	return []framework.Option{
-		framework.WithProcesses(sentry, c.kubeapi, c.daprd),
+		framework.WithProcesses(sentry, c.kubeapi, c.daprd1, c.daprd2),
 	}
 }
 
 func (c *components) Run(t *testing.T, ctx context.Context) {
 	c.operator1.Run(t, ctx)
 	c.operator1.WaitUntilRunning(t, ctx)
-	c.daprd.WaitUntilRunning(t, ctx)
+	c.daprd1.WaitUntilRunning(t, ctx)
+	c.daprd2.WaitUntilRunning(t, ctx)
 
 	client := util.HTTPClient(t)
 
@@ -131,7 +135,8 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 	c.kubeapi.Informer().Add(t, &comp)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.Len(t, c.daprd.GetMetaRegistedComponents(t, ctx), 1)
+		assert.Len(t, c.daprd1.GetMetaRegistedComponents(t, ctx), 1)
+		assert.Len(t, c.daprd2.GetMetaRegistedComponents(t, ctx), 1)
 	}, time.Second*10, time.Millisecond*10)
 
 	c.operator1.Cleanup(t)
@@ -141,7 +146,8 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 	c.operator2.WaitUntilRunning(t, ctx)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()))
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd1.HTTPPort()))
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd2.HTTPPort()))
 	}, time.Second*10, time.Millisecond*10)
 
 	c.operator2.Cleanup(t)
@@ -150,7 +156,8 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 	c.operator3.Run(t, ctx)
 	c.operator3.WaitUntilRunning(t, ctx)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 1)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd1.HTTPPort()), 1)
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd2.HTTPPort()), 1)
 	}, time.Second*10, time.Millisecond*10)
 
 	c.operator3.Cleanup(t)

--- a/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
@@ -150,7 +150,7 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 	c.operator3.Run(t, ctx)
 	c.operator3.WaitUntilRunning(t, ctx)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()))
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 1)
 	}, time.Second*10, time.Millisecond*10)
 
 	c.operator3.Cleanup(t)

--- a/tests/integration/suite/daprd/hotreload/operator/informer/scopes/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/scopes/components.go
@@ -100,6 +100,7 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 		daprd.WithDisableK8sSecretStore(true),
 		daprd.WithEnableMTLS(true),
 		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
 		)),

--- a/tests/integration/suite/operator/api/api.go
+++ b/tests/integration/suite/operator/api/api.go
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package informer
+package api
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/reconnect"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/operator/api/componentupdate"
+	_ "github.com/dapr/dapr/tests/integration/suite/operator/api/listcomponents"
 )

--- a/tests/integration/suite/operator/api/authz.go
+++ b/tests/integration/suite/operator/api/authz.go
@@ -114,7 +114,7 @@ func (a *authz) Run(t *testing.T, ctx context.Context) {
 		assert.Nil(t, resp)
 	})
 
-	client := a.op.Dial(t, ctx, "default", a.sentry)
+	client := a.op.Dial(t, ctx, a.sentry, "myapp")
 
 	type tcase struct {
 		funcGoodNamespace func() (any, error)

--- a/tests/integration/suite/operator/api/componentupdate/basic.go
+++ b/tests/integration/suite/operator/api/componentupdate/basic.go
@@ -11,12 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package componentupdate
 
 import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
@@ -36,50 +37,50 @@ import (
 )
 
 func init() {
-	suite.Register(new(componentupdate))
+	suite.Register(new(basic))
 }
 
-// componentupdate tests the operator's ComponentUpdate API.
-type componentupdate struct {
+// basic tests the operator's ComponentUpdate API.
+type basic struct {
 	sentry   *sentry.Sentry
 	store    *store.Store
 	kubeapi  *kubernetes.Kubernetes
 	operator *operator.Operator
 }
 
-func (c *componentupdate) Setup(t *testing.T) []framework.Option {
-	c.sentry = sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	b.sentry = sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
 
-	c.store = store.New(metav1.GroupVersionKind{
+	b.store = store.New(metav1.GroupVersionKind{
 		Group:   "dapr.io",
 		Version: "v1alpha1",
 		Kind:    "Component",
 	})
-	c.kubeapi = kubernetes.New(t,
+	b.kubeapi = kubernetes.New(t,
 		kubernetes.WithBaseOperatorAPI(t,
 			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
 			"default",
-			c.sentry.Port(),
+			b.sentry.Port(),
 		),
-		kubernetes.WithClusterDaprComponentListFromStore(t, c.store),
+		kubernetes.WithClusterDaprComponentListFromStore(t, b.store),
 	)
 
-	c.operator = operator.New(t,
+	b.operator = operator.New(t,
 		operator.WithNamespace("default"),
-		operator.WithKubeconfigPath(c.kubeapi.KubeconfigPath(t)),
-		operator.WithTrustAnchorsFile(c.sentry.TrustAnchorsFile(t)),
+		operator.WithKubeconfigPath(b.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(b.sentry.TrustAnchorsFile(t)),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(c.kubeapi, c.sentry, c.operator),
+		framework.WithProcesses(b.kubeapi, b.sentry, b.operator),
 	}
 }
 
-func (c *componentupdate) Run(t *testing.T, ctx context.Context) {
-	c.sentry.WaitUntilRunning(t, ctx)
-	c.operator.WaitUntilRunning(t, ctx)
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.sentry.WaitUntilRunning(t, ctx)
+	b.operator.WaitUntilRunning(t, ctx)
 
-	client := c.operator.Dial(t, ctx, "default", c.sentry)
+	client := b.operator.Dial(t, ctx, b.sentry, "myapp")
 
 	stream, err := client.ComponentUpdate(ctx, &operatorv1.ComponentUpdateRequest{Namespace: "default"})
 	require.NoError(t, err)
@@ -101,18 +102,15 @@ func (c *componentupdate) Run(t *testing.T, ctx context.Context) {
 	}
 
 	t.Run("CREATE", func(t *testing.T) {
-		c.store.Add(comp)
-		c.kubeapi.Informer().Add(t, comp)
+		b.store.Add(comp)
+		b.kubeapi.Informer().Add(t, comp)
 
 		event, err := stream.Recv()
 		require.NoError(t, err)
-		assert.JSONEq(t, `{
-"metadata": { "name": "mycomponent", "namespace": "default", "creationTimestamp": null },
-"spec": {
-"ignoreErrors": false, "initTimeout": "", "type": "state.redis", "version": "v1", "metadata":
-[ { "name": "connectionString", "secretKeyRef": { "key": "", "name": "" }, "value": "foobar" } ] },
-"auth": { "secretStore": "" }
-}`, string(event.GetComponent()))
+
+		var gotComp compapi.Component
+		require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
+		assert.Equal(t, comp, &gotComp)
 		assert.Equal(t, operatorv1.ResourceEventType_CREATED, event.GetType())
 		assert.Equal(t, "CREATED", event.GetType().String())
 	})
@@ -120,39 +118,46 @@ func (c *componentupdate) Run(t *testing.T, ctx context.Context) {
 	t.Run("UPDATE", func(t *testing.T) {
 		comp.Spec.Type = "state.inmemory"
 		comp.Spec.Metadata = nil
-		c.store.Set(comp)
+		b.store.Set(comp)
+		b.kubeapi.Informer().Modify(t, comp)
 
 		b, err := json.Marshal(comp)
 		require.NoError(t, err)
 
-		event, err := stream.Recv()
-		require.NoError(t, err)
-		assert.JSONEq(t, `{
-"metadata": { "name": "mycomponent", "namespace": "default", "creationTimestamp": null },
-"spec":{"ignoreErrors": false, "initTimeout": "", "type": "state.inmemory", "version": "v1", "metadata": null},
-"auth": { "secretStore": "" }
-}`, string(event.GetComponent()))
-		assert.JSONEq(t, string(b), string(event.GetComponent()))
-		assert.Equal(t, operatorv1.ResourceEventType_UPDATED, event.GetType())
-		assert.Equal(t, "UPDATED", event.GetType().String())
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			event, err := stream.Recv()
+			//nolint:testifylint
+			if !assert.NoError(c, err) {
+				return
+			}
+			var gotComp compapi.Component
+			require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
+			assert.Equal(t, comp, &gotComp)
+			assert.JSONEq(c, string(b), string(event.GetComponent()))
+			assert.Equal(c, operatorv1.ResourceEventType_UPDATED, event.GetType())
+			assert.Equal(c, "UPDATED", event.GetType().String())
+		}, time.Second*10, time.Millisecond*10)
 	})
 
 	t.Run("DELETE", func(t *testing.T) {
-		c.store.Set()
-		c.kubeapi.Informer().Delete(t, comp)
+		b.store.Set()
+		b.kubeapi.Informer().Delete(t, comp)
 
 		b, err := json.Marshal(comp)
 		require.NoError(t, err)
 
-		event, err := stream.Recv()
-		require.NoError(t, err)
-		assert.JSONEq(t, `{
-"metadata": { "name": "mycomponent", "namespace": "default", "creationTimestamp": null },
-"spec":{"ignoreErrors": false, "initTimeout": "", "type": "state.inmemory", "version": "v1", "metadata": null},
-"auth": { "secretStore": "" }
-}`, string(event.GetComponent()))
-		assert.JSONEq(t, string(b), string(event.GetComponent()))
-		assert.Equal(t, operatorv1.ResourceEventType_DELETED, event.GetType())
-		assert.Equal(t, "DELETED", event.GetType().String())
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			event, err := stream.Recv()
+			//nolint:testifylint
+			if !assert.NoError(c, err) {
+				return
+			}
+			var gotComp compapi.Component
+			require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
+			assert.Equal(t, comp, &gotComp)
+			assert.JSONEq(c, string(b), string(event.GetComponent()))
+			assert.Equal(c, operatorv1.ResourceEventType_DELETED, event.GetType())
+			assert.Equal(c, "DELETED", event.GetType().String())
+		}, time.Second*10, time.Millisecond*10)
 	})
 }

--- a/tests/integration/suite/operator/api/componentupdate/basic.go
+++ b/tests/integration/suite/operator/api/componentupdate/basic.go
@@ -132,7 +132,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			}
 			var gotComp compapi.Component
 			require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
-			assert.Equal(t, comp, &gotComp)
+			assert.Equal(c, comp, &gotComp)
 			assert.JSONEq(c, string(b), string(event.GetComponent()))
 			assert.Equal(c, operatorv1.ResourceEventType_UPDATED, event.GetType())
 			assert.Equal(c, "UPDATED", event.GetType().String())

--- a/tests/integration/suite/operator/api/componentupdate/componentupdate.go
+++ b/tests/integration/suite/operator/api/componentupdate/componentupdate.go
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package informer
+package componentupdate
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/reconnect"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/operator/api/componentupdate/scopes"
 )

--- a/tests/integration/suite/operator/api/componentupdate/scopes/addapp.go
+++ b/tests/integration/suite/operator/api/componentupdate/scopes/addapp.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/dapr/pkg/apis/common"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/store"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(addapp))
+}
+
+type addapp struct {
+	sentry   *sentry.Sentry
+	store    *store.Store
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+}
+
+func (a *addapp) Setup(t *testing.T) []framework.Option {
+	a.sentry = sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	a.store = store.New(metav1.GroupVersionKind{
+		Group:   "dapr.io",
+		Version: "v1alpha1",
+		Kind:    "Component",
+	})
+	a.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			a.sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentListFromStore(t, a.store),
+	)
+
+	a.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(a.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(a.sentry.TrustAnchorsFile(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.sentry, a.kubeapi, a.operator),
+	}
+}
+
+func (a *addapp) Run(t *testing.T, ctx context.Context) {
+	a.sentry.WaitUntilRunning(t, ctx)
+	a.operator.WaitUntilRunning(t, ctx)
+
+	client := a.operator.Dial(t, ctx, a.sentry, "myapp")
+
+	comp := &compapi.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: "mycomponent", Namespace: "default", CreationTimestamp: metav1.Time{}},
+		Spec: compapi.ComponentSpec{
+			Type:         "state.redis",
+			Version:      "v1",
+			IgnoreErrors: false,
+			Metadata: []common.NameValuePair{
+				{Name: "connectionString", Value: common.DynamicValue{JSON: apiextv1.JSON{Raw: []byte(`"foobar"`)}}},
+			},
+		},
+	}
+	a.store.Add(comp)
+
+	stream, err := client.ComponentUpdate(ctx, &operatorv1.ComponentUpdateRequest{Namespace: "default"})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stream.CloseSend()) })
+
+	event, err := stream.Recv()
+	require.NoError(t, err)
+
+	var gotComp compapi.Component
+	require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
+	assert.Equal(t, comp, &gotComp)
+	assert.Equal(t, operatorv1.ResourceEventType_CREATED, event.GetType())
+	assert.Equal(t, "CREATED", event.GetType().String())
+
+	t.Run("Adding scope for another app ID should send update", func(t *testing.T) {
+		newcomp := comp.DeepCopy()
+		newcomp.Scopes = []string{"myapp", "app1"}
+		a.store.Set(newcomp)
+		a.kubeapi.Informer().Modify(t, newcomp)
+
+		event, err := stream.Recv()
+		require.NoError(t, err)
+
+		var gotComp compapi.Component
+		require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
+		assert.Equal(t, newcomp, &gotComp)
+		assert.Equal(t, operatorv1.ResourceEventType_UPDATED, event.GetType())
+		assert.Equal(t, "UPDATED", event.GetType().String())
+	})
+}

--- a/tests/integration/suite/operator/api/componentupdate/scopes/deleteapp.go
+++ b/tests/integration/suite/operator/api/componentupdate/scopes/deleteapp.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/dapr/pkg/apis/common"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/store"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(deleteapp))
+}
+
+type deleteapp struct {
+	sentry   *sentry.Sentry
+	store    *store.Store
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+}
+
+func (d *deleteapp) Setup(t *testing.T) []framework.Option {
+	d.sentry = sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	d.store = store.New(metav1.GroupVersionKind{
+		Group:   "dapr.io",
+		Version: "v1alpha1",
+		Kind:    "Component",
+	})
+	d.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			d.sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentListFromStore(t, d.store),
+	)
+
+	d.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(d.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(d.sentry.TrustAnchorsFile(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(d.sentry, d.kubeapi, d.operator),
+	}
+}
+
+func (d *deleteapp) Run(t *testing.T, ctx context.Context) {
+	d.sentry.WaitUntilRunning(t, ctx)
+	d.operator.WaitUntilRunning(t, ctx)
+
+	client := d.operator.Dial(t, ctx, d.sentry, "myapp")
+
+	comp := &compapi.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: "mycomponent", Namespace: "default", CreationTimestamp: metav1.Time{}},
+		Spec: compapi.ComponentSpec{
+			Type:         "state.redis",
+			Version:      "v1",
+			IgnoreErrors: false,
+			Metadata: []common.NameValuePair{
+				{Name: "connectionString", Value: common.DynamicValue{JSON: apiextv1.JSON{Raw: []byte(`"foobar"`)}}},
+			},
+		},
+	}
+	d.store.Add(comp)
+
+	stream, err := client.ComponentUpdate(ctx, &operatorv1.ComponentUpdateRequest{Namespace: "default"})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stream.CloseSend()) })
+
+	event, err := stream.Recv()
+	require.NoError(t, err)
+
+	var gotComp compapi.Component
+	require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
+	assert.Equal(t, comp, &gotComp)
+	assert.Equal(t, operatorv1.ResourceEventType_CREATED, event.GetType())
+	assert.Equal(t, "CREATED", event.GetType().String())
+
+	t.Run("Adding scope for another app ID should send delete", func(t *testing.T) {
+		newcomp := comp.DeepCopy()
+		newcomp.Scopes = []string{"app1"}
+		d.store.Set(newcomp)
+		d.kubeapi.Informer().Modify(t, newcomp)
+
+		event, err := stream.Recv()
+		require.NoError(t, err)
+
+		var gotComp compapi.Component
+		require.NoError(t, json.Unmarshal(event.GetComponent(), &gotComp))
+		assert.Equal(t, comp, &gotComp)
+		assert.Equal(t, operatorv1.ResourceEventType_DELETED, event.GetType())
+		assert.Equal(t, "DELETED", event.GetType().String())
+	})
+}

--- a/tests/integration/suite/operator/api/listcomponents/listcomponents.go
+++ b/tests/integration/suite/operator/api/listcomponents/listcomponents.go
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package informer
+package listcomponents
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/reconnect"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator/informer/scopes"
+	_ "github.com/dapr/dapr/tests/integration/suite/operator/api/listcomponents/scopes"
 )

--- a/tests/integration/suite/operator/api/listcomponents/scopes/addapp.go
+++ b/tests/integration/suite/operator/api/listcomponents/scopes/addapp.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/dapr/pkg/apis/common"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/store"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(addapp))
+}
+
+type addapp struct {
+	sentry   *sentry.Sentry
+	store    *store.Store
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+}
+
+func (a *addapp) Setup(t *testing.T) []framework.Option {
+	a.sentry = sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	a.store = store.New(metav1.GroupVersionKind{
+		Group:   "dapr.io",
+		Version: "v1alpha1",
+		Kind:    "Component",
+	})
+	a.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			a.sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentListFromStore(t, a.store),
+	)
+
+	a.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(a.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(a.sentry.TrustAnchorsFile(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.sentry, a.kubeapi, a.operator),
+	}
+}
+
+func (a *addapp) Run(t *testing.T, ctx context.Context) {
+	a.sentry.WaitUntilRunning(t, ctx)
+	a.operator.WaitUntilRunning(t, ctx)
+
+	client := a.operator.Dial(t, ctx, a.sentry, "myapp")
+
+	comp := &compapi.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: "mycomponent", Namespace: "default", CreationTimestamp: metav1.Time{}},
+		TypeMeta:   metav1.TypeMeta{Kind: "Component", APIVersion: "dapr.io/v1alpha1"},
+		Spec: compapi.ComponentSpec{
+			Type:         "state.redis",
+			Version:      "v1",
+			IgnoreErrors: false,
+			Metadata: []common.NameValuePair{
+				{Name: "connectionString", Value: common.DynamicValue{JSON: apiextv1.JSON{Raw: []byte(`"foobar"`)}}},
+			},
+		},
+	}
+	a.store.Add(comp)
+
+	var list *operatorv1.ListComponentResponse
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		list, err = client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
+		//nolint:testifylint
+		if assert.NoError(c, err) {
+			assert.Len(c, list.GetComponents(), 1)
+		}
+	}, time.Second*10, time.Millisecond*10)
+
+	var gotComp compapi.Component
+	require.NoError(t, json.Unmarshal(list.GetComponents()[0], &gotComp))
+	assert.Equal(t, comp, &gotComp)
+
+	t.Run("Adding scope for another app ID should still be sent", func(t *testing.T) {
+		newcomp := comp.DeepCopy()
+		newcomp.Scopes = []string{"myapp", "app1"}
+		a.store.Set(newcomp)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			list, err := client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
+			//nolint:testifylint
+			if !assert.NoError(c, err) {
+				return
+			}
+			if !assert.Len(c, list.GetComponents(), 1) {
+				return
+			}
+			var gotComp compapi.Component
+			require.NoError(t, json.Unmarshal(list.GetComponents()[0], &gotComp))
+			assert.Equal(c, newcomp, &gotComp)
+		}, time.Second*10, time.Millisecond*10)
+	})
+}

--- a/tests/integration/suite/operator/api/listcomponents/scopes/deleteapp.go
+++ b/tests/integration/suite/operator/api/listcomponents/scopes/deleteapp.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/dapr/pkg/apis/common"
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/store"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(deleteapp))
+}
+
+type deleteapp struct {
+	sentry   *sentry.Sentry
+	store    *store.Store
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+}
+
+func (d *deleteapp) Setup(t *testing.T) []framework.Option {
+	d.sentry = sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	d.store = store.New(metav1.GroupVersionKind{
+		Group:   "dapr.io",
+		Version: "v1alpha1",
+		Kind:    "Component",
+	})
+	d.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			d.sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentListFromStore(t, d.store),
+	)
+
+	d.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(d.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(d.sentry.TrustAnchorsFile(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(d.sentry, d.kubeapi, d.operator),
+	}
+}
+
+func (d *deleteapp) Run(t *testing.T, ctx context.Context) {
+	d.sentry.WaitUntilRunning(t, ctx)
+	d.operator.WaitUntilRunning(t, ctx)
+
+	client := d.operator.Dial(t, ctx, d.sentry, "myapp")
+
+	comp := &compapi.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: "mycomponent", Namespace: "default", CreationTimestamp: metav1.Time{}},
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Component"},
+		Spec: compapi.ComponentSpec{
+			Type:         "state.redis",
+			Version:      "v1",
+			IgnoreErrors: false,
+			Metadata: []common.NameValuePair{
+				{Name: "connectionString", Value: common.DynamicValue{JSON: apiextv1.JSON{Raw: []byte(`"foobar"`)}}},
+			},
+		},
+	}
+	d.store.Set(comp)
+
+	var list *operatorv1.ListComponentResponse
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		list, err = client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
+		//nolint:testifylint
+		if assert.NoError(c, err) {
+			assert.Len(c, list.GetComponents(), 1)
+		}
+	}, time.Second*10, time.Millisecond*10)
+
+	var gotComp compapi.Component
+	require.NoError(t, json.Unmarshal(list.GetComponents()[0], &gotComp))
+	assert.Equal(t, comp, &gotComp)
+
+	t.Run("Adding scope for another app ID should no longer be sent", func(t *testing.T) {
+		newcomp := comp.DeepCopy()
+		newcomp.Scopes = []string{"app1"}
+		d.store.Set(newcomp)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			list, err := client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
+			//nolint:testifylint
+			if assert.NoError(c, err) {
+				assert.Empty(c, list.GetComponents())
+			}
+		}, time.Second*10, time.Millisecond*10)
+	})
+}


### PR DESCRIPTION
Today, daprd's will receive Component from the operator, regardless of whether they are scoped for that Component or not. This means that clients do receive components (including its associated secrets) that they are not scoped for.

Updates Operator API ComponentUpdate to perform service side Component Scope filtering based on the authenticated client App ID. When a Component is de-scoped, daprd will receive a DELETE for the previous Component manifest. When a Component is scoped-in, daprd will receive an CREATE for the new Component manifest.

Updates Operator API ListComponents to perform service side Component Scope filtering based on the authenticated client App ID.

Uses updated events batcher which ensures queue items are sent in order.

Uses kit change from PR https://github.com/dapr/kit/pull/89