### PR TITLE
fix: image registry used for perf app

### DIFF
--- a/tests/apps/perf/actor-activation-locker/Dockerfile
+++ b/tests/apps/perf/actor-activation-locker/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go get -d -v
 RUN go build -o app .
 
-FROM ggcr.io/distroless/base-nossl:nonroot
+FROM gcr.io/distroless/base-nossl:nonroot
 WORKDIR /
 COPY --from=build_env /app/app /
 CMD ["/app"]


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
Original change - #7830

Fixes a typo in the registry: `ggcr.io` -> `gcr.io`

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
