### PR TITLE
Fix Duplicate workflow reminder execution in Scheduler mode

### DIFF
--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -73,7 +73,6 @@ func New(origArgs []string) (*Options, error) {
 	fs.StringVar(&opts.TrustDomain, "trust-domain", "localhost", "Trust domain for the Dapr control plane")
 	fs.StringVar(&opts.taFile, "trust-anchors-file", securityConsts.ControlPlaneDefaultTrustAnchorsPath, "Filepath to the trust anchors for the Dapr control plane")
 	fs.StringVar(&opts.SentryAddress, "sentry-address", fmt.Sprintf("dapr-sentry.%s.svc:443", security.CurrentNamespace()), "Address of the Sentry service")
-	fs.StringVar(&opts.PlacementAddress, "placement-address", "", "Addresses for Dapr Actor Placement service")
 	fs.StringVar(&opts.Mode, "mode", string(modes.StandaloneMode), "Runtime mode for Dapr Scheduler")
 
 	fs.StringVar(&opts.ID, "id", "dapr-scheduler-server-0", "Scheduler server ID")

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1126,11 +1126,13 @@ func (a *actorsRuntime) doExecuteReminderOrTimerOnInternalActor(ctx context.Cont
 			delete(a.internalReminderInProgress, key)
 			a.lock.Unlock()
 		}
-		if err != nil && !errors.Is(err, ErrReminderCanceled) {
-			log.Errorf("Error executing reminder for internal actor '%s': %v", reminder.Key(), err)
-		}
 
-		return err
+		if err != nil {
+			if !errors.Is(err, ErrReminderCanceled) {
+				log.Errorf("Error executing reminder for internal actor '%s': %v", reminder.Key(), err)
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -1199,7 +1199,7 @@ func (a *actorsRuntime) ExecuteLocalOrRemoteActorReminder(ctx context.Context, r
 			delete(a.internalReminderInProgress, constructCompositeKey(reminder.ActorType, reminder.ActorID, reminder.Name))
 			a.lock.Unlock()
 		}()
-		return nil
+		return ErrReminderCanceled
 	}
 
 	return err

--- a/pkg/actors/actors_mock.go
+++ b/pkg/actors/actors_mock.go
@@ -126,10 +126,6 @@ type MockActors struct {
 	mock.Mock
 }
 
-func (_m *MockActors) UsingSchedulerReminders() bool {
-	return false // by default, need preview feature
-}
-
 func (_m *MockActors) Entities() []string {
 	return nil
 }
@@ -368,10 +364,6 @@ func (_m *MockActors) GetRuntimeStatus(ctx context.Context) *runtimev1pb.ActorRu
 
 type FailingActors struct {
 	Failure daprt.Failure
-}
-
-func (f *FailingActors) UsingSchedulerReminders() bool {
-	return false // by default, need preview feature
 }
 
 func (f *FailingActors) Entities() []string {

--- a/pkg/actors/reminders/scheduler.go
+++ b/pkg/actors/reminders/scheduler.go
@@ -224,9 +224,8 @@ func (s *scheduler) DeleteReminder(ctx context.Context, req internal.DeleteRemin
 			},
 		},
 	}
-	reqCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	_, err := s.clients.Next().DeleteJob(reqCtx, internalDeleteJobReq)
+
+	_, err := s.clients.Next().DeleteJob(context.Background(), internalDeleteJobReq)
 	if err != nil {
 		log.Errorf("Error deleting reminder job %s due to: %s", req.Name, err)
 	}

--- a/pkg/runtime/scheduler/streamer.go
+++ b/pkg/runtime/scheduler/streamer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/dapr/pkg/actors"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
@@ -109,6 +110,23 @@ func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsRe
 
 	case *schedulerv1pb.JobTargetMetadata_Actor:
 		if err := s.invokeActorReminder(ctx, job); err != nil {
+			// this err is expected if the reminder was triggered once already, the next time it goes to get
+			// triggered by scheduler it sees that it's been canceled and does not invoke the 2nd time. This
+			// more relevant for workflows which currently has a repeat set to 2 since setting it to 1 caused
+			// issues. This will be updated in the future releases, but for now we will see this err. To not
+			// spam users only log if the error is not reminder canceled because this is expected for now.
+			if errors.Is(err, actors.ErrReminderCanceled) {
+				return
+			}
+
+			// If the actor was hosted on another instance, the error will be a gRPC status error,
+			// so we need to unwrap it and match on the error message
+			if st, ok := status.FromError(err); ok {
+				if st.Message() == actors.ErrReminderCanceled.Error() {
+					return
+				}
+			}
+
 			log.Errorf("failed to invoke scheduled actor reminder named: %s due to: %s", job.GetName(), err)
 		}
 

--- a/pkg/runtime/scheduler/streamer.go
+++ b/pkg/runtime/scheduler/streamer.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/dapr/dapr/pkg/actors"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
@@ -110,23 +109,6 @@ func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsRe
 
 	case *schedulerv1pb.JobTargetMetadata_Actor:
 		if err := s.invokeActorReminder(ctx, job); err != nil {
-			// this err is expected if the reminder was triggered once already, the next time it goes to get
-			// triggered by scheduler it sees that it's been canceled and does not invoke the 2nd time. This
-			// more relevant for workflows which currently has a repeat set to 2 since setting it to 1 caused
-			// issues. This will be updated in the future releases, but for now we will see this err. To not
-			// spam users only log if the error is not reminder canceled because this is expected for now.
-			if errors.Is(err, actors.ErrReminderCanceled) {
-				return
-			}
-
-			// If the actor was hosted on another instance, the error will be a gRPC status error,
-			// so we need to unwrap it and match on the error message
-			if st, ok := status.FromError(err); ok {
-				if st.Message() == actors.ErrReminderCanceled.Error() {
-					return
-				}
-			}
-
 			log.Errorf("failed to invoke scheduled actor reminder named: %s due to: %s", job.GetName(), err)
 		}
 

--- a/pkg/scheduler/server/api.go
+++ b/pkg/scheduler/server/api.go
@@ -57,9 +57,7 @@ func (s *Server) ScheduleJob(ctx context.Context, req *schedulerv1pb.ScheduleJob
 		Payload:  req.GetJob().GetData(),
 	}
 
-	reqCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	err = s.cron.Add(reqCtx, jobName, job)
+	err = s.cron.Add(ctx, jobName, job)
 	if err != nil {
 		log.Errorf("error scheduling job %s: %s", req.GetName(), err)
 		return nil, err
@@ -84,9 +82,7 @@ func (s *Server) DeleteJob(ctx context.Context, req *schedulerv1pb.DeleteJobRequ
 		return nil, err
 	}
 
-	reqCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	err = s.cron.Delete(reqCtx, jobName)
+	err = s.cron.Delete(ctx, jobName)
 	if err != nil {
 		log.Errorf("error deleting job %s: %s", jobName, err)
 		return nil, err
@@ -111,9 +107,7 @@ func (s *Server) GetJob(ctx context.Context, req *schedulerv1pb.GetJobRequest) (
 		return nil, err
 	}
 
-	reqCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	job, err := s.cron.Get(reqCtx, jobName)
+	job, err := s.cron.Get(ctx, jobName)
 	if err != nil {
 		log.Errorf("error getting job %s: %s", jobName, err)
 		return nil, err


### PR DESCRIPTION
Workflow reminders must have a period set of repeating forever. This is what fundamentally ensures the durability of Workflows.

PR updates all workflow reminders to have an infinite period.

Workflow reminders repeat execution every 1 minute. In some cases, such as during extremely high load, a workflow reminder may execute whilst a previous execution is still in progress. This leads to situations such as double activity invocation. This patch adds a duplicate internal reminder detector, which silently returns if a duplicate reminder is detected.

Removes the background contexts to Scheduler APIs. The Scheduler API server must respect inbound client contexts.

Removes unused `--placement` flag from the Scheduler.
