### PR TITLE
feat(outbox): use content-type in the metadata for projections item

### DIFF
--- a/pkg/runtime/pubsub/outbox.go
+++ b/pkg/runtime/pubsub/outbox.go
@@ -178,6 +178,8 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 
 				if proj.ContentType != nil {
 					contentType = *proj.ContentType
+				} else if ct, ok := proj.Metadata[metadata.ContentType]; ok {
+					contentType = ct
 				}
 			} else {
 				payload = sr.Value


### PR DESCRIPTION
# Description

This request it is linked to PR https://github.com/dapr/dapr/pull/8062. In fact that PR didn't cover if we are using the projection item to publish the event. In this request if the item has `outbox.projection = true` the contentType in the metadata will be take if it's not set in the request

PR cloned from https://github.com/dapr/dapr/pull/8132 for branch `release-1.14`
<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
