### PR TITLE
Actors: State store actor reminder drain wait group

### DIFF
--- a/pkg/actors/internal/reminders/storage/statestore/statestore.go
+++ b/pkg/actors/internal/reminders/storage/statestore/statestore.go
@@ -1021,7 +1021,7 @@ func (r *Statestore) startReminder(reminder *api.Reminder, stop *reminderStop) e
 			default:
 				close(stop.stopped)
 			}
-			defer r.wg.Done()
+			r.wg.Done()
 		}()
 
 		var (
@@ -1078,6 +1078,8 @@ func (r *Statestore) startReminder(reminder *api.Reminder, stop *reminderStop) e
 				break loop
 			}
 
+			tickExecuted := reminder.TickExecuted()
+
 			err = r.updateReminderTrack(context.TODO(), reminderKey, reminder.RepeatsLeft(), nextTick, eTag)
 			if err != nil {
 				log.Errorf("Error updating reminder track for reminder %s: %v", reminderKey, err)
@@ -1090,7 +1092,7 @@ func (r *Statestore) startReminder(reminder *api.Reminder, stop *reminderStop) e
 				eTag = track.Etag
 			}
 
-			if reminder.TickExecuted() {
+			if tickExecuted {
 				nextTimer = nil
 				break loop
 			}

--- a/pkg/actors/internal/reminders/storage/statestore/statestore.go
+++ b/pkg/actors/internal/reminders/storage/statestore/statestore.go
@@ -120,18 +120,12 @@ func (r *Statestore) OnPlacementTablesUpdated(ctx context.Context, fn func(conte
 func (r *Statestore) DrainRebalancedReminders() {
 	for _, remtypes := range r.reminders {
 		for _, rem := range remtypes {
-			go func(rem ActorReminderReference) {
-				reminderKey := rem.Reminder.Key()
-				stop, exists := r.activeReminders.LoadAndDelete(reminderKey)
-				if exists {
-					select {
-					case <-time.After(time.Second * 2):
-						close(stop.stopCh)
-					case <-stop.stopped:
-					}
-					<-stop.stopped
-				}
-			}(rem)
+			reminderKey := rem.Reminder.Key()
+			stop, exists := r.activeReminders.LoadAndDelete(reminderKey)
+			if exists {
+				close(stop.stopCh)
+				<-stop.stopped
+			}
 		}
 	}
 


### PR DESCRIPTION
Add wait group which waits for state store reminder loops to exit before continuing from a placement dissemination reminder drain.

Ensure ticks are always recorded to ensure we don't miss app reminder executions, and result in double invocations during disemination events.

Fixed e2e actor reminder e2e test.