### PR TITLE
Makefile: export `go/bin` to PATH for darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ ifeq ($(LOCAL_OS),Linux)
    TARGET_OS_LOCAL = linux
 else ifeq ($(LOCAL_OS),Darwin)
    TARGET_OS_LOCAL = darwin
+   PATH := $(PATH):$(HOME)/go/bin/darwin_$(GOARCH)
 else
    TARGET_OS_LOCAL = windows
    PROTOC_GEN_GO_NAME := "protoc-gen-go.exe"


### PR DESCRIPTION
Exports the `go/bin/darwin_$(arch)` directory to the PATH environment
variable when running on Darwin. This ensures that binaries installed by
`go install` are available in the Makefile exec path.
