### PR TITLE
Linter: Updates test code for new linter rules

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -81,9 +81,6 @@ jobs:
           version: ${{ env.GOLANGCILINT_VER }}
           skip-cache: true
           args: --build-tags allcomponents --timeout=10m
-          # TODO: @joshvanl remove once all new linter errors have been
-          # addressed.
-          only-new-issues: true
       - name: Run go mod tidy check diff
         run: make modtidy check-diff
       - name: Check for retracted dependencies

--- a/pkg/actors/actor_lock_test.go
+++ b/pkg/actors/actor_lock_test.go
@@ -50,7 +50,7 @@ func TestLockBypassWithMatchingID(t *testing.T) {
 	lock := NewActorLock(32)
 	requestID := &baseID
 
-	for i := 1; i < 5; i++ {
+	for i := uint32(1); i < 5; i++ {
 		err := lock.Lock(requestID)
 
 		require.NoError(t, err)

--- a/pkg/actors/actor_test.go
+++ b/pkg/actors/actor_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	clocktesting "k8s.io/utils/clock/testing"
 )
 
@@ -124,7 +123,7 @@ func TestPendingActorCalls(t *testing.T) {
 		go func() {
 			select {
 			case <-time.After(200 * time.Millisecond):
-				require.Fail(t, "channel should be closed before timeout")
+				assert.Fail(t, "channel should be closed before timeout")
 			case <-testActor.channel():
 				channelClosed.Store(true)
 				break
@@ -145,7 +144,7 @@ func TestPendingActorCalls(t *testing.T) {
 		nListeners := 10
 		releaseSignaled := make([]atomic.Bool, nListeners)
 
-		for i := 0; i < nListeners; i++ {
+		for i := range nListeners {
 			releaseCh := testActor.channel()
 			go func(listenerIndex int) {
 				select {
@@ -161,7 +160,7 @@ func TestPendingActorCalls(t *testing.T) {
 
 		assert.Eventually(t, func() bool {
 			clock.Step(100 * time.Millisecond)
-			for i := 0; i < nListeners; i++ {
+			for i := range nListeners {
 				if !releaseSignaled[i].Load() {
 					return false
 				}

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -138,7 +138,7 @@ func (r *reentrantAppChannel) InvokeMethod(ctx context.Context, req *invokev1.In
 		r.nextCall = r.nextCall[1:]
 
 		if val := req.Metadata()["Dapr-Reentrancy-Id"]; val != nil {
-			if nextReq.Metadata == nil { //nolint:protogetter
+			if nextReq.Metadata == nil {
 				nextReq.Metadata = make(map[string]*internalsv1pb.ListStringValue)
 			}
 			nextReq.Metadata["Dapr-Reentrancy-Id"] = &internalsv1pb.ListStringValue{
@@ -986,7 +986,7 @@ func TestTransactionalState(t *testing.T) {
 		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
 
 		ops := make([]TransactionalOperation, 20)
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			ops[i] = TransactionalOperation{
 				Operation: Upsert,
 				Request: TransactionalUpsert{

--- a/pkg/actors/actors_test.go
+++ b/pkg/actors/actors_test.go
@@ -986,7 +986,7 @@ func TestTransactionalState(t *testing.T) {
 		fakeCallAndActivateActor(testActorsRuntime, actorType, actorID, testActorsRuntime.clock)
 
 		ops := make([]TransactionalOperation, 20)
-		for i := range 20 {
+		for i := range ops {
 			ops[i] = TransactionalOperation{
 				Operation: Upsert,
 				Request: TransactionalUpsert{

--- a/pkg/actors/internal_actor_test.go
+++ b/pkg/actors/internal_actor_test.go
@@ -146,7 +146,6 @@ func TestInternalActorCall(t *testing.T) {
 	require.NoError(t, err)
 
 	// Need this nolint due to a bug in the linter
-	//nolint:protogetter
 	req := internals.NewInternalInvokeRequest(testMethod).
 		WithActor(testActorType, testActorID).
 		WithData([]byte(testInput)).

--- a/pkg/actors/placement/placement_test.go
+++ b/pkg/actors/placement/placement_test.go
@@ -66,7 +66,7 @@ func TestPlacementStream_RoundRobin(t *testing.T) {
 	testSrv := make([]*testServer, testServerCount)
 	cleanup := make([]func(), testServerCount)
 
-	for i := 0; i < testServerCount; i++ {
+	for i := range testServerCount {
 		address[i], testSrv[i], cleanup[i] = newTestServer()
 	}
 
@@ -549,7 +549,7 @@ func TestConcurrentUnblockPlacements(t *testing.T) {
 	testPlacement.hasPlacementTablesCh = nil
 
 	t.Run("concurrent unlock", func(t *testing.T) {
-		for i := 0; i < 10000; i++ {
+		for range 10000 {
 			testPlacement.blockPlacements()
 			wg := sync.WaitGroup{}
 			wg.Add(2)

--- a/pkg/actors/reminders/statestore_test.go
+++ b/pkg/actors/reminders/statestore_test.go
@@ -1030,7 +1030,6 @@ func TestReminderRepeats(t *testing.T) {
 				check := func() bool {
 					select {
 					case request := <-requestC:
-						// Decrease i since time hasn't increased.
 						assert.Equal(t, string(reminder.Data), "\""+request.Data.(string)+"\"")
 						return false
 					case <-ticker.C():
@@ -1164,7 +1163,6 @@ func TestReminderTTL(t *testing.T) {
 				check := func() bool {
 					select {
 					case request := <-requestC:
-						// Decrease i since time hasn't increased.
 						assert.Equal(t, string(req.Data), "\""+request.Data.(string)+"\"")
 						return false
 					case <-ctx.Done():

--- a/pkg/actors/timers/timers_test.go
+++ b/pkg/actors/timers/timers_test.go
@@ -441,7 +441,7 @@ func TestTimerRepeats(t *testing.T) {
 
 				for i := 0; i < 10; i++ {
 					if test.delAfterSeconds > 0 && clock.Now().Sub(start).Seconds() >= test.delAfterSeconds {
-						require.NoError(t, testTimers.DeleteTimer(ctx, req.Key()))
+						assert.NoError(t, testTimers.DeleteTimer(ctx, req.Key()))
 					}
 
 					select {
@@ -685,7 +685,7 @@ func TestTimerCounter(t *testing.T) {
 	var wg sync.WaitGroup
 
 	now := clock.Now()
-	for i := 0; i < numberOfLongTimersToCreate; i++ {
+	for i := range numberOfLongTimersToCreate {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -699,11 +699,11 @@ func TestTimerCounter(t *testing.T) {
 				Data:      json.RawMessage(`"testTimer"`),
 			})
 			err := provider.CreateTimer(context.Background(), timer)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}(i)
 	}
 
-	for i := 0; i < numberOfOneTimeTimersToCreate; i++ {
+	for i := range numberOfOneTimeTimersToCreate {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -716,7 +716,7 @@ func TestTimerCounter(t *testing.T) {
 				Data:      json.RawMessage(`"testTimer"`),
 			})
 			err := provider.CreateTimer(context.Background(), timer)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}(i)
 	}
 
@@ -746,7 +746,7 @@ func TestTimerCounter(t *testing.T) {
 		"Expected to have %d reminders executed, but got %d (note: this value may be outdated)", expectExecute, executeCount.Load(),
 	)
 
-	for i := 0; i < numberOfTimersToDelete; i++ {
+	for i := range numberOfTimersToDelete {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -756,7 +756,7 @@ func TestTimerCounter(t *testing.T) {
 				Name:      fmt.Sprintf("positiveTimer%d", idx),
 			}
 			err := provider.DeleteTimer(context.Background(), timer.Key())
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}(i)
 	}
 
@@ -808,12 +808,12 @@ func TestCreateTimerGoroutineLeak(t *testing.T) {
 	initialCount := runtime.NumGoroutine()
 
 	// Create 10 timers with unique names
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		require.NoError(t, createFn(i, false))
 	}
 
 	// Create 5 timers that override the first ones
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		require.NoError(t, createFn(i, false))
 	}
 
@@ -839,7 +839,7 @@ func createTimer(t *testing.T, now time.Time, req internal.CreateTimerRequest) *
 	t.Helper()
 
 	reminder, err := req.NewReminder(now)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	return reminder
 }

--- a/pkg/api/grpc/grpc_test.go
+++ b/pkg/api/grpc/grpc_test.go
@@ -2773,7 +2773,7 @@ func TestExecuteStateTransaction(t *testing.T) {
 	client := runtimev1pb.NewDaprClient(clientConn)
 
 	tooManyOperations := make([]*runtimev1pb.TransactionalStateOperation, 20)
-	for i := range 20 {
+	for i := range tooManyOperations {
 		tooManyOperations[i] = &runtimev1pb.TransactionalStateOperation{
 			OperationType: string(state.OperationUpsert),
 			Request: &commonv1pb.StateItem{

--- a/pkg/api/grpc/grpc_test.go
+++ b/pkg/api/grpc/grpc_test.go
@@ -636,6 +636,8 @@ func TestInvokeServiceFromHTTPResponse(t *testing.T) {
 
 	for _, tt := range httpResponseTests {
 		t.Run(fmt.Sprintf("handle http %d response code", tt.status), func(t *testing.T) {
+			// TODO: fix types
+			//nolint:gosec
 			fakeResp := invokev1.NewInvokeMethodResponse(int32(tt.status), tt.statusMessage, nil).
 				WithRawDataString(tt.errHTTPMessage).
 				WithContentType("application/json")
@@ -2094,7 +2096,7 @@ func TestGetBulkState(t *testing.T) {
 				if len(tt.expectedResponse) == 0 {
 					assert.Empty(t, resp.GetItems(), "Expected response to be empty")
 				} else {
-					for i := 0; i < len(resp.GetItems()); i++ {
+					for i := range resp.GetItems() {
 						if tt.expectedResponse[i].GetError() == "" {
 							assert.Equal(t, resp.GetItems()[i].GetData(), tt.expectedResponse[i].GetData(), "Expected response Data to be same")
 							assert.Equal(t, resp.GetItems()[i].GetEtag(), tt.expectedResponse[i].GetEtag(), "Expected response Etag to be same")
@@ -2771,7 +2773,7 @@ func TestExecuteStateTransaction(t *testing.T) {
 	client := runtimev1pb.NewDaprClient(clientConn)
 
 	tooManyOperations := make([]*runtimev1pb.TransactionalStateOperation, 20)
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		tooManyOperations[i] = &runtimev1pb.TransactionalStateOperation{
 			OperationType: string(state.OperationUpsert),
 			Request: &commonv1pb.StateItem{

--- a/pkg/api/grpc/manager/pool_test.go
+++ b/pkg/api/grpc/manager/pool_test.go
@@ -46,7 +46,7 @@ func TestConnectionPoolConnection(t *testing.T) {
 		cpc.MarkIdle()
 
 		// Increase time by 1s, 10 times
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			assert.False(t, cpc.Expired(maxConnIdle))
 			clockMock.Step(time.Second)
 		}
@@ -112,7 +112,8 @@ func TestConnectionPool(t *testing.T) {
 
 		// Share the connection grpcMaxConcurrentStreams times (100)
 		// Should always return the first connection
-		for i := 0; i < grpcMaxConcurrentStreams; i++ {
+		//nolint:gosec
+		for i := range grpcMaxConcurrentStreams {
 			conn = cp.Share()
 			require.Equal(t, conns[0], conn)
 			require.Equal(t, int32(i+1), cp.connections[0].referenceCount)
@@ -122,7 +123,8 @@ func TestConnectionPool(t *testing.T) {
 		require.Equal(t, int32(100), cp.connections[0].referenceCount)
 
 		// Next grpcMaxConcurrentStreams should return the second connection
-		for i := 0; i < grpcMaxConcurrentStreams; i++ {
+		//nolint:gosec
+		for i := range grpcMaxConcurrentStreams {
 			conn = cp.Share()
 			require.Equal(t, conns[1], conn)
 			require.Equal(t, int32(i+1), cp.connections[1].referenceCount)
@@ -185,12 +187,14 @@ func TestConnectionPool(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, conns[0], conn)
 			require.Equal(t, 1, n) // Should not have called createFn again
+			//nolint:gosec
 			require.Equal(t, int32(i+1), cp.connections[0].referenceCount)
 		}
 
 		// Next grpcMaxConcurrentStreams calls should return the second connection
 		// After having invoked the method one more time
-		for i := 0; i < grpcMaxConcurrentStreams; i++ {
+		//nolint:gosec
+		for i := range grpcMaxConcurrentStreams {
 			conn, err = cp.Get(createFn)
 			require.NoError(t, err)
 			require.Equal(t, conns[1], conn)
@@ -253,7 +257,7 @@ func TestConnectionPool(t *testing.T) {
 
 		return func(t *testing.T) {
 			// Start by fully using all available connections (requires grpcMaxConcurrentStreams+1 calls)
-			for i := 0; i < grpcMaxConcurrentStreams+1; i++ {
+			for i := range grpcMaxConcurrentStreams + 1 {
 				conn := cp.Share()
 				if i < grpcMaxConcurrentStreams {
 					require.Equal(t, conns[0], conn)
@@ -309,7 +313,7 @@ func TestConnectionPool(t *testing.T) {
 			require.Equal(t, int32(100), cp.connections[0].referenceCount)
 
 			// Release the first connection 100 times, to bring it to 0
-			for i := 0; i < grpcMaxConcurrentStreams; i++ {
+			for range grpcMaxConcurrentStreams {
 				cp.Release(conns[0])
 			}
 			idleStart := clock.Now()

--- a/pkg/api/grpc/server_test.go
+++ b/pkg/api/grpc/server_test.go
@@ -197,7 +197,7 @@ func TestGrpcAPILoggingMiddlewares(t *testing.T) {
 			assert.True(t, ok)
 			assert.Less(t, dur, 10.0)
 
-			assert.Equal(t, float64(codes.OK), logData["code"])
+			assert.InDelta(t, float64(codes.OK), logData["code"], 0)
 		}
 	}
 

--- a/pkg/api/http/directmessaging_test.go
+++ b/pkg/api/http/directmessaging_test.go
@@ -1092,6 +1092,8 @@ func getFakeDirectMessageResponse() *invokev1.InvokeMethodResponse {
 }
 
 func getFakeDirectMessageResponseWithStatusCode(code int) *invokev1.InvokeMethodResponse {
+	// TODO: fix types
+	//nolint:gosec
 	return invokev1.NewInvokeMethodResponse(int32(code), http.StatusText(code), nil).
 		WithRawDataString("fakeDirectMessageResponse").
 		WithContentType("application/json")

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -181,7 +181,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	fakeServer.StartServer(testAPI.constructPubSubEndpoints(), nil)
 
 	t.Run("Publish successfully - 204 No Content", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/pubsubname/topic", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -193,7 +193,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Publish multi path successfully - 204 No Content", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/pubsubname/A/B/C", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/pubsubname/A/B/C"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -205,7 +205,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Publish unsuccessfully - 500 InternalError", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/errorpubsub/topic", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/errorpubsub/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -217,7 +217,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Publish without topic name - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/pubsubname", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/pubsubname"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -228,7 +228,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Publish without topic name ending in / - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/pubsubname/", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/pubsubname/"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -239,7 +239,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Publish with topic name '/' - 204", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/pubsubname/%%2F", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/pubsubname/%2F"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -250,7 +250,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Publish without topic or pubsub name - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -261,7 +261,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Publish without topic or pubsub name ending in / - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -272,7 +272,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Pubsub not configured - 400", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/pubsubname/topic", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		savePubSubAdapter := testAPI.pubsubAdapter
 		testAPI.pubsubAdapter = nil
@@ -288,7 +288,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Pubsub not configured - 400", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/errnotfound/topic", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/errnotfound/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -301,7 +301,7 @@ func TestPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Pubsub not configured - 403", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/errnotallowed/topic", apiVersionV1)
+		apiPath := apiVersionV1 + "/publish/errnotallowed/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -400,7 +400,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	reqBytes, _ := json.Marshal(bulkRequest)
 	resBytes := []byte{}
 	t.Run("Bulk Publish successfully - 204", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -412,7 +412,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish multi path successfully - 204", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/A/B/C", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/A/B/C"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -424,7 +424,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish complete failure - 500 InternalError", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/errorpubsub/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/errorpubsub/topic"
 		testMethods := []string{"POST", "PUT"}
 
 		errBulkRequest := []bulkPublishMessageEntry{}
@@ -473,7 +473,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish partial failure - 500 InternalError", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/errorpubsub/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/errorpubsub/topic"
 		testMethods := []string{"POST", "PUT"}
 
 		errBulkRequest := []bulkPublishMessageEntry{}
@@ -521,7 +521,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish without topic name - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -553,7 +553,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 			},
 		}
 		reqBytesWithoutEntryId, _ := json.Marshal(reqWithoutEntryId) //nolint:stylecheck
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -589,7 +589,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 			},
 		}
 		reqBytesWithoutEntryId, _ := json.Marshal(reqWithoutEntryId) //nolint:stylecheck
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -602,7 +602,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish metadata error - 400", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic?metadata.rawPayload=100", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic?metadata.rawPayload=100"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -635,7 +635,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 			},
 		}
 		rBytes, _ := json.Marshal(reqInvalidCE)
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -671,7 +671,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 			},
 		}
 		rBytes, _ := json.Marshal(dCTMismatch)
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -684,7 +684,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish bad request - 400", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -697,7 +697,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish without topic name ending in / - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -708,7 +708,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish with topic name '/' - 204", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/%%2F", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/%2F"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -720,7 +720,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish without topic or pubsub name - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -731,7 +731,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish without topic or pubsub name ending in / - 404", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -742,7 +742,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk Publish Pubsub not configured - 400", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/pubsubname/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/pubsubname/topic"
 		testMethods := []string{"POST", "PUT"}
 		// setup
 		savePubSubAdapter := testAPI.pubsubAdapter
@@ -758,7 +758,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk publish Pubsub not found - 400", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/errnotfound/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/errnotfound/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -770,7 +770,7 @@ func TestBulkPubSubEndpoints(t *testing.T) {
 	})
 
 	t.Run("Bulk publish Pubsub not allowed - 403", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/publish/bulk/errnotallowed/topic", apiVersionV1alpha1)
+		apiPath := apiVersionV1alpha1 + "/publish/bulk/errnotallowed/topic"
 		testMethods := []string{"POST", "PUT"}
 		for _, method := range testMethods {
 			// act
@@ -801,7 +801,7 @@ func TestShutdownEndpoints(t *testing.T) {
 	defer fakeServer.Shutdown()
 
 	t.Run("Shutdown successfully - 204", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/shutdown", apiVersionV1)
+		apiPath := apiVersionV1 + "/shutdown"
 		resp := fakeServer.DoRequest("POST", apiPath, nil, nil)
 		assert.Equal(t, 204, resp.StatusCode)
 		select {
@@ -875,7 +875,7 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 	fakeServer.StartServer(testAPI.constructBindingsEndpoints(), nil)
 
 	t.Run("Invoke output bindings - 204 No Content empty response", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/bindings/testbinding", apiVersionV1)
+		apiPath := apiVersionV1 + "/bindings/testbinding"
 		req := OutputBindingRequest{
 			Data: "fake output",
 		}
@@ -891,7 +891,7 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 	})
 
 	t.Run("Invoke output bindings - 200 OK", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/bindings/testresponse", apiVersionV1)
+		apiPath := apiVersionV1 + "/bindings/testresponse"
 		req := OutputBindingRequest{
 			Data: "fake output",
 		}
@@ -907,7 +907,7 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 	})
 
 	t.Run("Invoke output bindings - 400 InternalError invalid req", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/bindings/testresponse", apiVersionV1)
+		apiPath := apiVersionV1 + "/bindings/testresponse"
 		req := `{"dat" : "invalid request"}`
 		b, _ := json.Marshal(&req)
 		testMethods := []string{"POST", "PUT"}
@@ -921,7 +921,7 @@ func TestV1OutputBindingsEndpoints(t *testing.T) {
 	})
 
 	t.Run("Invoke output bindings - 500 InternalError", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/bindings/notfound", apiVersionV1)
+		apiPath := apiVersionV1 + "/bindings/notfound"
 		req := OutputBindingRequest{
 			Data: "fake output",
 		}
@@ -964,7 +964,7 @@ func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 	})
 
 	t.Run("Invoke output bindings - 204 OK", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/bindings/testbinding", apiVersionV1)
+		apiPath := apiVersionV1 + "/bindings/testbinding"
 		req := OutputBindingRequest{
 			Data: "fake output",
 		}
@@ -982,7 +982,7 @@ func TestV1OutputBindingsEndpointsWithTracer(t *testing.T) {
 	})
 
 	t.Run("Invoke output bindings - 500 InternalError", func(t *testing.T) {
-		apiPath := fmt.Sprintf("%s/bindings/notfound", apiVersionV1)
+		apiPath := apiVersionV1 + "/bindings/notfound"
 		req := OutputBindingRequest{
 			Data: "fake output",
 		}
@@ -1038,7 +1038,7 @@ func TestV1ActorEndpoints(t *testing.T) {
 
 		for apiPath, testMethods := range apisAndMethods {
 			for _, method := range testMethods {
-				t.Run(fmt.Sprintf("%s %s", method, apiPath), func(t *testing.T) {
+				t.Run(method+" "+apiPath, func(t *testing.T) {
 					// act
 					resp := fakeServer.DoRequest(method, apiPath, fakeData, nil)
 
@@ -2259,7 +2259,7 @@ func TestConfigurationGet(t *testing.T) {
 	})
 
 	t.Run("Get All Configurations with empty key - alpha1", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0-alpha1/configuration/%s", storeName)
+		apiPath := "v1.0-alpha1/configuration/" + storeName
 		resp := fakeServer.DoRequest("GET", apiPath, nil, nil)
 		// assert
 		assert.Equal(t, 200, resp.StatusCode, "Accessing configuration store with empty key should return 200")
@@ -2287,7 +2287,7 @@ func TestConfigurationGet(t *testing.T) {
 	})
 
 	t.Run("Get All Configurations with empty key", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/configuration/%s", storeName)
+		apiPath := "v1.0/configuration/" + storeName
 		resp := fakeServer.DoRequest("GET", apiPath, nil, nil)
 		// assert
 		assert.Equal(t, 200, resp.StatusCode, "Accessing configuration store with empty key should return 200")
@@ -2568,7 +2568,7 @@ func TestV1Alpha1DistributedLock(t *testing.T) {
 		assert.NotNil(t, resp.JSONBody)
 		rspMap := resp.JSONBody.(map[string]any)
 		assert.NotNil(t, rspMap)
-		assert.Equal(t, float64(0), rspMap["status"])
+		assert.InDelta(t, float64(0), rspMap["status"], 0)
 	})
 
 	t.Run("Unlock with invalid resource id", func(t *testing.T) {
@@ -2623,7 +2623,7 @@ func TestV1Alpha1DistributedLock(t *testing.T) {
 		assert.NotNil(t, resp.JSONBody)
 		rspMap := resp.JSONBody.(map[string]interface{})
 		assert.NotNil(t, rspMap)
-		assert.Equal(t, float64(3), rspMap["status"])
+		assert.InDelta(t, float64(3), rspMap["status"], 0)
 	})
 }
 
@@ -3142,7 +3142,7 @@ func (f *fakeHTTPServer) Shutdown() {
 }
 
 func (f *fakeHTTPServer) DoRequestWithAPIToken(method, path, token string, body []byte) fakeHTTPResponse {
-	url := fmt.Sprintf("http://127.0.0.1/%s", path)
+	url := "http://127.0.0.1/" + path
 	r, _ := gohttp.NewRequest(method, url, bytes.NewBuffer(body))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("dapr-api-token", token)
@@ -3161,7 +3161,7 @@ func (f *fakeHTTPServer) DoRequestWithAPIToken(method, path, token string, body 
 }
 
 func (f *fakeHTTPServer) doRequest(basicAuth, method, path string, body []byte, params map[string]string, headers ...string) fakeHTTPResponse {
-	url := fmt.Sprintf("http://127.0.0.1/%s", path)
+	url := "http://127.0.0.1/" + path
 	if basicAuth != "" {
 		url = fmt.Sprintf("http://%s@127.0.0.1/%s", basicAuth, path)
 	}
@@ -3339,7 +3339,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update state - PUT verb supported", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{{
 			Key: "good-key",
 		}}
@@ -3352,7 +3352,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update state - No ETag", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{{
 			Key: "good-key",
 		}}
@@ -3365,7 +3365,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update state - State Error", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{{
 			Key:  "error-key",
 			ETag: ptr.Of(""),
@@ -3379,7 +3379,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update state - Matching ETag", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{{
 			Key:  "good-key",
 			ETag: &etag,
@@ -3394,7 +3394,7 @@ func TestV1StateEndpoints(t *testing.T) {
 
 	t.Run("Update state - Wrong ETag", func(t *testing.T) {
 		invalidEtag := "BAD ETAG"
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{{
 			Key:  "good-key",
 			ETag: &invalidEtag,
@@ -3407,7 +3407,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update bulk state - No ETag", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{
 			{Key: "good-key"},
 			{Key: "good-key2"},
@@ -3421,7 +3421,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update bulk state - State Error", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{
 			{Key: "good-key"},
 			{Key: "error-key"},
@@ -3435,7 +3435,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update bulk state - Matching ETag", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{
 			{Key: "good-key", ETag: &etag},
 			{Key: "good-key2", ETag: &etag},
@@ -3449,7 +3449,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("Update bulk state - One has invalid ETag", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", storeName)
+		apiPath := "v1.0/state/" + storeName
 		request := []state.SetRequest{
 			{Key: "good-key", ETag: &etag},
 			{Key: "good-key2", ETag: ptr.Of("BAD ETAG")},
@@ -3621,7 +3621,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("set state request retries with resiliency", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", "failStore")
+		apiPath := "v1.0/state/failStore"
 
 		request := []state.SetRequest{{
 			Key: "failingSetKey",
@@ -3634,7 +3634,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("set state request times out with resiliency", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", "failStore")
+		apiPath := "v1.0/state/failStore"
 
 		request := []state.SetRequest{{
 			Key: "timeoutSetKey",
@@ -3689,7 +3689,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("bulk state set recovers from single key failure with resiliency", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", "failStore")
+		apiPath := "v1.0/state/failStore"
 
 		reqs := []state.SetRequest{
 			{
@@ -3709,7 +3709,7 @@ func TestV1StateEndpoints(t *testing.T) {
 	})
 
 	t.Run("bulk state set times out with resiliency", func(t *testing.T) {
-		apiPath := fmt.Sprintf("v1.0/state/%s", "failStore")
+		apiPath := "v1.0/state/failStore"
 
 		reqs := []state.SetRequest{
 			{
@@ -4547,7 +4547,7 @@ func TestV1TransactionEndpoints(t *testing.T) {
 		apiPath := fmt.Sprintf("v1.0/state/%s/transaction", storeName)
 
 		testTransactionalOperations := make([]stateTransactionRequestBodyOperation, 20)
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			testTransactionalOperations[i] = stateTransactionRequestBodyOperation{
 				Operation: string(state.OperationUpsert),
 				Request: map[string]any{

--- a/pkg/api/http/server_test.go
+++ b/pkg/api/http/server_test.go
@@ -329,8 +329,8 @@ func TestAPILogging(t *testing.T) {
 					assert.True(t, ok)
 					assert.Less(t, dur, 10.0)
 
-					assert.Equal(t, float64(len(body)), logData["size"])
-					assert.Equal(t, float64(http.StatusOK), logData["code"])
+					assert.InDelta(t, float64(len(body)), logData["size"], 0)
+					assert.InDelta(t, float64(http.StatusOK), logData["code"], 0)
 
 					if userAgent != "" {
 						assert.Equal(t, userAgent, logData["useragent"])

--- a/pkg/apphealth/health_test.go
+++ b/pkg/apphealth/health_test.go
@@ -51,7 +51,7 @@ func TestAppHealth_setResult(t *testing.T) {
 
 	simulateFailures := func(n int32) {
 		statusChange <- 255 // Fill the channel
-		for i := int32(0); i < n; i++ {
+		for i := range n {
 			if i == threshold-1 {
 				<-statusChange // Allow the channel to be written into
 			}
@@ -89,10 +89,10 @@ func TestAppHealth_setResult(t *testing.T) {
 	// Multiple invocations in parallel
 	// Only one failure should be sent
 	wg := sync.WaitGroup{}
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go func() {
-			for i := int32(0); i < (threshold + 5); i++ {
+			for range threshold + 5 {
 				h.setResult(context.Background(), false)
 			}
 			wg.Done()
@@ -113,7 +113,7 @@ func TestAppHealth_setResult(t *testing.T) {
 	// Test overflows
 	h.failureCount.Store(int32(math.MaxInt32 - 2))
 	statusChange <- 255 // Fill the channel again
-	for i := int32(0); i < 5; i++ {
+	for range 5 {
 		h.setResult(context.Background(), false)
 	}
 	assert.Empty(t, unexpectedStatusChanges.Load())
@@ -158,7 +158,7 @@ func TestAppHealth_ratelimitReports(t *testing.T) {
 	totalPassed := atomic.Int64{}
 	start := clock.Now()
 	wg.Add(3)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		go func() {
 			totalPassed.Add(firehose(start, 3*time.Millisecond))
 			wg.Done()
@@ -188,7 +188,7 @@ func Test_StartProbes(t *testing.T) {
 
 		go func() {
 			defer close(done)
-			require.NoError(t, h.StartProbes(ctx))
+			assert.NoError(t, h.StartProbes(ctx))
 		}()
 
 		// Wait for ticker to start,
@@ -218,7 +218,7 @@ func Test_StartProbes(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			require.Error(t, h.StartProbes(ctx))
+			assert.Error(t, h.StartProbes(ctx))
 		}()
 
 		select {
@@ -244,7 +244,7 @@ func Test_StartProbes(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			require.NoError(t, h.StartProbes(ctx))
+			assert.NoError(t, h.StartProbes(ctx))
 		}()
 
 		// Wait for ticker to start,
@@ -279,7 +279,7 @@ func Test_StartProbes(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			require.NoError(t, h.StartProbes(ctx))
+			assert.NoError(t, h.StartProbes(ctx))
 		}()
 
 		h.OnHealthChange(func(ctx context.Context, status uint8) {

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -67,8 +67,7 @@ func (t *testHandlerHeaders) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for k, v := range r.Header {
 		headers[k] = v[0]
 	}
-	rsp, _ := json.Marshal(headers)
-	io.WriteString(w, string(rsp))
+	json.NewEncoder(w).Encode(headers)
 }
 
 // testQueryStringHandler is used for querystring test.
@@ -131,7 +130,7 @@ func (t *testUppercaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.WriteHeader(http.StatusOK)
-	for i := 0; i < len(b); i++ {
+	for i := range b {
 		if b[i] < 'A' || b[i] > 'Z' {
 			w.Write([]byte("false"))
 			return
@@ -542,14 +541,14 @@ func TestInvokeMethodMaxConcurrency(t *testing.T) {
 		// act
 		var wg sync.WaitGroup
 		wg.Add(5)
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			go func() {
 				req := invokev1.
 					NewInvokeMethodRequest("method").
 					WithHTTPExtension("GET", "")
 				defer req.Close()
 				resp, err := c.InvokeMethod(ctx, req, "")
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				defer resp.Close()
 				wg.Done()
 			}()
@@ -578,14 +577,14 @@ func TestInvokeMethodMaxConcurrency(t *testing.T) {
 		// act
 		var wg sync.WaitGroup
 		wg.Add(20)
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			go func() {
 				req := invokev1.
 					NewInvokeMethodRequest("method").
 					WithHTTPExtension("GET", "")
 				defer req.Close()
 				resp, err := c.InvokeMethod(ctx, req, "")
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				defer resp.Close()
 				wg.Done()
 			}()
@@ -613,7 +612,7 @@ func TestInvokeMethodMaxConcurrency(t *testing.T) {
 		}
 
 		// act
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			if i == 10 {
 				c.baseAddress = server.URL
 			}

--- a/pkg/components/state/bulk_test.go
+++ b/pkg/components/state/bulk_test.go
@@ -272,7 +272,7 @@ func TestPerformBulkStoreOperation(t *testing.T) {
 
 					// On the second attempt, key3 fails with etag error
 					require.Len(t, req, 2)
-					for i := 0; i < 2; i++ {
+					for i := range 2 {
 						switch req[i].Key {
 						case "key3", "key1":
 							// All good

--- a/pkg/components/state/state_config_test.go
+++ b/pkg/components/state/state_config_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -171,16 +172,16 @@ func TestStateConfigRace(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			for i := 0; i < iterations; i++ {
+			for i := range iterations {
 				err := SaveStateConfiguration(fmt.Sprintf("store%d", i), map[string]string{strategyKey: strategyNone})
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}()
 		go func() {
 			defer wg.Done()
-			for i := 0; i < iterations; i++ {
+			for i := range iterations {
 				_, err := GetModifiedStateKey(key, fmt.Sprintf("store%d", i), "appid")
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}()
 		wg.Wait()
@@ -191,16 +192,16 @@ func TestStateConfigRace(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			for i := 0; i < iterations; i++ {
+			for i := range iterations {
 				_, err := GetModifiedStateKey(key, fmt.Sprintf("store%d", i), "appid")
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}()
 		go func() {
 			defer wg.Done()
-			for i := 0; i < iterations; i++ {
+			for i := range iterations {
 				_, err := GetModifiedStateKey(key, fmt.Sprintf("store%d", i), "appid")
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}()
 		wg.Wait()

--- a/pkg/diagnostics/resiliency_monitoring_test.go
+++ b/pkg/diagnostics/resiliency_monitoring_test.go
@@ -2,7 +2,7 @@ package diagnostics_test
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -211,7 +211,7 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 			name: "EndpointPolicyCloseState",
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStateStore")
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 					policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 					_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
@@ -226,11 +226,11 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 			name: "EndpointPolicyOpenState",
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStateStore")
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 					policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 					_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-						return nil, fmt.Errorf("fake error")
+						return nil, errors.New("fake error")
 					})
 				}
 			},
@@ -244,11 +244,11 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 			name: "EndpointPolicyHalfOpenState",
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStateStore")
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 					policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 					_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-						return nil, fmt.Errorf("fake error")
+						return nil, errors.New("fake error")
 					})
 				}
 				// let the circuit breaker to go to half open state (5x cb timeout)
@@ -256,7 +256,7 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 				policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-					return nil, fmt.Errorf("fake error")
+					return nil, errors.New("fake error")
 				})
 			},
 			wantNumberOfRows: 5,
@@ -314,7 +314,7 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 			name: "EndpointPolicyNoActivations",
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStateStore")
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 					policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 					_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
@@ -331,7 +331,7 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 				policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-					return nil, fmt.Errorf("fake error")
+					return nil, errors.New("fake error")
 				})
 			},
 			wantNumberOfRows: 1,
@@ -349,10 +349,10 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStateStore")
 				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 					_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-						return nil, fmt.Errorf("fake error")
+						return nil, errors.New("fake error")
 					})
 				}
 			},
@@ -375,11 +375,11 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 				policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
 					time.Sleep(500 * time.Millisecond)
-					return nil, fmt.Errorf("fake error")
+					return nil, errors.New("fake error")
 				})
 				policyRunner = resiliency.NewRunner[any](context.Background(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-					return nil, fmt.Errorf("fake error")
+					return nil, errors.New("fake error")
 				})
 			},
 			wantNumberOfRows: 3,
@@ -399,11 +399,11 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 			name: "EndpointPolicyOpenAndCloseState",
 			unitFn: func() {
 				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStateStore")
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 					policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 					_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-						return nil, fmt.Errorf("fake error")
+						return nil, errors.New("fake error")
 					})
 				}
 				// let the circuit breaker to go to half open state (5x cb timeout) and then return success to close it
@@ -415,11 +415,11 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 				})
 
 				// now open the circuit breaker again
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 					policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
 					_, _ = policyRunner(func(ctx context.Context) (interface{}, error) {
-						return nil, fmt.Errorf("fake error")
+						return nil, errors.New("fake error")
 					})
 				}
 			},

--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -220,7 +220,7 @@ func runTraces(t *testing.T, testName string, numTraces int, samplingRate string
 	idg := defaultIDGenerator()
 	sampledCount := 0
 
-	for i := 0; i < numTraces; i++ {
+	for range numTraces {
 		ctx := context.Background()
 		if hasParentSpanContext {
 			traceID, _ := idg.NewIDs(context.Background())
@@ -387,6 +387,7 @@ func TestTraceIDAndStateFromSpan(t *testing.T) {
 		id, state := TraceIDAndStateFromSpan(span)
 		assert.NotEmpty(t, id)
 		assert.NotEmpty(t, state)
+		span.End()
 	})
 
 	t.Run("empty span, id and state are empty", func(t *testing.T) {
@@ -394,6 +395,7 @@ func TestTraceIDAndStateFromSpan(t *testing.T) {
 		id, state := TraceIDAndStateFromSpan(span)
 		assert.Empty(t, id)
 		assert.Empty(t, state)
+		span.End()
 	})
 
 	t.Run("nil span, id and state are empty", func(t *testing.T) {

--- a/pkg/diagnostics/utils/trace_utils_test.go
+++ b/pkg/diagnostics/utils/trace_utils_test.go
@@ -56,6 +56,7 @@ func TestSpanFromContext(t *testing.T) {
 		assert.NotNil(t, gotSp)
 		assert.Equal(t, expectedTraceID, gotSp.SpanContext().TraceID())
 		assert.Equal(t, expectedSpanID, gotSp.SpanContext().SpanID())
+		sp.End()
 	})
 
 	t.Run("nil span for context", func(t *testing.T) {
@@ -67,6 +68,7 @@ func TestSpanFromContext(t *testing.T) {
 		expectedType := "trace.noopSpan"
 		gotType := reflect.TypeOf(sp).String()
 		assert.Equal(t, expectedType, gotType)
+		sp.End()
 	})
 
 	t.Run("nil", func(t *testing.T) {
@@ -78,6 +80,7 @@ func TestSpanFromContext(t *testing.T) {
 		expectedType := "trace.noopSpan"
 		gotType := reflect.TypeOf(sp).String()
 		assert.Equal(t, expectedType, gotType)
+		sp.End()
 	})
 }
 

--- a/pkg/injector/annotations/annotations_test.go
+++ b/pkg/injector/annotations/annotations_test.go
@@ -73,7 +73,7 @@ func TestAnnotationCompletness(t *testing.T) {
 	// Load the annotations listed as properties in SidecarConfig
 	p := patcher.SidecarConfig{}
 	pt := reflect.TypeOf(p)
-	for i := 0; i < pt.NumField(); i++ {
+	for i := range pt.NumField() {
 		field := pt.Field(i)
 		an := field.Tag.Get("annotation")
 		if an != "" {

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -84,7 +84,6 @@ func TestParseEnvString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			c := NewSidecarConfig(&corev1.Pod{})
 			c.Env = tc.envStr

--- a/pkg/injector/patcher/sidecar_volumes_test.go
+++ b/pkg/injector/patcher/sidecar_volumes_test.go
@@ -91,7 +91,6 @@ func TestParseVolumeMountsString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			mounts := parseVolumeMountsString(tc.mountStr, tc.readOnly)
 			assert.Len(t, mounts, tc.expMountsLen)

--- a/pkg/injector/service/handler_test.go
+++ b/pkg/injector/service/handler_test.go
@@ -278,7 +278,6 @@ func TestHandleRequest(t *testing.T) {
 	defer ts.Close()
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			requestBytes, err := json.Marshal(tc.request)
 			require.NoError(t, err)

--- a/pkg/internal/loader/disk/disk_test.go
+++ b/pkg/internal/loader/disk/disk_test.go
@@ -94,7 +94,7 @@ name: statestore`
 			}
 			var scopeS string
 			if len(scopes) > 0 {
-				scopeS = fmt.Sprintf("\nscopes:\n- %s", strings.Join(scopes, "\n- "))
+				scopeS = "\nscopes:\n- " + strings.Join(scopes, "\n- ")
 			}
 			return fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
 kind: Component

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -453,7 +453,7 @@ func TestWithCustomHTTPMetadata(t *testing.T) {
 
 	numMetadata := 10
 	md := make(map[string]string, numMetadata)
-	for i := 0; i < numMetadata; i++ {
+	for i := range numMetadata {
 		md[customMetadataKey(i)] = customMetadataValue(i)
 	}
 
@@ -462,7 +462,7 @@ func TestWithCustomHTTPMetadata(t *testing.T) {
 	defer req.Close()
 
 	imrMd := req.Metadata()
-	for i := 0; i < numMetadata; i++ {
+	for i := range numMetadata {
 		val, ok := imrMd[customMetadataKey(i)]
 		assert.True(t, ok)
 		// We assume only 1 value per key as the input map can only support string -> string mapping.

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -334,7 +334,7 @@ func TestWithCustomGrpcMetadata(t *testing.T) {
 
 	numMetadata := 10
 	md := make(map[string]string, numMetadata)
-	for i := 0; i < numMetadata; i++ {
+	for i := range numMetadata {
 		md[customMetadataKey(i)] = customMetadataValue(i)
 	}
 
@@ -344,7 +344,7 @@ func TestWithCustomGrpcMetadata(t *testing.T) {
 	ctxMd, ok := metadata.FromOutgoingContext(ctx)
 	assert.True(t, ok)
 
-	for i := 0; i < numMetadata; i++ {
+	for i := range numMetadata {
 		val, ok := ctxMd[strings.ToLower(customMetadataKey(i))]
 		assert.True(t, ok)
 		// We assume only 1 value per key as the input map can only support string -> string mapping.

--- a/pkg/placement/hashing/consistent_hash_test.go
+++ b/pkg/placement/hashing/consistent_hash_test.go
@@ -26,7 +26,7 @@ var nodes = []string{"node1", "node2", "node3", "node4", "node5"}
 
 func TestReplicationFactor(t *testing.T) {
 	keys := []string{}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		keys = append(keys, strconv.Itoa(i))
 	}
 
@@ -98,7 +98,7 @@ func TestGetAndSetVirtualNodeCacheHashesConcurrently(t *testing.T) {
 	const goroutines = 10
 	var wg sync.WaitGroup
 
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/placement/leadership_test.go
+++ b/pkg/placement/leadership_test.go
@@ -32,7 +32,7 @@ func TestCleanupHeartBeats(t *testing.T) {
 	testServer.hasLeadership.Store(true)
 	maxClients := 3
 
-	for i := 0; i < maxClients; i++ {
+	for i := range maxClients {
 		testServer.lastHeartBeat.Store(fmt.Sprintf("ns-10.0.0.%d:1001", i), clock.Now().UnixNano())
 	}
 
@@ -64,7 +64,7 @@ func TestMonitorLeadership(t *testing.T) {
 	underlyingRaftServers := make([]*hashicorpRaft.Raft, numServers)
 
 	// Setup Raft and placement servers
-	for i := 0; i < numServers; i++ {
+	for i := range numServers {
 		raft, err := raftServers[i].Raft(ctx)
 		require.NoError(t, err)
 		leaderChannels[i] = raft.LeaderCh()
@@ -103,7 +103,7 @@ func TestMonitorLeadership(t *testing.T) {
 	}, time.Second*15, 10*time.Millisecond, "server was not properly re-elected in time")
 
 	t.Cleanup(func() {
-		for i := 0; i < numServers; i++ {
+		for i := range numServers {
 			cleanupFns[i]()
 		}
 		cancel()

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -93,9 +93,8 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		var operations1 []string
 		go func() {
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				placementOrder, streamErr := stream1.Recv()
-				//nolint:testifylint
 				assert.NoError(c, streamErr)
 				if placementOrder.GetOperation() == lockOperation {
 					operations1 = append(operations1, lockOperation)
@@ -122,9 +121,8 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		var operations2 []string
 		go func() {
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				placementOrder, streamErr := stream2.Recv()
-				//nolint:testifylint
 				assert.NoError(c, streamErr)
 				if placementOrder.GetOperation() == lockOperation {
 					operations2 = append(operations2, lockOperation)
@@ -155,9 +153,8 @@ func TestMembershipChangeWorker(t *testing.T) {
 
 		var operations3 []string
 		go func() {
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				placementOrder, streamErr := stream3.Recv()
-				//nolint:testifylint
 				assert.NoError(c, streamErr)
 				if placementOrder.GetOperation() == lockOperation {
 					operations3 = append(operations3, lockOperation)
@@ -388,14 +385,14 @@ func PerformTableUpdateCostTime(t *testing.T) (wastedTime int64) {
 	var (
 		overArr       [testClients]int64
 		overArrLock   sync.RWMutex
-		clientConns   []*grpc.ClientConn
-		clientStreams []v1pb.Placement_ReportDaprStatusClient
+		clientConns   = make([]*grpc.ClientConn, 0, 10)
+		clientStreams = make([]v1pb.Placement_ReportDaprStatusClient, 0, 10)
 		wg            sync.WaitGroup
 	)
 	startFlag := atomic.Bool{}
 	startFlag.Store(false)
 	wg.Add(testClients)
-	for i := 0; i < testClients; i++ {
+	for i := range testClients {
 		conn, _, stream := newTestClient(t, serverAddress)
 		clientConns = append(clientConns, conn)
 		clientStreams = append(clientStreams, stream)
@@ -435,7 +432,7 @@ func PerformTableUpdateCostTime(t *testing.T) (wastedTime int64) {
 	}
 
 	// register
-	for i := 0; i < testClients; i++ {
+	for i := range testClients {
 		host := &v1pb.Host{
 			Name:     fmt.Sprintf("127.0.0.1:5010%d", i),
 			Entities: []string{"DogActor", "CatActor"},
@@ -475,7 +472,7 @@ func PerformTableUpdateCostTime(t *testing.T) (wastedTime int64) {
 	overArrLock.RUnlock()
 
 	// clean up resources.
-	for i := 0; i < testClients; i++ {
+	for i := range testClients {
 		require.NoError(t, clientConns[i].Close())
 	}
 	cleanup()
@@ -483,7 +480,7 @@ func PerformTableUpdateCostTime(t *testing.T) (wastedTime int64) {
 }
 
 func TestPerformTableUpdatePerf(t *testing.T) {
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		fmt.Println("max cost time(ns)", PerformTableUpdateCostTime(t))
 	}
 }

--- a/pkg/placement/membership_test.go
+++ b/pkg/placement/membership_test.go
@@ -385,8 +385,8 @@ func PerformTableUpdateCostTime(t *testing.T) (wastedTime int64) {
 	var (
 		overArr       [testClients]int64
 		overArrLock   sync.RWMutex
-		clientConns   = make([]*grpc.ClientConn, 0, 10)
-		clientStreams = make([]v1pb.Placement_ReportDaprStatusClient, 0, 10)
+		clientConns   = make([]*grpc.ClientConn, 0, testClients)
+		clientStreams = make([]v1pb.Placement_ReportDaprStatusClient, 0, testClients)
 		wg            sync.WaitGroup
 	)
 	startFlag := atomic.Bool{}

--- a/pkg/placement/placement_test.go
+++ b/pkg/placement/placement_test.go
@@ -60,7 +60,7 @@ func newTestPlacementServer(t *testing.T, raftServer *raft.Server) (string, *Ser
 		defer close(serverStopped)
 		err := testServer.Start(ctx)
 		if !errors.Is(err, grpc.ErrServerStopped) {
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}
 	}()
 

--- a/pkg/placement/raft/ha_test.go
+++ b/pkg/placement/raft/ha_test.go
@@ -59,16 +59,16 @@ func TestRaftHA(t *testing.T) {
 	ready := make([]<-chan struct{}, 3)
 	raftServerCancel := make([]context.CancelFunc, 3)
 	peers := make([]PeerInfo, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		peers[i] = PeerInfo{
 			ID:      fmt.Sprintf("mynode-%d", i),
 			Address: fmt.Sprintf("127.0.0.1:%d", ports[i]),
 		}
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		raftServers[i], ready[i], raftServerCancel[i] = createRaftServer(t, i, peers)
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		select {
 		case <-ready[i]:
 			// nop
@@ -159,7 +159,7 @@ func TestRaftHA(t *testing.T) {
 		}
 
 		var running int
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			if raftServers[i] != nil {
 				running++
 			}
@@ -186,13 +186,13 @@ func TestRaftHA(t *testing.T) {
 	time.Sleep(time.Second * 3)
 
 	t.Run("leader elected when second node comes up", func(t *testing.T) {
-		var oldSvr int
-		for oldSvr = 0; oldSvr < 3; oldSvr++ {
+		for oldSvr := range 3 {
 			if raftServers[oldSvr] == nil {
 				break
 			}
 		}
 
+		oldSvr := 2
 		raftServers[oldSvr], ready[oldSvr], raftServerCancel[oldSvr] = createRaftServer(t, oldSvr, peers)
 		select {
 		case <-ready[oldSvr]:
@@ -202,7 +202,7 @@ func TestRaftHA(t *testing.T) {
 		}
 
 		var running int
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			if raftServers[i] != nil {
 				running++
 			}
@@ -258,11 +258,11 @@ func TestRaftHA(t *testing.T) {
 		time.Sleep(time.Second * 3)
 
 		// Restart all nodes
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			raftServers[i], ready[i], raftServerCancel[i] = createRaftServer(t, i, peers)
 		}
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			select {
 			case <-ready[i]:
 				// nop
@@ -315,7 +315,7 @@ func createRaftServer(t *testing.T, nodeID int, peers []PeerInfo) (*Server, <-ch
 	stopped := make(chan struct{})
 	go func() {
 		defer close(stopped)
-		require.NoError(t, srv.StartRaft(ctx))
+		assert.NoError(t, srv.StartRaft(ctx))
 	}()
 
 	ready := make(chan struct{})
@@ -325,7 +325,7 @@ func createRaftServer(t *testing.T, nodeID int, peers []PeerInfo) (*Server, <-ch
 			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Second*5)
 			defer timeoutCancel()
 			r, err := srv.Raft(timeoutCtx)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			if r.State() == hcraft.Follower || r.State() == hcraft.Leader {
 				return
 			}

--- a/pkg/resiliency/breaker/circuitbreaker_test.go
+++ b/pkg/resiliency/breaker/circuitbreaker_test.go
@@ -43,7 +43,7 @@ func TestCircuitBreaker(t *testing.T) {
 	cb.Initialize(log)
 	assert.Equal(t, breaker.StateClosed, cb.State())
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cb.Execute(func() (any, error) {
 			return nil, errors.New("test")
 		})

--- a/pkg/resiliency/policy_test.go
+++ b/pkg/resiliency/policy_test.go
@@ -116,7 +116,7 @@ func ExampleNewRunnerWithOptions_disposer() {
 
 	// The disposer should be 3 times called with values 1, 2, 3
 	disposed := []int32{}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		disposed = append(disposed, <-disposerCalled)
 	}
 	slices.Sort(disposed)
@@ -352,7 +352,7 @@ func TestPolicyDisposer(t *testing.T) {
 
 	// The disposer should be 3 times called with values 1, 2, 3
 	disposed := []int32{}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		disposed = append(disposed, <-disposerCalled)
 	}
 	// Shouldn't have more messages coming in

--- a/pkg/resiliency/resiliency_test.go
+++ b/pkg/resiliency/resiliency_test.go
@@ -687,7 +687,7 @@ func concurrentPolicyExec(t *testing.T, policyDefFn func(idx int) *PolicyDefinit
 	t.Helper()
 	wg := sync.WaitGroup{}
 	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(i int) {
 			defer wg.Done()
 			// Not defined

--- a/pkg/runtime/hotreload/differ/differ_test.go
+++ b/pkg/runtime/hotreload/differ/differ_test.go
@@ -31,11 +31,11 @@ func Test_toComparableObj(t *testing.T) {
 	components := make([]componentsapi.Component, numCases)
 
 	fz := fuzz.New()
-	for i := 0; i < numCases; i++ {
+	for i := range numCases {
 		fz.Fuzz(&components[i])
 	}
 
-	for i := 0; i < numCases; i++ {
+	for i := range numCases {
 		t.Run("Component", func(t *testing.T) {
 			compWithoutObject := components[i].DeepCopy()
 			compWithoutObject.ObjectMeta = metav1.ObjectMeta{
@@ -57,12 +57,12 @@ func Test_AreSame(t *testing.T) {
 	componentsDiff := make([]componentsapi.Component, numCases)
 
 	fz := fuzz.New()
-	for i := 0; i < numCases; i++ {
+	for i := range numCases {
 		fz.Fuzz(&components[i])
 		fz.Fuzz(&componentsDiff[i])
 	}
 
-	for i := 0; i < numCases; i++ {
+	for i := range numCases {
 		t.Run("Exact same resource should always return true", func(t *testing.T) {
 			t.Run("Component", func(t *testing.T) {
 				comp1 := components[i]
@@ -100,7 +100,7 @@ func Test_detectDiff(t *testing.T) {
 	componentsDiff := make([]componentsapi.Component, numCases)
 
 	fz := fuzz.New()
-	for i := 0; i < numCases; i++ {
+	for i := range numCases {
 		fz.Fuzz(&components[i])
 		fz.Fuzz(&componentsDiff[i])
 	}
@@ -137,7 +137,7 @@ func Test_detectDiff(t *testing.T) {
 
 		t.Run("Component", func(t *testing.T) {
 			expDiffComponents := make(map[string]componentsapi.Component)
-			for i := 0; i < numCases; i++ {
+			for i := range numCases {
 				expDiffComponents[componentsDiff[i].Name] = componentsDiff[i]
 			}
 			assert.Equal(t, expDiffComponents, detectDiff[componentsapi.Component](components, append(components, componentsDiff...), nil))
@@ -203,7 +203,7 @@ func Test_Diff(t *testing.T) {
 	}
 
 	fz := fuzz.New()
-	for i := 0; i < numCases; i++ {
+	for i := range numCases {
 		for forCh(components[i].Name) {
 			fz.Fuzz(&components[i])
 		}
@@ -316,7 +316,7 @@ func Test_Diff(t *testing.T) {
 
 		t.Run("Component", func(t *testing.T) {
 			remote := make([]componentsapi.Component, len(components))
-			for i := 0; i < len(components); i++ {
+			for i := range components {
 				comp := componentsDiff1[i].DeepCopy()
 				comp.Name = components[i].Name
 				remote[i] = *comp
@@ -338,7 +338,7 @@ func Test_Diff(t *testing.T) {
 
 		t.Run("Component", func(t *testing.T) {
 			remote := make([]componentsapi.Component, len(components)/2)
-			for i := 0; i < len(components)/2; i++ {
+			for i := range len(components) / 2 {
 				comp := componentsDiff1[i].DeepCopy()
 				comp.Name = components[i].Name
 				remote[i] = *comp

--- a/pkg/runtime/hotreload/loader/disk/resource_test.go
+++ b/pkg/runtime/hotreload/loader/disk/resource_test.go
@@ -95,7 +95,7 @@ func Test_Disk(t *testing.T) {
 	require.NoError(t, err)
 
 	var events []*loader.Event[componentsapi.Component]
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		select {
 		case event := <-conn.EventCh:
 			events = append(events, event)
@@ -175,7 +175,7 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, err)
 
 		var events []*loader.Event[componentsapi.Component]
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			select {
 			case event := <-conn.EventCh:
 				events = append(events, event)
@@ -258,7 +258,7 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, err)
 
 		var events []*loader.Event[componentsapi.Component]
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			select {
 			case event := <-conn.EventCh:
 				events = append(events, event)
@@ -342,7 +342,7 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, err)
 
 		var events []*loader.Event[componentsapi.Component]
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			select {
 			case event := <-conn.EventCh:
 				events = append(events, event)

--- a/pkg/runtime/hotreload/loader/operator/resource_test.go
+++ b/pkg/runtime/hotreload/loader/operator/resource_test.go
@@ -82,7 +82,7 @@ func Test_generic(t *testing.T) {
 		assert.NotNil(t, ch)
 		require.NoError(t, err)
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			comp := new(loader.Event[componentsapi.Component])
 			select {
 			case recCh <- comp:

--- a/pkg/runtime/hotreload/reconciler/reconciler_test.go
+++ b/pkg/runtime/hotreload/reconciler/reconciler_test.go
@@ -294,7 +294,7 @@ func Test_reconcile(t *testing.T) {
 	created := make([]componentsapi.Component, caseNum)
 
 	fz := fuzz.New()
-	for i := 0; i < caseNum; i++ {
+	for i := range caseNum {
 		fz.Fuzz(&deleted[i])
 		fz.Fuzz(&updated[i])
 		fz.Fuzz(&created[i])
@@ -325,7 +325,7 @@ func Test_reconcile(t *testing.T) {
 		}()
 
 		var got []componentsapi.Component
-		for i := 0; i < caseNum; i++ {
+		for range caseNum {
 			select {
 			case e := <-eventCh:
 				got = append(got, e)
@@ -336,7 +336,7 @@ func Test_reconcile(t *testing.T) {
 		assert.ElementsMatch(t, deleted, got)
 
 		got = []componentsapi.Component{}
-		for i := 0; i < caseNum; i++ {
+		for range caseNum {
 			select {
 			case e := <-eventCh:
 				got = append(got, e)
@@ -347,7 +347,7 @@ func Test_reconcile(t *testing.T) {
 		assert.ElementsMatch(t, updated, got)
 
 		got = []componentsapi.Component{}
-		for i := 0; i < caseNum; i++ {
+		for range caseNum {
 			select {
 			case e := <-eventCh:
 				got = append(got, e)

--- a/pkg/runtime/pubsub/default_bulkpub_test.go
+++ b/pkg/runtime/pubsub/default_bulkpub_test.go
@@ -16,7 +16,6 @@ package pubsub
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,7 +76,7 @@ func TestBulkPublish_DefaultBulkPublisher(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			// Create publish requests for each message in the bulk request.
 			var pubReqs []*contribPubsub.PublishRequest
 			for _, entry := range req.Entries {

--- a/pkg/runtime/pubsub/outbox_test.go
+++ b/pkg/runtime/pubsub/outbox_test.go
@@ -664,7 +664,7 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 				doneCh <- errors.New("timeout waiting for externalCalledCh")
 			}
 		}()
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			require.NoError(t, <-doneCh)
 		}
 		require.GreaterOrEqual(t, time.Since(start), d)
@@ -816,7 +816,7 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 				doneCh <- nil
 			}
 		}()
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			require.NoError(t, <-doneCh)
 		}
 		require.GreaterOrEqual(t, time.Since(start), d)
@@ -944,7 +944,7 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 				doneCh <- nil
 			}
 		}()
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			require.NoError(t, <-doneCh)
 		}
 		require.GreaterOrEqual(t, time.Since(start), d)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -187,7 +187,7 @@ func TestDoProcessComponent(t *testing.T) {
 
 		// assert
 		require.Error(t, err, "expected an error")
-		assert.Equal(t, err.Error(), rterrors.NewInit(rterrors.CreateComponentFailure, "testlock (lock.mockLock/v3)", fmt.Errorf("couldn't find lock store lock.mockLock/v3")).Error())
+		assert.Equal(t, err.Error(), rterrors.NewInit(rterrors.CreateComponentFailure, "testlock (lock.mockLock/v3)", errors.New("couldn't find lock store lock.mockLock/v3")).Error())
 	})
 
 	t.Run("test error when lock prefix strategy invalid", func(t *testing.T) {

--- a/pkg/runtime/subscription/bulksubscription_test.go
+++ b/pkg/runtime/subscription/bulksubscription_test.go
@@ -54,21 +54,20 @@ const (
 
 	eventKey = `"event":`
 
-	data1     string = `{"orderId":"1"}`
-	data2     string = `{"orderId":"2"}`
-	data3     string = `{"orderId":"3"}`
-	data4     string = `{"orderId":"4"}`
-	data5     string = `{"orderId":"5"}`
-	data6     string = `{"orderId":"6"}`
-	data7     string = `{"orderId":"7"}`
-	data8     string = `{"orderId":"8"}`
-	data9     string = ``
-	data10    string = `{"orderId":"10"}`
-	ext1Key   string = "ext1Key"
-	ext1Value string = "ext1Value"
-	ext2Key   string = "ext2Key"
-	ext2Value string = "ext2Value"
-	//nolint:goconst
+	data1      string = `{"orderId":"1"}`
+	data2      string = `{"orderId":"2"}`
+	data3      string = `{"orderId":"3"}`
+	data4      string = `{"orderId":"4"}`
+	data5      string = `{"orderId":"5"}`
+	data6      string = `{"orderId":"6"}`
+	data7      string = `{"orderId":"7"}`
+	data8      string = `{"orderId":"8"}`
+	data9      string = ``
+	data10     string = `{"orderId":"10"}`
+	ext1Key    string = "ext1Key"
+	ext1Value  string = "ext1Value"
+	ext2Key    string = "ext2Key"
+	ext2Value  string = "ext2Value"
 	order1     string = `{"data":` + data1 + `,"datacontenttype":"application/json","` + ext1Key + `":"` + ext1Value + `","id":"9b6767c3-04b5-4871-96ae-c6bde0d5e16d","pubsubname":"orderpubsub","source":"checkout","specversion":"1.0","topic":"orders","traceid":"00-e61de949bb4de415a7af49fc86675648-ffb64972bb907224-01","traceparent":"00-e61de949bb4de415a7af49fc86675648-ffb64972bb907224-01","tracestate":"","type":"type1"}`
 	order2     string = `{"data":` + data2 + `,"datacontenttype":"application/json","` + ext2Key + `":"` + ext2Value + `","id":"993f4e4a-05e5-4772-94a4-e899b1af0131","pubsubname":"orderpubsub","source":"checkout","specversion":"1.0","topic":"orders","traceid":"00-1343b02c3af4f9b352d4cb83d6c8cb81-82a64f8c4433e2c4-01","traceparent":"00-1343b02c3af4f9b352d4cb83d6c8cb81-82a64f8c4433e2c4-01","tracestate":"","type":"type2"}`
 	order3     string = `{"data":` + data3 + `,"datacontenttype":"application/json","` + ext1Key + `":"` + ext1Value + `","id":"6767010u-04b5-4871-96ae-c6bde0d5e16d","pubsubname":"orderpubsub","source":"checkout","specversion":"1.0","topic":"orders","traceid":"00-e61de949bb4de415a7af49fc86675648-ffb64972bb907224-01","traceparent":"00-e61de949bb4de415a7af49fc86675648-ffb64972bb907224-01","tracestate":"","type":"type1"}`

--- a/pkg/runtime/wfengine/backends/actors/backend_test.go
+++ b/pkg/runtime/wfengine/backends/actors/backend_test.go
@@ -57,7 +57,7 @@ func TestDefaultWorkflowState(t *testing.T) {
 
 func TestAddingToInbox(t *testing.T) {
 	state := NewWorkflowState(NewActorsBackendConfig(testAppID))
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		state.AddToInbox(&backend.HistoryEvent{})
 	}
 
@@ -74,7 +74,7 @@ func TestAddingToInbox(t *testing.T) {
 
 func TestClearingInbox(t *testing.T) {
 	state := NewWorkflowState(NewActorsBackendConfig(testAppID))
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		// Simulate the loadng of inbox events from storage
 		state.Inbox = append(state.Inbox, &backend.HistoryEvent{})
 	}
@@ -94,7 +94,7 @@ func TestClearingInbox(t *testing.T) {
 func TestAddingToHistory(t *testing.T) {
 	wfstate := NewWorkflowState(NewActorsBackendConfig(testAppID))
 	runtimeState := backend.NewOrchestrationRuntimeState(api.InstanceID("wf1"), nil)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		err := runtimeState.AddEvent(&backend.HistoryEvent{})
 		require.NoError(t, err)
 	}
@@ -115,14 +115,16 @@ func TestLoadSavedState(t *testing.T) {
 	wfstate := NewWorkflowState(NewActorsBackendConfig(testAppID))
 
 	runtimeState := backend.NewOrchestrationRuntimeState(api.InstanceID("wf1"), nil)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
+		//nolint:gosec
 		err := runtimeState.AddEvent(&backend.HistoryEvent{EventId: int32(i)})
 		require.NoError(t, err)
 	}
 	wfstate.ApplyRuntimeStateChanges(runtimeState)
 	wfstate.CustomStatus = "my custom status"
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
+		//nolint:gosec
 		wfstate.AddToInbox(&backend.HistoryEvent{EventId: int32(i)})
 	}
 
@@ -146,10 +148,12 @@ func TestLoadSavedState(t *testing.T) {
 	assert.Equal(t, uint64(1), wfstate.Generation)
 	require.Len(t, wfstate.History, 10)
 	for i, e := range wfstate.History {
+		//nolint:gosec
 		assert.Equal(t, int32(i), e.GetEventId())
 	}
 	require.Len(t, wfstate.Inbox, 5)
 	for i, e := range wfstate.Inbox {
+		//nolint:gosec
 		assert.Equal(t, int32(i), e.GetEventId())
 	}
 }
@@ -176,12 +180,12 @@ func TestResetLoadedState(t *testing.T) {
 	wfstate := NewWorkflowState(NewActorsBackendConfig(testAppID))
 
 	runtimeState := backend.NewOrchestrationRuntimeState(api.InstanceID("wf1"), nil)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		require.NoError(t, runtimeState.AddEvent(&backend.HistoryEvent{}))
 	}
 	wfstate.ApplyRuntimeStateChanges(runtimeState)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wfstate.AddToInbox(&backend.HistoryEvent{})
 	}
 

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -310,7 +310,7 @@ func TestActivityChainingWorkflow(t *testing.T) {
 	r := task.NewTaskRegistry()
 	r.AddOrchestratorN("ActivityChain", func(ctx *task.OrchestrationContext) (any, error) {
 		val := 0
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			if err := ctx.CallActivity("PlusOne", task.WithActivityInput(val)).Await(&val); err != nil {
 				return nil, err
 			}
@@ -347,7 +347,7 @@ func TestConcurrentActivityExecution(t *testing.T) {
 	r := task.NewTaskRegistry()
 	r.AddOrchestratorN("ActivityFanOut", func(ctx *task.OrchestrationContext) (any, error) {
 		tasks := []task.Task{}
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			tasks = append(tasks, ctx.CallActivity("ToString", task.WithActivityInput(i)))
 		}
 		results := []string{}
@@ -650,7 +650,7 @@ func TestConcurrentTimerExecution(t *testing.T) {
 	r := task.NewTaskRegistry()
 	r.AddOrchestratorN("TimerFanOut", func(ctx *task.OrchestrationContext) (any, error) {
 		tasks := []task.Task{}
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			tasks = append(tasks, ctx.CreateTimer(1*time.Second))
 		}
 		for _, t := range tasks {
@@ -739,7 +739,7 @@ func TestContinueAsNew_WithEvents(t *testing.T) {
 			// Run the orchestration
 			id, err := client.ScheduleNewOrchestration(ctx, "ContinueAsNewTest", api.WithInput(0))
 			require.NoError(t, err)
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				require.NoError(t, client.RaiseEvent(ctx, id, "MyEvent", api.WithEventPayload(false)))
 			}
 			require.NoError(t, client.RaiseEvent(ctx, id, "MyEvent", api.WithEventPayload(true)))
@@ -757,7 +757,7 @@ func TestPurge(t *testing.T) {
 	r := task.NewTaskRegistry()
 	r.AddOrchestratorN("ActivityChainToPurge", func(ctx *task.OrchestrationContext) (any, error) {
 		val := 0
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			if err := ctx.CallActivity("PlusOne", task.WithActivityInput(val)).Await(&val); err != nil {
 				return nil, err
 			}

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -109,7 +109,7 @@ func Test_Start(t *testing.T) {
 		providerStopped := make(chan struct{})
 		go func() {
 			defer close(providerStopped)
-			require.NoError(t, p.Run(ctx))
+			assert.NoError(t, p.Run(ctx))
 		}()
 
 		prov := p.(*provider)

--- a/pkg/sentry/server/server_test.go
+++ b/pkg/sentry/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -110,7 +111,7 @@ func TestRun(t *testing.T) {
 				return spiffeid.RequireTrustDomainFromString("test"), nil
 			}),
 			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
-				return nil, fmt.Errorf("signing error")
+				return nil, errors.New("signing error")
 			}).WithTrustAnchors(func() []byte {
 				return []byte("my-trust-anchors")
 			}),
@@ -155,7 +156,7 @@ func TestRun(t *testing.T) {
 				return grpc.Creds(insecure.NewCredentials())
 			}),
 			val: validatorfake.New().WithValidateFn(func(ctx context.Context, req *sentryv1pb.SignCertificateRequest) (spiffeid.TrustDomain, error) {
-				return spiffeid.TrustDomain{}, fmt.Errorf("validation error")
+				return spiffeid.TrustDomain{}, errors.New("validation error")
 			}),
 			ca: cafake.New().WithSignIdentity(func(ctx context.Context, req *ca.SignRequest) ([]*x509.Certificate, error) {
 				return []*x509.Certificate{crtX509}, nil
@@ -290,7 +291,7 @@ func TestRun(t *testing.T) {
 
 			go func() {
 				defer close(serverClosed)
-				require.NoError(t, New(opts).Start(ctx))
+				assert.NoError(t, New(opts).Start(ctx))
 			}()
 
 			require.Eventually(t, func() bool {

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -24,7 +24,7 @@ import (
 func TestValidateKubernetesAppID(t *testing.T) {
 	t.Run("invalid length", func(t *testing.T) {
 		id := ""
-		for i := 0; i < 64; i++ {
+		for range 64 {
 			id += "a"
 		}
 		err := ValidateKubernetesAppID(id)

--- a/tests/apps/actorapp/app.go
+++ b/tests/apps/actorapp/app.go
@@ -156,7 +156,7 @@ func deactivateActorHandler(w http.ResponseWriter, r *http.Request) {
 	_, ok := actors.Load(actorID)
 	log.Printf("loading returned:%t\n", ok)
 
-	if ok && r.Method == "DELETE" {
+	if ok && r.Method == http.MethodDelete {
 		action = "deactivation"
 		actors.Delete(actorID)
 	}

--- a/tests/apps/actorfeatures/app.go
+++ b/tests/apps/actorfeatures/app.go
@@ -334,7 +334,7 @@ func deactivateActorHandler(w http.ResponseWriter, r *http.Request) {
 	action := ""
 
 	_, ok := actors.Load(actorID)
-	if ok && r.Method == "DELETE" {
+	if ok && r.Method == http.MethodDelete {
 		action = "deactivation"
 		actors.Delete(actorID)
 	}

--- a/tests/apps/actorreentrancy/app.go
+++ b/tests/apps/actorreentrancy/app.go
@@ -225,7 +225,7 @@ func actorMethodHandler(w http.ResponseWriter, r *http.Request) {
 
 func reentrantCallHandler(w http.ResponseWriter, r *http.Request) {
 	log.Print("Handling reentrant call")
-	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Enter %s", mux.Vars(r)["method"]))
+	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], "Enter "+mux.Vars(r)["method"])
 	body, err := io.ReadAll(r.Body)
 	defer r.Body.Close()
 
@@ -257,17 +257,17 @@ func reentrantCallHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Call status: %d", resp.StatusCode)
 	if err != nil || resp.StatusCode == http.StatusInternalServerError {
 		w.WriteHeader(http.StatusInternalServerError)
-		appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Error %s", mux.Vars(r)["method"]))
+		appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], "Error "+mux.Vars(r)["method"])
 	} else {
-		appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Exit %s", mux.Vars(r)["method"]))
+		appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], "Exit "+mux.Vars(r)["method"])
 	}
 	defer resp.Body.Close()
 }
 
 func standardHandler(w http.ResponseWriter, r *http.Request) {
 	log.Print("Handling standard call")
-	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Enter %s", mux.Vars(r)["method"]))
-	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], fmt.Sprintf("Exit %s", mux.Vars(r)["method"]))
+	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], "Enter "+mux.Vars(r)["method"])
+	appendLog(mux.Vars(r)["actorType"], mux.Vars(r)["id"], "Exit "+mux.Vars(r)["method"])
 }
 
 func advanceCallStackForNextRequest(req reentrantRequest) (actorCall, []byte) {

--- a/tests/apps/binding_input/app.go
+++ b/tests/apps/binding_input/app.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -199,8 +198,8 @@ func appRouter() http.Handler {
 	router.Use(utils.LoggerMiddleware)
 
 	router.HandleFunc("/", indexHandler).Methods("GET")
-	router.HandleFunc(fmt.Sprintf("/%s", topicName), testTopicHandler).Methods("POST", "OPTIONS")
-	router.HandleFunc(fmt.Sprintf("/%s", topicCustomPath), testRoutedTopicHandler).Methods("POST", "OPTIONS")
+	router.HandleFunc("/"+topicName, testTopicHandler).Methods("POST", "OPTIONS")
+	router.HandleFunc("/"+topicCustomPath, testRoutedTopicHandler).Methods("POST", "OPTIONS")
 	router.HandleFunc("/tests/get_received_topics", testHandler).Methods("POST")
 
 	router.Use(mux.CORSMethodMiddleware(router))

--- a/tests/apps/binding_input_grpc/app.go
+++ b/tests/apps/binding_input_grpc/app.go
@@ -100,7 +100,7 @@ func main() {
 	log.Printf("Initializing grpc")
 
 	/* #nosec */
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", appPort))
+	lis, err := net.Listen("tcp", ":"+appPort)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/tests/apps/binding_output/app.go
+++ b/tests/apps/binding_output/app.go
@@ -78,7 +78,6 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(indexHandlerResponse{Message: "OK"})
 }
 
-//nolint:gosec
 func testHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Entered testHandler")
 	var requestBody testCommandRequest
@@ -128,7 +127,6 @@ func sendGRPC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, message := range requestBody.Messages {
-		//nolint:gosec
 		body, _ := json.Marshal(&message)
 
 		log.Printf("Sending message: %s", body)

--- a/tests/apps/configurationapp/app.go
+++ b/tests/apps/configurationapp/app.go
@@ -214,7 +214,7 @@ func buildAddQuery(items map[string]*Item, configTable string) (string, []interf
 	paramWildcard := make([]string, 0, len(items))
 	params := make([]interface{}, 0, 4*len(items))
 	if len(items) == 0 {
-		return query, params, fmt.Errorf("empty list of items")
+		return query, params, errors.New("empty list of items")
 	}
 	var queryBuilder strings.Builder
 	queryBuilder.WriteString("INSERT INTO " + configTable + " (KEY, VALUE, VERSION, METADATA) VALUES ")
@@ -244,7 +244,7 @@ func (r *PostgresUpdater) AddKey(items map[string]*Item) error {
 
 func (r *PostgresUpdater) UpdateKey(items map[string]*Item) error {
 	if len(items) == 0 {
-		return fmt.Errorf("empty list of items")
+		return errors.New("empty list of items")
 	}
 	for key, item := range items {
 		var params []interface{}
@@ -384,7 +384,7 @@ func subscribeGRPC(keys []string, endpointType string, configStore string, compo
 	res, err := client.Recv()
 	if errors.Is(err, io.EOF) {
 		cancel()
-		return "", fmt.Errorf("error subscribe: stream closed before receiving ID")
+		return "", errors.New("error subscribe: stream closed before receiving ID")
 	}
 	if err != nil {
 		cancel()

--- a/tests/apps/hellodapr/app.go
+++ b/tests/apps/hellodapr/app.go
@@ -71,7 +71,7 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Trigger the test
-	res := appResponse{Message: fmt.Sprintf("%s is not supported", testCommand)}
+	res := appResponse{Message: testCommand + " is not supported"}
 	statusCode := http.StatusBadRequest
 
 	startTime := epoch()

--- a/tests/apps/injectorapp/app.go
+++ b/tests/apps/injectorapp/app.go
@@ -124,7 +124,7 @@ func commandHandler(w http.ResponseWriter, r *http.Request) {
 	testCommand := mux.Vars(r)["command"]
 
 	// Trigger the test
-	res := appResponse{Message: fmt.Sprintf("%s is not supported", testCommand)}
+	res := appResponse{Message: testCommand + " is not supported"}
 	statusCode := http.StatusBadRequest
 
 	startTime := epoch()

--- a/tests/apps/job-publisher/app.go
+++ b/tests/apps/job-publisher/app.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"time"
 
@@ -37,7 +38,7 @@ var httpClient = utils.NewHTTPClient()
 
 func stopSidecar() {
 	log.Printf("Shutting down the sidecar at %s", fmt.Sprintf("http://localhost:%d/v1.0/shutdown", daprPort))
-	for retryCount := 0; retryCount < 200; retryCount++ {
+	for range 200 {
 		r, err := httpClient.Post(fmt.Sprintf("http://localhost:%d/v1.0/shutdown", daprPort), "", bytes.NewBuffer([]byte{}))
 		if r != nil {
 			// Drain before closing
@@ -48,7 +49,7 @@ func stopSidecar() {
 			log.Printf("Error stopping the sidecar %s", err)
 		}
 
-		if r.StatusCode != 200 && r.StatusCode != 204 {
+		if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusNoContent {
 			log.Printf("Received Non-200 from shutdown API. Code: %d", r.StatusCode)
 			time.Sleep(10 * time.Second)
 			continue
@@ -78,7 +79,7 @@ func publishMessagesToPubsub() error {
 }
 
 func main() {
-	for retryCount := 0; retryCount < publishRetries; retryCount++ {
+	for range publishRetries {
 		err := publishMessagesToPubsub()
 		if err != nil {
 			log.Printf("Unable to publish, retrying.")

--- a/tests/apps/perf/configuration/app.go
+++ b/tests/apps/perf/configuration/app.go
@@ -307,7 +307,7 @@ func subscribeGRPC(keys []string) (string, error) {
 	}
 	res, err := client.Recv()
 	if errors.Is(err, io.EOF) {
-		return "", fmt.Errorf("error subscribe: stream closed before receiving ID")
+		return "", errors.New("error subscribe: stream closed before receiving ID")
 	}
 	if err != nil {
 		return "", fmt.Errorf("error subscribe: %w", err)

--- a/tests/apps/pubsub-bulk-subscriber/app.go
+++ b/tests/apps/pubsub-bulk-subscriber/app.go
@@ -333,7 +333,7 @@ func subscribeHandler(w http.ResponseWriter, r *http.Request) {
 		// This case is triggered when there is multiple redelivery of same message or a message
 		// is thre for an unknown URL path
 
-		errorMessage := fmt.Sprintf("Unexpected/Multiple redelivery of message from %s", r.URL.String())
+		errorMessage := "Unexpected/Multiple redelivery of message from " + r.URL.String()
 		log.Printf("(%s) Responding with DROP. %s", reqID, errorMessage)
 		// Return success with DROP status to drop message
 		w.WriteHeader(http.StatusOK)
@@ -410,7 +410,7 @@ func bulkSubscribeHandler(w http.ResponseWriter, r *http.Request) {
 			// This case is triggered when there is multiple redelivery of same message or a message
 			// is thre for an unknown URL path
 
-			errorMessage := fmt.Sprintf("Unexpected/Multiple redelivery of message during bulk subscribe from %s", r.URL.String())
+			errorMessage := "Unexpected/Multiple redelivery of message during bulk subscribe from " + r.URL.String()
 			log.Printf("(%s) Responding with DROP during bulk subscribe. %s", reqID, errorMessage)
 			entryResponse.Status = statusDrop
 		}

--- a/tests/apps/pubsub-publisher/app.go
+++ b/tests/apps/pubsub-publisher/app.go
@@ -334,7 +334,7 @@ func performBulkPublishHTTP(reqID string, pubsubToPublish, topic string, jsonVal
 	if len(reqMeta) > 0 {
 		params := netUrl.Values{}
 		for k, v := range reqMeta {
-			params.Set(fmt.Sprintf("metadata.%s", k), v)
+			params.Set("metadata."+k, v)
 		}
 		url = url + "?" + params.Encode()
 	}
@@ -402,7 +402,7 @@ func performPublish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// based on commandBody.Topic, send to the appropriate topic
-	resp := appResponse{Message: fmt.Sprintf("%s is not supported", commandBody.Topic)}
+	resp := appResponse{Message: commandBody.Topic + " is not supported"}
 
 	jsonValue, err := json.Marshal(commandBody.Data)
 	if err != nil {
@@ -464,7 +464,7 @@ func performPublishHTTP(reqID string, topic string, jsonValue []byte, contentTyp
 	if len(metadata) > 0 {
 		params := netUrl.Values{}
 		for k, v := range metadata {
-			params.Set(fmt.Sprintf("metadata.%s", k), v)
+			params.Set("metadata.%s"+k, v)
 		}
 		url = url + "?" + params.Encode()
 	}

--- a/tests/apps/pubsub-publisher/app.go
+++ b/tests/apps/pubsub-publisher/app.go
@@ -464,7 +464,7 @@ func performPublishHTTP(reqID string, topic string, jsonValue []byte, contentTyp
 	if len(metadata) > 0 {
 		params := netUrl.Values{}
 		for k, v := range metadata {
-			params.Set("metadata.%s"+k, v)
+			params.Set("metadata."+k, v)
 		}
 		url = url + "?" + params.Encode()
 	}

--- a/tests/apps/pubsub-subscriber/app.go
+++ b/tests/apps/pubsub-subscriber/app.go
@@ -323,7 +323,7 @@ func subscribeHandler(w http.ResponseWriter, r *http.Request) {
 		// This case is triggered when there is multiple redelivery of same message or a message
 		// is thre for an unknown URL path
 
-		errorMessage := fmt.Sprintf("Unexpected/Multiple redelivery of message from %s", r.URL.String())
+		errorMessage := "Unexpected/Multiple redelivery of message from " + r.URL.String()
 		log.Printf("(%s) Responding with DROP. %s", reqID, errorMessage)
 		// Return success with DROP status to drop message
 		w.WriteHeader(http.StatusOK)

--- a/tests/apps/pubsub-subscriber_grpc/app.go
+++ b/tests/apps/pubsub-subscriber_grpc/app.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"net/url"
@@ -103,7 +102,7 @@ func main() {
 	log.Printf("Initializing grpc")
 
 	/* #nosec */
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", appPort))
+	lis, err := net.Listen("tcp", ":"+appPort)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/tests/apps/runtime_init/app.go
+++ b/tests/apps/runtime_init/app.go
@@ -40,7 +40,7 @@ func publishMessagesToPubsub(wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	daprPubsubURL := fmt.Sprintf("http://localhost:%d/v1.0/publish/%s", daprPort, pubsubTopic)
-	for i := 0; i < numPubsubMessages; i++ {
+	for i := range numPubsubMessages {
 		m := fmt.Sprintf("message-%d", i)
 		jsonValue, err := json.Marshal(m)
 		if err != nil {
@@ -61,7 +61,7 @@ func publishMessagesToBinding(wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	daprBindingURL := fmt.Sprintf("http://localhost:%d/v1.0/bindings/%s", daprPort, bindingTopic)
-	for i := 0; i < numBindingMessage; i++ {
+	for i := range numBindingMessage {
 		b := []byte(fmt.Sprintf(`{"data": {"id": "message%d"}}`, i))
 		log.Printf("Publishing to %s", daprBindingURL)
 		r, err := httpClient.Post(daprBindingURL, "application/json", bytes.NewBuffer(b))

--- a/tests/apps/schedulerapp_grpc/app.go
+++ b/tests/apps/schedulerapp_grpc/app.go
@@ -65,7 +65,7 @@ type job struct {
 	Name     string  `json:"name,omitempty"`
 	Data     jobData `json:"data,omitempty"`
 	Schedule string  `json:"schedule,omitempty"`
-	Repeats  int     `json:"repeats,omitempty"`
+	Repeats  uint32  `json:"repeats,omitempty"`
 	DueTime  string  `json:"dueTime,omitempty"`
 	TTL      string  `json:"ttl,omitempty"`
 }
@@ -89,7 +89,7 @@ func scheduleJobGRPC(name string, jobWrapper JobWrapper) error {
 		Job: &runtimev1pb.Job{
 			Name:     name,
 			Schedule: ptr.Of(jobWrapper.Job.Schedule),
-			Repeats:  ptr.Of(uint32(jobWrapper.Job.Repeats)),
+			Repeats:  ptr.Of(jobWrapper.Job.Repeats),
 			Data: &anypb.Any{
 				Value: dataBytes,
 			},

--- a/tests/apps/secretapp/app.go
+++ b/tests/apps/secretapp/app.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -128,7 +129,7 @@ func getAll(secrets []daprSecret) ([]daprSecret, int, error) {
 
 func getBulk(secrets []daprSecret) ([]daprSecret, int, error) {
 	if len(secrets) == 0 {
-		return nil, http.StatusBadRequest, fmt.Errorf("no secret store specified")
+		return nil, http.StatusBadRequest, errors.New("no secret store specified")
 	}
 	store := secrets[0].Store
 	log.Println("Processing get bulk request for secrerts.")
@@ -170,7 +171,6 @@ func getBulk(secrets []daprSecret) ([]daprSecret, int, error) {
 	}
 
 	for key, value := range resMap {
-		value := value
 		output = append(output, daprSecret{
 			Key:   key,
 			Value: &value,

--- a/tests/apps/service_invocation/app.go
+++ b/tests/apps/service_invocation/app.go
@@ -1242,7 +1242,7 @@ func badServiceCallTestHTTP(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("badServiceCallTestHTTP - target app: %s\n", commandBody.RemoteApp)
 
-	daprAddress := fmt.Sprintf("localhost:%s", strconv.Itoa(daprHTTPPort))
+	daprAddress := "localhost:" + strconv.Itoa(daprHTTPPort)
 
 	fmt.Printf("dapr address is %s\n", daprAddress)
 	var testMessage struct {
@@ -1281,7 +1281,7 @@ func badServiceCallTestHTTP(w http.ResponseWriter, r *http.Request) {
 		httpClient.Timeout = prevTimeout
 	}
 
-	testResponse.MainCallSuccessful = err == nil && resp.StatusCode == 200
+	testResponse.MainCallSuccessful = err == nil && resp.StatusCode == http.StatusOK
 
 	if resp != nil && resp.Body != nil {
 		fmt.Printf("badServiceCallTestHTTP - Response Code: %d\n", resp.StatusCode)
@@ -1430,7 +1430,7 @@ func largeDataErrorServiceCall(w http.ResponseWriter, r *http.Request, isHTTP bo
 
 		if isHTTP {
 			resp, err := httpClient.Post(sanitizeHTTPURL(url), jsonContentType, bytes.NewReader(jsonBody))
-			result.CallSuccessful = !((resp != nil && resp.StatusCode != 200) || err != nil)
+			result.CallSuccessful = !((resp != nil && resp.StatusCode != http.StatusOK) || err != nil)
 			if resp != nil {
 				// Drain before closing
 				_, _ = io.Copy(io.Discard, resp.Body)
@@ -1504,7 +1504,7 @@ func logAndSetResponse(w http.ResponseWriter, statusCode int, message string) {
 
 func sanitizeHTTPURL(url string) string {
 	if !strings.Contains(url, "http") {
-		url = fmt.Sprintf("http://%s", url)
+		url = "http://" + url
 	}
 
 	return url

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -110,7 +110,7 @@ func HealthCheckApps(urls ...string) error {
 
 	// Collect all errors
 	errs := make([]error, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		errs[i] = <-errCh
 	}
 

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework/iowriter"
@@ -62,6 +63,8 @@ func BuildAll(t *testing.T) {
 		}
 	}
 	wg.Wait()
+
+	require.False(t, t.Failed())
 }
 
 func GetRootDir(t *testing.T) string {
@@ -129,12 +132,12 @@ func Build(t *testing.T, name string, bopts ...func(*buildOpts)) {
 		cmd.Stderr = ioerr
 		// Ensure CGO is disabled to avoid linking against system libraries.
 		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
-		require.NoError(t, cmd.Run())
+		assert.NoError(t, cmd.Run())
 
-		require.NoError(t, ioout.Close())
-		require.NoError(t, ioerr.Close())
+		assert.NoError(t, ioout.Close())
+		assert.NoError(t, ioerr.Close())
 
-		require.NoError(t, os.Setenv(EnvKey(name), binPath))
+		assert.NoError(t, os.Setenv(EnvKey(name), binPath))
 	} else {
 		t.Logf("%q set, using %q pre-built binary", EnvKey(name), EnvValue(name))
 	}

--- a/tests/integration/framework/file/file.go
+++ b/tests/integration/framework/file/file.go
@@ -26,7 +26,7 @@ func Names(t *testing.T, num int) []string {
 	require.GreaterOrEqual(t, num, 1)
 
 	names := make([]string, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		names[i] = name(t)
 	}
 
@@ -38,7 +38,7 @@ func Paths(t *testing.T, num int) []string {
 
 	dir := t.TempDir()
 	names := make([]string, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		names[i] = filepath.Join(dir, name(t))
 	}
 

--- a/tests/integration/framework/framework.go
+++ b/tests/integration/framework/framework.go
@@ -38,7 +38,6 @@ func Run(t *testing.T, ctx context.Context, opts ...Option) {
 	t.Logf("starting %d processes", len(o.procs))
 
 	for i, proc := range o.procs {
-		i := i
 		proc.Run(t, ctx)
 		t.Cleanup(func() { o.procs[i].Cleanup(t) })
 	}

--- a/tests/integration/framework/iowriter/iowriter_test.go
+++ b/tests/integration/framework/iowriter/iowriter_test.go
@@ -149,14 +149,14 @@ func TestConcurrency(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			for i := 0; i < 1000; i++ {
+			for i := range 1000 {
 				fmt.Fprintf(writer, "test %d\n", i)
 			}
 		}()
 
 		go func() {
 			defer wg.Done()
-			for i := 0; i < 1000; i++ {
+			for i := range 1000 {
 				fmt.Fprintf(writer, "test %d\n", i)
 			}
 		}()

--- a/tests/integration/framework/parallel/parallel.go
+++ b/tests/integration/framework/parallel/parallel.go
@@ -50,7 +50,7 @@ func New(t *testing.T, fns ...func(*assert.CollectT)) *Test {
 			require.NoError(t, err)
 		}
 
-		for i := 0; i < workers; i++ {
+		for range workers {
 			go p.worker(jobs)
 		}
 
@@ -59,7 +59,6 @@ func New(t *testing.T, fns ...func(*assert.CollectT)) *Test {
 		var wg sync.WaitGroup
 		wg.Add(len(p.fns))
 		for i := range p.fns {
-			i := i
 			collects[i] = new(assert.CollectT)
 			jobs <- func() {
 				defer wg.Done()

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -461,7 +461,6 @@ func (d *Daprd) meta(t assert.TestingT, ctx context.Context) metaResponse {
 
 	var meta metaResponse
 	resp, err := d.httpClient.Do(req)
-	//nolint:testifylint
 	if assert.NoError(t, err) {
 		defer resp.Body.Close()
 		assert.NoError(t, json.NewDecoder(resp.Body).Decode(&meta))

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -92,7 +92,6 @@ func WithExit1() Option {
 	return WithExecOptions(
 		exec.WithExitCode(1),
 		exec.WithRunError(func(t *testing.T, err error) {
-			//nolint:testifylint
 			assert.ErrorContains(t, err, "exit status 1")
 		}),
 	)

--- a/tests/integration/framework/process/grpc/app/proto/test.v1.pb.go
+++ b/tests/integration/framework/process/grpc/app/proto/test.v1.pb.go
@@ -155,11 +155,13 @@ func file_test_v1_proto_rawDescGZIP() []byte {
 	return file_test_v1_proto_rawDescData
 }
 
-var file_test_v1_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_test_v1_proto_goTypes = []interface{}{
-	(*PingRequest)(nil),  // 0: dapr.io.testproto.PingRequest
-	(*PingResponse)(nil), // 1: dapr.io.testproto.PingResponse
-}
+var (
+	file_test_v1_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+	file_test_v1_proto_goTypes  = []interface{}{
+		(*PingRequest)(nil),  // 0: dapr.io.testproto.PingRequest
+		(*PingResponse)(nil), // 1: dapr.io.testproto.PingResponse
+	}
+)
 var file_test_v1_proto_depIdxs = []int32{
 	0, // 0: dapr.io.testproto.TestService.Ping:input_type -> dapr.io.testproto.PingRequest
 	1, // 1: dapr.io.testproto.TestService.Ping:output_type -> dapr.io.testproto.PingResponse

--- a/tests/integration/framework/process/grpc/app/proto/test.v1_grpc.pb.go
+++ b/tests/integration/framework/process/grpc/app/proto/test.v1_grpc.pb.go
@@ -56,8 +56,7 @@ type TestServiceServer interface {
 }
 
 // UnimplementedTestServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedTestServiceServer struct {
-}
+type UnimplementedTestServiceServer struct{}
 
 func (UnimplementedTestServiceServer) Ping(context.Context, *PingRequest) (*PingResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")

--- a/tests/integration/framework/process/http/http.go
+++ b/tests/integration/framework/process/http/http.go
@@ -102,7 +102,7 @@ func (h *HTTP) Run(t *testing.T, ctx context.Context) {
 
 func (h *HTTP) Cleanup(t *testing.T) {
 	close(h.stopCh)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		require.NoError(t, <-h.srvErrCh)
 	}
 }

--- a/tests/integration/framework/process/http/subscriber/subscriber.go
+++ b/tests/integration/framework/process/http/subscriber/subscriber.go
@@ -89,7 +89,7 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 	for _, route := range opts.routes {
 		appOpts = append(appOpts, app.WithHandlerFunc(route, func(w http.ResponseWriter, r *http.Request) {
 			var ce event.Event
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&ce))
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&ce))
 			select {
 			case inCh <- &RouteEvent{Route: r.URL.Path, Event: &ce}:
 			case <-closeCh:
@@ -100,7 +100,7 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 	for _, route := range opts.bulkRoutes {
 		appOpts = append(appOpts, app.WithHandlerFunc(route, func(w http.ResponseWriter, r *http.Request) {
 			var ce pubsub.BulkSubscribeEnvelope
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&ce))
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&ce))
 			select {
 			case inBulk <- &ce:
 			case <-closeCh:
@@ -125,7 +125,7 @@ func New(t *testing.T, fopts ...Option) *Subscriber {
 
 	if opts.progSubs != nil {
 		appOpts = append(appOpts, app.WithHandlerFunc("/dapr/subscribe", func(w http.ResponseWriter, r *http.Request) {
-			require.NoError(t, json.NewEncoder(w).Encode(*opts.progSubs))
+			assert.NoError(t, json.NewEncoder(w).Encode(*opts.progSubs))
 		}))
 	}
 

--- a/tests/integration/framework/process/injector/injector.go
+++ b/tests/integration/framework/process/injector/injector.go
@@ -139,7 +139,6 @@ func (i *Injector) Cleanup(t *testing.T) {
 
 func (i *Injector) WaitUntilRunning(t *testing.T, ctx context.Context) {
 	client := client.HTTP(t)
-	//nolint:testifylint
 	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/healthz", i.healthzPort), nil)
 		if !assert.NoError(t, err) {

--- a/tests/integration/framework/process/kubernetes/options.go
+++ b/tests/integration/framework/process/kubernetes/options.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -182,7 +183,7 @@ func handleGetResource(t *testing.T, apigv, resource, ns, name string, obj runti
 func handleObj(t *testing.T, obj runtime.Object) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		objB, err := json.Marshal(obj)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		w.Header().Add("Content-Length", strconv.Itoa(len(objB)))
 		w.Header().Add("Content-Type", "application/json")
 		w.Write(objB)
@@ -192,7 +193,7 @@ func handleObj(t *testing.T, obj runtime.Object) http.HandlerFunc {
 func handleObjFromStore(t *testing.T, store *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		objB, err := json.Marshal(store.Objects())
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		w.Header().Add("Content-Length", strconv.Itoa(len(objB)))
 		w.Header().Add("Content-Type", "application/json")
 		w.Write(objB)

--- a/tests/integration/framework/process/logline/logline.go
+++ b/tests/integration/framework/process/logline/logline.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Option is a function that configures the process.
@@ -98,7 +97,7 @@ func (l *LogLine) FoundAll() bool {
 
 func (l *LogLine) Cleanup(t *testing.T) {
 	close(l.closeCh)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		for expLine := range <-l.outCheck {
 			assert.Fail(t, "expected to log line: "+expLine, l.got.String())
 		}
@@ -134,7 +133,8 @@ func (l *LogLine) checkOut(t *testing.T, ctx context.Context, expLines map[strin
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
 			break
 		}
-		require.NoError(t, err)
+		//nolint:testifylint
+		assert.NoError(t, err)
 
 		l.got.Write(append(line, '\n'))
 

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -140,7 +140,6 @@ func (p *Placement) WaitUntilRunning(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := client.Do(req)
-		//nolint:testifylint
 		if assert.NoError(c, err) {
 			defer resp.Body.Close()
 			assert.Equal(c, http.StatusOK, resp.StatusCode)
@@ -196,19 +195,16 @@ func (p *Placement) RegisterHostWithMetadata(t *testing.T, parentCtx context.Con
 	var stream placementv1pb.Placement_ReportDaprStatusClient
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		stream, err = client.ReportDaprStatus(parentCtx)
-		//nolint:testifylint
 		if !assert.NoError(c, err) {
 			return
 		}
 
-		//nolint:testifylint
 		if !assert.NoError(c, stream.Send(msg)) {
 			_ = stream.CloseSend()
 			return
 		}
 
 		_, err = stream.Recv()
-		//nolint:testifylint
 		if !assert.NoError(c, err) {
 			_ = stream.CloseSend()
 			return
@@ -256,7 +252,7 @@ func (p *Placement) RegisterHostWithMetadata(t *testing.T, parentCtx context.Con
 
 			if in.GetOperation() == "update" {
 				tables := in.GetTables()
-				require.NotEmptyf(t, tables, "Placement table is empty")
+				assert.NotEmptyf(t, tables, "Placement table is empty")
 
 				select {
 				case placementUpdateCh <- tables:
@@ -276,13 +272,13 @@ func (p *Placement) RegisterHost(t *testing.T, ctx context.Context, msg *placeme
 }
 
 // AssertRegisterHostFails Expect the registration to fail with FailedPrecondition.
-func (p *Placement) AssertRegisterHostFails(t *testing.T, ctx context.Context, apiLevel int) {
+func (p *Placement) AssertRegisterHostFails(t *testing.T, ctx context.Context, apiLevel uint32) {
 	msg := &placementv1pb.Host{
 		Name:     "myapp-fail",
 		Port:     1234,
 		Entities: []string{"someactor"},
 		Id:       "myapp",
-		ApiLevel: uint32(apiLevel),
+		ApiLevel: apiLevel,
 	}
 	//nolint:staticcheck
 	conn, err := grpc.DialContext(ctx, p.Address(),

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -165,7 +165,6 @@ func (s *Sentry) WaitUntilRunning(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := client.Do(req)
-		//nolint:testifylint
 		if assert.NoError(c, err) {
 			defer resp.Body.Close()
 			assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/framework/process/statestore/statestore.go
+++ b/tests/integration/framework/process/statestore/statestore.go
@@ -98,7 +98,6 @@ func (s *StateStore) Run(t *testing.T, ctx context.Context) {
 	client := compv1pb.NewStateStoreClient(conn)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, err = client.Ping(ctx, new(compv1pb.PingRequest))
-		//nolint:testifylint
 		assert.NoError(c, err)
 	}, 10*time.Second, 10*time.Millisecond)
 	require.NoError(t, conn.Close())

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -65,7 +65,6 @@ func RunIntegrationTests(t *testing.T) {
 	})
 
 	for _, tcase := range focusedTests {
-		tcase := tcase
 		t.Run(tcase.Name(), func(t *testing.T) {
 			if *parallelFlag {
 				t.Parallel()

--- a/tests/integration/suite/actors/grpc/ttl.go
+++ b/tests/integration/suite/actors/grpc/ttl.go
@@ -98,7 +98,6 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 			ActorId:   "myactorid",
 			Method:    "foo",
 		})
-		//nolint:testifylint
 		assert.NoError(c, err)
 	}, time.Second*20, time.Millisecond*10, "actor not ready")
 

--- a/tests/integration/suite/actors/healthz/deactivate-on-placement-fail.go
+++ b/tests/integration/suite/actors/healthz/deactivate-on-placement-fail.go
@@ -118,7 +118,7 @@ func (h *deactivateOnPlacementFail) Run(t *testing.T, ctx context.Context) {
 
 	// Validate invocations
 	invoked := make([]string, 2)
-	for i := range 2 {
+	for i := range invoked {
 		select {
 		case invoked[i] = <-h.invokedActorsCh:
 		case <-time.After(time.Second * 5):

--- a/tests/integration/suite/actors/healthz/deactivate-on-placement-fail.go
+++ b/tests/integration/suite/actors/healthz/deactivate-on-placement-fail.go
@@ -102,7 +102,7 @@ func (h *deactivateOnPlacementFail) Run(t *testing.T, ctx context.Context) {
 	client := client.HTTP(t)
 
 	// Activate 2 actors
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			daprdURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactortype/myactor%d/method/foo", h.daprd.HTTPPort(), i)
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, daprdURL, nil)
@@ -118,7 +118,7 @@ func (h *deactivateOnPlacementFail) Run(t *testing.T, ctx context.Context) {
 
 	// Validate invocations
 	invoked := make([]string, 2)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		select {
 		case invoked[i] = <-h.invokedActorsCh:
 		case <-time.After(time.Second * 5):

--- a/tests/integration/suite/actors/healthz/endpoint/allenabled.go
+++ b/tests/integration/suite/actors/healthz/endpoint/allenabled.go
@@ -97,7 +97,6 @@ func (a *allenabled) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := gclient.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.True(c, meta.GetActorRuntime().GetHostReady())
 		assert.Len(c, meta.GetActorRuntime().GetActiveActors(), 1)

--- a/tests/integration/suite/actors/healthz/endpoint/noapp.go
+++ b/tests/integration/suite/actors/healthz/endpoint/noapp.go
@@ -92,7 +92,6 @@ func (n *noapp) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := gclient.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.True(c, meta.GetActorRuntime().GetHostReady())
 		assert.Len(c, meta.GetActorRuntime().GetActiveActors(), 1)

--- a/tests/integration/suite/actors/healthz/endpoint/noappentities.go
+++ b/tests/integration/suite/actors/healthz/endpoint/noappentities.go
@@ -114,7 +114,6 @@ func (n *noappentities) Run(t *testing.T, ctx context.Context) {
 	} {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			meta, err := tv.cl.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.True(c, meta.GetActorRuntime().GetHostReady())
 			assert.Equal(c, tv.activeActors, meta.GetActorRuntime().GetActiveActors())

--- a/tests/integration/suite/actors/healthz/endpoint/noentities.go
+++ b/tests/integration/suite/actors/healthz/endpoint/noentities.go
@@ -108,7 +108,6 @@ func (n *noentities) Run(t *testing.T, ctx context.Context) {
 	} {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			meta, err := tv.cl.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.True(c, meta.GetActorRuntime().GetHostReady())
 			assert.Equal(c, tv.activeActors, meta.GetActorRuntime().GetActiveActors())

--- a/tests/integration/suite/actors/healthz/endpoint/path.go
+++ b/tests/integration/suite/actors/healthz/endpoint/path.go
@@ -97,7 +97,6 @@ func (p *path) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := gclient.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.True(c, meta.GetActorRuntime().GetHostReady())
 		assert.Len(c, meta.GetActorRuntime().GetActiveActors(), 1)

--- a/tests/integration/suite/actors/http/ttl.go
+++ b/tests/integration/suite/actors/http/ttl.go
@@ -109,7 +109,6 @@ func (l *ttl) Run(t *testing.T, ctx context.Context) {
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, rErr := client.Do(req)
-		//nolint:testifylint
 		if assert.NoError(c, rErr) {
 			require.NoError(c, resp.Body.Close())
 			assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/actors/reminders/basic.go
+++ b/tests/integration/suite/actors/reminders/basic.go
@@ -94,7 +94,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, rErr := client.Do(req)
-			//nolint:testifylint
 			if assert.NoError(c, rErr) {
 				assert.NoError(c, resp.Body.Close())
 				assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/actors/reminders/duetime.go
+++ b/tests/integration/suite/actors/reminders/duetime.go
@@ -92,7 +92,6 @@ func (d *duetime) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, rErr := client.Do(req)
-			//nolint:testifylint
 			if assert.NoError(c, rErr) {
 				assert.NoError(c, resp.Body.Close())
 				assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/actors/reminders/scheduler/basic.go
+++ b/tests/integration/suite/actors/reminders/scheduler/basic.go
@@ -103,7 +103,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, rErr := client.Do(req)
-		//nolint:testifylint
 		if assert.NoError(c, rErr) {
 			assert.NoError(c, resp.Body.Close())
 			assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/actors/reminders/scheduler/duetime.go
+++ b/tests/integration/suite/actors/reminders/scheduler/duetime.go
@@ -109,7 +109,6 @@ func (d *duetime) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, rErr := client.Do(req)
-			//nolint:testifylint
 			if assert.NoError(c, rErr) {
 				assert.NoError(c, resp.Body.Close())
 				assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/actors/reminders/scheduler/hop.go
+++ b/tests/integration/suite/actors/reminders/scheduler/hop.go
@@ -70,7 +70,7 @@ spec:
 			w.WriteHeader(http.StatusOK)
 		})
 
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			handler.HandleFunc("/actors/myactortype/foo/method/remind/"+strconv.Itoa(i), func(http.ResponseWriter, *http.Request) {
 				called.Add(1)
 			})
@@ -111,7 +111,7 @@ func (h *hop) Run(t *testing.T, ctx context.Context) {
 	h.daprd2.WaitUntilRunning(t, ctx)
 
 	gclient := h.daprd1.GRPCClient(t, ctx)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		_, err := gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
 			ActorType: "myactortype",
 			ActorId:   "foo",

--- a/tests/integration/suite/actors/reminders/scheduler/idtypes.go
+++ b/tests/integration/suite/actors/reminders/scheduler/idtypes.go
@@ -91,20 +91,17 @@ spec:
 	procs[0] = i.scheduler
 	procs[1] = i.place
 
-	for x := 0; x < i.daprdsNum; x++ {
-		x := x
+	for x := range i.daprdsNum {
 		i.actorDaprds[x].actorTypes = make([]actortype, i.actorTypesNum)
 
 		var appOpts []app.Option
-		for y := 0; y < i.actorTypesNum; y++ {
-			y := y
+		for y := range i.actorTypesNum {
 			typeuid, err := uuid.NewUUID()
 			require.NoError(t, err)
 			i.actorDaprds[x].actorTypes[y].typename = typeuid.String()
 			i.actorDaprds[x].actorTypes[y].ids = make([]string, i.actorIDsNum)
 
-			for z := 0; z < i.actorIDsNum; z++ {
-				z := z
+			for z := range i.actorIDsNum {
 				iduid, err := uuid.NewUUID()
 				require.NoError(t, err)
 				i.actorDaprds[x].actorTypes[y].ids[z] = iduid.String()
@@ -157,22 +154,21 @@ func (i *idtype) Run(t *testing.T, ctx context.Context) {
 	i.scheduler.WaitUntilRunning(t, ctx)
 	i.place.WaitUntilRunning(t, ctx)
 
-	for x := 0; x < i.daprdsNum; x++ {
+	for x := range i.daprdsNum {
 		i.daprds[x].WaitUntilRunning(t, ctx)
 	}
 
 	client := client.HTTP(t)
 
 	daprdURL := "http://" + i.daprds[0].HTTPAddress() + "/v1.0/actors/"
-	for x := 0; x < i.daprdsNum; x++ {
-		for y := 0; y < i.actorTypesNum; y++ {
-			for z := 0; z < i.actorIDsNum; z++ {
+	for x := range i.daprdsNum {
+		for y := range i.actorTypesNum {
+			for z := range i.actorIDsNum {
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					invoke := fmt.Sprintf("%s/%s/%s/method/foo", daprdURL, i.actorDaprds[x].actorTypes[y].typename, i.actorDaprds[x].actorTypes[y].ids[z])
 					req, err := http.NewRequestWithContext(ctx, http.MethodPost, invoke, nil)
 					require.NoError(t, err)
 					resp, err := client.Do(req)
-					//nolint:testifylint
 					if assert.NoError(c, err) {
 						assert.NoError(c, resp.Body.Close())
 						assert.Equal(c, http.StatusOK, resp.StatusCode)
@@ -182,9 +178,9 @@ func (i *idtype) Run(t *testing.T, ctx context.Context) {
 		}
 	}
 
-	for x := 0; x < i.daprdsNum; x++ {
-		for y := 0; y < i.actorTypesNum; y++ {
-			for z := 0; z < i.actorIDsNum; z++ {
+	for x := range i.daprdsNum {
+		for y := range i.actorTypesNum {
+			for z := range i.actorIDsNum {
 				_, err := i.daprds[x].GRPCClient(t, ctx).RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
 					ActorType: i.actorDaprds[x].actorTypes[y].typename,
 					ActorId:   i.actorDaprds[x].actorTypes[y].ids[z],

--- a/tests/integration/suite/actors/reminders/scheduler/reminder.go
+++ b/tests/integration/suite/actors/reminders/scheduler/reminder.go
@@ -115,7 +115,6 @@ func (r *reminder) Run(t *testing.T, ctx context.Context) {
 
 	require.EventuallyWithT(t, func(r *assert.CollectT) {
 		resp, rErr := client.Do(req)
-		//nolint:testifylint
 		if assert.NoError(r, rErr) {
 			assert.NoError(r, resp.Body.Close())
 			assert.Equal(r, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/actors/reminders/scheduler/remote.go
+++ b/tests/integration/suite/actors/reminders/scheduler/remote.go
@@ -77,7 +77,7 @@ spec:
 	r.actorIDsNum = 500
 	r.methodcalled.Store(make([]string, 0, r.actorIDsNum))
 	r.actorIDs = make([]string, r.actorIDsNum)
-	for i := 0; i < r.actorIDsNum; i++ {
+	for i := range r.actorIDsNum {
 		uid, err := uuid.NewUUID()
 		require.NoError(t, err)
 		r.actorIDs[i] = uid.String()
@@ -93,7 +93,6 @@ spec:
 		})
 
 		for _, id := range r.actorIDs {
-			id := id
 			handler.HandleFunc(fmt.Sprintf("/actors/myactortype/%s/method/remind/remindermethod", id), func(http.ResponseWriter, *http.Request) {
 				r.lock.Lock()
 				defer r.lock.Unlock()

--- a/tests/integration/suite/actors/reminders/scheduler/remove.go
+++ b/tests/integration/suite/actors/reminders/scheduler/remove.go
@@ -147,7 +147,7 @@ func (r *remove) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.GreaterOrEqual(c, r.triggered.Load(), int64(1))
-	}, 30*time.Second, 10*time.Millisecond, fmt.Sprintf("failed to wait for 'triggered' to be greatrer or equal 1, actual value %d", r.triggered.Load()))
+	}, 30*time.Second, 10*time.Millisecond, "failed to wait for 'triggered' to be greatrer or equal 1, actual value %d", r.triggered.Load())
 
 	_, err = client.UnregisterActorReminder(ctx, &runtimev1pb.UnregisterActorReminderRequest{
 		ActorType: "myactortype",

--- a/tests/integration/suite/actors/reminders/scheduler/repeats.go
+++ b/tests/integration/suite/actors/reminders/scheduler/repeats.go
@@ -108,7 +108,6 @@ func (r *repeats) Run(t *testing.T, ctx context.Context) {
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, rErr := client.Do(req)
-		//nolint:testifylint
 		if assert.NoError(c, rErr) {
 			assert.NoError(c, resp.Body.Close())
 			assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/actors/reminders/serialization/common.go
+++ b/tests/integration/suite/actors/reminders/serialization/common.go
@@ -32,7 +32,6 @@ func invokeActor(t *testing.T, ctx context.Context, baseURL string, client *http
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/method/foo", nil)
 		require.NoError(c, err)
 		resp, rErr := client.Do(req)
-		//nolint:testifylint
 		if assert.NoError(c, rErr) {
 			assert.NoError(c, resp.Body.Close())
 			assert.Equal(c, http.StatusOK, resp.StatusCode)

--- a/tests/integration/suite/daprd/hotreload/operator/binding/input/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/input/grpc.go
@@ -149,7 +149,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	t.Run("expect 1 component to be loaded", func(t *testing.T) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*20, time.Millisecond*10)

--- a/tests/integration/suite/daprd/hotreload/operator/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/operator/crypto.go
@@ -128,7 +128,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Len(c, resp.GetRegisteredComponents(), 1)
 		}, time.Second*10, time.Millisecond*10)
@@ -159,7 +158,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*10, time.Millisecond*10)
@@ -190,7 +188,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Len(c, resp.GetRegisteredComponents(), 3)
 		}, time.Second*10, time.Millisecond*10)
@@ -214,7 +211,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{Name: "crypto1", Type: "crypto.dapr.localstorage", Version: "v1"},
@@ -238,7 +234,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*10, time.Millisecond*10)
@@ -256,7 +251,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
@@ -286,7 +280,6 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Len(c, resp.GetRegisteredComponents(), 2)
 		}, time.Second*10, time.Millisecond*10)

--- a/tests/integration/suite/daprd/hotreload/operator/middleware/http/app/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/operator/middleware/http/app/uppercase.go
@@ -73,7 +73,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 	handler.HandleFunc("/", func(nethttp.ResponseWriter, *nethttp.Request) {})
 	handler.HandleFunc("/foo", func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		_, err := io.Copy(w, r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	srv := prochttp.New(t, prochttp.WithHandler(handler))
 

--- a/tests/integration/suite/daprd/hotreload/operator/middleware/http/server/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/operator/middleware/http/server/uppercase.go
@@ -73,7 +73,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 	handler.HandleFunc("/", func(nethttp.ResponseWriter, *nethttp.Request) {})
 	handler.HandleFunc("/foo", func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		_, err := io.Copy(w, r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	srv := prochttp.New(t, prochttp.WithHandler(handler))
 

--- a/tests/integration/suite/daprd/hotreload/operator/state.go
+++ b/tests/integration/suite/daprd/hotreload/operator/state.go
@@ -477,7 +477,7 @@ func (s *state) writeRead(t *testing.T, ctx context.Context, client *http.Client
 	t.Helper()
 
 	postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", s.daprd.HTTPPort(), url.QueryEscape(compName))
-	getURL := fmt.Sprintf("%s/foo", postURL)
+	getURL := postURL + "/foo"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL,
 		strings.NewReader(`[{"key": "foo", "value": "bar"}]`))

--- a/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/app/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/app/uppercase.go
@@ -74,7 +74,7 @@ spec:
 	handler.HandleFunc("/", func(nethttp.ResponseWriter, *nethttp.Request) {})
 	handler.HandleFunc("/foo", func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		_, err := io.Copy(w, r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	srv := prochttp.New(t, prochttp.WithHandler(handler))
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/server/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/server/uppercase.go
@@ -74,7 +74,7 @@ spec:
 	handler.HandleFunc("/", func(nethttp.ResponseWriter, *nethttp.Request) {})
 	handler.HandleFunc("/foo", func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		_, err := io.Copy(w, r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	srv := prochttp.New(t, prochttp.WithHandler(handler))
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/state.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/state.go
@@ -418,7 +418,7 @@ func (s *state) writeRead(t *testing.T, ctx context.Context, client *http.Client
 	t.Helper()
 
 	postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", s.daprd.HTTPPort(), url.QueryEscape(compName))
-	getURL := fmt.Sprintf("%s/foo", postURL)
+	getURL := postURL + "/foo"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL,
 		strings.NewReader(`[{"key": "foo", "value": "bar"}]`))

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/stream/persist.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/stream/persist.go
@@ -15,7 +15,6 @@ package stream
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,7 +56,7 @@ spec:
 
 	p.dir = t.TempDir()
 
-	require.NoError(t, os.WriteFile(filepath.Join(p.dir, "pubsub.yaml"), []byte(fmt.Sprintf(`
+	require.NoError(t, os.WriteFile(filepath.Join(p.dir, "pubsub.yaml"), []byte(`
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -65,7 +64,7 @@ metadata:
 spec:
  type: pubsub.in-memory
  version: v1
-`)), 0o600))
+`), 0o600))
 
 	p.daprd = daprd.New(t,
 		daprd.WithAppPort(p.sub.Port(t)),

--- a/tests/integration/suite/daprd/jobs/grpc/http.go
+++ b/tests/integration/suite/daprd/jobs/grpc/http.go
@@ -53,7 +53,7 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 	app := app.New(t,
 		app.WithHandlerFunc("/job/", func(w nethttp.ResponseWriter, r *nethttp.Request) {
 			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			h.dataCh <- body
 		}),
 	)

--- a/tests/integration/suite/daprd/jobs/http/api.go
+++ b/tests/integration/suite/daprd/jobs/http/api.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
@@ -49,7 +48,7 @@ func (a *api) Setup(t *testing.T) []framework.Option {
 	app := app.New(t,
 		app.WithHandlerFunc("/job/", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			a.dataCh <- body
 		}),
 	)

--- a/tests/integration/suite/daprd/jobs/http/errors.go
+++ b/tests/integration/suite/daprd/jobs/http/errors.go
@@ -94,7 +94,7 @@ func (e *errors) Run(t *testing.T, ctx context.Context) {
 		// Confirm that the 'message' field exists and contains the correct error message
 		errMsg, exists := data["message"]
 		require.True(t, exists)
-		require.Equal(t, fmt.Sprintf("Schedule is empty"), errMsg)
+		require.Equal(t, "Schedule is empty", errMsg)
 
 		// Confirm that the 'details' field exists and has one element
 		details, exists := data["details"]
@@ -143,7 +143,7 @@ func (e *errors) Run(t *testing.T, ctx context.Context) {
 		// Confirm that the 'message' field exists and contains the correct error message
 		errMsg, exists := data["message"]
 		require.True(t, exists)
-		require.Equal(t, fmt.Sprintf("Name is empty"), errMsg)
+		require.Equal(t, "Name is empty", errMsg)
 
 		// Confirm that the 'details' field exists and has one element
 		details, exists := data["details"]
@@ -191,7 +191,7 @@ func (e *errors) Run(t *testing.T, ctx context.Context) {
 		// Confirm that the 'message' field exists and contains the correct error message
 		errMsg, exists := data["message"]
 		require.True(t, exists)
-		require.Equal(t, fmt.Sprintf("Set the job name in the url only"), errMsg)
+		require.Equal(t, "Set the job name in the url only", errMsg)
 
 		// Confirm that the 'details' field exists and has one element
 		details, exists := data["details"]

--- a/tests/integration/suite/daprd/jobs/streaming/stream.go
+++ b/tests/integration/suite/daprd/jobs/streaming/stream.go
@@ -130,7 +130,7 @@ func (s *streaming) Run(t *testing.T, ctx context.Context) {
 		case job := <-s.jobChan:
 			assert.NotNil(t, job)
 			assert.Equal(t, "job/test", job.GetMethod())
-		case <-time.After(time.Second * 10):
+		case <-time.After(time.Second * 3):
 			assert.Fail(t, "timed out waiting for triggered job")
 		}
 	})

--- a/tests/integration/suite/daprd/jobs/streaming/stream.go
+++ b/tests/integration/suite/daprd/jobs/streaming/stream.go
@@ -130,7 +130,7 @@ func (s *streaming) Run(t *testing.T, ctx context.Context) {
 		case job := <-s.jobChan:
 			assert.NotNil(t, job)
 			assert.Equal(t, "job/test", job.GetMethod())
-		case <-time.After(time.Second * 3):
+		case <-time.After(time.Second * 10):
 			assert.Fail(t, "timed out waiting for triggered job")
 		}
 	})

--- a/tests/integration/suite/daprd/metrics/workflow.go
+++ b/tests/integration/suite/daprd/metrics/workflow.go
@@ -15,7 +15,7 @@ package metrics
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/microsoft/durabletask-go/api"
@@ -70,7 +70,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 		return "success", nil
 	})
 	r.AddActivityN("activity_failure", func(ctx task.ActivityContext) (any, error) {
-		return nil, fmt.Errorf("failure")
+		return nil, errors.New("failure")
 	})
 	r.AddOrchestratorN("workflow", func(ctx *task.OrchestrationContext) (any, error) {
 		var input string

--- a/tests/integration/suite/daprd/middleware/http/app/uppercase.go
+++ b/tests/integration/suite/daprd/middleware/http/app/uppercase.go
@@ -60,7 +60,7 @@ spec:
 	handler.HandleFunc("/", func(http.ResponseWriter, *http.Request) {})
 	handler.HandleFunc("/foo", func(w http.ResponseWriter, r *http.Request) {
 		_, err := io.Copy(w, r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	srv := prochttp.New(t, prochttp.WithHandler(handler))
 

--- a/tests/integration/suite/daprd/middleware/http/uppercase.go
+++ b/tests/integration/suite/daprd/middleware/http/uppercase.go
@@ -61,7 +61,7 @@ spec:
 	handler.HandleFunc("/", func(nethttp.ResponseWriter, *nethttp.Request) {})
 	handler.HandleFunc("/foo", func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		_, err := io.Copy(w, r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 	srv := prochttp.New(t, prochttp.WithHandler(handler))
 

--- a/tests/integration/suite/daprd/outbox/http/basic.go
+++ b/tests/integration/suite/daprd/outbox/http/basic.go
@@ -174,7 +174,6 @@ func (o *basic) Run(t *testing.T, ctx context.Context) {
 
 		var ce map[string]string
 		err = json.Unmarshal(body, &ce)
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.Equal(c, "2", ce["data"])
 		assert.Equal(c, "myapp1", ce["outbox.cloudevent.myapp"])

--- a/tests/integration/suite/daprd/outbox/http/projection.go
+++ b/tests/integration/suite/daprd/outbox/http/projection.go
@@ -172,7 +172,6 @@ func (o *projection) Run(t *testing.T, ctx context.Context) {
 
 		var ce map[string]string
 		err = json.Unmarshal(body, &ce)
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.Equal(c, "3", ce["data"])
 	}, time.Second*10, time.Millisecond*10)

--- a/tests/integration/suite/daprd/pubsub/grpc/compname.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/compname.go
@@ -65,7 +65,7 @@ func (c *componentName) Setup(t *testing.T) []framework.Option {
 	c.pubsubNames = make([]string, numTests)
 	c.topicNames = make([]string, numTests)
 	files := make([]string, numTests)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz.Fuzz(&c.pubsubNames[i])
 		fz.Fuzz(&c.topicNames[i])
 
@@ -108,7 +108,6 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 				Topic:      topicName,
 				Data:       []byte(`{"status": "completed"}`),
 			})
-			//nolint:testifylint
 			assert.NoError(col, err)
 		})
 	}

--- a/tests/integration/suite/daprd/pubsub/grpc/errors.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/errors.go
@@ -197,7 +197,7 @@ func (e *errorcodes) Run(t *testing.T, ctx context.Context) {
 		s, ok := status.FromError(err)
 		require.True(t, ok)
 		require.Equal(t, grpcCodes.InvalidArgument, s.Code())
-		require.Equal(t, fmt.Sprintf("topic is empty in pubsub mypubsub"), s.Message())
+		require.Equal(t, "topic is empty in pubsub mypubsub", s.Message())
 
 		// Check status details
 		require.Len(t, s.Details(), 2)
@@ -243,7 +243,7 @@ func (e *errorcodes) Run(t *testing.T, ctx context.Context) {
 		require.True(t, ok)
 		require.Equal(t, grpcCodes.InvalidArgument, s.Code())
 		expectedErr := "rawPayload value must be a valid boolean: actual is 'invalidBooleanValue'"
-		require.Equal(t, fmt.Sprintf("failed deserializing metadata. Error: %s", expectedErr), s.Message())
+		require.Equal(t, "failed deserializing metadata. Error: "+expectedErr, s.Message())
 		// Check status details
 		require.Len(t, s.Details(), 2)
 

--- a/tests/integration/suite/daprd/pubsub/http/compname.go
+++ b/tests/integration/suite/daprd/pubsub/http/compname.go
@@ -66,7 +66,7 @@ func (c *componentName) Setup(t *testing.T) []framework.Option {
 	c.pubsubNames = make([]string, numTests)
 	c.topicNames = make([]string, numTests)
 	files := make([]string, numTests)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz.Fuzz(&c.pubsubNames[i])
 		fz.Fuzz(&c.topicNames[i])
 

--- a/tests/integration/suite/daprd/pubsub/http/errors.go
+++ b/tests/integration/suite/daprd/pubsub/http/errors.go
@@ -264,7 +264,7 @@ func (e *errorcodes) Run(t *testing.T, ctx context.Context) {
 		errMsg, exists := data["message"]
 		require.True(t, exists)
 		expectedErr := "rawPayload value must be a valid boolean: actual is 'invalidBooleanValue'"
-		require.Equal(t, fmt.Sprintf("failed deserializing metadata. Error: %s", expectedErr), errMsg)
+		require.Equal(t, "failed deserializing metadata. Error: "+expectedErr, errMsg)
 
 		// Confirm that the 'details' field exists and has one element
 		details, exists := data["details"]

--- a/tests/integration/suite/daprd/pubsub/http/fuzz.go
+++ b/tests/integration/suite/daprd/pubsub/http/fuzz.go
@@ -139,14 +139,14 @@ func (f *fuzzpubsub) Setup(t *testing.T) []framework.Option {
 	f.respChan = make(map[string]chan []byte)
 
 	files := make([]string, numTests)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		psNameFz.Fuzz(&f.pubSubs[i].Name)
 
 		topicsB, err := rand.Int(rand.Reader, big.NewInt(30))
 		require.NoError(t, err)
 		topics := int(topicsB.Int64() + 1)
 		f.pubSubs[i].Topics = make([]testTopic, topics)
-		for j := 0; j < topics; j++ {
+		for j := range topics {
 			psTopicFz.Fuzz(&f.pubSubs[i].Topics[j].Name)
 			psRouteFz.Fuzz(&f.pubSubs[i].Topics[j].Route)
 			f.respChan[f.pubSubs[i].Topics[j].Route] = make(chan []byte, 0)

--- a/tests/integration/suite/daprd/secret/http/compname.go
+++ b/tests/integration/suite/daprd/secret/http/compname.go
@@ -65,7 +65,7 @@ func (c *componentName) Setup(t *testing.T) []framework.Option {
 	})
 
 	c.secretStoreNames = make([]string, numTests)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz.Fuzz(&c.secretStoreNames[i])
 	}
 
@@ -106,7 +106,6 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 
 	pt := parallel.New(t)
 	for _, secretStoreName := range c.secretStoreNames {
-		secretStoreName := secretStoreName
 		pt.Add(func(t *assert.CollectT) {
 			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/key1", c.daprd.HTTPPort(), url.QueryEscape(secretStoreName))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)

--- a/tests/integration/suite/daprd/secret/http/fuzz.go
+++ b/tests/integration/suite/daprd/secret/http/fuzz.go
@@ -61,7 +61,7 @@ func (f *fuzzsecret) Setup(t *testing.T) []framework.Option {
 	f.secretStoreName = uid.String()
 
 	f.values = make(map[string]string)
-	for i := 0; i < numTests; i++ {
+	for range numTests {
 		var key, value string
 		for len(key) == 0 || takenNames[key] {
 			fuzz.New().Fuzz(&key)
@@ -116,8 +116,6 @@ func (f *fuzzsecret) Run(t *testing.T, ctx context.Context) {
 
 	pt := parallel.New(t)
 	for key, value := range f.values {
-		key := key
-		value := value
 		pt.Add(func(t *assert.CollectT) {
 			getURL := fmt.Sprintf("http://localhost:%d/v1.0/secrets/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.secretStoreName), url.QueryEscape(key))
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/basic.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/basic.go
@@ -238,7 +238,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 	})
 
 	pt := parallel.New(t)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		pt.Add(func(c *assert.CollectT) {
 			host := b.daprd1.GRPCAddress()
 			//nolint:staticcheck

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
@@ -82,7 +82,7 @@ func (f *fuzzgrpc) Run(t *testing.T, ctx context.Context) {
 	f.daprd2.WaitUntilRunning(t, ctx)
 
 	pt := parallel.New(t)
-	for i := range len(f.methods) {
+	for i := range f.methods {
 		method := f.methods[i]
 		body := f.bodies[i]
 		query := f.queries[i]

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
@@ -65,7 +65,7 @@ func (f *fuzzgrpc) Setup(t *testing.T) []framework.Option {
 	f.methods = make([]string, numTests)
 	f.bodies = make([][]byte, numTests)
 	f.queries = make([]map[string]string, numTests)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz := fuzz.New()
 		fz.NumElements(0, 100).Fuzz(&f.methods[i])
 		fz.NumElements(0, 100).Fuzz(&f.bodies[i])
@@ -82,7 +82,7 @@ func (f *fuzzgrpc) Run(t *testing.T, ctx context.Context) {
 	f.daprd2.WaitUntilRunning(t, ctx)
 
 	pt := parallel.New(t)
-	for i := 0; i < len(f.methods); i++ {
+	for i := range len(f.methods) {
 		method := f.methods[i]
 		body := f.bodies[i]
 		query := f.queries[i]

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/slowappstartup.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/slowappstartup.go
@@ -113,7 +113,6 @@ func (s *slowappstartup) Run(t *testing.T, ctx context.Context) {
 		})
 		// This function must only return that the app is not in a healthy state
 		// until the app is in a healthy state.
-		//nolint:testifylint
 		if !assert.NoError(c, err) {
 			require.ErrorContains(c, err, "app is not in a healthy state")
 		}

--- a/tests/integration/suite/daprd/serviceinvocation/http/basic.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/basic.go
@@ -216,7 +216,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 
 	client := client.HTTP(t)
 	pt := parallel.New(t)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		pt.Add(func(t *assert.CollectT) {
 			u := uuid.New().String()
 			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo", b.daprd1.HTTPPort(), b.daprd2.AppID())

--- a/tests/integration/suite/daprd/serviceinvocation/http/fuzz.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/fuzz.go
@@ -113,23 +113,23 @@ func (f *fuzzhttp) Setup(t *testing.T) []framework.Option {
 		n := c.Rand.Intn(100) + 1
 		var sb strings.Builder
 		sb.Grow(n)
-		for i := 0; i < n; i++ {
+		for range n {
 			sb.WriteRune(headerNameChars[c.Rand.Intn(len(headerNameChars))])
 		}
 		s.name = sb.String()
 		sb.Reset()
 		sb.Grow(n)
-		for i := 0; i < n; i++ {
+		for range n {
 			sb.WriteRune(headerValueChars[c.Rand.Intn(len(headerValueChars))])
 		}
 		s.value = sb.String()
 	}
 	queryFuzz := func(m map[string]string, c fuzz.Continue) {
 		n := c.Rand.Intn(4) + 1
-		for i := 0; i < n; i++ {
+		for range n {
 			var sb strings.Builder
 			sb.Grow(n)
-			for i := 0; i < n; i++ {
+			for range n {
 				sb.WriteRune(queryChars[c.Rand.Intn(len(queryChars))])
 			}
 			m[sb.String()] = sb.String()
@@ -141,7 +141,7 @@ func (f *fuzzhttp) Setup(t *testing.T) []framework.Option {
 	f.headers = make([][]header, numTests)
 	f.queries = make([]map[string]string, numTests)
 
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz := fuzz.New()
 		fz.NumElements(0, 100).Funcs(methodFuzz).Fuzz(&f.methods[i])
 		fz.NumElements(0, 100).Fuzz(&f.bodies[i])
@@ -162,7 +162,7 @@ func (f *fuzzhttp) Run(t *testing.T, ctx context.Context) {
 
 	pt := parallel.New(t)
 
-	for i := 0; i < len(f.methods); i++ {
+	for i := range len(f.methods) {
 		method := f.methods[i]
 		body := f.bodies[i]
 		headers := f.headers[i]

--- a/tests/integration/suite/daprd/shutdown/block/app/healthy.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/healthy.go
@@ -123,7 +123,6 @@ func (h *healthy) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.Len(c, resp.GetSubscriptions(), 1)
 	}, time.Second*5, time.Millisecond*10)
@@ -184,7 +183,6 @@ func (h *healthy) Run(t *testing.T, ctx context.Context) {
 			Topic:      "topic",
 			Data:       []byte(`{"status":"completed"}`),
 		})
-		//nolint:testifylint
 		assert.Error(c, err)
 	}, time.Second*5, time.Millisecond*10)
 	_, err = client.SaveState(ctx, &rtv1.SaveStateRequest{

--- a/tests/integration/suite/daprd/shutdown/block/app/unhealthy.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/unhealthy.go
@@ -115,7 +115,6 @@ func (u *unhealthy) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.Len(c, resp.GetSubscriptions(), 1)
 	}, time.Second*5, time.Millisecond*10)
@@ -142,7 +141,6 @@ func (u *unhealthy) Run(t *testing.T, ctx context.Context) {
 				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
 			},
 		})
-		//nolint:testifylint
 		assert.ErrorContains(c, err, "app is not in a healthy state")
 	}, time.Second*5, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/shutdown/block/timeout.go
+++ b/tests/integration/suite/daprd/shutdown/block/timeout.go
@@ -138,7 +138,6 @@ func (i *timeout) Run(t *testing.T, ctx context.Context) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-		//nolint:testifylint
 		assert.NoError(c, err)
 		assert.Len(c, resp.GetSubscriptions(), 1)
 	}, time.Second*5, time.Millisecond*10)

--- a/tests/integration/suite/daprd/state/grpc/compname.go
+++ b/tests/integration/suite/daprd/state/grpc/compname.go
@@ -64,7 +64,7 @@ func (c *componentName) Setup(t *testing.T) []framework.Option {
 
 	c.storeNames = make([]string, numTests)
 	files := make([]string, numTests)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz.Fuzz(&c.storeNames[i])
 
 		files[i] = fmt.Sprintf(`
@@ -92,7 +92,6 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 
 	pt := parallel.New(t)
 	for _, storeName := range c.storeNames {
-		storeName := storeName
 		pt.Add(func(col *assert.CollectT) {
 			//nolint:staticcheck
 			conn, err := grpc.DialContext(ctx, c.daprd.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())

--- a/tests/integration/suite/daprd/state/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/state/grpc/fuzz.go
@@ -192,7 +192,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	httpClient := fclient.HTTP(t)
 
 	pt := parallel.New(t)
-	for i := range len(f.getFuzzKeys) {
+	for i := range f.getFuzzKeys {
 		pt.Add(func(t *assert.CollectT) {
 			for _, req := range [][]*commonv1.StateItem{f.saveReqBinaries[i], f.saveReqStrings[i]} {
 				_, err := client.SaveState(ctx, &rtv1.SaveStateRequest{

--- a/tests/integration/suite/daprd/state/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/state/grpc/fuzz.go
@@ -128,7 +128,7 @@ spec:
 			i--
 		}
 	}
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		var (
 			srb     []saveReqBinary
 			srbHTTP []saveReqBinary
@@ -178,7 +178,6 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	t.Run("get", func(t *testing.T) {
 		pt := parallel.New(t)
 		for i := range f.getFuzzKeys {
-			i := i
 			pt.Add(func(t *assert.CollectT) {
 				resp, err := client.GetState(ctx, &rtv1.GetStateRequest{
 					StoreName: f.storeName,
@@ -193,8 +192,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	httpClient := fclient.HTTP(t)
 
 	pt := parallel.New(t)
-	for i := 0; i < len(f.getFuzzKeys); i++ {
-		i := i
+	for i := range len(f.getFuzzKeys) {
 		pt.Add(func(t *assert.CollectT) {
 			for _, req := range [][]*commonv1.StateItem{f.saveReqBinaries[i], f.saveReqStrings[i]} {
 				_, err := client.SaveState(ctx, &rtv1.SaveStateRequest{

--- a/tests/integration/suite/daprd/state/http/compname.go
+++ b/tests/integration/suite/daprd/state/http/compname.go
@@ -64,7 +64,7 @@ func (c *componentName) Setup(t *testing.T) []framework.Option {
 
 	c.storeNames = make([]string, numTests)
 	files := make([]string, numTests)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz.Fuzz(&c.storeNames[i])
 
 		files[i] = fmt.Sprintf(`
@@ -94,7 +94,6 @@ func (c *componentName) Run(t *testing.T, ctx context.Context) {
 
 	pt := parallel.New(t)
 	for _, storeName := range c.storeNames {
-		storeName := storeName
 		pt.Add(func(t *assert.CollectT) {
 			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", c.daprd.HTTPPort(), url.QueryEscape(storeName))
 			req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, strings.NewReader(`[{"key": "key1", "value": "value1"}]`))

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -139,7 +139,7 @@ spec:
 			i--
 		}
 	}
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		fz.Fuzz(&f.saveReqBinaries[i])
 		fz.Fuzz(&f.saveReqStrings[i])
 		fz.Fuzz(&f.saveReqAnys[i])
@@ -162,7 +162,6 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	t.Run("get", func(t *testing.T) {
 		pt := parallel.New(t)
 		for i := range f.getFuzzKeys {
-			i := i
 			pt.Add(func(t *assert.CollectT) {
 				getURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName), url.QueryEscape(f.getFuzzKeys[i]))
 				// t.Log("URL", getURL)
@@ -182,8 +181,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	})
 
 	pt := parallel.New(t)
-	for i := 0; i < len(f.getFuzzKeys); i++ {
-		i := i
+	for i := range len(f.getFuzzKeys) {
 		pt.Add(func(t *assert.CollectT) {
 			for _, req := range []any{f.saveReqBinaries[i], f.saveReqStrings[i]} {
 				postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName))

--- a/tests/integration/suite/daprd/state/http/fuzz.go
+++ b/tests/integration/suite/daprd/state/http/fuzz.go
@@ -181,7 +181,7 @@ func (f *fuzzstate) Run(t *testing.T, ctx context.Context) {
 	})
 
 	pt := parallel.New(t)
-	for i := range len(f.getFuzzKeys) {
+	for i := range f.getFuzzKeys {
 		pt.Add(func(t *assert.CollectT) {
 			for _, req := range []any{f.saveReqBinaries[i], f.saveReqStrings[i]} {
 				postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/%s", f.daprd.HTTPPort(), url.QueryEscape(f.storeName))

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v1alpha1/bulk/grpc.go
@@ -135,7 +135,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
@@ -153,6 +153,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.AssertBulkEventChanLen(t, 0)
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/operator/v2alpha1/bulk/grpc.go
@@ -147,7 +147,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
@@ -165,6 +165,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.AssertBulkEventChanLen(t, 0)
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v1alpha1/bulk/grpc.go
@@ -95,7 +95,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
@@ -113,6 +113,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.AssertBulkEventChanLen(t, 0)
 }

--- a/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/grpc.go
+++ b/tests/integration/suite/daprd/subscriptions/declarative/selfhosted/v2alpha1/bulk/grpc.go
@@ -97,7 +97,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
 	g.sub.ReceiveBulk(t, ctx)
@@ -115,6 +115,6 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	g.sub.AssertBulkEventChanLen(t, 0)
 }

--- a/tests/integration/suite/daprd/subscriptions/programmatic/grpc/bulk.go
+++ b/tests/integration/suite/daprd/subscriptions/programmatic/grpc/bulk.go
@@ -113,7 +113,7 @@ func (b *bulk) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	b.sub.ReceiveBulk(t, ctx)
 	b.sub.ReceiveBulk(t, ctx)
 	b.sub.ReceiveBulk(t, ctx)
@@ -131,6 +131,6 @@ func (b *bulk) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 	b.sub.AssertBulkEventChanLen(t, 0)
 }

--- a/tests/integration/suite/daprd/subscriptions/stream/bulk.go
+++ b/tests/integration/suite/daprd/subscriptions/stream/bulk.go
@@ -90,7 +90,7 @@ func (b *bulk) Run(t *testing.T, ctx context.Context) {
 
 	errCh := make(chan error, 8)
 	go func() {
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			event, serr := stream.Recv()
 			errCh <- serr
 			errCh <- stream.Send(&rtv1.SubscribeTopicEventsRequestAlpha1{
@@ -115,9 +115,9 @@ func (b *bulk) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Empty(t, len(resp.GetFailedEntries()))
+	assert.Empty(t, resp.GetFailedEntries())
 
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		require.NoError(t, <-errCh)
 	}
 }

--- a/tests/integration/suite/daprd/tracing/serviceinvocation/serviceinvocation.go
+++ b/tests/integration/suite/daprd/tracing/serviceinvocation/serviceinvocation.go
@@ -173,8 +173,8 @@ func (i *invoke) Run(t *testing.T, ctx context.Context) {
 		}
 
 		tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-02"
-		ctx = grpcMetadata.AppendToOutgoingContext(ctx, "traceparent", tp)
-		svcresp, err := client.InvokeService(ctx, &svcreq)
+		tctx := grpcMetadata.AppendToOutgoingContext(ctx, "traceparent", tp)
+		svcresp, err := client.InvokeService(tctx, &svcreq)
 		require.NoError(t, err)
 		require.NotNil(t, svcresp)
 		assert.True(t, i.traceparent.Load())
@@ -193,9 +193,9 @@ func (i *invoke) Run(t *testing.T, ctx context.Context) {
 		}
 
 		tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-03"
-		ctx = grpcMetadata.AppendToOutgoingContext(ctx, "traceparent", tp)
-		grpcclient := i.grpcdaprd.GRPCClient(t, ctx)
-		svcresp, err = grpcclient.InvokeService(ctx, &grpcappreq)
+		tctx = grpcMetadata.AppendToOutgoingContext(tctx, "traceparent", tp)
+		grpcclient := i.grpcdaprd.GRPCClient(t, tctx)
+		svcresp, err = grpcclient.InvokeService(tctx, &grpcappreq)
 		require.NoError(t, err)
 		require.NotNil(t, svcresp)
 		assert.True(t, i.grpctracectxkey.Load()) // this is set for grpc, instead of traceparent

--- a/tests/integration/suite/daprd/workflow/basic.go
+++ b/tests/integration/suite/daprd/workflow/basic.go
@@ -127,7 +127,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		r := task.NewTaskRegistry()
 		r.AddOrchestratorN("Root", func(ctx *task.OrchestrationContext) (any, error) {
 			tasks := []task.Task{}
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				task := ctx.CallSubOrchestrator("L1", task.WithSubOrchestrationInstanceID(string(ctx.ID)+"_L1_"+strconv.Itoa(i)))
 				tasks = append(tasks, task)
 			}
@@ -160,7 +160,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		assert.Eventually(t, func() bool {
 			// List of all orchestrations created
 			orchestrationIDs := []string{string(id)}
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				orchestrationIDs = append(orchestrationIDs, string(id)+"_L1_"+strconv.Itoa(i), string(id)+"_L1_"+strconv.Itoa(i)+"_L2")
 			}
 			for _, orchID := range orchestrationIDs {
@@ -184,7 +184,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 
 		// Wait for all L2 suborchestrations to complete
 		orchIDs := []string{}
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			orchIDs = append(orchIDs, string(id)+"_L1_"+strconv.Itoa(i)+"_L2")
 		}
 		for _, orchID := range orchIDs {

--- a/tests/integration/suite/daprd/workflow/memory/scheduler.go
+++ b/tests/integration/suite/daprd/workflow/memory/scheduler.go
@@ -63,7 +63,7 @@ func (s *scheduler) Run(t *testing.T, ctx context.Context) {
 
 	var actorMemBaseline float64
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		resp, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
 			WorkflowComponent: "dapr",
 			WorkflowName:      "foo",

--- a/tests/integration/suite/daprd/workflow/memory/state.go
+++ b/tests/integration/suite/daprd/workflow/memory/state.go
@@ -62,7 +62,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 
 	var actorMemBaseline float64
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		resp, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
 			WorkflowComponent: "dapr",
 			WorkflowName:      "foo",

--- a/tests/integration/suite/daprd/workflow/scheduler/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/basic.go
@@ -155,7 +155,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		r := task.NewTaskRegistry()
 		r.AddOrchestratorN("Root", func(ctx *task.OrchestrationContext) (any, error) {
 			tasks := []task.Task{}
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				task := ctx.CallSubOrchestrator("N1", task.WithSubOrchestrationInstanceID(string(ctx.ID)+"_N1_"+strconv.Itoa(i)))
 				tasks = append(tasks, task)
 			}
@@ -188,7 +188,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		assert.Eventually(t, func() bool {
 			// List of all orchestrations created
 			orchestrationIDs := []string{string(id)}
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				orchestrationIDs = append(orchestrationIDs, string(id)+"_N1_"+strconv.Itoa(i), string(id)+"_N1_"+strconv.Itoa(i)+"_N2")
 			}
 			for _, orchID := range orchestrationIDs {
@@ -200,7 +200,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 				}
 			}
 			return true
-		}, 2*time.Second, 10*time.Millisecond)
+		}, 10*time.Second, 10*time.Millisecond)
 
 		// Terminate the root orchestration
 		b.terminateWorkflow(t, ctx, string(id))
@@ -212,7 +212,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 
 		// Wait for all N2 suborchestrations to complete
 		orchIDs := []string{}
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			orchIDs = append(orchIDs, string(id)+"_N1_"+strconv.Itoa(i)+"_N2")
 		}
 		for _, orchID := range orchIDs {

--- a/tests/integration/suite/daprd/workflow/scheduler/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/basic.go
@@ -200,7 +200,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 				}
 			}
 			return true
-		}, 10*time.Second, 10*time.Millisecond)
+		}, 2*time.Second, 10*time.Millisecond)
 
 		// Terminate the root orchestration
 		b.terminateWorkflow(t, ctx, string(id))

--- a/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
@@ -83,7 +83,7 @@ func (d *deletereminder) Run(t *testing.T, ctx context.Context) {
 	d.daprd.WaitUntilRunning(t, ctx)
 
 	etcdClient := clients.Etcd(t, clientv3.Config{
-		Endpoints:   []string{fmt.Sprintf("localhost:%s", d.scheduler.EtcdClientPort())},
+		Endpoints:   []string{"localhost:" + d.scheduler.EtcdClientPort()},
 		DialTimeout: 5 * time.Second,
 	})
 

--- a/tests/integration/suite/healthz/daprd.go
+++ b/tests/integration/suite/healthz/daprd.go
@@ -63,7 +63,6 @@ func (d *daprd) Run(t *testing.T, ctx context.Context) {
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				resp, err := client.Do(req)
-				//nolint:testifylint
 				if assert.NoError(c, err) {
 					require.NoError(t, resp.Body.Close())
 					assert.Equal(c, http.StatusNoContent, resp.StatusCode)
@@ -91,7 +90,6 @@ func (d *daprd) Run(t *testing.T, ctx context.Context) {
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 			require.NoError(t, err)
 
-			//nolint:testifylint
 			assert.EventuallyWithT(t, func(t *assert.CollectT) {
 				resp, err := client.Do(req)
 				if assert.NoError(t, err) {

--- a/tests/integration/suite/operator/api/componentupdate/basic.go
+++ b/tests/integration/suite/operator/api/componentupdate/basic.go
@@ -126,7 +126,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			event, err := stream.Recv()
-			//nolint:testifylint
 			if !assert.NoError(c, err) {
 				return
 			}
@@ -148,7 +147,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			event, err := stream.Recv()
-			//nolint:testifylint
 			if !assert.NoError(c, err) {
 				return
 			}

--- a/tests/integration/suite/operator/api/listcomponents/scopes/addapp.go
+++ b/tests/integration/suite/operator/api/listcomponents/scopes/addapp.go
@@ -99,7 +99,6 @@ func (a *addapp) Run(t *testing.T, ctx context.Context) {
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
 		list, err = client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
-		//nolint:testifylint
 		if assert.NoError(c, err) {
 			assert.Len(c, list.GetComponents(), 1)
 		}
@@ -116,7 +115,6 @@ func (a *addapp) Run(t *testing.T, ctx context.Context) {
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			list, err := client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
-			//nolint:testifylint
 			if !assert.NoError(c, err) {
 				return
 			}

--- a/tests/integration/suite/operator/api/listcomponents/scopes/deleteapp.go
+++ b/tests/integration/suite/operator/api/listcomponents/scopes/deleteapp.go
@@ -99,7 +99,6 @@ func (d *deleteapp) Run(t *testing.T, ctx context.Context) {
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		var err error
 		list, err = client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
-		//nolint:testifylint
 		if assert.NoError(c, err) {
 			assert.Len(c, list.GetComponents(), 1)
 		}
@@ -116,7 +115,6 @@ func (d *deleteapp) Run(t *testing.T, ctx context.Context) {
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			list, err := client.ListComponents(ctx, &operatorv1.ListComponentsRequest{Namespace: "default"})
-			//nolint:testifylint
 			if assert.NoError(c, err) {
 				assert.Empty(c, list.GetComponents())
 			}

--- a/tests/integration/suite/placement/dissemination/tls.go
+++ b/tests/integration/suite/placement/dissemination/tls.go
@@ -157,7 +157,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Equal(t, "OK1", string(val1.GetData()))
 
@@ -166,7 +165,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.Error(c, err)
 
 			_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
@@ -175,7 +173,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				Method:    "foo",
 			})
 
-			//nolint:testifylint
 			assert.Error(c, err)
 
 			_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
@@ -183,8 +180,7 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
-			assert.Error(c, err, err)
+			assert.Error(c, err)
 		}, time.Second*20, time.Millisecond*10, "actor not ready")
 	})
 
@@ -197,7 +193,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Equal(t, "OK3", string(val2.GetData()))
 
@@ -206,7 +201,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.NoError(c, err)
 
 			_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
@@ -214,7 +208,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.NoError(c, err)
 
 			_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
@@ -222,8 +215,7 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
-			assert.Error(c, err, err)
+			assert.Error(c, err)
 		}, time.Second*20, time.Millisecond*10, "actors not ready")
 	})
 
@@ -236,7 +228,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.NoError(c, err)
 			assert.Equal(t, "OK3", string(val3.GetData()))
 
@@ -245,7 +236,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.NoError(c, err)
 
 			_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
@@ -253,7 +243,6 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
 			assert.NoError(c, err)
 
 			_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
@@ -261,8 +250,7 @@ func (n *tls) Run(t *testing.T, ctx context.Context) {
 				ActorId:   "myactorid",
 				Method:    "foo",
 			})
-			//nolint:testifylint
-			assert.Error(c, err, err)
+			assert.Error(c, err)
 		}, time.Second*20, time.Millisecond*10, "actors not ready")
 	})
 }

--- a/tests/integration/suite/placement/quorum/jwks.go
+++ b/tests/integration/suite/placement/quorum/jwks.go
@@ -61,7 +61,7 @@ func (j *jwks) Setup(t *testing.T) []framework.Option {
 	jwtPriv, jwtPub := j.genPrivateJWK(t)
 
 	tokenFiles := make([]string, 3)
-	for i := range 3 {
+	for i := range tokenFiles {
 		token := j.signJWT(t, jwtPriv, "spiffe://localhost/ns/default/dapr-placement")
 		tokenFiles[i] = filepath.Join(t.TempDir(), "token-"+strconv.Itoa(i))
 		require.NoError(t, os.WriteFile(tokenFiles[i], token, 0o600))

--- a/tests/integration/suite/placement/quorum/jwks.go
+++ b/tests/integration/suite/placement/quorum/jwks.go
@@ -61,7 +61,7 @@ func (j *jwks) Setup(t *testing.T) []framework.Option {
 	jwtPriv, jwtPub := j.genPrivateJWK(t)
 
 	tokenFiles := make([]string, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		token := j.signJWT(t, jwtPriv, "spiffe://localhost/ns/default/dapr-placement")
 		tokenFiles[i] = filepath.Join(t.TempDir(), "token-"+strconv.Itoa(i))
 		require.NoError(t, os.WriteFile(tokenFiles[i], token, 0o600))

--- a/tests/integration/suite/ports/injector.go
+++ b/tests/integration/suite/ports/injector.go
@@ -61,7 +61,6 @@ func (i *injector) Run(t *testing.T, ctx context.Context) {
 	} {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			conn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("localhost:%d", port))
-			//nolint:testifylint
 			_ = assert.NoError(c, err) && assert.NoError(c, conn.Close())
 		}, time.Second*10, 100*time.Millisecond, "port %s (:%d) was not available in time", name, port)
 	}

--- a/tests/integration/suite/ports/operator.go
+++ b/tests/integration/suite/ports/operator.go
@@ -72,7 +72,6 @@ func (o *operator) Run(t *testing.T, ctx context.Context) {
 	} {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			conn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("localhost:%d", port))
-			//nolint:testifylint
 			_ = assert.NoError(c, err) && assert.NoError(c, conn.Close())
 		}, time.Second*10, 10*time.Millisecond, "port %s (:%d) was not available in time", name, port)
 	}

--- a/tests/integration/suite/scheduler/quorum/notls.go
+++ b/tests/integration/suite/scheduler/quorum/notls.go
@@ -131,7 +131,7 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 	}, time.Second*40, time.Millisecond*10, "failed to find job's key in etcd")
 
 	// ensure data exists on ALL schedulers
-	for i := range 3 {
+	for i := range n.schedulers {
 		diffScheduler := n.schedulers[i]
 
 		diffSchedulerPort := diffScheduler.EtcdClientPort()

--- a/tests/integration/suite/scheduler/quorum/notls.go
+++ b/tests/integration/suite/scheduler/quorum/notls.go
@@ -131,7 +131,7 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 	}, time.Second*40, time.Millisecond*10, "failed to find job's key in etcd")
 
 	// ensure data exists on ALL schedulers
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		diffScheduler := n.schedulers[i]
 
 		diffSchedulerPort := diffScheduler.EtcdClientPort()
@@ -166,7 +166,7 @@ func (n *notls) checkKeysForJobName(t *testing.T, jobName string, keys []*mvccpb
 
 func getEtcdKeys(t *testing.T, port string) []*mvccpb.KeyValue {
 	client, err := clientv3.New(clientv3.Config{
-		Endpoints:   []string{fmt.Sprintf("127.0.0.1:%s", port)},
+		Endpoints:   []string{"127.0.0.1:" + port},
 		DialTimeout: 40 * time.Second,
 	})
 	require.NoError(t, err)

--- a/tests/perf/actor_double_activation/actor_double_activation_test.go
+++ b/tests/perf/actor_double_activation/actor_double_activation_test.go
@@ -34,9 +34,7 @@ const (
 	serviceApplicationName = "perf-actor-double-activation"
 )
 
-var (
-	tr *runner.TestRunner
-)
+var tr *runner.TestRunner
 
 func TestMain(m *testing.M) {
 	utils.SetupLogs("actor_double_activation")

--- a/tests/perf/actor_id_scale/actor_id_scale_test.go
+++ b/tests/perf/actor_id_scale/actor_id_scale_test.go
@@ -35,9 +35,7 @@ const (
 	actorType              = "scale-id"
 )
 
-var (
-	tr *runner.TestRunner
-)
+var tr *runner.TestRunner
 
 func TestMain(m *testing.M) {
 	utils.SetupLogs("actor_id_stress_test")

--- a/tests/perf/actor_reminder/actor_reminder_test.go
+++ b/tests/perf/actor_reminder/actor_reminder_test.go
@@ -424,7 +424,6 @@ func TestActorReminderSchedulerTriggerPerformance(t *testing.T) {
 	worker := func(i int) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			_, err = utils.HTTPPost(fmt.Sprintf("%s/actors/%s/abc/reminders/myreminder%d", testAppURL, actorTypeScheduler, i), reminderB)
-			//nolint:testifylint
 			assert.NoError(c, err)
 		}, 10*time.Second, time.Millisecond*100)
 

--- a/tests/perf/configuration/configuration_test.go
+++ b/tests/perf/configuration/configuration_test.go
@@ -31,9 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	tr *runner.TestRunner
-)
+var tr *runner.TestRunner
 
 const (
 	numHealthChecks                   = 60 // Number of times to check for endpoint health per app.

--- a/tests/perf/pubsub_bulk_publish_http/pubsub_bulk_publish_http_test.go
+++ b/tests/perf/pubsub_bulk_publish_http/pubsub_bulk_publish_http_test.go
@@ -31,9 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	tr *runner.TestRunner
-)
+var tr *runner.TestRunner
 
 const (
 	k6AppName = "k6-test-app"

--- a/tests/perf/pubsub_publish_http/pubsub_publish_http_test.go
+++ b/tests/perf/pubsub_publish_http/pubsub_publish_http_test.go
@@ -31,9 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	tr *runner.TestRunner
-)
+var tr *runner.TestRunner
 
 const (
 	k6AppName     = "k6-test-app"

--- a/tests/perf/pubsub_subscribe_http/pubsub_subscribe_test.go
+++ b/tests/perf/pubsub_subscribe_http/pubsub_subscribe_test.go
@@ -81,14 +81,14 @@ func getAppDescription(pubsubComponent Component, pubsubType string) kube.AppDes
 func TestMain(m *testing.M) {
 	utils.SetupLogs(testLabel)
 
-	//Read env variable for pubsub test config file, this will decide whether to run single component or all the components.
+	// Read env variable for pubsub test config file, this will decide whether to run single component or all the components.
 	pubsubTestConfigFileName := os.Getenv("DAPR_PERF_PUBSUB_SUBS_HTTP_TEST_CONFIG_FILE_NAME")
 
 	if pubsubTestConfigFileName == "" {
 		pubsubTestConfigFileName = "test_kafka.yaml"
 	}
 
-	//Read the config file for individual components
+	// Read the config file for individual components
 	data, err := os.ReadFile(pubsubTestConfigFileName)
 	if err != nil {
 		fmt.Printf("error reading %v: %v\n", pubsubTestConfigFileName, err)
@@ -99,17 +99,17 @@ func TestMain(m *testing.M) {
 
 	err = yaml.Unmarshal(data, &configs)
 
-	//set the configuration as environment variables for the test app.
+	// set the configuration as environment variables for the test app.
 	var testApps []kube.AppDescription
 
 	for _, pubsubComponent := range configs.Components {
-		//normal pubsub app
+		// normal pubsub app
 		if slices.Contains(pubsubComponent.Operations, normalPubsubType) {
 			fmt.Println("image used: ", pubsubComponent.ImageName, pubsubComponent.TestAppName, pubsubComponent.Name, normalPubsubType)
 			testApps = append(testApps, getAppDescription(pubsubComponent, normalPubsubType))
 		}
 
-		//bulk pubsub app
+		// bulk pubsub app
 		if slices.Contains(pubsubComponent.Operations, bulkPubsubType) {
 			fmt.Println("image used: ", pubsubComponent.ImageName, pubsubComponent.TestAppName, pubsubComponent.Name, bulkPubsubType)
 			testApps = append(testApps, getAppDescription(pubsubComponent, bulkPubsubType))
@@ -126,7 +126,7 @@ func runTest(t *testing.T, testAppURL, publishType, subscribeType, httpReqDurati
 	k6Test := loadtest.NewK6("./test.js",
 		loadtest.WithParallelism(1),
 		loadtest.WithAppID("k6-tester-pubsub-subscribe-http"),
-		//loadtest.EnableLog(), // uncomment this to enable k6 logs, this however breaks reporting, only for debugging.
+		// loadtest.EnableLog(), // uncomment this to enable k6 logs, this however breaks reporting, only for debugging.
 		loadtest.WithRunnerEnvVar("TARGET_URL", testAppURL),
 		loadtest.WithRunnerEnvVar("PUBSUB_NAME", component.Name),
 		loadtest.WithRunnerEnvVar("PUBLISH_TYPE", publishType),
@@ -142,7 +142,7 @@ func runTest(t *testing.T, testAppURL, publishType, subscribeType, httpReqDurati
 	require.NoError(t, err)
 	require.NotNil(t, sm)
 
-	var testAppName = component.TestAppName + "-" + subscribeType
+	testAppName := component.TestAppName + "-" + subscribeType
 
 	appUsage, err := tr.Platform.GetAppUsage(testAppName)
 	require.NoError(t, err)

--- a/tests/perf/utils/http.go
+++ b/tests/perf/utils/http.go
@@ -15,7 +15,6 @@ package utils
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -107,7 +106,7 @@ func HTTPDelete(url string) ([]byte, error) {
 
 func sanitizeHTTPURL(url string) string {
 	if !strings.Contains(url, "http") {
-		url = fmt.Sprintf("http://%s", url)
+		url = "http://%s" + url
 	}
 
 	return url

--- a/tests/perf/utils/http.go
+++ b/tests/perf/utils/http.go
@@ -106,7 +106,7 @@ func HTTPDelete(url string) ([]byte, error) {
 
 func sanitizeHTTPURL(url string) string {
 	if !strings.Contains(url, "http") {
-		url = "http://%s" + url
+		url = "http://" + url
 	}
 
 	return url

--- a/tests/perf/utils/prometheus_metrics.go
+++ b/tests/perf/utils/prometheus_metrics.go
@@ -37,7 +37,6 @@ type DaprMetrics struct {
 
 // DAPR_PERF_METRICS_PROMETHEUS_PUSHGATEWAY_URL needs to be set
 func PushPrometheusMetrics(metrics DaprMetrics, perfTest, component string) {
-
 	prometheusPushgatewayURL := os.Getenv("DAPR_PERF_METRICS_PROMETHEUS_PUSHGATEWAY_URL")
 	if prometheusPushgatewayURL == "" {
 		log.Println("DAPR_PERF_METRICS_PROMETHEUS_PUSHGATEWAY_URL is not set, skipping pushing perf test metrics to Prometheus Pushgateway")

--- a/tests/perf/workflows/workflow_test.go
+++ b/tests/perf/workflows/workflow_test.go
@@ -39,8 +39,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var tr *runner.TestRunner
-var appNamePrefix = "perf-workflowsapp"
+var (
+	tr            *runner.TestRunner
+	appNamePrefix = "perf-workflowsapp"
+)
 
 type K6RunConfig struct {
 	TARGET_URL     string
@@ -180,7 +182,6 @@ func testWorkflow(t *testing.T, workflowName string, testAppName string, inputs 
 					require.NoError(t, err)
 					assert.EventuallyWithT(t, func(c *assert.CollectT) {
 						err = cl.Get(context.Background(), client.ObjectKey{Namespace: kube.DaprTestNamespace, Name: "dapr-scheduler-server-0"}, &pod)
-						//nolint:testifylint
 						if assert.NoError(c, err) {
 							assert.Equal(c, corev1.PodRunning, pod.Status.Phase)
 						}
@@ -235,7 +236,6 @@ func testWorkflow(t *testing.T, workflowName string, testAppName string, inputs 
 				url = fmt.Sprintf("http://%s/shutdown-workflow-runtime", externalURL)
 				_, err = utils.HTTPGet(url)
 				require.NoError(t, err, "error shutdown workflow runtime")
-
 			})
 		}
 	}

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -336,8 +336,9 @@ func buildServiceObject(namespace string, appDesc AppDescription) *apiv1.Service
 			},
 			Ports: []apiv1.ServicePort{
 				{
-					Protocol:   apiv1.ProtocolTCP,
-					Port:       DefaultExternalPort,
+					Protocol: apiv1.ProtocolTCP,
+					Port:     DefaultExternalPort,
+					//nolint:gosec
 					TargetPort: intstr.IntOrString{IntVal: int32(targetPort)},
 				},
 			},

--- a/tests/platforms/kubernetes/portforward.go
+++ b/tests/platforms/kubernetes/portforward.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -59,22 +60,22 @@ func NewPodPortForwarder(c *KubeClient, namespace string) *PodPortForwarder {
 // Connect establishes a new connection to a given app on the provided target ports.
 func (p *PodPortForwarder) Connect(name string, targetPorts ...int) ([]int, error) {
 	if name == "" {
-		return nil, fmt.Errorf("name must be set to establish connection")
+		return nil, errors.New("name must be set to establish connection")
 	}
 	if len(targetPorts) == 0 {
-		return nil, fmt.Errorf("cannot establish connection without target ports")
+		return nil, errors.New("cannot establish connection without target ports")
 	}
 	if p.namespace == "" {
-		return nil, fmt.Errorf("namespace must be set to establish connection")
+		return nil, errors.New("namespace must be set to establish connection")
 	}
 	if p.client == nil {
-		return nil, fmt.Errorf("client must be set to establish connection")
+		return nil, errors.New("client must be set to establish connection")
 	}
 
 	config := p.client.GetClientConfig()
 
-	var ports []int
-	for i := 0; i < len(targetPorts); i++ {
+	ports := make([]int, 0, len(targetPorts))
+	for range len(targetPorts) {
 		p, perr := freeport.GetFreePort()
 		if perr != nil {
 			return nil, perr

--- a/tests/runner/kube_testplatform.go
+++ b/tests/runner/kube_testplatform.go
@@ -15,6 +15,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -25,7 +26,7 @@ import (
 	kube "github.com/dapr/dapr/tests/platforms/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -86,7 +87,7 @@ func (c *KubeTestPlatform) TearDown() error {
 // addComponents adds component to disposable Resource queues.
 func (c *KubeTestPlatform) AddComponents(comps []kube.ComponentDescription) error {
 	if c.KubeClient == nil {
-		return fmt.Errorf("kubernetes cluster needs to be setup")
+		return errors.New("kubernetes cluster needs to be setup")
 	}
 
 	for _, comp := range comps {
@@ -104,7 +105,7 @@ func (c *KubeTestPlatform) AddComponents(comps []kube.ComponentDescription) erro
 // AddSecrets adds secrets to disposable Resource queues.
 func (c *KubeTestPlatform) AddSecrets(secrets []kube.SecretDescription) error {
 	if c.KubeClient == nil {
-		return fmt.Errorf("kubernetes cluster needs to be setup")
+		return errors.New("kubernetes cluster needs to be setup")
 	}
 
 	for _, secret := range secrets {
@@ -122,7 +123,7 @@ func (c *KubeTestPlatform) AddSecrets(secrets []kube.SecretDescription) error {
 // addApps adds test apps to disposable App Resource queues.
 func (c *KubeTestPlatform) AddApps(apps []kube.AppDescription) error {
 	if c.KubeClient == nil {
-		return fmt.Errorf("kubernetes cluster needs to be setup before calling BuildAppResources")
+		return errors.New("kubernetes cluster needs to be setup before calling BuildAppResources")
 	}
 
 	dt := c.disableTelemetry()
@@ -277,7 +278,7 @@ func (c *KubeTestPlatform) GetOrCreateNamespace(parentCtx context.Context, names
 	ns, err := namespaceClient.Get(ctx, namespace, metav1.GetOptions{})
 	cancel()
 
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && apierrors.IsNotFound(err) {
 		log.Printf("Creating namespace %q ...", namespace)
 		obj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		ctx, cancel = context.WithTimeout(parentCtx, 30*time.Second)
@@ -373,7 +374,7 @@ func (c *KubeTestPlatform) PortForwardToApp(appName string, targetPorts ...int) 
 	}
 
 	if targetPorts == nil {
-		return nil, fmt.Errorf("cannot open connection with no target ports")
+		return nil, errors.New("cannot open connection with no target ports")
 	}
 	return appManager.DoPortForwarding("", targetPorts...)
 }

--- a/tests/runner/loadtest/fortio.go
+++ b/tests/runner/loadtest/fortio.go
@@ -16,7 +16,6 @@ package loadtest
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/dapr/dapr/tests/perf"
@@ -109,7 +108,7 @@ func (f *Fortio) Run(platform runner.PlatformInterface) error {
 		return err
 	}
 
-	daprResp, err := utils.HTTPPost(fmt.Sprintf("%s/test", f.testerAppURL), body)
+	daprResp, err := utils.HTTPPost(f.testerAppURL+"/test", body)
 	if err != nil {
 		return err
 	}

--- a/tests/runner/loadtest/k6.go
+++ b/tests/runner/loadtest/k6.go
@@ -274,6 +274,7 @@ func (k6 *K6) k8sRun(k8s *runner.KubeTestPlatform) error {
 					File: scriptName,
 				},
 			},
+			//nolint:gosec
 			Parallelism: int32(k6.parallelism),
 			Arguments:   args,
 			Starter: k6api.Pod{
@@ -556,7 +557,7 @@ func NewK6(scriptPath string, opts ...K6Opt) *K6 {
 	log.Printf("starting %s k6 test", uniqueTestID)
 
 	k6Tester := &K6{
-		name:              fmt.Sprintf("k6-test-%s", uniqueTestID),
+		name:              "k6-test-" + uniqueTestID,
 		appID:             "k6-tester",
 		script:            scriptPath,
 		parallelism:       1,

--- a/tests/runner/summary/summary.go
+++ b/tests/runner/summary/summary.go
@@ -162,12 +162,12 @@ var unitFormats = map[unit]string{
 
 // OutputK6Trend outputs the given k6trend using the given prefix.
 func (t *Table) OutputK6Trend(prefix string, unit unit, trend loadtest.K6TrendMetric) *Table {
-	t.Outputf(fmt.Sprintf("%s MAX", prefix), unitFormats[unit], trend.Values.Max)
-	t.Outputf(fmt.Sprintf("%s MIN", prefix), unitFormats[unit], trend.Values.Min)
-	t.Outputf(fmt.Sprintf("%s AVG", prefix), unitFormats[unit], trend.Values.Avg)
-	t.Outputf(fmt.Sprintf("%s MED", prefix), unitFormats[unit], trend.Values.Med)
-	t.Outputf(fmt.Sprintf("%s P90", prefix), unitFormats[unit], trend.Values.P90)
-	t.Outputf(fmt.Sprintf("%s P95", prefix), unitFormats[unit], trend.Values.P95)
+	t.Outputf(prefix+" MAX", unitFormats[unit], trend.Values.Max)
+	t.Outputf(prefix+" MIN", unitFormats[unit], trend.Values.Min)
+	t.Outputf(prefix+" AVG", unitFormats[unit], trend.Values.Avg)
+	t.Outputf(prefix+" MED", unitFormats[unit], trend.Values.Med)
+	t.Outputf(prefix+" P90", unitFormats[unit], trend.Values.P90)
+	t.Outputf(prefix+" P95", unitFormats[unit], trend.Values.P95)
 	return t
 }
 
@@ -215,6 +215,7 @@ func (t *Table) Flush() error {
 		filePrefixOutput = "./test_report"
 	}
 
+	//nolint:gosec
 	err = os.WriteFile(filePath(filePrefixOutput, t.Test), bts, os.ModePerm)
 	if err != nil {
 		log.Errorf("error when saving table %s: %v", t.Test, err)

--- a/tests/runner/testresource.go
+++ b/tests/runner/testresource.go
@@ -108,7 +108,7 @@ func (r *TestResources) setup() error {
 	}
 
 	allErrs := make([]error, 0)
-	for i := 0; i < resourceCount; i++ {
+	for range resourceCount {
 		err := <-errs
 		if err != nil {
 			allErrs = append(allErrs, err)
@@ -139,7 +139,7 @@ func (r *TestResources) tearDown() error {
 	}
 
 	allErrs := make([]error, 0)
-	for i := 0; i < resourceCount; i++ {
+	for range resourceCount {
 		err := <-errs
 		if err != nil {
 			os.Stderr.WriteString(err.Error() + "\n")

--- a/tests/runner/testresource_test.go
+++ b/tests/runner/testresource_test.go
@@ -15,6 +15,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -47,7 +48,7 @@ func (m *MockDisposable) Dispose(wait bool) error {
 func TestAdd(t *testing.T) {
 	resource := new(TestResources)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		r := new(MockDisposable)
 		r.On("Name").Return(fmt.Sprintf("resource - %d", i))
 		resource.Add(r)
@@ -62,7 +63,7 @@ func TestSetup(t *testing.T) {
 	t.Run("active all resources", func(t *testing.T) {
 		expect := []string{}
 		resource := new(TestResources)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			name := fmt.Sprintf("resource - %d", i)
 			r := new(MockDisposable)
 			r.On("Name").Return(name)
@@ -88,7 +89,7 @@ func TestSetup(t *testing.T) {
 	t.Run("fails to setup resources and stops the process", func(t *testing.T) {
 		expect := []string{}
 		resource := new(TestResources)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			name := fmt.Sprintf("resource - %d", i)
 			r := new(MockDisposable)
 			r.On("Name").Return(name)
@@ -123,7 +124,7 @@ func TestTearDown(t *testing.T) {
 	t.Run("tear down successfully", func(t *testing.T) {
 		// adding 3 mock resources
 		resource := new(TestResources)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			r := new(MockDisposable)
 			r.On("Name").Return(fmt.Sprintf("resource - %d", i))
 			r.On("Init").Return(nil)
@@ -146,12 +147,12 @@ func TestTearDown(t *testing.T) {
 	t.Run("ignore failures of disposing resources", func(t *testing.T) {
 		// adding 3 mock resources
 		resource := new(TestResources)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			r := new(MockDisposable)
 			r.On("Name").Return(fmt.Sprintf("resource - %d", i))
 			r.On("Init").Return(nil)
 			if i == 1 {
-				r.On("Dispose").Return(fmt.Errorf("dispose error"))
+				r.On("Dispose").Return(errors.New("dispose error"))
 			} else {
 				r.On("Dispose").Return(nil)
 			}

--- a/tests/runner/testrunner_test.go
+++ b/tests/runner/testrunner_test.go
@@ -14,7 +14,7 @@ limitations under the License.
 package runner
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,7 +179,7 @@ func TestStartRunner(t *testing.T) {
 
 	t.Run("setup is failed, but teardown is called", func(t *testing.T) {
 		mockPlatform := new(MockPlatform)
-		mockPlatform.On("Setup").Return(fmt.Errorf("setup is failed"))
+		mockPlatform.On("Setup").Return(errors.New("setup is failed"))
 		mockPlatform.On("TearDown").Return(nil)
 		mockPlatform.On("AddApps", fakeTestApps).Return(nil)
 		mockPlatform.On("AddComponents", fakeComps).Return(nil)


### PR DESCRIPTION
Updates all test code to adhear to the knew linter rules.

Branched from https://github.com/dapr/dapr/pull/8146 to ensure that no
test changes were made for that PR to test that no implementation
functional changes were made.

Removes rule in github workflows to only test new changes.
