### PR TITLE
Expose internal component loaded for CLI validation

### DIFF
--- a/pkg/components/loader/localloader.go
+++ b/pkg/components/loader/localloader.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+
+	"github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	internalloader "github.com/dapr/dapr/pkg/internal/loader"
+	"github.com/dapr/dapr/pkg/internal/loader/disk"
+)
+
+// LocalLoader Exposes the internal Components loader for CLI to use as validation of components loading from the local file system
+type LocalLoader struct {
+	loader internalloader.Loader[v1alpha1.Component]
+}
+
+func NewLocalLoader(appID string, paths []string) *LocalLoader {
+	l := disk.NewComponents(disk.Options{
+		AppID: appID,
+		Paths: paths,
+	})
+	return &LocalLoader{
+		loader: l,
+	}
+}
+
+// Load loads components from the local file system, used for testing
+func (l *LocalLoader) Load(ctx context.Context) ([]v1alpha1.Component, error) {
+	components, err := l.loader.Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return components, nil
+}
+
+func (l *LocalLoader) Validate(ctx context.Context) error {
+	// Dismiss the manifests as we are only interested in the error returned by the loader as indication of any component loading errors
+	_, err := l.loader.Load(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/components/loader/localloader_test.go
+++ b/pkg/components/loader/localloader_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalLoader_Load(t *testing.T) {
+	t.Run("Test Load 1 Component", func(t *testing.T) {
+		tmp := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "test-component.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.couchbase
+`), fs.FileMode(0o600)))
+
+		loader := NewLocalLoader("", []string{tmp})
+		components, err := loader.Load(context.Background())
+		require.NoError(t, err)
+		require.Len(t, components, 1)
+		require.Equal(t, "statestore", components[0].Name)
+	})
+
+	t.Run("Test Load Invalid Component YAML no error no components", func(t *testing.T) {
+		tmp := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "test-component.yaml"), []byte(`
+INVALID YAML
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.couchbase
+`), fs.FileMode(0o600)))
+
+		loader := NewLocalLoader("", []string{tmp})
+		components, err := loader.Load(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, components)
+	})
+
+	t.Run("Test Non Existent Directory", func(t *testing.T) {
+		loader := NewLocalLoader("", []string{"/non-existent-directory"})
+		_, err := loader.Load(context.Background())
+		require.Error(t, err)
+	})
+}
+
+func TestLocalLoader_Validate(t *testing.T) {
+	t.Run("Test Validate", func(t *testing.T) {
+		tmp := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "test-component.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.couchbase
+`), fs.FileMode(0o600)))
+
+		loader := NewLocalLoader("", []string{tmp})
+		err := loader.Validate(context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("Test Validate Invalid Component YAML no error no components", func(t *testing.T) {
+		tmp := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "test-component.yaml"), []byte(`
+INVALID YAML
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.couchbase
+`), fs.FileMode(0o600)))
+
+		loader := NewLocalLoader("", []string{tmp})
+		err := loader.Validate(context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("Test Validate Non Existent Directory", func(t *testing.T) {
+		loader := NewLocalLoader("", []string{"/non-existent-directory"})
+		err := loader.Validate(context.Background())
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
During the `dapr/cli` dependencies update, bumping `dapr/dapr` dependency to >1.14, lacks a validation of components loading in Standalone mode.
This was due to recent changes in the component loaded and hotreload changes when loaders were moved into the `internal` directory.
With this PR, we wrap and expose publicly only the disk loader portion to ensure CLI can continue to use this validation as a replacement for the previous one.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
