### PR TITLE
Workflow: gracefully recover from legacy state read errors

### DIFF
--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -15,6 +15,7 @@ package state
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -58,6 +59,13 @@ type State struct {
 	inboxRemovedCount   int
 	historyAddedCount   int
 	historyRemovedCount int
+}
+
+// TODO: @joshvanl: remove in v1.16
+type legacyWorkflowStateMetadata struct {
+	InboxLength   uint64
+	HistoryLength uint64
+	Generation    uint64
 }
 
 func NewState(opts Options) *State {
@@ -258,7 +266,6 @@ func addPurgeStateOperations(req *api.TransactionalRequest, keyPrefix string, ev
 
 func LoadWorkflowState(ctx context.Context, state state.Interface, actorID string, opts Options) (*State, error) {
 	loadStartTime := time.Now()
-	loadedRecords := 0
 
 	// Load metadata
 	req := api.GetStateRequest{
@@ -267,7 +274,6 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		Key:       metadataKey,
 	}
 	res, err := state.Get(ctx, &req)
-	loadedRecords++
 	if err != nil {
 		return nil, fmt.Errorf("failed to load workflow metadata: %w", err)
 	}
@@ -277,7 +283,16 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	}
 	var metadata backend.WorkflowStateMetadata
 	if err = proto.Unmarshal(res.Data, &metadata); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal workflow metadata: %w", err)
+		// TODO: @joshvanl: remove in v1.16
+		var metadataJSON legacyWorkflowStateMetadata
+		if jerr := json.Unmarshal(res.Data, &metadataJSON); jerr != nil {
+			return nil, fmt.Errorf("failed to unmarshal workflow metadata: %w", err)
+		}
+
+		wfLogger.Debugf("Loaded legacy workflow state metadata: %s", res.Data)
+		metadata.Generation = metadataJSON.Generation
+		metadata.InboxLength = metadataJSON.InboxLength
+		metadata.HistoryLength = metadataJSON.HistoryLength
 	}
 
 	// Load inbox, history, and custom status using a bulk request
@@ -311,8 +326,15 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		return nil, fmt.Errorf("failed to load workflow state: %w", err)
 	}
 
+	defer func() {
+		// TODO: @joshvanl: remove in v1.16 where we will no longer have legacy
+		// state parsing issues.
+		if recover() != nil {
+			wfLogger.Warnf("Found legacy workflow state, ignoring and overwriting with new storage API: %s", actorID)
+		}
+	}()
+
 	// Parse responses
-	loadedRecords += len(bulkRes)
 	var key string
 	for i := range metadata.GetInboxLength() {
 		key = getMultiEntryKeyName(inboxKeyPrefix, i)
@@ -340,7 +362,7 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		}
 	}
 
-	wfLogger.Infof("%s: loaded %d state records in %v", actorID, loadedRecords, time.Since(loadStartTime))
+	wfLogger.Infof("%s: loaded %d state records in %v", actorID, 1+len(bulkRes), time.Since(loadStartTime))
 	return wState, nil
 }
 


### PR DESCRIPTION
Currently, after upgrading from Dapr v1.14 to v1.15 and executing a workflow which has state from v1.14, the workflow state will fail to parse and cause the workflow to error. This is due to the storage API changing moving to v1 GA.

To resolve this, we fall back to parsing the workflow metadata key as JSON, then in the case of event history, ignoring the existing state if it fails to parse. Practically, this means a mid-running workflow will be abandoned when upgrading to v1.15 which seems acceptable. The other approach to this would be for use intervention to manually clean up the actor state store which is unreasonable.

cc @olitomlinson 