### PR TITLE
Add arm64 node affinity to test DBs

### DIFF
--- a/tests/config/kafka_override.yaml
+++ b/tests/config/kafka_override.yaml
@@ -34,6 +34,7 @@ affinity:
             operator: In
             values:
             - amd64
+            - arm64
 
 zookeeper:
   persistence:
@@ -51,3 +52,4 @@ zookeeper:
               operator: In
               values:
               - amd64
+              - arm64

--- a/tests/config/mongodb_override.yaml
+++ b/tests/config/mongodb_override.yaml
@@ -30,3 +30,4 @@ affinity:
             operator: In
             values:
             - amd64
+            - arm64

--- a/tests/config/postgres_override.yaml
+++ b/tests/config/postgres_override.yaml
@@ -22,6 +22,7 @@ primary:
                 operator: In
                 values:
                   - amd64
+                  - arm64
   persistence:
     enabled: false
 tls:

--- a/tests/config/redis_override.yaml
+++ b/tests/config/redis_override.yaml
@@ -41,3 +41,4 @@ master:
               operator: In
               values:
               - amd64
+              - arm64

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -623,7 +623,7 @@ setup-kind:
 	# Connect the registry to the KinD network.
 	docker network connect "kind" kind-registry
 	# Setup metrics-server
-	helm install ms stable/metrics-server -n kube-system --set=args={--kubelet-insecure-tls}
+	helm upgrade --install metrics-server metrics-server/metrics-server --namespace kube-system --set=args={--kubelet-insecure-tls}
 
 describe-kind-env:
 	@echo "\


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
Adding arm64 node affinity to test DBs will allow to run tests locally on Arm Mac machines or in cloud.
Fix local kind metrics-server install

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
