### PR TITLE
Fixes datarace in `WaitUntilRunning`

### DIFF
--- a/tests/integration/framework/process/operator/operator.go
+++ b/tests/integration/framework/process/operator/operator.go
@@ -117,13 +117,13 @@ func (o *Operator) Cleanup(t *testing.T) {
 }
 
 func (o *Operator) WaitUntilRunning(t *testing.T, ctx context.Context) {
-	client := client.HTTP(t)
+	cl := client.HTTP(t)
 	assert.Eventually(t, func() bool {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/healthz", o.healthzPort), nil)
 		if err != nil {
 			return false
 		}
-		resp, err := client.Do(req)
+		resp, err := cl.Do(req)
 		if err != nil {
 			return false
 		}

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -159,17 +159,22 @@ func (s *Sentry) Cleanup(t *testing.T) {
 }
 
 func (s *Sentry) WaitUntilRunning(t *testing.T, ctx context.Context) {
-	client := client.HTTP(t)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/healthz", s.healthzPort), nil)
-	require.NoError(t, err)
+	cl := client.HTTP(t)
 
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		resp, err := client.Do(req)
-		if assert.NoError(c, err) {
-			defer resp.Body.Close()
-			assert.Equal(c, http.StatusOK, resp.StatusCode)
+	assert.Eventually(t, func() bool {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/healthz", s.healthzPort), nil)
+		if err != nil {
+			return false
 		}
+
+		resp, err := cl.Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
 	}, time.Second*20, 10*time.Millisecond)
+
 }
 
 func (s *Sentry) TrustAnchorsFile(t *testing.T) string {


### PR DESCRIPTION
Something got borked on my computer and I started getting this error on int tests (it went away after a restart):

```bash
failed to listen on :1091: listen tcp :1091: bind: address already in use\nraft server is not ready in time\nfailed to serve: grpc: the server has been stopped
```

This caused the  `EventuallyWithT` loop in `WaitUntilRunning` to run over itself so I was getting a data race warning:

```bash
==================
WARNING: DATA RACE
Write at 0x00c0005c4420 by goroutine 29767:
  github.com/stretchr/testify/assert.(*CollectT).Errorf()
      /Users/elenakolevska/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1869 +0x114
  github.com/stretchr/testify/assert.Fail()
      /Users/elenakolevska/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:333 +0x3a0
  github.com/stretchr/testify/assert.NoError()
      /Users/elenakolevska/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1495 +0x110
  github.com/dapr/dapr/tests/integration/framework/process/placement.(*Placement).WaitUntilRunning.func1()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/framework/process/placement/placement.go:140 +0x6c
  github.com/stretchr/testify/assert.EventuallyWithT.func1()
      /Users/elenakolevska/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1933 +0x44

Previous read at 0x00c0005c4420 by goroutine 165:
  github.com/stretchr/testify/assert.(*CollectT).Copy()
      /Users/elenakolevska/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1887 +0x6c
  github.com/stretchr/testify/assert.EventuallyWithT()
      /Users/elenakolevska/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1927 +0x38c
  github.com/dapr/dapr/tests/integration/framework/process/placement.(*Placement).WaitUntilRunning()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/framework/process/placement/placement.go:138 +0x1d0
  github.com/dapr/dapr/tests/integration/suite/placement/quorum.(*notls).Run()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/suite/placement/quorum/notls.go:64 +0xf0
  github.com/dapr/dapr/tests/integration.RunIntegrationTests.func3.1()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/integration.go:92 +0x9c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.3/libexec/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.23.3/libexec/src/testing/testing.go:1743 +0x40

Goroutine 29767 (running) created at:
  github.com/stretchr/testify/assert.EventuallyWithT()
      /Users/elenakolevska/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1932 +0x348
  github.com/dapr/dapr/tests/integration/framework/process/placement.(*Placement).WaitUntilRunning()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/framework/process/placement/placement.go:138 +0x1d0
  github.com/dapr/dapr/tests/integration/suite/placement/quorum.(*notls).Run()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/suite/placement/quorum/notls.go:64 +0xf0
  github.com/dapr/dapr/tests/integration.RunIntegrationTests.func3.1()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/integration.go:92 +0x9c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.3/libexec/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.23.3/libexec/src/testing/testing.go:1743 +0x40

Goroutine 165 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.23.3/libexec/src/testing/testing.go:1743 +0x5e0
  github.com/dapr/dapr/tests/integration.RunIntegrationTests.func3()
      /Users/elenakolevska/Diagrid/Code/dapr/tests/integration/integration.go:90 +0x200
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.23.3/libexec/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.23.3/libexec/src/testing/testing.go:1743 +0x40      
```