### PR TITLE
Updates k8s version for e2e tests on AKS

### DIFF
--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -43,7 +43,7 @@ param diagStorageResourceId string = ''
 var osDiskSizeGB = 0
 
 // Version of Kubernetes
-var kubernetesVersion = '1.27'
+var kubernetesVersion = '1.30'
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
   name: '${namePrefix}acr'


### PR DESCRIPTION
# Description

e2e tests have been failing for a while because of old k8s version that is not supported any more in the region we're using. The currently supported versions in the westus3 are 1.27 through 1.30. This PR updates the k8s version we're using to 1.30.