### PR TITLE
Operator: Fix race for subscribing API and operator close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.14.4
-	github.com/dapr/kit v0.13.1-0.20240724000121-26b564d9d0f5
+	github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb
 	github.com/diagridio/go-etcd-cron v0.2.3
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.14.4 h1:ikBWb3c5OS4ntsYTWkJ2ZnskQ0CKquJ6V3pLusnIrDg=
 github.com/dapr/components-contrib v1.14.4/go.mod h1:h2OsxAGYLVR/chY2hThFbulEupHWPvVI3BpMQBXcJtg=
-github.com/dapr/kit v0.13.1-0.20240724000121-26b564d9d0f5 h1:FQKdGOG6Zi3gBhtnxPQmrd8QFLs8e6JTGkts+aaXba0=
-github.com/dapr/kit v0.13.1-0.20240724000121-26b564d9d0f5/go.mod h1:Hz1W2LmWfA4UX/12MdA+brsf+np6f/1dJt6C6F63cjI=
+github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb h1:ahLO7pMmX6HAuT6/RxYWBY4AN2fXQJcYlU1msY6Kt7U=
+github.com/dapr/kit v0.13.1-0.20240909215017-3823663aa4bb/go.mod h1:Hz1W2LmWfA4UX/12MdA+brsf+np6f/1dJt6C6F63cjI=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -76,6 +76,7 @@ type apiServer struct {
 	connLock                  sync.Mutex
 	readyCh                   chan struct{}
 	running                   atomic.Bool
+	closed                    atomic.Bool
 }
 
 // NewAPIServer returns a new API server.
@@ -127,6 +128,7 @@ func (a *apiServer) Run(ctx context.Context) error {
 		func(ctx context.Context) error {
 			// Block until context is done
 			<-ctx.Done()
+			a.closed.Store(true)
 			a.connLock.Lock()
 			for key, ch := range a.allSubscriptionUpdateChan {
 				close(ch)

--- a/pkg/operator/api/httpendpoints.go
+++ b/pkg/operator/api/httpendpoints.go
@@ -150,6 +150,10 @@ func (a *apiServer) HTTPEndpointUpdate(in *operatorv1pb.HTTPEndpointUpdateReques
 	key := keyObj.String()
 
 	a.endpointLock.Lock()
+	if a.closed.Load() {
+		a.connLock.Unlock()
+		return nil
+	}
 	a.allEndpointsUpdateChan[key] = make(chan *httpendpointsapi.HTTPEndpoint, 1)
 	updateChan := a.allEndpointsUpdateChan[key]
 	a.endpointLock.Unlock()

--- a/pkg/operator/api/subscriptions.go
+++ b/pkg/operator/api/subscriptions.go
@@ -104,6 +104,10 @@ func (a *apiServer) SubscriptionUpdate(in *operatorv1pb.SubscriptionUpdateReques
 	key := keyObj.String()
 
 	a.connLock.Lock()
+	if a.closed.Load() {
+		a.connLock.Unlock()
+		return nil
+	}
 	updateChan := make(chan *SubscriptionUpdateEvent)
 	a.allSubscriptionUpdateChan[key] = updateChan
 	a.connLock.Unlock()


### PR DESCRIPTION
Adds a closed check in `Subscription` and `Endpoint` streaming API to fix reconnect & shutdown race.

Updates dapr/kit to main 3823663