### PR TITLE
Adds retry to runtime scheduler connector WatchJobs API call.

### DIFF
--- a/pkg/runtime/scheduler/connector.go
+++ b/pkg/runtime/scheduler/connector.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"time"
 
+	retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+
 	"github.com/dapr/dapr/pkg/actors"
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 	"github.com/dapr/dapr/pkg/runtime/channels"
@@ -33,7 +35,10 @@ type connector struct {
 // to WatchJobs on non-terminal errors.
 func (c *connector) run(ctx context.Context) error {
 	for {
-		stream, err := c.client.WatchJobs(ctx)
+		stream, err := c.client.WatchJobs(ctx,
+			retry.WithMax(3),
+			retry.WithPerRetryTimeout(time.Second/2),
+		)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}


### PR DESCRIPTION
Adds a small retry to the runtime WatchJobs API call. This is mostly useful for testing whereby there is a race condition between the processes running, the API being available, and attempting to consume this API, causing failures.