### PR TITLE
Parallel workflow fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.14.0-rc.4
-	github.com/dapr/kit v0.13.1-0.20240624212434-e2508d6e9e79
-	github.com/diagridio/go-etcd-cron v0.1.0
+	github.com/dapr/kit v0.13.1-0.20240722163453-58c6d9df14d3
+	github.com/diagridio/go-etcd-cron v0.2.0
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-chi/cors v1.2.1
@@ -493,7 +493,3 @@ replace github.com/stretchr/testify => github.com/stretchr/testify v1.8.4
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
-
-replace github.com/diagridio/go-etcd-cron => ../../diagridio/go-etcd-cron
-
-replace github.com/dapr/kit => ../kit

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.14.0-rc.4
-	github.com/dapr/kit v0.13.1-0.20240523225705-106329e5839f
+	github.com/dapr/kit v0.13.1-0.20240624212434-e2508d6e9e79
 	github.com/diagridio/go-etcd-cron v0.1.0
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11
@@ -493,3 +493,7 @@ replace github.com/stretchr/testify => github.com/stretchr/testify v1.8.4
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
+
+replace github.com/diagridio/go-etcd-cron => ../../diagridio/go-etcd-cron
+
+replace github.com/dapr/kit => ../kit

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,6 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.14.0-rc.4 h1:rHrEB+/a1FZqrKjLHGxocBspN5RfKOIOS3GU7IW47FE=
 github.com/dapr/components-contrib v1.14.0-rc.4/go.mod h1:kz8mWLcedMJHmB3WJMmoU27peNpXfT+ryYKQPzY+Hw4=
-github.com/dapr/kit v0.13.1-0.20240523225705-106329e5839f h1:X/QX+YP+2z/f5F5XGpUsZ7hfdwYTlcK6M3n7D/mkpcM=
-github.com/dapr/kit v0.13.1-0.20240523225705-106329e5839f/go.mod h1:LkPZyrSpa2xLBgYMwUhDbWZcZVt/WdL7FSPlN0PrSog=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -471,8 +469,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.1.0 h1:7UbG/NrzrGolQAh99Qap+Gb7cMP0aKg2sexWvL55CBc=
-github.com/diagridio/go-etcd-cron v0.1.0/go.mod h1:OwyFpbtOGOlnvgDUosUDSynGa2fB4vgmThhYEf/l/10=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.14.0-rc.4 h1:rHrEB+/a1FZqrKjLHGxocBspN5RfKOIOS3GU7IW47FE=
 github.com/dapr/components-contrib v1.14.0-rc.4/go.mod h1:kz8mWLcedMJHmB3WJMmoU27peNpXfT+ryYKQPzY+Hw4=
+github.com/dapr/kit v0.13.1-0.20240722163453-58c6d9df14d3 h1:+HZd67sGtxQq7UoEXpby0x0pE0XcZwTY03UuZc48P/M=
+github.com/dapr/kit v0.13.1-0.20240722163453-58c6d9df14d3/go.mod h1:Hz1W2LmWfA4UX/12MdA+brsf+np6f/1dJt6C6F63cjI=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -469,6 +471,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/diagridio/go-etcd-cron v0.2.0 h1:+L+p+kgjGHspGrQa+wMam8huDHXPxDgDg+DFD8WmURs=
+github.com/diagridio/go-etcd-cron v0.2.0/go.mod h1:2ZB5U4iPRUiIOCnBKu6nTpT1PLKMDd6W4/FH0K03m78=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=

--- a/pkg/runtime/scheduler/connector.go
+++ b/pkg/runtime/scheduler/connector.go
@@ -67,7 +67,11 @@ func (c *connector) run(ctx context.Context) error {
 			channels: c.channels,
 		}).run(ctx)
 
-		log.Errorf("Scheduler stream disconnected: %s", err)
+		if err == nil {
+			log.Infof("Scheduler stream disconnected")
+		} else {
+			log.Errorf("Scheduler stream disconnected: %s", err)
+		}
 
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/pkg/runtime/scheduler/connector.go
+++ b/pkg/runtime/scheduler/connector.go
@@ -70,7 +70,7 @@ func (c *connector) run(ctx context.Context) error {
 		if err == nil {
 			log.Infof("Scheduler stream disconnected")
 		} else {
-			log.Errorf("Scheduler stream disconnected: %s", err)
+			log.Errorf("Scheduler stream disconnected: %v", err)
 		}
 
 		if ctx.Err() != nil {

--- a/tests/integration/suite/actors/reminders/scheduler/crud.go
+++ b/tests/integration/suite/actors/reminders/scheduler/crud.go
@@ -138,13 +138,14 @@ func (c *crud) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 
+	last := c.methodcalled.Load()
 	time.Sleep(time.Second * 2)
 
-	last := c.methodcalled.Load()
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		called := c.methodcalled.Load()
-		defer func() { last = called }()
-		return called == last
+		prevLast := last
+		last = called
+		assert.Equal(ct, int(prevLast), int(called))
 	}, time.Second*15, time.Second*2)
 
 	time.Sleep(time.Second)

--- a/tests/integration/suite/daprd/workflow/parallel.go
+++ b/tests/integration/suite/daprd/workflow/parallel.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	"github.com/microsoft/durabletask-go/client"
+	"github.com/microsoft/durabletask-go/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(parallel))
+}
+
+type parallel struct {
+	legacy    *daprd.Daprd
+	scheduler *daprd.Daprd
+}
+
+func (p *parallel) Setup(t *testing.T) []framework.Option {
+	app := app.New(t)
+	place := placement.New(t)
+	scheduler := scheduler.New(t)
+
+	opts := []daprd.Option{
+		daprd.WithAppPort(app.Port()),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithInMemoryActorStateStore("statestore"),
+		daprd.WithSchedulerAddresses(scheduler.Address()),
+	}
+
+	p.legacy = daprd.New(t, opts...)
+	p.scheduler = daprd.New(t, append(opts, daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: schedulerreminders
+spec:
+  features:
+  - name: SchedulerReminders
+    enabled: true`))...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(scheduler, place, app, p.legacy, p.scheduler),
+	}
+}
+
+func (p *parallel) Run(t *testing.T, ctx context.Context) {
+	p.legacy.WaitUntilRunning(t, ctx)
+	p.scheduler.WaitUntilRunning(t, ctx)
+
+	for _, daprd := range []*daprd.Daprd{p.legacy, p.scheduler} {
+		releaseCh := make(chan struct{})
+		var activityWaiting atomic.Int64
+
+		r := task.NewTaskRegistry()
+		require.NoError(t, r.AddOrchestratorN("foo", func(c *task.OrchestrationContext) (any, error) {
+			ts := make([]task.Task, 10)
+			for i := range ts {
+				ts[i] = c.CallActivity("bar", task.WithActivityInput(strconv.Itoa(i)))
+			}
+			for _, task := range ts {
+				require.NoError(t, task.Await(nil))
+			}
+			return nil, nil
+		}))
+		require.NoError(t, r.AddActivityN("bar", func(c task.ActivityContext) (any, error) {
+			activityWaiting.Add(1)
+			select {
+			case <-releaseCh:
+			case <-ctx.Done():
+				require.Fail(t, "timeout waiting for activities to release")
+			}
+			return nil, nil
+		}))
+
+		backendClient := client.NewTaskHubGrpcClient(daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+		require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
+		resp, err := daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "foo",
+		})
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool {
+			return activityWaiting.Load() == 10
+		}, 10*time.Second, 10*time.Millisecond)
+		close(releaseCh)
+
+		metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, api.InstanceID(resp.GetInstanceId()))
+		require.NoError(t, err)
+		assert.True(t, metadata.IsComplete())
+	}
+}


### PR DESCRIPTION
Updates go-etcd-cron to fix parallel activities in workflows.

Adds integration test to ensure parallel activities work as expected, for both db and scheduler reminders.