### PR TITLE
Revert docker images to static:nonroot images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # current directory must be ./dist
 
-FROM gcr.io/distroless/base-nossl:nonroot
+FROM gcr.io/distroless/static:nonroot
 ARG PKG_FILES
 WORKDIR /
 COPY /$PKG_FILES /

--- a/tests/apps/Dockerfile
+++ b/tests/apps/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/distroless/base-nossl:nonroot
+FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /app
 COPY . .

--- a/tests/apps/crypto/Dockerfile
+++ b/tests/apps/crypto/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY *.go /app/
 RUN go build -o app .
 
-FROM gcr.io/distroless/base-nossl:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=build_env /app/app /
 CMD ["/app"]

--- a/tests/apps/perf/actor-activation-locker/Dockerfile
+++ b/tests/apps/perf/actor-activation-locker/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go get -d -v
 RUN go build -o app .
 
-FROM gcr.io/distroless/base-nossl:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=build_env /app/app /
 CMD ["/app"]

--- a/tests/apps/perf/service_invocation_grpc/Dockerfile
+++ b/tests/apps/perf/service_invocation_grpc/Dockerfile
@@ -19,7 +19,7 @@ COPY go.mod go.sum app.go .
 RUN go get -d -v
 RUN go build -o app .
 
-FROM gcr.io/distroless/base-nossl:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=build_env /app/app /
 CMD ["/app"]

--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN go get -d -v
 RUN go build -o app .
 
-FROM gcr.io/distroless/base-nossl:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=build_env /app/app /
 CMD ["/app"]


### PR DESCRIPTION
Accepted suggestion by @ItalyPaleAle to make `static:nonroot` the default images again due to potential future CVEs associated with libc. We will look into adding additional variants in the future.
