### PR TITLE
feat(metrics): allow for service ports for global prometheus

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -40,7 +40,7 @@ spec:
 {{ end }}
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
-    containerPort: {{ .Values.global.prometheus.port }}
+    port: {{ .Values.global.prometheus.port }}
     protocol: TCP
 {{- end}}
 ---

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -38,6 +38,11 @@ spec:
     targetPort: {{ .Values.ports.targetPort }}
     name: legacy
 {{ end }}
+{{- if eq .Values.global.prometheus.enabled true }}
+  - name: metrics
+    containerPort: {{ .Values.global.prometheus.port }}
+    protocol: TCP
+{{- end}}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -41,6 +41,7 @@ spec:
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
+    targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
 {{- end}}
 ---

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -36,6 +36,7 @@ spec:
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
+    targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
 {{- end}}
   clusterIP: None

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -35,7 +35,7 @@ spec:
     port: {{ .Values.ports.raftRPCPort }}
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
-    containerPort: {{ .Values.global.prometheus.port }}
+    port: {{ .Values.global.prometheus.port }}
     protocol: TCP
 {{- end}}
   clusterIP: None

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -33,5 +33,10 @@ spec:
     port: {{ .Values.ports.apiPort }}
   - name: raft-node
     port: {{ .Values.ports.raftRPCPort }}
+{{- if eq .Values.global.prometheus.enabled true }}
+  - name: metrics
+    containerPort: {{ .Values.global.prometheus.port }}
+    protocol: TCP
+{{- end}}
   clusterIP: None
 {{- end }}

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
@@ -39,7 +39,7 @@ spec:
     port: {{ .Values.ports.etcdGRPCPeerPort }}
   {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
-    containerPort: {{ .Values.global.prometheus.port }}
+    port: {{ .Values.global.prometheus.port }}
     protocol: TCP
   {{- end}}
   clusterIP: None # make the service headless

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
@@ -40,6 +40,7 @@ spec:
   {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
+    targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
   {{- end}}
   clusterIP: None # make the service headless

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
@@ -37,5 +37,10 @@ spec:
     port: {{ .Values.ports.etcdHTTPClientPort }}
   - name: etcd-peer
     port: {{ .Values.ports.etcdGRPCPeerPort }}
+  {{- if eq .Values.global.prometheus.enabled true }}
+  - name: metrics
+    containerPort: {{ .Values.global.prometheus.port }}
+    protocol: TCP
+  {{- end}}
   clusterIP: None # make the service headless
 {{- end }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
@@ -32,5 +32,6 @@ spec:
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
+    targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
 {{- end}}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
@@ -31,6 +31,6 @@ spec:
     name: grpc
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
-    containerPort: {{ .Values.global.prometheus.port }}
+    port: {{ .Values.global.prometheus.port }}
     protocol: TCP
 {{- end}}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
@@ -29,3 +29,8 @@ spec:
     port: {{ .Values.ports.port }}
     targetPort: {{ .Values.ports.targetPort }}
     name: grpc
+{{- if eq .Values.global.prometheus.enabled true }}
+  - name: metrics
+    containerPort: {{ .Values.global.prometheus.port }}
+    protocol: TCP
+{{- end}}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -30,4 +30,9 @@ spec:
     targetPort: https
     protocol: TCP
     name: https
+  {{- if eq .Values.global.prometheus.enabled true }}
+  - name: metrics
+    containerPort: {{ .Values.global.prometheus.port }}
+    protocol: TCP
+  {{- end}}
 {{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -33,6 +33,7 @@ spec:
   {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
+    targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
   {{- end}}
 {{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -32,7 +32,7 @@ spec:
     name: https
   {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
-    containerPort: {{ .Values.global.prometheus.port }}
+    port: {{ .Values.global.prometheus.port }}
     protocol: TCP
   {{- end}}
 {{- end }}


### PR DESCRIPTION
# Description

Add port for when allowing for prometheus metrics on the services for the dapr controlplane.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
