### PR TITLE
fix: add apiVersion and kind to volumeClaimTemplates

### DIFF
--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
@@ -256,7 +256,9 @@ spec:
 {{- if or (eq .Values.global.ha.enabled true) (eq .Values.ha true) }}
   {{- if eq .Values.cluster.forceInMemoryLog false }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: raft-log
     spec:
       accessModes:

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -18,7 +18,9 @@ spec:
       app: dapr-scheduler-server
   {{- if not .Values.cluster.inMemoryStorage }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: dapr-scheduler-data-dir
     spec:
       accessModes: [ "ReadWriteOnce" ]


### PR DESCRIPTION
# Description

Kubernetes adds apiVersion and kind to volumeClaimTemplates, which makes the StatefulSets always appear out of sync when using any manifest diffing tool such as helm diff, argocd, or flux.

This PR adds them to the helm template to avoid this issue.

## Issue reference

Please reference the issue this PR will close: none

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
