### PR TITLE
[Cherrypick] Updates k8s version for e2e tests (#8023)

### DIFF
--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -43,7 +43,7 @@ param diagStorageResourceId string = ''
 var osDiskSizeGB = 0
 
 // Version of Kubernetes
-var kubernetesVersion = '1.27'
+var kubernetesVersion = '1.30'
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
   name: '${namePrefix}acr'


### PR DESCRIPTION
Brings back the fix done in master to 1.14. The old k8s version prevented the deploy of infrastructure for e2e and perf tests to complete successfully.