### PR TITLE
Do not use f-string when there are no placeholders

### DIFF
--- a/.github/scripts/validate_sidecar_resources.py
+++ b/.github/scripts/validate_sidecar_resources.py
@@ -66,7 +66,7 @@ def get_goroutine_count():
 def run_sidecar(executable, app_id):
     print(f"Running {executable} ...")
     expanded_executable=Path(executable).expanduser()
-    args = [expanded_executable, f"--app-id", f"{app_id}"]
+    args = [expanded_executable, "--app-id", f"{app_id}"]
 
     # Run the process in the background
     background_process = run_process_background(args)


### PR DESCRIPTION
# Description

Another _typo-fix-like_ PR similar to #8415.

<!--
Please explain the changes you've made.
-->

Removes some _trailing spaces_ and makes the code conformant with [`F541`](https://docs.astral.sh/ruff/rules/f-string-missing-placeholders/#f-string-missing-placeholders-f541) or [`W1309`](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/f-string-without-interpolation.html).

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

I decided not to create an issue for such small change. If really needed I can do it - just please let me know.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] ~Code compiles correctly~ (not relevant)
- [x] ~Created/updated tests~ (not relevant)
- [x] ~Unit tests passing~ (not relevant)
- [x] ~End-to-end tests passing~ (not relevant)

