### PR TITLE
Actors: Placement lock grace period

### DIFF
--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -122,9 +122,10 @@ func (l *Lock) handleHold(h *hold) {
 	rcancelGrace := func() {
 		select {
 		case <-time.After(2 * time.Second):
-			rcancel()
+		case <-l.closeCh:
 		case <-doneCh:
 		}
+		rcancel()
 	}
 
 	l.rcancels[i] = rcancelGrace

--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/dapr/kit/concurrency/fifo"
 )
@@ -102,12 +103,14 @@ func (l *Lock) handleHold(h *hold) {
 
 	l.wg.Add(1)
 	var done bool
+	doneCh := make(chan bool)
 	rctx, cancel := context.WithCancel(h.rctx)
 	i := l.rcancelx
 
 	rcancel := func() {
 		l.rcancelLock.Lock()
 		if !done {
+			close(doneCh)
 			cancel()
 			delete(l.rcancels, i)
 			l.wg.Done()
@@ -116,7 +119,15 @@ func (l *Lock) handleHold(h *hold) {
 		l.rcancelLock.Unlock()
 	}
 
-	l.rcancels[i] = rcancel
+	rcancelGrace := func() {
+		select {
+		case <-time.After(2 * time.Second):
+			rcancel()
+		case <-doneCh:
+		}
+	}
+
+	l.rcancels[i] = rcancelGrace
 	l.rcancelx++
 
 	l.rcancelLock.Unlock()

--- a/pkg/actors/internal/placement/placement.go
+++ b/pkg/actors/internal/placement/placement.go
@@ -270,7 +270,7 @@ func (p *placement) handleLockOperation(ctx context.Context) {
 		defer p.wg.Done()
 		select {
 		case <-ctx.Done():
-		case <-time.After(time.Second * 10):
+		case <-time.After(time.Second * 15):
 			p.operationLock.Lock()
 			defer p.operationLock.Unlock()
 			if p.updateVersion.Load() < lockVersion {


### PR DESCRIPTION
Update placement outer lock to give inner locks a grace period of 2 seconds before cancelling the context. This allows a reasonable amount of time for active in flights requests to complete before cancelling all actor executions.
