### PR TITLE
diagrid.io/go-etcd-cron: update to v0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dapr/components-contrib v1.15.0-rc.3
 	github.com/dapr/durabletask-go v0.6.3
 	github.com/dapr/kit v0.15.0
-	github.com/diagridio/go-etcd-cron v0.4.1
+	github.com/diagridio/go-etcd-cron v0.4.2
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.4.1 h1:Hd19m/rrgRASCF/kWRm/9pxctT1YliRyvcwpFqhTujY=
-github.com/diagridio/go-etcd-cron v0.4.1/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
+github.com/diagridio/go-etcd-cron v0.4.2 h1:adX0SDPNMoEdHQpI/aRoOHTtV1L81l6uw9BANKqt/mI=
+github.com/diagridio/go-etcd-cron v0.4.2/go.mod h1:x+ar+z4SZW46AvjFnWmBOCjoAE5V+HGeu9YbhDg4B3M=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -362,7 +362,7 @@ func (abe *Actors) GetOrchestrationRuntimeState(ctx context.Context, owi *backen
 }
 
 func (abe *Actors) WatchOrchestrationRuntimeStatus(ctx context.Context, id api.InstanceID, ch chan<- *backend.OrchestrationMetadata) error {
-	log.Debug("Actor backend streaming OrchestrationRuntimeStatus %s", id)
+	log.Debugf("Actor backend streaming OrchestrationRuntimeStatus %s", id)
 
 	engine, err := abe.actors.Engine(ctx)
 	if err != nil {


### PR DESCRIPTION
Also sneaks in a log fmt fix.