### PR TITLE
Fix Helm chart to work if scheduler is disabled

### DIFF
--- a/charts/dapr/charts/dapr_scheduler/templates/_helpers.tpl
+++ b/charts/dapr/charts/dapr_scheduler/templates/_helpers.tpl
@@ -86,9 +86,11 @@ Create etcd client http ports list dynamically based on replicaCount.
 Gets the number of replicas. If global.ha.enabled is true, then 3. Otherwise, 1.
 */}}
 {{- define "dapr_scheduler.get-replicas" -}}
-{{-   $replicas := 1 }}
-{{-   if eq true .Values.global.ha.enabled }}
+{{-   $replicas := 0 }}
+{{-   if and (eq true .Values.global.ha.enabled) (eq .Values.global.scheduler.enabled true) }}
 {{-       $replicas = 3 }}
+{{-   else if and (eq false .Values.global.ha.enabled) (eq .Values.global.scheduler.enabled true) -}}
+{{-       $replicas = 1 }}
 {{-   end }}
 {{-   $replicas }}
 {{- end -}}

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -1,4 +1,3 @@
-{{- if (eq .Values.global.scheduler.enabled true) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -135,7 +134,11 @@ spec:
         - "--id"
         - "$(SCHEDULER_ID)"
         - "--replica-count"
+        {{- if (eq .Values.global.scheduler.enabled true) }}
         - "{{ $replicas }}"
+        {{- else }}
+        - "0"
+        {{- end }}
         - "--initial-cluster"
         - {{ include "dapr_scheduler.initialcluster" . | toYaml | trim }}
         - "--etcd-client-ports"
@@ -263,5 +266,4 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName:
 {{ toYaml .Values.global.priorityClassName | indent 8 }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
Scheduler StatefulSet to be always deployed for Injector to stop failing
Set replicas for scheduler according to enabled/disabled and ha.enabled/disabled

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #7930

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
