### PR TITLE
Remove useless retry matching test that caused panic in test app

### DIFF
--- a/tests/integration/suite/daprd/resiliency/apps/retrymatchinghttp.go
+++ b/tests/integration/suite/daprd/resiliency/apps/retrymatchinghttp.go
@@ -148,12 +148,6 @@ func (d *retrymatchinghttp) Run(t *testing.T, ctx context.Context) {
 			expectRetries:      false,
 		},
 		{
-			title:              "invalid status not in matching list 0",
-			statusCode:         0,
-			expectedStatusCode: 500,
-			expectRetries:      true, // this is retried because there is not a valid code to compare against
-		},
-		{
 			title:              "status in matching list 100",
 			statusCode:         100,
 			expectedStatusCode: 200,


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
