### PR TITLE
Revert default cardinality to high for metrics

### DIFF
--- a/charts/dapr/crds/configuration.yaml
+++ b/charts/dapr/crds/configuration.yaml
@@ -253,8 +253,9 @@ spec:
                       the HTTP server
                     properties:
                       increasedCardinality:
-                        description: |-
-                          If false (the default), metrics for the HTTP server are collected with increased cardinality.
+                        description: 'If true, metrics for the HTTP server are collected
+                          with increased cardinality. The default is true in Dapr 1.13,
+                          but will be changed to false in 1.15+'
                         type: boolean
                     type: object
                   rules:

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -219,8 +219,9 @@ type MetricSpec struct {
 
 // MetricHTTP defines configuration for metrics for the HTTP server
 type MetricHTTP struct {
-	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
-	// +optional
+	// If false, metrics for the HTTP server are collected with increased cardinality.
+	// The default is true in Dapr 1.13, but will be changed to false in 1.15+
+	// TODO @ItalyPaleAle [MetricsCardinality] Change default in 1.15+
 	IncreasedCardinality *bool `json:"increasedCardinality,omitempty"`
 }
 

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -263,15 +263,19 @@ func (m MetricSpec) GetEnabled() bool {
 // GetHTTPIncreasedCardinality returns true if increased cardinality is enabled for HTTP metrics
 func (m MetricSpec) GetHTTPIncreasedCardinality(log logger.Logger) bool {
 	if m.HTTP == nil || m.HTTP.IncreasedCardinality == nil {
-		// The default is false
-		return false
+		// The default is true in Dapr 1.13, but will be changed to false in 1.15+
+		// TODO @ItalyPaleAle [MetricsCardinality] Change default in 1.15
+		log.Warn("The default value for 'spec.metric.http.increasedCardinality' will change to 'false' in Dapr 1.15")
+		return true
 	}
 	return *m.HTTP.IncreasedCardinality
 }
 
 // MetricHTTP defines configuration for metrics for the HTTP server
 type MetricHTTP struct {
-	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
+	// If false, metrics for the HTTP server are collected with increased cardinality.
+	// The default is true in Dapr 1.13, but will be changed to false in 1.15+
+	// TODO @ItalyPaleAle [MetricsCardinality] Change default in 1.15
 	IncreasedCardinality *bool `json:"increasedCardinality,omitempty" yaml:"increasedCardinality,omitempty"`
 }
 

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -596,20 +596,20 @@ func TestMetricsGetHTTPIncreasedCardinality(t *testing.T) {
 	log := logger.NewLogger("test")
 	log.SetOutput(io.Discard)
 
-	t.Run("no http configuration, returns false", func(t *testing.T) {
+	t.Run("no http configuration, returns true", func(t *testing.T) {
 		m := MetricSpec{
 			HTTP: nil,
 		}
-		assert.False(t, m.GetHTTPIncreasedCardinality(log))
+		assert.True(t, m.GetHTTPIncreasedCardinality(log))
 	})
 
-	t.Run("nil value, returns false", func(t *testing.T) {
+	t.Run("nil value, returns true", func(t *testing.T) {
 		m := MetricSpec{
 			HTTP: &MetricHTTP{
 				IncreasedCardinality: nil,
 			},
 		}
-		assert.False(t, m.GetHTTPIncreasedCardinality(log))
+		assert.True(t, m.GetHTTPIncreasedCardinality(log))
 	})
 
 	t.Run("value is set to true", func(t *testing.T) {

--- a/tests/integration/suite/daprd/metrics/http/basic.go
+++ b/tests/integration/suite/daprd/metrics/http/basic.go
@@ -62,7 +62,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	t.Run("service invocation", func(t *testing.T) {
 		b.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/hi")
 		metrics := b.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:InvokeService/myapp|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/hi|status:200"]))
 	})
 
 	t.Run("state stores", func(t *testing.T) {
@@ -72,7 +72,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		b.daprd.HTTPGet2xx(t, ctx, "/v1.0/state/mystore/myvalue")
 
 		metrics := b.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:SaveState|status:204"]))
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GetState|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:/v1.0/state/mystore|status:204"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/state/mystore|status:200"]))
 	})
 }


### PR DESCRIPTION
# Description

This PR reverts the changes introduced in https://github.com/dapr/dapr/pull/7522 and restores the default cardinality until version 1.15. The intention is to revert to a lower cardinality as the default setting in the upcoming Dapr version. This is a temporary measure while we work on addressing other issues related to metrics cardinality.

## Issue reference

Motivation described here: https://github.com/dapr/dapr/issues/7719

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
