### PR TITLE
Disk Loader: Scope filtering

### DIFF
--- a/pkg/internal/loader/disk/components.go
+++ b/pkg/internal/loader/disk/components.go
@@ -18,6 +18,6 @@ import (
 	"github.com/dapr/dapr/pkg/internal/loader"
 )
 
-func NewComponents(paths ...string) loader.Loader[compapi.Component] {
-	return new[compapi.Component](paths...)
+func NewComponents(opts Options) loader.Loader[compapi.Component] {
+	return new[compapi.Component](opts)
 }

--- a/pkg/internal/loader/disk/disk_test.go
+++ b/pkg/internal/loader/disk/disk_test.go
@@ -241,7 +241,7 @@ metadata:
 func Test_loadWithOrder(t *testing.T) {
 	t.Run("no file should return empty set", func(t *testing.T) {
 		tmp := t.TempDir()
-		d := NewComponents(tmp).(*disk[compapi.Component])
+		d := NewComponents(Options{Paths: []string{tmp}}).(*disk[compapi.Component])
 		set, err := d.loadWithOrder()
 		require.NoError(t, err)
 		assert.Empty(t, set.order)
@@ -259,7 +259,7 @@ spec:
   type: state.couchbase
 `), fs.FileMode(0o600)))
 
-		d := NewComponents(tmp).(*disk[compapi.Component])
+		d := NewComponents(Options{Paths: []string{tmp}}).(*disk[compapi.Component])
 		set, err := d.loadWithOrder()
 		require.NoError(t, err)
 		assert.Equal(t, []manifestOrder{
@@ -293,7 +293,7 @@ spec:
   type: state.couchbase
 `), fs.FileMode(0o600)))
 
-		d := NewComponents(tmp).(*disk[compapi.Component])
+		d := NewComponents(Options{Paths: []string{tmp}}).(*disk[compapi.Component])
 		set, err := d.loadWithOrder()
 		require.NoError(t, err)
 		assert.Equal(t, []manifestOrder{
@@ -334,7 +334,9 @@ spec:
 			}
 		}
 
-		d := NewComponents(tmp1, tmp2, tmp3).(*disk[compapi.Component])
+		d := NewComponents(Options{
+			Paths: []string{tmp1, tmp2, tmp3},
+		}).(*disk[compapi.Component])
 		set, err := d.loadWithOrder()
 		require.NoError(t, err)
 		assert.Equal(t, []manifestOrder{

--- a/pkg/internal/loader/disk/httpendpoints.go
+++ b/pkg/internal/loader/disk/httpendpoints.go
@@ -18,6 +18,6 @@ import (
 	"github.com/dapr/dapr/pkg/internal/loader"
 )
 
-func NewHTTPEndpoints(paths ...string) loader.Loader[endpointapi.HTTPEndpoint] {
-	return new[endpointapi.HTTPEndpoint](paths...)
+func NewHTTPEndpoints(opts Options) loader.Loader[endpointapi.HTTPEndpoint] {
+	return new[endpointapi.HTTPEndpoint](opts)
 }

--- a/pkg/internal/loader/disk/subscriptions.go
+++ b/pkg/internal/loader/disk/subscriptions.go
@@ -27,10 +27,10 @@ type subscriptions struct {
 	v2 *disk[v2alpha1.Subscription]
 }
 
-func NewSubscriptions(paths ...string) loader.Loader[v2alpha1.Subscription] {
+func NewSubscriptions(opts Options) loader.Loader[v2alpha1.Subscription] {
 	return &subscriptions{
-		v1: new[v1alpha1.Subscription](paths...),
-		v2: new[v2alpha1.Subscription](paths...),
+		v1: new[v1alpha1.Subscription](opts),
+		v2: new[v2alpha1.Subscription](opts),
 	}
 }
 

--- a/pkg/runtime/hotreload/hotreload.go
+++ b/pkg/runtime/hotreload/hotreload.go
@@ -35,6 +35,7 @@ var log = logger.NewLogger("dapr.runtime.hotreload")
 
 type OptionsReloaderDisk struct {
 	Config         *config.Configuration
+	AppID          string
 	Dirs           []string
 	ComponentStore *compstore.ComponentStore
 	Authorizer     *authorizer.Authorizer
@@ -60,6 +61,7 @@ type Reloader struct {
 
 func NewDisk(opts OptionsReloaderDisk) (*Reloader, error) {
 	loader, err := disk.New(disk.Options{
+		AppID:          opts.AppID,
 		Dirs:           opts.Dirs,
 		ComponentStore: opts.ComponentStore,
 	})

--- a/pkg/runtime/hotreload/loader/disk/disk.go
+++ b/pkg/runtime/hotreload/loader/disk/disk.go
@@ -35,6 +35,7 @@ import (
 var log = logger.NewLogger("dapr.runtime.hotreload.loader.disk")
 
 type Options struct {
+	AppID          string
 	Dirs           []string
 	ComponentStore *compstore.ComponentStore
 }
@@ -63,14 +64,20 @@ func New(opts Options) (loader.Interface, error) {
 		fs: fs,
 		components: newResource[compapi.Component](
 			resourceOptions[compapi.Component]{
-				loader:  loaderdisk.NewComponents(opts.Dirs...),
+				loader: loaderdisk.NewComponents(loaderdisk.Options{
+					AppID: opts.AppID,
+					Paths: opts.Dirs,
+				}),
 				store:   store.NewComponents(opts.ComponentStore),
 				batcher: batcher,
 			},
 		),
 		subscriptions: newResource[subapi.Subscription](
 			resourceOptions[subapi.Subscription]{
-				loader:  loaderdisk.NewSubscriptions(opts.Dirs...),
+				loader: loaderdisk.NewSubscriptions(loaderdisk.Options{
+					AppID: opts.AppID,
+					Paths: opts.Dirs,
+				}),
 				store:   store.NewSubscriptions(opts.ComponentStore),
 				batcher: batcher,
 			},

--- a/pkg/runtime/hotreload/loader/disk/resource_test.go
+++ b/pkg/runtime/hotreload/loader/disk/resource_test.go
@@ -148,7 +148,9 @@ func Test_Stream(t *testing.T) {
 		r := newResource[componentsapi.Component](resourceOptions[componentsapi.Component]{
 			store:   loadercompstore.NewComponents(store),
 			batcher: batcher,
-			loader:  loaderdisk.NewComponents(dir),
+			loader: loaderdisk.NewComponents(loaderdisk.Options{
+				Paths: []string{dir},
+			}),
 		})
 
 		errCh := make(chan error)
@@ -229,7 +231,9 @@ func Test_Stream(t *testing.T) {
 		r := newResource[componentsapi.Component](resourceOptions[componentsapi.Component]{
 			store:   loadercompstore.NewComponents(store),
 			batcher: batcher,
-			loader:  loaderdisk.NewComponents(dir),
+			loader: loaderdisk.NewComponents(loaderdisk.Options{
+				Paths: []string{dir},
+			}),
 		})
 
 		errCh := make(chan error)
@@ -311,7 +315,9 @@ func Test_Stream(t *testing.T) {
 		r := newResource[componentsapi.Component](resourceOptions[componentsapi.Component]{
 			store:   loadercompstore.NewComponents(store),
 			batcher: batcher,
-			loader:  loaderdisk.NewComponents(dir),
+			loader: loaderdisk.NewComponents(loaderdisk.Options{
+				Paths: []string{dir},
+			}),
 		})
 
 		errCh := make(chan error)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -218,6 +218,7 @@ func newDaprRuntime(ctx context.Context,
 			ComponentStore: compStore,
 			Authorizer:     authz,
 			Processor:      processor,
+			AppID:          runtimeConfig.id,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1005,7 +1005,10 @@ func (a *DaprRuntime) loadComponents(ctx context.Context) error {
 			PodName:   a.podName,
 		})
 	case modes.StandaloneMode:
-		loader = disk.NewComponents(a.runtimeConfig.standalone.ResourcesPath...)
+		loader = disk.NewComponents(disk.Options{
+			AppID: a.runtimeConfig.id,
+			Paths: a.runtimeConfig.standalone.ResourcesPath,
+		})
 	default:
 		return nil
 	}
@@ -1052,7 +1055,10 @@ func (a *DaprRuntime) loadDeclarativeSubscriptions(ctx context.Context) error {
 			PodName:   a.podName,
 		})
 	case modes.StandaloneMode:
-		loader = disk.NewSubscriptions(a.runtimeConfig.standalone.ResourcesPath...)
+		loader = disk.NewSubscriptions(disk.Options{
+			AppID: a.runtimeConfig.id,
+			Paths: a.runtimeConfig.standalone.ResourcesPath,
+		})
 	default:
 		return nil
 	}
@@ -1100,7 +1106,10 @@ func (a *DaprRuntime) loadHTTPEndpoints(ctx context.Context) error {
 			PodName:   a.podName,
 		})
 	case modes.StandaloneMode:
-		loader = disk.NewHTTPEndpoints(a.runtimeConfig.standalone.ResourcesPath...)
+		loader = disk.NewHTTPEndpoints(disk.Options{
+			AppID: a.runtimeConfig.id,
+			Paths: a.runtimeConfig.standalone.ResourcesPath,
+		})
 	default:
 		return nil
 	}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/scopes/components.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/scopes/components.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scopes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(components))
+}
+
+type components struct {
+	daprd  *daprd.Daprd
+	resDir string
+}
+
+func (c *components) Setup(t *testing.T) []framework.Option {
+	c.resDir = t.TempDir()
+
+	c.daprd = daprd.New(t,
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+ name: hotreloading
+spec:
+ features:
+ - name: HotReload
+   enabled: true`),
+		daprd.WithResourcesDir(c.resDir),
+		daprd.WithNamespace("default"),
+		daprd.WithAppID("myappid"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.daprd),
+	}
+}
+
+func (c *components) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	client := util.HTTPClient(t)
+
+	file := filepath.Join(c.resDir, "res.yaml")
+	require.NoError(t, os.WriteFile(file, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 123
+spec:
+ type: state.in-memory
+ version: v1
+`), 0o600))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 1)
+	}, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, os.WriteFile(file, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 123
+spec:
+ type: state.in-memory
+ version: v1
+scopes:
+- foo
+`), 0o600))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()))
+	}, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, os.WriteFile(file, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 123
+spec:
+ type: state.in-memory
+ version: v1
+scopes:
+- foo
+- myappid
+`), 0o600))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 1)
+	}, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, os.WriteFile(file, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 123
+spec:
+ type: state.in-memory
+ version: v1
+scopes:
+- foo
+`), 0o600))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Empty(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()))
+	}, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, os.WriteFile(file, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 123
+spec:
+ type: state.in-memory
+ version: v1
+`), 0o600))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 1)
+	}, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, os.WriteFile(file, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 123
+spec:
+ type: state.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 456
+spec:
+ type: state.in-memory
+ version: v1
+scopes:
+- myappid
+`), 0o600))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.Len(t, util.GetMetaComponents(t, ctx, client, c.daprd.HTTPPort()), 2)
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/selfhosted.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/selfhosted.go
@@ -18,5 +18,6 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted/middleware"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted/namespace"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted/pubsub"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted/scopes"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions"
 )


### PR DESCRIPTION
Adds scope filtering to the disk manifest loader.

Though this doesn't have any security benefits, it does mean manifests
are filtered much sooner in the runtime when running in self-hosted mode
and prevents logging/errors downstream in modules like the hot reloading
reconciler.


Branched from https://github.com/dapr/dapr/pull/7579