### PR TITLE
Subscriptions: Fix regression to not subscribe with no app

### DIFF
--- a/pkg/runtime/processor/subscriber/subscriber.go
+++ b/pkg/runtime/processor/subscriber/subscriber.go
@@ -177,7 +177,7 @@ func (s *Subscriber) ReloadDeclaredAppSubscription(name, pubsubName string) erro
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if s.closed {
+	if !s.appSubActive || s.closed {
 		return nil
 	}
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -793,18 +793,20 @@ func (a *DaprRuntime) appHealthChanged(ctx context.Context, status uint8) {
 			a.appHealthReady = nil
 		}
 
-		// Start subscribing to topics and reading from input bindings
-		if err := a.processor.Subscriber().StartAppSubscriptions(); err != nil {
-			log.Warnf("failed to subscribe to topics: %s ", err)
-		}
-		err := a.processor.Binding().StartReadingFromBindings(ctx)
-		if err != nil {
-			log.Warnf("failed to read from bindings: %s ", err)
-		}
+		if a.channels.AppChannel() != nil {
+			// Start subscribing to topics and reading from input bindings
+			if err := a.processor.Subscriber().StartAppSubscriptions(); err != nil {
+				log.Warnf("failed to subscribe to topics: %s ", err)
+			}
+			err := a.processor.Binding().StartReadingFromBindings(ctx)
+			if err != nil {
+				log.Warnf("failed to read from bindings: %s ", err)
+			}
 
-		// Start subscribing to outbox topics
-		if err := a.outbox.SubscribeToInternalTopics(ctx, a.runtimeConfig.id); err != nil {
-			log.Warnf("failed to subscribe to outbox topics: %s", err)
+			// Start subscribing to outbox topics
+			if err := a.outbox.SubscribeToInternalTopics(ctx, a.runtimeConfig.id); err != nil {
+				log.Warnf("failed to subscribe to outbox topics: %s", err)
+			}
 		}
 
 		if a.runtimeConfig.SchedulerEnabled() {

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -40,20 +40,18 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/client"
 	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
-	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/ports"
 )
 
 type Daprd struct {
 	exec       process.Interface
-	appHTTP    process.Interface
 	ports      *ports.Ports
 	httpClient *http.Client
 
 	appID            string
 	namespace        string
 	appProtocol      string
-	appPort          int
+	appPort          *int
 	grpcPort         int
 	httpPort         int
 	internalGRPCPort int
@@ -68,12 +66,9 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	uid, err := uuid.NewRandom()
 	require.NoError(t, err)
 
-	appHTTP := prochttp.New(t)
-
 	fp := ports.Reserve(t, 6)
 	opts := options{
 		appID:            uid.String(),
-		appPort:          appHTTP.Port(),
 		appProtocol:      "http",
 		grpcPort:         fp.Port(t),
 		httpPort:         fp.Port(t),
@@ -97,7 +92,6 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	args := []string{
 		"--log-level=" + opts.logLevel,
 		"--app-id=" + opts.appID,
-		"--app-port=" + strconv.Itoa(opts.appPort),
 		"--app-protocol=" + opts.appProtocol,
 		"--dapr-grpc-port=" + strconv.Itoa(opts.grpcPort),
 		"--dapr-http-port=" + strconv.Itoa(opts.httpPort),
@@ -114,6 +108,10 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 		"--app-health-threshold=" + strconv.Itoa(opts.appHealthProbeThreshold),
 		"--mode=" + opts.mode,
 		"--enable-mtls=" + strconv.FormatBool(opts.enableMTLS),
+	}
+
+	if opts.appPort != nil {
+		args = append(args, "--app-port="+strconv.Itoa(*opts.appPort))
 	}
 	if opts.appHealthCheckPath != "" {
 		args = append(args, "--app-health-check-path="+opts.appHealthCheckPath)
@@ -164,7 +162,6 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 		exec:             exec.New(t, binary.EnvValue("daprd"), args, opts.execOpts...),
 		ports:            fp,
 		httpClient:       client.HTTP(t),
-		appHTTP:          appHTTP,
 		appID:            opts.appID,
 		namespace:        ns,
 		appProtocol:      opts.appProtocol,
@@ -179,14 +176,12 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 }
 
 func (d *Daprd) Run(t *testing.T, ctx context.Context) {
-	d.appHTTP.Run(t, ctx)
 	d.ports.Free(t)
 	d.exec.Run(t, ctx)
 }
 
 func (d *Daprd) Cleanup(t *testing.T) {
 	d.exec.Cleanup(t)
-	d.appHTTP.Cleanup(t)
 }
 
 func (d *Daprd) WaitUntilTCPReady(t *testing.T, ctx context.Context) {
@@ -233,7 +228,7 @@ func (d *Daprd) WaitUntilAppHealth(t *testing.T, ctx context.Context) {
 	case "grpc":
 		assert.Eventually(t, func() bool {
 			//nolint:staticcheck
-			conn, err := grpc.Dial(d.AppAddress(),
+			conn, err := grpc.Dial(d.AppAddress(t),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock())
 			if conn != nil {
@@ -279,12 +274,14 @@ func (d *Daprd) ipPort(port int) string {
 	return "127.0.0.1:" + strconv.Itoa(port)
 }
 
-func (d *Daprd) AppPort() int {
-	return d.appPort
+func (d *Daprd) AppPort(t *testing.T) int {
+	t.Helper()
+	require.NotNil(t, d.appPort, "no app port specified")
+	return *d.appPort
 }
 
-func (d *Daprd) AppAddress() string {
-	return d.ipPort(d.AppPort())
+func (d *Daprd) AppAddress(t *testing.T) string {
+	return d.ipPort(d.AppPort(t))
 }
 
 func (d *Daprd) GRPCPort() int {

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -37,7 +37,7 @@ type options struct {
 
 	appID                   string
 	namespace               *string
-	appPort                 int
+	appPort                 *int
 	grpcPort                int
 	httpPort                int
 	internalGRPCPort        int
@@ -99,7 +99,7 @@ func WithExit1() Option {
 
 func WithAppPort(port int) Option {
 	return func(o *options) {
-		o.appPort = port
+		o.appPort = &port
 	}
 }
 

--- a/tests/integration/framework/process/grpc/subscriber/options.go
+++ b/tests/integration/framework/process/grpc/subscriber/options.go
@@ -24,10 +24,17 @@ import (
 // options contains the options for running a pubsub subscriber gRPC server app.
 type options struct {
 	listTopicSubFn func(ctx context.Context, in *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)
+	initialHealth  bool
 }
 
 func WithListTopicSubscriptions(fn func(ctx context.Context, in *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error)) func(*options) {
 	return func(opts *options) {
 		opts.listTopicSubFn = fn
+	}
+}
+
+func WithInitialHealth(health bool) func(*options) {
+	return func(opts *options) {
+		opts.initialHealth = health
 	}
 }

--- a/tests/integration/framework/process/grpc/subscriber/subscriber.go
+++ b/tests/integration/framework/process/grpc/subscriber/subscriber.go
@@ -15,11 +15,13 @@ package subscriber
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
@@ -30,15 +32,19 @@ type Option func(*options)
 
 type Subscriber struct {
 	app      *app.App
+	healthy  *atomic.Bool
 	inCh     chan *rtv1.TopicEventRequest
 	inBulkCh chan *rtv1.TopicEventBulkRequest
 	closeCh  chan struct{}
+	closed   atomic.Bool
 }
 
 func New(t *testing.T, fopts ...Option) *Subscriber {
 	t.Helper()
 
-	var opts options
+	opts := options{
+		initialHealth: true,
+	}
 	for _, fopt := range fopts {
 		fopt(&opts)
 	}
@@ -47,11 +53,21 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 	inBulkCh := make(chan *rtv1.TopicEventBulkRequest, 100)
 	closeCh := make(chan struct{})
 
+	var healthy atomic.Bool
+	healthy.Store(opts.initialHealth)
+
 	return &Subscriber{
 		inCh:     inCh,
 		inBulkCh: inBulkCh,
 		closeCh:  closeCh,
+		healthy:  &healthy,
 		app: app.New(t,
+			app.WithHealthCheckFn(func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error) {
+				if healthy.Load() {
+					return &rtv1.HealthCheckResponse{}, nil
+				}
+				return nil, assert.AnError
+			}),
 			app.WithListTopicSubscriptions(opts.listTopicSubFn),
 			app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
 				select {
@@ -87,8 +103,10 @@ func (s *Subscriber) Run(t *testing.T, ctx context.Context) {
 
 func (s *Subscriber) Cleanup(t *testing.T) {
 	t.Helper()
-	close(s.closeCh)
-	s.app.Cleanup(t)
+	if s.closed.CompareAndSwap(false, true) {
+		close(s.closeCh)
+		s.app.Cleanup(t)
+	}
 }
 
 func (s *Subscriber) Port(t *testing.T) int {
@@ -155,4 +173,8 @@ func (s *Subscriber) ExpectPublishNoReceive(t *testing.T, ctx context.Context, d
 	_, err := daprd.GRPCClient(t, ctx).PublishEvent(ctx, req)
 	require.NoError(t, err)
 	s.AssertEventChanLen(t, 0)
+}
+
+func (s *Subscriber) SetHealth(healthy bool) {
+	s.healthy.Store(healthy)
 }

--- a/tests/integration/framework/process/http/app/app.go
+++ b/tests/integration/framework/process/http/app/app.go
@@ -78,3 +78,7 @@ func (a *App) Cleanup(t *testing.T) {
 func (a *App) Port() int {
 	return a.http.Port()
 }
+
+func (a *App) SetHealth(health bool) {
+	a.healthz.Store(health)
+}

--- a/tests/integration/framework/process/http/subscriber/options.go
+++ b/tests/integration/framework/process/http/subscriber/options.go
@@ -24,6 +24,7 @@ type options struct {
 	bulkRoutes   []string
 	handlerFuncs []app.Option
 	progSubs     *[]SubscriptionJSON
+	initHealth   bool
 }
 
 func WithRoutes(routes ...string) Option {
@@ -50,5 +51,11 @@ func WithProgrammaticSubscriptions(subs ...SubscriptionJSON) Option {
 			o.progSubs = new([]SubscriptionJSON)
 		}
 		*o.progSubs = append(*o.progSubs, subs...)
+	}
+}
+
+func WithInitialHealth(health bool) Option {
+	return func(o *options) {
+		o.initHealth = health
 	}
 }

--- a/tests/integration/framework/process/http/subscriber/subscriber.go
+++ b/tests/integration/framework/process/http/subscriber/subscriber.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -62,17 +63,20 @@ type PublishBulkRequest struct {
 }
 
 type Subscriber struct {
-	app     *app.App
-	client  *http.Client
-	inCh    chan *RouteEvent
-	inBulk  chan *pubsub.BulkSubscribeEnvelope
-	closeCh chan struct{}
+	app       *app.App
+	client    *http.Client
+	inCh      chan *RouteEvent
+	inBulk    chan *pubsub.BulkSubscribeEnvelope
+	closeCh   chan struct{}
+	closeOnce atomic.Bool
 }
 
 func New(t *testing.T, fopts ...Option) *Subscriber {
 	t.Helper()
 
-	var opts options
+	opts := options{
+		initHealth: true,
+	}
 	for _, fopt := range fopts {
 		fopt(&opts)
 	}
@@ -81,7 +85,7 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 	inBulk := make(chan *pubsub.BulkSubscribeEnvelope, 100)
 	closeCh := make(chan struct{})
 
-	appOpts := make([]app.Option, 0, len(opts.routes)+len(opts.bulkRoutes)+len(opts.handlerFuncs))
+	appOpts := make([]app.Option, 0, len(opts.routes)+len(opts.bulkRoutes)+len(opts.handlerFuncs)+1)
 	for _, route := range opts.routes {
 		appOpts = append(appOpts, app.WithHandlerFunc(route, func(w http.ResponseWriter, r *http.Request) {
 			var ce event.Event
@@ -126,6 +130,7 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 	}
 
 	appOpts = append(appOpts, opts.handlerFuncs...)
+	appOpts = append(appOpts, app.WithInitialHealth(opts.initHealth))
 
 	return &Subscriber{
 		app:     app.New(t, appOpts...),
@@ -143,8 +148,10 @@ func (s *Subscriber) Run(t *testing.T, ctx context.Context) {
 
 func (s *Subscriber) Cleanup(t *testing.T) {
 	t.Helper()
-	close(s.closeCh)
-	s.app.Cleanup(t)
+	if s.closeOnce.CompareAndSwap(false, true) {
+		close(s.closeCh)
+		s.app.Cleanup(t)
+	}
 }
 
 func (s *Subscriber) Port() int {
@@ -181,8 +188,7 @@ func (s *Subscriber) ReceiveBulk(t *testing.T, ctx context.Context) *pubsub.Bulk
 	}
 }
 
-func (s *Subscriber) AssertEventChanLen(t *testing.T, l int) {
-	t.Helper()
+func (s *Subscriber) AssertEventChanLen(t assert.TestingT, l int) {
 	assert.Len(t, s.inCh, l)
 }
 
@@ -249,4 +255,8 @@ func (s *Subscriber) publishBulk(t *testing.T, ctx context.Context, req PublishB
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	return resp
+}
+
+func (s *Subscriber) SetHealth(health bool) {
+	s.app.SetHealth(health)
 }

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/noapp.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/noapp.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriptions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noapp))
+}
+
+type noapp struct {
+	daprd *daprd.Daprd
+}
+
+func (n *noapp) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t)
+
+	operator := operator.New(t,
+		operator.WithSentry(sentry),
+		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
+			return &operatorv1.GetConfigurationResponse{
+				Configuration: []byte(
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
+				),
+			}, nil
+		}),
+	)
+
+	n.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithConfigs("hotreloading"),
+		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors))),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(operator.Address(t)),
+		daprd.WithDisableK8sSecretStore(true),
+	)
+
+	pubsub := compapi.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Name: "pubsub", Namespace: "default"},
+		Spec:       compapi.ComponentSpec{Type: "pubsub.in-memory", Version: "v1"},
+	}
+	operator.AddComponents(pubsub)
+
+	sub := subapi.Subscription{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v2alpha1", Kind: "Subscription"},
+		ObjectMeta: metav1.ObjectMeta{Name: "sub", Namespace: "default"},
+		Spec: subapi.SubscriptionSpec{
+			Pubsubname: "pubsub", Topic: "a",
+			Routes: subapi.Routes{Default: "/a"},
+		},
+	}
+	operator.AddSubscriptions(sub)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, operator, n.daprd),
+	}
+}
+
+func (n *noapp) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Len(t, n.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+	assert.Empty(t, n.daprd.GetMetaSubscriptions(t, ctx))
+}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/noapp.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/noapp.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriptions
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noapp))
+}
+
+type noapp struct {
+	daprd *daprd.Daprd
+	dir   string
+}
+
+func (n *noapp) Setup(t *testing.T) []framework.Option {
+	n.dir = t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(n.dir, "comp.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 'pubsub'
+spec:
+ type: pubsub.in-memory
+ version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+ name: sub1
+spec:
+ pubsubname: pubsub
+ topic: a
+ routes:
+  default: '/a'
+`), 0o600))
+
+	n.daprd = daprd.New(t,
+		daprd.WithResourcesDir(n.dir),
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configun
+metadata:
+  name: hotreloading
+spec:
+  features:
+  - name: HotReload
+    enabled: true`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(n.daprd),
+	}
+}
+
+func (n *noapp) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+	assert.Len(t, n.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+	assert.Len(t, n.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	_, err := n.daprd.GRPCClient(t, ctx).PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "pubsub",
+		Topic:      "a",
+		Data:       []byte("hello"),
+	})
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/jobs/noapp.go
+++ b/tests/integration/suite/daprd/jobs/noapp.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(noapp))
+}
+
+type noapp struct {
+	scheduler *scheduler.Scheduler
+	daprd     *daprd.Daprd
+}
+
+func (n *noapp) Setup(t *testing.T) []framework.Option {
+	n.scheduler = scheduler.New(t)
+	n.daprd = daprd.New(t,
+		daprd.WithSchedulerAddresses(n.scheduler.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(n.scheduler, n.daprd),
+	}
+}
+
+func (n *noapp) Run(t *testing.T, ctx context.Context) {
+	n.scheduler.WaitUntilRunning(t, ctx)
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	client := n.daprd.GRPCClient(t, ctx)
+
+	_, err := client.ScheduleJobAlpha1(ctx, &rtv1.ScheduleJobRequest{
+		Job: &rtv1.Job{
+			Name:    "helloworld",
+			DueTime: ptr.Of("2s"),
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := client.GetJobAlpha1(ctx, &rtv1.GetJobRequest{
+		Name: "helloworld",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "helloworld", resp.GetJob().GetName())
+
+	time.Sleep(3 * time.Second)
+	resp, err = client.GetJobAlpha1(ctx, &rtv1.GetJobRequest{
+		Name: "helloworld",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/tests/integration/suite/daprd/metadata/metadata.go
+++ b/tests/integration/suite/daprd/metadata/metadata.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/client"
 	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -37,9 +38,11 @@ func init() {
 // metadata tests Dapr's response to metadata API requests.
 type metadata struct {
 	proc *procdaprd.Daprd
+	app  *app.App
 }
 
 func (m *metadata) Setup(t *testing.T) []framework.Option {
+	m.app = app.New(t)
 	subComponentAndConfiguration := `
 apiVersion: dapr.io/v1alpha1
 kind: Component
@@ -58,9 +61,12 @@ spec:
   route: /B
   pubsubname: pubsub
 `
-	m.proc = procdaprd.New(t, procdaprd.WithResourceFiles(subComponentAndConfiguration))
+	m.proc = procdaprd.New(t,
+		procdaprd.WithResourceFiles(subComponentAndConfiguration),
+		procdaprd.WithAppPort(m.app.Port()),
+	)
 	return []framework.Option{
-		framework.WithProcesses(m.proc),
+		framework.WithProcesses(m.app, m.proc),
 	}
 }
 
@@ -86,7 +92,7 @@ func (m *metadata) Run(t *testing.T, parentCtx context.Context) {
 				require.NoError(t, err)
 				defer resp.Body.Close()
 
-				validateResponse(t, m.proc.AppID(), m.proc.AppPort(), resp.Body)
+				validateResponse(t, m.proc.AppID(), m.app.Port(), resp.Body)
 			})
 		}
 	})

--- a/tests/integration/suite/daprd/outbox/grpc/noapp.go
+++ b/tests/integration/suite/daprd/outbox/grpc/noapp.go
@@ -15,48 +15,28 @@ package grpc
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/dapr/pkg/proto/common/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
 func init() {
-	suite.Register(new(basic))
+	suite.Register(new(noapp))
 }
 
-type basic struct {
-	eventCalled atomic.Int32
-	daprd       *daprd.Daprd
-	lock        sync.Mutex
-	msg         []byte
+type noapp struct {
+	daprd *daprd.Daprd
 }
 
-func (o *basic) Setup(t *testing.T) []framework.Option {
-	onTopicEvent := func(ctx context.Context, in *runtimev1pb.TopicEventRequest) (*runtimev1pb.TopicEventResponse, error) {
-		o.lock.Lock()
-		defer o.lock.Unlock()
-		o.eventCalled.Add(1)
-		o.msg = in.GetData()
-		return &runtimev1pb.TopicEventResponse{
-			Status: runtimev1pb.TopicEventResponse_SUCCESS,
-		}, nil
-	}
-
-	srv1 := app.New(t, app.WithOnTopicEventFn(onTopicEvent))
-	o.daprd = daprd.New(t, daprd.WithAppID("outboxtest"), daprd.WithAppPort(srv1.Port(t)), daprd.WithAppProtocol("grpc"), daprd.WithResourceFiles(`
+func (n *noapp) Setup(t *testing.T) []framework.Option {
+	n.daprd = daprd.New(t, daprd.WithResourceFiles(`
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -69,8 +49,7 @@ spec:
     value: "mypubsub"
   - name: outboxPublishTopic
     value: "test"
-`,
-		`
+---
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -78,8 +57,7 @@ metadata:
 spec:
   type: pubsub.in-memory
   version: v1
-`,
-		`
+---
 apiVersion: dapr.io/v2alpha1
 kind: Subscription
 metadata:
@@ -94,18 +72,18 @@ scopes:
 `))
 
 	return []framework.Option{
-		framework.WithProcesses(srv1, o.daprd),
+		framework.WithProcesses(n.daprd),
 	}
 }
 
-func (o *basic) Run(t *testing.T, ctx context.Context) {
-	o.daprd.WaitUntilRunning(t, ctx)
+func (n *noapp) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
 
-	conn, err := grpc.DialContext(ctx, o.daprd.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock()) //nolint:staticcheck
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	assert.Len(t, n.daprd.GetMetaRegisteredComponents(t, ctx), 2)
+	assert.Empty(t, n.daprd.GetMetaSubscriptions(t, ctx))
 
-	_, err = runtimev1pb.NewDaprClient(conn).ExecuteStateTransaction(ctx, &runtimev1pb.ExecuteStateTransactionRequest{
+	client := n.daprd.GRPCClient(t, ctx)
+	_, err := client.ExecuteStateTransaction(ctx, &runtimev1pb.ExecuteStateTransactionRequest{
 		StoreName: "mystore",
 		Operations: []*runtimev1pb.TransactionalStateOperation{
 			{
@@ -118,12 +96,4 @@ func (o *basic) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-
-	assert.Eventually(t, func() bool {
-		o.lock.Lock()
-		defer o.lock.Unlock()
-		return string(o.msg) == "2"
-	}, time.Second*5, time.Millisecond*10, "failed to receive message in time")
-
-	assert.Equal(t, int32(1), o.eventCalled.Load())
 }

--- a/tests/integration/suite/daprd/outbox/http/noapp.go
+++ b/tests/integration/suite/daprd/outbox/http/noapp.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noapp))
+}
+
+type noapp struct {
+	daprd *procdaprd.Daprd
+}
+
+func (n *noapp) Setup(t *testing.T) []framework.Option {
+	n.daprd = procdaprd.New(t, procdaprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: outboxPublishPubsub
+    value: "mypubsub"
+  - name: outboxPublishTopic
+    value: "test"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mypubsub'
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: 'order'
+spec:
+  topic: 'test'
+  routes:
+    default: '/test'
+  pubsubname: 'mypubsub'
+scopes:
+- outboxtest
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(n.daprd),
+	}
+}
+
+func (n *noapp) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Len(t, n.daprd.GetMetaRegisteredComponents(t, ctx), 2)
+	assert.Empty(t, n.daprd.GetMetaSubscriptions(t, ctx))
+
+	postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/mystore/transaction", n.daprd.HTTPPort())
+	stateReq := state.SetRequest{
+		Key:      "1",
+		Value:    "2",
+		Metadata: map[string]string{"outbox.cloudevent.myapp": "myapp1", "data": "a", "id": "b"},
+	}
+	tr := stateTransactionRequestBody{
+		Operations: []stateTransactionRequestBodyOperation{
+			{
+				Operation: "upsert",
+				Request:   stateReq,
+			},
+		},
+	}
+
+	b, err := json.Marshal(&tr)
+	require.NoError(t, err)
+
+	httpClient := client.HTTP(t)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, bytes.NewReader(b))
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Empty(t, string(body))
+}

--- a/tests/integration/suite/daprd/outbox/http/projection.go
+++ b/tests/integration/suite/daprd/outbox/http/projection.go
@@ -160,7 +160,7 @@ func (o *projection) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		// validate projection data is reflected in final publish
-		req, err = http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%v/getValue", o.daprd.AppPort()), nil)
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%v/getValue", o.daprd.AppPort(t)), nil)
 		require.NoError(c, err)
 		resp, err = httpClient.Do(req)
 		require.NoError(c, err)

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/noapp.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/noapp.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noapp))
+}
+
+type noapp struct {
+	daprd    *daprd.Daprd
+	operator *operator.Operator
+}
+
+func (n *noapp) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	kubeapi := kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+				Spec: subapi.SubscriptionSpec{
+					Pubsubname: "mypubsub",
+					Topic:      "a",
+					Routes: subapi.Routes{
+						Default: "/a",
+					},
+				},
+			}},
+		}),
+	)
+
+	n.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	n.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(n.operator.Address()),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, kubeapi, n.operator, n.daprd),
+	}
+}
+
+func (n *noapp) Run(t *testing.T, ctx context.Context) {
+	n.operator.WaitUntilRunning(t, ctx)
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Len(t, n.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+	assert.Len(t, n.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	_, err := n.daprd.GRPCClient(t, ctx).PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypubsub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/unhealthy.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/unhealthy.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(unhealthy))
+}
+
+type unhealthy struct {
+	daprd     *daprd.Daprd
+	operator  *operator.Operator
+	app       *app.App
+	appCalled atomic.Bool
+}
+
+func (u *unhealthy) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+
+	u.app = app.New(t,
+		app.WithHandlerFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			u.appCalled.Store(true)
+		}),
+		app.WithInitialHealth(false),
+	)
+
+	kubeapi := kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			sentry.Port(),
+		),
+		kubernetes.WithClusterDaprComponentList(t, &compapi.ComponentList{
+			Items: []compapi.Component{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypubsub", Namespace: "default"},
+				Spec: compapi.ComponentSpec{
+					Type: "pubsub.in-memory", Version: "v1",
+				},
+			}},
+		}),
+		kubernetes.WithClusterDaprSubscriptionListV2(t, &subapi.SubscriptionList{
+			Items: []subapi.Subscription{{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysub", Namespace: "default"},
+				Spec: subapi.SubscriptionSpec{
+					Pubsubname: "mypubsub",
+					Topic:      "a",
+					Routes: subapi.Routes{
+						Default: "/a",
+					},
+				},
+			}},
+		}),
+	)
+
+	u.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sentry.TrustAnchorsFile(t)),
+	)
+
+	u.daprd = daprd.New(t,
+		daprd.WithAppPort(u.app.Port()),
+		daprd.WithAppHealthCheck(true),
+		daprd.WithAppHealthProbeInterval(1),
+		daprd.WithAppHealthProbeThreshold(1),
+		daprd.WithMode("kubernetes"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(u.operator.Address()),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors),
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, kubeapi, u.app, u.operator, u.daprd),
+	}
+}
+
+func (u *unhealthy) Run(t *testing.T, ctx context.Context) {
+	u.operator.WaitUntilRunning(t, ctx)
+	u.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Len(t, u.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	_, err := u.daprd.GRPCClient(t, ctx).PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypubsub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.False(t, u.appCalled.Load())
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/noapp.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/noapp.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noapp))
+}
+
+type noapp struct {
+	daprd *daprd.Daprd
+}
+
+func (n *noapp) Setup(t *testing.T) []framework.Option {
+	n.daprd = daprd.New(t,
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  routes:
+    default: /a
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(n.daprd),
+	}
+}
+
+func (n *noapp) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Len(t, n.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+	assert.Len(t, n.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	_, err := n.daprd.GRPCClient(t, ctx).PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/unhealthy.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/unhealthy.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(unhealthy))
+}
+
+type unhealthy struct {
+	daprd     *daprd.Daprd
+	app       *app.App
+	appCalled atomic.Bool
+}
+
+func (u *unhealthy) Setup(t *testing.T) []framework.Option {
+	u.app = app.New(t,
+		app.WithHandlerFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			u.appCalled.Store(true)
+		}),
+		app.WithInitialHealth(false),
+	)
+
+	u.daprd = daprd.New(t,
+		daprd.WithAppPort(u.app.Port()),
+		daprd.WithAppHealthCheck(true),
+		daprd.WithAppHealthProbeInterval(1),
+		daprd.WithAppHealthProbeThreshold(1),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+---
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  routes:
+    default: /a
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(u.app, u.daprd),
+	}
+}
+
+func (u *unhealthy) Run(t *testing.T, ctx context.Context) {
+	u.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Len(t, u.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	_, err := u.daprd.GRPCClient(t, ctx).PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a", Data: []byte(`{"status": "completed"}`),
+	})
+	require.NoError(t, err)
+	assert.False(t, u.appCalled.Load())
+}

--- a/tests/integration/suite/ports/daprd.go
+++ b/tests/integration/suite/ports/daprd.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -38,16 +39,17 @@ type daprd struct {
 }
 
 func (d *daprd) Setup(t *testing.T) []framework.Option {
-	d.proc = procdaprd.New(t)
+	app := app.New(t)
+	d.proc = procdaprd.New(t, procdaprd.WithAppPort(app.Port(t)))
 	return []framework.Option{
-		framework.WithProcesses(d.proc),
+		framework.WithProcesses(app, d.proc),
 	}
 }
 
 func (d *daprd) Run(t *testing.T, ctx context.Context) {
 	dialer := net.Dialer{Timeout: time.Second * 5}
 	for name, port := range map[string]int{
-		"app":           d.proc.AppPort(),
+		"app":           d.proc.AppPort(t),
 		"grpc":          d.proc.GRPCPort(),
 		"http":          d.proc.HTTPPort(),
 		"metrics":       d.proc.MetricsPort(),


### PR DESCRIPTION
Due to the changes to the subscription machinery to support HotReloading, a regression was introduced whereby declarative subscriptions would be started, even if the app was no present or healthy, leading to attempts to process pubsub messages and potentially panic.

Updates subscription machinery to not start declarative subscriptions if the app is not present or healthy.

Adds integration tests to cover these cases.

Credit @famarting 