### PR TITLE
Fix: Don't track duplicate in-flight reminders for non-scheduler reminders

### DIFF
--- a/tests/integration/suite/daprd/workflow/raise.go
+++ b/tests/integration/suite/daprd/workflow/raise.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	"github.com/microsoft/durabletask-go/client"
+	"github.com/microsoft/durabletask-go/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(raise))
+}
+
+type raise struct {
+	daprd *daprd.Daprd
+}
+
+func (r *raise) Setup(t *testing.T) []framework.Option {
+	app := app.New(t)
+	place := placement.New(t)
+
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithInMemoryActorStateStore("statestore"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(place, app, r.daprd),
+	}
+}
+
+func (r *raise) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	gclient := r.daprd.GRPCClient(t, ctx)
+
+	var stage atomic.Int64
+
+	reg := task.NewTaskRegistry()
+	reg.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		var input int
+		require.NoError(t, ctx.GetInput(&input))
+
+		require.NoError(t, ctx.CallActivity("bar", task.WithActivityInput(input)).Await(new([]byte)))
+		require.NoError(t, ctx.WaitForSingleEvent("testEvent", time.Second*60).Await(new([]byte)))
+		require.NoError(t, ctx.CallActivity("bar", task.WithActivityInput(input)).Await(new([]byte)))
+
+		return "", nil
+	})
+	require.NoError(t, reg.AddActivityN("bar", func(c task.ActivityContext) (any, error) {
+		var input int
+		require.NoError(t, c.GetInput(&input))
+		stage.Add(int64(input))
+		return "", nil
+	}))
+
+	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
+
+	resp, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "foo",
+		InstanceId:        "my-custom-instance-id",
+		Input:             []byte("1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-custom-instance-id", resp.GetInstanceId())
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	get, err := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "RUNNING", get.GetRuntimeStatus())
+
+	_, err = gclient.PauseWorkflowBeta1(ctx, &rtv1.PauseWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+
+	get, err = gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "SUSPENDED", get.GetRuntimeStatus())
+
+	_, err = gclient.ResumeWorkflowAlpha1(ctx, &rtv1.ResumeWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		get, err = gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        "my-custom-instance-id",
+			WorkflowComponent: "dapr",
+		})
+		require.NoError(t, err)
+		assert.Equal(c, "RUNNING", get.GetRuntimeStatus())
+	}, time.Second*5, time.Millisecond*10)
+
+	_, err = gclient.RaiseEventWorkflowBeta1(ctx, &rtv1.RaiseEventWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+		EventName:         "testEvent",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(2), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, api.InstanceID("my-custom-instance-id"))
+	require.NoError(t, err)
+	assert.True(t, metadata.IsComplete())
+
+	_, err = gclient.PurgeWorkflowBeta1(ctx, &rtv1.PurgeWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+
+	stage.Store(0)
+
+	// Workflow client
+	_, err = backendClient.ScheduleNewOrchestration(ctx, "foo", api.WithInstanceID("my-custom-instance-id"), api.WithInput(1))
+	require.NoError(t, err)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	require.NoError(t, backendClient.RaiseEvent(ctx, "my-custom-instance-id", "testEvent"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(2), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	_, err = backendClient.WaitForOrchestrationCompletion(ctx, api.InstanceID("my-custom-instance-id"))
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/raise.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/raise.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	"github.com/microsoft/durabletask-go/client"
+	"github.com/microsoft/durabletask-go/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(raise))
+}
+
+type raise struct {
+	daprd *daprd.Daprd
+}
+
+func (r *raise) Setup(t *testing.T) []framework.Option {
+	app := app.New(t)
+	place := placement.New(t)
+	scheduler := scheduler.New(t)
+
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithInMemoryActorStateStore("statestore"),
+		daprd.WithSchedulerAddresses(scheduler.Address()),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: schedulerreminders
+spec:
+  features:
+  - name: SchedulerReminders
+    enabled: true`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(scheduler, place, app, r.daprd),
+	}
+}
+
+func (r *raise) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	gclient := r.daprd.GRPCClient(t, ctx)
+
+	var stage atomic.Int64
+
+	reg := task.NewTaskRegistry()
+	reg.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		var input int
+		require.NoError(t, ctx.GetInput(&input))
+
+		require.NoError(t, ctx.CallActivity("bar", task.WithActivityInput(input)).Await(new([]byte)))
+		require.NoError(t, ctx.WaitForSingleEvent("testEvent", time.Second*60).Await(new([]byte)))
+		require.NoError(t, ctx.CallActivity("bar", task.WithActivityInput(input)).Await(new([]byte)))
+
+		return "", nil
+	})
+	require.NoError(t, reg.AddActivityN("bar", func(c task.ActivityContext) (any, error) {
+		var input int
+		require.NoError(t, c.GetInput(&input))
+		stage.Add(int64(input))
+		return "", nil
+	}))
+
+	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
+
+	resp, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "foo",
+		InstanceId:        "my-custom-instance-id",
+		Input:             []byte("1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-custom-instance-id", resp.GetInstanceId())
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	get, err := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		get, err = gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        "my-custom-instance-id",
+			WorkflowComponent: "dapr",
+		})
+		require.NoError(t, err)
+		assert.Equal(c, "RUNNING", get.GetRuntimeStatus())
+	}, time.Second*5, time.Millisecond*10)
+
+	_, err = gclient.PauseWorkflowBeta1(ctx, &rtv1.PauseWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+
+	get, err = gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "SUSPENDED", get.GetRuntimeStatus())
+
+	_, err = gclient.ResumeWorkflowAlpha1(ctx, &rtv1.ResumeWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		get, err = gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        "my-custom-instance-id",
+			WorkflowComponent: "dapr",
+		})
+		require.NoError(t, err)
+		assert.Equal(c, "RUNNING", get.GetRuntimeStatus())
+	}, time.Second*5, time.Millisecond*10)
+
+	_, err = gclient.RaiseEventWorkflowBeta1(ctx, &rtv1.RaiseEventWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+		EventName:         "testEvent",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(2), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	metadata, err := backendClient.WaitForOrchestrationCompletion(ctx, api.InstanceID("my-custom-instance-id"))
+	require.NoError(t, err)
+	assert.True(t, metadata.IsComplete())
+
+	_, err = gclient.PurgeWorkflowBeta1(ctx, &rtv1.PurgeWorkflowRequest{
+		InstanceId:        "my-custom-instance-id",
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+
+	stage.Store(0)
+
+	// Workflow client
+	_, err = backendClient.ScheduleNewOrchestration(ctx, "foo", api.WithInstanceID("my-custom-instance-id"), api.WithInput(1))
+	require.NoError(t, err)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	require.NoError(t, backendClient.RaiseEvent(ctx, "my-custom-instance-id", "testEvent"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(2), stage.Load())
+	}, time.Second*3, time.Millisecond*10)
+
+	_, err = backendClient.WaitForOrchestrationCompletion(ctx, api.InstanceID("my-custom-instance-id"))
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/raise.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/raise.go
@@ -128,12 +128,14 @@ func (r *raise) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 
-	get, err = gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
-		InstanceId:        "my-custom-instance-id",
-		WorkflowComponent: "dapr",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "SUSPENDED", get.GetRuntimeStatus())
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		get, err = gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        "my-custom-instance-id",
+			WorkflowComponent: "dapr",
+		})
+		require.NoError(t, err)
+		assert.Equal(c, "SUSPENDED", get.GetRuntimeStatus())
+	}, time.Second*5, time.Millisecond*10)
 
 	_, err = gclient.ResumeWorkflowAlpha1(ctx, &rtv1.ResumeWorkflowRequest{
 		InstanceId:        "my-custom-instance-id",


### PR DESCRIPTION
Don't track in-flight internal (workflow) reminders when not using scheduler reminders. This is because they only get un-tracked when they are deleted in the scheduler code-path. This caused workflow activities to not fire when triggering a workflow multiple times with the same instance ID - since the had the same reminder key.

Adds int tests for both scheduler and non-scheduler reminders which trigger a workflow with the same instance ID multiple times.