### PR TITLE
Restore legacy `dapr_http_server_response_count` HTTP metric

### DIFF
--- a/tests/integration/suite/daprd/metrics/http/cardinality/high.go
+++ b/tests/integration/suite/daprd/metrics/http/cardinality/high.go
@@ -73,6 +73,8 @@ func (h *high) Run(t *testing.T, ctx context.Context) {
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/hi")
 		metrics := h.daprd.Metrics(t, ctx)
 		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/hi|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_response_count|app_id:myapp|method:GET|path:/v1.0/healthz|status:204"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_response_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/hi|status:200"]))
 	})
 
 	t.Run("state stores", func(t *testing.T) {

--- a/tests/integration/suite/daprd/metrics/http/cardinality/low.go
+++ b/tests/integration/suite/daprd/metrics/http/cardinality/low.go
@@ -73,6 +73,8 @@ func (l *low) Run(t *testing.T, ctx context.Context) {
 		l.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/hi")
 		metrics := l.daprd.Metrics(t, ctx)
 		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:InvokeService/myapp|status:200"]))
+		assert.NotContains(t, metrics, "dapr_http_server_response_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/hi|status:200")
+		assert.NotContains(t, metrics, "dapr_http_server_response_count|app_id:myapp|method:GET|path:/v1.0/healthz|status:204 1.000000")
 	})
 
 	t.Run("state stores", func(t *testing.T) {


### PR DESCRIPTION
The legacy `dapr_http_server_response_count` metric had been removed from being served. This metric was relied upon by users.

Adds metric back to be served when in legacy metric mode. Should be backported and patch released in 1.13.

/cc @jjcollinge 

closes  https://github.com/dapr/dapr/issues/7642