### PR TITLE
Remove HTTP mem leak from release notes for 1.14.3

### DIFF
--- a/docs/release_notes/v1.14.3.md
+++ b/docs/release_notes/v1.14.3.md
@@ -4,7 +4,6 @@ This update includes bug fixes:
 
 - [Fix AWS Secrets Manager and Parameter Store components when working with more granular IAM permissions](#fix-aws-secrets-manager-and-parameter-store-components-when-working-with-more-granular-iam-permissions)
 - [Fix Scheduler embedded ETCD database running out of memory](#fix-scheduler-embedded-etcd-database-running-out-of-memory)
-- [Fix Memory leak in daprd when using the HTTP API](#fix-memory-leak-in-daprd-when-using-the-http-api)
 - [Fix the Job HTTP Trigger Request body base64 encoding values](#fix-the-job-http-trigger-request-body-base64-encoding-values)
 - [Change the HTTP Job API request body data field to accept JSON strings](#change-the-http-job-api-request-body-data-field-to-accept-json-strings)
 - [Add securityContext/runAsGroup and securityContext/runAsUser as sidecar injector options](#add-securitycontextrunasgroup-and-securitycontextrunasuser-as-sidecar-injector-options)
@@ -46,23 +45,7 @@ The default storage size of the embedded ETCD database was too small, as well as
 Increase the default storage size of the embedded ETCD database from 2Gi to 16Gi, increase the frequency of purging of deleted data.
 More options are now exposed on the Scheduler to tune these values further.
 
-## Fix Memory leak in daprd when using the HTTP API
 
-### Problem
-
-When using the HTTP API, particularly with requests bodies of significant size, the daprd process would increase in memory indefinitely.
-
-### Impact
-
-The daprd process would eventually run out of memory and crash, making all runtime APIs unavailable.
-
-### Root cause
-
-Most of the previous HTTP API implementations used a library in such a way that old request body and intermediate data would be kept in memory indefinitely.
-
-### Solution
-
-The HTTP API implementations were updated to remove this library and handle memory in a streaming manner wherever possible.
 
 ## Fix the Job HTTP Trigger Request body base64 encoding values
 


### PR DESCRIPTION
# Description

Remove HTTP mem leak from release notes for 1.14.3

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: patch release

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
