### PR TITLE
support un-register internal actor

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1305,16 +1305,16 @@ func (a *actorsRuntime) RegisterInternalActor(ctx context.Context, actorType str
 
 func (a *actorsRuntime) UnregisterInternalActor(ctx context.Context, actorType string) error {
 	if !a.haveCompatibleStorage() {
-		return fmt.Errorf("unable to register internal actor type '%s': %w", actorType, ErrIncompatibleStateStore)
+		return fmt.Errorf("unable to unregister internal actor type '%s': %w", actorType, ErrIncompatibleStateStore)
 	}
 
-	// Call GetOrSet which returns "existing=true" if the actor type was already registered
+	// Call GetAndDel which returns "existing=true" if the actor type was already registered
 	_, existing := a.internalActorTypes.GetAndDel(actorType)
 	if !existing {
 		return nil
 	}
 
-	log.Debugf("UnRegistered internal actor type '%s'", actorType)
+	log.Debugf("Unregistered internal actor type '%s'", actorType)
 
 	a.actorsConfig.Config.HostedActorTypes.RemoveActorType(actorType)
 

--- a/pkg/actors/actors_mock.go
+++ b/pkg/actors/actors_mock.go
@@ -59,6 +59,10 @@ func (*MockPlacement) AddHostedActorType(string, time.Duration) error {
 	return nil
 }
 
+func (*MockPlacement) DeleteHostedActorType(string) error {
+	return nil
+}
+
 func (p *MockPlacement) SetLookupActorResponse(req internal.LookupActorRequest, res internal.LookupActorResponse) {
 	p.lookupActorResponses[req.ActorKey()] = res
 }
@@ -131,6 +135,10 @@ func (_m *MockActors) Entities() []string {
 }
 
 func (_m *MockActors) RegisterInternalActor(ctx context.Context, actorType string, actor InternalActorFactory, actorIdleTimeout time.Duration) error {
+	return nil
+}
+
+func (_m *MockActors) UnregisterInternalActor(ctx context.Context, actorType string) error {
 	return nil
 }
 
@@ -371,6 +379,10 @@ func (f *FailingActors) Entities() []string {
 }
 
 func (f *FailingActors) RegisterInternalActor(ctx context.Context, actorType string, actor InternalActorFactory, actorIdleTimeout time.Duration) error {
+	return nil
+}
+
+func (f *FailingActors) UnregisterInternalActor(ctx context.Context, actorType string) error {
 	return nil
 }
 

--- a/pkg/actors/internal/config.go
+++ b/pkg/actors/internal/config.go
@@ -97,6 +97,13 @@ func (ha *hostedActors) AddActorType(actorType string, idleTimeout time.Duration
 	ha.lock.Unlock()
 }
 
+// RemoveActorType removes an actor type
+func (ha *hostedActors) RemoveActorType(actorType string) {
+	ha.lock.Lock()
+	delete(ha.actors, actorType)
+	ha.lock.Unlock()
+}
+
 // IsActorTypeHosted returns true if the actor type is hosted.
 func (ha *hostedActors) IsActorTypeHosted(actorType string) bool {
 	ha.lock.RLock()

--- a/pkg/actors/internal/placement_service.go
+++ b/pkg/actors/internal/placement_service.go
@@ -35,6 +35,7 @@ type PlacementService interface {
 	WaitUntilReady(ctx context.Context) error
 	LookupActor(ctx context.Context, req LookupActorRequest) (LookupActorResponse, error)
 	AddHostedActorType(actorType string, idleTimeout time.Duration) error
+	DeleteHostedActorType(actorType string) error
 	ReportActorDeactivation(ctx context.Context, actorType, actorID string) error
 
 	SetHaltActorFns(haltFn HaltActorFn, haltAllFn HaltAllActorsFn)

--- a/pkg/actors/placement/placement.go
+++ b/pkg/actors/placement/placement.go
@@ -157,6 +157,18 @@ func (p *actorPlacement) AddHostedActorType(actorType string, idleTimeout time.D
 	return nil
 }
 
+// Delete an actor type from the list of known actor types (if it's already registered)
+// The placement tables will get updated when the next heartbeat fires
+func (p *actorPlacement) DeleteHostedActorType(actorType string) error {
+	for i, t := range p.actorTypes {
+		if t == actorType {
+			p.actorTypes = append(p.actorTypes[:i], p.actorTypes[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("actor type %s not found", actorType)
+}
+
 // Start connects placement service to register to membership and send heartbeat
 // to report the current member status periodically.
 func (p *actorPlacement) Start(ctx context.Context) error {

--- a/pkg/actors/reminders/statestore.go
+++ b/pkg/actors/reminders/statestore.go
@@ -1037,7 +1037,7 @@ func (r *statestore) startReminder(reminder *internal.Reminder, stopChannel chan
 
 			_, exists := r.activeReminders.Load(reminderKey)
 			if !exists {
-				log.Error("Could not find active reminder with key: " + reminderKey)
+				log.Errorf("Could not find active reminder with key: %v", reminderKey)
 				nextTimer = nil
 				return
 			}
@@ -1067,7 +1067,7 @@ func (r *statestore) startReminder(reminder *internal.Reminder, stopChannel chan
 					eTag = track.Etag
 				}
 			} else {
-				log.Error("Could not find active reminder with key: %s", reminderKey)
+				log.Errorf("Could not find active reminder with key: %s", reminderKey)
 				nextTimer = nil
 				return
 			}

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -294,7 +294,7 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 
 			if len(req.GetEntities()) == 0 {
 				// is this an existing member that reported actor types before but now it has unregistered all of them?
-				if !p.raftNode.FSM().State().HasMember(namespace, req) {
+				if !p.raftNode.FSM().State().HasMember(namespace, req.GetName(), req.GetId()) {
 					continue
 				}
 				isActorRuntime = true
@@ -315,13 +315,17 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 			// Upsert incoming member only if the existing member info
 			// doesn't match with the incoming member info.
 			if p.raftNode.FSM().State().UpsertRequired(namespace, req) {
+				entities := req.GetEntities()
+				if entities == nil {
+					entities = []string{}
+				}
 				p.membershipCh <- hostMemberChange{
 					cmdType: raft.MemberUpsert,
 					host: raft.DaprHostMember{
 						Name:      req.GetName(),
 						AppID:     req.GetId(),
 						Namespace: namespace,
-						Entities:  req.GetEntities(),
+						Entities:  entities,
 						UpdatedAt: now.UnixNano(),
 						APILevel:  req.GetApiLevel(),
 					},

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -292,15 +292,14 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 				}
 			}
 
-			if len(req.GetEntities()) == 0 {
-				// is this an existing member that reported actor types before but now it has unregistered all of them?
-				if !p.raftNode.FSM().State().HasMember(namespace, req.GetName(), req.GetId()) {
-					continue
-				}
-				isActorRuntime = true
-			} else {
-				isActorRuntime = true
+			// Is this an existing member that reported actor types before,
+			// but now it unregistered all of them?
+			// (happens when unregistering internal workflow actors)
+			if len(req.GetEntities()) == 0 && !p.raftNode.FSM().State().HasMember(namespace, req.GetName(), req.GetId()) {
+				continue
 			}
+
+			isActorRuntime = true
 
 			now := p.clock.Now()
 

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -292,12 +292,14 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 				}
 			}
 
-			// Ensure that the incoming runtime is actor instance.
-			isActorRuntime = len(req.GetEntities()) > 0
-			if !isActorRuntime {
-				// we already disseminated the existing tables to this member,
-				// so we can ignore the rest if it's a non-actor.
-				continue
+			if len(req.GetEntities()) == 0 {
+				// is this an existing member that reported actor types before but now it has unregistered all of them?
+				if !p.raftNode.FSM().State().HasMember(namespace, req) {
+					continue
+				}
+				isActorRuntime = true
+			} else {
+				isActorRuntime = true
 			}
 
 			now := p.clock.Now()

--- a/pkg/placement/raft/state.go
+++ b/pkg/placement/raft/state.go
@@ -200,6 +200,23 @@ func (s *DaprHostMemberState) MemberCountInNamespace(ns string) int {
 	return len(n.Members)
 }
 
+func (s *DaprHostMemberState) HasMember(ns string, new *placementv1pb.Host) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	n, ok := s.data.Namespace[ns]
+	if !ok {
+		return false
+	}
+
+	m, ok := n.Members[new.GetName()]
+	if !ok {
+		return false
+	}
+
+	return m.AppID == new.GetId() && m.Name == new.GetName()
+}
+
 // UpsertRequired checks if the newly reported data matches the saved state, or needs to be updated
 func (s *DaprHostMemberState) UpsertRequired(ns string, new *placementv1pb.Host) bool {
 	s.lock.RLock()
@@ -210,8 +227,12 @@ func (s *DaprHostMemberState) UpsertRequired(ns string, new *placementv1pb.Host)
 		return true // If the member doesn't exist, we need to upsert
 	}
 	if m, ok := n.Members[new.GetName()]; ok {
+		newE := new.GetEntities()
+		if newE == nil {
+			newE = []string{}
+		}
 		// If all attributes match, no upsert is required
-		return !(m.AppID == new.GetId() && m.Name == new.GetName() && cmp.Equal(m.Entities, new.GetEntities()))
+		return !(m.AppID == new.GetId() && m.Name == new.GetName() && cmp.Equal(m.Entities, newE))
 	}
 
 	return true
@@ -349,6 +370,13 @@ func (s *DaprHostMemberState) updateHashingTables(host *DaprHostMember) {
 
 		s.data.Namespace[host.Namespace].hashingTableMap[e].Add(host.Name, host.AppID, 0)
 	}
+	if len(host.Entities) == 0 {
+		if s.data.Namespace[host.Namespace].hashingTableMap != nil {
+			for _, v := range s.data.Namespace[host.Namespace].hashingTableMap {
+				_ = v.Remove(host.Name)
+			}
+		}
+	}
 }
 
 // removeHashingTables caller should hold Lock.
@@ -373,10 +401,6 @@ func (s *DaprHostMemberState) removeHashingTables(host *DaprHostMember) {
 // upsertMember upserts member host info to the FSM state and returns true
 // if the hashing table update happens.
 func (s *DaprHostMemberState) upsertMember(host *DaprHostMember) bool {
-	if !s.isActorHost(host) {
-		return false
-	}
-
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/pkg/placement/raft/state.go
+++ b/pkg/placement/raft/state.go
@@ -353,28 +353,31 @@ func (s *DaprHostMemberState) clone() *DaprHostMemberState {
 
 // caller should hold Lock.
 func (s *DaprHostMemberState) updateHashingTables(host *DaprHostMember) {
-	if _, ok := s.data.Namespace[host.Namespace]; !ok {
+	ns, ok := s.data.Namespace[host.Namespace]
+
+	if !ok {
 		s.data.Namespace[host.Namespace] = &daprNamespace{
 			Members:         make(map[string]*DaprHostMember),
 			hashingTableMap: make(map[string]*hashing.Consistent),
 		}
+		ns = s.data.Namespace[host.Namespace]
 	}
+
 	for _, e := range host.Entities {
-		if s.data.Namespace[host.Namespace].hashingTableMap == nil {
-			s.data.Namespace[host.Namespace].hashingTableMap = make(map[string]*hashing.Consistent)
+		if ns.hashingTableMap == nil {
+			ns.hashingTableMap = make(map[string]*hashing.Consistent)
 		}
 
-		if _, ok := s.data.Namespace[host.Namespace].hashingTableMap[e]; !ok {
-			s.data.Namespace[host.Namespace].hashingTableMap[e] = hashing.NewConsistentHash(s.config.replicationFactor)
+		if _, ok := ns.hashingTableMap[e]; !ok {
+			ns.hashingTableMap[e] = hashing.NewConsistentHash(s.config.replicationFactor)
 		}
 
-		s.data.Namespace[host.Namespace].hashingTableMap[e].Add(host.Name, host.AppID, 0)
+		ns.hashingTableMap[e].Add(host.Name, host.AppID, 0)
 	}
-	if len(host.Entities) == 0 {
-		if s.data.Namespace[host.Namespace].hashingTableMap != nil {
-			for _, v := range s.data.Namespace[host.Namespace].hashingTableMap {
-				_ = v.Remove(host.Name)
-			}
+
+	if len(host.Entities) == 0 && ns.hashingTableMap != nil {
+		for _, v := range ns.hashingTableMap {
+			v.Remove(host.Name)
 		}
 	}
 }
@@ -411,7 +414,8 @@ func (s *DaprHostMemberState) upsertMember(host *DaprHostMember) bool {
 	ns, ok := s.data.Namespace[host.Namespace]
 	if !ok {
 		s.data.Namespace[host.Namespace] = &daprNamespace{
-			Members: make(map[string]*DaprHostMember),
+			Members:         make(map[string]*DaprHostMember),
+			hashingTableMap: make(map[string]*hashing.Consistent),
 		}
 		ns = s.data.Namespace[host.Namespace]
 	}

--- a/pkg/placement/raft/state_test.go
+++ b/pkg/placement/raft/state_test.go
@@ -174,6 +174,36 @@ func TestUpsertMemberNonActorHost(t *testing.T) {
 	require.False(t, updated)
 }
 
+func TestUpsertMemberEmptyEntities(t *testing.T) {
+	s := newDaprHostMemberState(DaprHostMemberStateConfig{
+		replicationFactor: 10,
+		minAPILevel:       0,
+		maxAPILevel:       100,
+	})
+
+	testMember := &DaprHostMember{
+		Name:      "127.0.0.1:8080",
+		Namespace: "ns1",
+		AppID:     "FakeID",
+		Entities:  []string{"a", "b"},
+		UpdatedAt: 100,
+	}
+
+	updated := s.upsertMember(testMember)
+	require.True(t, updated)
+
+	testMember = &DaprHostMember{
+		Name:      "127.0.0.1:8080",
+		Namespace: "ns1",
+		AppID:     "FakeID",
+		Entities:  []string{},
+		UpdatedAt: 100,
+	}
+
+	updated = s.upsertMember(testMember)
+	require.True(t, updated)
+}
+
 func TestUpdateHashingTable(t *testing.T) {
 	// each subtest has dependency on the state
 

--- a/pkg/placement/raft/state_test.go
+++ b/pkg/placement/raft/state_test.go
@@ -678,7 +678,7 @@ func TestHasMember(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := state.HasMember(tt.ns, tt.host.Name, tt.host.Id)
+			result := state.HasMember(tt.ns, tt.host.GetName(), tt.host.GetId())
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/tests/integration/suite/placement/dissemination/notls.go
+++ b/tests/integration/suite/placement/dissemination/notls.go
@@ -201,30 +201,30 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream1.Recv()
+			placementTables, errR := stream1.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream1.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Len(c, placementTables.Tables.Entries, 1)
-				assert.Contains(c, placementTables.Tables.Entries, "actor1")
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Len(c, placementTables.GetTables().GetEntries(), 1)
+				assert.Contains(c, placementTables.GetTables().GetEntries(), "actor1")
 			}
 		}, time.Second*15, time.Millisecond*10)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream2.Recv()
+			placementTables, errR := stream2.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream2.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Len(c, placementTables.Tables.Entries, 1)
-				assert.Contains(c, placementTables.Tables.Entries, "actor1")
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Len(c, placementTables.GetTables().GetEntries(), 1)
+				assert.Contains(c, placementTables.GetTables().GetEntries(), "actor1")
 			}
 		}, time.Second*15, time.Millisecond*10)
 
@@ -240,27 +240,27 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		err = stream1.Send(hostNoActors)
 		require.NoError(t, err)
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream1.Recv()
+			placementTables, errR := stream1.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream1.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Empty(c, placementTables.Tables.Entries)
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Empty(c, placementTables.GetTables().GetEntries())
 			}
 		}, time.Second*15, time.Millisecond*10)
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream2.Recv()
+			placementTables, errR := stream2.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream2.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Empty(c, placementTables.Tables.Entries)
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Empty(c, placementTables.GetTables().GetEntries())
 			}
 		}, time.Second*15, time.Millisecond*10)
 
@@ -268,7 +268,6 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 			stream1.CloseSend()
 			stream2.CloseSend()
 		})
-
 	})
 
 	t.Run("deactivated actors are removed from the placement table if other actors are present in the namespace", func(t *testing.T) {
@@ -298,30 +297,30 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream1.Recv()
+			placementTables, errR := stream1.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream1.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Len(c, placementTables.Tables.Entries, 3)
-				assert.Contains(c, placementTables.Tables.Entries, "actor1", "actor2", "actor3")
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Len(c, placementTables.GetTables().GetEntries(), 3)
+				assert.Contains(c, placementTables.GetTables().GetEntries(), "actor1", "actor2", "actor3")
 			}
 		}, time.Second*15, time.Millisecond*10)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream2.Recv()
+			placementTables, errR := stream2.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream2.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Len(c, placementTables.Tables.Entries, 3)
-				assert.Contains(c, placementTables.Tables.Entries, "actor1", "actor2", "actor3")
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Len(c, placementTables.GetTables().GetEntries(), 3)
+				assert.Contains(c, placementTables.GetTables().GetEntries(), "actor1", "actor2", "actor3")
 			}
 		}, time.Second*15, time.Millisecond*10)
 
@@ -337,29 +336,29 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		err = stream1.Send(hostNoActors)
 		require.NoError(t, err)
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream1.Recv()
+			placementTables, errR := stream1.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream1.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Len(c, placementTables.Tables.Entries, 2)
-				assert.Contains(c, placementTables.Tables.Entries, "actor2", "actor3")
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Len(c, placementTables.GetTables().GetEntries(), 2)
+				assert.Contains(c, placementTables.GetTables().GetEntries(), "actor2", "actor3")
 			}
 		}, time.Second*15, time.Millisecond*10)
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			placementTables, err := stream2.Recv()
+			placementTables, errR := stream2.Recv()
 			//nolint:testifylint
-			if !assert.NoError(c, err) {
+			if !assert.NoError(c, errR) {
 				_ = stream2.CloseSend()
 				return
 			}
 
-			if assert.Equal(c, "update", placementTables.Operation) {
-				assert.Len(c, placementTables.Tables.Entries, 2)
-				assert.Contains(c, placementTables.Tables.Entries, "actor2", "actor3")
+			if assert.Equal(c, "update", placementTables.GetOperation()) {
+				assert.Len(c, placementTables.GetTables().GetEntries(), 2)
+				assert.Contains(c, placementTables.GetTables().GetEntries(), "actor2", "actor3")
 			}
 		}, time.Second*15, time.Millisecond*10)
 
@@ -367,7 +366,6 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 			stream1.CloseSend()
 			stream2.CloseSend()
 		})
-
 	})
 
 	// old sidecars = pre 1.14
@@ -482,12 +480,12 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 			}
 		}, 10*time.Second, 10*time.Millisecond)
 	})
-
 }
 
 func (n *notls) getStream(t *testing.T, ctx context.Context) v1pb.Placement_ReportDaprStatusClient {
 	t.Helper()
 
+	//nolint:staticcheck
 	conn, err := grpc.DialContext(ctx, n.place.Address(),
 		grpc.WithBlock(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),


### PR DESCRIPTION
# Description

This PR adds functions to the actor runtime to support un-registering actor types, this can be useful later for dynamically registering workflow actors

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
