### PR TITLE
New default values for raft snapshots in the placement service

### DIFF
--- a/pkg/placement/raft/server.go
+++ b/pkg/placement/raft/server.go
@@ -240,9 +240,9 @@ func (s *Server) StartRaft(ctx context.Context, sec security.Handler, config *ra
 				CommitTimeout:      100 * time.Millisecond,
 				MaxAppendEntries:   64,
 				ShutdownOnRemove:   true,
-				TrailingLogs:       500,
-				SnapshotInterval:   60 * time.Second,
-				SnapshotThreshold:  1000,
+				TrailingLogs:       1000,
+				SnapshotInterval:   30 * time.Second,
+				SnapshotThreshold:  2000,
 				LeaderLeaseTimeout: 2 * time.Second,
 			}
 		}

--- a/pkg/placement/raft/server.go
+++ b/pkg/placement/raft/server.go
@@ -227,9 +227,9 @@ func (s *Server) StartRaft(ctx context.Context, sec security.Handler, config *ra
 				CommitTimeout:      5 * time.Millisecond,
 				MaxAppendEntries:   64,
 				ShutdownOnRemove:   true,
-				TrailingLogs:       10240,
-				SnapshotInterval:   120 * time.Second,
-				SnapshotThreshold:  8192,
+				TrailingLogs:       500,
+				SnapshotInterval:   60 * time.Second,
+				SnapshotThreshold:  1000,
 				LeaderLeaseTimeout: 5 * time.Millisecond,
 			}
 		} else {
@@ -240,9 +240,9 @@ func (s *Server) StartRaft(ctx context.Context, sec security.Handler, config *ra
 				CommitTimeout:      100 * time.Millisecond,
 				MaxAppendEntries:   64,
 				ShutdownOnRemove:   true,
-				TrailingLogs:       10240,
-				SnapshotInterval:   120 * time.Second,
-				SnapshotThreshold:  8192,
+				TrailingLogs:       500,
+				SnapshotInterval:   60 * time.Second,
+				SnapshotThreshold:  1000,
 				LeaderLeaseTimeout: 2 * time.Second,
 			}
 		}


### PR DESCRIPTION
# Description

The Dapr placement service uses the HashiCorp Raft library ([github.com/hashicorp/raft](https://github.com/hashicorp/raft)), integrated with raft-boltdb (https://github.com/hashicorp/raft-boltdb), to manage distributed consensus. 

When the `--raft-logstore-path` flag is set, stable store information, as well as the raft logs, are written to a file saved on disk. 

Raft logs are produced in the following events:
- An actor hosting sidecar joins or leaves the cluster
- An application changes the actor types it hosts
- A new workflow is registered or deleted (this is a specific case of the point above because two new actor types are created)

As the number of these events increases, the number of logs increases as well and the file size grows. Raft uses snapshots to compact the log and prevent it from growing indefinitely. Snapshots capture the entire state of the system at a specific point in time. Once a snapshot is taken, log entries that are covered by the snapshot can be discarded.
The on-disk log store implementation [raft-boltdb](github.com/hashicorp/raft-boltdb) that the raft library uses has a known issue where the discarded logs don't release the memory back to the operating system, but the library reuses the memory, so we can't allow the file to grow too much, otherwise, we run into issues with disk space.

I ran some benchmarks and found the following numbers:
- For sidecars with an average of 1000 actor types we use around 23KB per log
- For sidecars with an average of 5000 actor types we use around 72KB per log
- For sidecars with an average of 10000 actor types we use around 150KB per log

As an example, a quick calculation for the last case of 10K actor types, with the current number of logs we keep on disk (10240) would result in a file size of around 1.5GB, which even after snapshotting would never get released to the operating system. 

Based on these numbers and the fact that snapshotting will not block the raft db operation I propose we update the default values to: 
```
TrailingLogs:       500,
SnapshotInterval:   60 * time.Second,
SnapshotThreshold:  1000,
```