### PR TITLE
Move over fuzz tests from cncf-fuzzing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.1
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/PuerkitoBio/purell v1.2.1
 	github.com/aavaz-ai/pii-scrubber v0.0.0-20220812094047-3fa450ab6973

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMb
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/99designs/keyring v1.2.1 h1:tYLp1ULvO7i3fI5vE21ReQuj99QFSs7lGm0xWyJo87o=
 github.com/99designs/keyring v1.2.1/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AthenZ/athenz v1.10.39 h1:mtwHTF/v62ewY2Z5KWhuZgVXftBej1/Tn80zx4DcawY=
 github.com/AthenZ/athenz v1.10.39/go.mod h1:3Tg8HLsiQZp81BJY58JBeU2BR6B/H4/0MQGfCwhHNEA=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=

--- a/pkg/acl/fuzz_test.go
+++ b/pkg/acl/fuzz_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acl
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"github.com/dapr/kit/logger"
+
+	"github.com/dapr/dapr/pkg/config"
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	"github.com/dapr/dapr/pkg/security/spiffe"
+)
+
+func init() {
+	log.SetOutputLevel(logger.FatalLevel)
+}
+
+// Tests ParseAccessControlSpec with random values
+func FuzzParseAccessControlSpec(f *testing.F) {
+	f.Fuzz(func(t *testing.T, specData []byte) {
+		ff := fuzz.NewConsumer(specData)
+		s := &config.AccessControlSpec{}
+		ff.GenerateStruct(s)
+		b, err := ff.GetBool()
+		if err != nil {
+			return
+		}
+		_, _ = ParseAccessControlSpec(s, b)
+	})
+}
+
+// Tests normalizeOperation with a random string.
+// normalizeOperation has complex parsing routines
+// which this test focuses on.
+func FuzzPurellTest(f *testing.F) {
+	f.Fuzz(func(t *testing.T, operation string) {
+		normalizeOperation(operation)
+	})
+}
+
+// Tests isOperationAllowedByAccessControlPolicy with random values
+func FuzzIsOperationAllowedByAccessControlPolicy(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, inputOperation string, httpVerbInd int32) {
+		ff := fuzz.NewConsumer(data)
+		spiffeID := &spiffe.Parsed{}
+		ff.GenerateStruct(spiffeID)
+		srcAppID, err := ff.GetString()
+		if err != nil {
+			return
+		}
+		if srcAppID == "" {
+			return
+		}
+		httpVerbInt32 := httpVerbInd % 10
+		httpVerb := commonv1pb.HTTPExtension_Verb(httpVerbInt32)
+		isHTTP, err := ff.GetBool()
+		if err != nil {
+			return
+		}
+		accessControlList := &config.AccessControlList{}
+		ff.GenerateStruct(accessControlList)
+		accessControlList.DefaultAction = config.DenyAccess
+		_, _ = isOperationAllowedByAccessControlPolicy(spiffeID, inputOperation, httpVerb, isHTTP, accessControlList)
+	})
+}

--- a/pkg/actors/fuzz_test.go
+++ b/pkg/actors/fuzz_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+
+	"github.com/dapr/kit/logger"
+)
+
+func init() {
+	log.SetOutputLevel(logger.FatalLevel)
+}
+
+// This fuzz test tests different methods of the Actors runtime.
+// The test will choose a method in each iteration and then
+// generate the necessary objects that the method accepts.
+func FuzzActorsRuntime(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, apiCall int) {
+		var testActorsRuntime *actorsRuntime
+		testActorsRuntime = newTestActorsRuntime(t)
+		err := testActorsRuntime.Init(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		ff := fuzz.NewConsumer(data)
+		switch apiCall % 8 {
+		case 0:
+			r := &CreateTimerRequest{}
+			ff.GenerateStruct(r)
+			_ = testActorsRuntime.CreateTimer(context.Background(), r)
+		case 1:
+			ff.AllowUnexportedFields()
+			req := &internalsv1pb.InternalInvokeRequest{}
+			ff.GenerateStruct(req)
+
+			_, _ = testActorsRuntime.Call(context.Background(), req)
+		case 2:
+			r := &GetStateRequest{}
+			err := ff.GenerateStruct(r)
+			if err != nil {
+				return
+			}
+			testActorsRuntime.GetState(context.Background(), r)
+		case 3:
+			r := &TransactionalRequest{}
+			err := ff.GenerateStruct(r)
+			if err != nil {
+				return
+			}
+			testActorsRuntime.TransactionalStateOperation(context.Background(), r)
+		case 4:
+			r := &ActorHostedRequest{}
+			err := ff.GenerateStruct(r)
+			if err != nil {
+				return
+			}
+			testActorsRuntime.IsActorHosted(context.Background(), r)
+		case 5:
+			r := &CreateReminderRequest{}
+			err := ff.GenerateStruct(r)
+			if err != nil {
+				return
+			}
+			testActorsRuntime.CreateReminder(context.Background(), r)
+		case 6:
+			r := &CreateTimerRequest{}
+			err := ff.GenerateStruct(r)
+			if err != nil {
+				return
+			}
+			testActorsRuntime.CreateTimer(context.Background(), r)
+		case 7:
+			r := &DeleteTimerRequest{}
+			err := ff.GenerateStruct(r)
+			if err != nil {
+				return
+			}
+			testActorsRuntime.DeleteTimer(context.Background(), r)
+		}
+	})
+}

--- a/pkg/injector/service/fuzz_test.go
+++ b/pkg/injector/service/fuzz_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	v1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/dapr/kit/logger"
+
+	"github.com/dapr/dapr/pkg/client/clientset/versioned/fake"
+	"github.com/dapr/dapr/pkg/healthz"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+var des = serializer.NewCodecFactory(
+	runtime.NewScheme(),
+).UniversalDeserializer()
+
+func init() {
+	log.SetOutputLevel(logger.FatalLevel)
+}
+
+type MockWriter struct{}
+
+func (m MockWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (m MockWriter) Write(data []byte) (int, error) {
+	return 0, nil
+}
+
+func (m MockWriter) WriteHeader(statusCode int) {
+}
+
+// This fuzz test sends randomized requests to handleRequest.
+func FuzzHandleRequest(f *testing.F) {
+	f.Fuzz(func(t *testing.T, body []byte) {
+		ar1 := &v1.AdmissionReview{}
+		ff := fuzz.NewConsumer(body)
+		ff.GenerateStruct(ar1)
+		if ar1.Request == nil {
+			return
+		}
+		arBody, err := json.Marshal(ar1)
+		if err != nil {
+			return
+		}
+		ar := v1.AdmissionReview{}
+		_, _, err = des.Decode(arBody, nil, &ar)
+		if err != nil {
+			return
+		}
+		if ar.Request == nil {
+			return
+		}
+		r, err := http.NewRequest(http.MethodPost, "", bytes.NewReader(arBody))
+		if err != nil {
+			return
+		}
+		r.Header.Add("Content-Type", runtime.ContentTypeJSON)
+		authID := "test-auth-id"
+		i, err := NewInjector(Options{
+			AuthUIDs: []string{authID},
+			Config: Config{
+				SidecarImage:                      "test-image",
+				Namespace:                         "test-ns",
+				ControlPlaneTrustDomain:           "test-trust-domain",
+				AllowedServiceAccountsPrefixNames: "vc-proj*:sa-dev*,vc-all-allowed*:*",
+			},
+			DaprClient: fake.NewSimpleClientset(),
+			KubeClient: kubernetesfake.NewSimpleClientset(),
+			Healthz:    healthz.New(),
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		i.(*injector).handleRequest(MockWriter{}, r)
+	})
+}

--- a/pkg/messaging/fuzz_test.go
+++ b/pkg/messaging/fuzz_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package messaging
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	grpc "google.golang.org/grpc"
+
+	grpcMetadata "google.golang.org/grpc/metadata"
+
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	v1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+type fakeStream struct {
+	ff  *fuzz.ConsumeFuzzer
+	ctx context.Context
+}
+
+func (f *fakeStream) Context() context.Context {
+	if f.ctx == nil {
+		return context.Background()
+	}
+	return f.ctx
+}
+
+func (f *fakeStream) Header() (grpcMetadata.MD, error) {
+	md := make(grpcMetadata.MD)
+	err := f.ff.FuzzMap(&md)
+	return md, err
+}
+
+func (f *fakeStream) SetHeader(grpcMetadata.MD) error {
+	return nil
+}
+
+func (f *fakeStream) SendHeader(grpcMetadata.MD) error {
+	return nil
+}
+
+func (f *fakeStream) SetTrailer(grpcMetadata.MD) {
+}
+
+func (f *fakeStream) Trailer() grpcMetadata.MD {
+	md := make(grpcMetadata.MD)
+	f.ff.FuzzMap(&md)
+	return md
+}
+
+func (f *fakeStream) SendMsg(m any) error {
+	return nil
+}
+
+func (f *fakeStream) RecvMsg(chunk interface{}) error {
+	resp := &internalv1pb.InternalInvokeResponse{}
+	payload := &v1.StreamPayload{}
+	f.ff.GenerateStruct(resp)
+	f.ff.GenerateStruct(payload)
+	chunk.(*internalv1pb.InternalInvokeResponseStream).Response = resp
+	chunk.(*internalv1pb.InternalInvokeResponseStream).Payload = payload
+	return nil
+}
+
+func (f *fakeStream) CloseSend() error {
+	return nil
+}
+
+func (f *fakeStream) Send(*internalv1pb.InternalInvokeRequestStream) error {
+	return nil
+}
+
+func (f *fakeStream) Recv() (*internalv1pb.InternalInvokeResponseStream, error) {
+	return &internalv1pb.InternalInvokeResponseStream{}, nil
+}
+
+type serviceInvocationClientForFuzing struct {
+	ff *fuzz.ConsumeFuzzer
+}
+
+func (c *serviceInvocationClientForFuzing) CallActor(ctx context.Context, in *internalv1pb.InternalInvokeRequest, opts ...grpc.CallOption) (*internalv1pb.InternalInvokeResponse, error) {
+	return &internalv1pb.InternalInvokeResponse{}, nil
+}
+
+func (c *serviceInvocationClientForFuzing) CallActorReminder(ctx context.Context, in *internalv1pb.Reminder, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (c *serviceInvocationClientForFuzing) CallLocal(ctx context.Context, in *internalv1pb.InternalInvokeRequest, opts ...grpc.CallOption) (*internalv1pb.InternalInvokeResponse, error) {
+	return &internalv1pb.InternalInvokeResponse{}, nil
+}
+
+func (c *serviceInvocationClientForFuzing) CallLocalStream(ctx context.Context, opts ...grpc.CallOption) (internalv1pb.ServiceInvocation_CallLocalStreamClient, error) {
+	return &fakeStream{
+		ff:  c.ff,
+		ctx: context.Background(),
+	}, nil
+}
+
+// Tests invokeRemoteStream with a randomized request.
+// This test needs some mocked services which are
+// implemented above.
+func FuzzInvokeRemote(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data1, data2, data3 []byte, actorType, actorID string) {
+		ff := fuzz.NewConsumer(data1)
+		ff.AllowUnexportedFields()
+		ir := &v1.InvokeRequest{}
+		ff.GenerateStruct(ir)
+		md := make(map[string][]string)
+		ff.FuzzMap(&md)
+		r := invokev1.FromInvokeRequestMessage(ir).
+			WithRawData(bytes.NewReader(data2)).
+			WithRawDataBytes(data3).
+			WithActor(actorType, actorID).
+			WithMetadata(md)
+		d := &directMessaging{}
+		c := &serviceInvocationClientForFuzing{
+			ff: ff,
+		}
+		_, _ = d.invokeRemoteStream(context.Background(), c, r, "appID", nil)
+	})
+}

--- a/pkg/placement/raft/fuzz_test.go
+++ b/pkg/placement/raft/fuzz_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package raft
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"github.com/hashicorp/raft"
+
+	"github.com/dapr/kit/logger"
+)
+
+func init() {
+	logging.SetOutputLevel(logger.FatalLevel)
+}
+
+// Tests PlacementState with a randomized Log entry
+func FuzzFSMPlacementState(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte, str1 string, b1 bool) {
+		ff := fuzz.NewConsumer(data)
+		rl := &raft.Log{}
+		err := ff.GenerateStruct(rl)
+		if err != nil {
+			return
+		}
+		fsm := newFSM(DaprHostMemberStateConfig{
+			replicationFactor: 5,
+		})
+		fsm.Apply(rl)
+
+		_ = fsm.PlacementState(b1, str1)
+	})
+}

--- a/pkg/runtime/processor/fuzz_test.go
+++ b/pkg/runtime/processor/fuzz_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package processor
+
+import (
+	"context"
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+)
+
+// Tests processComponentAndDependents with a randomized
+// component
+func FuzzProcessComponentsAndDependents(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fdp := fuzz.NewConsumer(data)
+		comp := &componentsapi.Component{}
+		fdp.GenerateStruct(comp)
+		proc, _ := newTestProc()
+		proc.processComponentAndDependents(context.Background(), *comp)
+	})
+}


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Dapr underwent [a fuzzing audit last](https://blog.dapr.io/posts/2023/06/30/dapr-completes-fuzzing-audit/) year and has a bunch of fuzz tests [over at CNCF-Fuzzing](https://github.com/cncf/cncf-fuzzing/tree/main/projects/dapr). OSS-Fuzz builds those tests regularly to run them, but due to upstream changes in Dapr, the fuzz tests often break. It will be much more maintainable to have the fuzz tests in Daprs own source repository, so that they can follow source changes.

This PR is the first in a series that refactors the fuzz tests at CNCF-Fuzzing and moves them upstream to Dapr. The goal is to move all fuzz tests upstream which will also fix the currently broken OSS-Fuzz build.

The fuzz tests can be run locally with `go test -fuzz=TESTNAME` and some of them may need `-tags=unit`.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
