### PR TITLE
fix: runtime outputs memory address on startup for metrics spec

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -281,7 +281,11 @@ func (m MetricSpec) GetHTTPIncreasedCardinality(log logger.Logger) bool {
 // GetLatencyDistribution returns a *view.Aggregration to be used for latency histograms
 func (m MetricSpec) GetLatencyDistribution(log logger.Logger) *view.Aggregation {
 	defaultLatencyDistribution := []float64{1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1_000, 2_000, 5_000, 10_000, 20_000, 50_000, 100_000}
-	log.Infof("metric spec: %v", m)
+	metricSpecBytes, err := json.Marshal(m)
+	if err != nil {
+		log.Errorf("Error marshalling metric spec to JSON: %s", err)
+	}
+	log.Infof("metric spec: %s", string(metricSpecBytes))
 	if m.LatencyDistributionBuckets == nil || len(*m.LatencyDistributionBuckets) == 0 {
 		// The default is defaultLatencyDistribution
 		log.Infof("Using default latency distribution buckets: %v", defaultLatencyDistribution)


### PR DESCRIPTION
# Description

Now, the runtime displays the memory address upon startup for metric specifications.

This PR resolves the issue by ensuring that the runtime outputs content instead of a memory address.

## Issue reference

close https://github.com/dapr/dapr/issues/8156

## Test result

```
# ./dist/darwin_arm64/release/daprd --app-id myapp
INFO[0000] Starting Dapr Runtime -- version edge -- commit dbf3aadd8a9a7e26bca26ef9cab78aff644e5969  app_id=myapp instance=Magi.local scope=dapr.runtime type=log ver=edge
INFO[0000] Log level set to: info                        app_id=myapp instance=Magi.local scope=dapr.runtime type=log ver=edge
WARN[0000] mTLS is disabled. Skipping certificate request and tls validation  app_id=myapp instance=Magi.local scope=dapr.runtime.security type=log ver=edge
INFO[0000] loading default configuration                 app_id=myapp instance=Magi.local scope=dapr.runtime type=log ver=edge
INFO[0000] metric spec: {"enabled":true}                 app_id=myapp instance=Magi.local scope=dapr.runtime.diagnostics type=log ver=edge
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
