### PR TITLE
Jobs: Return Job execution SUCCESS/FAILURE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.14.1-0.20241016043026-4ca04dbb61c5
 	github.com/dapr/kit v0.13.1-0.20241015130326-866002abe68a
-	github.com/diagridio/go-etcd-cron v0.3.1-0.20241021143028-8ee6207c5ea9
+	github.com/diagridio/go-etcd-cron v0.3.1-0.20241030204150-468a6e23bf53
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,8 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/diagridio/go-etcd-cron v0.3.1-0.20241021143028-8ee6207c5ea9 h1:7+j7UbNs3RekWc+d+jeeUiyABlj1cjTO3s8FCqwqHQ0=
 github.com/diagridio/go-etcd-cron v0.3.1-0.20241021143028-8ee6207c5ea9/go.mod h1:GiH3yYGvU8neLSTYWxQ8ceqU8MeBuDZgp4dij+cNazg=
+github.com/diagridio/go-etcd-cron v0.3.1-0.20241030204150-468a6e23bf53 h1:vjK/MuB/k5DLt56LEw+W33kJmE4s3xf6KmtLnW3hygQ=
+github.com/diagridio/go-etcd-cron v0.3.1-0.20241030204150-468a6e23bf53/go.mod h1:GiH3yYGvU8neLSTYWxQ8ceqU8MeBuDZgp4dij+cNazg=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.3.1-0.20241021143028-8ee6207c5ea9 h1:7+j7UbNs3RekWc+d+jeeUiyABlj1cjTO3s8FCqwqHQ0=
-github.com/diagridio/go-etcd-cron v0.3.1-0.20241021143028-8ee6207c5ea9/go.mod h1:GiH3yYGvU8neLSTYWxQ8ceqU8MeBuDZgp4dij+cNazg=
 github.com/diagridio/go-etcd-cron v0.3.1-0.20241030204150-468a6e23bf53 h1:vjK/MuB/k5DLt56LEw+W33kJmE4s3xf6KmtLnW3hygQ=
 github.com/diagridio/go-etcd-cron v0.3.1-0.20241030204150-468a6e23bf53/go.mod h1:GiH3yYGvU8neLSTYWxQ8ceqU8MeBuDZgp4dij+cNazg=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=

--- a/pkg/runtime/scheduler/streamer.go
+++ b/pkg/runtime/scheduler/streamer.go
@@ -63,7 +63,7 @@ func (s *streamer) receive(ctx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			s.handleJob(ctx, resp)
+			result := s.handleJob(ctx, resp)
 			select {
 			case <-ctx.Done():
 			case <-s.stream.Context().Done():
@@ -71,7 +71,7 @@ func (s *streamer) receive(ctx context.Context) error {
 				WatchJobRequestType: &schedulerv1pb.WatchJobsRequest_Result{
 					Result: &schedulerv1pb.WatchJobsRequestResult{
 						Id:     resp.GetId(),
-						Status: schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS,
+						Status: result,
 					},
 				},
 			}:
@@ -100,14 +100,16 @@ func (s *streamer) outgoing(ctx context.Context) error {
 }
 
 // handleJob invokes the appropriate app or actor reminder based on the job metadata.
-func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsResponse) {
+func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsResponse) schedulerv1pb.WatchJobsRequestResultStatus {
 	meta := job.GetMetadata()
 
 	switch t := meta.GetTarget(); t.GetType().(type) {
 	case *schedulerv1pb.JobTargetMetadata_Job:
 		if err := s.invokeApp(ctx, job); err != nil {
 			log.Errorf("failed to invoke schedule app job: %s", err)
+			return schedulerv1pb.WatchJobsRequestResultStatus_FAILED
 		}
+		return schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS
 
 	case *schedulerv1pb.JobTargetMetadata_Actor:
 		if err := s.invokeActorReminder(ctx, job); err != nil {
@@ -117,22 +119,26 @@ func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsRe
 			// issues. This will be updated in the future releases, but for now we will see this err. To not
 			// spam users only log if the error is not reminder canceled because this is expected for now.
 			if errors.Is(err, actors.ErrReminderCanceled) {
-				return
+				return schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS
 			}
 
 			// If the actor was hosted on another instance, the error will be a gRPC status error,
 			// so we need to unwrap it and match on the error message
 			if st, ok := status.FromError(err); ok {
 				if st.Message() == actors.ErrReminderCanceled.Error() {
-					return
+					return schedulerv1pb.WatchJobsRequestResultStatus_FAILED
 				}
 			}
 
 			log.Errorf("failed to invoke scheduled actor reminder named: %s due to: %s", job.GetName(), err)
+			return schedulerv1pb.WatchJobsRequestResultStatus_FAILED
 		}
+
+		return schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS
 
 	default:
 		log.Errorf("Unknown job metadata type: %+v", t)
+		return schedulerv1pb.WatchJobsRequestResultStatus_FAILED
 	}
 }
 
@@ -160,13 +166,16 @@ func (s *streamer) invokeApp(ctx context.Context, job *schedulerv1pb.WatchJobsRe
 	switch codes.Code(statusCode) {
 	case codes.OK:
 		log.Debugf("Sent job %s to app", job.GetName())
+		return nil
 	case codes.NotFound:
 		log.Errorf("non-retriable error returned from app while processing triggered job %s. status code returned: %v", job.GetName(), statusCode)
+		// return nil to signal SUCCESS
+		return nil
 	default:
-		log.Errorf("unexpected status code returned from app while processing triggered job %s. status code returned: %v", job.GetName(), statusCode)
+		err := fmt.Errorf("unexpected status code returned from app while processing triggered job %s. status code returned: %v", job.GetName(), statusCode)
+		log.Error(err.Error())
+		return err
 	}
-
-	return nil
 }
 
 // invokeActorReminder calls the actor ID with the given reminder data.

--- a/tests/integration/suite/actors/reminders/failurepolicy/failurepolicy.go
+++ b/tests/integration/suite/actors/reminders/failurepolicy/failurepolicy.go
@@ -11,11 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reminders
+package failurepolicy
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/failurepolicy"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/migration"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/scheduler"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/serialization"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/failurepolicy/noset"
 )

--- a/tests/integration/suite/actors/reminders/failurepolicy/noset/allfail.go
+++ b/tests/integration/suite/actors/reminders/failurepolicy/noset/allfail.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+)
+
+func init() {
+	suite.Register(new(allfail))
+}
+
+type allfail struct {
+	actors    *actors.Actors
+	triggered slice.Slice[string]
+}
+
+func (a *allfail) Setup(t *testing.T) []framework.Option {
+	a.triggered = slice.String()
+
+	scheduler := scheduler.New(t)
+	a.actors = actors.New(t,
+		actors.WithScheduler(scheduler),
+		actors.WithFeatureSchedulerReminders(true),
+		actors.WithActorTypes("helloworld"),
+		actors.WithActorTypeHandler("helloworld", func(w http.ResponseWriter, req *http.Request) {
+			a.triggered.Append(path.Base(req.URL.Path))
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(scheduler, a.actors),
+	}
+}
+
+func (a *allfail) Run(t *testing.T, ctx context.Context) {
+	a.actors.WaitUntilRunning(t, ctx)
+
+	_, err := a.actors.GRPCClient(t, ctx).RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+		ActorType: "helloworld",
+		ActorId:   "1234",
+		Name:      "test",
+		DueTime:   "0s",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test", "test"}, a.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test", "test", "test"}, a.triggered.Slice())
+}

--- a/tests/integration/suite/actors/reminders/failurepolicy/noset/failfirst.go
+++ b/tests/integration/suite/actors/reminders/failurepolicy/noset/failfirst.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+)
+
+func init() {
+	suite.Register(new(failfirst))
+}
+
+type failfirst struct {
+	actors    *actors.Actors
+	triggered slice.Slice[string]
+	respErr   atomic.Bool
+}
+
+func (f *failfirst) Setup(t *testing.T) []framework.Option {
+	f.triggered = slice.String()
+	f.respErr.Store(true)
+
+	scheduler := scheduler.New(t)
+	f.actors = actors.New(t,
+		actors.WithScheduler(scheduler),
+		actors.WithFeatureSchedulerReminders(true),
+		actors.WithActorTypes("helloworld"),
+		actors.WithActorTypeHandler("helloworld", func(w http.ResponseWriter, req *http.Request) {
+			defer f.triggered.Append(path.Base(req.URL.Path))
+			if f.respErr.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(scheduler, f.actors),
+	}
+}
+
+func (f *failfirst) Run(t *testing.T, ctx context.Context) {
+	f.actors.WaitUntilRunning(t, ctx)
+
+	_, err := f.actors.GRPCClient(t, ctx).RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+		ActorType: "helloworld",
+		ActorId:   "1234",
+		Name:      "test",
+		DueTime:   "0s",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	f.respErr.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test"}, f.triggered.Slice())
+}

--- a/tests/integration/suite/actors/reminders/failurepolicy/noset/failsecond.go
+++ b/tests/integration/suite/actors/reminders/failurepolicy/noset/failsecond.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+)
+
+func init() {
+	suite.Register(new(failsecond))
+}
+
+type failsecond struct {
+	actors    *actors.Actors
+	triggered slice.Slice[string]
+	respErr   atomic.Bool
+}
+
+func (f *failsecond) Setup(t *testing.T) []framework.Option {
+	f.triggered = slice.String()
+	f.respErr.Store(true)
+
+	scheduler := scheduler.New(t)
+	f.actors = actors.New(t,
+		actors.WithScheduler(scheduler),
+		actors.WithFeatureSchedulerReminders(true),
+		actors.WithActorTypes("helloworld"),
+		actors.WithActorTypeHandler("helloworld", func(w http.ResponseWriter, req *http.Request) {
+			defer f.triggered.Append(path.Base(req.URL.Path))
+			if f.respErr.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(scheduler, f.actors),
+	}
+}
+
+func (f *failsecond) Run(t *testing.T, ctx context.Context) {
+	f.actors.WaitUntilRunning(t, ctx)
+
+	_, err := f.actors.GRPCClient(t, ctx).RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+		ActorType: "helloworld",
+		ActorId:   "1234",
+		Name:      "test",
+		DueTime:   "0s",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	f.respErr.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test", "test"}, f.triggered.Slice())
+}

--- a/tests/integration/suite/actors/reminders/failurepolicy/noset/failthird.go
+++ b/tests/integration/suite/actors/reminders/failurepolicy/noset/failthird.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+)
+
+func init() {
+	suite.Register(new(failthird))
+}
+
+type failthird struct {
+	actors    *actors.Actors
+	triggered slice.Slice[string]
+	respErr   atomic.Bool
+}
+
+func (f *failthird) Setup(t *testing.T) []framework.Option {
+	f.triggered = slice.String()
+	f.respErr.Store(true)
+
+	scheduler := scheduler.New(t)
+	f.actors = actors.New(t,
+		actors.WithScheduler(scheduler),
+		actors.WithFeatureSchedulerReminders(true),
+		actors.WithActorTypes("helloworld"),
+		actors.WithActorTypeHandler("helloworld", func(w http.ResponseWriter, req *http.Request) {
+			defer f.triggered.Append(path.Base(req.URL.Path))
+			if f.respErr.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(scheduler, f.actors),
+	}
+}
+
+func (f *failthird) Run(t *testing.T, ctx context.Context) {
+	f.actors.WaitUntilRunning(t, ctx)
+
+	_, err := f.actors.GRPCClient(t, ctx).RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+		ActorType: "helloworld",
+		ActorId:   "1234",
+		Name:      "test",
+		DueTime:   "0s",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	f.respErr.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test", "test", "test"}, f.triggered.Slice())
+}

--- a/tests/integration/suite/daprd/jobs/failurepolicy/failurepolicy.go
+++ b/tests/integration/suite/daprd/jobs/failurepolicy/failurepolicy.go
@@ -11,11 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reminders
+package failurepolicy
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/failurepolicy"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/migration"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/scheduler"
-	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders/serialization"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/jobs/failurepolicy/noset"
 )

--- a/tests/integration/suite/daprd/jobs/failurepolicy/noset/allfail.go
+++ b/tests/integration/suite/daprd/jobs/failurepolicy/noset/allfail.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(allfail))
+}
+
+type allfail struct {
+	scheduler *scheduler.Scheduler
+	daprd     *daprd.Daprd
+	triggered slice.Slice[string]
+}
+
+func (a *allfail) Setup(t *testing.T) []framework.Option {
+	a.triggered = slice.String()
+
+	app := app.New(t,
+		app.WithOnJobEventFn(func(_ context.Context, req *rtv1.JobEventRequest) (*rtv1.JobEventResponse, error) {
+			a.triggered.Append(req.GetName())
+			return nil, errors.New("an error")
+		}),
+	)
+
+	a.scheduler = scheduler.New(t)
+
+	a.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithScheduler(a.scheduler),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, a.scheduler, a.daprd),
+	}
+}
+
+func (a *allfail) Run(t *testing.T, ctx context.Context) {
+	a.scheduler.WaitUntilRunning(t, ctx)
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	_, err := a.daprd.GRPCClient(t, ctx).ScheduleJobAlpha1(ctx, &rtv1.ScheduleJobRequest{
+		Job: &rtv1.Job{
+			Name:    "test",
+			DueTime: ptr.Of("0s"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test", "test"}, a.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test", "test", "test"}, a.triggered.Slice())
+}

--- a/tests/integration/suite/daprd/jobs/failurepolicy/noset/failfirst.go
+++ b/tests/integration/suite/daprd/jobs/failurepolicy/noset/failfirst.go
@@ -1,0 +1,97 @@
+/* Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(failfirst))
+}
+
+type failfirst struct {
+	scheduler *scheduler.Scheduler
+	daprd     *daprd.Daprd
+	respErr   atomic.Bool
+	triggered slice.Slice[string]
+}
+
+func (f *failfirst) Setup(t *testing.T) []framework.Option {
+	f.triggered = slice.String()
+	f.respErr.Store(true)
+
+	app := app.New(t,
+		app.WithOnJobEventFn(func(_ context.Context, req *rtv1.JobEventRequest) (*rtv1.JobEventResponse, error) {
+			defer f.triggered.Append(req.GetName())
+			if f.respErr.Load() {
+				return nil, errors.New("an error")
+			}
+			return new(rtv1.JobEventResponse), nil
+		}),
+	)
+
+	f.scheduler = scheduler.New(t)
+
+	f.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithScheduler(f.scheduler),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, f.scheduler, f.daprd),
+	}
+}
+
+func (f *failfirst) Run(t *testing.T, ctx context.Context) {
+	f.scheduler.WaitUntilRunning(t, ctx)
+	f.daprd.WaitUntilRunning(t, ctx)
+
+	_, err := f.daprd.GRPCClient(t, ctx).ScheduleJobAlpha1(ctx, &rtv1.ScheduleJobRequest{
+		Job: &rtv1.Job{
+			Name:    "test",
+			DueTime: ptr.Of("0s"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	f.respErr.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test"}, f.triggered.Slice())
+}

--- a/tests/integration/suite/daprd/jobs/failurepolicy/noset/failsecond.go
+++ b/tests/integration/suite/daprd/jobs/failurepolicy/noset/failsecond.go
@@ -1,0 +1,97 @@
+/* Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(failsecond))
+}
+
+type failsecond struct {
+	scheduler *scheduler.Scheduler
+	daprd     *daprd.Daprd
+	respErr   atomic.Bool
+	triggered slice.Slice[string]
+}
+
+func (f *failsecond) Setup(t *testing.T) []framework.Option {
+	f.triggered = slice.String()
+	f.respErr.Store(true)
+
+	app := app.New(t,
+		app.WithOnJobEventFn(func(_ context.Context, req *rtv1.JobEventRequest) (*rtv1.JobEventResponse, error) {
+			defer f.triggered.Append(req.GetName())
+			if f.respErr.Load() {
+				return nil, errors.New("an error")
+			}
+			return new(rtv1.JobEventResponse), nil
+		}),
+	)
+
+	f.scheduler = scheduler.New(t)
+
+	f.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithScheduler(f.scheduler),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, f.scheduler, f.daprd),
+	}
+}
+
+func (f *failsecond) Run(t *testing.T, ctx context.Context) {
+	f.scheduler.WaitUntilRunning(t, ctx)
+	f.daprd.WaitUntilRunning(t, ctx)
+
+	_, err := f.daprd.GRPCClient(t, ctx).ScheduleJobAlpha1(ctx, &rtv1.ScheduleJobRequest{
+		Job: &rtv1.Job{
+			Name:    "test",
+			DueTime: ptr.Of("0s"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	f.respErr.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test", "test"}, f.triggered.Slice())
+}

--- a/tests/integration/suite/daprd/jobs/failurepolicy/noset/failthird.go
+++ b/tests/integration/suite/daprd/jobs/failurepolicy/noset/failthird.go
@@ -1,0 +1,97 @@
+/* Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noset
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(failthird))
+}
+
+type failthird struct {
+	scheduler *scheduler.Scheduler
+	daprd     *daprd.Daprd
+	respErr   atomic.Bool
+	triggered slice.Slice[string]
+}
+
+func (f *failthird) Setup(t *testing.T) []framework.Option {
+	f.triggered = slice.String()
+	f.respErr.Store(true)
+
+	app := app.New(t,
+		app.WithOnJobEventFn(func(_ context.Context, req *rtv1.JobEventRequest) (*rtv1.JobEventResponse, error) {
+			defer f.triggered.Append(req.GetName())
+			if f.respErr.Load() {
+				return nil, errors.New("an error")
+			}
+			return new(rtv1.JobEventResponse), nil
+		}),
+	)
+
+	f.scheduler = scheduler.New(t)
+
+	f.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithScheduler(f.scheduler),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, f.scheduler, f.daprd),
+	}
+}
+
+func (f *failthird) Run(t *testing.T, ctx context.Context) {
+	f.scheduler.WaitUntilRunning(t, ctx)
+	f.daprd.WaitUntilRunning(t, ctx)
+
+	_, err := f.daprd.GRPCClient(t, ctx).ScheduleJobAlpha1(ctx, &rtv1.ScheduleJobRequest{
+		Job: &rtv1.Job{
+			Name:    "test",
+			DueTime: ptr.Of("0s"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	f.respErr.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test", "test", "test", "test"}, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, []string{"test", "test", "test", "test"}, f.triggered.Slice())
+}

--- a/tests/integration/suite/daprd/jobs/failurepolicy/notfound.go
+++ b/tests/integration/suite/daprd/jobs/failurepolicy/notfound.go
@@ -1,0 +1,89 @@
+/* Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failurepolicy
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(notfound))
+}
+
+// status NotFound does not trigger failure policy.
+type notfound struct {
+	scheduler *scheduler.Scheduler
+	daprd     *daprd.Daprd
+	triggered slice.Slice[string]
+}
+
+func (n *notfound) Setup(t *testing.T) []framework.Option {
+	n.triggered = slice.String()
+
+	app := app.New(t,
+		app.WithHandlerFunc("/job/test", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			n.triggered.Append(path.Base(r.URL.Path))
+		}),
+	)
+
+	n.scheduler = scheduler.New(t)
+
+	n.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithScheduler(n.scheduler),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, n.scheduler, n.daprd),
+	}
+}
+
+func (n *notfound) Run(t *testing.T, ctx context.Context) {
+	n.scheduler.WaitUntilRunning(t, ctx)
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	_, err := n.daprd.GRPCClient(t, ctx).ScheduleJobAlpha1(ctx, &rtv1.ScheduleJobRequest{
+		Job: &rtv1.Job{
+			Name:    "test",
+			DueTime: ptr.Of("0s"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test"}, n.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, []string{"test"}, n.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/jobs/jobs.go
+++ b/tests/integration/suite/daprd/jobs/jobs.go
@@ -14,6 +14,7 @@ limitations under the License.
 package jobs
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/jobs/failurepolicy"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/jobs/grpc"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/jobs/http"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/jobs/kubernetes"

--- a/tests/integration/suite/daprd/jobs/noapp.go
+++ b/tests/integration/suite/daprd/jobs/noapp.go
@@ -71,9 +71,10 @@ func (n *noapp) Run(t *testing.T, ctx context.Context) {
 	assert.Equal(t, "helloworld", resp.GetJob().GetName())
 
 	time.Sleep(3 * time.Second)
+
 	resp, err = client.GetJobAlpha1(ctx, &rtv1.GetJobRequest{
 		Name: "helloworld",
 	})
-	require.Error(t, err)
-	assert.Nil(t, resp)
+	require.NoError(t, err)
+	assert.Equal(t, "helloworld", resp.GetJob().GetName())
 }

--- a/tests/integration/suite/daprd/workflow/memory/state.go
+++ b/tests/integration/suite/daprd/workflow/memory/state.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/microsoft/durabletask-go/api"
 	"github.com/microsoft/durabletask-go/task"
@@ -76,10 +77,12 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		}
 	}
 
-	assert.InDelta(t,
-		s.workflow.Metrics(t, ctx)["process_resident_memory_bytes"]*1e-6,
-		actorMemBaseline,
-		35,
-		"workflow memory leak",
-	)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.InDelta(c,
+			s.workflow.Metrics(t, ctx)["process_resident_memory_bytes"]*1e-6,
+			actorMemBaseline,
+			35,
+			"workflow memory leak",
+		)
+	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/scheduler/failurepolicy/constant/interval.go
+++ b/tests/integration/suite/scheduler/failurepolicy/constant/interval.go
@@ -65,14 +65,23 @@ func (i *interval) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	})
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timed out waiting for job")
+	}
 
-	time.Sleep(time.Second * 1)
-	assert.ElementsMatch(t, []string{"test"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second):
+	}
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test", "test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timed out waiting for job")
+	}
 }

--- a/tests/integration/suite/scheduler/failurepolicy/constant/maxretries.go
+++ b/tests/integration/suite/scheduler/failurepolicy/constant/maxretries.go
@@ -65,10 +65,18 @@ func (m *maxretires) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	})
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test", "test", "test", "test", "test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	for range 5 {
+		select {
+		case name := <-triggered:
+			assert.Equal(t, "test", name)
+		case <-time.After(time.Second * 5):
+			require.Fail(t, "timed out waiting for job")
+		}
+	}
 
-	time.Sleep(time.Second * 2)
-	assert.ElementsMatch(t, []string{"test", "test", "test", "test", "test"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second * 2):
+	}
 }

--- a/tests/integration/suite/scheduler/failurepolicy/drop/failed.go
+++ b/tests/integration/suite/scheduler/failurepolicy/drop/failed.go
@@ -61,10 +61,16 @@ func (f *failed) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	})
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timed out waiting for job")
+	}
 
-	time.Sleep(time.Second * 2)
-	assert.ElementsMatch(t, []string{"test"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second * 2):
+	}
 }

--- a/tests/integration/suite/scheduler/failurepolicy/drop/success.go
+++ b/tests/integration/suite/scheduler/failurepolicy/drop/success.go
@@ -61,10 +61,16 @@ func (s *success) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	})
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timed out waiting for job")
+	}
 
-	time.Sleep(time.Second * 2)
-	assert.ElementsMatch(t, []string{"test"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second * 2):
+	}
 }

--- a/tests/integration/suite/scheduler/failurepolicy/noset/failfirst.go
+++ b/tests/integration/suite/scheduler/failurepolicy/noset/failfirst.go
@@ -57,16 +57,25 @@ func (f *failfirst) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	}, &respStatus)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timed out waiting for job")
+	}
 
 	respStatus.Store(schedulerv1.WatchJobsRequestResultStatus_SUCCESS)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test", "test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 2):
+		require.Fail(t, "timed out waiting for job")
+	}
 
-	time.Sleep(time.Second * 2)
-	assert.ElementsMatch(t, []string{"test", "test"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second * 2):
+	}
 }

--- a/tests/integration/suite/scheduler/failurepolicy/noset/failsecond.go
+++ b/tests/integration/suite/scheduler/failurepolicy/noset/failsecond.go
@@ -57,16 +57,27 @@ func (f *failsecond) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	}, &respStatus)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test", "test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	for range 2 {
+		select {
+		case name := <-triggered:
+			assert.Equal(t, "test", name)
+		case <-time.After(time.Second * 5):
+			require.Fail(t, "timed out waiting for job")
+		}
+	}
 
 	respStatus.Store(schedulerv1.WatchJobsRequestResultStatus_SUCCESS)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test", "test", "test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 5):
+		require.Fail(t, "timed out waiting for job")
+	}
 
-	time.Sleep(time.Second * 2)
-	assert.ElementsMatch(t, []string{"test", "test", "test"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second * 2):
+	}
 }

--- a/tests/integration/suite/scheduler/failurepolicy/noset/failthird.go
+++ b/tests/integration/suite/scheduler/failurepolicy/noset/failthird.go
@@ -57,16 +57,27 @@ func (f *failthird) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	}, &respStatus)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test", "test", "test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	for range 3 {
+		select {
+		case name := <-triggered:
+			assert.Equal(t, "test", name)
+		case <-time.After(time.Second * 5):
+			require.Fail(t, "timed out waiting for job")
+		}
+	}
 
 	respStatus.Store(schedulerv1.WatchJobsRequestResultStatus_SUCCESS)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, []string{"test", "test", "test", "test"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test", name)
+	case <-time.After(time.Second * 10):
+		require.Fail(t, "timed out waiting for job")
+	}
 
-	time.Sleep(time.Second * 2)
-	assert.ElementsMatch(t, []string{"test", "test", "test", "test"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second * 2):
+	}
 }

--- a/tests/integration/suite/scheduler/staging/multiple.go
+++ b/tests/integration/suite/scheduler/staging/multiple.go
@@ -76,11 +76,16 @@ func (m *multiple) Run(t *testing.T, ctx context.Context) {
 		AppId: "appid1", Namespace: "namespace",
 	})
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(t, []string{"test1"}, triggered.Slice())
-	}, time.Second*10, time.Millisecond*10)
+	select {
+	case name := <-triggered:
+		assert.Equal(t, "test1", name)
+	case <-time.After(time.Second * 2):
+		require.Fail(t, "timed out waiting for job")
+	}
 
-	time.Sleep(time.Second * 2)
-
-	assert.ElementsMatch(t, []string{"test1"}, triggered.Slice())
+	select {
+	case <-triggered:
+		assert.Fail(t, "unexpected trigger")
+	case <-time.After(time.Second * 2):
+	}
 }


### PR DESCRIPTION
Returns the job execution result to scheduler (SUCCESS/FAILURE) to
correctly trigger failure policy if required. Adds daprd jobs/actor
reminder failure policy integration tests.

Adds test to job execution to ensure NotFound HTTP status is treated as
SUCCESS as it is "not retry-able".
