### PR TITLE
Scheduler: adds --override-broadcast-host-port

### DIFF
--- a/cmd/scheduler/app/app.go
+++ b/cmd/scheduler/app/app.go
@@ -93,11 +93,13 @@ func Run() {
 			}
 
 			server, serr := server.New(server.Options{
-				Port:          opts.Port,
-				ListenAddress: opts.ListenAddress,
-				Mode:          modes.DaprMode(opts.Mode),
-				Security:      secHandler,
-				Healthz:       healthz,
+				Port:                      opts.Port,
+				ListenAddress:             opts.ListenAddress,
+				OverrideBroadcastHostPort: opts.OverrideBroadcastHostPort,
+
+				Mode:     modes.DaprMode(opts.Mode),
+				Security: secHandler,
+				Healthz:  healthz,
 
 				DataDir:                 opts.EtcdDataDir,
 				KubeConfig:              opts.KubeConfig,

--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -34,7 +34,9 @@ type Options struct {
 	HealthzPort          int
 	HealthzListenAddress string
 
-	ListenAddress    string
+	ListenAddress             string
+	OverrideBroadcastHostPort *string
+
 	TLSEnabled       bool
 	TrustDomain      string
 	TrustAnchorsFile *string
@@ -58,9 +60,10 @@ type Options struct {
 	Logger  logger.Options
 	Metrics *metrics.FlagOptions
 
-	taFile         string
-	kubeconfig     string
-	etcdSpaceQuota string
+	taFile                    string
+	kubeconfig                string
+	etcdSpaceQuota            string
+	overrideBroadcastHostPort string
 }
 
 func New(origArgs []string) (*Options, error) {
@@ -75,6 +78,7 @@ func New(origArgs []string) (*Options, error) {
 	fs.StringVar(&opts.HealthzListenAddress, "healthz-listen-address", "", "The listening address for the healthz server")
 
 	fs.StringVar(&opts.ListenAddress, "listen-address", "", "The address for the Scheduler to listen on")
+	fs.StringVar(&opts.overrideBroadcastHostPort, "override-broadcast-host-port", "", "Override the address (host:port) which is broadcast by this scheduler host that daprd instances will use to connect to this scheduler. This option should only be set by the CLI when in standalone mode, or in exotic environments whereby the routable scheduler address (host:port) is different from its own understood routable address, i.e. in a layered or natted network.")
 	fs.BoolVar(&opts.TLSEnabled, "tls-enabled", false, "Should TLS be enabled for the scheduler gRPC server")
 	fs.StringVar(&opts.TrustDomain, "trust-domain", "localhost", "Trust domain for the Dapr control plane")
 	fs.StringVar(&opts.taFile, "trust-anchors-file", securityConsts.ControlPlaneDefaultTrustAnchorsPath, "Filepath to the trust anchors for the Dapr control plane")
@@ -120,6 +124,10 @@ func New(origArgs []string) (*Options, error) {
 			return nil, errors.New("kubeconfig flag is only valid in --mode=kubernetes")
 		}
 		opts.KubeConfig = &opts.kubeconfig
+	}
+
+	if fs.Changed("override-broadcast-host-port") {
+		opts.OverrideBroadcastHostPort = &opts.overrideBroadcastHostPort
 	}
 
 	return &opts, nil

--- a/pkg/scheduler/server/internal/cron/cron.go
+++ b/pkg/scheduler/server/internal/cron/cron.go
@@ -116,6 +116,7 @@ func (c *cron) Run(ctx context.Context) error {
 
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints: endpoints,
+		Context:   ctx,
 	})
 	if err != nil {
 		return err

--- a/tests/integration/framework/process/scheduler/options.go
+++ b/tests/integration/framework/process/scheduler/options.go
@@ -38,6 +38,8 @@ type options struct {
 	dataDir       *string
 	kubeconfig    *string
 	mode          *string
+
+	overrideBroadcastHostPort *string
 }
 
 func WithExecOptions(execOptions ...exec.Option) Option {
@@ -128,5 +130,11 @@ func WithKubeconfig(kubeconfig string) Option {
 func WithMode(mode string) Option {
 	return func(o *options) {
 		o.mode = &mode
+	}
+}
+
+func WithOverrideBroadcastHostPort(address string) Option {
+	return func(o *options) {
+		o.overrideBroadcastHostPort = &address
 	}
 }

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -137,6 +137,9 @@ func New(t *testing.T, fopts ...Option) *Scheduler {
 	if opts.mode != nil {
 		args = append(args, "--mode="+*opts.mode)
 	}
+	if opts.overrideBroadcastHostPort != nil {
+		args = append(args, "--override-broadcast-host-port="+*opts.overrideBroadcastHostPort)
+	}
 
 	clientPorts := make(map[string]string)
 	for _, input := range opts.etcdClientPorts {
@@ -231,6 +234,8 @@ func (s *Scheduler) DataDir() string {
 }
 
 func (s *Scheduler) Client(t *testing.T, ctx context.Context) schedulerv1pb.SchedulerClient {
+	t.Helper()
+
 	//nolint:staticcheck
 	conn, err := grpc.DialContext(ctx, s.Address(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(math.MaxInt32), grpc.MaxCallRecvMsgSize(math.MaxInt32)),

--- a/tests/integration/suite/scheduler/api/api.go
+++ b/tests/integration/suite/scheduler/api/api.go
@@ -15,4 +15,5 @@ package api
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/api/list"
+	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/api/watchhosts"
 )

--- a/tests/integration/suite/scheduler/api/watchhosts/cluster.go
+++ b/tests/integration/suite/scheduler/api/watchhosts/cluster.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package api
+package watchhosts
 
 import (
 	"context"
@@ -33,10 +33,10 @@ import (
 )
 
 func init() {
-	suite.Register(new(watchhosts))
+	suite.Register(new(cluster))
 }
 
-type watchhosts struct {
+type cluster struct {
 	scheduler1 *scheduler.Scheduler
 	scheduler2 *scheduler.Scheduler
 	scheduler3 *scheduler.Scheduler
@@ -48,7 +48,7 @@ type watchhosts struct {
 	s4addr string
 }
 
-func (w *watchhosts) Setup(t *testing.T) []framework.Option {
+func (c *cluster) Setup(t *testing.T) []framework.Option {
 	if runtime.GOOS == "windows" {
 		t.Skip("Cleanup does not work cleanly on windows")
 	}
@@ -70,46 +70,46 @@ func (w *watchhosts) Setup(t *testing.T) []framework.Option {
 		"scheduler-2=" + strconv.Itoa(fp.Port(t)),
 	}
 
-	w.scheduler1 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-0"), scheduler.WithEtcdClientPorts(clientPorts))...)
-	w.scheduler2 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-1"), scheduler.WithEtcdClientPorts(clientPorts))...)
-	w.scheduler3 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-2"), scheduler.WithEtcdClientPorts(clientPorts))...)
+	c.scheduler1 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-0"), scheduler.WithEtcdClientPorts(clientPorts))...)
+	c.scheduler2 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-1"), scheduler.WithEtcdClientPorts(clientPorts))...)
+	c.scheduler3 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-2"), scheduler.WithEtcdClientPorts(clientPorts))...)
 
-	w.scheduler4 = scheduler.New(t,
-		scheduler.WithID(w.scheduler2.ID()),
+	c.scheduler4 = scheduler.New(t,
+		scheduler.WithID(c.scheduler2.ID()),
 		scheduler.WithEtcdClientPorts(clientPorts),
-		scheduler.WithInitialCluster(w.scheduler2.InitialCluster()),
-		scheduler.WithDataDir(w.scheduler2.DataDir()),
-		scheduler.WithPort(w.scheduler2.Port()),
+		scheduler.WithInitialCluster(c.scheduler2.InitialCluster()),
+		scheduler.WithDataDir(c.scheduler2.DataDir()),
+		scheduler.WithPort(c.scheduler2.Port()),
 	)
 
-	w.s1addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(w.scheduler1.Port()))
-	w.s2addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(w.scheduler2.Port()))
-	w.s3addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(w.scheduler3.Port()))
-	w.s4addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(w.scheduler4.Port()))
+	c.s1addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(c.scheduler1.Port()))
+	c.s2addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(c.scheduler2.Port()))
+	c.s3addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(c.scheduler3.Port()))
+	c.s4addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(c.scheduler4.Port()))
 
 	return []framework.Option{
 		framework.WithProcesses(fp),
 	}
 }
 
-func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
-	w.scheduler1.Run(t, ctx)
-	w.scheduler2.Run(t, ctx)
-	w.scheduler3.Run(t, ctx)
+func (c *cluster) Run(t *testing.T, ctx context.Context) {
+	c.scheduler1.Run(t, ctx)
+	c.scheduler2.Run(t, ctx)
+	c.scheduler3.Run(t, ctx)
 	t.Cleanup(func() {
-		w.scheduler1.Cleanup(t)
-		w.scheduler2.Cleanup(t)
-		w.scheduler3.Cleanup(t)
+		c.scheduler1.Cleanup(t)
+		c.scheduler2.Cleanup(t)
+		c.scheduler3.Cleanup(t)
 	})
-	w.scheduler1.WaitUntilRunning(t, ctx)
-	w.scheduler2.WaitUntilRunning(t, ctx)
-	w.scheduler3.WaitUntilRunning(t, ctx)
+	c.scheduler1.WaitUntilRunning(t, ctx)
+	c.scheduler2.WaitUntilRunning(t, ctx)
+	c.scheduler3.WaitUntilRunning(t, ctx)
 
 	var stream schedulerv1pb.Scheduler_WatchHostsClient
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
 		var err error
-		stream, err = w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
-		if !assert.NoError(c, err) {
+		stream, err = c.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+		if !assert.NoError(col, err) {
 			return
 		}
 
@@ -125,19 +125,19 @@ func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
 			got = append(got, host.GetAddress())
 		}
 
-		assert.ElementsMatch(c, []string{
-			w.s1addr,
-			w.s2addr,
-			w.s3addr,
+		assert.ElementsMatch(col, []string{
+			c.s1addr,
+			c.s2addr,
+			c.s3addr,
 		}, got)
 	}, time.Second*20, time.Millisecond*10)
 
-	w.scheduler2.Cleanup(t)
+	c.scheduler2.Cleanup(t)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(col *assert.CollectT) {
 		resp, err := stream.Recv()
-		if !assert.NoError(c, err) {
-			stream, err = w.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+		if !assert.NoError(col, err) {
+			stream, err = c.scheduler3.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
 			require.NoError(t, err)
 			return
 		}
@@ -145,17 +145,17 @@ func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
 		for _, host := range resp.GetHosts() {
 			got = append(got, host.GetAddress())
 		}
-		assert.ElementsMatch(c, []string{
-			w.s1addr,
-			w.s3addr,
+		assert.ElementsMatch(col, []string{
+			c.s1addr,
+			c.s3addr,
 		}, got)
 	}, time.Second*20, time.Millisecond*10)
 
-	w.scheduler4.Run(t, ctx)
-	w.scheduler4.WaitUntilRunning(t, ctx)
-	t.Cleanup(func() { w.scheduler4.Cleanup(t) })
+	c.scheduler4.Run(t, ctx)
+	c.scheduler4.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { c.scheduler4.Cleanup(t) })
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(col *assert.CollectT) {
 		resp, err := stream.Recv()
 		require.NoError(t, err)
 
@@ -164,10 +164,10 @@ func (w *watchhosts) Run(t *testing.T, ctx context.Context) {
 			got = append(got, host.GetAddress())
 		}
 
-		assert.ElementsMatch(c, []string{
-			w.s1addr,
-			w.s3addr,
-			w.s4addr,
+		assert.ElementsMatch(col, []string{
+			c.s1addr,
+			c.s3addr,
+			c.s4addr,
 		}, got)
 	}, time.Second*20, time.Millisecond*10)
 }

--- a/tests/integration/suite/scheduler/api/watchhosts/override/cluster.go
+++ b/tests/integration/suite/scheduler/api/watchhosts/override/cluster.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	schedulercluster "github.com/dapr/dapr/tests/integration/framework/process/scheduler/cluster"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(cluster))
+}
+
+type cluster struct {
+	schedulers *schedulercluster.Cluster
+}
+
+func (c *cluster) Setup(t *testing.T) []framework.Option {
+	c.schedulers = schedulercluster.New(t,
+		schedulercluster.WithCount(3),
+		schedulercluster.WithOverrideBroadcastHostPorts(
+			"1.2.3.4:5000",
+			"2.3.4.5:5001",
+			"3.4.5.6:5002",
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.schedulers),
+	}
+}
+
+func (c *cluster) Run(t *testing.T, ctx context.Context) {
+	c.schedulers.WaitUntilRunning(t, ctx)
+
+	stream, err := c.schedulers.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		got := make([]string, 0, len(resp.GetHosts()))
+		for _, host := range resp.GetHosts() {
+			got = append(got, host.GetAddress())
+		}
+		assert.ElementsMatch(col, []string{
+			"1.2.3.4:5000",
+			"2.3.4.5:5001",
+			"3.4.5.6:5002",
+		}, got)
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/scheduler/api/watchhosts/override/single.go
+++ b/tests/integration/suite/scheduler/api/watchhosts/override/single.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package override
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(single))
+}
+
+type single struct {
+	scheduler *scheduler.Scheduler
+}
+
+func (s *single) Setup(t *testing.T) []framework.Option {
+	s.scheduler = scheduler.New(t,
+		scheduler.WithOverrideBroadcastHostPort("1.2.3.4:5678"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.scheduler),
+	}
+}
+
+func (s *single) Run(t *testing.T, ctx context.Context) {
+	s.scheduler.WaitUntilRunning(t, ctx)
+
+	stream, err := s.scheduler.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+
+	require.Len(t, resp.GetHosts(), 1)
+	assert.Equal(t, "1.2.3.4:5678", resp.GetHosts()[0].GetAddress())
+}

--- a/tests/integration/suite/scheduler/api/watchhosts/watchhosts.go
+++ b/tests/integration/suite/scheduler/api/watchhosts/watchhosts.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Dapr Authors
+Copyright 2025 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,24 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cluster
+package watchhosts
 
-type Option func(*options)
-
-type options struct {
-	count uint32
-
-	overrideBroadcastHostPorts []string
-}
-
-func WithCount(count uint32) Option {
-	return func(o *options) {
-		o.count = count
-	}
-}
-
-func WithOverrideBroadcastHostPorts(addresses ...string) Option {
-	return func(o *options) {
-		o.overrideBroadcastHostPorts = append(o.overrideBroadcastHostPorts, addresses...)
-	}
-}
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/api/watchhosts/override"
+)


### PR DESCRIPTION
Override the address (host:port) which is broadcast by this scheduler host that daprd instances will use to connect to this scheduler. This option should only be set by the CLI when in standalone mode, or in exotic environments whereby the routable scheduler address (host:port) is different from its own understood routable address, i.e. in a layered or natted network.

Adds int tests to ensure value it propagated correctly.