### PR TITLE
log err if reminder is not canceled

### DIFF
--- a/pkg/runtime/scheduler/streamer.go
+++ b/pkg/runtime/scheduler/streamer.go
@@ -109,7 +109,14 @@ func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsRe
 
 	case *schedulerv1pb.JobTargetMetadata_Actor:
 		if err := s.invokeActorReminder(ctx, job); err != nil {
-			log.Errorf("failed to invoke scheduled actor reminder: %s", err)
+			// this err is expected if the reminder was triggered once already, the next time it goes to get
+			// triggered by scheduler it sees that it's been canceled and does not invoke the 2nd time. This
+			// more relevant for workflows which currently has a repeat set to 2 since setting it to 1 caused
+			// issues. This will be updated in the future releases, but for now we will see this err. To not
+			// spam users only log if the error is not reminder canceled because this is expected for now.
+			if !errors.Is(err, actors.ErrReminderCanceled) {
+				log.Errorf("failed to invoke scheduled actor reminder named: %s due to: %s", job.GetName(), err)
+			}
 		}
 
 	default:


### PR DESCRIPTION
Only log the failed to invoke reminder if the reminder was not canceled bc for now we are expecting to hit this code path for scheduler reminders on the 2nd repeat given once the first one completes it sets it to cancelled so the 2nd time it is triggered from scheduler it finds out in dapr its canceled and logs this err. Bc it is expected, only log if the err is not reminder canceled to not spam that err msg.