### PR TITLE
Placement leadership fix

### DIFF
--- a/pkg/placement/leadership.go
+++ b/pkg/placement/leadership.go
@@ -75,6 +75,12 @@ func (p *Service) MonitorLeadership(parentCtx context.Context) error {
 							p.wg.Done()
 							close(loopNotRunning)
 							leaderLoopRunning.Store(false)
+							// If the placement server is restarted without receiving a leadership change event,
+							// the leaderLoopCancel will not be nil, so we need to cancel it here.
+							if leaderLoopCancel != nil {
+								leaderLoopCancel()
+								leaderLoopCancel = nil
+							}
 						}()
 
 						log.Info("Cluster leadership acquired")

--- a/pkg/placement/leadership.go
+++ b/pkg/placement/leadership.go
@@ -59,6 +59,7 @@ func (p *Service) MonitorLeadership(parentCtx context.Context) error {
 	close(loopNotRunning)
 
 	var leaderLoopCancel context.CancelFunc
+	var leaderCtx context.Context
 	for {
 		select {
 		case <-ctx.Done():
@@ -67,7 +68,7 @@ func (p *Service) MonitorLeadership(parentCtx context.Context) error {
 			if isLeader {
 				if leaderLoopRunning.CompareAndSwap(false, true) {
 					loopNotRunning = make(chan struct{})
-					leaderCtx, leaderLoopCancel := context.WithCancel(ctx)
+					leaderCtx, leaderLoopCancel = context.WithCancel(ctx)
 					p.wg.Add(1)
 					go func() {
 						defer func() {

--- a/pkg/placement/leadership.go
+++ b/pkg/placement/leadership.go
@@ -75,8 +75,6 @@ func (p *Service) MonitorLeadership(parentCtx context.Context) error {
 							p.wg.Done()
 							close(loopNotRunning)
 							leaderLoopRunning.Store(false)
-							leaderLoopCancel()
-							leaderLoopCancel = nil
 						}()
 
 						log.Info("Cluster leadership acquired")

--- a/pkg/placement/raft/server.go
+++ b/pkg/placement/raft/server.go
@@ -390,3 +390,11 @@ func (s *Server) ApplyCommand(cmdType CommandType, data DaprHostMember) (bool, e
 	resp := future.Response()
 	return resp.(bool), nil
 }
+
+func (s *Server) GetID() string {
+	return s.id
+}
+
+func (s *Server) GetRaftBind() string {
+	return s.raftBind
+}

--- a/tests/integration/suite/placement/ha/failover.go
+++ b/tests/integration/suite/placement/ha/failover.go
@@ -193,7 +193,7 @@ func (n *failover) Run(t *testing.T, ctx context.Context) {
 		assert.GreaterOrEqual(c, msgCnt, 1)
 	}, 10*time.Second, 10*time.Millisecond)
 
-	// Stop the placement leader and don't reconnect one fo the hosts in ns2. Check that:
+	// Stop the placement leader and don't reconnect one of the hosts in ns2. Check that:
 	// - a new leader has been elected
 	// - dissemination message hasn't been sent to host1, because there haven't been changes in ns1
 	// - dissemination message has been sent to host2, because host 3 hasn't reconnected, thus


### PR DESCRIPTION
Fixes a situation where the placement cluster would be stuck in a leaderless state, even though a raft leader has been elected.
The placement server gets in this state when a raft node has been elected leader, then follower, and then leader again. Raft re-election like this can be triggered due to:
- faulty network
- lost majority (two non-leader pods going down at around the same time)