### PR TITLE
Update sidecar liveness probe to use tcp socket

### DIFF
--- a/pkg/injector/patcher/sidecar_container.go
+++ b/pkg/injector/patcher/sidecar_container.go
@@ -228,7 +228,8 @@ func (c *SidecarConfig) getSidecarContainer(opts getSidecarContainerOpts) (*core
 	}
 
 	// Create the container object
-	probeHTTPHandler := getProbeHTTPHandler(c.SidecarPublicPort, injectorConsts.APIVersionV1, injectorConsts.SidecarHealthzPath)
+	readinessProbeHandler := getReadinessProbeHandler(c.SidecarPublicPort, injectorConsts.APIVersionV1, injectorConsts.SidecarHealthzPath)
+	livenessProbeHandler := getLivenessProbeHandler(c.SidecarPublicPort)
 	env := []corev1.EnvVar{
 		{
 			Name:  "NAMESPACE",
@@ -289,14 +290,14 @@ func (c *SidecarConfig) getSidecarContainer(opts getSidecarContainerOpts) (*core
 		Env:             env,
 		VolumeMounts:    opts.VolumeMounts,
 		ReadinessProbe: &corev1.Probe{
-			ProbeHandler:        probeHTTPHandler,
+			ProbeHandler:        readinessProbeHandler,
 			InitialDelaySeconds: c.SidecarReadinessProbeDelaySeconds,
 			TimeoutSeconds:      c.SidecarReadinessProbeTimeoutSeconds,
 			PeriodSeconds:       c.SidecarReadinessProbePeriodSeconds,
 			FailureThreshold:    c.SidecarReadinessProbeThreshold,
 		},
 		LivenessProbe: &corev1.Probe{
-			ProbeHandler:        probeHTTPHandler,
+			ProbeHandler:        livenessProbeHandler,
 			InitialDelaySeconds: c.SidecarLivenessProbeDelaySeconds,
 			TimeoutSeconds:      c.SidecarLivenessProbeTimeoutSeconds,
 			PeriodSeconds:       c.SidecarLivenessProbePeriodSeconds,
@@ -509,10 +510,18 @@ func (c *SidecarConfig) GetAppProtocol() string {
 	}
 }
 
-func getProbeHTTPHandler(port int32, pathElements ...string) corev1.ProbeHandler {
+func getReadinessProbeHandler(port int32, pathElements ...string) corev1.ProbeHandler {
 	return corev1.ProbeHandler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Path: formatProbePath(pathElements...),
+			Port: intstr.IntOrString{IntVal: port},
+		},
+	}
+}
+
+func getLivenessProbeHandler(port int32) corev1.ProbeHandler {
+	return corev1.ProbeHandler{
+		TCPSocket: &corev1.TCPSocketAction{
 			Port: intstr.IntOrString{IntVal: port},
 		},
 	}

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -227,7 +227,7 @@ func TestGetProbeHttpHandler(t *testing.T) {
 		},
 	}
 
-	assert.EqualValues(t, expectedHandler, getProbeHTTPHandler(3500, pathElements...))
+	assert.EqualValues(t, expectedHandler, getReadinessProbeHandler(3500, pathElements...))
 }
 
 func TestFormatProbePath(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: GitHub Actions Bot <action@github.com>

# Description
Updates the Dapr sidecar liveness probe to use a simple tcp socket probe on the public dapr http server instead of using the current `/v1.0/healthz` endpoint as this produces in correct behaiour where the app health check can influence the liveness of the sidecar and force restart. Ideally the liveness probe should be as simple as possible in order to not cause unnecessary destruction.

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
