### PR TITLE
Stop nightly buids and remove longhaul update.

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -15,8 +15,6 @@ name: dapr
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "00 22 * * *"
   push:
     branches:
       - main
@@ -740,59 +738,3 @@ jobs:
             echo "::error::There is no change for ${daprVersion} Helm chart. Did you forget to update the chart version before tagging?"
             exit -1
           fi
-
-  update-longhauls:
-    name: Update the dapr version in long haul tests
-    needs: helmpublish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    if: startswith(github.ref, 'refs/tags/v') && github.repository_owner == 'dapr'
-    env:
-      LONG_HAUL_REPO: test-infra
-    steps:
-      - name: Get Token
-        id: get_workflow_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APPLICATION_ID }}
-          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-          repositories: ${{ env.LONG_HAUL_REPO }}
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          path: dapr
-      - name: Checkout the longhaul tests repo
-        uses: actions/checkout@v4
-        with:
-          repository: dapr/${{ env.LONG_HAUL_REPO }}
-          token: ${{ steps.get_workflow_token.outputs.token }}
-          path: ${{ env.LONG_HAUL_REPO }}
-      - name: Install Python Dependencies
-        run: |
-          pip install packaging
-      - name: Parse release version and set REL_VERSION and LATEST_RELEASE
-        run: python dapr/.github/scripts/get_release_version.py ${{ github.event_name }}
-
-      - name: Compare versions and determine if update of long haul tests is required
-        id: compare_versions
-        run: |
-          EXISTING_VERSION=$(cat "${{ env.LONG_HAUL_REPO }}/config/dapr_runtime.version")
-          echo "Existing version in long haul tests: $EXISTING_VERSION"
-          echo "New version: ${{ env.REL_VERSION }}"
-          python dapr/.github/scripts/compare_versions.py "${{ env.REL_VERSION }}" "$EXISTING_VERSION"
-
-      - name: Update dapr runtime version in the long haul tests repo
-        if: env.VERSION_UPDATE_REQUIRED == 'true'
-        run: |
-          echo "${REL_VERSION}" > ${{ env.LONG_HAUL_REPO }}/config/dapr_runtime.version
-
-      - name: Commit and Push Changes to repoB
-        if: env.VERSION_UPDATE_REQUIRED == 'true'
-        run: |
-          cd ${{ env.LONG_HAUL_REPO }}
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git add config/dapr_runtime.version
-          git commit -m "Updates dapr runtime version to ${REL_VERSION}"
-          git push


### PR DESCRIPTION
# Description

Nightly builds cause Dapr CLI to crash when trying to find the next version.
Longhaul env update should not be here, it can trigger a workflow in dapr/test-infra in a later PR.

## Issue reference

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
