### PR TITLE
Conversation API: add integration tests

### DIFF
--- a/cmd/daprd/components/conversation_echo.go
+++ b/cmd/daprd/components/conversation_echo.go
@@ -1,19 +1,27 @@
+//go:build allcomponents
+
 /*
 Copyright 2024 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package conversation
+package components
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/conversation/grpc"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/conversation/http"
+	"github.com/dapr/components-contrib/conversation/echo"
+	"github.com/dapr/dapr/pkg/components/conversation"
 )
+
+func init() {
+	conversation.DefaultRegistry.RegisterComponent(echo.NewEcho, "echo")
+}

--- a/pkg/messages/predefined.go
+++ b/pkg/messages/predefined.go
@@ -129,6 +129,7 @@ var (
 
 	// Conversation
 	ErrConversationNotFound      = APIError{"failed finding conversation component %s", "ERR_CONVERSATION_NOT_FOUND", http.StatusBadRequest, grpcCodes.InvalidArgument}
-	ErrConversationInvalidParams = APIError{"failed valid params %s", "ERR_CONVERSATION_INVALID_PARMS", http.StatusBadRequest, grpcCodes.InvalidArgument}
+	ErrConversationInvalidParams = APIError{"failed conversing with component %s: invalid params", "ERR_CONVERSATION_INVALID_PARMS", http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrConversationInvoke        = APIError{"failed conversing with component %s: %s", "ERR_CONVERSATION_INVOKE", http.StatusInternalServerError, grpcCodes.Internal}
+	ErrConversationMissingInputs = APIError{"failed conversing with component %s: missing inputs in request", "ERR_CONVERSATION_MISSING_INPUTS", http.StatusBadRequest, grpcCodes.InvalidArgument}
 )

--- a/tests/integration/suite/daprd/conversation/grpc/basic.go
+++ b/tests/integration/suite/daprd/conversation/grpc/basic.go
@@ -22,7 +22,7 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 

--- a/tests/integration/suite/daprd/conversation/grpc/basic.go
+++ b/tests/integration/suite/daprd/conversation/grpc/basic.go
@@ -35,7 +35,7 @@ type basic struct {
 }
 
 func (b *basic) Setup(t *testing.T) []framework.Option {
-	b.daprd = procdaprd.New(t, procdaprd.WithResourceFiles(`
+	b.daprd = daprd.New(t, daprd.WithResourceFiles(`
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -64,7 +64,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			Inputs: []string{"well hello there"},
 		})
 		require.NoError(t, err)
-		require.Len(t, "well hello there", resp.GetOutputs(), 1)
+		require.Len(t, resp.GetOutputs(), 1)
 		require.Equal(t, "well hello there", resp.GetOutputs()[0].GetResult())
 	})
 }

--- a/tests/integration/suite/daprd/conversation/grpc/basic.go
+++ b/tests/integration/suite/daprd/conversation/grpc/basic.go
@@ -15,17 +15,13 @@ package http
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/client"
 	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
@@ -60,31 +56,15 @@ spec:
 func (b *basic) Run(t *testing.T, ctx context.Context) {
 	b.daprd.WaitUntilRunning(t, ctx)
 
-	postURL := fmt.Sprintf("http://localhost:%d/v1.0-alpha1/conversation/echo/converse", b.daprd.HTTPPort())
+	client := b.daprd.GRPCClient(t, ctx)
 
-	httpClient := client.HTTP(t)
+	t.Run("good input", func(t *testing.T) {
+		resp, err := client.ConverseAlpha1(ctx, &rtv1.ConversationAlpha1Request{
+			Name:   "echo",
+			Inputs: []string{"well hello there"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "well hello there", resp.Outputs[0].Result)
 
-	t.Run("good json", func(t *testing.T) {
-		body := `{"inputs": ["well hello there"] }`
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, strings.NewReader(body))
-		require.NoError(t, err)
-		resp, err := httpClient.Do(req)
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-		respBody, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		require.NoError(t, resp.Body.Close())
-		require.Equal(t, `{"outputs":[{"result":"well hello there"}]}`, string(respBody))
-	})
-
-	t.Run("invalid json", func(t *testing.T) {
-		body := `{"metadata": {"model": "daprGPT"} }`
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, strings.NewReader(body))
-		require.NoError(t, err)
-		resp, err := httpClient.Do(req)
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 }

--- a/tests/integration/suite/daprd/conversation/grpc/basic.go
+++ b/tests/integration/suite/daprd/conversation/grpc/basic.go
@@ -64,6 +64,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			Inputs: []string{"well hello there"},
 		})
 		require.NoError(t, err)
+		require.Len(t, "well hello there", resp.GetOutputs(), 1)
 		require.Equal(t, "well hello there", resp.GetOutputs()[0].GetResult())
 	})
 }

--- a/tests/integration/suite/daprd/conversation/grpc/basic.go
+++ b/tests/integration/suite/daprd/conversation/grpc/basic.go
@@ -64,7 +64,6 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			Inputs: []string{"well hello there"},
 		})
 		require.NoError(t, err)
-		require.Equal(t, "well hello there", resp.Outputs[0].Result)
-
+		require.Equal(t, "well hello there", resp.GetOutputs()[0].GetResult())
 	})
 }

--- a/tests/integration/suite/daprd/conversation/grpc/basic.go
+++ b/tests/integration/suite/daprd/conversation/grpc/basic.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 type basic struct {
-	daprd *procdaprd.Daprd
+	daprd *daprd.Daprd
 }
 
 func (b *basic) Setup(t *testing.T) []framework.Option {

--- a/tests/integration/suite/daprd/conversation/http/basic.go
+++ b/tests/integration/suite/daprd/conversation/http/basic.go
@@ -60,7 +60,7 @@ spec:
 func (b *basic) Run(t *testing.T, ctx context.Context) {
 	b.daprd.WaitUntilRunning(t, ctx)
 
-	postURL := fmt.Sprintf("http://localhost:%d/v1.0-alpha1/conversation/echo/converse", b.daprd.HTTPPort())
+	postURL := fmt.Sprintf("http://%sv1.0-alpha1/conversation/echo/converse", b.daprd.HTTPAddress())
 
 	httpClient := client.HTTP(t)
 

--- a/tests/integration/suite/daprd/conversation/http/basic.go
+++ b/tests/integration/suite/daprd/conversation/http/basic.go
@@ -85,6 +85,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 		resp, err := httpClient.Do(req)
 		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 }

--- a/tests/integration/suite/daprd/conversation/http/basic.go
+++ b/tests/integration/suite/daprd/conversation/http/basic.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/client"
-	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -35,11 +35,11 @@ func init() {
 }
 
 type basic struct {
-	daprd *procdaprd.Daprd
+	daprd *daprd.Daprd
 }
 
 func (b *basic) Setup(t *testing.T) []framework.Option {
-	b.daprd = procdaprd.New(t, procdaprd.WithResourceFiles(`
+	b.daprd = daprd.New(t, daprd.WithResourceFiles(`
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
@@ -59,8 +59,7 @@ spec:
 
 func (b *basic) Run(t *testing.T, ctx context.Context) {
 	b.daprd.WaitUntilRunning(t, ctx)
-
-	postURL := fmt.Sprintf("http://%sv1.0-alpha1/conversation/echo/converse", b.daprd.HTTPAddress())
+	postURL := fmt.Sprintf("http://%s/v1.0-alpha1/conversation/echo/converse", b.daprd.HTTPAddress())
 
 	httpClient := client.HTTP(t)
 

--- a/tests/integration/suite/daprd/daprd.go
+++ b/tests/integration/suite/daprd/daprd.go
@@ -15,6 +15,7 @@ package daprd
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/binding"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/conversation"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/httpendpoints"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/httpserver"


### PR DESCRIPTION
This PR adds integration tests to the conversational API, registers the echo component and fixes a few small serialization issues.

