### PR TITLE
fix: update batcher signature so my contrib pr is happy in ci

### DIFF
--- a/pkg/runtime/hotreload/loader/disk/disk.go
+++ b/pkg/runtime/hotreload/loader/disk/disk.go
@@ -43,7 +43,7 @@ type disk struct {
 	components    *resource[compapi.Component]
 	subscriptions *resource[subapi.Subscription]
 	fs            *fswatcher.FSWatcher
-	batcher       *batcher.Batcher[int, struct{}]
+	batcher       *batcher.Batcher[int]
 }
 
 func New(opts Options) (loader.Interface, error) {

--- a/pkg/runtime/hotreload/loader/disk/resource.go
+++ b/pkg/runtime/hotreload/loader/disk/resource.go
@@ -30,8 +30,8 @@ import (
 // resource is a generic implementation of a disk resource loader. resource
 // will watch and load resources from disk.
 type resource[T differ.Resource] struct {
-	sourceBatcher *batcher.Batcher[int, struct{}]
-	streamBatcher *batcher.Batcher[int, struct{}]
+	sourceBatcher *batcher.Batcher[int]
+	streamBatcher *batcher.Batcher[int]
 	store         store.Store[T]
 	diskLoader    internalloader.Loader[T]
 
@@ -47,7 +47,7 @@ type resource[T differ.Resource] struct {
 type resourceOptions[T differ.Resource] struct {
 	loader  internalloader.Loader[T]
 	store   store.Store[T]
-	batcher *batcher.Batcher[int, struct{}]
+	batcher *batcher.Batcher[int]
 }
 
 func newResource[T differ.Resource](opts resourceOptions[T]) *resource[T] {


### PR DESCRIPTION
# Description

context: https://github.com/dapr/components-contrib/pull/3410

I'm dealing with incompatible func signatures between dapr and kit causing my contrib pr ci runs to fail when bumping cert test dependencies...

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
