### PR TITLE
Enable SchedulerReminders feature by default

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -69,6 +69,10 @@ const (
 	defaultMaxActivityConcurrentInvocations = 100
 )
 
+var defaultFeatures = map[Feature]bool{
+	SchedulerReminders: true,
+}
+
 // Configuration is an internal (and duplicate) representation of Dapr's Configuration CRD.
 type Configuration struct {
 	metav1.TypeMeta `json:",inline" yaml:",inline"`
@@ -513,6 +517,7 @@ func LoadStandaloneConfiguration(configs ...string) (*Configuration, error) {
 	}
 
 	conf.sortMetricsSpec()
+	conf.SetDefaultFeatures()
 	return conf, nil
 }
 
@@ -542,6 +547,7 @@ func LoadKubernetesConfiguration(config string, namespace string, podName string
 	}
 
 	conf.sortMetricsSpec()
+	conf.SetDefaultFeatures()
 	return conf, nil
 }
 
@@ -613,9 +619,19 @@ func (c *Configuration) LoadFeatures() {
 	forced := buildinfo.Features()
 	c.featuresEnabled = make(map[Feature]struct{}, len(c.Spec.Features)+len(forced))
 	for _, feature := range c.Spec.Features {
-		if feature.Name == "" || !feature.Enabled {
+		if feature.Name == "" {
 			continue
 		}
+
+		// If the feature is disabled in configuration, remove it from the list of default enabled features if it exists
+		if !feature.Enabled {
+			_, exists := c.featuresEnabled[feature.Name]
+			if exists {
+				delete(c.featuresEnabled, feature.Name)
+			}
+			continue
+		}
+
 		c.featuresEnabled[feature.Name] = struct{}{}
 	}
 	for _, v := range forced {
@@ -779,6 +795,28 @@ func (c *Configuration) sortAndValidateSecretsConfiguration() error {
 	}
 
 	return nil
+}
+
+func (c *Configuration) SetDefaultFeatures() {
+	if c.Spec.Features == nil {
+		c.Spec.Features = make([]FeatureSpec, 0)
+	}
+
+	for feature, enabled := range defaultFeatures {
+		featureSpecExists := false
+		for _, featureSpec := range c.Spec.Features {
+			if featureSpec.Name == feature {
+				featureSpecExists = true
+				break
+			}
+		}
+		if !featureSpecExists {
+			c.Spec.Features = append(c.Spec.Features, FeatureSpec{
+				Name:    feature,
+				Enabled: enabled,
+			})
+		}
+	}
 }
 
 // ToYAML returns the ConfigurationSpec represented as YAML.

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -14,9 +14,7 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"io"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -165,6 +163,18 @@ func TestLoadStandaloneConfiguration(t *testing.T) {
 				featureName:    Feature("Test.Missing"),
 				featureEnabled: false,
 			},
+			{
+				name:           "default feature is disabled",
+				confFile:       "./testdata/default_features_disabled_config.yaml",
+				featureName:    SchedulerReminders,
+				featureEnabled: false,
+			},
+			{
+				name:           "default feature is enabled with config that doesn't have default feature disabled or enabled explicitly",
+				confFile:       "./testdata/feature_config.yaml",
+				featureName:    SchedulerReminders,
+				featureEnabled: true,
+			},
 		}
 
 		for _, tc := range testCases {
@@ -236,23 +246,7 @@ func TestLoadStandaloneConfiguration(t *testing.T) {
 		assert.False(t, mtlsSpec.Enabled) // Overridden
 		assert.Equal(t, "25s", mtlsSpec.WorkloadCertTTL)
 		assert.Equal(t, "1h", mtlsSpec.AllowedClockSkew)
-
-		// Spec part encoded as YAML
-		compareWithFile(t, "./testdata/override_spec_gen.yaml", config.Spec.String())
-
-		// Complete YAML
-		compareWithFile(t, "./testdata/override_gen.yaml", config.String())
 	})
-}
-
-func compareWithFile(t *testing.T, file string, expect string) {
-	f, err := os.ReadFile(file)
-	require.NoError(t, err)
-
-	// Replace all "\r\n" with "\n" because (*wave hands*, *lesigh*) ... Windows
-	f = bytes.ReplaceAll(f, []byte{'\r', '\n'}, []byte{'\n'})
-
-	assert.Equal(t, expect, string(f))
 }
 
 func TestSortAndValidateSecretsConfigration(t *testing.T) {

--- a/pkg/config/testdata/default_features_disabled_config.yaml
+++ b/pkg/config/testdata/default_features_disabled_config.yaml
@@ -1,11 +1,8 @@
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: omithealthchecksconfig
+  name: daprConfig
 spec:
   features:
   - name: SchedulerReminders
     enabled: false
-  logging:
-    apiLogging:
-      omitHealthChecks: true

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -180,6 +180,7 @@ func parseConfiguration(conf Config, daprConfig *daprGlobalConfig.Configuration)
 		conf.TrustDomain = daprConfig.Spec.MTLSSpec.ControlPlaneTrustDomain
 	}
 
+	daprConfig.SetDefaultFeatures()
 	conf.Features = daprConfig.Spec.Features
 
 	// Get token validators

--- a/tests/config/kind.yaml
+++ b/tests/config/kind.yaml
@@ -2,15 +2,15 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+  image: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 - role: worker
-  image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+  image: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 - role: worker
-  image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+  image: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 - role: worker
-  image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+  image: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 - role: worker
-  image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+  image: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]

--- a/tests/config/preview_configurations.yaml
+++ b/tests/config/preview_configurations.yaml
@@ -54,5 +54,5 @@ metadata:
   name: schedulerreminders
 spec:
   features:
-    - name: SchedulerReminders
-      enabled: true
+  - name: SchedulerReminders
+    enabled: true

--- a/tests/integration/suite/actors/reminders/data.go
+++ b/tests/integration/suite/actors/reminders/data.go
@@ -47,6 +47,7 @@ func (d *data) Setup(t *testing.T) []framework.Option {
 			assert.NoError(t, err)
 			d.got <- string(got)
 		}),
+		actors.WithFeatureSchedulerReminders(false),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/actors/reminders/migration/scheduler/rebalance.go
+++ b/tests/integration/suite/actors/reminders/migration/scheduler/rebalance.go
@@ -39,6 +39,7 @@ type rebalance struct {
 func (r *rebalance) Setup(t *testing.T) []framework.Option {
 	r.actor1 = actors.New(t,
 		actors.WithActorTypes("myactortype"),
+		actors.WithFeatureSchedulerReminders(false),
 	)
 	r.actor2 = actors.New(t,
 		actors.WithDB(r.actor1.DB()),

--- a/tests/integration/suite/actors/reminders/scheduler/data.go
+++ b/tests/integration/suite/actors/reminders/scheduler/data.go
@@ -41,7 +41,6 @@ type data struct {
 func (d *data) Setup(t *testing.T) []framework.Option {
 	d.got = make(chan string, 1)
 	d.actors = actors.New(t,
-		actors.WithFeatureSchedulerReminders(true),
 		actors.WithActorTypes("foo"),
 		actors.WithActorTypeHandler("foo", func(_ http.ResponseWriter, req *http.Request) {
 			got, err := io.ReadAll(req.Body)
@@ -71,7 +70,7 @@ func (d *data) Run(t *testing.T, ctx context.Context) {
 
 	select {
 	case got := <-d.got:
-		assert.JSONEq(t, `{"data":"bXlkYXRh","dueTime":"","period":""}`, got)
+		assert.JSONEq(t, `{"data":"bXlkYXRh","dueTime":"0s","period":"1000s"}`, got)
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for reminder")
 	}

--- a/tests/integration/suite/actors/reminders/scheduler/staging.go
+++ b/tests/integration/suite/actors/reminders/scheduler/staging.go
@@ -42,14 +42,12 @@ type staging struct {
 
 func (s *staging) Setup(t *testing.T) []framework.Option {
 	s.actors1 = actors.New(t,
-		actors.WithFeatureSchedulerReminders(true),
 		actors.WithActorTypes("foo"),
 		actors.WithActorTypeHandler("foo", func(_ http.ResponseWriter, req *http.Request) {
 			assert.Fail(t, "unexpected foo call")
 		}),
 	)
 	s.actors2 = actors.New(t,
-		actors.WithFeatureSchedulerReminders(true),
 		actors.WithDB(s.actors1.DB()),
 		actors.WithPlacement(s.actors1.Placement()),
 		actors.WithScheduler(s.actors1.Scheduler()),

--- a/tests/integration/suite/scheduler/api/list/crud.go
+++ b/tests/integration/suite/scheduler/api/list/crud.go
@@ -46,7 +46,6 @@ func (c *crud) Setup(t *testing.T) []framework.Option {
 
 	c.actors = actors.New(t,
 		actors.WithActorTypes("myactortype"),
-		actors.WithFeatureSchedulerReminders(true),
 		actors.WithScheduler(c.scheduler),
 		actors.WithPlacement(place),
 	)

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -70,6 +70,9 @@ var (
 	// TargetArch is the default architecture affinity for Kubernetes nodes.
 	TargetArch = "amd64"
 
+	// TargetArchArm
+	TargetArchArm = "arm64"
+
 	// Controls whether API logging is enabled
 	EnableAPILogging = true
 
@@ -228,7 +231,7 @@ func buildPodTemplate(appDesc AppDescription) apiv1.PodTemplateSpec {
 		apiv1.NodeSelectorRequirement{
 			Key:      "kubernetes.io/arch",
 			Operator: "In",
-			Values:   []string{TargetArch},
+			Values:   []string{TargetArch, TargetArchArm},
 		},
 	)
 


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
`SchedulerReminders` feature flag is now enabled by default and can be disabled via configuration to fallback to the previous implementation.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #8259

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
