### PR TITLE
Workflow: Remove actor table memory leak

### DIFF
--- a/pkg/actors/table/table.go
+++ b/pkg/actors/table/table.go
@@ -53,6 +53,7 @@ type Interface interface {
 	Halt(ctx context.Context, actorType, actorID string) error
 	HaltIdlable(ctx context.Context, target targets.Idlable) error
 	Drain(fn func(actorType, actorID string) bool)
+	DeleteFromTable(actorType, actorID string)
 	Len() map[string]int
 }
 
@@ -266,6 +267,12 @@ func (t *table) Halt(ctx context.Context, actorType, actorID string) error {
 		return target.Deactivate(ctx)
 	}
 	return nil
+}
+
+func (t *table) DeleteFromTable(actorType, actorID string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.table.Delete(actorType + api.DaprSeparator + actorID)
 }
 
 // HaltAll halts all actors currently in the table.

--- a/pkg/actors/targets/workflow/activity.go
+++ b/pkg/actors/targets/workflow/activity.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -27,6 +26,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors"
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
+	"github.com/dapr/dapr/pkg/actors/table"
 	"github.com/dapr/dapr/pkg/actors/targets"
 	"github.com/dapr/dapr/pkg/actors/targets/internal"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -59,11 +59,11 @@ type activity struct {
 	workflowActorType string
 
 	actors actors.Interface
+	table  table.Interface
 	lock   *internal.Lock
 
 	scheduler          todo.ActivityScheduler
 	reminderInterval   time.Duration
-	completed          atomic.Bool
 	schedulerReminders bool
 }
 
@@ -74,6 +74,7 @@ type ActivityOptions struct {
 	ReminderInterval   *time.Duration
 	Scheduler          todo.ActivityScheduler
 	Actors             actors.Interface
+	Table              table.Interface
 	SchedulerReminders bool
 }
 
@@ -92,6 +93,7 @@ func ActivityFactory(opts ActivityOptions) targets.Factory {
 			workflowActorType:  opts.WorkflowActorType,
 			reminderInterval:   reminderInterval,
 			actors:             opts.Actors,
+			table:              opts.Table,
 			scheduler:          opts.Scheduler,
 			schedulerReminders: opts.SchedulerReminders,
 			lock:               internal.NewLock(internal.LockOptions{ActorType: opts.ActivityActorType}),
@@ -145,7 +147,7 @@ func (a *activity) InvokeReminder(ctx context.Context, reminder *actorapi.Remind
 
 	completed, err := a.executeActivity(ctx, reminder.Name, &state)
 	if completed == runCompletedTrue {
-		a.completed.Store(true)
+		a.table.DeleteFromTable(a.actorType, a.actorID)
 	}
 
 	// Returning nil signals that we want the execution to be retried in the next period interval
@@ -179,10 +181,6 @@ func (a *activity) InvokeReminder(ctx context.Context, reminder *actorapi.Remind
 		// TODO: Reply with a failure - this requires support from durabletask-go to produce TaskFailure results
 		return actorerrors.ErrReminderCanceled
 	}
-}
-
-func (a *activity) Completed() bool {
-	return a.completed.Load()
 }
 
 func (a *activity) executeActivity(ctx context.Context, name string, taskEvent *backend.HistoryEvent) (runCompleted, error) {
@@ -346,7 +344,6 @@ func (a *activity) createReliableReminder(ctx context.Context, his *backend.Hist
 
 // DeactivateActor implements actors.InternalActor
 func (a *activity) Deactivate(ctx context.Context) error {
-	// TODO: @joshvanl: close everything else in this actor and wait
 	log.Debugf("Activity actor '%s': deactivating", a.actorID)
 	a.lock.Close()
 	return nil

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors"
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
+	"github.com/dapr/dapr/pkg/actors/table"
 	"github.com/dapr/dapr/pkg/actors/targets"
 	"github.com/dapr/dapr/pkg/actors/targets/internal"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -62,6 +63,7 @@ type workflow struct {
 
 	resiliency resiliency.Provider
 	actors     actors.Interface
+	table      table.Interface
 
 	lock             *internal.Lock
 	reminderInterval time.Duration
@@ -76,7 +78,6 @@ type workflow struct {
 	completed             atomic.Bool
 	schedulerReminders    bool
 	closeCh               chan struct{}
-	closed                atomic.Bool
 }
 
 type WorkflowOptions struct {
@@ -87,6 +88,7 @@ type WorkflowOptions struct {
 
 	Resiliency         resiliency.Provider
 	Actors             actors.Interface
+	Table              table.Interface
 	Scheduler          todo.WorkflowScheduler
 	SchedulerReminders bool
 }
@@ -108,6 +110,7 @@ func WorkflowFactory(opts WorkflowOptions) targets.Factory {
 			reminderInterval:   reminderInterval,
 			resiliency:         opts.Resiliency,
 			actors:             opts.Actors,
+			table:              opts.Table,
 			schedulerReminders: opts.SchedulerReminders,
 			lock: internal.NewLock(internal.LockOptions{
 				ActorType: opts.WorkflowActorType,
@@ -190,7 +193,7 @@ func (w *workflow) InvokeReminder(ctx context.Context, reminder *actorapi.Remind
 	completed, err := w.runWorkflow(ctx, reminder)
 
 	if completed == runCompletedTrue {
-		w.completed.Store(true)
+		w.table.DeleteFromTable(w.actorType, w.actorID)
 	}
 
 	// We delete the reminder on success and on non-recoverable errors.
@@ -363,9 +366,8 @@ func (w *workflow) cleanupWorkflowStateInternal(ctx context.Context, state *wfen
 	if err != nil {
 		return err
 	}
-	w.state = nil
-	w.rstate = nil
-	w.ometa = nil
+	w.table.DeleteFromTable(w.actorType, w.actorID)
+	w.cleanup()
 	return nil
 }
 
@@ -950,15 +952,16 @@ func (w *workflow) removeCompletedStateData(ctx context.Context, state *wfengine
 // DeactivateActor implements actors.InternalActor
 func (w *workflow) Deactivate(ctx context.Context) error {
 	log.Debugf("Workflow actor '%s': deactivating", w.actorID)
-	if w.closed.CompareAndSwap(false, true) {
-		close(w.closeCh)
-	}
+	w.cleanup()
+	return nil
+}
+
+func (w *workflow) cleanup() {
 	w.ometaBroadcaster.Close()
 	w.state = nil // A bit of extra caution, shouldn't be necessary
 	w.rstate = nil
 	w.ometa = nil
 	w.lock.Close()
-	return nil
 }
 
 // CloseUntil closes the actor but backs out sooner if the duration is reached.
@@ -967,10 +970,6 @@ func (w *workflow) CloseUntil(d time.Duration) {
 }
 
 func (w *workflow) InvokeStream(ctx context.Context, req *internalsv1pb.InternalInvokeRequest, stream chan<- *internalsv1pb.InternalInvokeResponse) error {
-	if w.closed.Load() {
-		return nil
-	}
-
 	lockCancel, err := w.lock.Lock()
 	if err != nil {
 		return err
@@ -1035,6 +1034,11 @@ func (w *workflow) handleStreamInitial(ctx context.Context, req *internalsv1pb.I
 			Status:  &internalsv1pb.Status{Code: http.StatusOK},
 			Message: &commonv1pb.InvokeResponse{Data: arstate},
 		}:
+		}
+
+		if api.OrchestrationMetadataIsComplete(w.ometa) {
+			w.table.DeleteFromTable(w.actorType, w.actorID)
+			w.cleanup()
 		}
 	}
 

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -106,6 +106,7 @@ func (abe *Actors) RegisterActors(ctx context.Context) error {
 						ReminderInterval:  abe.defaultReminderInterval,
 						Resiliency:        abe.resiliency,
 						Actors:            abe.actors,
+						Table:             atable,
 						Scheduler: func(ctx context.Context, wi *backend.OrchestrationWorkItem) error {
 							log.Debugf("%s: scheduling workflow execution with durabletask engine", wi.InstanceID)
 							select {
@@ -139,6 +140,7 @@ func (abe *Actors) RegisterActors(ctx context.Context) error {
 							}
 						},
 						Actors:             abe.actors,
+						Table:              atable,
 						SchedulerReminders: abe.schedulerReminders,
 					}),
 				},


### PR DESCRIPTION
Remove memory leak whereby workflow actor objects were not be pruned from the actor table slice.

After an activity fires, delete the object from the actor table.

When a workflow reaches a terminal state or is purged, remove it from the actor table.
