### PR TITLE
Fix Membership Unit Test Flakiness

### DIFF
--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -116,7 +116,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 					require.Equal(c, updateOperation, operations1[1])
 					require.Equal(c, unlockOperation, operations1[2])
 				}
-			}, 10*time.Second, 100*time.Millisecond)
+			}, 20*time.Second, 100*time.Millisecond)
 			ch <- struct{}{}
 		}()
 
@@ -149,7 +149,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 				// Depending on the timing of the host 3 registration
 				// we may receive one or two update messages
 				assert.GreaterOrEqual(c, len(operations2), 3)
-			}, 10*time.Second, 100*time.Millisecond)
+			}, 20*time.Second, 100*time.Millisecond)
 			ch <- struct{}{}
 		}()
 
@@ -186,7 +186,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 					require.Equal(c, updateOperation, operations3[1])
 					require.Equal(c, unlockOperation, operations3[2])
 				}
-			}, 10*time.Second, 100*time.Millisecond)
+			}, 20*time.Second, 100*time.Millisecond)
 			ch <- struct{}{}
 		}()
 
@@ -216,29 +216,24 @@ func TestMembershipChangeWorker(t *testing.T) {
 		require.NoError(t, stream2.Send(host2))
 		require.NoError(t, stream3.Send(host3))
 
-		require.Eventually(t, func() bool {
-			assert.Equal(t, 1, testServer.streamConnPool.getStreamCount("ns1"))
-			assert.Equal(t, 2, testServer.streamConnPool.getStreamCount("ns2"))
-			assert.Equal(t, uint32(3), testServer.streamConnPool.streamIndex.Load())
-			assert.Len(t, testServer.streamConnPool.reverseLookup, 3)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 1, testServer.streamConnPool.getStreamCount("ns1"))
+			assert.Equal(c, 2, testServer.streamConnPool.getStreamCount("ns2"))
+			assert.Equal(c, uint32(3), testServer.streamConnPool.streamIndex.Load())
+			assert.Len(c, testServer.streamConnPool.reverseLookup, 3)
 
 			// This indicates the member has been added to the dissemination queue and is
 			// going to be disseminated in the next tick
 			ts1, ok := testServer.disseminateNextTime.Get("ns1")
-			if assert.True(t, ok) {
-				assert.Equal(t, clock.Now().Add(disseminateTimeout).UnixNano(), ts1.Load())
-			} else {
-				return false
-			}
-			ts2, ok := testServer.disseminateNextTime.Get("ns2")
-			if assert.True(t, ok) {
-				assert.Equal(t, clock.Now().Add(disseminateTimeout).UnixNano(), ts2.Load())
-			} else {
-				return false
+			if assert.True(c, ok) {
+				assert.Equal(c, clock.Now().Add(disseminateTimeout).UnixNano(), ts1.Load())
 			}
 
-			return true
-		}, 20*time.Second, 100*time.Millisecond)
+			ts2, ok := testServer.disseminateNextTime.Get("ns2")
+			if assert.True(c, ok) {
+				assert.Equal(c, clock.Now().Add(disseminateTimeout).UnixNano(), ts2.Load())
+			}
+		}, 10*time.Second, 100*time.Millisecond)
 
 		// Move the clock forward so dissemination is triggered
 		clock.Step(disseminateTimeout)
@@ -251,7 +246,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 				updateMsgCnt++
 			}
 			return updateMsgCnt == 3
-		}, 10*time.Second, 100*time.Millisecond)
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// Ignore the next disseminateTimeout.
 		val, _ := testServer.disseminateNextTime.GetOrSet("ns1", &atomic.Int64{})
@@ -303,89 +298,86 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		// Disconnect the host in ns1
 		conn1.Close()
-
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 2, testServer.raftNode.FSM().State().MemberCount())
-		}, 30*time.Second, 100*time.Millisecond)
 
-		// Disseminate locks have been deleted for ns1, but not ns2
-		assert.Equal(t, 1, testServer.disseminateLocks.ItemCount())
+			// Disseminate locks have been deleted for ns1, but not ns2
+			assert.Equal(c, 1, testServer.disseminateLocks.ItemCount())
 
-		// Disseminate timers have been deleted for ns1, but not ns2
-		_, ok := testServer.disseminateNextTime.Get("ns1")
-		assert.False(t, ok)
-		_, ok = testServer.disseminateNextTime.Get("ns2")
-		assert.True(t, ok)
+			// Disseminate timers have been deleted for ns1, but not ns2
+			_, ok := testServer.disseminateNextTime.Get("ns1")
+			assert.False(c, ok)
+			_, ok = testServer.disseminateNextTime.Get("ns2")
+			assert.True(c, ok)
 
-		// Member update counts have been deleted for ns1, but not ns2
-		_, ok = testServer.memberUpdateCount.Get("ns1")
-		assert.False(t, ok)
-		_, ok = testServer.memberUpdateCount.Get("ns2")
-		assert.True(t, ok)
+			// Member update counts have been deleted for ns1, but not ns2
+			_, ok = testServer.memberUpdateCount.Get("ns1")
+			assert.False(c, ok)
+			_, ok = testServer.memberUpdateCount.Get("ns2")
+			assert.True(c, ok)
 
-		assert.Equal(t, 0, testServer.streamConnPool.getStreamCount("ns1"))
-		assert.Equal(t, 2, testServer.streamConnPool.getStreamCount("ns2"))
-		assert.Equal(t, uint32(3), testServer.streamConnPool.streamIndex.Load())
-		testServer.streamConnPool.lock.RLock()
-		assert.Len(t, testServer.streamConnPool.reverseLookup, 2)
-		testServer.streamConnPool.lock.RUnlock()
+			assert.Equal(c, 0, testServer.streamConnPool.getStreamCount("ns1"))
+			assert.Equal(c, 2, testServer.streamConnPool.getStreamCount("ns2"))
+			assert.Equal(c, uint32(3), testServer.streamConnPool.streamIndex.Load())
+			testServer.streamConnPool.lock.RLock()
+			assert.Len(c, testServer.streamConnPool.reverseLookup, 2)
+			testServer.streamConnPool.lock.RUnlock()
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// // Disconnect one host in ns2
 		conn2.Close()
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 1, testServer.raftNode.FSM().State().MemberCount())
-		}, 30*time.Second, 100*time.Millisecond)
 
-		// Disseminate lock for ns2 hasn't been deleted
-		assert.Equal(t, 1, testServer.disseminateLocks.ItemCount())
+			// Disseminate lock for ns2 hasn't been deleted
+			assert.Equal(c, 1, testServer.disseminateLocks.ItemCount())
 
-		// Disseminate timer for ns2 hasn't been deleted,
-		// because there's still streams in the namespace
-		_, ok = testServer.disseminateNextTime.Get("ns1")
-		assert.False(t, ok)
-		_, ok = testServer.disseminateNextTime.Get("ns2")
-		assert.True(t, ok)
+			// Disseminate timer for ns2 hasn't been deleted,
+			// because there's still streams in the namespace
+			_, ok := testServer.disseminateNextTime.Get("ns1")
+			assert.False(c, ok)
+			_, ok = testServer.disseminateNextTime.Get("ns2")
+			assert.True(c, ok)
 
-		// Member update count for ns2 hasn't been deleted,
-		// because there's still streams in the namespace
-		_, ok = testServer.memberUpdateCount.Get("ns2")
-		assert.True(t, ok)
+			// Member update count for ns2 hasn't been deleted,
+			// because there's still streams in the namespace
+			_, ok = testServer.memberUpdateCount.Get("ns2")
+			assert.True(c, ok)
 
-		assert.Equal(t, 0, testServer.streamConnPool.getStreamCount("ns1"))
-		assert.Equal(t, 1, testServer.streamConnPool.getStreamCount("ns2"))
-		assert.Equal(t, uint32(3), testServer.streamConnPool.streamIndex.Load())
-		testServer.streamConnPool.lock.RLock()
-		assert.Len(t, testServer.streamConnPool.reverseLookup, 1)
-		testServer.streamConnPool.lock.RUnlock()
+			assert.Equal(c, 0, testServer.streamConnPool.getStreamCount("ns1"))
+			assert.Equal(c, 1, testServer.streamConnPool.getStreamCount("ns2"))
+			assert.Equal(c, uint32(3), testServer.streamConnPool.streamIndex.Load())
+			testServer.streamConnPool.lock.RLock()
+			assert.Len(c, testServer.streamConnPool.reverseLookup, 1)
+			testServer.streamConnPool.lock.RUnlock()
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// Last host is disconnected
-		err := conn3.Close()
-		require.NoError(t, err)
-
+		conn3.Close()
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 0, testServer.raftNode.FSM().State().MemberCount())
-		}, 30*time.Second, 100*time.Millisecond)
 
-		// Disseminate locks have been deleted
-		require.Equal(t, 0, testServer.disseminateLocks.ItemCount())
+			// Disseminate locks have been deleted
+			assert.Equal(c, 0, testServer.disseminateLocks.ItemCount())
 
-		// Disseminate timers have been deleted
-		_, ok = testServer.disseminateNextTime.Get("ns1")
-		require.False(t, ok)
-		_, ok = testServer.disseminateNextTime.Get("ns2")
-		require.False(t, ok)
+			// Disseminate timers have been deleted
+			_, ok := testServer.disseminateNextTime.Get("ns1")
+			assert.False(c, ok)
+			_, ok = testServer.disseminateNextTime.Get("ns2")
+			assert.False(c, ok)
 
-		// Member update counts have been deleted
-		_, ok = testServer.memberUpdateCount.Get("ns1")
-		require.False(t, ok)
-		_, ok = testServer.memberUpdateCount.Get("ns2")
-		require.False(t, ok)
+			// Member update counts have been deleted
+			_, ok = testServer.memberUpdateCount.Get("ns1")
+			assert.False(c, ok)
+			_, ok = testServer.memberUpdateCount.Get("ns2")
+			assert.False(c, ok)
 
-		assert.Equal(t, 0, testServer.streamConnPool.getStreamCount("ns1"))
-		assert.Equal(t, 0, testServer.streamConnPool.getStreamCount("ns2"))
-		testServer.streamConnPool.lock.RLock()
-		assert.Empty(t, testServer.streamConnPool.reverseLookup)
-		testServer.streamConnPool.lock.RUnlock()
+			assert.Equal(c, 0, testServer.streamConnPool.getStreamCount("ns1"))
+			assert.Equal(c, 0, testServer.streamConnPool.getStreamCount("ns2"))
+			testServer.streamConnPool.lock.RLock()
+			assert.Empty(c, testServer.streamConnPool.reverseLookup)
+			testServer.streamConnPool.lock.RUnlock()
+		}, 20*time.Second, 100*time.Millisecond)
 	})
 }
 
@@ -394,9 +386,8 @@ func PerformTableUpdateCostTime(t *testing.T) (wastedTime int64) {
 	serverAddress, testServer, _, cleanup := newTestPlacementServer(t, tests.Raft(t))
 	testServer.hasLeadership.Store(true)
 	var (
-		overArr     [testClients]int64
-		overArrLock sync.RWMutex
-		// arrange.
+		overArr       [testClients]int64
+		overArrLock   sync.RWMutex
 		clientConns   []*grpc.ClientConn
 		clientStreams []v1pb.Placement_ReportDaprStatusClient
 		wg            sync.WaitGroup

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -364,7 +364,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 0, testServer.raftNode.FSM().State().MemberCount())
-		}, 50*time.Second, 100*time.Millisecond)
+		}, 30*time.Second, 100*time.Millisecond)
 
 		// Disseminate locks have been deleted
 		require.Equal(t, 0, testServer.disseminateLocks.ItemCount())

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -359,10 +359,12 @@ func TestMembershipChangeWorker(t *testing.T) {
 		testServer.streamConnPool.lock.RUnlock()
 
 		// Last host is disconnected
-		conn3.Close()
+		err := conn3.Close()
+		require.NoError(t, err)
+
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			require.Equal(c, 0, testServer.raftNode.FSM().State().MemberCount())
-		}, 30*time.Second, 100*time.Millisecond)
+		}, 50*time.Second, 100*time.Millisecond)
 
 		// Disseminate locks have been deleted
 		require.Equal(t, 0, testServer.disseminateLocks.ItemCount())

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -238,7 +238,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 			}
 
 			return true
-		}, 10*time.Second, 100*time.Millisecond)
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// Move the clock forward so dissemination is triggered
 		clock.Step(disseminateTimeout)

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -306,7 +306,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 2, testServer.raftNode.FSM().State().MemberCount())
-		}, 10*time.Second, 100*time.Millisecond)
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// Disseminate locks have been deleted for ns1, but not ns2
 		assert.Equal(t, 1, testServer.disseminateLocks.ItemCount())
@@ -334,7 +334,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 		conn2.Close()
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 1, testServer.raftNode.FSM().State().MemberCount())
-		}, 10*time.Second, 100*time.Millisecond)
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// Disseminate lock for ns2 hasn't been deleted
 		assert.Equal(t, 1, testServer.disseminateLocks.ItemCount())
@@ -362,7 +362,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 		conn3.Close()
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			require.Equal(c, 0, testServer.raftNode.FSM().State().MemberCount())
-		}, 10*time.Second, 100*time.Millisecond)
+		}, 20*time.Second, 100*time.Millisecond)
 
 		// Disseminate locks have been deleted
 		require.Equal(t, 0, testServer.disseminateLocks.ItemCount())

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -363,7 +363,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 		require.NoError(t, err)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			require.Equal(c, 0, testServer.raftNode.FSM().State().MemberCount())
+			assert.Equal(c, 0, testServer.raftNode.FSM().State().MemberCount())
 		}, 50*time.Second, 100*time.Millisecond)
 
 		// Disseminate locks have been deleted

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -306,7 +306,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 2, testServer.raftNode.FSM().State().MemberCount())
-		}, 20*time.Second, 100*time.Millisecond)
+		}, 30*time.Second, 100*time.Millisecond)
 
 		// Disseminate locks have been deleted for ns1, but not ns2
 		assert.Equal(t, 1, testServer.disseminateLocks.ItemCount())
@@ -334,7 +334,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 		conn2.Close()
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Equal(c, 1, testServer.raftNode.FSM().State().MemberCount())
-		}, 20*time.Second, 100*time.Millisecond)
+		}, 30*time.Second, 100*time.Millisecond)
 
 		// Disseminate lock for ns2 hasn't been deleted
 		assert.Equal(t, 1, testServer.disseminateLocks.ItemCount())
@@ -362,7 +362,7 @@ func TestMembershipChangeWorker(t *testing.T) {
 		conn3.Close()
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			require.Equal(c, 0, testServer.raftNode.FSM().State().MemberCount())
-		}, 20*time.Second, 100*time.Millisecond)
+		}, 30*time.Second, 100*time.Millisecond)
 
 		// Disseminate locks have been deleted
 		require.Equal(t, 0, testServer.disseminateLocks.ItemCount())


### PR DESCRIPTION
Update membership test to fix unit test flakiness. Should be no diff other than indentation and wrapping the `membercount` call in the `require.EventuallyWithT`