### PR TITLE
go.mod: Update go-etcd-cron to HEAD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9
 	github.com/dapr/durabletask-go v0.5.1-0.20250124181508-a1b42ae65aee
 	github.com/dapr/kit v0.13.1-0.20250129050741-c46009f360b0
-	github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36
+	github.com/diagridio/go-etcd-cron v0.4.0
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-chi/cors v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9
 	github.com/dapr/durabletask-go v0.5.1-0.20250124181508-a1b42ae65aee
 	github.com/dapr/kit v0.13.1-0.20250129050741-c46009f360b0
-	github.com/diagridio/go-etcd-cron v0.3.2-0.20250130202842-74ca1105c851
+	github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-chi/cors v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9
-	github.com/dapr/durabletask-go v0.5.1-0.20250124181508-a1b42ae65aee
+	github.com/dapr/durabletask-go v0.6.0
 	github.com/dapr/kit v0.13.1-0.20250129050741-c46009f360b0
 	github.com/diagridio/go-etcd-cron v0.4.0
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9 h1:y68C9PNQKZULAd+z9VsflNgpBGafwnrk+sYl57tBYeA=
 github.com/dapr/components-contrib v1.15.0-rc.1.0.20241216170750-aca5116d95c9/go.mod h1:jzKIWl+mK+iH2COvGMcc4sV1fFeB8RZ5q312CF2ZKok=
-github.com/dapr/durabletask-go v0.5.1-0.20250124181508-a1b42ae65aee h1:uRleodP/a0X360mVtSau97wygHtIdQY5DZ9oMe1s0DY=
-github.com/dapr/durabletask-go v0.5.1-0.20250124181508-a1b42ae65aee/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
+github.com/dapr/durabletask-go v0.6.0 h1:Z/cg5RRq6O68mRaEvH5RRphdw0lsw/diqCTFSraJWTE=
+github.com/dapr/durabletask-go v0.6.0/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/dapr/kit v0.13.1-0.20250129050741-c46009f360b0 h1:NDEXog+/PDZoHquVQKj495UIbfrtejH+R+NlHQoAc9U=
 github.com/dapr/kit v0.13.1-0.20250129050741-c46009f360b0/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36 h1:YLRMmAQZEty96RSi2a1pvudoZmJQGtFPYbL+nb2ydTk=
-github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
+github.com/diagridio/go-etcd-cron v0.4.0 h1:wqz/fyZESvEa+0iSh5IMpCtVgb/2KYGTpSIflEw7u+A=
+github.com/diagridio/go-etcd-cron v0.4.0/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,8 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/diagridio/go-etcd-cron v0.3.2-0.20250130202842-74ca1105c851 h1:Y9egnZ9qN5EqTWvrEYUH7rl4Yt1r3pZcDPZgXMOAnJM=
 github.com/diagridio/go-etcd-cron v0.3.2-0.20250130202842-74ca1105c851/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
+github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36 h1:YLRMmAQZEty96RSi2a1pvudoZmJQGtFPYbL+nb2ydTk=
+github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.3.2-0.20250130202842-74ca1105c851 h1:Y9egnZ9qN5EqTWvrEYUH7rl4Yt1r3pZcDPZgXMOAnJM=
-github.com/diagridio/go-etcd-cron v0.3.2-0.20250130202842-74ca1105c851/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
 github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36 h1:YLRMmAQZEty96RSi2a1pvudoZmJQGtFPYbL+nb2ydTk=
 github.com/diagridio/go-etcd-cron v0.3.2-0.20250203232339-51d0598b5d36/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=

--- a/tests/integration/suite/daprd/jobs/schedule.go
+++ b/tests/integration/suite/daprd/jobs/schedule.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(schedule))
+}
+
+type schedule struct {
+	daprd     *daprd.Daprd
+	scheduler *scheduler.Scheduler
+}
+
+func (s *schedule) Setup(t *testing.T) []framework.Option {
+	s.scheduler = scheduler.New(t)
+
+	srv := app.New(t)
+
+	s.daprd = daprd.New(t,
+		daprd.WithSchedulerAddresses(s.scheduler.Address()),
+		daprd.WithAppPort(srv.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.scheduler, s.daprd),
+	}
+}
+
+func (s *schedule) Run(t *testing.T, ctx context.Context) {
+	s.scheduler.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	client := s.daprd.GRPCClient(t, ctx)
+
+	_, err := client.ScheduleJobAlpha1(ctx, &runtimev1pb.ScheduleJobRequest{
+		Job: &runtimev1pb.Job{
+			Name:     "test",
+			Schedule: ptr.Of("1 2 3 4 5 6"),
+		},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Updates go-etcd-cron to head. Include an int test to ensure a client can create a job with a schedule with 6 columns in cron style.

Updates durabletask-go to vanity tag v0.6.0.
Updates go-etcd-cron to vanity tag v0.4.0.