### PR TITLE
add myself to daprbot

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -6,6 +6,7 @@ const owners = [
     'artursouza',
     'ashiquemd',
     'berndverst',
+    'cicoyle',
     'daixiang0',
     'deepanshua',
     'halspang',


### PR DESCRIPTION
I would like to be able to run `ok-to-perf` since Im the perf test lead and am unable to run perf tests currently. I'm trying to figure out what caused the perf test regression.