### PR TITLE
Revert "Change default cardinality to low for metrics (#7522)"

### DIFF
--- a/charts/dapr/crds/configuration.yaml
+++ b/charts/dapr/crds/configuration.yaml
@@ -253,8 +253,9 @@ spec:
                       the HTTP server
                     properties:
                       increasedCardinality:
-                        description: |-
-                          If false (the default), metrics for the HTTP server are collected with increased cardinality.
+                        description: 'If true, metrics for the HTTP server are collected
+                          with increased cardinality. The default is true in Dapr 1.13,
+                          but will be changed to false in 1.15+'
                         type: boolean
                       pathMatching:
                         description: PathMatching defines the path matching configuration for HTTP server metrics.

--- a/pkg/api/http/actors.go
+++ b/pkg/api/http/actors.go
@@ -76,7 +76,7 @@ func actorInvocationMethodNameFn(r *http.Request) string {
 
 func (a *api) constructActorEndpoints() []endpoints.Endpoint {
 	methodNameFn := actorInvocationMethodNameWithIDFn
-	if a.metricSpec != nil && !a.metricSpec.GetHTTPIncreasedCardinality() {
+	if a.metricSpec != nil && !a.metricSpec.GetHTTPIncreasedCardinality(log) {
 		methodNameFn = actorInvocationMethodNameFn
 	}
 	return []endpoints.Endpoint{

--- a/pkg/apis/configuration/v1alpha1/types.go
+++ b/pkg/apis/configuration/v1alpha1/types.go
@@ -219,7 +219,9 @@ type MetricSpec struct {
 
 // MetricHTTP defines configuration for metrics for the HTTP server
 type MetricHTTP struct {
-	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
+	// If false, metrics for the HTTP server are collected with increased cardinality.
+	// The default is true in Dapr 1.13, but will be changed to false in 1.15+
+	// TODO: [MetricsCardinality] Change default in 1.15+
 	// +optional
 	IncreasedCardinality *bool `json:"increasedCardinality,omitempty"`
 	// +optional

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -32,6 +32,7 @@ import (
 	env "github.com/dapr/dapr/pkg/config/env"
 	operatorv1pb "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/dapr/dapr/utils"
+	"github.com/dapr/kit/logger"
 	"github.com/dapr/kit/ptr"
 )
 
@@ -260,10 +261,12 @@ func (m MetricSpec) GetEnabled() bool {
 }
 
 // GetHTTPIncreasedCardinality returns true if increased cardinality is enabled for HTTP metrics
-func (m MetricSpec) GetHTTPIncreasedCardinality() bool {
+func (m MetricSpec) GetHTTPIncreasedCardinality(log logger.Logger) bool {
 	if m.HTTP == nil || m.HTTP.IncreasedCardinality == nil {
-		// The default is false
-		return false
+		// The default is true in Dapr 1.13, but will be changed to false in 1.15+
+		// TODO: [MetricsCardinality] Change default in 1.15+
+		log.Warn("The default value for 'spec.metric.http.increasedCardinality' will change to 'false' in Dapr 1.15 or later")
+		return true
 	}
 	return *m.HTTP.IncreasedCardinality
 }
@@ -278,7 +281,9 @@ func (m MetricSpec) GetHTTPPathMatching() *PathMatching {
 
 // MetricHTTP defines configuration for metrics for the HTTP server
 type MetricHTTP struct {
-	// If false (the default), metrics for the HTTP server are collected with increased cardinality.
+	// If false, metrics for the HTTP server are collected with increased cardinality.
+	// The default is true in Dapr 1.13, but will be changed to false in 1.14+
+	// TODO: [MetricsCardinality] Change default in 1.15+
 	IncreasedCardinality *bool         `json:"increasedCardinality,omitempty" yaml:"increasedCardinality,omitempty"`
 	PathMatching         *PathMatching `json:"pathMatching,omitempty" yaml:"pathMatching,omitempty"`
 }

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"reflect"
 	"sort"
@@ -25,6 +26,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/dapr/dapr/pkg/buildinfo"
+	"github.com/dapr/kit/logger"
 	"github.com/dapr/kit/ptr"
 )
 
@@ -591,20 +593,23 @@ func TestSortMetrics(t *testing.T) {
 }
 
 func TestMetricsGetHTTPIncreasedCardinality(t *testing.T) {
-	t.Run("no http configuration, returns false", func(t *testing.T) {
+	log := logger.NewLogger("test")
+	log.SetOutput(io.Discard)
+
+	t.Run("no http configuration, returns true", func(t *testing.T) {
 		m := MetricSpec{
 			HTTP: nil,
 		}
-		assert.False(t, m.GetHTTPIncreasedCardinality())
+		assert.True(t, m.GetHTTPIncreasedCardinality(log))
 	})
 
-	t.Run("nil value, returns false", func(t *testing.T) {
+	t.Run("nil value, returns true", func(t *testing.T) {
 		m := MetricSpec{
 			HTTP: &MetricHTTP{
 				IncreasedCardinality: nil,
 			},
 		}
-		assert.False(t, m.GetHTTPIncreasedCardinality())
+		assert.True(t, m.GetHTTPIncreasedCardinality(log))
 	})
 
 	t.Run("value is set to true", func(t *testing.T) {
@@ -613,7 +618,7 @@ func TestMetricsGetHTTPIncreasedCardinality(t *testing.T) {
 				IncreasedCardinality: ptr.Of(true),
 			},
 		}
-		assert.True(t, m.GetHTTPIncreasedCardinality())
+		assert.True(t, m.GetHTTPIncreasedCardinality(log))
 	})
 
 	t.Run("value is set to false", func(t *testing.T) {
@@ -622,7 +627,7 @@ func TestMetricsGetHTTPIncreasedCardinality(t *testing.T) {
 				IncreasedCardinality: ptr.Of(false),
 			},
 		}
-		assert.False(t, m.GetHTTPIncreasedCardinality())
+		assert.False(t, m.GetHTTPIncreasedCardinality(log))
 	})
 }
 

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -236,7 +236,7 @@ func FromConfig(ctx context.Context, cfg *Config) (*DaprRuntime, error) {
 			namespace,
 			metricsSpec.Rules,
 			metricsSpec.GetHTTPPathMatching(),
-			metricsSpec.GetHTTPIncreasedCardinality(),
+			metricsSpec.GetHTTPIncreasedCardinality(log),
 		)
 		if err != nil {
 			log.Errorf(rterrors.NewInit(rterrors.InitFailure, "metrics", err).Error())

--- a/tests/integration/suite/daprd/metrics/http/basic.go
+++ b/tests/integration/suite/daprd/metrics/http/basic.go
@@ -62,7 +62,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	t.Run("service invocation", func(t *testing.T) {
 		b.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/hi")
 		metrics := b.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:InvokeService/myapp|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/hi|status:200"]))
 	})
 
 	t.Run("state stores", func(t *testing.T) {
@@ -72,7 +72,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		b.daprd.HTTPGet2xx(t, ctx, "/v1.0/state/mystore/myvalue")
 
 		metrics := b.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:SaveState|status:204"]))
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GetState|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:/v1.0/state/mystore|status:204"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/state/mystore|status:200"]))
 	})
 }

--- a/tests/integration/suite/daprd/metrics/http/pathmatching/default.go
+++ b/tests/integration/suite/daprd/metrics/http/pathmatching/default.go
@@ -70,6 +70,6 @@ func (h *defaultCardinality) Run(t *testing.T, ctx context.Context) {
 	t.Run("service invocation - default", func(t *testing.T) {
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/123")
 		metrics := h.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:InvokeService/myapp|status:200"]))
+		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/123|status:200"]))
 	})
 }


### PR DESCRIPTION
# Description

This reverts commit c3baea50a19e8e00793f5d79929edce45fc4c5e2.

Proposal to postpone decision to make low cardinality default, done in https://github.com/dapr/dapr/pull/7522

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
