### PR TITLE
processor: fix waitgroup panic

### DIFF
--- a/pkg/runtime/processor/components.go
+++ b/pkg/runtime/processor/components.go
@@ -144,13 +144,14 @@ func (p *Processor) AddPendingComponent(ctx context.Context, comp componentsapi.
 		return false
 	}
 
-	p.pendingComponentsWaiting.Add(1)
+	p.pendingComponentsWaiting.RLock()
+
 	select {
 	case <-ctx.Done():
-		p.pendingComponentsWaiting.Done()
+		p.pendingComponentsWaiting.RUnlock()
 		return false
 	case <-p.closedCh:
-		p.pendingComponentsWaiting.Done()
+		p.pendingComponentsWaiting.RUnlock()
 		return false
 	case p.pendingComponents <- comp:
 		return true
@@ -177,7 +178,7 @@ func (p *Processor) processComponents(ctx context.Context) error {
 
 	for comp := range p.pendingComponents {
 		err := process(comp)
-		p.pendingComponentsWaiting.Done()
+		p.pendingComponentsWaiting.RUnlock()
 		if err != nil {
 			return err
 		}
@@ -188,7 +189,8 @@ func (p *Processor) processComponents(ctx context.Context) error {
 
 // WaitForEmptyComponentQueue waits for the component queue to be empty.
 func (p *Processor) WaitForEmptyComponentQueue() {
-	p.pendingComponentsWaiting.Wait()
+	p.pendingComponentsWaiting.Lock()
+	defer p.pendingComponentsWaiting.Unlock()
 }
 
 func (p *Processor) processComponentAndDependents(ctx context.Context, comp componentsapi.Component) error {

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -125,7 +125,7 @@ type Processor struct {
 
 	pendingHTTPEndpoints       chan httpendpointsapi.HTTPEndpoint
 	pendingComponents          chan componentsapi.Component
-	pendingComponentsWaiting   sync.WaitGroup
+	pendingComponentsWaiting   sync.RWMutex
 	pendingComponentDependents map[string][]componentsapi.Component
 	subErrCh                   chan error
 


### PR DESCRIPTION
# Description

red test:

`go test -v -count 1 -tags=unit -race -run='TestProcessorWaitGroupError'`

```
panic: sync: WaitGroup is reused before previous Wait has returned

goroutine 4037 [running]:
sync.(*WaitGroup).Wait(0xc0001c0590)
        /opt/local/lib/go/src/sync/waitgroup.go:120 +0xe0
github.com/dapr/dapr/pkg/runtime/processor.(*Processor).WaitForEmptyComponentQueue(...)
        /Users/luis.rascao/Projects/dapr/core/pkg/runtime/processor/components.go:196
github.com/dapr/dapr/pkg/runtime/processor.TestProcessorWaitGroupError.func2()
        /Users/luis.rascao/Projects/dapr/core/pkg/runtime/processor/processor_test.go:694 +0xb4
created by github.com/dapr/dapr/pkg/runtime/processor.TestProcessorWaitGroupError in goroutine 48
        /Users/luis.rascao/Projects/dapr/core/pkg/runtime/processor/processor_test.go:692 +0xba0
exit status 2
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
