### PR TITLE
do not ingore dlq errors

### DIFF
--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -281,7 +281,8 @@ func New(opts Options) (*Subscription, error) {
 			}
 			return nil, pErr
 		})
-		if err != nil {
+		// when runtime shutting down, don't send to DLQ
+		if err != nil && err != context.Canceled {
 			// Sending msg to dead letter queue.
 			// If no DLQ is configured, return error for backwards compatibility (component-level retry).
 			if route.DeadLetterTopic != "" {

--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -272,6 +272,7 @@ func New(opts Options) (*Subscription, error) {
 					derr := s.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic)
 					if derr != nil {
 						log.Warnf("failed to send dropped message to dead letter queue for topic %s: %v", msgTopic, derr)
+						return nil, pErr
 					}
 				}
 				return nil, nil
@@ -280,14 +281,18 @@ func New(opts Options) (*Subscription, error) {
 			}
 			return nil, pErr
 		})
-		if err != nil && err != context.Canceled {
+		if err != nil {
 			// Sending msg to dead letter queue.
 			// If no DLQ is configured, return error for backwards compatibility (component-level retry).
-			if route.DeadLetterTopic == "" {
-				return err
+			if route.DeadLetterTopic != "" {
+				if dlqErr := s.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic); dlqErr == nil {
+					// dlq has been configured and message is successfully sent to dlq.
+					diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Drop)), "", msgTopic, 0)
+					return nil
+				}
 			}
-			_ = s.sendToDeadLetter(ctx, name, msg, route.DeadLetterTopic)
-			return nil
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, name, strings.ToLower(string(contribpubsub.Retry)), "", msgTopic, 0)
+			return err
 		}
 		return err
 	})


### PR DESCRIPTION
# Description

All failed DLQ attempts must be reported as an error. Before publishing to subscribers it does, after it ignores those. It leads to lost messages

## Issue reference



Please reference the issue this PR will close: #8284

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
