### PR TITLE
1.14: Integration test stabilization (#8001)

### DIFF
--- a/pkg/actors/reminders/scheduler.go
+++ b/pkg/actors/reminders/scheduler.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
+	retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -122,7 +124,10 @@ func (s *scheduler) CreateReminder(ctx context.Context, reminder *internal.Creat
 		},
 	}
 
-	_, err = s.clients.Next().ScheduleJob(ctx, internalScheduleJobReq)
+	_, err = s.clients.Next().ScheduleJob(ctx, internalScheduleJobReq,
+		retry.WithMax(3),
+		retry.WithPerRetryTimeout(time.Second/2),
+	)
 	if err != nil {
 		log.Errorf("Error scheduling reminder job %s due to: %s", reminder.Name, err)
 	}

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -359,9 +359,13 @@ func (p *Service) ReportDaprStatus(stream placementv1pb.Placement_ReportDaprStat
 			}
 
 			if isActorRuntime {
-				p.membershipCh <- hostMemberChange{
+				select {
+				case p.membershipCh <- hostMemberChange{
 					cmdType: raft.MemberRemove,
 					host:    raft.DaprHostMember{Name: registeredMemberID, Namespace: namespace},
+				}:
+				case <-p.closedCh:
+					return errors.New("placement service is closed")
 				}
 			}
 

--- a/pkg/runtime/scheduler/connector.go
+++ b/pkg/runtime/scheduler/connector.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"time"
 
+	retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+
 	"github.com/dapr/dapr/pkg/actors"
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 	"github.com/dapr/dapr/pkg/runtime/channels"
@@ -33,7 +35,10 @@ type connector struct {
 // to WatchJobs on non-terminal errors.
 func (c *connector) run(ctx context.Context) error {
 	for {
-		stream, err := c.client.WatchJobs(ctx)
+		stream, err := c.client.WatchJobs(ctx,
+			retry.WithMax(3),
+			retry.WithPerRetryTimeout(time.Second/2),
+		)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -133,19 +133,19 @@ func (p *Placement) Cleanup(t *testing.T) {
 }
 
 func (p *Placement) WaitUntilRunning(t *testing.T, ctx context.Context) {
+	t.Helper()
+
 	client := client.HTTP(t)
-	assert.Eventually(t, func() bool {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/healthz", p.healthzPort), nil)
-		if err != nil {
-			return false
-		}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/healthz", p.healthzPort), nil)
+	require.NoError(t, err)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := client.Do(req)
-		if err != nil {
-			return false
+		//nolint:testifylint
+		if assert.NoError(c, err) {
+			defer resp.Body.Close()
+			assert.Equal(c, http.StatusOK, resp.StatusCode)
 		}
-		defer resp.Body.Close()
-		return http.StatusOK == resp.StatusCode
-	}, time.Second*5, 10*time.Millisecond)
+	}, time.Second*10, 10*time.Millisecond)
 }
 
 func (p *Placement) ID() string {

--- a/tests/integration/suite/actors/reminders/scheduler/idtypes.go
+++ b/tests/integration/suite/actors/reminders/scheduler/idtypes.go
@@ -84,7 +84,7 @@ spec:
 
 	i.daprdsNum = 4
 	i.actorTypesNum = 2
-	i.actorIDsNum = 25
+	i.actorIDsNum = 15
 	i.daprds = make([]*daprd.Daprd, i.daprdsNum)
 	i.actorDaprds = make([]actordaprd, i.daprdsNum)
 	procs := make([]process.Interface, i.daprdsNum*2+2)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/http.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/http.go
@@ -283,7 +283,7 @@ spec:
 
 	require.NoError(t, os.Remove(filepath.Join(h.resDir2, "pubsub.yaml")))
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, h.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+		assert.Len(c, h.daprd.GetMetaRegisteredComponents(c, ctx), 1)
 	}, time.Second*5, time.Millisecond*10)
 	h.sub.ExpectPublishReceive(t, ctx, newReq(h.daprd, "pubsub0", "d"))
 	h.sub.ExpectPublishError(t, ctx, newReq(h.daprd, "pubsub1", "c"))

--- a/tests/integration/suite/daprd/jobs/http/api.go
+++ b/tests/integration/suite/daprd/jobs/http/api.go
@@ -90,6 +90,7 @@ func (a *api) Run(t *testing.T, ctx context.Context) {
 	body := `{
 "schedule": "@every 1s",
 "repeats": 10,
+"dueTime": "0s",
 "data": {
 	"@type": "type.googleapis.com/google.protobuf.StringValue",
 	"value": "\"someData\""
@@ -119,7 +120,7 @@ func (a *api) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(t, []byte(`"someData"`), bytes.TrimSpace(job.GetData().GetValue()))
 		assert.Equal(t, "type.googleapis.com/google.protobuf.StringValue", job.GetData().GetTypeUrl())
 
-	case <-time.After(time.Second * 3):
+	case <-time.After(time.Second * 10):
 		assert.Fail(t, "timed out waiting for triggered job")
 	}
 

--- a/tests/integration/suite/daprd/jobs/streaming/stream.go
+++ b/tests/integration/suite/daprd/jobs/streaming/stream.go
@@ -116,6 +116,7 @@ func (s *streaming) Run(t *testing.T, ctx context.Context) {
 				Name:     "test",
 				Schedule: ptr.Of("@every 1s"),
 				Repeats:  ptr.Of(uint32(1)),
+				DueTime:  ptr.Of("0m"),
 				Data: &anypb.Any{
 					TypeUrl: "type.googleapis.com/google.type.Expr",
 				},

--- a/tests/integration/suite/daprd/metrics/grpc/basic.go
+++ b/tests/integration/suite/daprd/metrics/grpc/basic.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,8 +78,10 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 
 		// Verify metrics
-		metrics := b.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_grpc_io_server_completed_rpcs|app_id:myapp|grpc_server_method:/dapr.proto.runtime.v1.Dapr/InvokeService|grpc_server_status:OK"]))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			metrics := b.daprd.Metrics(t, ctx)
+			assert.Equal(c, 1, int(metrics["dapr_grpc_io_server_completed_rpcs|app_id:myapp|grpc_server_method:/dapr.proto.runtime.v1.Dapr/InvokeService|grpc_server_status:OK"]))
+		}, time.Second*10, time.Millisecond*10)
 	})
 
 	t.Run("state stores", func(t *testing.T) {
@@ -99,8 +102,10 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 
 		// Verify metrics
-		metrics := b.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_grpc_io_server_completed_rpcs|app_id:myapp|grpc_server_method:/dapr.proto.runtime.v1.Dapr/SaveState|grpc_server_status:OK"]))
-		assert.Equal(t, 1, int(metrics["dapr_grpc_io_server_completed_rpcs|app_id:myapp|grpc_server_method:/dapr.proto.runtime.v1.Dapr/GetState|grpc_server_status:OK"]))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			metrics := b.daprd.Metrics(t, ctx)
+			assert.Equal(c, 1, int(metrics["dapr_grpc_io_server_completed_rpcs|app_id:myapp|grpc_server_method:/dapr.proto.runtime.v1.Dapr/SaveState|grpc_server_status:OK"]))
+			assert.Equal(c, 1, int(metrics["dapr_grpc_io_server_completed_rpcs|app_id:myapp|grpc_server_method:/dapr.proto.runtime.v1.Dapr/GetState|grpc_server_status:OK"]))
+		}, time.Second*10, time.Millisecond*10)
 	})
 }

--- a/tests/integration/suite/daprd/metrics/http/basic.go
+++ b/tests/integration/suite/daprd/metrics/http/basic.go
@@ -75,7 +75,9 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		b.daprd.HTTPGet2xx(t, ctx, "/v1.0/state/mystore/myvalue")
 
 		metrics := b.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:/v1.0/state/mystore|status:204"]))
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/state/mystore|status:200"]))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:/v1.0/state/mystore|status:204"]))
+			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/state/mystore|status:200"]))
+		}, time.Second*3, time.Millisecond*10)
 	})
 }

--- a/tests/integration/suite/daprd/metrics/http/excludeverbs/default.go
+++ b/tests/integration/suite/daprd/metrics/http/excludeverbs/default.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -69,6 +70,8 @@ func (h *defaultExcludeVerbs) Run(t *testing.T, ctx context.Context) {
 	t.Run("service invocation - default", func(t *testing.T) {
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/123")
 		metrics := h.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/123|status:200"]))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/123|status:200"]))
+		}, time.Second*5, time.Millisecond*10)
 	})
 }

--- a/tests/integration/suite/daprd/metrics/http/excludeverbs/excludeverbs.go
+++ b/tests/integration/suite/daprd/metrics/http/excludeverbs/excludeverbs.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -71,7 +72,9 @@ func (h *excludeVerbs) Run(t *testing.T, ctx context.Context) {
 
 	t.Run("service invocation - exclude http verbs", func(t *testing.T) {
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/123")
-		metrics := h.daprd.Metrics(t, ctx)
-		assert.Equal(t, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:|path:/v1.0/invoke/myapp/method/orders/123|status:200"]))
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			metrics := h.daprd.Metrics(t, ctx)
+			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:|path:/v1.0/invoke/myapp/method/orders/123|status:200"]))
+		}, time.Second*10, time.Millisecond*10)
 	})
 }

--- a/tests/integration/suite/daprd/pubsub/grpc/appready.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/appready.go
@@ -143,19 +143,22 @@ func (a *appready) Run(t *testing.T, ctx context.Context) {
 		return resp.StatusCode == http.StatusOK
 	}, time.Second*5, 10*time.Millisecond)
 
-	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
-		PubsubName: "mypubsub",
-		Topic:      "mytopic",
-		Data:       []byte(`{"status": "completed"}`),
-	})
-	require.NoError(t, err)
+	assert.Eventually(t, func() bool {
+		_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+			PubsubName: "mypubsub",
+			Topic:      "mytopic",
+			Data:       []byte(`{"status": "completed"}`),
+		})
+		require.NoError(t, err)
 
-	select {
-	case resp := <-a.topicChan:
-		assert.Equal(t, "/myroute", resp)
-	case <-time.After(time.Second * 10):
-		assert.Fail(t, "timeout waiting for topic to return")
-	}
+		select {
+		case resp := <-a.topicChan:
+			assert.Equal(t, "/myroute", resp)
+			return true
+		case <-time.After(time.Second):
+			return false
+		}
+	}, time.Second*5, time.Millisecond*10)
 
 	// Should stop sending messages to subscribed app when it becomes unhealthy.
 	a.appHealthy.Store(false)

--- a/tests/integration/suite/daprd/shutdown/block/app/healthy.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/healthy.go
@@ -29,7 +29,6 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/logline"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -92,7 +91,7 @@ func (h *healthy) Setup(t *testing.T) []framework.Option {
 		daprd.WithAppHealthCheckPath("/healthz"),
 		daprd.WithAppHealthProbeInterval(1),
 		daprd.WithAppHealthProbeThreshold(1),
-		daprd.WithExecOptions(exec.WithStdout(h.logline.Stdout())),
+		daprd.WithLogLineStdout(h.logline),
 		daprd.WithResourceFiles(`
 apiVersion: dapr.io/v1alpha1
 kind: Component

--- a/tests/integration/suite/daprd/shutdown/block/app/pubsub/single.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/pubsub/single.go
@@ -113,6 +113,9 @@ func (s *single) Run(t *testing.T, ctx context.Context) {
 	client := s.daprd.GRPCClient(t, ctx)
 
 	assert.Len(t, s.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, s.daprd.GetMetaSubscriptions(t, ctx), 2)
+	}, time.Second*10, time.Millisecond, 10)
 
 	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
 		PubsubName: "foo",


### PR DESCRIPTION
* Integration test stabilization

Use collectT in Eventually for daprd/hotreload/selfhosted/subscriptions/http.go



* Wrap publishing message for app ready in Eventually



* Wrap metric check in Eventually



* More stability



* More eventuallys around metrics checks



* Adds check to wait for subscription to be available



* Increase timeout for placement to become ready



* Lint



* Add eventually around metrics



* Increase timeout for job to be triggered



* Reduce number in idtypes



* Increase timeout for metrics



* Trigger immediately



* Move metrics Get inside Eventually



* Adds closeCh check during channel message send



* Print got output in logline failure



* Fix logline error got output newline



---------

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
* [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
