### PR TITLE
Workflow: Return input & output from Get

### DIFF
--- a/pkg/runtime/wfengine/client.go
+++ b/pkg/runtime/wfengine/client.go
@@ -184,6 +184,16 @@ func (c *client) Get(ctx context.Context, req *workflows.GetRequest) (*workflows
 		res.Workflow.Properties["dapr.workflow.custom_status"] = metadata.GetCustomStatus().GetValue()
 	}
 
+	//nolint:protogetter
+	if metadata.Input != nil {
+		res.Workflow.Properties["dapr.workflow.input"] = metadata.GetInput().GetValue()
+	}
+
+	//nolint:protogetter
+	if metadata.Output != nil {
+		res.Workflow.Properties["dapr.workflow.output"] = metadata.GetOutput().GetValue()
+	}
+
 	// Status-specific fields
 	//nolint:protogetter
 	if metadata.FailureDetails != nil {

--- a/tests/integration/framework/process/workflow/workflow.go
+++ b/tests/integration/framework/process/workflow/workflow.go
@@ -139,6 +139,10 @@ func (w *Workflow) GRPCClient(t *testing.T, ctx context.Context) rtv1.DaprClient
 	return w.daprd.GRPCClient(t, ctx)
 }
 
+func (w *Workflow) Dapr() *daprd.Daprd {
+	return w.daprd
+}
+
 func (w *Workflow) Metrics(t *testing.T, ctx context.Context) map[string]float64 {
 	t.Helper()
 	return w.daprd.Metrics(t, ctx).All()

--- a/tests/integration/suite/daprd/workflow/get.go
+++ b/tests/integration/suite/daprd/workflow/get.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(get))
+}
+
+type get struct {
+	workflow *workflow.Workflow
+}
+
+func (g *get) Setup(t *testing.T) []framework.Option {
+	g.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(g.workflow),
+	}
+}
+
+func (g *get) Run(t *testing.T, ctx context.Context) {
+	g.workflow.WaitUntilRunning(t, ctx)
+
+	g.workflow.Registry().AddOrchestratorN("getter", func(ctx *task.OrchestrationContext) (any, error) {
+		ctx.SetCustomStatus("my custom status")
+		return "return value", nil
+	})
+
+	client := g.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewOrchestration(ctx, "getter", api.WithInput("input value"))
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+
+	meta, err := client.FetchOrchestrationMetadata(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.Equal(t, `"input value"`, meta.GetInput().GetValue())
+	assert.Equal(t, `"return value"`, meta.GetOutput().GetValue())
+	assert.Equal(t, `my custom status`, meta.GetCustomStatus().GetValue())
+
+	gclient := g.workflow.GRPCClient(t, ctx)
+	resp, err := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+		InstanceId:        string(id),
+		WorkflowComponent: "dapr",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"dapr.workflow.custom_status": "my custom status",
+		"dapr.workflow.input":         `"input value"`,
+		"dapr.workflow.output":        `"return value"`,
+	}, resp.GetProperties())
+
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodGet,
+		fmt.Sprintf("http://%s/v1.0-beta1/workflows/dapr/%s", g.workflow.Dapr().HTTPAddress(), id),
+		nil,
+	)
+	require.NoError(t, err)
+
+	hresp, err := fclient.HTTP(t).Do(req)
+	require.NoError(t, err)
+
+	type wresp struct {
+		Properties map[string]string `json:"properties"`
+	}
+	var w wresp
+	require.NoError(t, json.NewDecoder(hresp.Body).Decode(&w))
+	require.NoError(t, hresp.Body.Close())
+
+	assert.Equal(t, map[string]string{
+		"dapr.workflow.custom_status": "my custom status",
+		"dapr.workflow.input":         `"input value"`,
+		"dapr.workflow.output":        `"return value"`,
+	}, w.Properties)
+}


### PR DESCRIPTION
Update Workflow universal Get response to include the input & output values in the Properties, as they were before.

Adds int tests.