### PR TITLE
Integration: increase timeout to 30m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ test-integration: test-deps
 			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
 			--format testname \
 			-- \
-			./tests/integration -timeout=20m -count=1 -v -tags="integration$(TEST_ADDITIONAL_TAGS)" -integration-parallel=false
+			./tests/integration -timeout=30m -count=1 -v -tags="integration$(TEST_ADDITIONAL_TAGS)" -integration-parallel=false
 
 .PHONY: test-integration-parallel
 test-integration-parallel: test-deps
@@ -392,7 +392,7 @@ test-integration-parallel: test-deps
 			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
 			--format testname \
 			-- \
-			./tests/integration -timeout=20m -count=1 -v -tags="integration$(TEST_ADDITIONAL_TAGS)" -integration-parallel=true
+			./tests/integration -timeout=30m -count=1 -v -tags="integration$(TEST_ADDITIONAL_TAGS)" -integration-parallel=true
 
 ################################################################################
 # Target: lint                                                                 #


### PR DESCRIPTION
CI is currently faiing int tests because they are slow, and take longer than 20m to run the tests. Updates the timeout to 30m.