### PR TITLE
Scheduler: fix data dir in standalone mode

### DIFF
--- a/pkg/scheduler/server/config.go
+++ b/pkg/scheduler/server/config.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"go.etcd.io/etcd/server/v3/embed"
@@ -85,7 +86,7 @@ func config(opts Options) (*embed.Config, error) {
 			}}
 		}
 	default:
-		config.Dir = opts.DataDir + "-" + security.CurrentNamespace() + "-" + opts.EtcdID
+		config.Dir = filepath.Join(opts.DataDir, security.CurrentNamespace()+"-"+opts.EtcdID)
 
 		config.ListenPeerUrls = []url.URL{{
 			Scheme: "http",

--- a/pkg/scheduler/server/server_test.go
+++ b/pkg/scheduler/server/server_test.go
@@ -136,7 +136,7 @@ func TestServerConf(t *testing.T) {
 		config := s.config
 
 		assert.Equal(t, "id1=http://localhost:5001,id2=http://localhost:5002", config.InitialCluster)
-		assert.Equal(t, "./data-default-id2", config.Dir)
+		assert.Equal(t, "data/default-id2", config.Dir)
 
 		clientURL := url.URL{
 			Scheme: "http",

--- a/tests/integration/foo
+++ b/tests/integration/foo
@@ -1,1 +1,0 @@
-{"name":"jobforjabba", "schedule":"@every 1m", "repeats":5, "data":{"@type":"type.googleapis.com/google.protobuf.StringValue", "value":"Running spice"}}


### PR DESCRIPTION
Use correct root data dir for standalone mode. Namespace and instance IDs are now correctly string concatenated subdirectories of the defined root data directory.
