### PR TITLE
Removes integration tests log spam

### DIFF
--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -64,12 +64,12 @@ func RunIntegrationTests(t *testing.T) {
 	startTime := time.Now()
 	t.Cleanup(func() {
 		executionMessage := fmt.Sprintf("Total integration test execution time for %d test cases: %s", len(focusedTests), time.Since(startTime).Truncate(time.Millisecond*100))
-		t.Logf(strings.Repeat("-", len(executionMessage)))
+		t.Log(strings.Repeat("-", len(executionMessage)))
 		if skippedTests > 0 {
 			t.Logf("%d test cases were skipped due to focus", skippedTests)
 		}
-		t.Logf(executionMessage)
-		t.Logf(strings.Repeat("-", len(executionMessage)))
+		t.Log(executionMessage)
+		t.Log(strings.Repeat("-", len(executionMessage)))
 	})
 
 	for _, tcase := range focusedTests {
@@ -80,7 +80,7 @@ func RunIntegrationTests(t *testing.T) {
 
 			options := tcase.Setup(t)
 
-			t.Logf("setting up test case")
+			t.Log("setting up test case")
 
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			t.Cleanup(cancel)


### PR DESCRIPTION
Instead of the many `skipping test case due to focus ...` lines when running integration tests with focus, now we have a single line at the end that shows how many tests have been skipped. I believe this makes local dev experience a bit easier, because we have less logs to scroll through to find the bit that interests us.

It looks like this:

```bash
    exec.go:147: waiting for "placement" process to exit
    exec.go:147: "placement" process exited
=== NAME  Test_Integration
    integration.go:67: -------------------------------------------------------------
    integration.go:69: 421 test cases were skipped due to focus
    integration.go:71: Total integration test execution time for 3 test cases: 20.5s
    integration.go:72: -------------------------------------------------------------
--- PASS: Test_Integration (1.67s)
    --- PASS: Test_Integration/build_binaries (1.67s)
    --- PASS: Test_Integration/placement/quorum/notls (5.50s)
        --- PASS: Test_Integration/placement/quorum/notls/run (5.48s)
    --- PASS: Test_Integration/scheduler/quorum/notls (8.36s)
        --- PASS: Test_Integration/scheduler/quorum/notls/run (3.24s)
    --- PASS: Test_Integration/placement/dissemination/notls (20.50s)
        --- PASS: Test_Integration/placement/dissemination/notls/run (20.48s)
            --- PASS: Test_Integration/placement/dissemination/notls/run/actors_in_different_namespaces_are_disseminated_properly (10.00s)
            --- PASS: Test_Integration/placement/dissemination/notls/run/namespaces_are_disseminated_properly_when_there_are_old_sidecars_in_the_cluster (10.00s)
PASS
ok  	github.com/dapr/dapr/tests/integration	23.964s
```