### PR TITLE
Provide ability to configure dapr grpc ports through dapr pod annotations

### DIFF
--- a/pkg/injector/annotations/annotations.go
+++ b/pkg/injector/annotations/annotations.go
@@ -35,6 +35,8 @@ const (
 	KeyEnableDebug                      = "dapr.io/enable-debug"
 	KeyDebugPort                        = "dapr.io/debug-port"
 	KeyEnv                              = "dapr.io/env"
+	KeyAPIGRPCPort                      = "dapr.io/grpc-port"
+	KeyInternalGRPCPort                 = "dapr.io/internal-grpc-port"
 	KeyCPURequest                       = "dapr.io/sidecar-cpu-request"
 	KeyCPULimit                         = "dapr.io/sidecar-cpu-limit"
 	KeyMemoryRequest                    = "dapr.io/sidecar-memory-request"

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -56,8 +56,6 @@ type SidecarConfig struct {
 	RemindersService            string
 	SentrySPIFFEID              string
 	SidecarHTTPPort             int32 `default:"3500"`
-	SidecarAPIGRPCPort          int32 `default:"50001"`
-	SidecarInternalGRPCPort     int32 `default:"50002"`
 	SidecarPublicPort           int32 `default:"3501"`
 
 	Enabled                             bool    `annotation:"dapr.io/enabled"`
@@ -77,6 +75,8 @@ type SidecarConfig struct {
 	EnableDebug                         bool    `annotation:"dapr.io/enable-debug" default:"false"`
 	SidecarDebugPort                    int32   `annotation:"dapr.io/debug-port" default:"40000"`
 	Env                                 string  `annotation:"dapr.io/env"`
+	SidecarAPIGRPCPort                  int32   `annotation:"dapr.io/grpc-port" default:"50001"`
+	SidecarInternalGRPCPort             int32   `annotation:"dapr.io/internal-grpc-port" default:"50002"`
 	SidecarCPURequest                   string  `annotation:"dapr.io/sidecar-cpu-request"`
 	SidecarCPULimit                     string  `annotation:"dapr.io/sidecar-cpu-limit"`
 	SidecarMemoryRequest                string  `annotation:"dapr.io/sidecar-memory-request"`


### PR DESCRIPTION
# Description

Provide ability to configure dapr grpc ports through dapr pod annotations

## Issue reference

#8227

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
