### PR TITLE
Scheduler: Add options for ETCD storage options

### DIFF
--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -160,9 +160,12 @@ spec:
         - "--enable-metrics=false"
 {{- end }}
         - "--etcd-data-dir={{ if eq .Values.global.daprControlPlaneOs "windows" }}{{ .Values.cluster.etcdDataDirWinPath }}{{- else }}{{ .Values.cluster.etcdDataDirPath }}{{- end }}/{{ .Release.Namespace }}/$(SCHEDULER_ID)"
-        - "--etcd-space-quota={{ int .Values.etcdSpaceQuota }}"
+        - "--etcd-space-quota={{ .Values.etcdSpaceQuota }}"
         - "--etcd-compaction-mode={{ .Values.etcdCompactionMode }}"
         - "--etcd-compaction-retention={{ .Values.etcdCompactionRetention }}"
+        - "--etcd-snapshot-count={{ .Values.etcdSnapshotCount }}"
+        - "--etcd-max-snapshots={{ .Values.etcdMaxSnapshots }}"
+        - "--etcd-max-wals={{ .Values.etcdMaxWals }}"
         - "--tls-enabled"
         - "--trust-domain={{ .Values.global.mtls.controlPlaneTrustDomain }}"
         - "--trust-anchors-file=/var/run/secrets/dapr.io/tls/ca.crt"

--- a/charts/dapr/charts/dapr_scheduler/values.yaml
+++ b/charts/dapr/charts/dapr_scheduler/values.yaml
@@ -31,12 +31,15 @@ cluster:
   etcdDataDirPath: /var/run/data/dapr-scheduler
   etcdDataDirWinPath: C:\\dapr-scheduler
   storageClassName: ""
-  storageSize: 1Gi
+  storageSize: 16Gi
   inMemoryStorage: false
 
-etcdSpaceQuota: 2147483648
+etcdSpaceQuota: 16Gi
 etcdCompactionMode: periodic
-etcdCompactionRetention: 24h
+etcdCompactionRetention: 10m
+etcdSnapshotCount: 10000
+etcdMaxSnapshots: 5
+etcdMaxWals: 5
 
 livenessProbe:
   initialDelaySeconds: 10

--- a/cmd/scheduler/app/app.go
+++ b/cmd/scheduler/app/app.go
@@ -109,6 +109,9 @@ func Run() {
 				EtcdCompactionMode:      opts.EtcdCompactionMode,
 				EtcdCompactionRetention: opts.EtcdCompactionRetention,
 				EtcdClientHTTPPorts:     opts.EtcdClientHTTPPorts,
+				EtcdSnapshotCount:       opts.EtcdSnapshotCount,
+				EtcdMaxSnapshots:        opts.EtcdMaxSnapshots,
+				EtcdMaxWALs:             opts.EtcdMaxWALs,
 			})
 			if serr != nil {
 				return serr

--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/dapr/dapr/pkg/metrics"
 	"github.com/dapr/dapr/pkg/modes"
@@ -50,11 +51,15 @@ type Options struct {
 	EtcdSpaceQuota          int64
 	EtcdCompactionMode      string
 	EtcdCompactionRetention string
+	EtcdSnapshotCount       uint64
+	EtcdMaxSnapshots        uint
+	EtcdMaxWALs             uint
 
 	Logger  logger.Options
 	Metrics *metrics.FlagOptions
 
-	taFile string
+	taFile         string
+	etcdSpaceQuota string
 }
 
 func New(origArgs []string) (*Options, error) {
@@ -81,9 +86,12 @@ func New(origArgs []string) (*Options, error) {
 	fs.StringVar(&opts.EtcdDataDir, "etcd-data-dir", "./data", "Directory to store scheduler etcd data")
 	fs.StringSliceVar(&opts.EtcdClientPorts, "etcd-client-ports", []string{"dapr-scheduler-server-0=2379"}, "Ports for etcd client communication")
 	fs.StringSliceVar(&opts.EtcdClientHTTPPorts, "etcd-client-http-ports", nil, "Ports for etcd client http communication")
-	fs.Int64Var(&opts.EtcdSpaceQuota, "etcd-space-quota", 2*1024*1024*1024, "Space quota for etcd")
+	fs.StringVar(&opts.etcdSpaceQuota, "etcd-space-quota", resource.NewQuantity(16*1024*1024*1024, resource.BinarySI).String(), "Space quota for etcd")
 	fs.StringVar(&opts.EtcdCompactionMode, "etcd-compaction-mode", "periodic", "Compaction mode for etcd. Can be 'periodic' or 'revision'")
-	fs.StringVar(&opts.EtcdCompactionRetention, "etcd-compaction-retention", "24h", "Compaction retention for etcd. Can express time  or number of revisions, depending on the value of 'etcd-compaction-mode'")
+	fs.StringVar(&opts.EtcdCompactionRetention, "etcd-compaction-retention", "10m", "Compaction retention for etcd. Can express time  or number of revisions, depending on the value of 'etcd-compaction-mode'")
+	fs.Uint64Var(&opts.EtcdSnapshotCount, "etcd-snapshot-count", 10000, "Number of committed transactions to trigger a snapshot to disk.")
+	fs.UintVar(&opts.EtcdMaxSnapshots, "etcd-max-snapshots", 5, "Maximum number of snapshot files to retain (0 is unlimited).")
+	fs.UintVar(&opts.EtcdMaxWALs, "etcd-max-wals", 5, "Maximum number of write-ahead logs to retain (0 is unlimited).")
 
 	opts.Logger = logger.DefaultOptions()
 	opts.Logger.AttachCmdFlags(fs.StringVar, fs.BoolVar)
@@ -111,6 +119,12 @@ func New(origArgs []string) (*Options, error) {
 	if fs.Changed("trust-anchors-file") {
 		opts.TrustAnchorsFile = &opts.taFile
 	}
+
+	etcdSpaceQuota, err := resource.ParseQuantity(opts.etcdSpaceQuota)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse etcd space quota: %s", err)
+	}
+	opts.EtcdSpaceQuota, _ = etcdSpaceQuota.AsInt64()
 
 	return &opts, nil
 }

--- a/pkg/scheduler/server/config.go
+++ b/pkg/scheduler/server/config.go
@@ -47,10 +47,6 @@ func config(opts Options) (*embed.Config, error) {
 	config.Name = opts.EtcdID
 	config.InitialCluster = strings.Join(opts.EtcdInitialPeers, ",")
 
-	config.QuotaBackendBytes = opts.EtcdSpaceQuota
-	config.AutoCompactionMode = opts.EtcdCompactionMode
-	config.AutoCompactionRetention = opts.EtcdCompactionRetention
-
 	etcdURL, peerPort, err := peerHostAndPort(opts.EtcdID, opts.EtcdInitialPeers)
 	if err != nil {
 		return nil, fmt.Errorf("invalid format for initial cluster. Make sure to include 'http://' in Scheduler URL: %s", err)
@@ -117,6 +113,13 @@ func config(opts Options) (*embed.Config, error) {
 	// TODO: Cassie do extra validation that the client port != peer port -> dont fail silently
 	// TODO: Cassie do extra validation if people forget to put http:// -> dont fail silently
 	// TODO: Cassie do extra validation to ensure that the list of ids sent in for the clientPort == list of ids from initial cluster
+
+	config.QuotaBackendBytes = opts.EtcdSpaceQuota
+	config.AutoCompactionMode = opts.EtcdCompactionMode
+	config.AutoCompactionRetention = opts.EtcdCompactionRetention
+	config.MaxSnapFiles = opts.EtcdMaxSnapshots
+	config.MaxWalFiles = opts.EtcdMaxWALs
+	config.SnapshotCount = opts.EtcdSnapshotCount
 
 	return config, nil
 }

--- a/pkg/scheduler/server/server.go
+++ b/pkg/scheduler/server/server.go
@@ -54,6 +54,9 @@ type Options struct {
 	EtcdSpaceQuota          int64
 	EtcdCompactionMode      string
 	EtcdCompactionRetention string
+	EtcdSnapshotCount       uint64
+	EtcdMaxSnapshots        uint
+	EtcdMaxWALs             uint
 }
 
 // Server is the gRPC server for the Scheduler service.


### PR DESCRIPTION
Adds `etcd-snapshot-count`, `etcd-max-snapshots`, and `etcd-max-wals` to the scheduler options.

`etcd-space-quota` has the default increased to 16Gi. The flag value format has been changed to now accept a SI unit suffix (e.g. 16Gi).

`etcd-compaction-retention` has been reduced from `24h` to `10m`.

The default Scheduler volume size has been increase to `16Gi`.