### PR TITLE
Fix Scheduler readOnlyRootFilesystem: true

### DIFF
--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -172,7 +172,7 @@ spec:
           capabilities:
             add: ["SYS_PTRACE"]
   {{- else }}
-          readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
   {{- end }}

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -95,6 +95,8 @@ spec:
             mountPath: {{ .Values.cluster.etcdDataDirPath }}/
           {{- end }}
             readOnly: false
+          - name: dapr-scheduler-writeable-identity
+            mountPath: /tmp
           - name: dapr-trust-bundle
             mountPath: /var/run/secrets/dapr.io/tls
             readOnly: true
@@ -170,7 +172,7 @@ spec:
           capabilities:
             add: ["SYS_PTRACE"]
   {{- else }}
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
           capabilities:
             drop: ["ALL"]
   {{- end }}
@@ -203,6 +205,8 @@ spec:
         emptyDir:
           medium: Memory
       {{- end }}
+      - name: dapr-scheduler-writeable-identity
+        emptyDir: {}
       - name: dapr-trust-bundle
         configMap:
           name: dapr-trust-bundle

--- a/charts/dapr/charts/dapr_scheduler/values.yaml
+++ b/charts/dapr/charts/dapr_scheduler/values.yaml
@@ -57,7 +57,7 @@ debug:
 securityContext:
   runAsNonRoot: true
   fsGroup: 65532
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
 
 resources: {}
 

--- a/charts/dapr/charts/dapr_scheduler/values.yaml
+++ b/charts/dapr/charts/dapr_scheduler/values.yaml
@@ -57,7 +57,6 @@ debug:
 securityContext:
   runAsNonRoot: true
   fsGroup: 65532
-  readOnlyRootFilesystem: false
 
 resources: {}
 

--- a/charts/dapr/charts/dapr_scheduler/values.yaml
+++ b/charts/dapr/charts/dapr_scheduler/values.yaml
@@ -57,6 +57,7 @@ debug:
 securityContext:
   runAsNonRoot: true
   fsGroup: 65532
+  readOnlyRootFilesystem: true
 
 resources: {}
 


### PR DESCRIPTION
Add writable identity directory for Scheduler's etcd TLS certificates to support readOnlyRootFilesystem.

