### PR TITLE
activity actor: prevent nil pointer

### DIFF
--- a/pkg/runtime/wfengine/backends/actors/activity_actor.go
+++ b/pkg/runtime/wfengine/backends/actors/activity_actor.go
@@ -131,6 +131,9 @@ func (a *activityActor) InvokeReminder(ctx context.Context, reminder actors.Inte
 
 	state, _ := a.loadActivityState(ctx)
 	// TODO: On error, reply with a failure - this requires support from durabletask-go to produce TaskFailure results
+	if state == nil {
+		return errors.New("no activity state found")
+	}
 
 	timeoutCtx, cancelTimeout := context.WithTimeout(ctx, a.defaultTimeout)
 	defer cancelTimeout()


### PR DESCRIPTION
# Description

If a workflow activity somehow is being retried after a successfull execution the activity actor can incurr into a nil pointer error on line 141

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
