### PR TITLE
Fix Scheduler Delete race condition and workflow reminder delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -493,3 +493,7 @@ replace github.com/stretchr/testify => github.com/stretchr/testify v1.8.4
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
+
+replace github.com/diagridio/go-etcd-cron => ../../diagridio/go-etcd-cron
+
+replace github.com/dapr/kit => ../kit

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,6 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.14.0-rc.4 h1:rHrEB+/a1FZqrKjLHGxocBspN5RfKOIOS3GU7IW47FE=
 github.com/dapr/components-contrib v1.14.0-rc.4/go.mod h1:kz8mWLcedMJHmB3WJMmoU27peNpXfT+ryYKQPzY+Hw4=
-github.com/dapr/kit v0.13.1-0.20240722163453-58c6d9df14d3 h1:+HZd67sGtxQq7UoEXpby0x0pE0XcZwTY03UuZc48P/M=
-github.com/dapr/kit v0.13.1-0.20240722163453-58c6d9df14d3/go.mod h1:Hz1W2LmWfA4UX/12MdA+brsf+np6f/1dJt6C6F63cjI=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -471,8 +469,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.2.0 h1:+L+p+kgjGHspGrQa+wMam8huDHXPxDgDg+DFD8WmURs=
-github.com/diagridio/go-etcd-cron v0.2.0/go.mod h1:2ZB5U4iPRUiIOCnBKu6nTpT1PLKMDd6W4/FH0K03m78=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1151,14 +1151,19 @@ func (a *actorsRuntime) ExecuteLocalOrRemoteActorReminder(ctx context.Context, r
 
 	// If the reminder was cancelled, delete it.
 	if errors.Is(err, ErrReminderCanceled) {
-		log.Debugf("Deleting reminder which was cancelled: %s", reminder.Key())
-		reqCtx, cancel := context.WithTimeout(context.Background(), time.Second*15)
-		defer cancel()
-		return a.DeleteReminder(reqCtx, &DeleteReminderRequest{
-			Name:      reminder.Name,
-			ActorType: reminder.ActorType,
-			ActorID:   reminder.ActorID,
-		})
+		go func() {
+			log.Debugf("Deleting reminder which was cancelled: %s", reminder.Key())
+			reqCtx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+			defer cancel()
+			if err := a.DeleteReminder(reqCtx, &DeleteReminderRequest{
+				Name:      reminder.Name,
+				ActorType: reminder.ActorType,
+				ActorID:   reminder.ActorID,
+			}); err != nil {
+				log.Errorf("Error deleting reminder %s: %s", reminder.Key(), err)
+			}
+		}()
+		return ErrReminderCanceled
 	}
 
 	return err

--- a/tests/integration/suite/actors/reminders/scheduler/remove.go
+++ b/tests/integration/suite/actors/reminders/scheduler/remove.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(remove))
+}
+
+type remove struct {
+	place     *placement.Placement
+	scheduler *scheduler.Scheduler
+	triggered atomic.Int64
+
+	daprd    *daprd.Daprd
+	etcdPort int
+}
+
+func (r *remove) Setup(t *testing.T) []framework.Option {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: schedulerreminders
+spec:
+  features:
+  - name: SchedulerReminders
+    enabled: true`), 0o600))
+
+	fp := ports.Reserve(t, 2)
+	port1 := fp.Port(t)
+	port2 := fp.Port(t)
+	r.etcdPort = port2
+	clientPorts := []string{
+		"scheduler-0=" + strconv.Itoa(r.etcdPort),
+	}
+	r.scheduler = scheduler.New(t,
+		scheduler.WithID("scheduler-0"),
+		scheduler.WithInitialCluster(fmt.Sprintf("scheduler-0=http://localhost:%d", port1)),
+		scheduler.WithInitialClusterPorts(port1),
+		scheduler.WithEtcdClientPorts(clientPorts),
+	)
+
+	app := app.New(t,
+		app.WithHandlerFunc("/actors/myactortype/myactorid/method/remind/remindermethod", func(http.ResponseWriter, *http.Request) {
+			r.triggered.Add(1)
+		}),
+		app.WithHandlerFunc("/actors/myactortype/myactorid/method/foo", func(http.ResponseWriter, *http.Request) {}),
+		app.WithConfig(`{"entities": ["myactortype"]}`),
+	)
+
+	r.place = placement.New(t)
+
+	r.daprd = daprd.New(t,
+		daprd.WithConfigs(configFile),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithSchedulerAddresses(r.scheduler.Address()),
+		daprd.WithAppPort(app.Port()),
+	)
+
+	fp.Free(t)
+	return []framework.Option{
+		framework.WithProcesses(app, r.scheduler, r.place, r.daprd),
+	}
+}
+
+func (r *remove) Run(t *testing.T, ctx context.Context) {
+	r.scheduler.WaitUntilRunning(t, ctx)
+	r.place.WaitUntilRunning(t, ctx)
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	client := r.daprd.GRPCClient(t, ctx)
+
+	etcdClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{fmt.Sprintf("localhost:%d", r.etcdPort)},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, etcdClient.Close()) })
+
+	resp, err := etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Count)
+
+	_, err = client.InvokeActor(ctx, &runtimev1pb.InvokeActorRequest{
+		ActorType: "myactortype",
+		ActorId:   "myactorid",
+		Method:    "foo",
+	})
+	require.NoError(t, err)
+
+	_, err = client.RegisterActorReminder(ctx, &runtimev1pb.RegisterActorReminderRequest{
+		ActorType: "myactortype",
+		ActorId:   "myactorid",
+		Name:      "remindermethod",
+		DueTime:   "0s",
+		Period:    "1s",
+	})
+	require.NoError(t, err)
+
+	resp, err = etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Count)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), r.triggered.Load())
+	}, 30*time.Second, 10*time.Millisecond)
+
+	_, err = client.UnregisterActorReminder(ctx, &runtimev1pb.UnregisterActorReminderRequest{
+		ActorType: "myactortype",
+		ActorId:   "myactorid",
+		Name:      "remindermethod",
+	})
+	require.NoError(t, err)
+
+	resp, err = etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Count)
+}

--- a/tests/integration/suite/daprd/jobs/remove.go
+++ b/tests/integration/suite/daprd/jobs/remove.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(remove))
+}
+
+type remove struct {
+	daprd     *daprd.Daprd
+	scheduler *scheduler.Scheduler
+	triggered atomic.Int64
+
+	etcdPort int
+}
+
+func (r *remove) Setup(t *testing.T) []framework.Option {
+	fp := ports.Reserve(t, 2)
+	port1 := fp.Port(t)
+	port2 := fp.Port(t)
+	r.etcdPort = port2
+	clientPorts := []string{
+		"scheduler-0=" + strconv.Itoa(r.etcdPort),
+	}
+	r.scheduler = scheduler.New(t,
+		scheduler.WithID("scheduler-0"),
+		scheduler.WithInitialCluster(fmt.Sprintf("scheduler-0=http://localhost:%d", port1)),
+		scheduler.WithInitialClusterPorts(port1),
+		scheduler.WithEtcdClientPorts(clientPorts),
+	)
+
+	app := app.New(t,
+		app.WithOnJobEventFn(func(ctx context.Context, in *runtimev1pb.JobEventRequest) (*runtimev1pb.JobEventResponse, error) {
+			r.triggered.Add(1)
+			return new(runtimev1pb.JobEventResponse), nil
+		}),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithSchedulerAddresses(r.scheduler.Address()),
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+	)
+
+	fp.Free(t)
+	return []framework.Option{
+		framework.WithProcesses(r.scheduler, app, r.daprd),
+	}
+}
+
+func (r *remove) Run(t *testing.T, ctx context.Context) {
+	r.scheduler.WaitUntilRunning(t, ctx)
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	client := r.daprd.GRPCClient(t, ctx)
+
+	etcdClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{fmt.Sprintf("localhost:%d", r.etcdPort)},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, etcdClient.Close()) })
+
+	resp, err := etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Count)
+
+	req := &runtimev1pb.ScheduleJobRequest{
+		Job: &runtimev1pb.Job{
+			Name:     "test",
+			Schedule: ptr.Of("@every 20s"),
+			DueTime:  ptr.Of("0s"),
+		},
+	}
+	_, err = client.ScheduleJobAlpha1(ctx, req)
+	require.NoError(t, err)
+
+	resp, err = etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Count)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), r.triggered.Load())
+	}, 30*time.Second, 10*time.Millisecond)
+
+	_, err = client.DeleteJobAlpha1(ctx, &runtimev1pb.DeleteJobRequest{
+		Name: "test",
+	})
+	require.NoError(t, err)
+
+	resp, err = etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Count)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
@@ -127,5 +127,5 @@ func (d *deletereminder) Run(t *testing.T, ctx context.Context) {
 
 	kvs, err = etcdClient.KV.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
 	require.NoError(t, err)
-	require.Empty(t, kvs.Count)
+	assert.Empty(t, kvs.Count)
 }

--- a/tests/integration/suite/scheduler/api/remove.go
+++ b/tests/integration/suite/scheduler/api/remove.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	schedulerv1 "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(remove))
+}
+
+type remove struct {
+	scheduler *scheduler.Scheduler
+
+	etcdPort int
+}
+
+func (r *remove) Setup(t *testing.T) []framework.Option {
+	fp := ports.Reserve(t, 2)
+	port1 := fp.Port(t)
+	port2 := fp.Port(t)
+
+	r.etcdPort = port2
+
+	clientPorts := []string{
+		"scheduler-0=" + strconv.Itoa(r.etcdPort),
+	}
+	r.scheduler = scheduler.New(t,
+		scheduler.WithID("scheduler-0"),
+		scheduler.WithInitialCluster(fmt.Sprintf("scheduler-0=http://localhost:%d", port1)),
+		scheduler.WithInitialClusterPorts(port1),
+		scheduler.WithEtcdClientPorts(clientPorts),
+	)
+
+	fp.Free(t)
+	return []framework.Option{
+		framework.WithProcesses(fp, r.scheduler),
+	}
+}
+
+func (r *remove) Run(t *testing.T, ctx context.Context) {
+	r.scheduler.WaitUntilRunning(t, ctx)
+
+	etcdClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{fmt.Sprintf("localhost:%d", r.etcdPort)},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, etcdClient.Close()) })
+
+	client := r.scheduler.Client(t, ctx)
+
+	watch, err := client.WatchJobs(ctx)
+	require.NoError(t, err)
+	require.NoError(t, watch.Send(&schedulerv1.WatchJobsRequest{
+		WatchJobRequestType: &schedulerv1.WatchJobsRequest_Initial{
+			Initial: &schedulerv1.WatchJobsRequestInitial{
+				AppId:     "appid",
+				Namespace: "namespace",
+			},
+		},
+	}))
+
+	_, err = client.ScheduleJob(ctx, &schedulerv1.ScheduleJobRequest{
+		Name: "test",
+		Job: &schedulerv1.Job{
+			Schedule: ptr.Of("@every 20s"),
+			DueTime:  ptr.Of(time.Now().Format(time.RFC3339)),
+		},
+		Metadata: &schedulerv1.JobMetadata{
+			AppId:     "appid",
+			Namespace: "namespace",
+			Target: &schedulerv1.JobTargetMetadata{
+				Type: new(schedulerv1.JobTargetMetadata_Job),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Count)
+
+	job, err := watch.Recv()
+	require.NoError(t, err)
+	require.NoError(t, watch.Send(&schedulerv1.WatchJobsRequest{
+		WatchJobRequestType: &schedulerv1.WatchJobsRequest_Result{
+			Result: &schedulerv1.WatchJobsRequestResult{
+				Id: job.Id,
+			},
+		},
+	}))
+
+	resp, err = etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Count)
+
+	_, err = client.DeleteJob(ctx, &schedulerv1.DeleteJobRequest{
+		Name: "test",
+		Metadata: &schedulerv1.JobMetadata{
+			AppId:     "appid",
+			Namespace: "namespace",
+			Target: &schedulerv1.JobTargetMetadata{
+				Type: new(schedulerv1.JobTargetMetadata_Job),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err = etcdClient.Get(ctx, "dapr/jobs", clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Count)
+}


### PR DESCRIPTION
Fixes a Scheduler job Delete race condition whereby a job would continue to exist if it was deleted during execution on the same scheduler instance.

Fix workflow reminder deletion whereby a reminder is deleted separately to a workflow reminder completing (terminal) execution.

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
