### PR TITLE
Fix outbox regression

### DIFF
--- a/docs/release_notes/v1.14.2.md
+++ b/docs/release_notes/v1.14.2.md
@@ -107,3 +107,21 @@ Message processing logic moved on to process the next message instead of exiting
 ### Solution
 
 The code was changed to handle session context exiting prior to processing the next message.
+
+## Fix Outbox not sending messages to the user topic
+
+### Problem
+
+If outbox was being used and a publisher didn't have an app channel open or the subscriber didn't have access to the transactional state store, then outbox messages would not be published.
+
+### Impact
+
+Outbox messages could not be sent.
+
+### Root cause
+
+Faulty logic that required Dapr to have an app channel in order to subscribe to the internal topics.
+
+### Solution
+
+Enable Dapr to subscribe to internal topics without needing an app channel.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -783,11 +783,11 @@ func (a *DaprRuntime) appHealthChanged(ctx context.Context, status uint8) {
 			if err != nil {
 				log.Warnf("failed to read from bindings: %s ", err)
 			}
+		}
 
-			// Start subscribing to outbox topics
-			if err := a.outbox.SubscribeToInternalTopics(ctx, a.runtimeConfig.id); err != nil {
-				log.Warnf("failed to subscribe to outbox topics: %s", err)
-			}
+		// Start subscribing to outbox topics
+		if err := a.outbox.SubscribeToInternalTopics(ctx, a.runtimeConfig.id); err != nil {
+			log.Warnf("failed to subscribe to outbox topics: %s", err)
 		}
 
 		if a.runtimeConfig.SchedulerEnabled() {


### PR DESCRIPTION
Enables Dapr to subscribe to internal outbox topics without an app channel.
