### PR TITLE
Scheduler: fix scheduler listen hostname config

### DIFF
--- a/pkg/scheduler/server/config.go
+++ b/pkg/scheduler/server/config.go
@@ -86,6 +86,13 @@ func config(opts Options) (*embed.Config, error) {
 			}}
 		}
 	default:
+
+		// If not listening on an IP interface or localhost, replace host name with
+		// 0.0.0.0 to listen on all interfaces.
+		if net.ParseIP(etcdURL) == nil && etcdURL != "localhost" {
+			etcdURL = "0.0.0.0"
+		}
+
 		config.Dir = filepath.Join(opts.DataDir, security.CurrentNamespace()+"-"+opts.EtcdID)
 
 		config.ListenPeerUrls = []url.URL{{

--- a/pkg/scheduler/server/server_test.go
+++ b/pkg/scheduler/server/server_test.go
@@ -191,4 +191,78 @@ func TestServerConf(t *testing.T) {
 
 		assert.Empty(t, config.ListenClientHttpUrls)
 	})
+
+	t.Run("StandaloneMode listen on 0.0.0.0 when a host", func(t *testing.T) {
+		opts := Options{
+			Security:                nil,
+			ListenAddress:           "",
+			Port:                    0,
+			Mode:                    modes.StandaloneMode,
+			ReplicaCount:            0,
+			ReplicaID:               0,
+			DataDir:                 "./data",
+			EtcdID:                  "id2",
+			EtcdInitialPeers:        []string{"id1=http://hello1:5001", "id2=http://hello2:5002"},
+			EtcdClientPorts:         []string{"id1=5001", "id2=5002"},
+			EtcdClientHTTPPorts:     nil,
+			EtcdSpaceQuota:          0,
+			EtcdCompactionMode:      "",
+			EtcdCompactionRetention: "",
+			Healthz:                 healthz.New(),
+		}
+
+		s, err := New(opts)
+		if err != nil {
+			t.Fatalf("failed to create server: %s", err)
+		}
+
+		config := s.config
+
+		assert.Equal(t, "id1=http://hello1:5001,id2=http://hello2:5002", config.InitialCluster)
+
+		clientURL := url.URL{
+			Scheme: "http",
+			Host:   "0.0.0.0:5002",
+		}
+		assert.Equal(t, clientURL, config.ListenPeerUrls[0])
+		assert.Equal(t, clientURL, config.ListenClientUrls[0])
+		assert.Empty(t, config.ListenClientHttpUrls)
+	})
+
+	t.Run("StandaloneMode listen on IP when an IP", func(t *testing.T) {
+		opts := Options{
+			Security:                nil,
+			ListenAddress:           "",
+			Port:                    0,
+			Mode:                    modes.StandaloneMode,
+			ReplicaCount:            0,
+			ReplicaID:               0,
+			DataDir:                 "./data",
+			EtcdID:                  "id2",
+			EtcdInitialPeers:        []string{"id1=http://1.2.3.4:5001", "id2=http://1.2.3.4:5002"},
+			EtcdClientPorts:         []string{"id1=5001", "id2=5002"},
+			EtcdClientHTTPPorts:     nil,
+			EtcdSpaceQuota:          0,
+			EtcdCompactionMode:      "",
+			EtcdCompactionRetention: "",
+			Healthz:                 healthz.New(),
+		}
+
+		s, err := New(opts)
+		if err != nil {
+			t.Fatalf("failed to create server: %s", err)
+		}
+
+		config := s.config
+
+		assert.Equal(t, "id1=http://1.2.3.4:5001,id2=http://1.2.3.4:5002", config.InitialCluster)
+
+		clientURL := url.URL{
+			Scheme: "http",
+			Host:   "1.2.3.4:5002",
+		}
+		assert.Equal(t, clientURL, config.ListenPeerUrls[0])
+		assert.Equal(t, clientURL, config.ListenClientUrls[0])
+		assert.Empty(t, config.ListenClientHttpUrls)
+	})
 }


### PR DESCRIPTION
Fixes listen interface addresses by replacing non-localhost hostnames with `0.0.0.0` when running in selfhosted mode. This is required for running scheduler in docker-compose like environments.

Example docker-compose manifest:

```yaml
version: '3.4'
services:
  scheduler-0:
    #image: "daprio/dapr:1.14.0-rc.2"
    image: "diagrid/dapr/dapr:dev-linux-arm64"
    command:
    - "./scheduler"
    - "--id=scheduler-0"
    - "--replica-count=3"
    - "--initial-cluster=scheduler-0=http://scheduler-0:2380,scheduler-1=http://scheduler-1:2380,scheduler-2=http://scheduler-2:2380"
    - "--etcd-client-ports=scheduler-0=2379,scheduler-1=2379,scheduler-2=2379"
    - "--etcd-client-http-ports=scheduler-0=2330,scheduler-1=2330,scheduler-2=2330"
    - "--etcd-data-dir=/var/run/dapr/scheduler"
    volumes:
      - dapr_scheduler:/var/run/dapr/scheduler
    networks:
      - network
  scheduler-1:
    #image: "daprio/dapr:1.14.0-rc.2"
    image: "diagrid/dapr/dapr:dev-linux-arm64"
    command:
    - "./scheduler"
    - "--id=scheduler-1"
    - "--replica-count=3"
    - "--initial-cluster=scheduler-0=http://scheduler-0:2380,scheduler-1=http://scheduler-1:2380,scheduler-2=http://scheduler-2:2380"
    - "--etcd-client-ports=scheduler-0=2379,scheduler-1=2379,scheduler-2=2379"
    - "--etcd-client-http-ports=scheduler-0=2330,scheduler-1=2330,scheduler-2=2330"
    - "--etcd-data-dir=/var/run/dapr/scheduler"
    volumes:
      - dapr_scheduler:/var/run/dapr/scheduler
    networks:
      - network
  scheduler-2:
    #image: "daprio/dapr:1.14.0-rc.2"
    image: "diagrid/dapr/dapr:dev-linux-arm64"
    command:
    - "./scheduler"
    - "--id=scheduler-2"
    - "--replica-count=3"
    - "--initial-cluster=scheduler-0=http://scheduler-0:2380,scheduler-1=http://scheduler-1:2380,scheduler-2=http://scheduler-2:2380"
    - "--etcd-client-ports=scheduler-0=2379,scheduler-1=2379,scheduler-2=2379"
    - "--etcd-client-http-ports=scheduler-0=2330,scheduler-1=2330,scheduler-2=2330"
    - "--etcd-data-dir=/var/run/dapr/scheduler"
    volumes:
      - dapr_scheduler:/var/run/dapr/scheduler
    networks:
      - network
networks:
  network:
volumes:
  dapr_scheduler:
    driver: local
```