### PR TITLE
State read to backend

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -498,10 +498,14 @@ func (a *actors) WaitForRegisteredHosts(ctx context.Context) error {
 }
 
 func (a *actors) handleIdleActor(target targets.Idlable) {
-	if err := a.placement.Lock(context.Background()); err != nil {
+	// We don't use the placement context here as we are already deactivating the
+	// actor.
+	_, cancel, err := a.placement.Lock(context.Background())
+	if err != nil {
+		log.Errorf("Failed to lock placement for idle actor deactivation: %s", err)
 		return
 	}
-	defer a.placement.Unlock()
+	defer cancel()
 
 	log.Debugf("Actor %s is idle, deactivating", target.Key())
 

--- a/pkg/actors/engine/engine.go
+++ b/pkg/actors/engine/engine.go
@@ -120,7 +120,7 @@ func (e *engine) CallReminder(ctx context.Context, req *api.Reminder) error {
 func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
 	ctx, cancel, err := e.placement.Lock(ctx)
 	if err != nil {
-		return err
+		return backoff.Permanent(err)
 	}
 	defer cancel()
 
@@ -157,7 +157,7 @@ func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
 func (e *engine) callActor(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
 	ctx, cancel, err := e.placement.Lock(ctx)
 	if err != nil {
-		return nil, err
+		return nil, backoff.Permanent(err)
 	}
 	defer cancel()
 

--- a/pkg/actors/engine/engine.go
+++ b/pkg/actors/engine/engine.go
@@ -118,10 +118,11 @@ func (e *engine) CallReminder(ctx context.Context, req *api.Reminder) error {
 }
 
 func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
-	if err := e.placement.Lock(ctx); err != nil {
+	ctx, cancel, err := e.placement.Lock(ctx)
+	if err != nil {
 		return err
 	}
-	defer e.placement.Unlock()
+	defer cancel()
 
 	lar, err := e.placement.LookupActor(ctx, &api.LookupActorRequest{
 		ActorType: req.ActorType,
@@ -154,10 +155,11 @@ func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
 }
 
 func (e *engine) callActor(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
-	if err := e.placement.Lock(ctx); err != nil {
+	ctx, cancel, err := e.placement.Lock(ctx)
+	if err != nil {
 		return nil, err
 	}
-	defer e.placement.Unlock()
+	defer cancel()
 
 	lar, err := e.placement.LookupActor(ctx, &api.LookupActorRequest{
 		ActorType: req.GetActor().GetActorType(),

--- a/pkg/actors/internal/placement/client/client.go
+++ b/pkg/actors/internal/placement/client/client.go
@@ -124,11 +124,11 @@ func (c *Client) Run(ctx context.Context) error {
 		select {
 		case ch := <-c.reconnectCh:
 			c.ready.Store(false)
-			c.lock.LockTable()
+			unlock := c.lock.Lock()
 			connCancel()
 
 			if err := c.table.HaltAll(); err != nil {
-				c.lock.EnsureUnlockTable()
+				unlock()
 				return fmt.Errorf("failed to halt all actors: %s", err)
 			}
 
@@ -137,11 +137,11 @@ func (c *Client) Run(ctx context.Context) error {
 			}
 
 			connCtx, connCancel = context.WithCancel(ctx)
-			defer connCancel()
 			err := c.connectRoundRobin(connCtx)
 			ch <- err
-			c.lock.EnsureUnlockTable()
+			unlock()
 			if err != nil {
+				connCancel()
 				return err
 			}
 
@@ -150,8 +150,8 @@ func (c *Client) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			c.ready.Store(false)
 			connCancel()
-			c.lock.LockTable()
-			defer c.lock.EnsureUnlockTable()
+			unlock := c.lock.Lock()
+			defer unlock()
 			if err := c.table.HaltAll(); err != nil {
 				log.Errorf("Error whilst deactivating all actors when shutting down client: %s", err)
 			}

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -14,43 +14,156 @@ limitations under the License.
 package lock
 
 import (
+	"context"
+	"errors"
 	"sync"
 
 	"github.com/dapr/kit/concurrency/fifo"
 )
 
+var errLockClosed = errors.New("placement lock closed")
+
+type hold struct {
+	writeLock bool
+	rctx      context.Context
+	respCh    chan *holdresp
+}
+
+type holdresp struct {
+	rctx   context.Context
+	cancel context.CancelFunc
+}
+
 type Lock struct {
-	tableLock   *fifo.Mutex
-	inTableLock bool
-	lookupLock  sync.RWMutex
+	ch chan *hold
+
+	lock chan struct{}
+
+	wg          sync.WaitGroup
+	rcancelLock sync.Mutex
+	rcancelx    uint64
+	rcancels    map[uint64]context.CancelFunc
+
+	closeCh      chan struct{}
+	shutdownLock *fifo.Mutex
 }
 
 func New() *Lock {
 	return &Lock{
-		tableLock: fifo.New(),
+		lock:         make(chan struct{}, 1),
+		ch:           make(chan *hold),
+		rcancels:     make(map[uint64]context.CancelFunc),
+		closeCh:      make(chan struct{}),
+		shutdownLock: fifo.New(),
 	}
 }
 
-func (l *Lock) LockTable() {
-	l.tableLock.Lock()
-	defer l.tableLock.Unlock()
-	l.lookupLock.Lock()
-	l.inTableLock = true
-}
+func (l *Lock) Run(ctx context.Context) {
+	defer func() {
+		l.rcancelLock.Lock()
+		defer l.rcancelLock.Unlock()
 
-func (l *Lock) EnsureUnlockTable() {
-	l.tableLock.Lock()
-	defer l.tableLock.Unlock()
-	if l.inTableLock {
-		l.inTableLock = false
-		l.lookupLock.Unlock()
+		for _, cancel := range l.rcancels {
+			cancel()
+		}
+		l.wg.Wait()
+	}()
+
+	go func() {
+		<-ctx.Done()
+		close(l.closeCh)
+	}()
+
+	for {
+		select {
+		case <-l.closeCh:
+			return
+		case h := <-l.ch:
+			l.handleHold(h)
+		}
 	}
 }
 
-func (l *Lock) LockLookup() {
-	l.lookupLock.RLock()
+func (l *Lock) handleHold(h *hold) {
+	l.lock <- struct{}{}
+	l.rcancelLock.Lock()
+
+	if h.writeLock {
+		for _, cancel := range l.rcancels {
+			go cancel()
+		}
+		l.rcancelx = 0
+		l.rcancelLock.Unlock()
+		l.wg.Wait()
+
+		h.respCh <- &holdresp{cancel: func() { <-l.lock }}
+
+		return
+	}
+
+	l.wg.Add(1)
+	rctx, cancel := context.WithCancel(h.rctx)
+	i := l.rcancelx
+
+	rcancel := func() {
+		l.rcancelLock.Lock()
+		cancel()
+		delete(l.rcancels, i)
+		l.rcancelLock.Unlock()
+		l.wg.Done()
+	}
+
+	l.rcancels[i] = rcancel
+	l.rcancelx++
+
+	l.rcancelLock.Unlock()
+
+	h.respCh <- &holdresp{rctx: rctx, cancel: rcancel}
+
+	<-l.lock
 }
 
-func (l *Lock) UnlockLookup() {
-	l.lookupLock.RUnlock()
+func (l *Lock) Lock() context.CancelFunc {
+	h := hold{
+		writeLock: true,
+		respCh:    make(chan *holdresp),
+	}
+
+	select {
+	case <-l.closeCh:
+		l.shutdownLock.Lock()
+		return l.shutdownLock.Unlock
+	case l.ch <- &h:
+	}
+
+	select {
+	case <-l.closeCh:
+		l.shutdownLock.Lock()
+		return l.shutdownLock.Unlock
+	case resp := <-h.respCh:
+		return resp.cancel
+	}
+}
+
+func (l *Lock) RLock(ctx context.Context) (context.Context, context.CancelFunc, error) {
+	h := hold{
+		writeLock: false,
+		rctx:      ctx,
+		respCh:    make(chan *holdresp),
+	}
+
+	select {
+	case <-l.closeCh:
+		return nil, nil, errLockClosed
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case l.ch <- &h:
+	}
+
+	select {
+	case <-l.closeCh:
+		return nil, nil, errLockClosed
+	case resp := <-h.respCh:
+		return resp.rctx, resp.cancel, nil
+	}
 }

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -102,15 +102,19 @@ func (l *Lock) handleHold(h *hold) {
 	}
 
 	l.wg.Add(1)
+	var done bool
 	rctx, cancel := context.WithCancel(h.rctx)
 	i := l.rcancelx
 
 	rcancel := func() {
 		l.rcancelLock.Lock()
-		cancel()
-		delete(l.rcancels, i)
+		if !done {
+			cancel()
+			delete(l.rcancels, i)
+			l.wg.Done()
+			done = true
+		}
 		l.rcancelLock.Unlock()
-		l.wg.Done()
 	}
 
 	l.rcancels[i] = rcancel

--- a/pkg/actors/internal/placement/lock/lock_test.go
+++ b/pkg/actors/internal/placement/lock/lock_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Lock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("can rlock multiple times", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctx1, c1, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx2, c2, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx3, c3, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c1()
+		require.Error(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c2()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c3()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.Error(t, ctx3.Err())
+	})
+
+	t.Run("rlock unlock removes cancel state", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		_, c1, err := l.RLock(ctx)
+		require.NoError(t, err)
+		_, c2, err := l.RLock(ctx)
+		require.NoError(t, err)
+		_, c3, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		assert.Len(t, l.rcancels, 3)
+		c1()
+		assert.Len(t, l.rcancels, 2)
+		c2()
+		assert.Len(t, l.rcancels, 1)
+		c3()
+		assert.Empty(t, l.rcancels, 0)
+	})
+
+	t.Run("calling lock cancels all current rlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctx1, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx2, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx3, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		mcancel := l.Lock()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.Error(t, ctx3.Err())
+		mcancel()
+
+		assert.Empty(t, l.rcancels)
+	})
+
+	t.Run("rlock when closed should error", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		go l.Run(ctx)
+
+		select {
+		case <-l.closeCh:
+		case <-time.After(time.Second * 5):
+			assert.Fail(t, "expected close")
+		}
+
+		_, _, err := l.RLock(context.Background())
+		require.Error(t, err)
+	})
+
+	t.Run("rlock when context closed should error", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctxr, cancelr := context.WithCancel(context.Background())
+		cancelr()
+		_, _, err := l.RLock(ctxr)
+		require.Error(t, err)
+	})
+
+	t.Run("lock continues to work after close", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		l.Run(ctx)
+
+		lcancel := l.Lock()
+		lcancel()
+		lcancel = l.Lock()
+		lcancel()
+	})
+
+	t.Run("rlock blocks until outter unlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		lcancel := l.Lock()
+
+		gotRLock := make(chan struct{})
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, c1, err := l.RLock(ctx)
+			errCh <- err
+			t.Cleanup(c1)
+			close(gotRLock)
+		}()
+		t.Cleanup(func() {
+			require.NoError(t, <-errCh)
+		})
+
+		select {
+		case <-time.After(time.Millisecond * 500):
+		case <-gotRLock:
+			require.Fail(t, "unexpected rlock")
+		}
+
+		lcancel()
+	})
+
+	t.Run("lock blocks until outter unlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		lcancel := l.Lock()
+
+		gotLock := make(chan struct{})
+
+		go func() {
+			lockcancel := l.Lock()
+			t.Cleanup(lockcancel)
+			close(gotLock)
+		}()
+
+		select {
+		case <-time.After(time.Millisecond * 500):
+		case <-gotLock:
+			require.Fail(t, "unexpected rlock")
+		}
+
+		lcancel()
+	})
+}

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -94,8 +94,6 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	// do not check if actor is hosted...
-
 	storeName, store, err := s.stateStore()
 	if err != nil {
 		return nil, err
@@ -135,8 +133,6 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error) {
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
-
-	// do not check if actor is hosted...
 
 	storeName, store, err := s.stateStore()
 	if err != nil {

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -91,8 +91,11 @@ func New(opts Options) Interface {
 }
 
 func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateResponse, error) {
-	s.placement.Lock(ctx)
-	defer s.placement.Unlock()
+	ctx, cancel, err := s.placement.Lock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -131,8 +134,11 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 }
 
 func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error) {
-	s.placement.Lock(ctx)
-	defer s.placement.Unlock()
+	ctx, cancel, err := s.placement.Lock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -177,9 +183,12 @@ func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.
 	return bulkRes, nil
 }
 
-func (s *state) TransactionalStateOperation(ctx context.Context, req *api.TransactionalRequest) (err error) {
-	s.placement.Lock(ctx)
-	defer s.placement.Unlock()
+func (s *state) TransactionalStateOperation(ctx context.Context, req *api.TransactionalRequest) error {
+	ctx, cancel, err := s.placement.Lock(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
 
 	if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
 		return messages.ErrActorInstanceMissing

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -94,9 +94,16 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-		return nil, messages.ErrActorInstanceMissing
-	}
+	// TODO is it ok to allow access (just read only) to an actor state even if the instance is not hosted?
+	// this is needed for LoadWorkflowState in pkg/runtime/wfengine/state/state.go to work
+	// since now the workflow state is not read from the actor but from the backend interface
+	// the final goal is to be able to fetch the workflow state and metadata even if there is no workflows stream connected
+	// which now if there are no workflows stream connected the actor types are unregistered, hence making it impossible to read the workflow state (because the actor is no longer hosted...)
+
+	// do not check if actor is hosted...
+	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
+	// 	return nil, messages.ErrActorInstanceMissing
+	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -138,9 +145,10 @@ func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-		return nil, messages.ErrActorInstanceMissing
-	}
+	// do not check if actor is hosted...
+	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
+	// 	return nil, messages.ErrActorInstanceMissing
+	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -94,16 +94,7 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	// TODO is it ok to allow access (just read only) to an actor state even if the instance is not hosted?
-	// this is needed for LoadWorkflowState in pkg/runtime/wfengine/state/state.go to work
-	// since now the workflow state is not read from the actor but from the backend interface
-	// the final goal is to be able to fetch the workflow state and metadata even if there is no workflows stream connected
-	// which now if there are no workflows stream connected the actor types are unregistered, hence making it impossible to read the workflow state (because the actor is no longer hosted...)
-
 	// do not check if actor is hosted...
-	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-	// 	return nil, messages.ErrActorInstanceMissing
-	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -146,9 +137,6 @@ func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.
 	defer s.placement.Unlock()
 
 	// do not check if actor is hosted...
-	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-	// 	return nil, messages.ErrActorInstanceMissing
-	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -174,23 +174,6 @@ func (w *workflow) executeMethod(ctx context.Context, methodName string, request
 	case todo.CreateWorkflowInstanceMethod:
 		return nil, w.createWorkflowInstance(ctx, request)
 
-	case todo.GetWorkflowMetadataMethod:
-		meta, err := w.getWorkflowMetadata(ctx)
-		if err != nil {
-			log.Errorf("Workflow actor '%s': failed to get workflow metadata: %v", w.actorID, err)
-			return nil, err
-		}
-		return proto.Marshal(meta)
-
-	case todo.GetWorkflowStateMethod:
-		var state *wfenginestate.State
-		state, err := w.getWorkflowState(ctx)
-		if err != nil {
-			log.Errorf("Workflow actor '%s': failed to get workflow state: %v", w.actorID, err)
-			return nil, err
-		}
-		return state.EncodeWorkflowState()
-
 	case todo.AddWorkflowEventMethod:
 		return nil, w.addWorkflowEvent(ctx, request)
 
@@ -402,29 +385,6 @@ func (w *workflow) cleanupWorkflowStateInternal(ctx context.Context, state *wfen
 	w.rstate = nil
 	w.ometa = nil
 	return nil
-}
-
-func (w *workflow) getWorkflowMetadata(ctx context.Context) (*backend.OrchestrationMetadata, error) {
-	state, err := w.loadInternalState(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if state == nil {
-		return nil, api.ErrInstanceNotFound
-	}
-
-	return w.ometa, nil
-}
-
-func (w *workflow) getWorkflowState(ctx context.Context) (*wfenginestate.State, error) {
-	state, err := w.loadInternalState(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if state == nil {
-		return nil, api.ErrInstanceNotFound
-	}
-	return state, nil
 }
 
 // This method purges all the completed activity data from a workflow associated with the given actorID

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/pkg/actors"
 	"github.com/dapr/dapr/pkg/actors/table"
@@ -231,34 +233,35 @@ func (abe *Actors) CreateOrchestrationInstance(ctx context.Context, e *backend.H
 
 // GetOrchestrationMetadata implements backend.Backend
 func (abe *Actors) GetOrchestrationMetadata(ctx context.Context, id api.InstanceID) (*backend.OrchestrationMetadata, error) {
-	// Invoke the corresponding actor, which internally stores its own workflow metadata
-	req := internalsv1pb.
-		NewInternalInvokeRequest(todo.GetWorkflowMetadataMethod).
-		WithActor(abe.workflowActorType, string(id)).
-		WithContentType(invokev1.OctetStreamContentType)
-
-	engine, err := abe.actors.Engine(ctx)
+	state, err := abe.loadInternalState(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-
-	start := time.Now()
-	res, err := engine.Call(ctx, req)
-	elapsed := diag.ElapsedSince(start)
-	if err != nil {
-		// failed request to GET workflow Information, record count and latency metrics.
-		diag.DefaultWorkflowMonitoring.WorkflowOperationEvent(ctx, diag.GetWorkflow, diag.StatusFailed, elapsed)
-		return nil, err
-	}
-	// successful request to GET workflow information, record count and latency metrics.
-	diag.DefaultWorkflowMonitoring.WorkflowOperationEvent(ctx, diag.GetWorkflow, diag.StatusSuccess, elapsed)
-
-	var metadata backend.OrchestrationMetadata
-	if err := proto.Unmarshal(res.GetMessage().GetData().GetValue(), &metadata); err != nil {
-		return nil, fmt.Errorf("failed to decode the workflow actor response: %w", err)
+	if state == nil {
+		return nil, api.ErrInstanceNotFound
 	}
 
-	return &metadata, nil
+	// runtimeState := getRuntimeState(w.actorID, state)
+	runtimeState := backend.NewOrchestrationRuntimeState(id, state.History)
+
+	name, _ := runtimeState.Name()
+	createdAt, _ := runtimeState.CreatedTime()
+	lastUpdated, _ := runtimeState.LastUpdatedTime()
+	input, _ := runtimeState.Input()
+	output, _ := runtimeState.Output()
+	failureDetuils, _ := runtimeState.FailureDetails()
+
+	return &backend.OrchestrationMetadata{
+		InstanceId:     string(runtimeState.InstanceID()),
+		Name:           name,
+		RuntimeStatus:  runtimeState.RuntimeStatus(),
+		CreatedAt:      timestamppb.New(createdAt),
+		LastUpdatedAt:  timestamppb.New(lastUpdated),
+		Input:          wrapperspb.String(input),
+		Output:         wrapperspb.String(output),
+		CustomStatus:   state.CustomStatus,
+		FailureDetails: failureDetuils,
+	}, nil
 }
 
 // AbandonActivityWorkItem implements backend.Backend. It gets called by durabletask-go when there is
@@ -360,29 +363,14 @@ func (abe *Actors) GetActivityWorkItem(ctx context.Context) (*backend.ActivityWo
 
 // GetOrchestrationRuntimeState implements backend.Backend
 func (abe *Actors) GetOrchestrationRuntimeState(ctx context.Context, owi *backend.OrchestrationWorkItem) (*backend.OrchestrationRuntimeState, error) {
-	// Invoke the corresponding actor, which internally stores its own workflow state.
-	req := internalsv1pb.
-		NewInternalInvokeRequest(todo.GetWorkflowStateMethod).
-		WithActor(abe.workflowActorType, string(owi.InstanceID)).
-		WithContentType(invokev1.OctetStreamContentType)
-
-	engine, err := abe.actors.Engine(ctx)
+	state, err := abe.loadInternalState(ctx, owi.InstanceID)
 	if err != nil {
 		return nil, err
 	}
-
-	res, err := engine.Call(ctx, req)
-	if err != nil {
-		return nil, err
+	if state == nil {
+		return nil, api.ErrInstanceNotFound
 	}
-	wfState := &state.State{}
-	err = wfState.DecodeWorkflowState(res.GetMessage().GetData().GetValue())
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode the workflow actor response: %w", err)
-	}
-	// TODO: Add caching when a good invalidation policy can be determined
-	runtimeState := backend.NewOrchestrationRuntimeState(owi.InstanceID, wfState.History)
-
+	runtimeState := backend.NewOrchestrationRuntimeState(owi.InstanceID, state.History)
 	return runtimeState, nil
 }
 
@@ -477,4 +465,26 @@ func (*Actors) Stop(context.Context) error {
 // String displays the type information
 func (abe *Actors) String() string {
 	return "dapr.actors/v1"
+}
+
+func (abe *Actors) loadInternalState(ctx context.Context, id api.InstanceID) (*state.State, error) {
+	astate, err := abe.actors.State(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// actor id is workflow instance id
+	state, err := state.LoadWorkflowState(ctx, astate, string(id), state.Options{
+		AppID:             abe.appID,
+		WorkflowActorType: abe.workflowActorType,
+		ActivityActorType: abe.activityActorType,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		// No such state exists in the state store
+		return nil, nil
+	}
+	return state, nil
 }

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -241,7 +241,6 @@ func (abe *Actors) GetOrchestrationMetadata(ctx context.Context, id api.Instance
 		return nil, api.ErrInstanceNotFound
 	}
 
-	// runtimeState := getRuntimeState(w.actorID, state)
 	runtimeState := backend.NewOrchestrationRuntimeState(id, state.History)
 
 	name, _ := runtimeState.Name()

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -212,33 +212,6 @@ func (s *State) String() string {
 	)
 }
 
-// EncodeWorkflowState encodes the workflow state into a byte array.
-// It only encodes the inbox, history, and custom status.
-func (s *State) EncodeWorkflowState() ([]byte, error) {
-	return proto.Marshal(&backend.WorkflowState{
-		Inbox:        s.Inbox,
-		History:      s.History,
-		CustomStatus: s.CustomStatus,
-		Generation:   s.Generation,
-	})
-}
-
-// DecodeWorkflowState decodes the workflow state from a byte array encoded using `EncodeWorkflowState`.
-// It only decodes the inbox, history, and custom status.
-func (s *State) DecodeWorkflowState(encodedState []byte) error {
-	var decodedState backend.WorkflowState
-	if err := proto.Unmarshal(encodedState, &decodedState); err != nil {
-		return err
-	}
-
-	s.Inbox = decodedState.GetInbox()
-	s.History = decodedState.GetHistory()
-	s.CustomStatus = decodedState.CustomStatus //nolint:protogetter
-	s.Generation = decodedState.GetGeneration()
-
-	return nil
-}
-
 func addStateOperations(req *api.TransactionalRequest, keyPrefix string, events []*backend.HistoryEvent, addedCount int, removedCount int) error {
 	// TODO: Investigate whether Dapr state stores put limits on batch sizes. It seems some storage
 	//       providers have limits and we need to know if that impacts this algorithm:

--- a/pkg/runtime/wfengine/todo/todo.go
+++ b/pkg/runtime/wfengine/todo/todo.go
@@ -10,10 +10,8 @@ const (
 	CallbackChannelProperty = "dapr.callback"
 
 	CreateWorkflowInstanceMethod = "CreateWorkflowInstance"
-	GetWorkflowMetadataMethod    = "GetWorkflowMetadata"
 	AddWorkflowEventMethod       = "AddWorkflowEvent"
 	PurgeWorkflowStateMethod     = "PurgeWorkflowState"
-	GetWorkflowStateMethod       = "GetWorkflowState"
 	WaitForRuntimeStatus         = "WaitForRuntimeStatus"
 )
 

--- a/tests/integration/suite/actors/state/grpc.go
+++ b/tests/integration/suite/actors/state/grpc.go
@@ -60,11 +60,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		ActorId:   "123",
 		Key:       "key1",
 	})
-	require.Error(t, err)
-	s, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.Internal.String(), s.Code().String())
-	assert.Equal(t, "actor instance is missing", s.Message())
+	require.NoError(t, err)
 
 	_, err = client.ExecuteActorStateTransaction(ctx, &rtv1.ExecuteActorStateTransactionRequest{
 		ActorType: "abc",
@@ -76,7 +72,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		}},
 	})
 	require.Error(t, err)
-	s, ok = status.FromError(err)
+	s, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal.String(), s.Code().String())
 	assert.Equal(t, "actor instance is missing", s.Message())

--- a/tests/integration/suite/actors/state/http.go
+++ b/tests/integration/suite/actors/state/http.go
@@ -60,11 +60,11 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	assert.Equal(t, nethttp.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, nethttp.StatusNoContent, resp.StatusCode)
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, `{"errorCode":"ERR_ACTOR_INSTANCE_MISSING","message":"actor instance is missing"}`, string(b))
+	assert.Equal(t, ``, string(b))
 
 	reqBody := `[{"operation":"upsert","request":{"key":"key1","value":"value1"}}]`
 	url = fmt.Sprintf("http://%s/v1.0/actors/abc/123/state", h.app.Daprd().HTTPAddress())

--- a/tests/integration/suite/daprd/workflow/basic.go
+++ b/tests/integration/suite/daprd/workflow/basic.go
@@ -162,7 +162,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		id := api.InstanceID(b.startWorkflow(ctx, t, "Root", ""))
 
 		// Wait long enough to ensure all orchestrations have started (but not longer than the timer delay)
-		assert.Eventually(t, func() bool {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			// List of all orchestrations created
 			orchestrationIDs := []string{string(id)}
 			for i := range 5 {
@@ -170,13 +170,10 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			}
 			for _, orchID := range orchestrationIDs {
 				meta, err := backendClient.FetchOrchestrationMetadata(ctx, api.InstanceID(orchID))
-				require.NoError(t, err)
+				assert.NoError(c, err)
 				// All orchestrations should be running
-				if meta.GetRuntimeStatus() != api.RUNTIME_STATUS_RUNNING {
-					return false
-				}
+				assert.Equal(c, api.RUNTIME_STATUS_RUNNING, meta.GetRuntimeStatus())
 			}
-			return true
 		}, 2*time.Second, 10*time.Millisecond)
 
 		// Terminate the root orchestration

--- a/tests/integration/suite/daprd/workflow/scheduler/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/basic.go
@@ -193,7 +193,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			}
 			for _, orchID := range orchestrationIDs {
 				meta, err := backendClient.FetchOrchestrationMetadata(ctx, api.InstanceID(orchID))
-				require.NoError(t, err)
+				assert.NoError(c, err)
 				// All orchestrations should be running
 				assert.Equal(c, api.RUNTIME_STATUS_RUNNING.String(), meta.GetRuntimeStatus().String())
 			}

--- a/tests/integration/suite/scheduler/api/watchhosts.go
+++ b/tests/integration/suite/scheduler/api/watchhosts.go
@@ -129,13 +129,13 @@ func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
 
 	w.scheduler2.Cleanup(t)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		stream, err := w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, stream.CloseSend())
-		})
+	stream, err := w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, stream.CloseSend())
+	})
 
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := stream.Recv()
 		if !assert.NoError(c, err) {
 			return
@@ -153,11 +153,6 @@ func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
 	w.scheduler4.Run(t, ctx)
 	w.scheduler4.WaitUntilRunning(t, ctx)
 	t.Cleanup(func() { w.scheduler4.Cleanup(t) })
-	stream, err := w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, stream.CloseSend())
-	})
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := stream.Recv()


### PR DESCRIPTION
# Description

This needs some discussion because of the changes needed in `pkg/actors/state/state.go`

Since the last refactors, dapr now unregisters the workflow actor types when there are no workflow workers connected, this is makes everything that needs to read the workflow state to stop working... which previously, due to no actor types being unregistered, wasnt the case

The intention with this PR is to bring back that behavior, to be able to fetch the workflow state and metadata when there are no workflow workers connected.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
