### PR TITLE
processor: honour ignoreErrors flag when initializing component and dependents

### DIFF
--- a/pkg/runtime/processor/components.go
+++ b/pkg/runtime/processor/components.go
@@ -225,7 +225,7 @@ func (p *Processor) processComponentAndDependents(ctx context.Context, comp comp
 			return rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), err)
 		}
 
-		log.Errorf("Ignoring error processing component: %s", err)
+		log.Errorf("Ignoring error processing component %s: %s", comp.LogName(), err)
 	}
 
 	log.Info("Component loaded: " + comp.LogName())

--- a/pkg/runtime/processor/components.go
+++ b/pkg/runtime/processor/components.go
@@ -219,9 +219,13 @@ func (p *Processor) processComponentAndDependents(ctx context.Context, comp comp
 		err = fmt.Errorf("init timeout for component %s exceeded after %s", comp.LogName(), timeout.String())
 	}
 	if err != nil {
-		log.Errorf("Failed to init component %s: %s", comp.LogName(), err)
-		diag.DefaultMonitoring.ComponentInitFailed(comp.Spec.Type, "init", comp.ObjectMeta.Name)
-		return rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), err)
+		if !comp.Spec.IgnoreErrors {
+			log.Errorf("Failed to init component %s: %s", comp.LogName(), err)
+			diag.DefaultMonitoring.ComponentInitFailed(comp.Spec.Type, "init", comp.ObjectMeta.Name)
+			return rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), err)
+		}
+
+		log.Errorf("Ignoring error processing component: %s", err)
 	}
 
 	log.Info("Component loaded: " + comp.LogName())


### PR DESCRIPTION
# Description

Fix missing check of `ignoreErrors` when initializing components

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [ ] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
