### PR TITLE
Corrected incorrect comment in proto docs

### DIFF
--- a/dapr/proto/runtime/v1/dapr.proto
+++ b/dapr/proto/runtime/v1/dapr.proto
@@ -1206,7 +1206,7 @@ message Job {
   //
   // Systemd timer style cron accepts 6 fields:
   // seconds | minutes | hours | day of month | month        | day of week
-  // 0-59    | 0-59    | 0-23  | 1-31         | 1-12/jan-dec | 0-7/sun-sat
+  // 0-59    | 0-59    | 0-23  | 1-31         | 1-12/jan-dec | 0-6/sun-sat
   //
   // "0 30 * * * *" - every hour on the half hour
   // "0 15 3 * * *" - every day at 03:15


### PR DESCRIPTION
# Description

The dapr.proto provides some helpful commentary about the various values accepted when scheduling a Job, but it incorrectly indicated that a valid "day of week" value is one from 0-7. This PR tweaks this to properly reflect that it should be a valid of 0-6 instead.

## Issue reference

None - noticed while updating protos in .NET SDK

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [N/A] Code compiles correctly
- [N/A] Created/updated tests
- [N/A] Unit tests passing
- [N/A] End-to-end tests passing
- [X] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [N/A] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [N/A] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
