### PR TITLE
Update http monitoring method parsing in low cardinality cases

### DIFF
--- a/pkg/api/http/actors.go
+++ b/pkg/api/http/actors.go
@@ -76,7 +76,7 @@ func actorInvocationMethodNameFn(r *http.Request) string {
 
 func (a *api) constructActorEndpoints() []endpoints.Endpoint {
 	methodNameFn := actorInvocationMethodNameWithIDFn
-	if !a.metricSpec.GetHTTPIncreasedCardinality() {
+	if a.metricSpec != nil && !a.metricSpec.GetHTTPIncreasedCardinality() {
 		methodNameFn = actorInvocationMethodNameFn
 	}
 	return []endpoints.Endpoint{

--- a/pkg/api/http/actors.go
+++ b/pkg/api/http/actors.go
@@ -66,11 +66,19 @@ func appendActorInvocationSpanAttributesFn(r *http.Request, m map[string]string)
 	m[diagConsts.DaprAPISpanNameInternal] = "CallActor/" + actorType + "/" + chi.URLParam(r, "method")
 }
 
-func actorInvocationMethodNameFn(r *http.Request) string {
+func actorInvocationMethodNameWithIDFn(r *http.Request) string {
 	return "InvokeActor/" + chi.URLParam(r, actorTypeParam) + "." + chi.URLParam(r, actorIDParam)
 }
 
+func actorInvocationMethodNameFn(r *http.Request) string {
+	return "InvokeActor/" + chi.URLParam(r, actorTypeParam)
+}
+
 func (a *api) constructActorEndpoints() []endpoints.Endpoint {
+	methodNameFn := actorInvocationMethodNameWithIDFn
+	if !a.metricSpec.GetHTTPIncreasedCardinality() {
+		methodNameFn = actorInvocationMethodNameFn
+	}
 	return []endpoints.Endpoint{
 		{
 			Methods: []string{http.MethodPost, http.MethodPut},
@@ -90,7 +98,7 @@ func (a *api) constructActorEndpoints() []endpoints.Endpoint {
 				Name:                 endpoints.EndpointGroupActors,
 				Version:              endpoints.EndpointGroupVersion1,
 				AppendSpanAttributes: appendActorInvocationSpanAttributesFn,
-				MethodName:           actorInvocationMethodNameFn,
+				MethodName:           methodNameFn,
 			},
 			Handler: a.onDirectActorMessage,
 			Settings: endpoints.EndpointSettings{

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -73,6 +73,7 @@ type api struct {
 	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	readyStatus           bool
 	outboundReadyStatus   bool
+	metricSpec            config.MetricSpec
 	tracingSpec           config.TracingSpec
 	maxRequestBodySize    int64 // In bytes
 }
@@ -114,6 +115,7 @@ type APIOpts struct {
 	PubsubAdapter         runtimePubsub.Adapter
 	SendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	TracingSpec           config.TracingSpec
+	MetricSpec            config.MetricSpec
 	MaxRequestBodySize    int64 // In bytes
 }
 
@@ -126,6 +128,7 @@ func NewAPI(opts APIOpts) API {
 		pubsubAdapter:         opts.PubsubAdapter,
 		sendToOutputBindingFn: opts.SendToOutputBindingFn,
 		tracingSpec:           opts.TracingSpec,
+		metricSpec:            opts.MetricSpec,
 		maxRequestBodySize:    opts.MaxRequestBodySize,
 	}
 

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -73,7 +73,7 @@ type api struct {
 	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	readyStatus           bool
 	outboundReadyStatus   bool
-	metricSpec            config.MetricSpec
+	metricSpec            *config.MetricSpec
 	tracingSpec           config.TracingSpec
 	maxRequestBodySize    int64 // In bytes
 }
@@ -115,7 +115,7 @@ type APIOpts struct {
 	PubsubAdapter         runtimePubsub.Adapter
 	SendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
 	TracingSpec           config.TracingSpec
-	MetricSpec            config.MetricSpec
+	MetricSpec            *config.MetricSpec
 	MaxRequestBodySize    int64 // In bytes
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -783,6 +783,7 @@ func (a *DaprRuntime) startHTTPServer() error {
 		PubsubAdapter:         a.processor.PubSub(),
 		SendToOutputBindingFn: a.processor.Binding().SendToOutputBinding,
 		TracingSpec:           a.globalConfig.GetTracingSpec(),
+		MetricSpec:            a.globalConfig.GetMetricsSpec(),
 		MaxRequestBodySize:    int64(a.runtimeConfig.maxRequestBodySize),
 	})
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -776,6 +776,7 @@ func (a *DaprRuntime) initProxy() {
 }
 
 func (a *DaprRuntime) startHTTPServer() error {
+	getMetricSpec := a.globalConfig.GetMetricsSpec()
 	a.daprHTTPAPI = http.NewAPI(http.APIOpts{
 		Universal:             a.daprUniversal,
 		Channels:              a.channels,
@@ -783,7 +784,7 @@ func (a *DaprRuntime) startHTTPServer() error {
 		PubsubAdapter:         a.processor.PubSub(),
 		SendToOutputBindingFn: a.processor.Binding().SendToOutputBinding,
 		TracingSpec:           a.globalConfig.GetTracingSpec(),
-		MetricSpec:            a.globalConfig.GetMetricsSpec(),
+		MetricSpec:            &getMetricSpec,
 		MaxRequestBodySize:    int64(a.runtimeConfig.maxRequestBodySize),
 	})
 


### PR DESCRIPTION
# Description

Modified the http monitoring logic to reduce Method cardinality in low cardinality scenarios where the actorID is appended to the endpoint.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

closes: [#7736](https://github.com/dapr/dapr/issues/7736)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
