### PR TITLE
Fix Setup Go Action slow cache restore on Windows

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -285,7 +285,8 @@ jobs:
           ref: ${{ env.CHECKOUT_REF }}
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v5
+        # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
+        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
         with:
           go-version-file: "go.mod"
       - name: Login to Azure
@@ -458,7 +459,8 @@ jobs:
           ref: ${{ env.CHECKOUT_REF }}
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v5
+        # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
+        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
         with:
           go-version-file: "go.mod"
       - uses: azure/setup-kubectl@v3

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -131,7 +131,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Dependency review
         uses: actions/dependency-review-action@v4
-      - uses: actions/setup-go@v5
+        # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
+      - uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
         with:
           go-version-file: "go.mod"
       - name: Install govulncheck
@@ -171,7 +172,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v5
+        # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
+        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
         with:
           go-version-file: "go.mod"
       - name: Run make test
@@ -220,7 +222,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v5
+        # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
+        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
         with:
           go-version-file: "go.mod"
       - name: Override DAPR_HOST_IP for MacOS
@@ -313,7 +316,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v5
+        # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
+        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
         with:
           go-version-file: "go.mod"
       - name: Parse release version and set REL_VERSION and LATEST_RELEASE

--- a/.github/workflows/test-tooling.yml
+++ b/.github/workflows/test-tooling.yml
@@ -36,7 +36,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup
-        uses: actions/setup-go@v5
+        # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
+        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
         with:
           go-version-file: './.build-tools/go.mod'
 


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
temporary use forked `actions/setup-go` with a fix for slow Windows cache restore, until it's merged/fixed in the parent repo and can be used via the official channel.
- https://github.com/actions/setup-go/pull/515

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
