### PR TITLE
fix: use new linter install link

### DIFF
--- a/.build-tools/cmd/check-lint-version.go
+++ b/.build-tools/cmd/check-lint-version.go
@@ -92,7 +92,7 @@ func getCmdCheckLint(cmdType string) *cobra.Command {
 			res, err := compareVersions(path)
 			fmt.Println(res)
 			if err != nil {
-				fmt.Println("Please install the correct version using the guide - https://golangci-lint.run/usage/install/")
+				fmt.Println("Please install the correct version using the guide - https://golangci-lint.run/welcome/install/")
 				if err == ErrVersionNotSupported {
 					fmt.Println("Alternatively review the golangci-lint version in the workflow file at .github/workflows/dapr.yml")
 				}


### PR DESCRIPTION
# Description

Original link gives 404:
<img width="672" alt="image" src="https://github.com/dapr/dapr/assets/25728646/6389cb2f-864f-4852-9456-bc88053e6e8e">


Updated link is where I had to go to install the correct linter version.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
