### PR TITLE
Update performTablesUpdate to handle operations that time out

### DIFF
--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -294,15 +294,15 @@ func (p *Service) performTablesUpdate(ctx context.Context, req *tablesUpdateRequ
 		if err != nil {
 			errCh <- fmt.Errorf("dissemination of 'unlock' failed: %v", err)
 		}
-		errCh <- nil;
-	}();
+		errCh <- nil
+	}()
 
 	select {
-	case err := <- errCh:
+	case err := <-errCh:
 		if err != nil {
 			return err
 		}
-	case <- ctx.Done():
+	case <-ctx.Done():
 		return fmt.Errorf("performTablesUpdate failed: %v", ctx.Err())
 	}
 

--- a/pkg/placement/membership.go
+++ b/pkg/placement/membership.go
@@ -279,7 +279,7 @@ func (p *Service) performTablesUpdate(ctx context.Context, req *tablesUpdateRequ
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	errCh = make(chan error)
+	errCh := make(chan error)
 
 	go func() {
 		err := p.disseminateOperationOnHosts(ctx, req, lockOperation)


### PR DESCRIPTION
Update performTablesUpdate to handle operations that time out.

# Description

Launch disseminateOperationOnHosts calls in another thread, and wait for an error or a timeout to occur. If all calls succeed a nil error is returned and a success message is logged

## Issue reference

Please reference the issue this PR will close: #7031 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
