### PR TITLE
fix the log line to print the val

### DIFF
--- a/pkg/runtime/hotreload/reconciler/subscriptions.go
+++ b/pkg/runtime/hotreload/reconciler/subscriptions.go
@@ -36,7 +36,7 @@ func (s *subscriptions) update(ctx context.Context, sub subapi.Subscription) {
 	oldSub, exists := s.store.GetDeclarativeSubscription(sub.Name)
 
 	if exists {
-		log.Infof("Closing existing Subscription to reload: %s", oldSub.Name)
+		log.Infof("Closing existing Subscription to reload: %s", *oldSub.Name)
 		if err := s.proc.CloseSubscription(ctx, oldSub.Comp); err != nil {
 			log.Errorf("Failed to close existing Subscription: %s", err)
 			return


### PR DESCRIPTION
tiny PR to fix this log line to output the val. [Noticed it printing wrong in this flaky int test](https://github.com/dapr/dapr/actions/runs/9652295046/job/26622390332?pr=7768#step:5:3843) -> search for the string `Closing existing Subscription to reload` and you'll see it not printing properly