### PR TITLE
Fix scheduler address generation for GKE

### DIFF
--- a/pkg/injector/patcher/services.go
+++ b/pkg/injector/patcher/services.go
@@ -31,6 +31,8 @@ var (
 	ServiceAPI = Service{"dapr-api", 443}
 	// Dapr placement service.
 	ServicePlacement = Service{"dapr-placement-server", 50005}
+	// Dapr placement service.
+	ServiceScheduler = Service{"dapr-scheduler-server", 50006}
 	// Dapr Sentry service.
 	ServiceSentry = Service{"dapr-sentry", 443}
 )
@@ -57,4 +59,13 @@ func NewService(val string) (srv Service, err error) {
 // Address returns the address of a Dapr control plane service
 func (svc Service) Address(namespace, clusterDomain string) string {
 	return fmt.Sprintf("%s.%s.svc.%s:%d", svc.name, namespace, clusterDomain, svc.port)
+}
+
+// Address returns the address of a Dapr control plane service
+func (svc Service) AddressAllInstances(replicaCount int, namespace, clusterDomain string) []string {
+	allInstances := []string{}
+	for i := 0; i < replicaCount; i++ {
+		allInstances = append(allInstances, fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", svc.name, i, svc.name, namespace, clusterDomain, svc.port))
+	}
+	return allInstances
 }

--- a/pkg/injector/service/pod_patch.go
+++ b/pkg/injector/service/pod_patch.go
@@ -109,7 +109,9 @@ func (i *injector) getPodPatchOperations(ctx context.Context, ar *admissionv1.Ad
 	}
 
 	if sidecar.SchedulerAddress == "" {
-		sidecar.SchedulerAddress = strings.Join(i.schedulerAddresses, ",")
+		allSchedulerAddresses := patcher.ServiceScheduler.AddressAllInstances(
+			i.schedulerReplicaCount, i.config.Namespace, i.config.KubeClusterDomain)
+		sidecar.SchedulerAddress = strings.Join(allSchedulerAddresses, ",")
 	}
 
 	// Default value for the sidecar image, which can be overridden by annotations


### PR DESCRIPTION
# Description

The generation of scheduler address was not reusing the one for placement and, oddly, generating a different output in GKE. Changing it to match placement's.

## Issue reference


Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
