### PR TITLE
Add additional status properties for pub/sub metrics

### DIFF
--- a/pkg/diagnostics/component_monitoring.go
+++ b/pkg/diagnostics/component_monitoring.go
@@ -167,8 +167,8 @@ func (c *componentMetrics) Init(appID, namespace string) error {
 	c.namespace = namespace
 
 	return view.Register(
-		diagUtils.NewMeasureView(c.pubsubIngressLatency, []tag.Key{appIDKey, componentKey, namespaceKey, processStatusKey, topicKey}, defaultLatencyDistribution),
-		diagUtils.NewMeasureView(c.pubsubIngressCount, []tag.Key{appIDKey, componentKey, namespaceKey, processStatusKey, topicKey}, view.Count()),
+		diagUtils.NewMeasureView(c.pubsubIngressLatency, []tag.Key{appIDKey, componentKey, namespaceKey, processStatusKey, topicKey, statusKey}, defaultLatencyDistribution),
+		diagUtils.NewMeasureView(c.pubsubIngressCount, []tag.Key{appIDKey, componentKey, namespaceKey, processStatusKey, topicKey, statusKey}, view.Count()),
 		diagUtils.NewMeasureView(c.bulkPubsubIngressLatency, []tag.Key{appIDKey, componentKey, namespaceKey, processStatusKey, topicKey}, defaultLatencyDistribution),
 		diagUtils.NewMeasureView(c.bulkPubsubIngressCount, []tag.Key{appIDKey, componentKey, namespaceKey, processStatusKey, topicKey}, view.Count()),
 		diagUtils.NewMeasureView(c.bulkPubsubEventIngressCount, []tag.Key{appIDKey, componentKey, namespaceKey, processStatusKey, topicKey}, view.Count()),
@@ -192,17 +192,20 @@ func (c *componentMetrics) Init(appID, namespace string) error {
 }
 
 // PubsubIngressEvent records the metrics for a pub/sub ingress event.
-func (c *componentMetrics) PubsubIngressEvent(ctx context.Context, component, processStatus, topic string, elapsed float64) {
+func (c *componentMetrics) PubsubIngressEvent(ctx context.Context, component, processStatus, status, topic string, elapsed float64) {
 	if c.enabled {
+		if status == "" {
+			status = processStatus
+		}
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(c.pubsubIngressCount.Name(), appIDKey, c.appID, componentKey, component, namespaceKey, c.namespace, processStatusKey, processStatus, topicKey, topic),
+			diagUtils.WithTags(c.pubsubIngressCount.Name(), appIDKey, c.appID, componentKey, component, namespaceKey, c.namespace, processStatusKey, processStatus, statusKey, status, topicKey, topic),
 			c.pubsubIngressCount.M(1))
 
 		if elapsed > 0 {
 			stats.RecordWithTags(
 				ctx,
-				diagUtils.WithTags(c.pubsubIngressLatency.Name(), appIDKey, c.appID, componentKey, component, namespaceKey, c.namespace, processStatusKey, processStatus, topicKey, topic),
+				diagUtils.WithTags(c.pubsubIngressLatency.Name(), appIDKey, c.appID, componentKey, component, namespaceKey, c.namespace, processStatusKey, processStatus, statusKey, status, topicKey, topic),
 				c.pubsubIngressLatency.M(elapsed))
 		}
 	}

--- a/pkg/diagnostics/component_monitoring_test.go
+++ b/pkg/diagnostics/component_monitoring_test.go
@@ -21,10 +21,26 @@ func componentsMetrics() *componentMetrics {
 }
 
 func TestPubSub(t *testing.T) {
+	t.Run("record drop by app or sidecar", func(t *testing.T) {
+		c := componentsMetrics()
+
+		c.PubsubIngressEvent(context.Background(), componentName, "drop", "success", "A", 1)
+		c.PubsubIngressEvent(context.Background(), componentName, "drop", "drop", "A", 1)
+
+		viewData, _ := view.RetrieveData("component/pubsub_ingress/count")
+		v := view.Find("component/pubsub_ingress/count")
+
+		allTagsPresent(t, v, viewData[0].Tags)
+
+		assert.Len(t, viewData, 2)
+		assert.Equal(t, int64(1), viewData[0].Data.(*view.CountData).Value)
+		assert.Equal(t, int64(1), viewData[1].Data.(*view.CountData).Value)
+	})
+
 	t.Run("record ingress count", func(t *testing.T) {
 		c := componentsMetrics()
 
-		c.PubsubIngressEvent(context.Background(), componentName, "retry", "A", 0)
+		c.PubsubIngressEvent(context.Background(), componentName, "retry", "retry", "A", 0)
 
 		viewData, _ := view.RetrieveData("component/pubsub_ingress/count")
 		v := view.Find("component/pubsub_ingress/count")
@@ -35,7 +51,7 @@ func TestPubSub(t *testing.T) {
 	t.Run("record ingress latency", func(t *testing.T) {
 		c := componentsMetrics()
 
-		c.PubsubIngressEvent(context.Background(), componentName, "retry", "A", 1)
+		c.PubsubIngressEvent(context.Background(), componentName, "retry", "", "A", 1)
 
 		viewData, _ := view.RetrieveData("component/pubsub_ingress/latencies")
 		v := view.Find("component/pubsub_ingress/latencies")

--- a/pkg/runtime/processor/pubsub/topics.go
+++ b/pkg/runtime/processor/pubsub/topics.go
@@ -94,11 +94,11 @@ func (p *pubsub) subscribeTopic(name, topic string, route compstore.TopicRouteEl
 			if route.DeadLetterTopic != "" {
 				if dlqErr := p.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic); dlqErr == nil {
 					// dlq has been configured and message is successfully sent to dlq.
-					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), msgTopic, 0)
+					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), "", msgTopic, 0)
 					return nil
 				}
 			}
-			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), msgTopic, 0)
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), "", msgTopic, 0)
 			return err
 		}
 
@@ -112,11 +112,11 @@ func (p *pubsub) subscribeTopic(name, topic string, route compstore.TopicRouteEl
 				if route.DeadLetterTopic != "" {
 					if dlqErr := p.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic); dlqErr == nil {
 						// dlq has been configured and message is successfully sent to dlq.
-						diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), msgTopic, 0)
+						diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), "", msgTopic, 0)
 						return nil
 					}
 				}
-				diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), msgTopic, 0)
+				diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), "", msgTopic, 0)
 				return err
 			}
 		} else {
@@ -126,18 +126,18 @@ func (p *pubsub) subscribeTopic(name, topic string, route compstore.TopicRouteEl
 				if route.DeadLetterTopic != "" {
 					if dlqErr := p.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic); dlqErr == nil {
 						// dlq has been configured and message is successfully sent to dlq.
-						diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), msgTopic, 0)
+						diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), "", msgTopic, 0)
 						return nil
 					}
 				}
-				diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), msgTopic, 0)
+				diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), "", msgTopic, 0)
 				return err
 			}
 		}
 
 		if contribpubsub.HasExpired(cloudEvent) {
 			log.Warnf("dropping expired pub/sub event %v as of %v", cloudEvent[contribpubsub.IDField], cloudEvent[contribpubsub.ExpirationField])
-			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), msgTopic, 0)
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), "", msgTopic, 0)
 
 			if route.DeadLetterTopic != "" {
 				_ = p.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic)
@@ -151,17 +151,17 @@ func (p *pubsub) subscribeTopic(name, topic string, route compstore.TopicRouteEl
 			if route.DeadLetterTopic != "" {
 				if dlqErr := p.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic); dlqErr == nil {
 					// dlq has been configured and message is successfully sent to dlq.
-					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), msgTopic, 0)
+					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), "", msgTopic, 0)
 					return nil
 				}
 			}
-			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), msgTopic, 0)
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), "", msgTopic, 0)
 			return err
 		}
 		if !shouldProcess {
 			// The event does not match any route specified so ignore it.
 			log.Debugf("no matching route for event %v in pubsub %s and topic %s; skipping", cloudEvent[contribpubsub.IDField], name, msgTopic)
-			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), msgTopic, 0)
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), strings.ToLower(string(contribpubsub.Success)), msgTopic, 0)
 			if route.DeadLetterTopic != "" {
 				_ = p.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic)
 			}

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/inflight.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/inflight.go
@@ -143,7 +143,7 @@ func (i *inflight) Run(t *testing.T, ctx context.Context) {
 	}, time.Second*5, time.Millisecond*10)
 
 	egressMetric := fmt.Sprintf("dapr_component_pubsub_egress_count|app_id:%s|component:pubsub|namespace:|success:true|topic:a", i.daprd.AppID())
-	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:pubsub|namespace:|process_status:success|topic:a", i.daprd.AppID())
+	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:pubsub|namespace:|process_status:success|status:success|topic:a", i.daprd.AppID())
 	metrics := i.daprd.Metrics(t, ctx)
 	assert.Equal(t, 1, int(metrics[egressMetric]))
 	assert.Equal(t, 0, int(metrics[ingressMetric]))

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/inflight.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/inflight.go
@@ -131,7 +131,7 @@ spec:
 	}, time.Second*5, time.Millisecond*10)
 
 	egressMetric := fmt.Sprintf("dapr_component_pubsub_egress_count|app_id:%s|component:pubsub|namespace:|success:true|topic:a", i.daprd.AppID())
-	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:pubsub|namespace:|process_status:success|topic:a", i.daprd.AppID())
+	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:pubsub|namespace:|process_status:success|status:success|topic:a", i.daprd.AppID())
 	metrics := i.daprd.Metrics(t, ctx)
 	assert.Equal(t, 1, int(metrics[egressMetric]))
 	assert.Equal(t, 0, int(metrics[ingressMetric]))

--- a/tests/integration/suite/daprd/shutdown/block/app/pubsub/bulk.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/pubsub/bulk.go
@@ -166,7 +166,7 @@ LOOP:
 	close(b.returnPublish)
 
 	egressMetric := fmt.Sprintf("dapr_component_pubsub_egress_bulk_count|app_id:%s|component:foo|namespace:|success:true|topic:abc", b.daprd.AppID())
-	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:foo|namespace:|process_status:success|topic:abc", b.daprd.AppID())
+	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:foo|namespace:|process_status:success|status:success|topic:abc", b.daprd.AppID())
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		metrics := b.daprd.Metrics(t, ctx)

--- a/tests/integration/suite/daprd/shutdown/block/app/pubsub/single.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/pubsub/single.go
@@ -158,7 +158,7 @@ LOOP:
 	close(s.returnPublish)
 
 	egressMetric := fmt.Sprintf("dapr_component_pubsub_egress_count|app_id:%s|component:foo|namespace:|success:true|topic:abc", s.daprd.AppID())
-	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:foo|namespace:|process_status:success|topic:abc", s.daprd.AppID())
+	ingressMetric := fmt.Sprintf("dapr_component_pubsub_ingress_count|app_id:%s|component:foo|namespace:|process_status:success|status:success|topic:abc", s.daprd.AppID())
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		metrics := s.daprd.Metrics(t, ctx)


### PR DESCRIPTION
# Description

Add `status=drop/success` to  differentiate when this was dropped by the app or dropped by the Dapr sidecar.

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

https://github.com/dapr/dapr/issues/7610

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
