### PR TITLE
workflows small bugfixes

### DIFF
--- a/pkg/actors/table/table.go
+++ b/pkg/actors/table/table.go
@@ -227,14 +227,14 @@ func (t *table) UnRegisterActorTypes(actorTypes ...string) error {
 		errs = slice.New[error]()
 	)
 
-	t.table.Range(func(akey string, target targets.Interface) bool {
-		atype, _ := key.ActorTypeAndIDFromKey(akey)
+	t.table.Range(func(actorKey string, target targets.Interface) bool {
+		atype, _ := key.ActorTypeAndIDFromKey(actorKey)
 		if slices.Contains(actorTypes, atype) {
 			wg.Add(1)
-			go func(akey string) {
+			go func(actorKey string) {
 				defer wg.Done()
-				errs.Append(t.haltInLock(atype))
-			}(akey)
+				errs.Append(t.haltInLock(actorKey))
+			}(actorKey)
 		}
 
 		return true

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -97,6 +97,10 @@ func New(opts Options) (Interface, error) {
 			lock.Lock()
 			defer lock.Unlock()
 
+			if ctx.Err() != nil {
+				ctx = context.Background()
+			}
+
 			activeConns--
 			if activeConns == 0 {
 				log.Debug("Unregistering workflow actors")


### PR DESCRIPTION
# Description

Couple of small bugs found while testing the 1.15 rc3

the `UnRegisterActorTypes` function did not pass the actor key `haltInLock`

and the `WithOnGetWorkItemsDisconnectCallback` callback function could receive an already cancelled context

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
