### PR TITLE
richer errors for service invocation

### DIFF
--- a/pkg/api/errors/invoke.go
+++ b/pkg/api/errors/invoke.go
@@ -1,0 +1,86 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dapr/kit/errors"
+	"google.golang.org/grpc/codes"
+)
+
+type InvokeError struct {
+	name string
+}
+
+type InvokeMetadataError struct {
+	i                *InvokeError
+	metadata         map[string]string
+	skipResourceInfo bool
+}
+
+// this belongs in the dapr/kit repo?
+const codePrefixServiceInvocation = "DAPR_SERVICE_INVOCATION_"
+
+func (i *InvokeError) WithAppError(appID string, err error) *InvokeMetadataError {
+	var meta map[string]string
+	if len(appID) > 0 {
+		meta = map[string]string{
+			"appID": appID,
+		}
+	}
+	if err != nil {
+		meta["error"] = err.Error()
+	}
+
+	return &InvokeMetadataError{
+		i:        i,
+		metadata: meta,
+	}
+}
+
+func Invoke(name string) *InvokeError {
+	return &InvokeError{
+		name: name,
+	}
+}
+
+func (i *InvokeMetadataError) DirectInvoke() error {
+	msg := fmt.Sprintf("failed to invoke, id: %s, err: %v", i.metadata["appID"], i.metadata["error"])
+	return i.build(
+		codes.Internal,
+		http.StatusInternalServerError,
+		msg,
+		"ERR_DIRECT_INVOKE",
+		"INVOKE_ERROR",
+	)
+}
+
+func (i *InvokeMetadataError) NoAppID() error {
+	msg := "failed getting app id either from the URL path or the header dapr-app-id"
+	return i.build(
+		codes.NotFound,
+		http.StatusNotFound,
+		msg,
+		"ERR_DIRECT_INVOKE",
+		"APP_ID_EMPTY",
+	)
+}
+
+func (i *InvokeMetadataError) NotReady() error {
+	msg := fmt.Sprintf("Invoke API is not ready, id: %s", i.metadata["appID"])
+	return i.build(
+		codes.Internal,
+		http.StatusInternalServerError,
+		msg,
+		"ERR_DIRECT_INVOKE",
+		"NOT_READY",
+	)
+}
+
+func (i *InvokeMetadataError) build(grpcCode codes.Code, httpCode int, msg, tag, errCode string) error {
+	err := errors.NewBuilder(grpcCode, httpCode, msg, tag)
+	if !i.skipResourceInfo {
+		err.WithResourceInfo("invoke", i.i.name, "", msg)
+	}
+	return err.WithErrorInfo(codePrefixServiceInvocation+errCode, i.metadata).Build()
+}

--- a/pkg/api/errors/invoke.go
+++ b/pkg/api/errors/invoke.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dapr/kit/errors"
 	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/kit/errors"
 )
 
 type InvokeError struct {

--- a/pkg/api/http/directmessaging_test.go
+++ b/pkg/api/http/directmessaging_test.go
@@ -623,12 +623,12 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 	t.Run("Invoke returns error - 500 NO_TARGET_APP_ID ", func(t *testing.T) {
 		mockDirectMessaging1 := new(daprt.MockDirectMessaging)
 
-		compStore := compstore.New()
+		compStore1 := compstore.New()
 		fakeServer1 := newFakeHTTPServer()
 		testAPI := &api{
 			directMessaging: mockDirectMessaging1,
 			universal: universal.New(universal.Options{
-				CompStore:  compStore,
+				CompStore:  compStore1,
 				Resiliency: resiliency.New(nil),
 			}),
 		}

--- a/pkg/api/http/directmessaging_test.go
+++ b/pkg/api/http/directmessaging_test.go
@@ -621,25 +621,25 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 	})
 
 	t.Run("Invoke returns error - 500 NO_TARGET_APP_ID ", func(t *testing.T) {
-		mockDirectMessaging := new(daprt.MockDirectMessaging)
+		mockDirectMessaging1 := new(daprt.MockDirectMessaging)
 
 		compStore := compstore.New()
-		fakeServer := newFakeHTTPServer()
+		fakeServer1 := newFakeHTTPServer()
 		testAPI := &api{
-			directMessaging: mockDirectMessaging,
+			directMessaging: mockDirectMessaging1,
 			universal: universal.New(universal.Options{
 				CompStore:  compStore,
 				Resiliency: resiliency.New(nil),
 			}),
 		}
-		fakeServer.StartServer(testAPI.constructDirectMessagingEndpoints(), nil)
+		fakeServer1.StartServer(testAPI.constructDirectMessagingEndpoints(), nil)
 
 		apiPath := "noAppIDMethod"
 		fakeData := []byte("fakeData")
 
-		mockDirectMessaging.Calls = nil // reset call count
+		mockDirectMessaging1.Calls = nil // reset call count
 
-		mockDirectMessaging.
+		mockDirectMessaging1.
 			On(
 				"Invoke",
 				mock.MatchedBy(matchContextInterface),
@@ -661,6 +661,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 		// mockDirectMessaging.AssertNumberOfCalls(t, "Invoke", 1)
 		assert.Equal(t, 404, resp.StatusCode)
 		assert.Equal(t, "ERR_DIRECT_INVOKE", resp.ErrorBody["errorCode"])
+		fakeServer1.Shutdown()
 	})
 
 	t.Run("Invoke returns error - 500 ERR_DIRECT_INVOKE", func(t *testing.T) {
@@ -772,7 +773,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 	})
 
 	t.Run("Invoke returns error - no direct messaging ", func(t *testing.T) {
-		fakeServer := newFakeHTTPServer()
+		fakeServer1 := newFakeHTTPServer()
 		testAPI := &api{
 			directMessaging: nil,
 			universal: universal.New(universal.Options{
@@ -780,7 +781,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 				Resiliency: resiliency.New(nil),
 			}),
 		}
-		fakeServer.StartServer(testAPI.constructDirectMessagingEndpoints(), nil)
+		fakeServer1.StartServer(testAPI.constructDirectMessagingEndpoints(), nil)
 		apiPath := "v1.0/invoke/noDirectMessaging/method/fakeMethod"
 		fakeData := []byte("fakeData")
 		mockDirectMessaging.Calls = nil // reset call count
@@ -798,6 +799,7 @@ func TestV1DirectMessagingEndpoints(t *testing.T) {
 		resp := fakeServer.DoRequest("POST", apiPath, fakeData, nil)
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.Equal(t, "ERR_DIRECT_INVOKE", resp.ErrorBody["errorCode"])
+		fakeServer1.Shutdown()
 	})
 
 	fakeServer.Shutdown()

--- a/tests/integration/suite/daprd/serviceinvocation/http/errors.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/errors.go
@@ -86,6 +86,5 @@ func (e *errors) Run(t *testing.T, ctx context.Context) {
 
 		// Confirm that the first element of the 'details' array has the correct ErrorInfo details
 		// wip
-
 	})
 }

--- a/tests/integration/suite/daprd/serviceinvocation/http/errors.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/errors.go
@@ -1,0 +1,91 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+
+	// "github.com/dapr/dapr/tests/integration/framework/util"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(errors))
+}
+
+type errors struct {
+	daprd1 *procdaprd.Daprd
+	daprd2 *procdaprd.Daprd
+}
+
+func (e *errors) Setup(t *testing.T) []framework.Option {
+	newHTTPServer := func() *prochttp.HTTP {
+		handler := http.NewServeMux()
+		return prochttp.New(t, prochttp.WithHandler(handler))
+	}
+	srv1 := newHTTPServer()
+	srv2 := newHTTPServer()
+	e.daprd1 = procdaprd.New(t, procdaprd.WithAppPort(srv1.Port()))
+	e.daprd2 = procdaprd.New(t, procdaprd.WithAppPort(srv2.Port()))
+
+	return []framework.Option{
+		framework.WithProcesses(srv1, srv2, e.daprd1, e.daprd2),
+	}
+}
+
+func (e *errors) Run(t *testing.T, ctx context.Context) {
+	e.daprd1.WaitUntilRunning(t, ctx)
+	e.daprd2.WaitUntilRunning(t, ctx)
+	httpClient := client.HTTP(t)
+
+	// Covers apierrors.NoAppId()
+	t.Run("no app id", func(t *testing.T) {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/doesntexist", e.daprd1.HTTPPort(), "")
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+
+		var data map[string]interface{}
+		err = json.Unmarshal([]byte(string(body)), &data)
+		require.NoError(t, err)
+
+		// Confirm that the 'errorCode' field exists and contains the correct error code
+		errCode, exists := data["errorCode"]
+		require.True(t, exists)
+		require.Equal(t, "ERR_DIRECT_INVOKE", errCode)
+
+		// Confirm that the 'message' field exists and contains the correct error message
+		errMsg, exists := data["message"]
+		require.True(t, exists)
+		require.Equal(t, "failed getting app id either from the URL path or the header dapr-app-id", errMsg)
+
+		// Confirm that the 'details' field exists and has one element
+		details, exists := data["details"]
+		require.True(t, exists)
+
+		detailsArray, ok := details.([]interface{})
+		require.True(t, ok)
+		require.Len(t, detailsArray, 2)
+
+		// Confirm that the first element of the 'details' array has the correct ErrorInfo details
+		// wip
+
+	})
+}


### PR DESCRIPTION
# Description

_Note_: I've worked on http proxy, haven't started work on gRPC proxy yet.

- added a few errors for the Service Invocation API in the `pkg/api/errors/invoke.go` file
- used those errors in the `pkg/api/http/directmessaging.go` file
- added a unit test in the `pkg/api/http/directmessaging_test.go` file
- added integration test covering a single error (wip) and will cover more errors after learning about the integration testing framework.
## Doubts
- I haven't created richer errors for the dynamic errors in the `directmessaging.go` file. Examples: `invokeErr`, `codeErr`. Does it need to be done?
- @cicoyle can you please have a look and tell me if I'm headed in the right direction?
- How to craft a request URL in the integration test to create an error (`NotReady`) due to `directmessaging = nil` for the api? I need to do this to invoke the `NotReady` error.
- The unit test case which I've written for the `NoAppId` error has to be placed in the last of the test function. Placing it in the beginning or middle is causing failure of other test cases, maybe because I was invoking the error by making the target app id to be an empty string. Do you know why?

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

fixes #7969 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
