### PR TITLE
Don't publish alpha release to GitHub

### DIFF
--- a/.github/scripts/get_release_version.py
+++ b/.github/scripts/get_release_version.py
@@ -42,6 +42,7 @@ with open(os.getenv("GITHUB_ENV"), "a") as githubEnv:
         print ("Release Candidate build from {}...".format(gitRef))
     elif gitRef.find("-alpha.") > 0:
         print ("Release Alpha build from {}...".format(gitRef))
+        githubEnv.write("ALPHA_RELEASE=true\n")
     else:
         print ("Checking if {} exists".format(releaseNotePath))
         if os.path.exists(releaseNotePath):

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -492,7 +492,7 @@ jobs:
       - name: lists artifacts
         run: ls -l ${{ env.ARTIFACT_DIR }}
       - name: publish binaries to github
-        if: startswith(github.ref, 'refs/tags/v')
+        if: startswith(github.ref, 'refs/tags/v') && ${{ env.ALPHA_RELEASE }} != "true"
         run: |
           echo "installing github-release-cli..."
           sudo npm install --silent --no-progress -g github-release-cli@2.1.0


### PR DESCRIPTION
# Description

Don't publish alpha release to GitHub, to avoid CLI from installing it as the latest.

## Issue reference


Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
