### PR TITLE
Helm: Fix Service annotation indentation

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -15,9 +15,7 @@ metadata:
     prometheus.io/path: "/"
     {{- end }}
   {{- if .Values.apiService.annotations }}
-    {{- range $key, $value := .Values.apiService.annotations }}
-    {{ $key }}: "{{ $value }}"
-    {{- end }}
+  {{- .Values.apiService.annotations | toYaml | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
   {{- if .Values.apiService.annotations }}
     {{- range $key, $value := .Values.apiService.annotations }}
-      {{ $key }}: "{{ $value }}"
+    {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
   {{- end }}
@@ -49,6 +49,7 @@ metadata:
     {{ $key }}: {{ tpl $value $ }}
     {{- end }}
 {{- if .Values.webhookService.annotations }}
+  annotations:
 {{ toYaml .Values.webhookService.annotations | indent 4}}
 {{- end }}
 spec:

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
   {{- if .Values.service.annotations }}
     {{- range $key, $value := .Values.service.annotations }}
-      {{ $key }}: "{{ $value }}"
+    {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -17,9 +17,7 @@ metadata:
     prometheus.io/path: "/"
     {{- end }}
   {{- if .Values.service.annotations }}
-    {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: "{{ $value }}"
-    {{- end }}
+  {{- .Values.service.annotations | toYaml | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
   {{- if .Values.service.annotations }}
     {{- range $key, $value := .Values.service.annotations }}
-      {{ $key }}: "{{ $value }}"
+    {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
@@ -17,9 +17,7 @@ metadata:
     prometheus.io/path: "/"
     {{- end }}
   {{- if .Values.service.annotations }}
-    {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: "{{ $value }}"
-    {{- end }}
+  {{- .Values.service.annotations | toYaml | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
   {{- if .Values.service.annotations }}
     {{- range $key, $value := .Values.service.annotations }}
-      {{ $key }}: "{{ $value }}"
+    {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
@@ -15,9 +15,7 @@ metadata:
     prometheus.io/path: "/"
     {{- end }}
   {{- if .Values.service.annotations }}
-    {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: "{{ $value }}"
-    {{- end }}
+  {{- .Values.service.annotations | toYaml | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -16,9 +16,7 @@ metadata:
     prometheus.io/path: "/"
     {{- end }}
   {{- if .Values.service.annotations }}
-    {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: "{{ $value }}"
-    {{- end }}
+  {{- .Values.service.annotations | toYaml | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
   {{- if .Values.service.annotations }}
     {{- range $key, $value := .Values.service.annotations }}
-      {{ $key }}: "{{ $value }}"
+    {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
   {{- end }}

--- a/tests/integration/framework/process/helm/helm.go
+++ b/tests/integration/framework/process/helm/helm.go
@@ -57,7 +57,7 @@ func New(t *testing.T, fopts ...OptionFunc) *Helm {
 		args = append(args, "--namespace", *opts.namespace)
 	}
 
-	args = append(args, filepath.Join(binary.GetRootDir(t), "charts/dapr"))
+	args = append(args, filepath.Join(binary.GetRootDir(t), "charts", "dapr"))
 
 	stdoutPipeR, stdoutPipeW := io.Pipe()
 	stderrPipeR, stderrPipeW := io.Pipe()

--- a/tests/integration/framework/process/helm/helm.go
+++ b/tests/integration/framework/process/helm/helm.go
@@ -14,51 +14,41 @@ limitations under the License.
 package helm
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"io"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/dapr/dapr/tests/integration/framework/binary"
 	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/tee"
 )
 
 // Helm test helm chart template.  It is not really an integration test but this seems the best place to place it
 type Helm struct {
-	exec process.Interface
+	exec   process.Interface
+	stdout tee.Reader
+	stderr tee.Reader
 }
 
 func New(t *testing.T, fopts ...OptionFunc) *Helm {
 	t.Helper()
 
-	opts := options{
-		// Since helmtemplate self exists, expect it to always run without error,
-		// even on windows.
-		execOpts: []exec.Option{
-			exec.WithRunError(func(t *testing.T, err error) {
-				t.Helper()
-				require.NoError(t, err, "expected helmtemplate to run without error")
-			}),
-			exec.WithExitCode(0),
-		},
-	}
-
+	var opts options
 	for _, fopt := range fopts {
 		fopt(&opts)
 	}
 
 	// helm options (not all are available)
-	args := make([]string, 0, 2*(len(opts.setValues)+len(opts.setStringValues)+len(opts.showOnly)))
+	args := make([]string, 0, 2*(len(opts.setValues)+len(opts.showOnly)))
 	for _, v := range opts.setValues {
 		args = append(args, "--set", v)
-	}
-	for _, v := range opts.setStringValues {
-		args = append(args, "--set-string", v)
-	}
-	if opts.setJSONValue != nil {
-		args = append(args, "--set-json", *opts.setJSONValue)
 	}
 	for _, v := range opts.showOnly {
 		args = append(args, "--show-only", v)
@@ -67,15 +57,29 @@ func New(t *testing.T, fopts ...OptionFunc) *Helm {
 		args = append(args, "--namespace", *opts.namespace)
 	}
 
-	args = append(args, filepath.Join(binary.GetRootDir(t), "charts", "dapr"))
+	args = append(args, filepath.Join(binary.GetRootDir(t), "charts/dapr"))
 
-	execOpts := opts.execOpts
-	if opts.stdout != nil {
-		execOpts = append(execOpts, exec.WithStdout(opts.stdout))
+	stdoutPipeR, stdoutPipeW := io.Pipe()
+	stderrPipeR, stderrPipeW := io.Pipe()
+	stdout := tee.Buffer(t, stdoutPipeR)
+	stderr := tee.Buffer(t, stderrPipeR)
+
+	execOpts := []exec.Option{
+		// Since helmtemplate self exists, expect it to always run without error,
+		// even on windows.
+		exec.WithRunError(func(t *testing.T, err error) {
+			t.Helper()
+			require.NoError(t, err, "expected helmtemplate to run without error")
+		}),
+		exec.WithExitCode(0),
+		exec.WithStdout(stdoutPipeW),
+		exec.WithStderr(stderrPipeW),
 	}
 
 	return &Helm{
-		exec: exec.New(t, binary.EnvValue("helmtemplate"), args, execOpts...),
+		exec:   exec.New(t, binary.EnvValue("helmtemplate"), args, execOpts...),
+		stdout: stdout,
+		stderr: stderr,
 	}
 }
 
@@ -84,5 +88,44 @@ func (h *Helm) Run(t *testing.T, ctx context.Context) {
 }
 
 func (h *Helm) Cleanup(t *testing.T) {
+	_, err := io.ReadAll(h.Stdout(t))
+	require.NoError(t, err)
+	_, err = io.ReadAll(h.Stderr(t))
+	require.NoError(t, err)
 	h.exec.Cleanup(t)
+}
+
+func (h *Helm) Stdout(t *testing.T) io.Reader {
+	return h.stdout.Add(t)
+}
+
+func (h *Helm) Stderr(t *testing.T) io.Reader {
+	return h.stderr.Add(t)
+}
+
+func UnmarshalStdout[K any](t *testing.T, h *Helm) []K {
+	t.Helper()
+
+	s := bufio.NewScanner(h.Stdout(t))
+	s.Split(func(data []byte, atEOF bool) (int, []byte, error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := bytes.Index(data, []byte("\n---")); i >= 0 {
+			return i + 1, data[0:i], nil
+		}
+		if atEOF {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	})
+
+	var ks []K
+	for s.Scan() {
+		var k K
+		require.NoError(t, yaml.Unmarshal(s.Bytes(), &k))
+		ks = append(ks, k)
+	}
+
+	return ks
 }

--- a/tests/integration/framework/tee/buffer.go
+++ b/tests/integration/framework/tee/buffer.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tee
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buffer tees a Reader to multiple buffered Readers.
+type buffer struct {
+	cond *sync.Cond
+	data []byte
+	bufs []*bufReader
+	err  error
+}
+
+type bufReader struct {
+	buffer *buffer
+	data   *bytes.Buffer
+}
+
+// Buffer creates a buffered `tee` for multiple readers. Input reader must be
+// EOF terminated before end of test.
+func Buffer(t *testing.T, reader io.Reader) Reader {
+	b := &buffer{
+		cond: sync.NewCond(&sync.Mutex{}),
+	}
+	closed := make(chan struct{})
+
+	go func() {
+		for {
+			d := make([]byte, 512)
+			n, err := reader.Read(d)
+			b.cond.L.Lock()
+			b.data = append(b.data, d[:n]...)
+			b.err = err
+
+			for _, buf := range b.bufs {
+				var nBuf int
+				for {
+					written, werr := buf.data.Write(d[:n])
+					if werr != nil {
+						break
+					}
+					nBuf += written
+					if nBuf == n {
+						break
+					}
+				}
+			}
+
+			b.cond.L.Unlock()
+			b.cond.Broadcast()
+
+			if err != nil {
+				close(closed)
+				return
+			}
+		}
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-closed:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timeout waiting for buffered to close")
+		}
+	})
+
+	return b
+}
+
+// Add adds a new reader to the buffered.
+// Readers can be added at any time, even after the input reader has been
+// closed.
+// Added readers will always read the full content of the input reader.
+func (b *buffer) Add(t *testing.T) io.Reader {
+	b.cond.L.Lock()
+	defer b.cond.L.Unlock()
+
+	var data bytes.Buffer
+	var n int
+	for {
+		written, err := data.Write(b.data)
+		require.NoError(t, err)
+		n += written
+		if n == len(b.data) {
+			break
+		}
+	}
+
+	bufReader := &bufReader{
+		buffer: b,
+		data:   &data,
+	}
+	b.bufs = append(b.bufs, bufReader)
+
+	return bufReader
+}
+
+// Read implements the io.Reader interface.
+func (b *bufReader) Read(data []byte) (int, error) {
+	b.buffer.cond.L.Lock()
+	defer b.buffer.cond.L.Unlock()
+
+	for {
+		n, err := b.data.Read(data)
+
+		// If not closed and no read, wait for writing.
+		ok := err == io.EOF && b.buffer.err == nil && n == 0
+		if ok {
+			b.buffer.cond.Wait()
+			continue
+		}
+
+		if err == io.EOF {
+			return n, b.buffer.err
+		}
+
+		return n, err
+	}
+}

--- a/tests/integration/framework/tee/buffer_test.go
+++ b/tests/integration/framework/tee/buffer_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tee
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufio(t *testing.T) {
+	pr, pw := io.Pipe()
+	b := Buffer(t, pr)
+	t.Cleanup(func() { require.NoError(t, pw.Close()) })
+
+	r1 := b.Add(t)
+	r2 := b.Add(t)
+
+	m, err := pw.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, m)
+
+	resp := make([]byte, 1024)
+	n, err := r1.Read(resp)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", string(resp[:n]))
+
+	resp = make([]byte, 2)
+	n, err = r2.Read(resp)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, "he", string(resp[:n]))
+	n, err = r2.Read(resp)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, "ll", string(resp[:n]))
+	n, err = r2.Read(resp)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "o", string(resp[:n]))
+
+	pw.Write([]byte("world"))
+	require.NoError(t, pw.Close())
+
+	resp = make([]byte, 1024)
+	n, err = r1.Read(resp)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "world", string(resp[:n]))
+
+	all, err := io.ReadAll(r1)
+	require.NoError(t, err)
+	assert.Empty(t, all)
+
+	all, err = io.ReadAll(r2)
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(all))
+
+	r3 := b.Add(t)
+	all, err = io.ReadAll(r3)
+	require.NoError(t, err)
+	assert.Equal(t, "helloworld", string(all))
+
+	for _, r := range []io.Reader{r1, r2, r3} {
+		n, rerr := r.Read(resp)
+		require.ErrorIs(t, rerr, io.EOF)
+		assert.Equal(t, 0, n)
+	}
+
+	_, err = pw.Write([]byte("dapr"))
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}

--- a/tests/integration/framework/tee/tee.go
+++ b/tests/integration/framework/tee/tee.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tee
+
+import (
+	"io"
+	"testing"
+)
+
+// Reader is a `tee` implementation which returns a `tee` Reader of the input
+// Reader.
+type Reader interface {
+	// Add returns a new Reader which is a `tee` Reader of the input Reader.
+	Add(t *testing.T) io.Reader
+}

--- a/tests/integration/framework/tee/writecloser_test.go
+++ b/tests/integration/framework/tee/writecloser_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tee
+
+import (
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteCloser(t *testing.T) {
+	t.Run("no writers", func(t *testing.T) {
+		w := WriteCloser()
+		n, err := w.Write([]byte("test"))
+		require.NoError(t, err)
+		assert.Equal(t, 4, n)
+
+		require.NoError(t, w.Close())
+	})
+
+	t.Run("simple writers", func(t *testing.T) {
+		pr1, pw1 := io.Pipe()
+		pr2, pw2 := io.Pipe()
+		pr3, pw3 := io.Pipe()
+
+		w := WriteCloser(pw1, pw2, pw3)
+
+		var n int
+		var werr error
+		done := make(chan struct{})
+		go func() {
+			n, werr = w.Write([]byte("test"))
+			close(done)
+		}()
+
+		for _, reader := range []io.Reader{pr1, pr2, pr3} {
+			resp := make([]byte, 1024)
+			rn, err := reader.Read(resp)
+			require.NoError(t, err)
+			assert.Equal(t, 4, rn)
+			assert.Equal(t, "test", string(resp[:rn]))
+		}
+
+		select {
+		case <-done:
+			assert.Equal(t, 4, n)
+			require.NoError(t, werr)
+		case <-time.After(time.Second):
+			require.Fail(t, "timeout waiting for write to complete")
+		}
+
+		require.NoError(t, w.Close())
+		for _, reader := range []io.Reader{pr1, pr2, pr3} {
+			resp := make([]byte, 1024)
+			n, err := reader.Read(resp)
+			require.ErrorIs(t, err, io.EOF)
+			assert.Equal(t, 0, n)
+		}
+	})
+
+	t.Run("read all", func(t *testing.T) {
+		pr, pw := io.Pipe()
+		w := WriteCloser(pw)
+
+		var n int
+		var werr error
+		done := make(chan struct{})
+		go func() {
+			n, werr = w.Write([]byte("test"))
+			werr = errors.Join(werr, w.Close())
+			close(done)
+		}()
+
+		all, err := io.ReadAll(pr)
+		require.NoError(t, err)
+		assert.Equal(t, "test", string(all))
+
+		select {
+		case <-done:
+			assert.Equal(t, 4, n)
+			require.NoError(t, werr)
+		case <-time.After(time.Second):
+			require.Fail(t, "timeout waiting for write to complete")
+		}
+	})
+
+	t.Run("buffered writes", func(t *testing.T) {
+		pr1, pw1 := io.Pipe()
+		pr2, pw2 := io.Pipe()
+		w := WriteCloser(pw1, pw2)
+
+		var wn int
+		var werr error
+		done := make(chan struct{})
+		go func() {
+			wn, werr = w.Write([]byte("helloworld"))
+			werr = errors.Join(werr, w.Close())
+			close(done)
+		}()
+
+		var pr2resp atomic.Value
+		go func() {
+			resp := make([]byte, 1024)
+			pr2.Read(resp)
+			pr2resp.Store(string(resp))
+		}()
+
+		resp := make([]byte, 2)
+		n, err := pr1.Read(resp)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+		assert.Equal(t, "he", string(resp))
+
+		select {
+		case <-done:
+			require.Fail(t, "expected write to block until all data is read")
+		default:
+		}
+
+		assert.Nil(t, pr2resp.Load())
+
+		resp = make([]byte, 1024)
+		n, err = pr1.Read(resp)
+		require.NoError(t, err)
+		assert.Equal(t, 8, n)
+		assert.Equal(t, "lloworld", string(resp[:n]))
+
+		select {
+		case <-done:
+			assert.Equal(t, 10, wn)
+			require.NoError(t, werr)
+		case <-time.After(time.Second):
+			require.Fail(t, "timeout waiting for write to complete")
+		}
+
+		assert.Equal(t, "helloworld", pr2resp.Load().(string)[:10])
+
+		require.NoError(t, w.Close())
+		n, err = pr1.Read(resp)
+		require.ErrorIs(t, err, io.EOF)
+		assert.Equal(t, 0, n)
+	})
+}

--- a/tests/integration/import.go
+++ b/tests/integration/import.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/actors"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd"
 	_ "github.com/dapr/dapr/tests/integration/suite/healthz"
+	_ "github.com/dapr/dapr/tests/integration/suite/helm"
 	_ "github.com/dapr/dapr/tests/integration/suite/operator"
 	_ "github.com/dapr/dapr/tests/integration/suite/placement"
 	_ "github.com/dapr/dapr/tests/integration/suite/ports"

--- a/tests/integration/suite/helm/helm.go
+++ b/tests/integration/suite/helm/helm.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/helm/service"
+)

--- a/tests/integration/suite/helm/service/annotations.go
+++ b/tests/integration/suite/helm/service/annotations.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/helm"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(annotations))
+}
+
+type annotations struct {
+	base             *helm.Helm
+	withCustom       *helm.Helm
+	withNoProm       *helm.Helm
+	withCustomNoProm *helm.Helm
+}
+
+func (a *annotations) Setup(t *testing.T) []framework.Option {
+	a.base = helm.New(t,
+		helm.WithShowOnlyServices(t),
+	)
+
+	a.withCustom = helm.New(t,
+		helm.WithShowOnlyServices(t),
+		helm.WithValues(
+			"dapr_sentry.service.annotations.foo=sentry",
+			"dapr_sentry.service.annotations.123=456",
+			"dapr_operator.apiService.annotations.foo=operator",
+			"dapr_operator.apiService.annotations.123=456",
+			"dapr_operator.webhookService.annotations.foo=operator",
+			"dapr_operator.webhookService.annotations.123=456",
+			"dapr_scheduler.service.annotations.foo=scheduler",
+			"dapr_scheduler.service.annotations.123=456",
+			"dapr_placement.service.annotations.foo=placement",
+			"dapr_placement.service.annotations.123=456",
+			"dapr_sidecar_injector.service.annotations.foo=sidecar_injector",
+			"dapr_sidecar_injector.service.annotations.123=456",
+		),
+	)
+
+	a.withCustomNoProm = helm.New(t,
+		helm.WithShowOnlyServices(t),
+		helm.WithGlobalValues(
+			"prometheus.enabled=false",
+		),
+		helm.WithValues(
+			"dapr_sentry.service.annotations.foo=sentry",
+			"dapr_sentry.service.annotations.123=456",
+			"dapr_operator.apiService.annotations.foo=operator",
+			"dapr_operator.apiService.annotations.123=456",
+			"dapr_operator.webhookService.annotations.foo=operator",
+			"dapr_operator.webhookService.annotations.123=456",
+			"dapr_scheduler.service.annotations.foo=scheduler",
+			"dapr_scheduler.service.annotations.123=456",
+			"dapr_placement.service.annotations.foo=placement",
+			"dapr_placement.service.annotations.123=456",
+			"dapr_sidecar_injector.service.annotations.foo=sidecar_injector",
+			"dapr_sidecar_injector.service.annotations.123=456",
+		),
+	)
+
+	a.withNoProm = helm.New(t,
+		helm.WithShowOnlyServices(t),
+		helm.WithGlobalValues(
+			"prometheus.enabled=false",
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.base, a.withCustom, a.withCustomNoProm, a.withNoProm),
+	}
+}
+
+func (a *annotations) Run(t *testing.T, ctx context.Context) {
+	type nameAnnotations struct {
+		name        string
+		annotations map[string]string
+	}
+
+	t.Run("default", func(t *testing.T) {
+		svcs := helm.UnmarshalStdout[corev1.Service](t, a.base)
+		assert.Len(t, svcs, 6)
+		for _, svc := range svcs {
+			if svc.Name == "dapr-webhook" {
+				assert.Empty(t, svc.Annotations, svc.Name)
+			} else {
+				assert.Equal(t, map[string]string{
+					"prometheus.io/path":   "/",
+					"prometheus.io/port":   "9090",
+					"prometheus.io/scrape": "true",
+				}, svc.Annotations, svc.Name)
+			}
+		}
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		exp := []nameAnnotations{
+			{
+				name: "dapr-sentry",
+				annotations: map[string]string{
+					"foo":                  "sentry",
+					"123":                  "456",
+					"prometheus.io/path":   "/",
+					"prometheus.io/port":   "9090",
+					"prometheus.io/scrape": "true",
+				},
+			},
+			{
+				name: "dapr-api",
+				annotations: map[string]string{
+					"foo":                  "operator",
+					"123":                  "456",
+					"prometheus.io/path":   "/",
+					"prometheus.io/port":   "9090",
+					"prometheus.io/scrape": "true",
+				},
+			},
+			{
+				name: "dapr-scheduler-server",
+				annotations: map[string]string{
+					"foo":                  "scheduler",
+					"123":                  "456",
+					"prometheus.io/path":   "/",
+					"prometheus.io/port":   "9090",
+					"prometheus.io/scrape": "true",
+				},
+			},
+			{
+				name: "dapr-placement-server",
+				annotations: map[string]string{
+					"foo":                  "placement",
+					"123":                  "456",
+					"prometheus.io/path":   "/",
+					"prometheus.io/port":   "9090",
+					"prometheus.io/scrape": "true",
+				},
+			},
+			{
+				name: "dapr-sidecar-injector",
+				annotations: map[string]string{
+					"foo":                  "sidecar_injector",
+					"123":                  "456",
+					"prometheus.io/path":   "/",
+					"prometheus.io/port":   "9090",
+					"prometheus.io/scrape": "true",
+				},
+			},
+			{
+				name: "dapr-webhook",
+				annotations: map[string]string{
+					"foo": "operator",
+					"123": "456",
+				},
+			},
+		}
+		svcs := helm.UnmarshalStdout[corev1.Service](t, a.withCustom)
+		assert.Len(t, svcs, 6)
+		got := make([]nameAnnotations, 0, len(svcs))
+		for _, svc := range svcs {
+			got = append(got, nameAnnotations{
+				name:        svc.Name,
+				annotations: svc.Annotations,
+			})
+		}
+		assert.ElementsMatch(t, exp, got)
+	})
+
+	t.Run("custom without prometheus", func(t *testing.T) {
+		exp := []nameAnnotations{
+			{
+				name: "dapr-sentry",
+				annotations: map[string]string{
+					"foo": "sentry",
+					"123": "456",
+				},
+			},
+			{
+				name: "dapr-api",
+				annotations: map[string]string{
+					"foo": "operator",
+					"123": "456",
+				},
+			},
+			{
+				name: "dapr-scheduler-server",
+				annotations: map[string]string{
+					"foo": "scheduler",
+					"123": "456",
+				},
+			},
+			{
+				name: "dapr-placement-server",
+				annotations: map[string]string{
+					"foo": "placement",
+					"123": "456",
+				},
+			},
+			{
+				name: "dapr-sidecar-injector",
+				annotations: map[string]string{
+					"foo": "sidecar_injector",
+					"123": "456",
+				},
+			},
+			{
+				name: "dapr-webhook",
+				annotations: map[string]string{
+					"foo": "operator",
+					"123": "456",
+				},
+			},
+		}
+
+		svcs := helm.UnmarshalStdout[corev1.Service](t, a.withCustomNoProm)
+		assert.Len(t, svcs, 6)
+		got := make([]nameAnnotations, 0, len(svcs))
+		for _, svc := range svcs {
+			got = append(got, nameAnnotations{
+				name:        svc.Name,
+				annotations: svc.Annotations,
+			})
+		}
+		assert.ElementsMatch(t, exp, got)
+	})
+
+	t.Run("without prometheus", func(t *testing.T) {
+		exp := []nameAnnotations{
+			{
+				name:        "dapr-sentry",
+				annotations: nil,
+			},
+			{
+				name:        "dapr-api",
+				annotations: nil,
+			},
+			{
+				name:        "dapr-scheduler-server",
+				annotations: nil,
+			},
+			{
+				name:        "dapr-placement-server",
+				annotations: nil,
+			},
+			{
+				name:        "dapr-sidecar-injector",
+				annotations: nil,
+			},
+			{
+				name:        "dapr-webhook",
+				annotations: nil,
+			},
+		}
+
+		svcs := helm.UnmarshalStdout[corev1.Service](t, a.withNoProm)
+		assert.Len(t, svcs, 6)
+		got := make([]nameAnnotations, 0, len(svcs))
+		for _, svc := range svcs {
+			got = append(got, nameAnnotations{
+				name:        svc.Name,
+				annotations: svc.Annotations,
+			})
+		}
+		assert.ElementsMatch(t, exp, got)
+	})
+}

--- a/tests/integration/suite/placement/ha/failover.go
+++ b/tests/integration/suite/placement/ha/failover.go
@@ -72,11 +72,15 @@ func (n *failover) Setup(t *testing.T) []framework.Option {
 	n.srv = prochttp.New(t, prochttp.WithHandler(handler))
 
 	return []framework.Option{
-		framework.WithProcesses(n.fp, n.srv),
+		framework.WithProcesses(n.fp, n.srv, n.placements[0], n.placements[1], n.placements[2]),
 	}
 }
 
 func (n *failover) Run(t *testing.T, ctx context.Context) {
+	for _, p := range n.placements {
+		p.WaitUntilRunning(t, ctx)
+	}
+
 	host1 := &v1pb.Host{
 		Name:      "myapp1",
 		Namespace: "ns1",
@@ -102,16 +106,7 @@ func (n *failover) Run(t *testing.T, ctx context.Context) {
 		ApiLevel:  uint32(20),
 	}
 
-	n.placements[0].Run(t, ctx)
-	n.placements[1].Run(t, ctx)
-	n.placements[2].Run(t, ctx)
-
-	n.placements[0].WaitUntilRunning(t, ctx)
-	n.placements[1].WaitUntilRunning(t, ctx)
-	n.placements[2].WaitUntilRunning(t, ctx)
-
 	leaderIndex := n.getLeader(t, ctx, -1)
-	require.NotEqualf(t, -1, leaderIndex, "no leader elected")
 
 	placementMessageCh1 := n.placements[leaderIndex].RegisterHost(t, ctx, host1)
 	placementMessageCh2 := n.placements[leaderIndex].RegisterHost(t, ctx, host2)
@@ -206,7 +201,6 @@ func (n *failover) Run(t *testing.T, ctx context.Context) {
 	n.placements[leaderIndex].Cleanup(t)
 
 	leaderIndex = n.getLeader(t, ctx, leaderIndex)
-	require.NotEqualf(t, -1, leaderIndex, "no leader elected")
 
 	placementMessageCh2 = n.placements[leaderIndex].RegisterHost(t, ctx, host2)
 	n.placements[leaderIndex].RegisterHost(t, ctx, host1)

--- a/tests/integration/suite/scheduler/helm/basic.go
+++ b/tests/integration/suite/scheduler/helm/basic.go
@@ -32,20 +32,14 @@ func init() {
 	suite.Register(new(basic))
 }
 
-// basic tests the operator's ListCompontns API.
 type basic struct {
 	helm *helm.Helm
-
-	helmStdout io.ReadCloser
 }
 
 func (b *basic) Setup(t *testing.T) []framework.Option {
-	stdoutR, stdoutW := io.Pipe()
-	b.helmStdout = stdoutR
 	b.helm = helm.New(t,
 		helm.WithGlobalValues("ha.enabled=false"), // Not HA
 		helm.WithShowOnlySchedulerSTS(),
-		helm.WithStdout(stdoutW),
 	)
 
 	return []framework.Option{
@@ -55,7 +49,7 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
 
 func (b *basic) Run(t *testing.T, ctx context.Context) {
 	var sts appsv1.StatefulSet
-	bs, err := io.ReadAll(b.helmStdout)
+	bs, err := io.ReadAll(b.helm.Stdout(t))
 	require.NoError(t, err)
 	require.NoError(t, yaml.Unmarshal(bs, &sts))
 	require.Equal(t, int32(1), *sts.Spec.Replicas)


### PR DESCRIPTION
Fixes annotation indentation for Service manifests.

Adds integration tests to cover combinations of custom annotations and
prometheus enabled/disabled.

Adds int test framework `tee.buffer` to implement a buffered tee for
multiple writers. This allows for doing io reads on a io.Reader returned
from running processes, called at any time.

Fix placement failover int test.

/cc @sicoyle
