### PR TITLE
Update logging of empty 200 response for pub/sub messages

### DIFF
--- a/pkg/runtime/processor/pubsub/publish_test.go
+++ b/pkg/runtime/processor/pubsub/publish_test.go
@@ -108,6 +108,25 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("ok with empty body", func(t *testing.T) {
+		log.SetOutputLevel(logger.DebugLevel)
+		defer log.SetOutputLevel(logger.InfoLevel)
+
+		mockAppChannel := new(channelt.MockAppChannel)
+		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
+
+		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).WithRawData(nil)
+		defer fakeResp.Close()
+
+		mockAppChannel.On("InvokeMethod", mock.Anything, fakeReq).Return(fakeResp, nil)
+
+		// act
+		err := ps.publishMessageHTTP(context.Background(), testPubSubMessage)
+
+		// assert
+		require.NoError(t, err)
+	})
+
 	t.Run("ok with retry", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
 		ps.channels = new(channels.Channels).WithAppChannel(mockAppChannel)


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Update logging of `empty` 200 response for pub/sub messages to indicate success.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

https://github.com/dapr/dapr/issues/7561

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
