### PR TITLE
Actors: Add Placement client reconnect interval

### DIFF
--- a/pkg/actors/internal/placement/client/client.go
+++ b/pkg/actors/internal/placement/client/client.go
@@ -235,6 +235,11 @@ func (c *Client) Recv(ctx context.Context) (*v1pb.PlacementOrder, error) {
 			errors.Is(err, io.EOF) {
 			log.Infof("Placement service is closed, reconnecting...")
 			errCh := make(chan error, 1)
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Second):
+			}
+
 			c.reconnectCh <- errCh
 
 			select {

--- a/tests/integration/framework/metrics/metrics.go
+++ b/tests/integration/framework/metrics/metrics.go
@@ -40,7 +40,9 @@ func New(t assert.TestingT, ctx context.Context, url string) *Metrics {
 
 	httpclient := client.HTTP(t)
 	resp, err := httpclient.Do(req)
-	assert.NoError(t, err) //nolint:testifylint
+	if !assert.NoError(t, err) { //nolint:testifylint
+		return nil
+	}
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Extract the metrics


### PR DESCRIPTION
Adds a 1s duration interval before attempting to reconnect to placement in the event of a disconnect, likely due to leadership changes. This prevents large log spam due to a tight loop in the reconnect logic, where it will likely take some time for the new placement leader to be elected.



It's an arbitrary number which is "long enough" to not spam, and "short enough" to log that daprd is doing something. All this number is doing is setting the interval for when we try to connect to the placement leader again. Without it, we will have a reconnect error spam every few ms. This produces 1000s of log lines 

This is typically caused when the placement pod is restarted for whatever reason, e.g. being scheduled to a new node. It should be considered normal operation stuff.
