### PR TITLE
Fix incorrect content-length being sent to HTTP published message

### DIFF
--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -159,6 +159,12 @@ func (imr *InvokeMethodRequest) WithHTTPExtension(verb string, querystring strin
 // WithCustomHTTPMetadata applies a metadata map to a InvokeMethodRequest.
 func (imr *InvokeMethodRequest) WithCustomHTTPMetadata(md map[string]string) *InvokeMethodRequest {
 	for k, v := range md {
+		if strings.EqualFold(k, ContentLengthHeader) {
+			// There is no use of the original payload's content-length because
+			// the entire data is already in the cloud event.
+			continue
+		}
+
 		if imr.r.GetMetadata() == nil {
 			imr.r.Metadata = make(map[string]*internalv1pb.ListStringValue)
 		}

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 )
 
 // Option is a function that configures the dapr process.
@@ -279,4 +280,10 @@ func WithControlPlaneTrustDomain(trustDomain string) Option {
 	return func(o *options) {
 		o.controlPlaneTrustDomain = &trustDomain
 	}
+}
+
+func WithSocket(t *testing.T, socket *socket.Socket) Option {
+	return WithExecOptions(exec.WithEnvVars(t,
+		"DAPR_COMPONENTS_SOCKETS_FOLDER", socket.Directory(),
+	))
 }

--- a/tests/integration/framework/process/grpc/app/app.go
+++ b/tests/integration/framework/process/grpc/app/app.go
@@ -41,14 +41,16 @@ func New(t *testing.T, fopts ...Option) *App {
 	return &App{
 		GRPC: procgrpc.New(t, append(opts.grpcopts, procgrpc.WithRegister(func(s *grpc.Server) {
 			srv := &server{
-				onInvokeFn:       opts.onInvokeFn,
-				onTopicEventFn:   opts.onTopicEventFn,
-				listTopicSubFn:   opts.listTopicSubFn,
-				listInputBindFn:  opts.listInputBindFn,
-				onBindingEventFn: opts.onBindingEventFn,
-				healthCheckFn:    opts.healthCheckFn,
+				onInvokeFn:         opts.onInvokeFn,
+				onTopicEventFn:     opts.onTopicEventFn,
+				onBulkTopicEventFn: opts.onBulkTopicEventFn,
+				listTopicSubFn:     opts.listTopicSubFn,
+				listInputBindFn:    opts.listInputBindFn,
+				onBindingEventFn:   opts.onBindingEventFn,
+				healthCheckFn:      opts.healthCheckFn,
 			}
 			rtv1.RegisterAppCallbackServer(s, srv)
+			rtv1.RegisterAppCallbackAlphaServer(s, srv)
 			rtv1.RegisterAppCallbackHealthCheckServer(s, srv)
 			if opts.withRegister != nil {
 				opts.withRegister(s)

--- a/tests/integration/framework/process/grpc/app/options.go
+++ b/tests/integration/framework/process/grpc/app/options.go
@@ -26,14 +26,15 @@ import (
 
 // options contains the options for running a GRPC server in integration tests.
 type options struct {
-	grpcopts         []procgrpc.Option
-	withRegister     func(s *grpc.Server)
-	onTopicEventFn   func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error)
-	onInvokeFn       func(context.Context, *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error)
-	listTopicSubFn   func(ctx context.Context, in *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)
-	listInputBindFn  func(context.Context, *emptypb.Empty) (*rtv1.ListInputBindingsResponse, error)
-	onBindingEventFn func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error)
-	healthCheckFn    func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error)
+	grpcopts           []procgrpc.Option
+	withRegister       func(s *grpc.Server)
+	onTopicEventFn     func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error)
+	onBulkTopicEventFn func(context.Context, *rtv1.TopicEventBulkRequest) (*rtv1.TopicEventBulkResponse, error)
+	onInvokeFn         func(context.Context, *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error)
+	listTopicSubFn     func(ctx context.Context, in *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)
+	listInputBindFn    func(context.Context, *emptypb.Empty) (*rtv1.ListInputBindingsResponse, error)
+	onBindingEventFn   func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error)
+	healthCheckFn      func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error)
 }
 
 func WithGRPCOptions(opts ...procgrpc.Option) func(*options) {
@@ -45,6 +46,12 @@ func WithGRPCOptions(opts ...procgrpc.Option) func(*options) {
 func WithOnTopicEventFn(fn func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error)) func(*options) {
 	return func(opts *options) {
 		opts.onTopicEventFn = fn
+	}
+}
+
+func WithOnBulkTopicEventFn(fn func(context.Context, *rtv1.TopicEventBulkRequest) (*rtv1.TopicEventBulkResponse, error)) func(*options) {
+	return func(opts *options) {
+		opts.onBulkTopicEventFn = fn
 	}
 }
 

--- a/tests/integration/framework/process/grpc/app/server.go
+++ b/tests/integration/framework/process/grpc/app/server.go
@@ -23,12 +23,13 @@ import (
 )
 
 type server struct {
-	onInvokeFn       func(context.Context, *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error)
-	onTopicEventFn   func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error)
-	listTopicSubFn   func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)
-	listInputBindFn  func(context.Context, *emptypb.Empty) (*rtv1.ListInputBindingsResponse, error)
-	onBindingEventFn func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error)
-	healthCheckFn    func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error)
+	onInvokeFn         func(context.Context, *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error)
+	onTopicEventFn     func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error)
+	onBulkTopicEventFn func(context.Context, *rtv1.TopicEventBulkRequest) (*rtv1.TopicEventBulkResponse, error)
+	listTopicSubFn     func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)
+	listInputBindFn    func(context.Context, *emptypb.Empty) (*rtv1.ListInputBindingsResponse, error)
+	onBindingEventFn   func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error)
+	healthCheckFn      func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error)
 }
 
 func (s *server) OnInvoke(ctx context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
@@ -64,6 +65,13 @@ func (s *server) OnTopicEvent(ctx context.Context, in *rtv1.TopicEventRequest) (
 		return new(rtv1.TopicEventResponse), nil
 	}
 	return s.onTopicEventFn(ctx, in)
+}
+
+func (s *server) OnBulkTopicEventAlpha1(ctx context.Context, in *rtv1.TopicEventBulkRequest) (*rtv1.TopicEventBulkResponse, error) {
+	if s.onBulkTopicEventFn == nil {
+		return new(rtv1.TopicEventBulkResponse), nil
+	}
+	return s.onBulkTopicEventFn(ctx, in)
 }
 
 func (s *server) HealthCheck(ctx context.Context, e *emptypb.Empty) (*rtv1.HealthCheckResponse, error) {

--- a/tests/integration/framework/process/grpc/subscriber/options.go
+++ b/tests/integration/framework/process/grpc/subscriber/options.go
@@ -13,5 +13,21 @@ limitations under the License.
 
 package subscriber
 
+import (
+	"context"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+)
+
 // options contains the options for running a pubsub subscriber gRPC server app.
-type options struct{}
+type options struct {
+	listTopicSubFn func(ctx context.Context, in *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)
+}
+
+func WithListTopicSubscriptions(fn func(ctx context.Context, in *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)) func(*options) {
+	return func(opts *options) {
+		opts.listTopicSubFn = fn
+	}
+}

--- a/tests/integration/framework/process/http/subscriber/subscriber.go
+++ b/tests/integration/framework/process/http/subscriber/subscriber.go
@@ -14,6 +14,7 @@ limitations under the License.
 package subscriber
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -26,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/dapr/pkg/runtime/pubsub"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/util"
@@ -46,10 +48,24 @@ type PublishRequest struct {
 	DataContentType *string
 }
 
+type PublishBulkRequestEntry struct {
+	EntryID     string `json:"entryId"`
+	Event       string `json:"event"`
+	ContentType string `json:"contentType,omitempty"`
+}
+
+type PublishBulkRequest struct {
+	Daprd      *daprd.Daprd
+	PubSubName string
+	Topic      string
+	Entries    []PublishBulkRequestEntry
+}
+
 type Subscriber struct {
 	app     *app.App
 	client  *http.Client
 	inCh    chan *RouteEvent
+	inBulk  chan *pubsub.BulkSubscribeEnvelope
 	closeCh chan struct{}
 }
 
@@ -62,9 +78,10 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 	}
 
 	inCh := make(chan *RouteEvent, 100)
+	inBulk := make(chan *pubsub.BulkSubscribeEnvelope, 100)
 	closeCh := make(chan struct{})
 
-	appOpts := make([]app.Option, 0, len(opts.routes)+len(opts.handlerFuncs))
+	appOpts := make([]app.Option, 0, len(opts.routes)+len(opts.bulkRoutes)+len(opts.handlerFuncs))
 	for _, route := range opts.routes {
 		appOpts = append(appOpts, app.WithHandlerFunc(route, func(w http.ResponseWriter, r *http.Request) {
 			var ce event.Event
@@ -76,6 +93,31 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 			}
 		}))
 	}
+	for _, route := range opts.bulkRoutes {
+		appOpts = append(appOpts, app.WithHandlerFunc(route, func(w http.ResponseWriter, r *http.Request) {
+			var ce pubsub.BulkSubscribeEnvelope
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&ce))
+			select {
+			case inBulk <- &ce:
+			case <-closeCh:
+			case <-r.Context().Done():
+			}
+
+			type statusT struct {
+				EntryID string `json:"entryId"`
+				Status  string `json:"status"`
+			}
+			type respT struct {
+				Statuses []statusT `json:"statuses"`
+			}
+
+			var resp respT
+			for _, entry := range ce.Entries {
+				resp.Statuses = append(resp.Statuses, statusT{EntryID: entry.EntryId, Status: "SUCCESS"})
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+	}
 
 	appOpts = append(appOpts, opts.handlerFuncs...)
 
@@ -83,6 +125,7 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 		app:     app.New(t, appOpts...),
 		client:  util.HTTPClient(t),
 		inCh:    inCh,
+		inBulk:  inBulk,
 		closeCh: closeCh,
 	}
 }
@@ -113,6 +156,21 @@ func (s *Subscriber) Receive(t *testing.T, ctx context.Context) *RouteEvent {
 		require.Fail(t, "timed out waiting for event response")
 		return nil
 	case in := <-s.inCh:
+		return in
+	}
+}
+
+func (s *Subscriber) ReceiveBulk(t *testing.T, ctx context.Context) *pubsub.BulkSubscribeEnvelope {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "timed out waiting for event response")
+		return nil
+	case in := <-s.inBulk:
 		return in
 	}
 }
@@ -151,6 +209,13 @@ func (s *Subscriber) Publish(t *testing.T, ctx context.Context, req PublishReque
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+func (s *Subscriber) PublishBulk(t *testing.T, ctx context.Context, req PublishBulkRequest) {
+	t.Helper()
+	//nolint:bodyclose
+	resp := s.publishBulk(t, ctx, req)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
 func (s *Subscriber) publish(t *testing.T, ctx context.Context, req PublishRequest) *http.Response {
 	t.Helper()
 	reqURL := fmt.Sprintf("http://%s/v1.0/publish/%s/%s", req.Daprd.HTTPAddress(), req.PubSubName, req.Topic)
@@ -159,6 +224,21 @@ func (s *Subscriber) publish(t *testing.T, ctx context.Context, req PublishReque
 	if req.DataContentType != nil {
 		hreq.Header.Add("Content-Type", *req.DataContentType)
 	}
+	resp, err := s.client.Do(hreq)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	return resp
+}
+
+func (s *Subscriber) publishBulk(t *testing.T, ctx context.Context, req PublishBulkRequest) *http.Response {
+	t.Helper()
+
+	payload, err := json.Marshal(req.Entries)
+	require.NoError(t, err)
+	reqURL := fmt.Sprintf("http://%s/v1.0-alpha1/publish/bulk/%s/%s", req.Daprd.HTTPAddress(), req.PubSubName, req.Topic)
+	hreq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(payload))
+	require.NoError(t, err)
+	hreq.Header.Add("Content-Type", "application/json")
 	resp, err := s.client.Do(hreq)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())

--- a/tests/integration/framework/process/pubsub/options.go
+++ b/tests/integration/framework/process/pubsub/options.go
@@ -13,21 +13,32 @@ limitations under the License.
 
 package pubsub
 
-import "github.com/dapr/components-contrib/pubsub"
+import (
+	"github.com/dapr/components-contrib/pubsub"
+	compv1pb "github.com/dapr/dapr/pkg/proto/components/v1"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+)
 
 type options struct {
-	socketDir string
-	pubsub    pubsub.PubSub
+	socket *socket.Socket
+	pubsub pubsub.PubSub
+	pmrCh  <-chan *compv1pb.PullMessagesResponse
 }
 
-func WithSocketDirectory(dir string) Option {
+func WithSocket(socket *socket.Socket) Option {
 	return func(o *options) {
-		o.socketDir = dir
+		o.socket = socket
 	}
 }
 
 func WithPubSub(pubsub pubsub.PubSub) Option {
 	return func(o *options) {
 		o.pubsub = pubsub
+	}
+}
+
+func WithPullMessagesChannel(ch <-chan *compv1pb.PullMessagesResponse) Option {
+	return func(o *options) {
+		o.pmrCh = ch
 	}
 }

--- a/tests/integration/framework/process/statestore/options.go
+++ b/tests/integration/framework/process/statestore/options.go
@@ -15,17 +15,18 @@ package statestore
 
 import (
 	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 )
 
 // options contains the options for running a pluggable state store in integration tests.
 type options struct {
-	socketDir  string
+	socket     *socket.Socket
 	statestore state.Store
 }
 
-func WithSocketDirectory(dir string) Option {
+func WithSocket(socket *socket.Socket) Option {
 	return func(o *options) {
-		o.socketDir = dir
+		o.socket = socket
 	}
 }
 

--- a/tests/integration/framework/socket/socket.go
+++ b/tests/integration/framework/socket/socket.go
@@ -16,6 +16,7 @@ package socket
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ type File struct {
 }
 
 func New(t *testing.T) *Socket {
-	if runtime.OS() == "windows" {
+	if runtime.GOOS == "windows" {
 		t.Skip("Unix sockets are not supported on Windows")
 	}
 

--- a/tests/integration/framework/socket/socket.go
+++ b/tests/integration/framework/socket/socket.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package socket
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/nettest"
+
+	"github.com/dapr/dapr/tests/integration/framework/util"
+)
+
+// Socket is a helper to create a temporary directory hosting unix socket files
+// for Dapr pluggable components.
+type Socket struct {
+	dir string
+}
+
+type File struct {
+	name     string
+	filename string
+}
+
+func New(t *testing.T) *Socket {
+	// Darwin enforces a maximum 104 byte socket name limit, so we need to be a
+	// bit fancy on how we generate the name.
+	tmp, err := nettest.LocalPath()
+	require.NoError(t, err)
+
+	socketDir := filepath.Join(tmp, util.RandomString(t, 4))
+	require.NoError(t, os.MkdirAll(socketDir, 0o700))
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tmp)) })
+
+	return &Socket{
+		dir: socketDir,
+	}
+}
+
+func (s *Socket) Directory() string {
+	return s.dir
+}
+
+func (s *Socket) File(t *testing.T) *File {
+	socketFile := util.RandomString(t, 8)
+	return &File{
+		name:     socketFile,
+		filename: filepath.Join(s.dir, socketFile+".sock"),
+	}
+}
+
+func (f *File) Name() string {
+	return f.name
+}
+
+func (f *File) Filename() string {
+	return f.filename
+}

--- a/tests/integration/framework/socket/socket.go
+++ b/tests/integration/framework/socket/socket.go
@@ -36,6 +36,10 @@ type File struct {
 }
 
 func New(t *testing.T) *Socket {
+	if runtime.OS() == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+
 	// Darwin enforces a maximum 104 byte socket name limit, so we need to be a
 	// bit fancy on how we generate the name.
 	tmp, err := nettest.LocalPath()

--- a/tests/integration/suite/daprd/pubsub/contentlength/bulk.go
+++ b/tests/integration/suite/daprd/pubsub/contentlength/bulk.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contentlength
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	compv1pb "github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub"
+	inmemory "github.com/dapr/dapr/tests/integration/framework/process/pubsub/in-memory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(bulk))
+}
+
+type bulk struct {
+	daprd *daprd.Daprd
+	app   *subscriber.Subscriber
+	pmrCh chan *compv1pb.PullMessagesResponse
+}
+
+func (b *bulk) Setup(t *testing.T) []framework.Option {
+	b.pmrCh = make(chan *compv1pb.PullMessagesResponse)
+	b.app = subscriber.New(t, subscriber.WithBulkRoutes("/abc"))
+
+	socket := socket.New(t)
+
+	inmem := pubsub.New(t,
+		pubsub.WithSocket(socket),
+		pubsub.WithPullMessagesChannel(b.pmrCh),
+		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
+	)
+
+	b.daprd = daprd.New(t,
+		daprd.WithAppPort(b.app.Port()),
+		daprd.WithSocket(t, socket),
+		daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: foo
+spec:
+ type: pubsub.%s
+ version: v1
+ metadata:
+ - name: host
+   value: "localhost:6650"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ pubsubname: foo
+ topic: bar
+ route: /abc
+ bulkSubscribe:
+  enabled: true
+  maxMessagesCount: 100
+  maxAwaitDurationMs: 40
+`, inmem.SocketName())),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(inmem, b.app, b.daprd),
+	}
+}
+
+func (b *bulk) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	client := b.daprd.GRPCClient(t, ctx)
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	require.Len(t, meta.GetSubscriptions(), 1)
+
+	b.pmrCh <- &compv1pb.PullMessagesResponse{
+		Data:      []byte(`{"data":"helloworld","datacontenttype":"text/plain","id":"b959cd5a-29e5-42ca-89e2-c66f4402f273","pubsubname":"foo","source":"foo","specversion":"1.0","time":"2024-03-27T23:47:53Z","topic":"bar","traceid":"00-00000000000000000000000000000000-0000000000000000-00","traceparent":"00-00000000000000000000000000000000-0000000000000000-00","tracestate":"","type":"com.dapr.event.sent"}`),
+		TopicName: "bar",
+		Id:        "foo",
+		Metadata:  map[string]string{"content-length": "123"},
+	}
+
+	b.app.ReceiveBulk(t, ctx)
+}

--- a/tests/integration/suite/daprd/pubsub/contentlength/bulk.go
+++ b/tests/integration/suite/daprd/pubsub/contentlength/bulk.go
@@ -24,7 +24,8 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	grpcsub "github.com/dapr/dapr/tests/integration/framework/process/grpc/subscriber"
+	httpsub "github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
 	"github.com/dapr/dapr/tests/integration/framework/process/pubsub"
 	inmemory "github.com/dapr/dapr/tests/integration/framework/process/pubsub/in-memory"
 	"github.com/dapr/dapr/tests/integration/framework/socket"
@@ -36,14 +37,17 @@ func init() {
 }
 
 type bulk struct {
-	daprd *daprd.Daprd
-	app   *subscriber.Subscriber
-	pmrCh chan *compv1pb.PullMessagesResponse
+	daprdhttp *daprd.Daprd
+	daprdgrpc *daprd.Daprd
+	apphttp   *httpsub.Subscriber
+	appgrpc   *grpcsub.Subscriber
+	pmrCh     chan *compv1pb.PullMessagesResponse
 }
 
 func (b *bulk) Setup(t *testing.T) []framework.Option {
 	b.pmrCh = make(chan *compv1pb.PullMessagesResponse)
-	b.app = subscriber.New(t, subscriber.WithBulkRoutes("/abc"))
+	b.apphttp = httpsub.New(t, httpsub.WithRoutes("/abc"))
+	b.appgrpc = grpcsub.New(t)
 
 	socket := socket.New(t)
 
@@ -53,8 +57,8 @@ func (b *bulk) Setup(t *testing.T) []framework.Option {
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
 	)
 
-	b.daprd = daprd.New(t,
-		daprd.WithAppPort(b.app.Port()),
+	b.daprdhttp = daprd.New(t,
+		daprd.WithAppPort(b.apphttp.Port()),
 		daprd.WithSocket(t, socket),
 		daprd.WithResourceFiles(fmt.Sprintf(`
 apiVersion: dapr.io/v1alpha1
@@ -64,44 +68,76 @@ metadata:
 spec:
  type: pubsub.%s
  version: v1
- metadata:
- - name: host
-   value: "localhost:6650"
 ---
 apiVersion: dapr.io/v1alpha1
 kind: Subscription
 metadata:
- name: mysub
+ name: mysub1
 spec:
- pubsubname: foo
- topic: bar
+ topic: bar1
  route: /abc
+ pubsubname: foo
  bulkSubscribe:
   enabled: true
-  maxMessagesCount: 100
-  maxAwaitDurationMs: 40
+`, inmem.SocketName())),
+	)
+
+	b.daprdgrpc = daprd.New(t,
+		daprd.WithAppPort(b.appgrpc.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithSocket(t, socket),
+		daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: foo
+spec:
+ type: pubsub.%s
+ version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub1
+spec:
+ topic: bar2
+ route: /abc
+ pubsubname: foo
+ bulkSubscribe:
+  enabled: true
 `, inmem.SocketName())),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(inmem, b.app, b.daprd),
+		framework.WithProcesses(inmem, b.daprdhttp, b.daprdgrpc, b.apphttp, b.appgrpc),
 	}
 }
 
 func (b *bulk) Run(t *testing.T, ctx context.Context) {
-	b.daprd.WaitUntilRunning(t, ctx)
+	b.daprdhttp.WaitUntilRunning(t, ctx)
+	b.daprdgrpc.WaitUntilRunning(t, ctx)
 
-	client := b.daprd.GRPCClient(t, ctx)
-	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	clientHTTP := b.daprdhttp.GRPCClient(t, ctx)
+	meta, err := clientHTTP.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 	require.NoError(t, err)
 	require.Len(t, meta.GetSubscriptions(), 1)
-
 	b.pmrCh <- &compv1pb.PullMessagesResponse{
 		Data:      []byte(`{"data":"helloworld","datacontenttype":"text/plain","id":"b959cd5a-29e5-42ca-89e2-c66f4402f273","pubsubname":"foo","source":"foo","specversion":"1.0","time":"2024-03-27T23:47:53Z","topic":"bar","traceid":"00-00000000000000000000000000000000-0000000000000000-00","traceparent":"00-00000000000000000000000000000000-0000000000000000-00","tracestate":"","type":"com.dapr.event.sent"}`),
 		TopicName: "bar",
 		Id:        "foo",
 		Metadata:  map[string]string{"content-length": "123"},
 	}
+	b.apphttp.ReceiveBulk(t, ctx)
 
-	b.app.ReceiveBulk(t, ctx)
+	clientGRPC := b.daprdgrpc.GRPCClient(t, ctx)
+	meta, err = clientGRPC.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	require.Len(t, meta.GetSubscriptions(), 1)
+	b.pmrCh <- &compv1pb.PullMessagesResponse{
+		Data:      []byte(`{"data":{"foo": "helloworld"},"datacontenttype":"application/json","id":"b959cd5a-29e5-42ca-89e2-c66f4402f273","pubsubname":"foo","source":"foo","specversion":"1.0","time":"2024-03-27T23:47:53Z","topic":"bar2","traceid":"00-00000000000000000000000000000000-0000000000000000-00","traceparent":"00-00000000000000000000000000000000-0000000000000000-00","tracestate":"","type":"com.dapr.event.sent"}`),
+		TopicName: "bar",
+		Id:        "foo",
+		Metadata:  map[string]string{"content-length": "123"},
+	}
+	b.appgrpc.Receive(t, ctx)
 }

--- a/tests/integration/suite/daprd/pubsub/contentlength/singular.go
+++ b/tests/integration/suite/daprd/pubsub/contentlength/singular.go
@@ -41,25 +41,26 @@ type singular struct {
 	daprdgrpc *daprd.Daprd
 	apphttp   *httpsub.Subscriber
 	appgrpc   *grpcsub.Subscriber
-	pmrCh     chan *compv1pb.PullMessagesResponse
+	pmrChHTTP chan *compv1pb.PullMessagesResponse
+	pmrChGRPC chan *compv1pb.PullMessagesResponse
 }
 
 func (s *singular) Setup(t *testing.T) []framework.Option {
-	s.pmrCh = make(chan *compv1pb.PullMessagesResponse)
+	s.pmrChHTTP = make(chan *compv1pb.PullMessagesResponse)
+	s.pmrChGRPC = make(chan *compv1pb.PullMessagesResponse)
 	s.apphttp = httpsub.New(t, httpsub.WithRoutes("/abc"))
 	s.appgrpc = grpcsub.New(t)
 
-	socket := socket.New(t)
-
-	inmem := pubsub.New(t,
-		pubsub.WithSocket(socket),
-		pubsub.WithPullMessagesChannel(s.pmrCh),
+	socket1 := socket.New(t)
+	inmem1 := pubsub.New(t,
+		pubsub.WithSocket(socket1),
+		pubsub.WithPullMessagesChannel(s.pmrChHTTP),
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
 	)
 
 	s.daprdhttp = daprd.New(t,
 		daprd.WithAppPort(s.apphttp.Port()),
-		daprd.WithSocket(t, socket),
+		daprd.WithSocket(t, socket1),
 		daprd.WithResourceFiles(fmt.Sprintf(`
 apiVersion: dapr.io/v1alpha1
 kind: Component
@@ -77,13 +78,20 @@ spec:
  topic: bar1
  route: /abc
  pubsubname: foo
-`, inmem.SocketName())),
+`, inmem1.SocketName())),
+	)
+
+	socket2 := socket.New(t)
+	inmem2 := pubsub.New(t,
+		pubsub.WithSocket(socket2),
+		pubsub.WithPullMessagesChannel(s.pmrChGRPC),
+		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
 	)
 
 	s.daprdgrpc = daprd.New(t,
 		daprd.WithAppPort(s.appgrpc.Port(t)),
 		daprd.WithAppProtocol("grpc"),
-		daprd.WithSocket(t, socket),
+		daprd.WithSocket(t, socket2),
 		daprd.WithResourceFiles(fmt.Sprintf(`
 apiVersion: dapr.io/v1alpha1
 kind: Component
@@ -101,11 +109,11 @@ spec:
  topic: bar2
  route: /abc
  pubsubname: foo
-`, inmem.SocketName())),
+`, inmem2.SocketName())),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(inmem, s.daprdhttp, s.daprdgrpc, s.apphttp, s.appgrpc),
+		framework.WithProcesses(inmem1, inmem2, s.daprdhttp, s.daprdgrpc, s.apphttp, s.appgrpc),
 	}
 }
 
@@ -117,7 +125,7 @@ func (s *singular) Run(t *testing.T, ctx context.Context) {
 	meta, err := clientHTTP.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 	require.NoError(t, err)
 	require.Len(t, meta.GetSubscriptions(), 1)
-	s.pmrCh <- &compv1pb.PullMessagesResponse{
+	s.pmrChHTTP <- &compv1pb.PullMessagesResponse{
 		Data:      []byte(`{"data":{"foo": "helloworld"},"datacontenttype":"application/json","id":"b959cd5a-29e5-42ca-89e2-c66f4402f273","pubsubname":"foo","source":"foo","specversion":"1.0","time":"2024-03-27T23:47:53Z","topic":"bar1","traceid":"00-00000000000000000000000000000000-0000000000000000-00","traceparent":"00-00000000000000000000000000000000-0000000000000000-00","tracestate":"","type":"com.dapr.event.sent"}`),
 		TopicName: "bar",
 		Id:        "foo",
@@ -129,7 +137,7 @@ func (s *singular) Run(t *testing.T, ctx context.Context) {
 	meta, err = clientGRPC.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
 	require.NoError(t, err)
 	require.Len(t, meta.GetSubscriptions(), 1)
-	s.pmrCh <- &compv1pb.PullMessagesResponse{
+	s.pmrChGRPC <- &compv1pb.PullMessagesResponse{
 		Data:      []byte(`{"data":{"foo": "helloworld"},"datacontenttype":"application/json","id":"b959cd5a-29e5-42ca-89e2-c66f4402f273","pubsubname":"foo","source":"foo","specversion":"1.0","time":"2024-03-27T23:47:53Z","topic":"bar2","traceid":"00-00000000000000000000000000000000-0000000000000000-00","traceparent":"00-00000000000000000000000000000000-0000000000000000-00","tracestate":"","type":"com.dapr.event.sent"}`),
 		TopicName: "bar",
 		Id:        "foo",

--- a/tests/integration/suite/daprd/pubsub/contentlength/singular.go
+++ b/tests/integration/suite/daprd/pubsub/contentlength/singular.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contentlength
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	compv1pb "github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/subscriber"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub"
+	inmemory "github.com/dapr/dapr/tests/integration/framework/process/pubsub/in-memory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(singular))
+}
+
+type singular struct {
+	daprd *daprd.Daprd
+	app   *subscriber.Subscriber
+	pmrCh chan *compv1pb.PullMessagesResponse
+}
+
+func (s *singular) Setup(t *testing.T) []framework.Option {
+	s.pmrCh = make(chan *compv1pb.PullMessagesResponse)
+	s.app = subscriber.New(t, subscriber.WithRoutes("/abc"))
+
+	socket := socket.New(t)
+
+	inmem := pubsub.New(t,
+		pubsub.WithSocket(socket),
+		pubsub.WithPullMessagesChannel(s.pmrCh),
+		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
+	)
+
+	s.daprd = daprd.New(t,
+		daprd.WithAppPort(s.app.Port()),
+		daprd.WithSocket(t, socket),
+		daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: foo
+spec:
+ type: pubsub.%s
+ version: v1
+ metadata:
+ - name: host
+   value: "localhost:6650"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Subscription
+metadata:
+ name: mysub
+spec:
+ topic: bar
+ route: /abc
+ pubsubname: foo
+`, inmem.SocketName())),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(inmem, s.app, s.daprd),
+	}
+}
+
+func (s *singular) Run(t *testing.T, ctx context.Context) {
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	client := s.daprd.GRPCClient(t, ctx)
+	meta, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	require.Len(t, meta.GetSubscriptions(), 1)
+
+	s.pmrCh <- &compv1pb.PullMessagesResponse{
+		Data:      []byte(`{"data":{"foo": "helloworld"},"datacontenttype":"application/json","id":"b959cd5a-29e5-42ca-89e2-c66f4402f273","pubsubname":"foo","source":"foo","specversion":"1.0","time":"2024-03-27T23:47:53Z","topic":"bar","traceid":"00-00000000000000000000000000000000-0000000000000000-00","traceparent":"00-00000000000000000000000000000000-0000000000000000-00","tracestate":"","type":"com.dapr.event.sent"}`),
+		TopicName: "bar",
+		Id:        "foo",
+		Metadata:  map[string]string{"content-length": "123"},
+	}
+
+	s.app.Receive(t, ctx)
+}

--- a/tests/integration/suite/daprd/pubsub/grpc/errors.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/errors.go
@@ -17,19 +17,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 
-	"golang.org/x/net/nettest"
-
 	componentspubsub "github.com/dapr/components-contrib/pubsub"
 	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
-	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/pubsub"
 	inmemory "github.com/dapr/dapr/tests/integration/framework/process/pubsub/in-memory"
-	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -58,19 +53,10 @@ func (e *errorcodes) Setup(t *testing.T) []framework.Option {
 		t.Skip("skipping unix socket based test on windows")
 	}
 
-	// Darwin enforces a maximum 104 byte socket name limit, so we need to be a
-	// bit fancy on how we generate the name.
-	tmp, err := nettest.LocalPath()
-	require.NoError(t, err)
-
-	socketDir := filepath.Join(tmp, util.RandomString(t, 4))
-	require.NoError(t, os.MkdirAll(socketDir, 0o700))
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(socketDir))
-	})
+	socket := socket.New(t)
 
 	pubsubInMem := pubsub.New(t,
-		pubsub.WithSocketDirectory(socketDir),
+		pubsub.WithSocket(socket),
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t,
 			inmemory.WithFeatures(),
 			inmemory.WithPublishFn(func(ctx context.Context, req *componentspubsub.PublishRequest) error {
@@ -115,9 +101,7 @@ spec:
   - name: outboxDiscardWhenMissingState #Optional. Defaults to false
     value: false
 `, pubsubInMem.SocketName())),
-		daprd.WithExecOptions(exec.WithEnvVars(t,
-			"DAPR_COMPONENTS_SOCKETS_FOLDER", socketDir,
-		)),
+		daprd.WithSocket(t, socket),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/pubsub/http/errors.go
+++ b/tests/integration/suite/daprd/pubsub/http/errors.go
@@ -20,16 +20,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
-	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/nettest"
 
 	componentspubsub "github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/tests/integration/framework"
@@ -59,19 +56,10 @@ func (e *errorcodes) Setup(t *testing.T) []framework.Option {
 		t.Skip("skipping unix socket based test on windows")
 	}
 
-	// Darwin enforces a maximum 104 byte socket name limit, so we need to be a
-	// bit fancy on how we generate the name.
-	tmp, err := nettest.LocalPath()
-	require.NoError(t, err)
-
-	socketDir := filepath.Join(tmp, util.RandomString(t, 4))
-	require.NoError(t, os.MkdirAll(socketDir, 0o700))
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(socketDir))
-	})
+	socket := socket.New(t)
 
 	pubsubInMem := pubsub.New(t,
-		pubsub.WithSocketDirectory(socketDir),
+		pubsub.WithSocket(socket),
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t,
 			inmemory.WithFeatures(),
 			inmemory.WithPublishFn(func(ctx context.Context, req *componentspubsub.PublishRequest) error {
@@ -116,9 +104,7 @@ spec:
   - name: outboxDiscardWhenMissingState #Optional. Defaults to false
     value: false
 `, pubsubInMem.SocketName())),
-		daprd.WithExecOptions(exec.WithEnvVars(t,
-			"DAPR_COMPONENTS_SOCKETS_FOLDER", socketDir,
-		)),
+		daprd.WithSocket(t, socket),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/pubsub/pubsub.go
+++ b/tests/integration/suite/daprd/pubsub/pubsub.go
@@ -11,9 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package state
+package pubsub
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/contentlength"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/grpc"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub/http"
 )

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/contentlength.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/contentlength.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(contentlength))
+}
+
+type contentlength struct {
+	daprd1 *procdaprd.Daprd
+	daprd2 *procdaprd.Daprd
+}
+
+func (c *contentlength) Setup(t *testing.T) []framework.Option {
+	app := app.New(t,
+		app.WithHandlerFunc("/hi", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "OK")
+		}),
+	)
+
+	c.daprd1 = procdaprd.New(t, procdaprd.WithAppPort(app.Port()))
+	c.daprd2 = procdaprd.New(t, procdaprd.WithAppPort(app.Port()))
+
+	return []framework.Option{
+		framework.WithProcesses(app, c.daprd1, c.daprd2),
+	}
+}
+
+func (c *contentlength) Run(t *testing.T, ctx context.Context) {
+	c.daprd1.WaitUntilRunning(t, ctx)
+	c.daprd2.WaitUntilRunning(t, ctx)
+
+	client := util.HTTPClient(t)
+
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/hi", c.daprd1.HTTPAddress(), c.daprd2.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("helloworld"))
+	require.NoError(t, err)
+	req.Header.Set("content-length", "1024")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	gclient := c.daprd1.GRPCClient(t, ctx)
+	_, err = gclient.InvokeService(ctx, &rtv1.InvokeServiceRequest{
+		Id: c.daprd2.AppID(),
+		Message: &commonv1.InvokeRequest{
+			Method:        "hi",
+			HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+		},
+	})
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/state/grpc/errors.go
+++ b/tests/integration/suite/daprd/state/grpc/errors.go
@@ -17,13 +17,10 @@ package grpc
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/nettest"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	grpcCodes "google.golang.org/grpc/codes"
@@ -36,10 +33,9 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"
-	"github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -58,16 +54,7 @@ func (e *errors) Setup(t *testing.T) []framework.Option {
 		t.Skip("skipping unix socket based test on windows")
 	}
 
-	// Darwin enforces a maximum 104 byte socket name limit, so we need to be a
-	// bit fancy on how we generate the name.
-	tmp, err := nettest.LocalPath()
-	require.NoError(t, err)
-
-	socketDir := filepath.Join(tmp, util.RandomString(t, 4))
-	require.NoError(t, os.MkdirAll(socketDir, 0o700))
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(socketDir))
-	})
+	socket := socket.New(t)
 
 	e.queryErr = func(t *testing.T) error {
 		require.FailNow(t, "query should not be called")
@@ -75,14 +62,14 @@ func (e *errors) Setup(t *testing.T) []framework.Option {
 	}
 
 	storeWithNoTransactional := statestore.New(t,
-		statestore.WithSocketDirectory(socketDir),
+		statestore.WithSocket(socket),
 		statestore.WithStateStore(inmemory.New(t,
 			inmemory.WithFeatures(),
 		)),
 	)
 
 	storeWithQuerier := statestore.New(t,
-		statestore.WithSocketDirectory(socketDir),
+		statestore.WithSocket(socket),
 		statestore.WithStateStore(inmemory.NewQuerier(t,
 			inmemory.WithQueryFn(func(context.Context, *state.QueryRequest) (*state.QueryResponse, error) {
 				return nil, e.queryErr(t)
@@ -91,7 +78,7 @@ func (e *errors) Setup(t *testing.T) []framework.Option {
 	)
 
 	storeWithMultiMaxSize := statestore.New(t,
-		statestore.WithSocketDirectory(socketDir),
+		statestore.WithSocket(socket),
 		statestore.WithStateStore(inmemory.NewTransactionalMultiMaxSize(t,
 			inmemory.WithTransactionalStoreMultiMaxSizeFn(func() int {
 				return 1
@@ -132,9 +119,7 @@ spec:
   type: state.%s
   version: v1
 `, storeWithNoTransactional.SocketName(), storeWithQuerier.SocketName(), storeWithMultiMaxSize.SocketName())),
-		procdaprd.WithExecOptions(exec.WithEnvVars(t,
-			"DAPR_COMPONENTS_SOCKETS_FOLDER", socketDir,
-		)),
+		procdaprd.WithSocket(t, socket),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/state/http/errors.go
+++ b/tests/integration/suite/daprd/state/http/errors.go
@@ -19,22 +19,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/nettest"
 
 	"github.com/dapr/components-contrib/state"
 	apierrors "github.com/dapr/dapr/pkg/api/errors"
 	"github.com/dapr/dapr/tests/integration/framework"
 	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 	"github.com/dapr/dapr/tests/integration/framework/util"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
@@ -61,16 +58,7 @@ func (e *errors) Setup(t *testing.T) []framework.Option {
 		t.Skip("skipping unix socket based test on windows")
 	}
 
-	// Darwin enforces a maximum 104 byte socket name limit, so we need to be a
-	// bit fancy on how we generate the name.
-	tmp, err := nettest.LocalPath()
-	require.NoError(t, err)
-
-	socketDir := filepath.Join(tmp, util.RandomString(t, 4))
-	require.NoError(t, os.MkdirAll(socketDir, 0o700))
-	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(socketDir))
-	})
+	socket := socket.New(t)
 
 	e.queryErr = func(t *testing.T) error {
 		require.FailNow(t, "query should not be called")
@@ -78,14 +66,14 @@ func (e *errors) Setup(t *testing.T) []framework.Option {
 	}
 
 	storeWithNoTransactional := statestore.New(t,
-		statestore.WithSocketDirectory(socketDir),
+		statestore.WithSocket(socket),
 		statestore.WithStateStore(inmemory.New(t,
 			inmemory.WithFeatures(),
 		)),
 	)
 
 	storeWithQuerier := statestore.New(t,
-		statestore.WithSocketDirectory(socketDir),
+		statestore.WithSocket(socket),
 		statestore.WithStateStore(inmemory.NewQuerier(t,
 			inmemory.WithQueryFn(func(context.Context, *state.QueryRequest) (*state.QueryResponse, error) {
 				return nil, e.queryErr(t)
@@ -93,7 +81,7 @@ func (e *errors) Setup(t *testing.T) []framework.Option {
 		)),
 	)
 	storeWithMultiMaxSize := statestore.New(t,
-		statestore.WithSocketDirectory(socketDir),
+		statestore.WithSocket(socket),
 		statestore.WithStateStore(inmemory.NewTransactionalMultiMaxSize(t,
 			inmemory.WithTransactionalStoreMultiMaxSizeFn(func() int {
 				return 1
@@ -134,9 +122,7 @@ spec:
   type: state.%s
   version: v1
 `, storeWithNoTransactional.SocketName(), storeWithQuerier.SocketName(), storeWithMultiMaxSize.SocketName())),
-		procdaprd.WithExecOptions(exec.WithEnvVars(t,
-			"DAPR_COMPONENTS_SOCKETS_FOLDER", socketDir,
-		)),
+		procdaprd.WithSocket(t, socket),
 	)
 
 	return []framework.Option{


### PR DESCRIPTION
PR #7537 reverse revered the change which removed the content-length from being set on HTTP headers on sent messages. We still need to remove the content-length from messages from pubsub subscriptions as the pubsub may report a message with a content-length which does not actually match the size of the delivered message to the app.

content-length is only removed on HTTP published messages.

Change should be backported to 1.13