### PR TITLE
Ensure dapr-api-token gets removed from metadata after validaton

### DIFF
--- a/pkg/api/grpc/auth.go
+++ b/pkg/api/grpc/auth.go
@@ -4,44 +4,55 @@ import (
 	"context"
 	"net/http"
 
-	"google.golang.org/grpc"
-
 	"github.com/dapr/dapr/pkg/api/grpc/metadata"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"google.golang.org/grpc"
+	grpc_metadata "google.golang.org/grpc/metadata"
 )
+
+type wrappedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *wrappedStream) Context() context.Context {
+	return s.ctx
+}
 
 func getAPIAuthenticationMiddlewares(apiToken, authHeader string) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-			err := checkAPITokenInContext(ctx, apiToken, authHeader)
+			authCtx, err := checkAPITokenInContext(ctx, apiToken, authHeader)
 			if err != nil {
 				return nil, err
 			}
-			return handler(ctx, req)
+			return handler(authCtx, req)
 		},
 		func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-			err := checkAPITokenInContext(stream.Context(), apiToken, authHeader)
+			authCtx, err := checkAPITokenInContext(stream.Context(), apiToken, authHeader)
 			if err != nil {
 				return err
 			}
-			return handler(srv, stream)
+
+			return handler(srv, &wrappedStream{stream, authCtx})
 		}
 }
 
 // Checks if the API token in the gRPC request's context is valid; returns an error otherwise.
-func checkAPITokenInContext(ctx context.Context, apiToken, authHeader string) error {
+func checkAPITokenInContext(ctx context.Context, apiToken, authHeader string) (context.Context, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing metadata in request")
+		return ctx, invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing metadata in request")
 	}
 
 	if len(md[authHeader]) == 0 {
-		return invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing api token in request metadata")
+		return ctx, invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "missing api token in request metadata")
 	}
 
 	if md[authHeader][0] != apiToken {
-		return invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "authentication error: api token mismatch")
+		return ctx, invokev1.ErrorFromHTTPResponseCode(http.StatusUnauthorized, "authentication error: api token mismatch")
 	}
 
-	md.Set(authHeader, "")
-	return nil
+	md.Delete(authHeader)
+	ctx = grpc_metadata.NewIncomingContext(ctx, md.Copy())
+	return ctx, nil
 }

--- a/pkg/api/grpc/auth.go
+++ b/pkg/api/grpc/auth.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/dapr/dapr/pkg/api/grpc/metadata"
-	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"google.golang.org/grpc"
 	grpc_metadata "google.golang.org/grpc/metadata"
+
+	"github.com/dapr/dapr/pkg/api/grpc/metadata"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 )
 
 type wrappedStream struct {

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -304,6 +304,12 @@ func WithAppAPIToken(t *testing.T, token string) Option {
 	))
 }
 
+func WithDaprAPIToken(t *testing.T, token string) Option {
+	return WithExecOptions(exec.WithEnvVars(t,
+		"DAPR_API_TOKEN", token,
+	))
+}
+
 func WithSentry(t *testing.T, sentry *sentry.Sentry) Option {
 	return func(o *options) {
 		WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().TrustAnchors)))(o)

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/daprapitoken/remotenotoken.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/daprapitoken/remotenotoken.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daprapitoken
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	runtimev1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	testpb "github.com/dapr/dapr/tests/integration/framework/process/grpc/app/proto"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(remotenotoken))
+}
+
+type remotenotoken struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	ch     chan metadata.MD
+}
+
+func (b *remotenotoken) Setup(t *testing.T) []framework.Option {
+	b.ch = make(chan metadata.MD, 1)
+
+	app := app.New(t,
+		app.WithOnInvokeFn(func(ctx context.Context, _ *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
+			md, ok := metadata.FromIncomingContext(ctx)
+			require.True(t, ok)
+			b.ch <- md
+			return new(commonv1.InvokeResponse), nil
+		}),
+		app.WithPingFn(func(ctx context.Context, _ *testpb.PingRequest) (*testpb.PingResponse, error) {
+			md, _ := metadata.FromIncomingContext(ctx)
+			b.ch <- md
+			return new(testpb.PingResponse), nil
+		}),
+	)
+
+	b.daprd1 = daprd.New(t,
+		daprd.WithAppID("app1"),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithDaprAPIToken(t, "abc"),
+	)
+
+	b.daprd2 = daprd.New(t,
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppPort(app.Port(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, b.daprd1, b.daprd2),
+	}
+}
+
+func (b *remotenotoken) Run(t *testing.T, ctx context.Context) {
+	b.daprd1.WaitUntilRunning(t, ctx)
+	b.daprd2.WaitUntilRunning(t, ctx)
+
+	client := testpb.NewTestServiceClient(b.daprd1.GRPCConn(t, ctx))
+	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-app-id", b.daprd2.AppID(), "dapr-api-token", "abc")
+	_, err := client.Ping(ctx, new(testpb.PingRequest))
+	require.NoError(t, err)
+
+	select {
+	case md := <-b.ch:
+		require.Empty(t, md.Get("dapr-api-token"))
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "timed out waiting for metadata")
+	}
+
+	dclient := b.daprd1.GRPCClient(t, ctx)
+	_, err = dclient.InvokeService(ctx, &runtimev1.InvokeServiceRequest{
+		Id: b.daprd2.AppID(),
+		Message: &commonv1.InvokeRequest{
+			Method:        "helloworld",
+			Data:          new(anypb.Any),
+			HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+		},
+	})
+	require.NoError(t, err)
+
+	select {
+	case md := <-b.ch:
+		require.Empty(t, md.Get("dapr-api-token"))
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timed out waiting for metadata")
+	}
+}

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/grpc.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/grpc.go
@@ -15,4 +15,5 @@ package grpc
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/grpc/appapitoken"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/grpc/daprapitoken"
 )


### PR DESCRIPTION
[This PR](https://github.com/dapr/dapr/pull/8173) does the right thing in that it further validates that in case a calling sidecar's token arrives at the target, it doesn't get sent to the target app. However, the overall requirement is that App to Dapr tokens (used to validate access in the Dapr sidecar from an app) don't leave the originating sidecar. This requirement is met today with HTTP service invocation, but not with gRPC. This PR fixes that and adds a test to validate.
