### PR TITLE
Remove 70s timeout for integration test to default 45s

### DIFF
--- a/tests/integration/framework/process/scheduler/options.go
+++ b/tests/integration/framework/process/scheduler/options.go
@@ -34,7 +34,7 @@ type options struct {
 	port          int
 	healthzPort   int
 	metricsPort   int
-	listenAddress *string
+	listenAddress string
 	sentry        *sentry.Sentry
 	dataDir       *string
 }
@@ -102,7 +102,7 @@ func WithMetricsPort(port int) Option {
 
 func WithListenAddress(address string) Option {
 	return func(o *options) {
-		o.listenAddress = &address
+		o.listenAddress = address
 	}
 }
 

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -75,6 +75,7 @@ func New(t *testing.T, fopts ...Option) *Scheduler {
 
 	opts := options{
 		logLevel:        "info",
+		listenAddress:   "localhost",
 		id:              uids,
 		replicaCount:    1,
 		port:            fp.Port(t),
@@ -107,13 +108,9 @@ func New(t *testing.T, fopts ...Option) *Scheduler {
 		"--initial-cluster=" + opts.initialCluster,
 		"--etcd-data-dir=" + dataDir,
 		"--etcd-client-ports=" + strings.Join(opts.etcdClientPorts, ","),
+		"--listen-address=" + opts.listenAddress,
 	}
 
-	if opts.listenAddress != nil {
-		args = append(args, "--listen-address="+*opts.listenAddress)
-	} else {
-		args = append(args, "--listen-address=localhost")
-	}
 	if opts.sentry != nil {
 		taFile := filepath.Join(t.TempDir(), "ca.pem")
 		require.NoError(t, os.WriteFile(taFile, opts.sentry.CABundle().TrustAnchors, 0o600))

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -75,19 +75,7 @@ func RunIntegrationTests(t *testing.T) {
 
 			t.Logf("setting up test case")
 
-			var (
-				ctx    context.Context
-				cancel context.CancelFunc
-			)
-
-			if tcase.Name() == "daprd/workflow/scheduler/deletereminder" {
-				// this test needs longer to ensure that the records in etcd are cleaned up
-				// explicitly giving a longer time for this test so the test passes
-				ctx, cancel = context.WithTimeout(context.Background(), 70*time.Second)
-			} else {
-				ctx, cancel = context.WithTimeout(context.Background(), 45*time.Second)
-			}
-
+			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			t.Cleanup(cancel)
 
 			framework.Run(t, ctx, options...)

--- a/tests/integration/suite/actors/reminders/scheduler/idtypes.go
+++ b/tests/integration/suite/actors/reminders/scheduler/idtypes.go
@@ -208,5 +208,5 @@ func (i *idtype) Run(t *testing.T, ctx context.Context) {
 		i.lock.Lock()
 		defer i.lock.Unlock()
 		assert.ElementsMatch(c, i.expcalled, i.methodcalled)
-	}, time.Second*20, time.Millisecond*10)
+	}, time.Second*30, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
@@ -134,6 +134,6 @@ func (d *deletereminder) Run(t *testing.T, ctx context.Context) {
 		keys, rerr := etcdClient.ListAllKeys(ctx, etcdKeysPrefix)
 		require.NoError(c, rerr)
 		assert.Empty(c, keys)
-	}, time.Second*60, 10*time.Second) // account for cleanup time in etcd
+	}, time.Second*60, time.Millisecond*10) // account for cleanup time in etcd
 	// explicitly not checking the job/counters records since those get garbage collected after 180s
 }


### PR DESCRIPTION
Most integration tests should take between 1-2s max, with some outliers being closer to 10s. 45s is a safe max to allow for slow CI runners. 70s is too large and not appropriate for integration tests- tests which take this long should be moved to e2e. 