### PR TITLE
Workflow: Cache workflow state for 10s after Termination

### DIFF
--- a/pkg/actors/targets/app/app.go
+++ b/pkg/actors/targets/app/app.go
@@ -285,7 +285,6 @@ func (a *app) Deactivate(ctx context.Context) error {
 }
 
 // Key returns the key for this unique actor.
-// This is implemented to comply with the queueable interface.
 func (a *app) Key() string {
 	return a.actorType + api.DaprSeparator + a.actorID
 }
@@ -299,10 +298,6 @@ func (a *app) CloseUntil(d time.Duration) {
 // This is implemented to comply with the queueable interface.
 func (a *app) ScheduledTime() time.Time {
 	return *a.idleAt.Load()
-}
-
-func (a *app) IdleAt(t time.Time) {
-	a.idleAt.Store(&t)
 }
 
 func (a *app) InvokeStream(context.Context, *internalv1pb.InternalInvokeRequest, chan<- *internalv1pb.InternalInvokeResponse) error {

--- a/pkg/actors/targets/idler/idler.go
+++ b/pkg/actors/targets/idler/idler.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idler
+
+import (
+	"time"
+
+	"github.com/dapr/dapr/pkg/actors/targets"
+)
+
+// idler is a wrapper for an actor which should be idled in some time in the
+// future.
+type idler struct {
+	targets.Interface
+	idleTime time.Time
+}
+
+func New(actor targets.Interface, idleIn time.Duration) targets.Idlable {
+	return &idler{
+		Interface: actor,
+		idleTime:  time.Now().Add(idleIn),
+	}
+}
+
+func (i *idler) ScheduledTime() time.Time {
+	return i.idleTime
+}

--- a/pkg/actors/targets/targets.go
+++ b/pkg/actors/targets/targets.go
@@ -22,6 +22,7 @@ import (
 )
 
 type Interface interface {
+	Key() string
 	InvokeMethod(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error)
 	InvokeReminder(ctx context.Context, reminder *api.Reminder) error
 	InvokeTimer(ctx context.Context, reminder *api.Reminder) error
@@ -32,9 +33,7 @@ type Interface interface {
 
 type Idlable interface {
 	Interface
-	Key() string
 	ScheduledTime() time.Time
-	IdleAt(time.Time)
 }
 
 type Factory = func(actorID string) Interface

--- a/pkg/actors/targets/workflow/activity.go
+++ b/pkg/actors/targets/workflow/activity.go
@@ -357,3 +357,8 @@ func (a *activity) CloseUntil(d time.Duration) {
 func (a *activity) InvokeStream(context.Context, *internalsv1pb.InternalInvokeRequest, chan<- *internalsv1pb.InternalInvokeResponse) error {
 	return errors.New("not implemented")
 }
+
+// Key returns the key for this unique actor.
+func (a *activity) Key() string {
+	return a.actorType + actorapi.DaprSeparator + a.actorID
+}

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -326,7 +326,8 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetInboxLength() {
 		key = getMultiEntryKeyName(inboxKeyPrefix, i)
 		if bulkRes[key] == nil {
-			return nil, fmt.Errorf("failed to load inbox state key '%s': not found", key)
+			wfLogger.Warnf("Failed to load inbox state key '%s': not found", key)
+			return nil, nil
 		}
 		wState.Inbox[i] = &protos.HistoryEvent{}
 		if err = proto.Unmarshal(bulkRes[key], wState.Inbox[i]); err != nil {
@@ -336,7 +337,8 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetHistoryLength() {
 		key = getMultiEntryKeyName(historyKeyPrefix, i)
 		if bulkRes[key] == nil {
-			return nil, fmt.Errorf("failed to load history state key '%s': not found", key)
+			wfLogger.Warnf("Failed to load history state key '%s': not found", key)
+			return nil, nil
 		}
 		wState.History[i] = &protos.HistoryEvent{}
 		if err = proto.Unmarshal(bulkRes[key], wState.History[i]); err != nil {


### PR DESCRIPTION
Delay deleting the workflow orchestration actor from being deleted from the actor table for 10s in order to hold the cache for new streaming clients to observe the state.

Don't error the workflow when the inbox state cannot be found, which happens when the workflow has been terminated.

10s is enough, as the client is Terminating the workflow anyway.