### PR TITLE
Workflow: dont delete reminder on placement dissemination

### DIFF
--- a/pkg/actors/internal/placement/lock/lock.go
+++ b/pkg/actors/internal/placement/lock/lock.go
@@ -104,14 +104,14 @@ func (l *Lock) handleHold(h *hold) {
 	l.wg.Add(1)
 	var done bool
 	doneCh := make(chan bool)
-	rctx, cancel := context.WithCancel(h.rctx)
+	rctx, cancel := context.WithCancelCause(h.rctx)
 	i := l.rcancelx
 
 	rcancel := func() {
 		l.rcancelLock.Lock()
 		if !done {
 			close(doneCh)
-			cancel()
+			cancel(errors.New("placement is disseminating"))
 			delete(l.rcancels, i)
 			l.wg.Done()
 			done = true

--- a/pkg/actors/targets/workflow/activity.go
+++ b/pkg/actors/targets/workflow/activity.go
@@ -174,9 +174,9 @@ func (a *activity) InvokeReminder(ctx context.Context, reminder *actorapi.Remind
 		}
 		return nil
 	default: // Other error
-		log.Errorf("%s: execution failed with a non-recoverable error: %v", a.actorID, err)
+		log.Errorf("%s: execution failed with an error: %v", a.actorID, err)
 		if a.schedulerReminders {
-			return nil
+			return err
 		}
 		// TODO: Reply with a failure - this requires support from durabletask-go to produce TaskFailure results
 		return actorerrors.ErrReminderCanceled

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -214,9 +214,9 @@ func (w *workflow) InvokeReminder(ctx context.Context, reminder *actorapi.Remind
 		log.Warnf("Workflow actor '%s': execution failed with a recoverable error and will be retried later: '%v'", w.actorID, err)
 		return nil
 	default: // Other error
-		log.Errorf("Workflow actor '%s': execution failed with a non-recoverable error: %v", w.actorID, err)
+		log.Errorf("Workflow actor '%s': execution failed with an error: %v", w.actorID, err)
 		if w.schedulerReminders {
-			return nil
+			return err
 		}
 		return actorerrors.ErrReminderCanceled
 	}


### PR DESCRIPTION
Do not mark the workflow orchestration or activity reminder for deletion when placement dissemination events occurs.
