### PR TITLE
add global config override for increasedCardinality

### DIFF
--- a/charts/dapr/README.md
+++ b/charts/dapr/README.md
@@ -85,6 +85,7 @@ The Helm chart has the follow configuration options that can be supplied:
 | `global.ha.disruption.maximumUnavailable` | Maximum amount of instances that are allowed to be unavailable for control plane. This can either be effective count or %. | `25%`             |
 | `global.prometheus.enabled`               | Prometheus metrics enablement for control plane services                | `true`                  |
 | `global.prometheus.port`                  | Prometheus scrape http endpoint port                                    | `9090`                  |
+| `global.metrics.http.increasedCardinality`| Allow global change to cardinality on sidecars                          | `false`                 |
 | `global.mtls.enabled`                     | Mutual TLS enablement                                                   | `true`                  |
 | `global.mtls.workloadCertTTL`             | TTL for workload cert                                                   | `24h`                   |
 | `global.mtls.allowedClockSkew`            | Allowed clock skew for workload cert rotation                           | `15m`                   |

--- a/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
+++ b/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
@@ -18,6 +18,6 @@ spec:
   {{ if .Values.global.metrics.http }}
   metrics:
     http:
-      increasedCardinality: {{ default .Values.global.metrics.http.increasedCardinality false }}
+      increasedCardinality: {{ default false .Values.global.metrics.http.increasedCardinality }}
   {{- end }}
 {{- end }}

--- a/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
+++ b/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
@@ -15,4 +15,9 @@ spec:
     allowedClockSkew: {{ .Values.global.mtls.allowedClockSkew }}
     controlPlaneTrustDomain: {{ .Values.global.mtls.controlPlaneTrustDomain }}
     sentryAddress: {{ if .Values.global.mtls.sentryAddress }}{{ .Values.global.mtls.sentryAddress }}{{ else }}dapr-sentry.{{ .Release.Namespace }}.svc.cluster.local:443{{ end }}
+  {{ if .Values.global.metrics.http }}
+  metrics:
+    http:
+      increasedCardinality: {{ default .Values.global.metrics.http.increasedCardinality false }}
+  {{- end }}
 {{- end }}

--- a/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
+++ b/charts/dapr/charts/dapr_config/templates/dapr_default_config.yaml
@@ -15,7 +15,7 @@ spec:
     allowedClockSkew: {{ .Values.global.mtls.allowedClockSkew }}
     controlPlaneTrustDomain: {{ .Values.global.mtls.controlPlaneTrustDomain }}
     sentryAddress: {{ if .Values.global.mtls.sentryAddress }}{{ .Values.global.mtls.sentryAddress }}{{ else }}dapr-sentry.{{ .Release.Namespace }}.svc.cluster.local:443{{ end }}
-  {{ if .Values.global.metrics.http }}
+  {{- if .Values.global.metrics.http }}
   metrics:
     http:
       increasedCardinality: {{ default false .Values.global.metrics.http.increasedCardinality }}

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -35,6 +35,9 @@ global:
   prometheus:
     enabled: true
     port: 9090
+  metrics: {}
+  # http:
+  #   increasedCardinality: false # set to true to revert to old behavior by default (dapr < 1.14)
   mtls:
     enabled: true
     workloadCertTTL: 24h

--- a/pkg/operator/api/configurations.go
+++ b/pkg/operator/api/configurations.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -24,6 +27,69 @@ import (
 	"github.com/dapr/dapr/pkg/operator/api/authz"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 )
+
+const defaultConfig = "daprsystem"
+
+var defaultConfigObjKey = client.ObjectKey{Name: defaultConfig, Namespace: os.Getenv("NAMESPACE")}
+
+func (a *apiServer) getDaprSystemConfiguration(ctx context.Context) (*configurationapi.Configuration, error) {
+	cfg := &configurationapi.Configuration{}
+	// as we're using controller-runtime client, we will be using the cache/watch of it, making this call not expensive and up to date
+	err := a.Client.Get(ctx, defaultConfigObjKey, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("trying to get configuration %s: %w", defaultConfigObjKey.String(), err)
+	}
+	return cfg, nil
+}
+
+// sortMetricsSpec Apply .metrics if set. If not, retain .metric. following
+// https://github.com/dapr/dapr/blob/50757fed0b8545f55714885c97a1543607118c4c/pkg/config/configuration.go#L665 but for the k8s type
+func sortMetricsSpec(c *configurationapi.Configuration) {
+	if c.Spec.MetricsSpec == nil {
+		return
+	}
+
+	if c.Spec.MetricsSpec.Enabled != nil {
+		if c.Spec.MetricSpec == nil {
+			c.Spec.MetricSpec = &configurationapi.MetricSpec{}
+		}
+		c.Spec.MetricSpec.Enabled = c.Spec.MetricsSpec.Enabled
+	}
+
+	if len(c.Spec.MetricsSpec.Rules) > 0 {
+		if c.Spec.MetricSpec == nil {
+			c.Spec.MetricSpec = &configurationapi.MetricSpec{}
+		}
+		c.Spec.MetricSpec.Rules = c.Spec.MetricsSpec.Rules
+	}
+
+	if c.Spec.MetricsSpec.HTTP != nil {
+		if c.Spec.MetricSpec == nil {
+			c.Spec.MetricSpec = &configurationapi.MetricSpec{}
+		}
+		c.Spec.MetricSpec.HTTP = c.Spec.MetricsSpec.HTTP
+	}
+}
+
+func (a *apiServer) overrideConfigDefaults(ctx context.Context, cfg *configurationapi.Configuration) error {
+	// override Metric Spec with Dapr System Config if not set (check both forms of metric(s)Spec )
+	if (cfg.Spec.MetricSpec == nil || cfg.Spec.MetricSpec.HTTP == nil) && (cfg.Spec.MetricsSpec == nil || cfg.Spec.MetricsSpec.HTTP == nil) {
+		daprSystemConfig, err := a.getDaprSystemConfiguration(ctx)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err == nil { // skip if not found
+			sortMetricsSpec(daprSystemConfig)
+			if daprSystemConfig.Spec.MetricSpec != nil && daprSystemConfig.Spec.MetricSpec.HTTP != nil {
+				if cfg.Spec.MetricSpec == nil {
+					cfg.Spec.MetricSpec = &configurationapi.MetricSpec{}
+				}
+				cfg.Spec.MetricSpec.HTTP = daprSystemConfig.Spec.MetricSpec.HTTP
+			}
+		}
+	}
+	return nil
+}
 
 // GetConfiguration returns a Dapr configuration.
 func (a *apiServer) GetConfiguration(ctx context.Context, in *operatorv1pb.GetConfigurationRequest) (*operatorv1pb.GetConfigurationResponse, error) {
@@ -36,10 +102,16 @@ func (a *apiServer) GetConfiguration(ctx context.Context, in *operatorv1pb.GetCo
 	if err := a.Client.Get(ctx, key, &config); err != nil {
 		return nil, fmt.Errorf("error getting configuration %s/%s: %w", in.GetNamespace(), in.GetName(), err)
 	}
+
+	if err := a.overrideConfigDefaults(ctx, &config); err != nil {
+		return nil, fmt.Errorf("error overriding defaults: %w", err)
+	}
+
 	b, err := json.Marshal(&config)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling configuration: %w", err)
 	}
+
 	return &operatorv1pb.GetConfigurationResponse{
 		Configuration: b,
 	}, nil

--- a/pkg/operator/api/configurations.go
+++ b/pkg/operator/api/configurations.go
@@ -17,8 +17,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/operator/api/configurations_test.go
+++ b/pkg/operator/api/configurations_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newCardinalityConfig(objectMeta v1.ObjectMeta, increaseCardinality bool) *configapi.Configuration {
+	return &configapi.Configuration{
+		ObjectMeta: objectMeta,
+		Spec: configapi.ConfigurationSpec{
+			MetricSpec: &configapi.MetricSpec{
+				HTTP: &configapi.MetricHTTP{
+					IncreasedCardinality: ptr.To(increaseCardinality),
+				},
+			},
+		},
+	}
+}
+
+func Test_overrideConfigDefaults(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, configapi.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	defaultConfigObjKey.Namespace = "default"
+
+	defaultObjMeta := v1.ObjectMeta{
+		Name:      defaultConfig,
+		Namespace: "default",
+	}
+
+	t.Run("if default configuration doesn't exist, return no error", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+		a := &apiServer{Client: cl}
+		assert.Nil(t, a.overrideConfigDefaults(ctx, &configapi.Configuration{}))
+	})
+
+	t.Run("if default configuration doesn't exist, and we provide a Configuration, nothing should change", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+		a := &apiServer{Client: cl}
+		c := newCardinalityConfig(defaultObjMeta, true)
+		oldC := c.DeepCopy()
+		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assertEqual(t, c, oldC)
+	})
+
+	t.Run("if default configuration exist, and we provide a Configuration with HTTP info, nothing should change", func(t *testing.T) {
+		defaultC := newCardinalityConfig(defaultObjMeta, false)
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultC).Build()
+		a := &apiServer{Client: cl}
+		c := &configapi.Configuration{
+			Spec: configapi.ConfigurationSpec{
+				MetricSpec: &configapi.MetricSpec{
+					HTTP: &configapi.MetricHTTP{
+						IncreasedCardinality: ptr.To(true),
+					},
+				},
+			},
+		}
+		oldC := c.DeepCopy()
+		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assertEqual(t, c, oldC)
+	})
+
+	t.Run("if default configuration exist, and we provide a Configuration with HTTP info inside Metric(s)Spec, nothing should change", func(t *testing.T) {
+		defaultC := newCardinalityConfig(defaultObjMeta, false)
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultC).Build()
+		a := &apiServer{Client: cl}
+		c := &configapi.Configuration{
+			Spec: configapi.ConfigurationSpec{
+				MetricsSpec: &configapi.MetricSpec{
+					HTTP: &configapi.MetricHTTP{
+						IncreasedCardinality: ptr.To(true),
+					},
+				},
+			},
+		}
+		oldC := c.DeepCopy()
+		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assertEqual(t, c, oldC)
+	})
+
+	t.Run("if default configuration exist, and we provide a Configuration with NO HTTP info, use default config", func(t *testing.T) {
+		defaultC := newCardinalityConfig(defaultObjMeta, false)
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultC).Build()
+		a := &apiServer{Client: cl}
+		c := &configapi.Configuration{
+			Spec: configapi.ConfigurationSpec{
+				MetricSpec: &configapi.MetricSpec{},
+			},
+		}
+		expectedC := c.DeepCopy()
+		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
+			IncreasedCardinality: ptr.To(false),
+		}
+		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+
+		assertEqual(t, c, expectedC)
+	})
+
+	t.Run("if default configuration exist using metric instead of plural metrics, and we provide a Configuration with NO HTTP info, use default config", func(t *testing.T) {
+		defaultC := newCardinalityConfig(defaultObjMeta, false)
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultC).Build()
+		a := &apiServer{Client: cl}
+		c := &configapi.Configuration{
+			Spec: configapi.ConfigurationSpec{
+				MetricSpec: &configapi.MetricSpec{},
+			},
+		}
+		expectedC := c.DeepCopy()
+		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
+			IncreasedCardinality: ptr.To(false),
+		}
+		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+
+		assertEqual(t, c, expectedC)
+	})
+
+	t.Run("if default configuration exist, and we provide a Configuration with NO HTTP info, but provide other spec attributes, use default config only for HTTP", func(t *testing.T) {
+		defaultC := newCardinalityConfig(defaultObjMeta, false)
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultC).Build()
+		a := &apiServer{Client: cl}
+		c := &configapi.Configuration{
+			Spec: configapi.ConfigurationSpec{
+				MetricSpec: &configapi.MetricSpec{},
+				TracingSpec: &configapi.TracingSpec{
+					SamplingRate: "samplingrate",
+				},
+			},
+		}
+		expectedC := c.DeepCopy()
+		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
+			IncreasedCardinality: ptr.To(false),
+		}
+		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+
+		assertEqual(t, c, expectedC)
+	})
+}
+
+func assertEqual(t *testing.T, c, cExpected *configapi.Configuration) {
+	t.Helper()
+	expectedCData, err := json.Marshal(cExpected)
+	require.NoError(t, err)
+	cData, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	assert.Equal(t, cData, expectedCData)
+}

--- a/pkg/operator/api/configurations_test.go
+++ b/pkg/operator/api/configurations_test.go
@@ -55,7 +55,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		a := &apiServer{Client: cl}
 		c := newCardinalityConfig(defaultObjMeta, true)
 		oldC := c.DeepCopy()
-		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
+		require.NoError(t, a.overrideConfigDefaults(ctx, c))
 		assertEqual(t, c, oldC)
 	})
 
@@ -73,7 +73,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 			},
 		}
 		oldC := c.DeepCopy()
-		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
+		require.NoError(t, a.overrideConfigDefaults(ctx, c))
 		assertEqual(t, c, oldC)
 	})
 
@@ -91,7 +91,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 			},
 		}
 		oldC := c.DeepCopy()
-		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
+		require.NoError(t, a.overrideConfigDefaults(ctx, c))
 		assertEqual(t, c, oldC)
 	})
 
@@ -108,7 +108,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
 			IncreasedCardinality: ptr.Of(false),
 		}
-		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
+		require.NoError(t, a.overrideConfigDefaults(ctx, c))
 
 		assertEqual(t, c, expectedC)
 	})
@@ -126,7 +126,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
 			IncreasedCardinality: ptr.Of(false),
 		}
-		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
+		require.NoError(t, a.overrideConfigDefaults(ctx, c))
 
 		assertEqual(t, c, expectedC)
 	})
@@ -147,7 +147,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
 			IncreasedCardinality: ptr.Of(false),
 		}
-		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
+		require.NoError(t, a.overrideConfigDefaults(ctx, c))
 
 		assertEqual(t, c, expectedC)
 	})

--- a/pkg/operator/api/configurations_test.go
+++ b/pkg/operator/api/configurations_test.go
@@ -3,16 +3,19 @@ package api
 import (
 	"context"
 	"encoding/json"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
-	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/kit/ptr"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
 )
 
 func newCardinalityConfig(objectMeta v1.ObjectMeta, increaseCardinality bool) *configapi.Configuration {
@@ -21,7 +24,7 @@ func newCardinalityConfig(objectMeta v1.ObjectMeta, increaseCardinality bool) *c
 		Spec: configapi.ConfigurationSpec{
 			MetricSpec: &configapi.MetricSpec{
 				HTTP: &configapi.MetricHTTP{
-					IncreasedCardinality: ptr.To(increaseCardinality),
+					IncreasedCardinality: ptr.Of(increaseCardinality),
 				},
 			},
 		},
@@ -44,7 +47,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 	t.Run("if default configuration doesn't exist, return no error", func(t *testing.T) {
 		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
 		a := &apiServer{Client: cl}
-		assert.Nil(t, a.overrideConfigDefaults(ctx, &configapi.Configuration{}))
+		assert.NoError(t, a.overrideConfigDefaults(ctx, &configapi.Configuration{}))
 	})
 
 	t.Run("if default configuration doesn't exist, and we provide a Configuration, nothing should change", func(t *testing.T) {
@@ -52,7 +55,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		a := &apiServer{Client: cl}
 		c := newCardinalityConfig(defaultObjMeta, true)
 		oldC := c.DeepCopy()
-		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
 		assertEqual(t, c, oldC)
 	})
 
@@ -64,13 +67,13 @@ func Test_overrideConfigDefaults(t *testing.T) {
 			Spec: configapi.ConfigurationSpec{
 				MetricSpec: &configapi.MetricSpec{
 					HTTP: &configapi.MetricHTTP{
-						IncreasedCardinality: ptr.To(true),
+						IncreasedCardinality: ptr.Of(true),
 					},
 				},
 			},
 		}
 		oldC := c.DeepCopy()
-		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
 		assertEqual(t, c, oldC)
 	})
 
@@ -82,13 +85,13 @@ func Test_overrideConfigDefaults(t *testing.T) {
 			Spec: configapi.ConfigurationSpec{
 				MetricsSpec: &configapi.MetricSpec{
 					HTTP: &configapi.MetricHTTP{
-						IncreasedCardinality: ptr.To(true),
+						IncreasedCardinality: ptr.Of(true),
 					},
 				},
 			},
 		}
 		oldC := c.DeepCopy()
-		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
 		assertEqual(t, c, oldC)
 	})
 
@@ -103,9 +106,9 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		}
 		expectedC := c.DeepCopy()
 		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
-			IncreasedCardinality: ptr.To(false),
+			IncreasedCardinality: ptr.Of(false),
 		}
-		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
 
 		assertEqual(t, c, expectedC)
 	})
@@ -121,9 +124,9 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		}
 		expectedC := c.DeepCopy()
 		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
-			IncreasedCardinality: ptr.To(false),
+			IncreasedCardinality: ptr.Of(false),
 		}
-		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
 
 		assertEqual(t, c, expectedC)
 	})
@@ -142,9 +145,9 @@ func Test_overrideConfigDefaults(t *testing.T) {
 		}
 		expectedC := c.DeepCopy()
 		expectedC.Spec.MetricSpec.HTTP = &configapi.MetricHTTP{
-			IncreasedCardinality: ptr.To(false),
+			IncreasedCardinality: ptr.Of(false),
 		}
-		assert.Nil(t, a.overrideConfigDefaults(ctx, c))
+		assert.NoError(t, a.overrideConfigDefaults(ctx, c))
 
 		assertEqual(t, c, expectedC)
 	})
@@ -157,5 +160,5 @@ func assertEqual(t *testing.T, c, cExpected *configapi.Configuration) {
 	cData, err := json.Marshal(c)
 	require.NoError(t, err)
 
-	assert.Equal(t, cData, expectedCData)
+	assert.Equal(t, expectedCData, cData)
 }

--- a/pkg/operator/api/configurations_test.go
+++ b/pkg/operator/api/configurations_test.go
@@ -47,7 +47,7 @@ func Test_overrideConfigDefaults(t *testing.T) {
 	t.Run("if default configuration doesn't exist, return no error", func(t *testing.T) {
 		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
 		a := &apiServer{Client: cl}
-		assert.NoError(t, a.overrideConfigDefaults(ctx, &configapi.Configuration{}))
+		require.NoError(t, a.overrideConfigDefaults(ctx, &configapi.Configuration{}))
 	})
 
 	t.Run("if default configuration doesn't exist, and we provide a Configuration, nothing should change", func(t *testing.T) {

--- a/tests/integration/suite/operator/api/api.go
+++ b/tests/integration/suite/operator/api/api.go
@@ -15,5 +15,6 @@ package api
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/operator/api/componentupdate"
+	_ "github.com/dapr/dapr/tests/integration/suite/operator/api/getconfigurations"
 	_ "github.com/dapr/dapr/tests/integration/suite/operator/api/listcomponents"
 )

--- a/tests/integration/suite/operator/api/getconfigurations/basic.go
+++ b/tests/integration/suite/operator/api/getconfigurations/basic.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dapr/kit/ptr"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/dapr/kit/ptr"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
@@ -49,7 +50,6 @@ type basic struct {
 	operator *operator.Operator
 
 	conf1 *confapi.Configuration
-	conf2 *confapi.Configuration
 }
 
 func (b *basic) Setup(t *testing.T) []framework.Option {
@@ -123,7 +123,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			var err error
 			resp, err = client.GetConfiguration(ctx, &operatorv1.GetConfigurationRequest{Namespace: "default", Name: "myconfig"})
 			require.NoError(t, err)
-			assert.Greater(c, len(resp.GetConfiguration()), 0)
+			assert.NotEmpty(c, resp.GetConfiguration())
 		}, time.Second*20, time.Millisecond*10)
 
 		b1, err := json.Marshal(b.conf1)

--- a/tests/integration/suite/operator/api/getconfigurations/basic.go
+++ b/tests/integration/suite/operator/api/getconfigurations/basic.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package getconfigurations
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dapr/kit/ptr"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	confapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	operator "github.com/dapr/dapr/tests/integration/framework/process/operator"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+// basic tests the operator's ListCompontns API.
+type basic struct {
+	sentry   *procsentry.Sentry
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+
+	conf1 *confapi.Configuration
+	conf2 *confapi.Configuration
+}
+
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	b.sentry = procsentry.New(t, procsentry.WithTrustDomain("integration.test.dapr.io"))
+
+	b.conf1 = &confapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{Kind: "Configuration", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "myconfig", Namespace: "default"},
+		Spec: confapi.ConfigurationSpec{
+			MetricSpec: &confapi.MetricSpec{
+				Enabled: ptr.Of(true),
+				Rules: []confapi.MetricsRule{
+					{
+						Name: "dapr_runtime_service_invocation_req_sent_total",
+						Labels: []confapi.MetricLabel{
+							{
+								Name:  "method",
+								Regex: map[string]string{"orders/": "orders/.+"},
+							},
+						},
+					},
+				},
+			},
+			LoggingSpec: &confapi.LoggingSpec{
+				APILogging: &confapi.APILoggingSpec{
+					Enabled: ptr.Of(false),
+				},
+			},
+		},
+	}
+
+	// This configuration should not be listed as it is in a different namespace.
+	conf3 := &confapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{Kind: "Configuration", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "myconfig3", Namespace: "bar"},
+		Spec:       confapi.ConfigurationSpec{},
+	}
+
+	b.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			b.sentry.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationList(t, &confapi.ConfigurationList{
+			TypeMeta: metav1.TypeMeta{Kind: "ConfigurationList", APIVersion: "dapr.io/v1alpha1"},
+			Items:    []confapi.Configuration{*b.conf1, *conf3},
+		}),
+	)
+
+	b.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(b.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(b.sentry.TrustAnchorsFile(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(b.kubeapi, b.sentry, b.operator),
+	}
+}
+
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.sentry.WaitUntilRunning(t, ctx)
+	b.operator.WaitUntilRunning(t, ctx)
+
+	client := b.operator.Dial(t, ctx, b.sentry, "myapp")
+
+	t.Run("GET", func(t *testing.T) {
+		var resp *operatorv1.GetConfigurationResponse
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			resp, err = client.GetConfiguration(ctx, &operatorv1.GetConfigurationRequest{Namespace: "default", Name: "myconfig"})
+			require.NoError(t, err)
+			assert.Greater(c, len(resp.GetConfiguration()), 0)
+		}, time.Second*20, time.Millisecond*10)
+
+		b1, err := json.Marshal(b.conf1)
+		require.NoError(t, err)
+
+		require.True(t, strings.Contains(string(resp.GetConfiguration()), "myconfig"))
+		assert.JSONEq(t, string(b1), string(resp.GetConfiguration()))
+	})
+	t.Run("GET_wrong_namespace", func(t *testing.T) {
+		var resp *operatorv1.GetConfigurationResponse
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			resp, err = client.GetConfiguration(ctx, &operatorv1.GetConfigurationRequest{Namespace: "bar", Name: "myconfig3"})
+			s, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, codes.PermissionDenied.String(), s.Code().String())
+			assert.Contains(t, s.Message(), "identity does not match requested namespace")
+			assert.Nil(t, resp)
+		}, time.Second*20, time.Millisecond*10)
+	})
+}

--- a/tests/integration/suite/operator/api/getconfigurations/basic_increased_cardinality.go
+++ b/tests/integration/suite/operator/api/getconfigurations/basic_increased_cardinality.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package getconfigurations
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dapr/kit/ptr"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	confapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	operator "github.com/dapr/dapr/tests/integration/framework/process/operator"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(basicIncreasedCardinality))
+}
+
+// basic tests the operator's ListCompontns API.
+type basicIncreasedCardinality struct {
+	sentry   *procsentry.Sentry
+	kubeapi  *kubernetes.Kubernetes
+	operator *operator.Operator
+
+	conf1      *confapi.Configuration
+	conf1Exp   *confapi.Configuration
+	daprsystem *confapi.Configuration
+}
+
+func (b *basicIncreasedCardinality) Setup(t *testing.T) []framework.Option {
+	b.sentry = procsentry.New(t, procsentry.WithTrustDomain("integration.test.dapr.io"))
+
+	b.conf1 = &confapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{Kind: "Configuration", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "myconfig", Namespace: "default"},
+		Spec: confapi.ConfigurationSpec{
+			MetricSpec: &confapi.MetricSpec{
+				Enabled: ptr.Of(true),
+				Rules: []confapi.MetricsRule{
+					{
+						Name: "dapr_runtime_service_invocation_req_sent_total",
+						Labels: []confapi.MetricLabel{
+							{
+								Name:  "method",
+								Regex: map[string]string{"orders/": "orders/.+"},
+							},
+						},
+					},
+				},
+			},
+			LoggingSpec: &confapi.LoggingSpec{
+				APILogging: &confapi.APILoggingSpec{
+					Enabled: ptr.Of(false),
+				},
+			},
+		},
+	}
+	b.daprsystem = &confapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{Kind: "Configuration", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "daprsystem", Namespace: "default"},
+		Spec: confapi.ConfigurationSpec{
+			MetricSpec: &confapi.MetricSpec{
+				HTTP: &confapi.MetricHTTP{
+					IncreasedCardinality: ptr.Of(true),
+				},
+			},
+		},
+	}
+	b.conf1Exp = b.conf1.DeepCopy()
+	b.conf1Exp.Spec.MetricSpec.HTTP = &confapi.MetricHTTP{
+		IncreasedCardinality: ptr.Of(true),
+	}
+
+	// This configuration should not be listed as it is in a different namespace.
+	conf3 := &confapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{Kind: "Configuration", APIVersion: "dapr.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "myconfig3", Namespace: "bar"},
+		Spec:       confapi.ConfigurationSpec{},
+	}
+
+	b.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			b.sentry.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationList(t, &confapi.ConfigurationList{
+			TypeMeta: metav1.TypeMeta{Kind: "ConfigurationList", APIVersion: "dapr.io/v1alpha1"},
+			Items:    []confapi.Configuration{*b.conf1, *b.daprsystem, *conf3},
+		}),
+	)
+
+	b.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(b.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(b.sentry.TrustAnchorsFile(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(b.kubeapi, b.sentry, b.operator),
+	}
+}
+
+func (b *basicIncreasedCardinality) Run(t *testing.T, ctx context.Context) {
+	b.sentry.WaitUntilRunning(t, ctx)
+	b.operator.WaitUntilRunning(t, ctx)
+
+	client := b.operator.Dial(t, ctx, b.sentry, "myapp")
+
+	t.Run("GET", func(t *testing.T) {
+		var resp *operatorv1.GetConfigurationResponse
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			resp, err = client.GetConfiguration(ctx, &operatorv1.GetConfigurationRequest{Namespace: "default", Name: "myconfig"})
+			require.NoError(t, err)
+			assert.Greater(c, len(resp.GetConfiguration()), 0)
+		}, time.Second*20, time.Millisecond*10)
+
+		b1, err := json.Marshal(b.conf1Exp)
+		require.NoError(t, err)
+
+		require.True(t, strings.Contains(string(resp.GetConfiguration()), "myconfig"))
+		assert.JSONEq(t, string(b1), string(resp.GetConfiguration()))
+	})
+}

--- a/tests/integration/suite/operator/api/getconfigurations/basic_increased_cardinality.go
+++ b/tests/integration/suite/operator/api/getconfigurations/basic_increased_cardinality.go
@@ -137,7 +137,7 @@ func (b *basicIncreasedCardinality) Run(t *testing.T, ctx context.Context) {
 			var err error
 			resp, err = client.GetConfiguration(ctx, &operatorv1.GetConfigurationRequest{Namespace: "default", Name: "myconfig"})
 			require.NoError(t, err)
-			assert.Greater(c, len(resp.GetConfiguration()), 0)
+			assert.NotEmpty(c, resp.GetConfiguration())
 		}, time.Second*20, time.Millisecond*10)
 
 		b1, err := json.Marshal(b.conf1Exp)


### PR DESCRIPTION
# Description

As part of the work defined in https://github.com/dapr/dapr/issues/7719#issuecomment-2115859125. Adding a global configuration override to help users to set this value in a central place as it is a cross cutting concern, instead of having to change all configurations

## Issue reference

Please reference the issue this PR will close: #7719 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
