### PR TITLE
The shebang must be on the first line

### DIFF
--- a/tools/proto/generate.sh
+++ b/tools/proto/generate.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright 2021 The Dapr Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -9,9 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
-#!/bin/bash
 
 set +x
 


### PR DESCRIPTION
# Description

This PR fixes the [`SC1128`](https://www.shellcheck.net/wiki/SC1128) warning.

<!--
Please explain the changes you've made.
-->

Moves the shebang to the first line. No other shell scripts had this issue.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

I decided not to create an issue for such small change. If really needed I can do it - just please let me know.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] ~Code compiles correctly~ (not relevant)
- [x] ~Created/updated tests~ (not relevant)
- [x] ~Unit tests passing~ (not relevant)
- [x] ~End-to-end tests passing~ (not relevant)

