### PR TITLE
Workflow: Terminate sync API not found

### DIFF
--- a/pkg/api/universal/workflow.go
+++ b/pkg/api/universal/workflow.go
@@ -159,11 +159,9 @@ func (a *Universal) TerminateWorkflow(ctx context.Context, in *runtimev1pb.Termi
 		gresp, err := a.workflowEngine.Client().Get(ctx, &workflows.GetRequest{
 			InstanceID: in.GetInstanceId(),
 		})
-		if err != nil {
-			return nil, fmt.Errorf("workflow started, but failed to get status: %w", err)
-		}
 
-		if gresp.Workflow.RuntimeStatus == "TERMINATED" {
+		// Not found error so terminated.
+		if err != nil || gresp.Workflow.RuntimeStatus == "TERMINATED" {
 			return emptyResponse, nil
 		}
 

--- a/pkg/api/universal/workflow.go
+++ b/pkg/api/universal/workflow.go
@@ -162,6 +162,7 @@ func (a *Universal) TerminateWorkflow(ctx context.Context, in *runtimev1pb.Termi
 
 		// Not found error so terminated.
 		if err != nil || gresp.Workflow.RuntimeStatus == "TERMINATED" {
+			//nolint:nilerr
 			return emptyResponse, nil
 		}
 


### PR DESCRIPTION
Also allow the Workflow to be considered Terminated once the Workflow metadata can no longer be found.