### PR TITLE
Workflow: fixup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -506,3 +506,5 @@ replace github.com/stretchr/testify => github.com/stretchr/testify v1.8.4
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
+
+replace github.com/dapr/durabletask-go => ../copy-durabletask-go

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9
-	github.com/dapr/durabletask-go v0.5.1-0.20250110210942-3c1cc0f50d3e
+	github.com/dapr/durabletask-go 47efd41cb84726d4dba2e2307d3cf56d5a6c37b6
 	github.com/dapr/kit v0.13.1-0.20250110192255-fb195706966f
 	github.com/diagridio/go-etcd-cron v0.3.2-0.20250114230631-fc7656460fe8
 	github.com/evanphx/json-patch/v5 v5.9.0
@@ -326,7 +326,6 @@ require (
 	github.com/machinebox/graphql v0.2.2 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/marusama/semaphore/v2 v2.5.0 // indirect
 	github.com/matoous/go-nanoid/v2 v2.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9
-	github.com/dapr/durabletask-go 47efd41cb84726d4dba2e2307d3cf56d5a6c37b6
+	github.com/dapr/durabletask-go v0.5.1-0.20250115143652-bb9397142c68
 	github.com/dapr/kit v0.13.1-0.20250110192255-fb195706966f
 	github.com/diagridio/go-etcd-cron v0.3.2-0.20250114230631-fc7656460fe8
 	github.com/evanphx/json-patch/v5 v5.9.0
@@ -505,5 +505,3 @@ replace github.com/stretchr/testify => github.com/stretchr/testify v1.8.4
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
-
-replace github.com/dapr/durabletask-go => ../copy-durabletask-go

--- a/go.sum
+++ b/go.sum
@@ -466,6 +466,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9 h1:y68C9PNQKZULAd+z9VsflNgpBGafwnrk+sYl57tBYeA=
 github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9/go.mod h1:jzKIWl+mK+iH2COvGMcc4sV1fFeB8RZ5q312CF2ZKok=
+github.com/dapr/durabletask-go v0.5.1-0.20250115143652-bb9397142c68 h1:QClE+zvTxyK/JmQSmyFRrCLGaG8xcTP6PNCGBMXOv74=
+github.com/dapr/durabletask-go v0.5.1-0.20250115143652-bb9397142c68/go.mod h1:uXofzwmQ68j1GflMILMiJfvwi1eZKM5OYLRDp7k1+GI=
 github.com/dapr/kit v0.13.1-0.20250110192255-fb195706966f h1:gugkO8r833phJ31v/HhCUOHxznAkuxdsC6KMh391NOE=
 github.com/dapr/kit v0.13.1-0.20250110192255-fb195706966f/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,6 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9 h1:y68C9PNQKZULAd+z9VsflNgpBGafwnrk+sYl57tBYeA=
 github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9/go.mod h1:jzKIWl+mK+iH2COvGMcc4sV1fFeB8RZ5q312CF2ZKok=
-github.com/dapr/durabletask-go v0.5.1-0.20250110210942-3c1cc0f50d3e h1:imTVKzBePUuM22ksh9KC+6k/8i7C5oWYkwV1TIB4dKs=
-github.com/dapr/durabletask-go v0.5.1-0.20250110210942-3c1cc0f50d3e/go.mod h1:9OKiBAxWjwVct4YaxoLLOlDGGJxCC3a5zi8zCX4AAQY=
 github.com/dapr/kit v0.13.1-0.20250110192255-fb195706966f h1:gugkO8r833phJ31v/HhCUOHxznAkuxdsC6KMh391NOE=
 github.com/dapr/kit v0.13.1-0.20250110192255-fb195706966f/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/go.sum
+++ b/go.sum
@@ -1163,8 +1163,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/marusama/semaphore/v2 v2.5.0 h1:o/1QJD9DBYOWRnDhPwDVAXQn6mQYD0gZaS1Tpx6DJGM=
-github.com/marusama/semaphore/v2 v2.5.0/go.mod h1:z9nMiNUekt/LTpTUQdpp+4sJeYqUGpwMHfW0Z8V8fnQ=
 github.com/matoous/go-nanoid v1.5.0/go.mod h1:zyD2a71IubI24efhpvkJz+ZwfwagzgSO6UNiFsZKN7U=
 github.com/matoous/go-nanoid/v2 v2.0.0 h1:d19kur2QuLeHmJBkvYkFdhFBzLoo1XVm2GgTpL+9Tj0=
 github.com/matoous/go-nanoid/v2 v2.0.0/go.mod h1:FtS4aGPVfEkxKxhdWPAspZpZSh1cOjtM7Ej/So3hR0g=

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -498,10 +498,14 @@ func (a *actors) WaitForRegisteredHosts(ctx context.Context) error {
 }
 
 func (a *actors) handleIdleActor(target targets.Idlable) {
-	if err := a.placement.Lock(context.Background()); err != nil {
+	// We don't use the placement context here as we are already deactivating the
+	// actor.
+	_, cancel, err := a.placement.Lock(context.Background())
+	if err != nil {
+		log.Errorf("Failed to lock placement for idle actor deactivation: %s", err)
 		return
 	}
-	defer a.placement.Unlock()
+	defer cancel()
 
 	log.Debugf("Actor %s is idle, deactivating", target.Key())
 

--- a/pkg/actors/engine/engine.go
+++ b/pkg/actors/engine/engine.go
@@ -120,7 +120,7 @@ func (e *engine) CallReminder(ctx context.Context, req *api.Reminder) error {
 func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
 	ctx, cancel, err := e.placement.Lock(ctx)
 	if err != nil {
-		return err
+		return backoff.Permanent(err)
 	}
 	defer cancel()
 
@@ -157,7 +157,7 @@ func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
 func (e *engine) callActor(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
 	ctx, cancel, err := e.placement.Lock(ctx)
 	if err != nil {
-		return nil, err
+		return nil, backoff.Permanent(err)
 	}
 	defer cancel()
 

--- a/pkg/actors/engine/engine.go
+++ b/pkg/actors/engine/engine.go
@@ -118,10 +118,11 @@ func (e *engine) CallReminder(ctx context.Context, req *api.Reminder) error {
 }
 
 func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
-	if err := e.placement.Lock(ctx); err != nil {
+	ctx, cancel, err := e.placement.Lock(ctx)
+	if err != nil {
 		return err
 	}
-	defer e.placement.Unlock()
+	defer cancel()
 
 	lar, err := e.placement.LookupActor(ctx, &api.LookupActorRequest{
 		ActorType: req.ActorType,
@@ -154,10 +155,11 @@ func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
 }
 
 func (e *engine) callActor(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
-	if err := e.placement.Lock(ctx); err != nil {
+	ctx, cancel, err := e.placement.Lock(ctx)
+	if err != nil {
 		return nil, err
 	}
-	defer e.placement.Unlock()
+	defer cancel()
 
 	lar, err := e.placement.LookupActor(ctx, &api.LookupActorRequest{
 		ActorType: req.GetActor().GetActorType(),

--- a/pkg/actors/internal/placement/client/client.go
+++ b/pkg/actors/internal/placement/client/client.go
@@ -16,7 +16,6 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -129,7 +128,8 @@ func (c *Client) Run(ctx context.Context) error {
 
 			if err := c.table.HaltAll(); err != nil {
 				unlock()
-				return fmt.Errorf("failed to halt all actors: %s", err)
+				log.Errorf("Error whilst deactivating all actors when shutting down client: %s", err)
+				return nil
 			}
 
 			if ctx.Err() != nil {

--- a/pkg/actors/internal/placement/client/client.go
+++ b/pkg/actors/internal/placement/client/client.go
@@ -124,11 +124,11 @@ func (c *Client) Run(ctx context.Context) error {
 		select {
 		case ch := <-c.reconnectCh:
 			c.ready.Store(false)
-			c.lock.LockTable()
+			unlock := c.lock.Lock()
 			connCancel()
 
 			if err := c.table.HaltAll(); err != nil {
-				c.lock.EnsureUnlockTable()
+				unlock()
 				return fmt.Errorf("failed to halt all actors: %s", err)
 			}
 
@@ -137,11 +137,11 @@ func (c *Client) Run(ctx context.Context) error {
 			}
 
 			connCtx, connCancel = context.WithCancel(ctx)
-			defer connCancel()
 			err := c.connectRoundRobin(connCtx)
 			ch <- err
-			c.lock.EnsureUnlockTable()
+			unlock()
 			if err != nil {
+				connCancel()
 				return err
 			}
 
@@ -150,8 +150,8 @@ func (c *Client) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			c.ready.Store(false)
 			connCancel()
-			c.lock.LockTable()
-			defer c.lock.EnsureUnlockTable()
+			unlock := c.lock.Lock()
+			defer unlock()
 			if err := c.table.HaltAll(); err != nil {
 				log.Errorf("Error whilst deactivating all actors when shutting down client: %s", err)
 			}

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -51,7 +51,7 @@ type Lock struct {
 func New() *Lock {
 	return &Lock{
 		lock:         make(chan struct{}, 1),
-		ch:           make(chan *hold),
+		ch:           make(chan *hold, 1),
 		rcancels:     make(map[uint64]context.CancelFunc),
 		closeCh:      make(chan struct{}),
 		shutdownLock: fifo.New(),
@@ -129,7 +129,7 @@ func (l *Lock) handleHold(h *hold) {
 func (l *Lock) Lock() context.CancelFunc {
 	h := hold{
 		writeLock: true,
-		respCh:    make(chan *holdresp),
+		respCh:    make(chan *holdresp, 1),
 	}
 
 	select {
@@ -152,7 +152,7 @@ func (l *Lock) RLock(ctx context.Context) (context.Context, context.CancelFunc, 
 	h := hold{
 		writeLock: false,
 		rctx:      ctx,
-		respCh:    make(chan *holdresp),
+		respCh:    make(chan *holdresp, 1),
 	}
 
 	select {

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -14,43 +14,156 @@ limitations under the License.
 package lock
 
 import (
+	"context"
+	"errors"
 	"sync"
 
 	"github.com/dapr/kit/concurrency/fifo"
 )
 
+var errLockClosed = errors.New("placement lock closed")
+
+type hold struct {
+	writeLock bool
+	rctx      context.Context
+	respCh    chan *holdresp
+}
+
+type holdresp struct {
+	rctx   context.Context
+	cancel context.CancelFunc
+}
+
 type Lock struct {
-	tableLock   *fifo.Mutex
-	inTableLock bool
-	lookupLock  sync.RWMutex
+	ch chan *hold
+
+	lock chan struct{}
+
+	wg          sync.WaitGroup
+	rcancelLock sync.Mutex
+	rcancelx    uint64
+	rcancels    map[uint64]context.CancelFunc
+
+	closeCh      chan struct{}
+	shutdownLock *fifo.Mutex
 }
 
 func New() *Lock {
 	return &Lock{
-		tableLock: fifo.New(),
+		lock:         make(chan struct{}, 1),
+		ch:           make(chan *hold),
+		rcancels:     make(map[uint64]context.CancelFunc),
+		closeCh:      make(chan struct{}),
+		shutdownLock: fifo.New(),
 	}
 }
 
-func (l *Lock) LockTable() {
-	l.tableLock.Lock()
-	defer l.tableLock.Unlock()
-	l.lookupLock.Lock()
-	l.inTableLock = true
-}
+func (l *Lock) Run(ctx context.Context) {
+	defer func() {
+		l.rcancelLock.Lock()
+		defer l.rcancelLock.Unlock()
 
-func (l *Lock) EnsureUnlockTable() {
-	l.tableLock.Lock()
-	defer l.tableLock.Unlock()
-	if l.inTableLock {
-		l.inTableLock = false
-		l.lookupLock.Unlock()
+		for _, cancel := range l.rcancels {
+			cancel()
+		}
+		l.wg.Wait()
+	}()
+
+	go func() {
+		<-ctx.Done()
+		close(l.closeCh)
+	}()
+
+	for {
+		select {
+		case <-l.closeCh:
+			return
+		case h := <-l.ch:
+			l.handleHold(h)
+		}
 	}
 }
 
-func (l *Lock) LockLookup() {
-	l.lookupLock.RLock()
+func (l *Lock) handleHold(h *hold) {
+	l.lock <- struct{}{}
+	l.rcancelLock.Lock()
+
+	if h.writeLock {
+		for _, cancel := range l.rcancels {
+			go cancel()
+		}
+		l.rcancelx = 0
+		l.rcancelLock.Unlock()
+		l.wg.Wait()
+
+		h.respCh <- &holdresp{cancel: func() { <-l.lock }}
+
+		return
+	}
+
+	l.wg.Add(1)
+	rctx, cancel := context.WithCancel(h.rctx)
+	i := l.rcancelx
+
+	rcancel := func() {
+		l.rcancelLock.Lock()
+		cancel()
+		delete(l.rcancels, i)
+		l.rcancelLock.Unlock()
+		l.wg.Done()
+	}
+
+	l.rcancels[i] = rcancel
+	l.rcancelx++
+
+	l.rcancelLock.Unlock()
+
+	h.respCh <- &holdresp{rctx: rctx, cancel: rcancel}
+
+	<-l.lock
 }
 
-func (l *Lock) UnlockLookup() {
-	l.lookupLock.RUnlock()
+func (l *Lock) Lock() context.CancelFunc {
+	h := hold{
+		writeLock: true,
+		respCh:    make(chan *holdresp),
+	}
+
+	select {
+	case <-l.closeCh:
+		l.shutdownLock.Lock()
+		return l.shutdownLock.Unlock
+	case l.ch <- &h:
+	}
+
+	select {
+	case <-l.closeCh:
+		l.shutdownLock.Lock()
+		return l.shutdownLock.Unlock
+	case resp := <-h.respCh:
+		return resp.cancel
+	}
+}
+
+func (l *Lock) RLock(ctx context.Context) (context.Context, context.CancelFunc, error) {
+	h := hold{
+		writeLock: false,
+		rctx:      ctx,
+		respCh:    make(chan *holdresp),
+	}
+
+	select {
+	case <-l.closeCh:
+		return nil, nil, errLockClosed
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case l.ch <- &h:
+	}
+
+	select {
+	case <-l.closeCh:
+		return nil, nil, errLockClosed
+	case resp := <-h.respCh:
+		return resp.rctx, resp.cancel, nil
+	}
 }

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -66,7 +66,6 @@ func (l *Lock) Run(ctx context.Context) {
 		for _, cancel := range l.rcancels {
 			cancel()
 		}
-		l.wg.Wait()
 	}()
 
 	go func() {

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -102,15 +102,19 @@ func (l *Lock) handleHold(h *hold) {
 	}
 
 	l.wg.Add(1)
+	var done bool
 	rctx, cancel := context.WithCancel(h.rctx)
 	i := l.rcancelx
 
 	rcancel := func() {
 		l.rcancelLock.Lock()
-		cancel()
-		delete(l.rcancels, i)
+		if !done {
+			cancel()
+			delete(l.rcancels, i)
+			l.wg.Done()
+			done = true
+		}
 		l.rcancelLock.Unlock()
-		l.wg.Done()
 	}
 
 	l.rcancels[i] = rcancel

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -64,7 +64,7 @@ func (l *Lock) Run(ctx context.Context) {
 		defer l.rcancelLock.Unlock()
 
 		for _, cancel := range l.rcancels {
-			cancel()
+			go cancel()
 		}
 	}()
 

--- a/pkg/actors/internal/placement/lock/lock_test.go
+++ b/pkg/actors/internal/placement/lock/lock_test.go
@@ -138,22 +138,6 @@ func Test_Lock(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("rlock when context closed should error", func(t *testing.T) {
-		t.Parallel()
-
-		l := New()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-
-		go l.Run(ctx)
-
-		ctxr, cancelr := context.WithCancel(context.Background())
-		cancelr()
-		_, _, err := l.RLock(ctxr)
-		require.Error(t, err)
-	})
-
 	t.Run("lock continues to work after close", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/actors/internal/placement/lock/lock_test.go
+++ b/pkg/actors/internal/placement/lock/lock_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Lock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("can rlock multiple times", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctx1, c1, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx2, c2, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx3, c3, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c1()
+		require.Error(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c2()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		c3()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.Error(t, ctx3.Err())
+	})
+
+	t.Run("rlock unlock removes cancel state", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		_, c1, err := l.RLock(ctx)
+		require.NoError(t, err)
+		_, c2, err := l.RLock(ctx)
+		require.NoError(t, err)
+		_, c3, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		assert.Len(t, l.rcancels, 3)
+		c1()
+		assert.Len(t, l.rcancels, 2)
+		c2()
+		assert.Len(t, l.rcancels, 1)
+		c3()
+		assert.Empty(t, l.rcancels, 0)
+	})
+
+	t.Run("calling lock cancels all current rlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctx1, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx2, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+		ctx3, _, err := l.RLock(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, ctx1.Err())
+		require.NoError(t, ctx2.Err())
+		require.NoError(t, ctx3.Err())
+
+		mcancel := l.Lock()
+		require.Error(t, ctx1.Err())
+		require.Error(t, ctx2.Err())
+		require.Error(t, ctx3.Err())
+		mcancel()
+
+		assert.Empty(t, l.rcancels)
+	})
+
+	t.Run("rlock when closed should error", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		go l.Run(ctx)
+
+		select {
+		case <-l.closeCh:
+		case <-time.After(time.Second * 5):
+			assert.Fail(t, "expected close")
+		}
+
+		_, _, err := l.RLock(context.Background())
+		require.Error(t, err)
+	})
+
+	t.Run("rlock when context closed should error", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		ctxr, cancelr := context.WithCancel(context.Background())
+		cancelr()
+		_, _, err := l.RLock(ctxr)
+		require.Error(t, err)
+	})
+
+	t.Run("lock continues to work after close", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		l.Run(ctx)
+
+		lcancel := l.Lock()
+		lcancel()
+		lcancel = l.Lock()
+		lcancel()
+	})
+
+	t.Run("rlock blocks until outter unlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		lcancel := l.Lock()
+
+		gotRLock := make(chan struct{})
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, c1, err := l.RLock(ctx)
+			errCh <- err
+			t.Cleanup(c1)
+			close(gotRLock)
+		}()
+		t.Cleanup(func() {
+			require.NoError(t, <-errCh)
+		})
+
+		select {
+		case <-time.After(time.Millisecond * 500):
+		case <-gotRLock:
+			require.Fail(t, "unexpected rlock")
+		}
+
+		lcancel()
+	})
+
+	t.Run("lock blocks until outter unlocks", func(t *testing.T) {
+		t.Parallel()
+
+		l := New()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		go l.Run(ctx)
+
+		lcancel := l.Lock()
+
+		gotLock := make(chan struct{})
+
+		go func() {
+			lockcancel := l.Lock()
+			t.Cleanup(lockcancel)
+			close(gotLock)
+		}()
+
+		select {
+		case <-time.After(time.Millisecond * 500):
+		case <-gotLock:
+			require.Fail(t, "unexpected rlock")
+		}
+
+		lcancel()
+	})
+}

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -94,8 +94,6 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	// do not check if actor is hosted...
-
 	storeName, store, err := s.stateStore()
 	if err != nil {
 		return nil, err
@@ -135,8 +133,6 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error) {
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
-
-	// do not check if actor is hosted...
 
 	storeName, store, err := s.stateStore()
 	if err != nil {

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -91,8 +91,11 @@ func New(opts Options) Interface {
 }
 
 func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateResponse, error) {
-	s.placement.Lock(ctx)
-	defer s.placement.Unlock()
+	ctx, cancel, err := s.placement.Lock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -131,8 +134,11 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 }
 
 func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error) {
-	s.placement.Lock(ctx)
-	defer s.placement.Unlock()
+	ctx, cancel, err := s.placement.Lock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -177,9 +183,12 @@ func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.
 	return bulkRes, nil
 }
 
-func (s *state) TransactionalStateOperation(ctx context.Context, req *api.TransactionalRequest) (err error) {
-	s.placement.Lock(ctx)
-	defer s.placement.Unlock()
+func (s *state) TransactionalStateOperation(ctx context.Context, req *api.TransactionalRequest) error {
+	ctx, cancel, err := s.placement.Lock(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
 
 	if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
 		return messages.ErrActorInstanceMissing

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -94,9 +94,16 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-		return nil, messages.ErrActorInstanceMissing
-	}
+	// TODO is it ok to allow access (just read only) to an actor state even if the instance is not hosted?
+	// this is needed for LoadWorkflowState in pkg/runtime/wfengine/state/state.go to work
+	// since now the workflow state is not read from the actor but from the backend interface
+	// the final goal is to be able to fetch the workflow state and metadata even if there is no workflows stream connected
+	// which now if there are no workflows stream connected the actor types are unregistered, hence making it impossible to read the workflow state (because the actor is no longer hosted...)
+
+	// do not check if actor is hosted...
+	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
+	// 	return nil, messages.ErrActorInstanceMissing
+	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -138,9 +145,10 @@ func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-		return nil, messages.ErrActorInstanceMissing
-	}
+	// do not check if actor is hosted...
+	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
+	// 	return nil, messages.ErrActorInstanceMissing
+	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -94,16 +94,7 @@ func (s *state) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateRe
 	s.placement.Lock(ctx)
 	defer s.placement.Unlock()
 
-	// TODO is it ok to allow access (just read only) to an actor state even if the instance is not hosted?
-	// this is needed for LoadWorkflowState in pkg/runtime/wfengine/state/state.go to work
-	// since now the workflow state is not read from the actor but from the backend interface
-	// the final goal is to be able to fetch the workflow state and metadata even if there is no workflows stream connected
-	// which now if there are no workflows stream connected the actor types are unregistered, hence making it impossible to read the workflow state (because the actor is no longer hosted...)
-
 	// do not check if actor is hosted...
-	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-	// 	return nil, messages.ErrActorInstanceMissing
-	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {
@@ -146,9 +137,6 @@ func (s *state) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.
 	defer s.placement.Unlock()
 
 	// do not check if actor is hosted...
-	// if _, ok := s.table.HostedTarget(req.ActorType, req.ActorID); !ok {
-	// 	return nil, messages.ErrActorInstanceMissing
-	// }
 
 	storeName, store, err := s.stateStore()
 	if err != nil {

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -164,23 +164,6 @@ func (w *workflow) executeMethod(ctx context.Context, methodName string, request
 	case todo.CreateWorkflowInstanceMethod:
 		return nil, w.createWorkflowInstance(ctx, request)
 
-	case todo.GetWorkflowMetadataMethod:
-		meta, err := w.getWorkflowMetadata(ctx)
-		if err != nil {
-			log.Errorf("Workflow actor '%s': failed to get workflow metadata: %v", w.actorID, err)
-			return nil, err
-		}
-		return proto.Marshal(meta)
-
-	case todo.GetWorkflowStateMethod:
-		var state *wfenginestate.State
-		state, err := w.getWorkflowState(ctx)
-		if err != nil {
-			log.Errorf("Workflow actor '%s': failed to get workflow state: %v", w.actorID, err)
-			return nil, err
-		}
-		return state.EncodeWorkflowState()
-
 	case todo.AddWorkflowEventMethod:
 		return nil, w.addWorkflowEvent(ctx, request)
 
@@ -389,29 +372,6 @@ func (w *workflow) cleanupWorkflowStateInternal(ctx context.Context, state *wfen
 	w.rstate = nil
 	w.ometa = nil
 	return nil
-}
-
-func (w *workflow) getWorkflowMetadata(ctx context.Context) (*backend.OrchestrationMetadata, error) {
-	state, err := w.loadInternalState(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if state == nil {
-		return nil, api.ErrInstanceNotFound
-	}
-
-	return w.ometa, nil
-}
-
-func (w *workflow) getWorkflowState(ctx context.Context) (*wfenginestate.State, error) {
-	state, err := w.loadInternalState(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if state == nil {
-		return nil, api.ErrInstanceNotFound
-	}
-	return state, nil
 }
 
 // This method purges all the completed activity data from a workflow associated with the given actorID

--- a/pkg/runtime/scheduler/scheduler.go
+++ b/pkg/runtime/scheduler/scheduler.go
@@ -111,11 +111,12 @@ func (s *Scheduler) Run(ctx context.Context) error {
 					return nil
 				}
 
+				defer stream.CloseSend()
+
 				var resp *schedulerv1pb.WatchHostsResponse
 				resp, err = stream.Recv()
 				if err != nil {
 					log.Errorf("Failed to receive scheduler hosts: %s", err)
-					//nolint:nilerr
 					return nil
 				}
 				addresses = make([]string, 0, len(resp.GetHosts()))
@@ -128,10 +129,6 @@ func (s *Scheduler) Run(ctx context.Context) error {
 				return nil
 			},
 		).Run(ctx)
-
-		if stream != nil {
-			stream.CloseSend()
-		}
 
 		if err != nil || ctx.Err() != nil {
 			return err

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -123,7 +123,6 @@ func (abe *Actors) RegisterActors(ctx context.Context) error {
 						ActivityActorType: abe.activityActorType,
 						WorkflowActorType: abe.workflowActorType,
 						ReminderInterval:  abe.defaultReminderInterval,
-						Scheduler:         getActivityScheduler(abe.activityWorkItemChan),
 						Scheduler: func(ctx context.Context, wi *backend.ActivityWorkItem) error {
 							log.Debugf(
 								"%s: scheduling [%s#%d] activity execution with durabletask engine",

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -234,7 +234,6 @@ func (abe *Actors) GetOrchestrationMetadata(ctx context.Context, id api.Instance
 		return nil, api.ErrInstanceNotFound
 	}
 
-	// runtimeState := getRuntimeState(w.actorID, state)
 	runtimeState := backend.NewOrchestrationRuntimeState(id, state.History)
 
 	name, _ := runtimeState.Name()

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -97,18 +97,18 @@ func (s *State) ResetChangeTracking() {
 	s.historyRemovedCount = 0
 }
 
-func (s *State) ApplyRuntimeStateChanges(runtimeState *backend.OrchestrationRuntimeState) {
-	if runtimeState.ContinuedAsNew() {
+func (s *State) ApplyRuntimeStateChanges(rs *backend.OrchestrationRuntimeState) {
+	if rs.GetContinuedAsNew() {
 		s.historyRemovedCount += len(s.History)
 		s.historyAddedCount = 0
 		s.History = nil
 	}
 
-	newHistoryEvents := runtimeState.NewEvents()
+	newHistoryEvents := rs.GetNewEvents()
 	s.History = append(s.History, newHistoryEvents...)
 	s.historyAddedCount += len(newHistoryEvents)
 
-	s.CustomStatus = runtimeState.CustomStatus
+	s.CustomStatus = rs.GetCustomStatus()
 }
 
 func (s *State) AddToInbox(e *backend.HistoryEvent) {

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -212,33 +212,6 @@ func (s *State) String() string {
 	)
 }
 
-// EncodeWorkflowState encodes the workflow state into a byte array.
-// It only encodes the inbox, history, and custom status.
-func (s *State) EncodeWorkflowState() ([]byte, error) {
-	return proto.Marshal(&backend.WorkflowState{
-		Inbox:        s.Inbox,
-		History:      s.History,
-		CustomStatus: s.CustomStatus,
-		Generation:   s.Generation,
-	})
-}
-
-// DecodeWorkflowState decodes the workflow state from a byte array encoded using `EncodeWorkflowState`.
-// It only decodes the inbox, history, and custom status.
-func (s *State) DecodeWorkflowState(encodedState []byte) error {
-	var decodedState backend.WorkflowState
-	if err := proto.Unmarshal(encodedState, &decodedState); err != nil {
-		return err
-	}
-
-	s.Inbox = decodedState.GetInbox()
-	s.History = decodedState.GetHistory()
-	s.CustomStatus = decodedState.CustomStatus //nolint:protogetter
-	s.Generation = decodedState.GetGeneration()
-
-	return nil
-}
-
 func addStateOperations(req *api.TransactionalRequest, keyPrefix string, events []*backend.HistoryEvent, addedCount int, removedCount int) error {
 	// TODO: Investigate whether Dapr state stores put limits on batch sizes. It seems some storage
 	//       providers have limits and we need to know if that impacts this algorithm:

--- a/pkg/runtime/wfengine/todo/todo.go
+++ b/pkg/runtime/wfengine/todo/todo.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	// TODO: @joshvanl: remove
 	CallbackChannelProperty = "dapr.callback"
 
 	CreateWorkflowInstanceMethod = "CreateWorkflowInstance"
@@ -16,9 +17,7 @@ const (
 )
 
 // WorkflowScheduler is a func interface for pushing workflow (orchestration) work items into the backend
-// TODO: @joshvanl: remove
 type WorkflowScheduler func(ctx context.Context, wi *backend.OrchestrationWorkItem) error
 
 // ActivityScheduler is a func interface for pushing activity work items into the backend
-// TODO: @joshvanl: remove
 type ActivityScheduler func(ctx context.Context, wi *backend.ActivityWorkItem) error

--- a/pkg/runtime/wfengine/todo/todo.go
+++ b/pkg/runtime/wfengine/todo/todo.go
@@ -10,10 +10,8 @@ const (
 	CallbackChannelProperty = "dapr.callback"
 
 	CreateWorkflowInstanceMethod = "CreateWorkflowInstance"
-	GetWorkflowMetadataMethod    = "GetWorkflowMetadata"
 	AddWorkflowEventMethod       = "AddWorkflowEvent"
 	PurgeWorkflowStateMethod     = "PurgeWorkflowState"
-	GetWorkflowStateMethod       = "GetWorkflowState"
 	WaitForRuntimeStatus         = "WaitForRuntimeStatus"
 )
 

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -112,17 +112,17 @@ func New(opts Options) (Interface, error) {
 	)
 
 	// There are separate "workers" for executing orchestrations (workflows) and activities
-	orchestrationWorker := backend.NewOrchestrationWorker(
+	oworker := backend.NewOrchestrationWorker(
 		abackend,
 		executor,
 		wfBackendLogger,
 		backend.WithMaxParallelism(opts.Spec.GetMaxConcurrentWorkflowInvocations()))
-	activityWorker := backend.NewActivityTaskWorker(
+	aworker := backend.NewActivityTaskWorker(
 		abackend,
 		executor,
 		wfBackendLogger,
 		backend.WithMaxParallelism(opts.Spec.GetMaxConcurrentActivityInvocations()))
-	worker := backend.NewTaskHubWorker(abackend, orchestrationWorker, activityWorker, wfBackendLogger)
+	worker := backend.NewTaskHubWorker(abackend, oworker, aworker, wfBackendLogger)
 
 	return &engine{
 		appID:                opts.AppID,

--- a/pkg/scheduler/server/internal/cron/cron.go
+++ b/pkg/scheduler/server/internal/cron/cron.go
@@ -15,6 +15,7 @@ package cron
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -240,9 +241,9 @@ func (c *cron) HostsWatch(stream schedulerv1pb.Scheduler_WatchHostsServer) error
 	for {
 		select {
 		case <-stream.Context().Done():
-			return nil
+			return stream.Context().Err()
 		case <-c.closeCh:
-			return nil
+			return errors.New("cron closed")
 		case hosts, ok := <-watchHostsCh:
 			if !ok {
 				return nil

--- a/pkg/scheduler/server/server.go
+++ b/pkg/scheduler/server/server.go
@@ -134,7 +134,14 @@ func (s *Server) Run(ctx context.Context) error {
 
 	runners := []concurrency.Runner{
 		s.runServer,
-		s.cron.Run,
+		func(ctx context.Context) error {
+			err := s.cron.Run(ctx)
+			if ctx.Err() != nil {
+				log.Errorf("Error running scheduler cron: %s", err)
+				return ctx.Err()
+			}
+			return err
+		},
 		func(ctx context.Context) error {
 			<-ctx.Done()
 			close(s.closeCh)

--- a/pkg/scheduler/server/server.go
+++ b/pkg/scheduler/server/server.go
@@ -137,7 +137,9 @@ func (s *Server) Run(ctx context.Context) error {
 		func(ctx context.Context) error {
 			err := s.cron.Run(ctx)
 			if ctx.Err() != nil {
-				log.Errorf("Error running scheduler cron: %s", err)
+				if err != nil {
+					log.Errorf("Error running scheduler cron: %s", err)
+				}
 				return ctx.Err()
 			}
 			return err

--- a/tests/e2e/actor_state/actor_state_test.go
+++ b/tests/e2e/actor_state/actor_state_test.go
@@ -120,10 +120,6 @@ func TestActorState(t *testing.T) {
 			assert.Equal(t, http.StatusOK, code)
 			assert.Equal(t, `"myData"`, string(resp))
 
-			_, code, err = utils.HTTPGetWithStatus(fmt.Sprintf("%s/httpMyActorType/%s-notMyActorID/myKey", httpURL, actuid))
-			require.NoError(t, err)
-			assert.Equal(t, http.StatusBadRequest, code)
-
 			newData := []byte(`[{"operation":"upsert","request":{"key":"myKey","value":"newData"}}]`)
 			resp, code, err = utils.HTTPPostWithStatus(fmt.Sprintf("%s/httpMyActorType/%s-myActorID", httpURL, actuid), newData)
 			require.NoError(t, err)
@@ -237,14 +233,6 @@ func TestActorState(t *testing.T) {
 			var gresp runtimev1.GetActorStateResponse
 			require.NoError(t, json.Unmarshal(resp, &gresp))
 			assert.Equal(t, []byte("myData"), gresp.Data)
-
-			b, err = json.Marshal(&runtimev1.GetActorStateRequest{
-				ActorType: "grpcMyActorType", ActorId: "notmyActorID", Key: "myKey",
-			})
-			require.NoError(t, err)
-			_, code, err = utils.HTTPGetWithStatusWithData(grpcURL, b)
-			require.NoError(t, err)
-			assert.Equal(t, http.StatusInternalServerError, code)
 
 			b, err = json.Marshal(&runtimev1.ExecuteActorStateTransactionRequest{
 				ActorType: "grpcMyActorType", ActorId: fmt.Sprintf("%s-myActorID", actuid),

--- a/tests/e2e/workflows/workflow_test.go
+++ b/tests/e2e/workflows/workflow_test.go
@@ -251,7 +251,7 @@ func purgeTest(url string, instanceID string) func(t *testing.T) {
 		resp, err = utils.HTTPPost(fmt.Sprintf("%s/StartWorkflow/dapr/placeOrder/%s", url, instanceID), nil)
 		require.NoError(t, err, "failure starting workflow")
 
-		require.Equal(t, instanceID, string(resp))
+		assert.Equal(t, instanceID, string(resp))
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			resp, err = utils.HTTPGet(getString)

--- a/tests/e2e/workflows/workflow_test.go
+++ b/tests/e2e/workflows/workflow_test.go
@@ -102,7 +102,7 @@ func startTest(url string, instanceID string) func(t *testing.T) {
 			resp, err = utils.HTTPGet(getString)
 			assert.NoError(t, err, "failure getting info on workflow")
 			assert.Equalf(t, "Running", string(resp), "expected workflow to be Running, actual workflow state is: %s", string(resp))
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 10*time.Second, 100*time.Millisecond)
 	}
 }
 
@@ -217,7 +217,7 @@ func purgeTest(url string, instanceID string) func(t *testing.T) {
 			resp, err = utils.HTTPGet(getString)
 			require.NoError(t, err, "failure getting info on workflow")
 			assert.Equalf(t, "Running", string(resp), "expected workflow to be Running, actual workflow state is: %s", string(resp))
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 10*time.Second, 100*time.Millisecond)
 
 		// Raise an event on the workflow
 		resp, err = utils.HTTPPost(fmt.Sprintf("%s/RaiseWorkflowEvent/dapr/%s/ChangePurchaseItem/1", url, instanceID), nil)
@@ -287,7 +287,7 @@ func monitorTest(url string, instanceID string) func(t *testing.T) {
 			resp, err = utils.HTTPGet(getString)
 			assert.NoError(t, err, "failure getting info on workflow")
 			assert.Equalf(t, "Running", string(resp), "expected workflow to be Running, actual workflow state is: %s", string(resp))
-		}, 5*time.Second, 100*time.Millisecond)
+		}, 10*time.Second, 100*time.Millisecond)
 
 		// Start the monitor workflow
 		monitorInstanceID := "m-" + instanceID

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -16,7 +16,9 @@ package placement
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -228,7 +230,9 @@ func (p *Placement) RegisterHost(t *testing.T, parentCtx context.Context, msg *p
 		cancel()
 		select {
 		case err := <-doneCh:
-			require.NoError(t, err)
+			if !errors.Is(err, io.EOF) {
+				require.NoError(t, err)
+			}
 		case <-time.After(time.Second * 5):
 			assert.Fail(t, "timeout waiting for stream to close")
 		}

--- a/tests/integration/suite/actors/state/grpc.go
+++ b/tests/integration/suite/actors/state/grpc.go
@@ -60,11 +60,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		ActorId:   "123",
 		Key:       "key1",
 	})
-	require.Error(t, err)
-	s, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.Internal.String(), s.Code().String())
-	assert.Equal(t, "actor instance is missing", s.Message())
+	require.NoError(t, err)
 
 	_, err = client.ExecuteActorStateTransaction(ctx, &rtv1.ExecuteActorStateTransactionRequest{
 		ActorType: "abc",
@@ -76,7 +72,7 @@ func (g *grpc) Run(t *testing.T, ctx context.Context) {
 		}},
 	})
 	require.Error(t, err)
-	s, ok = status.FromError(err)
+	s, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal.String(), s.Code().String())
 	assert.Equal(t, "actor instance is missing", s.Message())

--- a/tests/integration/suite/actors/state/http.go
+++ b/tests/integration/suite/actors/state/http.go
@@ -60,11 +60,11 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	assert.Equal(t, nethttp.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, nethttp.StatusNoContent, resp.StatusCode)
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, `{"errorCode":"ERR_ACTOR_INSTANCE_MISSING","message":"actor instance is missing"}`, string(b))
+	assert.Equal(t, ``, string(b))
 
 	reqBody := `[{"operation":"upsert","request":{"key":"key1","value":"value1"}}]`
 	url = fmt.Sprintf("http://%s/v1.0/actors/abc/123/state", h.app.Daprd().HTTPAddress())

--- a/tests/integration/suite/daprd/jobs/streaming/staged.go
+++ b/tests/integration/suite/daprd/jobs/streaming/staged.go
@@ -129,7 +129,7 @@ func (s *staged) Run(t *testing.T, ctx context.Context) {
 		// Allow for greater that three "test"s because a trigger may have failed
 		// on the backend due to scheduler shutting down during tick execution.
 		assert.GreaterOrEqual(c, numOf(s.triggered.Slice(), "test"), 2)
-		assert.Contains(t, s.triggered.Slice(), "test2")
+		assert.Contains(c, s.triggered.Slice(), "test2")
 	}, 10*time.Second, 10*time.Millisecond)
 
 	s.daprdB.Cleanup(t)

--- a/tests/integration/suite/daprd/workflow/basic.go
+++ b/tests/integration/suite/daprd/workflow/basic.go
@@ -162,7 +162,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		id := api.InstanceID(b.startWorkflow(ctx, t, "Root", ""))
 
 		// Wait long enough to ensure all orchestrations have started (but not longer than the timer delay)
-		assert.Eventually(t, func() bool {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			// List of all orchestrations created
 			orchestrationIDs := []string{string(id)}
 			for i := range 5 {
@@ -170,13 +170,10 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			}
 			for _, orchID := range orchestrationIDs {
 				meta, err := backendClient.FetchOrchestrationMetadata(ctx, api.InstanceID(orchID))
-				require.NoError(t, err)
+				assert.NoError(c, err)
 				// All orchestrations should be running
-				if meta.GetRuntimeStatus() != api.RUNTIME_STATUS_RUNNING {
-					return false
-				}
+				assert.Equal(c, api.RUNTIME_STATUS_RUNNING, meta.GetRuntimeStatus())
 			}
-			return true
 		}, 2*time.Second, 10*time.Millisecond)
 
 		// Terminate the root orchestration

--- a/tests/integration/suite/daprd/workflow/scheduler/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/basic.go
@@ -193,7 +193,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			}
 			for _, orchID := range orchestrationIDs {
 				meta, err := backendClient.FetchOrchestrationMetadata(ctx, api.InstanceID(orchID))
-				require.NoError(t, err)
+				assert.NoError(c, err)
 				// All orchestrations should be running
 				assert.Equal(c, api.RUNTIME_STATUS_RUNNING.String(), meta.GetRuntimeStatus().String())
 			}

--- a/tests/integration/suite/daprd/workflow/timer.go
+++ b/tests/integration/suite/daprd/workflow/timer.go
@@ -51,7 +51,6 @@ func (i *timer) Run(t *testing.T, ctx context.Context) {
 		if err := ctx.CreateTimer(time.Second * 4).Await(nil); err != nil {
 			return nil, err
 		}
-
 		require.NoError(t, ctx.CallActivity("abc", task.WithActivityInput("abc")).Await(nil))
 		return nil, nil
 	})

--- a/tests/integration/suite/scheduler/api/watchhosts.go
+++ b/tests/integration/suite/scheduler/api/watchhosts.go
@@ -129,13 +129,13 @@ func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
 
 	w.scheduler2.Cleanup(t)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		stream, err := w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, stream.CloseSend())
-		})
+	stream, err := w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, stream.CloseSend())
+	})
 
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := stream.Recv()
 		if !assert.NoError(c, err) {
 			return
@@ -153,11 +153,6 @@ func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
 	w.scheduler4.Run(t, ctx)
 	w.scheduler4.WaitUntilRunning(t, ctx)
 	t.Cleanup(func() { w.scheduler4.Cleanup(t) })
-	stream, err := w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, stream.CloseSend())
-	})
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := stream.Recv()


### PR DESCRIPTION
Make GetActorState not dependent hosted so workflow doesn't need to be executing to get terminal status.

Create placement lock which doesn't deadlock on shutdown or workflow execution.

Ensure scheduler shutdown doesn't cause deadlock.

Update durabletask to use runtime status proto
