### PR TITLE
sentry: allow for self-hosted CA on Kubernetes

### DIFF
--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -163,6 +163,8 @@ spec:
         - "/sentry"
         - "--"
 {{- end }}
+        - "--mode"
+        - "kubernetes"
         - "--log-level"
         - {{ .Values.logLevel }}
 {{- if eq .Values.global.logAsJson true }}

--- a/cmd/sentry/app/app.go
+++ b/cmd/sentry/app/app.go
@@ -63,7 +63,6 @@ func Run() {
 	}
 
 	var (
-		watchDirs   []string
 		issuerEvent = make(chan struct{})
 		mngr        = concurrency.NewRunnerManager()
 	)
@@ -92,6 +91,7 @@ func Run() {
 			m[dir] = struct{}{}
 		}
 	}
+	watchDirs := make([]string, 0, len(m))
 	for dir := range m {
 		watchDirs = append(watchDirs, dir)
 	}

--- a/cmd/sentry/app/app.go
+++ b/cmd/sentry/app/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dapr/dapr/pkg/healthz"
 	healthzserver "github.com/dapr/dapr/pkg/healthz/server"
 	"github.com/dapr/dapr/pkg/metrics"
+	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/sentry"
 	"github.com/dapr/dapr/pkg/sentry/config"
 	"github.com/dapr/dapr/pkg/sentry/monitoring"
@@ -38,6 +39,10 @@ var log = logger.NewLogger("dapr.sentry")
 
 func Run() {
 	opts := options.New(os.Args[1:])
+
+	if err := opts.Validate(); err != nil {
+		log.Fatalf("Invalid options: %s", err)
+	}
 
 	// Apply options to all loggers
 	if err := logger.ApplyOptionsToLoggers(&opts.Logger); err != nil {
@@ -57,9 +62,39 @@ func Run() {
 		log.Fatal(err)
 	}
 
+	var (
+		watchDirs   []string
+		issuerEvent = make(chan struct{})
+		mngr        = concurrency.NewRunnerManager()
+	)
+
 	issuerCertPath := filepath.Join(opts.IssuerCredentialsPath, opts.IssuerCertFilename)
+	if filepath.IsAbs(opts.IssuerCertFilename) {
+		log.Debugf("Using user provided issuer cert path: %s", opts.IssuerCertFilename)
+		issuerCertPath = opts.IssuerCertFilename
+	}
 	issuerKeyPath := filepath.Join(opts.IssuerCredentialsPath, opts.IssuerKeyFilename)
+	if filepath.IsAbs(opts.IssuerKeyFilename) {
+		log.Debugf("Using user provided issuer key path: %s", opts.IssuerKeyFilename)
+		issuerKeyPath = opts.IssuerKeyFilename
+	}
 	rootCertPath := filepath.Join(opts.IssuerCredentialsPath, opts.RootCAFilename)
+	if filepath.IsAbs(opts.RootCAFilename) {
+		log.Debugf("Using user provided root cert path: %s", opts.RootCAFilename)
+		rootCertPath = opts.RootCAFilename
+	}
+
+	m := make(map[string]struct{})
+	// we need to watch over all these relevant directories
+	for _, path := range []string{issuerCertPath, issuerKeyPath, rootCertPath} {
+		dir := filepath.Dir(path)
+		if _, ok := m[dir]; !ok {
+			m[dir] = struct{}{}
+		}
+	}
+	for dir := range m {
+		watchDirs = append(watchDirs, dir)
+	}
 
 	cfg, err := config.FromConfigName(opts.ConfigName)
 	if err != nil {
@@ -72,12 +107,7 @@ func Run() {
 	cfg.TrustDomain = opts.TrustDomain
 	cfg.Port = opts.Port
 	cfg.ListenAddress = opts.ListenAddress
-
-	var (
-		watchDir    = filepath.Dir(cfg.IssuerCertPath)
-		issuerEvent = make(chan struct{})
-		mngr        = concurrency.NewRunnerManager()
-	)
+	cfg.Mode = modes.DaprMode(opts.Mode)
 
 	// We use runner manager inception here since we want the inner manager to be
 	// restarted when the CA server needs to be restarted because of file events.
@@ -147,15 +177,15 @@ func Run() {
 		log.Fatal(err)
 	}
 
-	// Watch for changes in the watchDir
+	// Watch for changes in the watchDirs
 	fs, err := fswatcher.New(fswatcher.Options{
-		Targets: []string{watchDir},
+		Targets: watchDirs,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 	if err = mngr.Add(func(ctx context.Context) error {
-		log.Infof("Starting watch on filesystem directory: %s", watchDir)
+		log.Infof("Starting watch on filesystem directories: %v", watchDirs)
 		return fs.Run(ctx, issuerEvent)
 	}); err != nil {
 		log.Fatal(err)

--- a/pkg/sentry/config/config.go
+++ b/pkg/sentry/config/config.go
@@ -26,6 +26,7 @@ import (
 
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	daprGlobalConfig "github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/modes"
 	sentryv1pb "github.com/dapr/dapr/pkg/proto/sentry/v1"
 	"github.com/dapr/dapr/pkg/security"
 	"github.com/dapr/dapr/utils"
@@ -65,6 +66,7 @@ type Config struct {
 	RootCertPath     string
 	IssuerCertPath   string
 	IssuerKeyPath    string
+	Mode             modes.DaprMode
 	Validators       map[sentryv1pb.SignCertificateRequest_TokenValidator]map[string]string
 	DefaultValidator sentryv1pb.SignCertificateRequest_TokenValidator
 	Features         []daprGlobalConfig.FeatureSpec

--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/security"
 	"github.com/dapr/dapr/pkg/security/spiffe"
 	"github.com/dapr/dapr/pkg/sentry/config"
@@ -83,7 +84,7 @@ type ca struct {
 
 func New(ctx context.Context, conf config.Config) (Signer, error) {
 	var castore store
-	if config.IsKubernetesHosted() {
+	if conf.Mode == modes.KubernetesMode {
 		log.Info("Using kubernetes secret store for trust bundle storage")
 
 		client, err := kubernetes.NewForConfig(utils.GetConfig())

--- a/pkg/sentry/server/ca/ca_test.go
+++ b/pkg/sentry/server/ca/ca_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/sentry/config"
 	"github.com/dapr/kit/crypto/pem"
 )
@@ -46,6 +47,7 @@ func TestNew(t *testing.T) {
 			IssuerCertPath: issuerCertPath,
 			IssuerKeyPath:  issuerKeyPath,
 			TrustDomain:    "test.example.com",
+			Mode:           modes.Standalone,
 		}
 
 		_, err := New(context.Background(), config)
@@ -90,6 +92,7 @@ func TestNew(t *testing.T) {
 			RootCertPath:   rootCertPath,
 			IssuerCertPath: issuerCertPath,
 			IssuerKeyPath:  issuerKeyPath,
+			Mode:           modes.Standalone,
 		}
 
 		rootPEM, rootCrt, _, rootPK := genCrt(t, "root", nil, nil)

--- a/pkg/sentry/server/ca/ca_test.go
+++ b/pkg/sentry/server/ca/ca_test.go
@@ -47,7 +47,7 @@ func TestNew(t *testing.T) {
 			IssuerCertPath: issuerCertPath,
 			IssuerKeyPath:  issuerKeyPath,
 			TrustDomain:    "test.example.com",
-			Mode:           modes.Standalone,
+			Mode:           modes.StandaloneMode,
 		}
 
 		_, err := New(context.Background(), config)
@@ -92,7 +92,7 @@ func TestNew(t *testing.T) {
 			RootCertPath:   rootCertPath,
 			IssuerCertPath: issuerCertPath,
 			IssuerKeyPath:  issuerKeyPath,
-			Mode:           modes.Standalone,
+			Mode:           modes.StandaloneMode,
 		}
 
 		rootPEM, rootCrt, _, rootPK := genCrt(t, "root", nil, nil)


### PR DESCRIPTION
# Description

Currently, any user running on kubernetes interesting on running a standalone Sentry is forced to provide both a `dapr-trust-bundle` Secret and ConfigMap. This is not ideal in the cases where you're generating the private key pair from eg. cert-manager and distributing trust in the cluster using trust-manager. On these use-cases it's simply enough to mount these resources and supply the correct CLI args.

## Checklist

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Unit tests passing
- [X] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
