### PR TITLE
feat: descriptive logging for component startup failure

### DIFF
--- a/pkg/internal/loader/disk/disk.go
+++ b/pkg/internal/loader/disk/disk.go
@@ -89,11 +89,7 @@ func (d *disk[T]) Load(context.Context) ([]T, error) {
 	}
 
 	if len(errs) > 0 {
-		wrappedErrs := make([]error, len(errs))
-		for i, err := range errs {
-			wrappedErrs[i] = fmt.Errorf("failed to load %s %s: %v", set.ts[i].Kind(), set.ts[i].LogName(), err)
-		}
-		return nil, errors.Join(wrappedErrs...)
+		return nil, errors.Join(errs...)
 	}
 
 	return filteredManifests, nil

--- a/pkg/internal/loader/disk/disk.go
+++ b/pkg/internal/loader/disk/disk.go
@@ -89,7 +89,11 @@ func (d *disk[T]) Load(context.Context) ([]T, error) {
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.Join(errs...)
+		wrappedErrs := make([]error, len(errs))
+		for i, err := range errs {
+			wrappedErrs[i] = fmt.Errorf("failed to load %s %s: %v", set.ts[i].Kind(), set.ts[i].LogName(), err)
+		}
+		return nil, errors.Join(wrappedErrs...)
 	}
 
 	return filteredManifests, nil

--- a/pkg/internal/loader/kubernetes/components.go
+++ b/pkg/internal/loader/kubernetes/components.go
@@ -51,7 +51,7 @@ func (c *components) Load(ctx context.Context) ([]compapi.Component, error) {
 		PodName:   c.podName,
 	}, grpcretry.WithMax(operatorMaxRetries), grpcretry.WithPerRetryTimeout(operatorCallTimeout))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error listing components: %s", err)
 	}
 	comps := resp.GetComponents()
 


### PR DESCRIPTION
# Description

> Currently, when dapr sidecar fails during startup, error logs lack clear component detection, making it difficult to identify which component caused the failure.

This PR optimizes error log display during component loading failures.
After code analysis, I decided to only modify the error log format in kubernetes mode for the following reasons:

For standalone mode:

- Current implementation already clearly shows which component failed to load
- Modifying this part would require extensive test case adjustments
- The code is referenced in multiple places, leading to broader impact


For kubernetes mode:

- Code analysis reveals that component information is not available before successful loading
- The "`rpc error: code = unknown`" issue mentioned primarily occurs during ListComponents calls
- These errors are typically caused by network-related RPC call failures



Therefore, this change only focuses on optimizing the error log format in kubernetes mode to provide clearer error context while maintaining consistency with existing log formats.

## Issue reference

close #8236 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
