### PR TITLE
GH Workflow: mov golanglangci-lint to its own job

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -46,7 +46,6 @@ jobs:
         target_os: ["linux"]
         target_arch: ["amd64"]
     env:
-      GOLANGCILINT_VER: "v1.61.0"
       PROTOC_VERSION: "25.4"
       GOOS: "${{ matrix.target_os }}"
       GOARCH: "${{ matrix.target_arch }}"
@@ -87,12 +86,6 @@ jobs:
           fi
       - name: Check for disallowed changes in go.mod
         run: node ./.github/scripts/check_go_mod.mjs
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.1.1
-        with:
-          version: ${{ env.GOLANGCILINT_VER }}
-          skip-cache: true
-          args: --build-tags allcomponents --timeout=10m
       - name: Run go mod tidy check diff
         run: make modtidy check-diff
       - name: Check for retracted dependencies
@@ -140,6 +133,37 @@ jobs:
       - name: Run govulncheck
         run: govulncheck -C '.' -format text --tags=uint,allcomponents,integration ./...
         shell: bash
+
+  lint-slow:
+    name: golangci-lint
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target_os: ["linux"]
+        target_arch: ["amd64"]
+    env:
+      GOLANGCILINT_VER: "v1.61.0"
+      GOOS: "${{ matrix.target_os }}"
+      GOARCH: "${{ matrix.target_arch }}"
+      GOPROXY: "https://proxy.golang.org"
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+      - name: Set up Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6.1.1
+        with:
+          version: ${{ env.GOLANGCILINT_VER }}
+          skip-cache: true
+          args: --build-tags allcomponents --timeout=15m
 
   unit-tests:
     name: Unit tests
@@ -238,7 +262,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: [unit-tests, integration-tests]
+    needs: [unit-tests, integration-tests, lint-slow]
     env:
       GOOS: "${{ matrix.target_os }}"
       GOARCH: "${{ matrix.target_arch }}"


### PR DESCRIPTION
Because golangci-lint is so slow, it means we wait a long time for the unit and int tests to begin running, slowing down over CI execution. Moves golangci-lint to be run along with uint and int tests.
