### PR TITLE
Fix lint for the release - reverts lint optimization

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -41,7 +41,7 @@ jobs:
         target_os: ["linux"]
         target_arch: ["amd64"]
     env:
-      GOLANGCILINT_VER: "v1.59.1"
+      GOLANGCILINT_VER: "v1.55.2"
       PROTOC_VERSION: "24.4"
       GOOS: "${{ matrix.target_os }}"
       GOARCH: "${{ matrix.target_arch }}"
@@ -76,12 +76,11 @@ jobs:
       - name: Check for disallowed changes in go.mod
         run: node ./.github/scripts/check_go_mod.mjs
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.0.1
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: ${{ env.GOLANGCILINT_VER }}
           skip-cache: true
-          only-new-issues: true
-          args: --build-tags allcomponents --timeout 15m
+          args: --build-tags allcomponents
       - name: Run go mod tidy check diff
         run: make modtidy check-diff
       - name: Check for retracted dependencies

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ run:
   # default value is empty list, but next dirs are always skipped independently
   # from this option's value:
   # third_party$, testdata$, examples$, Godeps$, builtin$
-  issues.exclude-dirs:
+  skip-dirs:
     - ^pkg.*client.*clientset.*versioned.*
     - ^pkg.*client.*informers.*externalversions.*
     - ^pkg.*proto.*
@@ -33,11 +33,11 @@ run:
   # skip-files:
   #  - ".*\\.my\\.go$"
   #  - lib/bad.go
-
+  
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-  formats: tab
+  format: tab
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -71,6 +71,9 @@ linters-settings:
     statements: 40
 
   govet:
+    # report about shadowed variables
+    check-shadowing: true
+
     # settings per analyzer
     settings:
       printf: # analyzer name, run `go tool vet help` to see all analyzers
@@ -83,7 +86,6 @@ linters-settings:
     # enable or disable analyzers by name
     enable:
       - atomicalign
-      - shadow
     enable-all: false
     disable:
       - shadow
@@ -107,6 +109,9 @@ linters-settings:
   gocognit:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
   dupl:
     # tokens count to trigger issue, 150 by default
     threshold: 100
@@ -119,10 +124,6 @@ linters-settings:
     rules:
       master:
         deny:
-        - pkg: "github.com/golang-jwt/jwt/v5"
-          desc: "must use github.com/lestrrat-go/jwx/v2/jwt"
-        - pkg: "github.com/golang-jwt/jwt/v4"
-          desc: "must use github.com/lestrrat-go/jwx/v2/jwt"
         - pkg: "github.com/Sirupsen/logrus"
           desc: "must use github.com/dapr/kit/logger"
         - pkg: "github.com/agrea/ptr"
@@ -272,7 +273,9 @@ linters:
   enable-all: true
   disable:
     # TODO Enforce the below linters later
+    - nosnakecase
     - musttag
+    - dupl
     - errcheck
     - funlen
     - gochecknoglobals
@@ -280,24 +283,28 @@ linters:
     - gocyclo
     - gocognit
     - godox
+    - interfacer
     - lll
+    - maligned
+    - scopelint
     - unparam
     - wsl
-    - mnd
     - gomnd
     - testpackage
-    - err113
+    - goerr113
     - nestif
     - nlreturn
     - exhaustive
     - exhaustruct
     - noctx
     - gci
+    - golint
     - tparallel
     - paralleltest
     - wrapcheck
     - tagliatelle
     - ireturn
+    - exhaustivestruct
     - errchkjson
     - contextcheck
     - gomoddirectives
@@ -306,6 +313,7 @@ linters:
     - varnamelen
     - errorlint
     - forcetypeassert
+    - ifshort
     - maintidx
     - nilnil
     - predeclared
@@ -318,5 +326,8 @@ linters:
     - asasalint
     - rowserrcheck
     - sqlclosecheck
+    - structcheck
+    - varcheck
+    - deadcode
     - inamedparam
     - tagalign

--- a/Makefile
+++ b/Makefile
@@ -391,12 +391,7 @@ test-integration-parallel: test-deps
 # You can download version v1.55.2 at https://github.com/golangci/golangci-lint/releases/tag/v1.55.2
 .PHONY: lint
 lint: check-linter
-ifdef LINT_BASE
-	@echo "LINT_BASE is set to "$(LINT_BASE)". Linter will only check diff."
-	$(GOLANGCI_LINT) run --build-tags=$(GOLANGCI_LINT_TAGS) --timeout=20m --new-from-rev $(shell git rev-parse $(LINT_BASE))
-else
 	$(GOLANGCI_LINT) run --build-tags=$(GOLANGCI_LINT_TAGS) --timeout=20m
-endif
 
 
 ################################################################################


### PR DESCRIPTION
This reverts commit 74bf26016f2f3313b2484779e18a7303e50417e3.

It causes error in lint during release.

Sorry, reverting this to unblock release: https://github.com/dapr/dapr/actions/runs/9783244470/job/27011390131

# Description

Fix lint for 1.14 release.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
