### PR TITLE
fix e2e - update deprecated field

### DIFF
--- a/tests/e2e/metrics/metrics_test.go
+++ b/tests/e2e/metrics/metrics_test.go
@@ -195,7 +195,7 @@ func testMetricDisabled(t *testing.T, app string, res *http.Response) {
 
 func findHTTPMetricFromPrometheus(t *testing.T, app string, res *http.Response) (foundMetric bool) {
 	rfmt := expfmt.ResponseFormat(res.Header)
-	require.NotEqual(t, rfmt, expfmt.FmtUnknown)
+	require.NotEqual(t, rfmt, expfmt.TypeUnknown)
 
 	decoder := expfmt.NewDecoder(res.Body, rfmt)
 
@@ -277,7 +277,7 @@ func testGRPCMetrics(t *testing.T, app string, res *http.Response) {
 	require.NotNil(t, res)
 
 	rfmt := expfmt.ResponseFormat(res.Header)
-	require.NotEqual(t, rfmt, expfmt.FmtUnknown)
+	require.NotEqual(t, rfmt, expfmt.TypeUnknown)
 
 	decoder := expfmt.NewDecoder(res.Body, rfmt)
 


### PR DESCRIPTION
Small fix for e2e failures due to a newly deprecated field in an update.