### PR TITLE
fix(helm): backport-1.14 Moved priority class declaration in the right position of dapr_placement_statefulset.yaml manifests

### DIFF
--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
@@ -253,6 +253,10 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.priorityClassName }}
+      priorityClassName:
+{{ toYaml .Values.global.priorityClassName | indent 8 }}
+{{- end }}
 {{- if or (eq .Values.global.ha.enabled true) (eq .Values.ha true) }}
   {{- if eq .Values.cluster.forceInMemoryLog false }}
   volumeClaimTemplates:
@@ -268,9 +272,5 @@ spec:
       storageClassName: {{ .Values.volumeclaims.storageClassName }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- if .Values.global.priorityClassName }}
-      priorityClassName:
-{{ toYaml .Values.global.priorityClassName | indent 8 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

Backport: #8205 

## Issue reference

-

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
