### PR TITLE
Workflow: default max parallel items to 1000

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -69,8 +69,8 @@ const (
 	ActionPolicyApp     = "app"
 	ActionPolicyGlobal  = "global"
 
-	defaultMaxWorkflowConcurrentInvocations = 100
-	defaultMaxActivityConcurrentInvocations = 100
+	defaultMaxWorkflowConcurrentInvocations = 1000
+	defaultMaxActivityConcurrentInvocations = 1000
 )
 
 var defaultFeatures = map[Feature]bool{


### PR DESCRIPTION
Up the number of work items which can be run in parallel from 100 to 1000