### PR TITLE
Actors: Regression: return 200 on reminder not found

### DIFF
--- a/pkg/actors/internal/reminders/storage/scheduler/scheduler.go
+++ b/pkg/actors/internal/reminders/storage/scheduler/scheduler.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/dapr/dapr/pkg/actors/api"
@@ -203,6 +205,11 @@ func (s *scheduler) Get(ctx context.Context, req *api.GetReminderRequest) (*api.
 			"jobType":   "reminder",
 		}
 		log.Errorf("Error getting reminder job %s due to: %s", req.Name, err)
+
+		if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {
+			return new(api.Reminder), nil
+		}
+
 		return nil, apierrors.SchedulerGetJob(errMetadata, err)
 	}
 

--- a/pkg/actors/internal/reminders/storage/scheduler/scheduler.go
+++ b/pkg/actors/internal/reminders/storage/scheduler/scheduler.go
@@ -204,7 +204,7 @@ func (s *scheduler) Get(ctx context.Context, req *api.GetReminderRequest) (*api.
 			"namespace": s.namespace,
 			"jobType":   "reminder",
 		}
-		log.Errorf("Error getting reminder job %s due to: %s", req.Name, err)
+		log.Debugf("Error getting reminder job %s due to: %s", req.Name, err)
 
 		if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {
 			return new(api.Reminder), nil

--- a/pkg/scheduler/server/api.go
+++ b/pkg/scheduler/server/api.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/diagridio/go-etcd-cron/api"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 	"github.com/dapr/dapr/pkg/scheduler/monitoring"
@@ -97,7 +99,7 @@ func (s *Server) GetJob(ctx context.Context, req *schedulerv1pb.GetJobRequest) (
 	}
 
 	if job == nil {
-		return nil, fmt.Errorf("job not found: %s", req.GetName())
+		return nil, status.Error(codes.NotFound, "job not found: "+req.GetName())
 	}
 
 	return &schedulerv1pb.GetJobResponse{

--- a/tests/integration/suite/actors/reminders/get.go
+++ b/tests/integration/suite/actors/reminders/get.go
@@ -54,10 +54,18 @@ func (g *get) Run(t *testing.T, ctx context.Context) {
 	client := client.HTTP(t)
 
 	url := g.actors.Daprd().ActorReminderURL("foo", "1234", "helloworld")
-	body := `{"data":"reminderdata","dueTime":"1s","period":"1s"}`
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := client.Do(req)
+	require.NoError(t, err)
+	// Not found returns 200.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	body := `{"data":"reminderdata","dueTime":"1s","period":"1s"}`
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+	resp, err = client.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/tests/integration/suite/actors/reminders/scheduler/get.go
+++ b/tests/integration/suite/actors/reminders/scheduler/get.go
@@ -53,10 +53,18 @@ func (g *get) Run(t *testing.T, ctx context.Context) {
 	client := client.HTTP(t)
 
 	url := g.actors.Daprd().ActorReminderURL("foo", "1234", "helloworld")
-	body := `{"data":"reminderdata","dueTime":"1s","period":"1s"}`
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := client.Do(req)
+	require.NoError(t, err)
+	// Not found returns 200.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	body := `{"data":"reminderdata","dueTime":"1s","period":"1s"}`
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+	resp, err = client.Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())


### PR DESCRIPTION
Update Get Actor Reminder to return a 200 rather than 500 when Scheduler reminders are enabled. This matches the same behavior as the state store reminder get request.

Adds integration test.