### PR TITLE
HTTP Metrics: Add verbs back and preserve static paths

### DIFF
--- a/charts/dapr/crds/configuration.yaml
+++ b/charts/dapr/crds/configuration.yaml
@@ -262,6 +262,9 @@ spec:
                         type: array
                         items:
                           type: string
+                      excludeVerbs:
+                        description: If true (default is false) HTTP verbs (e.g., GET, POST) are excluded from the metrics.
+                        type: boolean
                     type: object
                   rules:
                     items:
@@ -315,6 +318,9 @@ spec:
                         type: array
                         items:
                           type: string
+                      excludeVerbs:
+                          description: If true (default is false) HTTP verbs (e.g., GET, POST) are excluded from the metrics.
+                          type: boolean
                     type: object
                   rules:
                     items:

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -224,6 +224,9 @@ type MetricHTTP struct {
 	// TODO: [MetricsCardinality] Change default in 1.15+
 	// +optional
 	IncreasedCardinality *bool `json:"increasedCardinality,omitempty"`
+	// If true (default is false) HTTP verbs (e.g., GET, POST) are excluded from the metrics.
+	// +optional
+	ExcludeVerbs *bool `json:"excludeVerbs,omitempty"`
 	// +optional
 	PathMatching []string `json:"pathMatching,omitempty"`
 }

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -224,11 +224,11 @@ type MetricHTTP struct {
 	// TODO: [MetricsCardinality] Change default in 1.15+
 	// +optional
 	IncreasedCardinality *bool `json:"increasedCardinality,omitempty"`
+	// +optional
+	PathMatching []string `json:"pathMatching,omitempty"`
 	// If true (default is false) HTTP verbs (e.g., GET, POST) are excluded from the metrics.
 	// +optional
 	ExcludeVerbs *bool `json:"excludeVerbs,omitempty"`
-	// +optional
-	PathMatching []string `json:"pathMatching,omitempty"`
 }
 
 // MetricsRule defines configuration options for a metric.

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -296,12 +296,6 @@ type MetricHTTP struct {
 	ExcludeVerbs         *bool    `json:"excludeVerbs,omitempty" yaml:"excludeVerbs,omitempty"`
 }
 
-// PathMatching defines configuration options for path matching.
-type PathMatching struct {
-	IngressPaths []string `json:"ingress,omitempty" yaml:"ingress,omitempty"`
-	EgressPaths  []string `json:"egress,omitempty" yaml:"egress,omitempty"`
-}
-
 // MetricsRule defines configuration options for a metric.
 type MetricsRule struct {
 	Name   string        `json:"name,omitempty"   yaml:"name,omitempty"`

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -290,10 +290,16 @@ func (m MetricSpec) GetHTTPPathMatching() []string {
 
 // MetricHTTP defines configuration for metrics for the HTTP server
 type MetricHTTP struct {
-	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
-	IncreasedCardinality *bool    `json:"increasedCardinality,omitempty" yaml:"increasedCardinality,omitempty"`
-	PathMatching         []string `json:"pathMatching,omitempty" yaml:"pathMatching,omitempty"`
-	ExcludeVerbs         *bool    `json:"excludeVerbs,omitempty" yaml:"excludeVerbs,omitempty"`
+	// If false, metrics for the HTTP server are collected with increased cardinality.
+	// The default is true in Dapr 1.13, but will be changed to false in 1.15+
+	// TODO: [MetricsCardinality] Change default in 1.15+
+	// +optional
+	IncreasedCardinality *bool `json:"increasedCardinality,omitempty" yaml:"increasedCardinality,omitempty"`
+	// +optional
+	PathMatching []string `json:"pathMatching,omitempty" yaml:"pathMatching,omitempty"`
+	// If true (default is false) HTTP verbs (e.g., GET, POST) are excluded from the metrics.
+	// +optional
+	ExcludeVerbs *bool `json:"excludeVerbs,omitempty" yaml:"excludeVerbs,omitempty"`
 }
 
 // MetricsRule defines configuration options for a metric.

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -271,6 +271,15 @@ func (m MetricSpec) GetHTTPIncreasedCardinality(log logger.Logger) bool {
 	return *m.HTTP.IncreasedCardinality
 }
 
+// GetHTTPExcludeVerbs returns true if exclude verbs is enabled for HTTP metrics
+func (m MetricSpec) GetHTTPExcludeVerbs() bool {
+	if m.HTTP == nil || m.HTTP.ExcludeVerbs == nil {
+		// The default is false
+		return false
+	}
+	return *m.HTTP.ExcludeVerbs
+}
+
 // GetHTTPPathMatching returns the path matching configuration for HTTP metrics
 func (m MetricSpec) GetHTTPPathMatching() []string {
 	if m.HTTP == nil {
@@ -284,6 +293,13 @@ type MetricHTTP struct {
 	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
 	IncreasedCardinality *bool    `json:"increasedCardinality,omitempty" yaml:"increasedCardinality,omitempty"`
 	PathMatching         []string `json:"pathMatching,omitempty" yaml:"pathMatching,omitempty"`
+	ExcludeVerbs         *bool    `json:"excludeVerbs,omitempty" yaml:"excludeVerbs,omitempty"`
+}
+
+// PathMatching defines configuration options for path matching.
+type PathMatching struct {
+	IngressPaths []string `json:"ingress,omitempty" yaml:"ingress,omitempty"`
+	EgressPaths  []string `json:"egress,omitempty" yaml:"egress,omitempty"`
 }
 
 // MetricsRule defines configuration options for a metric.

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -658,3 +658,39 @@ func TestMetricsGetHTTPPathMatching(t *testing.T) {
 		assert.Equal(t, []string{"/resource/1"}, config)
 	})
 }
+
+func TestMetricsGetHTTPExcludeVerbs(t *testing.T) {
+	t.Run("no configuration, returns false", func(t *testing.T) {
+		m := MetricSpec{
+			HTTP: nil,
+		}
+		assert.False(t, m.GetHTTPExcludeVerbs())
+	})
+
+	t.Run("nil value, returns false", func(t *testing.T) {
+		m := MetricSpec{
+			HTTP: &MetricHTTP{
+				ExcludeVerbs: nil,
+			},
+		}
+		assert.False(t, m.GetHTTPExcludeVerbs())
+	})
+
+	t.Run("config is enabled", func(t *testing.T) {
+		m := MetricSpec{
+			HTTP: &MetricHTTP{
+				ExcludeVerbs: ptr.Of(true),
+			},
+		}
+		assert.True(t, m.GetHTTPExcludeVerbs())
+	})
+
+	t.Run("config is disabled", func(t *testing.T) {
+		m := MetricSpec{
+			HTTP: &MetricHTTP{
+				ExcludeVerbs: ptr.Of(false),
+			},
+		}
+		assert.False(t, m.GetHTTPExcludeVerbs())
+	})
+}

--- a/pkg/diagnostics/http_monitoring.go
+++ b/pkg/diagnostics/http_monitoring.go
@@ -23,7 +23,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	"github.com/dapr/dapr/pkg/api/http/endpoints"
 	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/dapr/dapr/pkg/responsewriter"
 	"github.com/dapr/kit/logger"
@@ -40,6 +39,13 @@ var (
 
 	log = logger.NewLogger("dapr.runtime.diagnostics")
 )
+
+var staticPaths = map[string]bool{
+	"/dapr/config":    true,
+	"/dapr/metrics":   true,
+	"/dapr/subscribe": true,
+	"/healthz":        true,
+}
 
 var (
 	// <<10 -> KBs; <<20 -> MBs; <<30 -> GBs
@@ -126,15 +132,25 @@ func (h *httpMetrics) IsEnabled() bool {
 	return h != nil && h.enabled
 }
 
+func (h *httpMetrics) getMetricsPath(path string) string {
+	if _, ok := staticPaths[path]; ok {
+		return path
+	}
+	if matchedPath, ok := h.pathMatcher.match(path); ok {
+		return matchedPath
+	}
+	if !h.legacy {
+		return ""
+	}
+	return path
+}
+
 func (h *httpMetrics) ServerRequestCompleted(ctx context.Context, method, path, status string, reqContentSize, resContentSize int64, elapsed float64) {
 	if !h.IsEnabled() {
 		return
 	}
 
-	matchedPath, ok := h.pathMatcher.match(path)
-	if ok {
-		path = matchedPath
-	}
+	path = h.getMetricsPath(path)
 
 	if h.legacy || h.pathMatcher.enabled() {
 		stats.RecordWithTags(
@@ -152,11 +168,11 @@ func (h *httpMetrics) ServerRequestCompleted(ctx context.Context, method, path, 
 	} else {
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(h.serverRequestCount.Name(), appIDKey, h.appID, httpMethodKey, method, httpStatusCodeKey, status),
+			diagUtils.WithTags(h.serverRequestCount.Name(), appIDKey, h.appID, httpMethodKey, method, httpPathKey, path, httpStatusCodeKey, status),
 			h.serverRequestCount.M(1))
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(h.serverLatency.Name(), appIDKey, h.appID, httpMethodKey, method, httpStatusCodeKey, status),
+			diagUtils.WithTags(h.serverLatency.Name(), appIDKey, h.appID, httpMethodKey, method, httpPathKey, path, httpStatusCodeKey, status),
 			h.serverLatency.M(elapsed))
 	}
 	stats.RecordWithTags(
@@ -172,10 +188,7 @@ func (h *httpMetrics) ClientRequestStarted(ctx context.Context, method, path str
 		return
 	}
 
-	matchedPath, ok := h.pathMatcher.match(path)
-	if ok {
-		path = matchedPath
-	}
+	path = h.getMetricsPath(path)
 
 	if h.legacy || h.pathMatcher.enabled() {
 		stats.RecordWithTags(
@@ -185,7 +198,7 @@ func (h *httpMetrics) ClientRequestStarted(ctx context.Context, method, path str
 	} else {
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(h.clientSentBytes.Name(), appIDKey, h.appID),
+			diagUtils.WithTags(h.clientSentBytes.Name(), appIDKey, h.appID, httpPathKey, path, httpMethodKey, method),
 			h.clientSentBytes.M(contentSize))
 	}
 }
@@ -195,10 +208,7 @@ func (h *httpMetrics) ClientRequestCompleted(ctx context.Context, method, path, 
 		return
 	}
 
-	matchedPath, ok := h.pathMatcher.match(path)
-	if ok {
-		path = matchedPath
-	}
+	path = h.getMetricsPath(path)
 
 	if h.legacy || h.pathMatcher.enabled() {
 		stats.RecordWithTags(
@@ -212,11 +222,11 @@ func (h *httpMetrics) ClientRequestCompleted(ctx context.Context, method, path, 
 	} else {
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(h.clientCompletedCount.Name(), appIDKey, h.appID, httpStatusCodeKey, status),
+			diagUtils.WithTags(h.clientCompletedCount.Name(), appIDKey, h.appID, httpPathKey, path, httpMethodKey, method, httpStatusCodeKey, status),
 			h.clientCompletedCount.M(1))
 		stats.RecordWithTags(
 			ctx,
-			diagUtils.WithTags(h.clientRoundtripLatency.Name(), appIDKey, h.appID, httpStatusCodeKey, status),
+			diagUtils.WithTags(h.clientRoundtripLatency.Name(), appIDKey, h.appID, httpPathKey, path, httpMethodKey, method, httpStatusCodeKey, status),
 			h.clientRoundtripLatency.M(elapsed))
 	}
 	stats.RecordWithTags(
@@ -258,19 +268,8 @@ func (h *httpMetrics) Init(appID string, paths []string, legacy bool) error {
 
 	tags := []tag.Key{appIDKey}
 
-	// In legacy mode, we are aggregating based on the path too
-	var serverTags, clientTags []tag.Key
-	if h.legacy {
-		serverTags = []tag.Key{appIDKey, httpMethodKey, httpPathKey, httpStatusCodeKey}
-		clientTags = []tag.Key{appIDKey, httpMethodKey, httpPathKey, httpStatusCodeKey}
-	} else {
-		serverTags = []tag.Key{appIDKey, httpMethodKey, httpStatusCodeKey}
-		clientTags = []tag.Key{appIDKey, httpStatusCodeKey}
-		if h.pathMatcher.enabled() {
-			serverTags = append(serverTags, httpPathKey)
-			clientTags = append(clientTags, httpPathKey, httpMethodKey)
-		}
-	}
+	serverTags := []tag.Key{appIDKey, httpMethodKey, httpPathKey, httpStatusCodeKey}
+	clientTags := []tag.Key{appIDKey, httpMethodKey, httpPathKey, httpStatusCodeKey}
 
 	views := []*view.View{
 		diagUtils.NewMeasureView(h.serverRequestBytes, tags, defaultSizeDistribution),
@@ -319,19 +318,7 @@ func (h *httpMetrics) HTTPMiddleware(next http.Handler) http.Handler {
 		status := strconv.Itoa(rw.Status())
 		respSize := int64(rw.Size())
 
-		var method string
-		if h.legacy || h.pathMatcher.enabled() {
-			method = r.Method
-		} else {
-			// Check if the context contains a MethodName method
-			endpointData, _ := r.Context().Value(endpoints.EndpointCtxKey{}).(*endpoints.EndpointCtxData)
-			method = endpointData.GetEndpointName()
-			if endpointData != nil && endpointData.Group != nil && endpointData.Group.MethodName != nil {
-				method = endpointData.Group.MethodName(r)
-			}
-		}
-
 		// Record the request
-		h.ServerRequestCompleted(r.Context(), method, path, status, reqContentSize, respSize, elapsed)
+		h.ServerRequestCompleted(r.Context(), r.Method, path, status, reqContentSize, respSize, elapsed)
 	})
 }

--- a/pkg/diagnostics/http_monitoring_benchmark_test.go
+++ b/pkg/diagnostics/http_monitoring_benchmark_test.go
@@ -30,7 +30,7 @@ const (
 
 func BenchmarkHTTPMiddlewareLowCardinalityNoPathMatching(b *testing.B) {
 	testHTTP := newHTTPMetrics()
-	configHTTP := NewHTTPMonitoringConfig(nil, false, true)
+	configHTTP := NewHTTPMonitoringConfig(nil, false, false)
 	testHTTP.Init("fakeID", configHTTP)
 
 	handler := testHTTP.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +47,7 @@ func BenchmarkHTTPMiddlewareLowCardinalityNoPathMatching(b *testing.B) {
 
 func BenchmarkHTTPMiddlewareHighCardinalityNoPathMatching(b *testing.B) {
 	testHTTP := newHTTPMetrics()
-	configHTTP := NewHTTPMonitoringConfig(nil, true, true)
+	configHTTP := NewHTTPMonitoringConfig(nil, true, false)
 	testHTTP.Init("fakeID", configHTTP)
 
 	handler := testHTTP.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -66,7 +66,7 @@ func BenchmarkHTTPMiddlewareLowCardinalityWithPathMatching(b *testing.B) {
 	testHTTP := newHTTPMetrics()
 	pathMatching := []string{"/invoke/method/orders/{orderID}"}
 
-	configHTTP := NewHTTPMonitoringConfig(pathMatching, false, true)
+	configHTTP := NewHTTPMonitoringConfig(pathMatching, false, false)
 	testHTTP.Init("fakeID", configHTTP)
 
 	handler := testHTTP.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/diagnostics/http_monitoring_benchmark_test.go
+++ b/pkg/diagnostics/http_monitoring_benchmark_test.go
@@ -30,7 +30,8 @@ const (
 
 func BenchmarkHTTPMiddlewareLowCardinalityNoPathMatching(b *testing.B) {
 	testHTTP := newHTTPMetrics()
-	testHTTP.Init("fakeID", nil, false)
+	configHTTP := NewHTTPMonitoringConfig(nil, false, true)
+	testHTTP.Init("fakeID", configHTTP)
 
 	handler := testHTTP.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Millisecond)
@@ -46,7 +47,8 @@ func BenchmarkHTTPMiddlewareLowCardinalityNoPathMatching(b *testing.B) {
 
 func BenchmarkHTTPMiddlewareHighCardinalityNoPathMatching(b *testing.B) {
 	testHTTP := newHTTPMetrics()
-	testHTTP.Init("fakeID", nil, true)
+	configHTTP := NewHTTPMonitoringConfig(nil, true, true)
+	testHTTP.Init("fakeID", configHTTP)
 
 	handler := testHTTP.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Millisecond)
@@ -63,7 +65,9 @@ func BenchmarkHTTPMiddlewareHighCardinalityNoPathMatching(b *testing.B) {
 func BenchmarkHTTPMiddlewareLowCardinalityWithPathMatching(b *testing.B) {
 	testHTTP := newHTTPMetrics()
 	pathMatching := []string{"/invoke/method/orders/{orderID}"}
-	testHTTP.Init("fakeID", pathMatching, false)
+
+	configHTTP := NewHTTPMonitoringConfig(pathMatching, false, true)
+	testHTTP.Init("fakeID", configHTTP)
 
 	handler := testHTTP.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Millisecond)
@@ -80,7 +84,7 @@ func BenchmarkHTTPMiddlewareLowCardinalityWithPathMatching(b *testing.B) {
 func BenchmarkHTTPMiddlewareHighCardinalityWithPathMatching(b *testing.B) {
 	testHTTP := newHTTPMetrics()
 	pathMatching := []string{"/invoke/method/orders/{orderID}"}
-	testHTTP.Init("fakeID", pathMatching, true)
+	testHTTP.Init("fakeID", HTTPMonitoringConfig{pathMatching: pathMatching, legacy: true})
 
 	handler := testHTTP.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Millisecond)

--- a/pkg/diagnostics/http_monitoring_test.go
+++ b/pkg/diagnostics/http_monitoring_test.go
@@ -37,8 +37,10 @@ func TestHTTPMiddleware(t *testing.T) {
 	assert.Len(t, rows, 1)
 	assert.Equal(t, "app_id", rows[0].Tags[0].Key.Name())
 	assert.Equal(t, "fakeID", rows[0].Tags[0].Value)
-	assert.Equal(t, "status", rows[0].Tags[1].Key.Name())
-	assert.Equal(t, "200", rows[0].Tags[1].Value)
+	assert.Equal(t, "method", rows[0].Tags[1].Key.Name())
+	assert.Equal(t, "POST", rows[0].Tags[1].Value)
+	assert.Equal(t, "status", rows[0].Tags[2].Key.Name())
+	assert.Equal(t, "200", rows[0].Tags[2].Value)
 
 	rows, err = view.RetrieveData("http/server/request_bytes")
 	require.NoError(t, err)

--- a/pkg/diagnostics/metrics.go
+++ b/pkg/diagnostics/metrics.go
@@ -45,7 +45,7 @@ var (
 )
 
 // InitMetrics initializes metrics.
-func InitMetrics(appID, namespace string, rules []config.MetricsRule, pathMatching []string, legacyMetricsHTTPMetrics bool) error {
+func InitMetrics(appID, namespace string, rules []config.MetricsRule, httpConfig HTTPMonitoringConfig) error {
 	if err := DefaultMonitoring.Init(appID); err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func InitMetrics(appID, namespace string, rules []config.MetricsRule, pathMatchi
 		return err
 	}
 
-	if err := DefaultHTTPMonitoring.Init(appID, pathMatching, legacyMetricsHTTPMetrics); err != nil {
+	if err := DefaultHTTPMonitoring.Init(appID, httpConfig); err != nil {
 		return err
 	}
 

--- a/pkg/diagnostics/metrics_regex_test.go
+++ b/pkg/diagnostics/metrics_regex_test.go
@@ -17,6 +17,7 @@ func TestRegexRulesSingle(t *testing.T) {
 	const statName = "test_stat_regex"
 	methodKey := tag.MustNewKey("method")
 	testStat := stats.Int64(statName, "Stat used in unit test", stats.UnitDimensionless)
+	httpConfig := NewHTTPMonitoringConfig(nil, false, true)
 
 	InitMetrics("testAppId2", "", []config.MetricsRule{
 		{
@@ -31,7 +32,7 @@ func TestRegexRulesSingle(t *testing.T) {
 				},
 			},
 		},
-	}, nil, false)
+	}, httpConfig)
 
 	t.Run("single regex rule applied", func(t *testing.T) {
 		view.Register(

--- a/pkg/diagnostics/resiliency_monitoring_test.go
+++ b/pkg/diagnostics/resiliency_monitoring_test.go
@@ -185,7 +185,8 @@ func TestResiliencyCountMonitoring(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cleanupRegisteredViews()
-			require.NoError(t, diag.InitMetrics(test.appID, "fakeRuntimeNamespace", nil, nil, false))
+			config := diag.NewHTTPMonitoringConfig(nil, false, false)
+			require.NoError(t, diag.InitMetrics(test.appID, "fakeRuntimeNamespace", nil, config))
 			test.unitFn()
 			rows, err := view.RetrieveData(resiliencyCountViewName)
 			if test.wantErr {
@@ -271,7 +272,8 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cleanupRegisteredViews()
-			require.NoError(t, diag.InitMetrics(testAppID, "fakeRuntimeNamespace", nil, nil, false))
+			config := diag.NewHTTPMonitoringConfig(nil, false, false)
+			require.NoError(t, diag.InitMetrics(testAppID, "fakeRuntimeNamespace", nil, config))
 			test.unitFn()
 			rows, err := view.RetrieveData(resiliencyCountViewName)
 			require.NoError(t, err)
@@ -439,7 +441,8 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cleanupRegisteredViews()
-			require.NoError(t, diag.InitMetrics(testAppID, "fakeRuntimeNamespace", nil, nil, false))
+			config := diag.NewHTTPMonitoringConfig(nil, false, false)
+			require.NoError(t, diag.InitMetrics(testAppID, "fakeRuntimeNamespace", nil, config))
 			test.unitFn()
 			rows, err := view.RetrieveData(resiliencyActivationViewName)
 			require.NoError(t, err)
@@ -496,7 +499,8 @@ func createDefaultTestResiliency(resiliencyName string, resiliencyNamespace stri
 func TestResiliencyLoadedMonitoring(t *testing.T) {
 	t.Run(resiliencyLoadedViewName, func(t *testing.T) {
 		cleanupRegisteredViews()
-		require.NoError(t, diag.InitMetrics(testAppID, "fakeRuntimeNamespace", nil, nil, false))
+		config := diag.NewHTTPMonitoringConfig(nil, false, false)
+		require.NoError(t, diag.InitMetrics(testAppID, "fakeRuntimeNamespace", nil, config))
 		_ = createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStoreName")
 
 		rows, err := view.RetrieveData(resiliencyLoadedViewName)

--- a/pkg/diagnostics/utils/metrics_utils.go
+++ b/pkg/diagnostics/utils/metrics_utils.go
@@ -27,6 +27,32 @@ import (
 
 var metricsRules map[string][]regexPair
 
+var StaticPaths = map[string]bool{
+	"/dapr/config":    true,
+	"/dapr/metrics":   true,
+	"/dapr/subscribe": true,
+	"/healthz":        true,
+}
+
+var ValidHTTPMethods = map[string]bool{
+	"GET":     true,
+	"PUT":     true,
+	"POST":    true,
+	"PATCH":   true,
+	"DELETE":  true,
+	"HEAD":    true,
+	"OPTIONS": true,
+	"CONNECT": true,
+	"TRACE":   true,
+}
+
+func GetMetricsMethod(method string) string {
+	if _, ok := ValidHTTPMethods[method]; !ok {
+		return "UNKNOWN"
+	}
+	return method
+}
+
 type regexPair struct {
 	regex   *regexp.Regexp
 	replace string

--- a/pkg/diagnostics/utils/metrics_utils.go
+++ b/pkg/diagnostics/utils/metrics_utils.go
@@ -34,7 +34,7 @@ var StaticPaths = map[string]bool{
 	"/healthz":        true,
 }
 
-var ValidHTTPMethods = map[string]bool{
+var ValidHTTPVerbs = map[string]bool{
 	"GET":     true,
 	"PUT":     true,
 	"POST":    true,
@@ -44,13 +44,6 @@ var ValidHTTPMethods = map[string]bool{
 	"OPTIONS": true,
 	"CONNECT": true,
 	"TRACE":   true,
-}
-
-func GetMetricsMethod(method string) string {
-	if _, ok := ValidHTTPMethods[method]; !ok {
-		return "UNKNOWN"
-	}
-	return method
 }
 
 type regexPair struct {

--- a/pkg/diagnostics/utils/metrics_utils_test.go
+++ b/pkg/diagnostics/utils/metrics_utils_test.go
@@ -102,3 +102,16 @@ func TestCreateRulesMap(t *testing.T) {
 		assert.NotNil(t, metricsRules["testlabel"][0].regex)
 	})
 }
+
+func TestGetMetricsMethod(t *testing.T) {
+	assert.Equal(t, "GET", GetMetricsMethod("GET"))
+	assert.Equal(t, "POST", GetMetricsMethod("POST"))
+	assert.Equal(t, "PUT", GetMetricsMethod("PUT"))
+	assert.Equal(t, "DELETE", GetMetricsMethod("DELETE"))
+	assert.Equal(t, "PATCH", GetMetricsMethod("PATCH"))
+	assert.Equal(t, "HEAD", GetMetricsMethod("HEAD"))
+	assert.Equal(t, "OPTIONS", GetMetricsMethod("OPTIONS"))
+	assert.Equal(t, "CONNECT", GetMetricsMethod("CONNECT"))
+	assert.Equal(t, "TRACE", GetMetricsMethod("TRACE"))
+	assert.Equal(t, "UNKNOWN", GetMetricsMethod("INVALID"))
+}

--- a/pkg/diagnostics/utils/metrics_utils_test.go
+++ b/pkg/diagnostics/utils/metrics_utils_test.go
@@ -102,16 +102,3 @@ func TestCreateRulesMap(t *testing.T) {
 		assert.NotNil(t, metricsRules["testlabel"][0].regex)
 	})
 }
-
-func TestGetMetricsMethod(t *testing.T) {
-	assert.Equal(t, "GET", GetMetricsMethod("GET"))
-	assert.Equal(t, "POST", GetMetricsMethod("POST"))
-	assert.Equal(t, "PUT", GetMetricsMethod("PUT"))
-	assert.Equal(t, "DELETE", GetMetricsMethod("DELETE"))
-	assert.Equal(t, "PATCH", GetMetricsMethod("PATCH"))
-	assert.Equal(t, "HEAD", GetMetricsMethod("HEAD"))
-	assert.Equal(t, "OPTIONS", GetMetricsMethod("OPTIONS"))
-	assert.Equal(t, "CONNECT", GetMetricsMethod("CONNECT"))
-	assert.Equal(t, "TRACE", GetMetricsMethod("TRACE"))
-	assert.Equal(t, "UNKNOWN", GetMetricsMethod("INVALID"))
-}

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -230,13 +230,17 @@ func FromConfig(ctx context.Context, cfg *Config) (*DaprRuntime, error) {
 
 	// Initialize metrics only if MetricSpec is enabled.
 	metricsSpec := globalConfig.GetMetricsSpec()
+	httpConfig := diag.NewHTTPMonitoringConfig(
+		metricsSpec.GetHTTPPathMatching(),
+		metricsSpec.GetHTTPIncreasedCardinality(log),
+		metricsSpec.GetHTTPExcludeVerbs(),
+	)
 	if metricsSpec.GetEnabled() {
 		err = diag.InitMetrics(
 			intc.id,
 			namespace,
 			metricsSpec.Rules,
-			metricsSpec.GetHTTPPathMatching(),
-			metricsSpec.GetHTTPIncreasedCardinality(log),
+			httpConfig,
 		)
 		if err != nil {
 			log.Errorf(rterrors.NewInit(rterrors.InitFailure, "metrics", err).Error())

--- a/tests/e2e/metrics/metrics_test.go
+++ b/tests/e2e/metrics/metrics_test.go
@@ -201,7 +201,7 @@ func findHTTPMetricFromPrometheus(t *testing.T, app string, res *http.Response) 
 
 	// This test will loop through each of the metrics and look for a specifc
 	// metric `dapr_http_server_request_count`.
-	var foundHealthz, foundInvocation bool
+	var foundGet, foundPost bool
 	for {
 		mf := &io_prometheus_client.MetricFamily{}
 		err := decoder.Decode(mf)
@@ -231,10 +231,10 @@ func findHTTPMetricFromPrometheus(t *testing.T, app string, res *http.Response) 
 					case "method":
 						if count.GetValue() > 0 {
 							switch val {
-							case "Healthz":
-								foundHealthz = true
-							case "InvokeService/httpmetrics":
-								foundInvocation = true
+							case "GET":
+								foundGet = true
+							case "POST":
+								foundPost = true
 							}
 						}
 					}
@@ -244,8 +244,8 @@ func findHTTPMetricFromPrometheus(t *testing.T, app string, res *http.Response) 
 	}
 
 	if foundMetric {
-		require.True(t, foundHealthz)
-		require.True(t, foundInvocation)
+		require.True(t, foundGet)
+		require.True(t, foundPost)
 	}
 
 	return foundMetric

--- a/tests/integration/suite/daprd/metrics/http/cardinality/low.go
+++ b/tests/integration/suite/daprd/metrics/http/cardinality/low.go
@@ -22,11 +22,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -85,7 +84,8 @@ func (l *low) Run(t *testing.T, ctx context.Context) {
 	t.Run("service invocation", func(t *testing.T) {
 		l.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/hi")
 		metrics := l.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:InvokeService/myapp|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_client_completed_count|app_id:myapp|method:GET|path:/dapr/config|status:200"]))
 		assert.NotContains(t, metrics, "dapr_http_server_response_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/hi|status:200")
 		assert.NotContains(t, metrics, "dapr_http_server_response_count|app_id:myapp|method:GET|path:/v1.0/healthz|status:204 1.000000")
 	})
@@ -95,14 +95,14 @@ func (l *low) Run(t *testing.T, ctx context.Context) {
 		l.daprd.HTTPPost2xx(t, ctx, "/v1.0/state/mystore", strings.NewReader(body), "content-type", "application/json")
 		l.daprd.HTTPGet2xx(t, ctx, "/v1.0/state/mystore/myvalue")
 		metrics := l.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:SaveState|status:204"]))
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GetState|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:|status:204"]))
+		assert.Equal(t, 2, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:|status:200"]))
 	})
 
 	t.Run("actor invocation", func(t *testing.T) {
 		l.daprd.HTTPPost2xx(t, ctx, "/v1.0/actors/myactortype/myactorid/method/foo", nil, "content-type", "application/json")
 		metrics := l.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:InvokeActor/myactortype|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:|status:200"]))
 		assert.NotContains(t, metrics, "method:InvokeActor/myactortype.")
 	})
 }

--- a/tests/integration/suite/daprd/metrics/http/excludeverbs/default.go
+++ b/tests/integration/suite/daprd/metrics/http/excludeverbs/default.go
@@ -47,7 +47,6 @@ func (h *defaultExcludeVerbs) Setup(t *testing.T) []framework.Option {
 		daprd.WithAppPort(app.Port()),
 		daprd.WithAppProtocol("http"),
 		daprd.WithAppID("myapp"),
-		daprd.WithInMemoryStateStore("mystore"),
 		daprd.WithConfigManifests(t, `
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
@@ -70,6 +69,6 @@ func (h *defaultExcludeVerbs) Run(t *testing.T, ctx context.Context) {
 	t.Run("service invocation - default", func(t *testing.T) {
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/123")
 		metrics := h.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/123|status:200"]))
 	})
 }

--- a/tests/integration/suite/daprd/metrics/http/excludeverbs/default.go
+++ b/tests/integration/suite/daprd/metrics/http/excludeverbs/default.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package excludeverbs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(defaultExcludeVerbs))
+}
+
+// defaultExcludeVerbs tests daprd metrics for the HTTP server configured with defaultExcludeVerbs option
+type defaultExcludeVerbs struct {
+	daprd *daprd.Daprd
+}
+
+func (h *defaultExcludeVerbs) Setup(t *testing.T) []framework.Option {
+	app := app.New(t,
+		app.WithHandlerFunc("/orders/{orderID}", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "OK")
+		}),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppID("myapp"),
+		daprd.WithInMemoryStateStore("mystore"),
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: excludeverbs
+spec:
+  metrics:
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, h.daprd),
+	}
+}
+
+func (h *defaultExcludeVerbs) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	t.Run("service invocation - default", func(t *testing.T) {
+		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/123")
+		metrics := h.daprd.Metrics(t, ctx)
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:|status:200"]))
+	})
+}

--- a/tests/integration/suite/daprd/metrics/http/excludeverbs/excludeverbs.go
+++ b/tests/integration/suite/daprd/metrics/http/excludeverbs/excludeverbs.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package excludeverbs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(excludeVerbs))
+}
+
+// excludeVerbs tests daprd metrics for the HTTP server configured with excludeVerbs option
+type excludeVerbs struct {
+	daprd *daprd.Daprd
+}
+
+func (h *excludeVerbs) Setup(t *testing.T) []framework.Option {
+	app := app.New(t,
+		app.WithHandlerFunc("/orders/{orderID}", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "OK")
+		}),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppID("myapp"),
+		daprd.WithInMemoryStateStore("mystore"),
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: excludeverbs
+spec:
+  metrics:
+    enabled: true
+    http:
+      excludeVerbs: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, h.daprd),
+	}
+}
+
+func (h *excludeVerbs) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	t.Run("service invocation - exclude http verbs", func(t *testing.T) {
+		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/123")
+		metrics := h.daprd.Metrics(t, ctx)
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:|path:|status:200"]))
+	})
+}

--- a/tests/integration/suite/daprd/metrics/http/excludeverbs/excludeverbs.go
+++ b/tests/integration/suite/daprd/metrics/http/excludeverbs/excludeverbs.go
@@ -72,6 +72,6 @@ func (h *excludeVerbs) Run(t *testing.T, ctx context.Context) {
 	t.Run("service invocation - exclude http verbs", func(t *testing.T) {
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/123")
 		metrics := h.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:|path:|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:|path:/v1.0/invoke/myapp/method/orders/123|status:200"]))
 	})
 }

--- a/tests/integration/suite/daprd/metrics/http/http.go
+++ b/tests/integration/suite/daprd/metrics/http/http.go
@@ -15,5 +15,6 @@ package http
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metrics/http/cardinality"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metrics/http/excludeverbs"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metrics/http/pathmatching"
 )


### PR DESCRIPTION
# Description

This PR addresses a part of the discussion initiated in issue [#7719](https://github.com/dapr/dapr/issues/7719).

Currently, in low cardinality, Dapr metrics perform a gRPC-like conversion on the method label. Since Dapr is moving away from this conversion (as discussed [here](https://github.com/dapr/dapr/issues/7719#issuecomment-2130730650)), we propose adding back the HTTP method to the metrics (GET, POST, PUT, etc.).

The new config option `excludeVerbs` allows users to configure whether HTTP verbs are added or not to the metrics. The default for this option is false, by default these should be included, that's why I decided to call the config ExcludeVerbs instead of IncludeVerbs, this way it's more explicit the act of excluding verbs from the metrics.

```
apiVersion: dapr.io/v1alpha1
kind: Configuration
metadata:
  name: excludeverbs
spec:
  metrics:
    enabled: true
    http:
      excludeVerbs: true
```

This change addresses one of the current issues with Dapr HTTP metrics: all HTTP calls are grouped into the same bucket. For instance, if my app has GET, POST, and PUT methods on the same resource, these are all exposed as InvokeService/myapp-id, making it difficult to differentiate between them.

```
OLD - 3 HTTP calls to GET/POST/PUT on the same resource would end all in the same bucket: 
dapr_http_server_request_count{app_id="my-service",method="InvokeService/my-service",status="200",le="100"} 3

NEW - 3 HTTP calls to GET/POST/PUT on the same resource: 
dapr_http_server_request_count{app_id="my-service",method="GET", path="", status="200",le="100"} 1
dapr_http_server_request_count{app_id="my-service",method="PUT", path="", status="200",le="100"} 1
dapr_http_server_request_count{app_id="my-service",method="POST", path="", status="200",le="100"} 1

NEW - 3 HTTP calls to GET/POST/PUT on the same resource with ExcludeVerbs == true: 
dapr_http_server_request_count{app_id="my-service",method="", path="", status="200",le="100"} 3
```
With this update, we will reintroduce the method labels, allowing us to distinguish between different HTTP methods in the metrics while maintaining constrained cardinality in paths. The path keys are also reintroduced as empty strings. Although this solution is not perfect (as it does not distinguish between different paths), it represents a more natural iteration towards HTTP protocol metrics. Users can further refine this with path matching, as proposed [here](https://github.com/dapr/proposals/pull/58).

Additionally, this PR preserves well-known dapr paths, I identified this initial list of static dapr paths:
```
"/dapr/config"
"/dapr/metrics"
"/dapr/subscribe"
"/healthz":    
```


## Issue reference

https://github.com/dapr/dapr/issues/7719

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
