### PR TITLE
Fix make lint

### DIFF
--- a/.build-tools/cmd/check-lint-version.go
+++ b/.build-tools/cmd/check-lint-version.go
@@ -24,7 +24,7 @@ type GHWorkflow struct {
 				GOVER           string `yaml:"GOVER"`
 				GOLANGCILINTVER string `yaml:"GOLANGCILINT_VER"`
 			} `yaml:"env"`
-		} `yaml:"lint"`
+		} `yaml:"lint-slow"`
 	} `yaml:"jobs"`
 }
 


### PR DESCRIPTION
The `make lint` command uses the `GOLANGCILINT_VER` variable from the github workflow `.github/workflows/dapr.yml`. The variable was moved from the `lint` to the `lint-slow` job, resulting in the command failing.