### PR TITLE
Actors: Fix Placement client reconnect

### DIFF
--- a/pkg/actors/internal/placement/client/client.go
+++ b/pkg/actors/internal/placement/client/client.go
@@ -16,7 +16,7 @@ package client
 import (
 	"context"
 	"errors"
-	"io"
+	"fmt"
 	"net"
 	"strings"
 	"sync/atomic"
@@ -24,8 +24,6 @@ import (
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/dapr/dapr/pkg/actors/internal/placement/lock"
 	"github.com/dapr/dapr/pkg/actors/table"
@@ -33,6 +31,7 @@ import (
 	"github.com/dapr/dapr/pkg/healthz"
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 	"github.com/dapr/dapr/pkg/security"
+	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/logger"
 )
 
@@ -41,11 +40,12 @@ const grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
 var log = logger.NewLogger("dapr.runtime.actors.placement.client")
 
 type Options struct {
-	Addresses []string
-	Security  security.Handler
-	Lock      *lock.Lock
-	Table     table.Interface
-	Healthz   healthz.Healthz
+	Addresses   []string
+	Security    security.Handler
+	Lock        *lock.Lock
+	Table       table.Interface
+	Healthz     healthz.Healthz
+	InitialHost *v1pb.Host
 }
 
 type Client struct {
@@ -54,15 +54,15 @@ type Client struct {
 	addresses    []string
 	htarget      healthz.Target
 
-	table       table.Interface
-	lock        *lock.Lock
-	reconnectCh chan chan error
+	table table.Interface
+	lock  *lock.Lock
 
-	conn   *grpc.ClientConn
-	stream atomic.Pointer[v1pb.Placement_ReportDaprStatusClient]
+	conn      *grpc.ClientConn
+	client    v1pb.Placement_ReportDaprStatusClient
+	sendQueue chan *v1pb.Host
+	recvQueue chan *v1pb.PlacementOrder
 
-	readyCh chan struct{}
-	ready   atomic.Bool
+	ready atomic.Bool
 }
 
 // New creates a new placement client for the given dial opts.
@@ -98,63 +98,84 @@ func New(opts Options) (*Client, error) {
 	}
 
 	return &Client{
-		grpcOpts:    gopts,
-		lock:        opts.Lock,
-		addresses:   addresses,
-		reconnectCh: make(chan chan error, 1),
-		readyCh:     make(chan struct{}),
-		table:       opts.Table,
-		htarget:     opts.Healthz.AddTarget(),
+		lock:      opts.Lock,
+		addresses: addresses,
+		grpcOpts:  gopts,
+		sendQueue: make(chan *v1pb.Host),
+		recvQueue: make(chan *v1pb.PlacementOrder),
+		table:     opts.Table,
+		htarget:   opts.Healthz.AddTarget(),
 	}, nil
 }
 
 func (c *Client) Run(ctx context.Context) error {
-	connCtx, connCancel := context.WithCancel(ctx)
-	if err := c.connectRoundRobin(connCtx); err != nil {
-		connCancel()
+	conctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if err := c.connectRoundRobin(conctx); err != nil {
 		return err
 	}
 
-	c.ready.Store(true)
-	close(c.readyCh)
 	c.htarget.Ready()
+	c.ready.Store(true)
+	log.Info("Connected to placement, ready for requests")
+
+	runner := func() *concurrency.RunnerManager {
+		return concurrency.NewRunnerManager(
+			func(ctx context.Context) error {
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case host := <-c.sendQueue:
+						if err := c.client.Send(host); err != nil {
+							return err
+						}
+					}
+				}
+			},
+			func(ctx context.Context) error {
+				for {
+					order, err := c.client.Recv()
+					if err != nil {
+						return err
+					}
+
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case c.recvQueue <- order:
+					}
+				}
+			},
+		)
+	}
 
 	for {
+		c.ready.Store(true)
+		c.htarget.Ready()
+
+		err := runner().Run(ctx)
+		if err == nil {
+			return c.table.HaltAll()
+		}
+
+		cancel()
+		c.ready.Store(false)
+		c.htarget.NotReady()
+
+		log.Errorf("Error communicating with placement: %s", err)
+		if ctx.Err() != nil {
+			return c.table.HaltAll()
+		}
+
 		select {
-		case ch := <-c.reconnectCh:
-			c.ready.Store(false)
-			unlock := c.lock.Lock()
-			connCancel()
-
-			if err := c.table.HaltAll(); err != nil {
-				unlock()
-				log.Errorf("Error whilst deactivating all actors when shutting down client: %s", err)
-				return nil
-			}
-
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-
-			connCtx, connCancel = context.WithCancel(ctx)
-			err := c.connectRoundRobin(connCtx)
-			ch <- err
-			unlock()
-			if err != nil {
-				connCancel()
-				return err
-			}
-
-			c.ready.Store(true)
-
+		case <-time.After(time.Second):
 		case <-ctx.Done():
-			c.ready.Store(false)
-			connCancel()
-			unlock := c.lock.Lock()
-			defer unlock()
-			if err := c.table.HaltAll(); err != nil {
-				log.Errorf("Error whilst deactivating all actors when shutting down client: %s", err)
-			}
+		}
+
+		cancel, err = c.handleReconnect(ctx)
+		if err != nil {
+			log.Errorf("Failed to reconnect to placement: %s", err)
 			return nil
 		}
 	}
@@ -162,6 +183,35 @@ func (c *Client) Run(ctx context.Context) error {
 
 func (c *Client) Ready() bool {
 	return c.ready.Load()
+}
+
+func (c *Client) handleReconnect(ctx context.Context) (context.CancelFunc, error) {
+	unlock := c.lock.Lock()
+	defer unlock()
+
+	log.Info("Placement stream disconnected")
+
+	if err := c.table.HaltAll(); err != nil {
+		return nil, fmt.Errorf("error whilst deactivating all actors when shutting down client: %s", err)
+	}
+
+	log.Info("Halted all actors on this host")
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	log.Infof("Reconnecting to placement...")
+
+	ctx, cancel := context.WithCancel(ctx)
+	if err := c.connectRoundRobin(ctx); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	log.Infof("Reconnected to placement")
+
+	return cancel, nil
 }
 
 func (c *Client) connectRoundRobin(ctx context.Context) error {
@@ -186,6 +236,8 @@ func (c *Client) connect(ctx context.Context) error {
 		c.addressIndex++
 	}()
 
+	log.Debugf("Attempting to connect to placement %s", c.addresses[c.addressIndex%len(c.addresses)])
+
 	var err error
 	// If we're trying to connect to the same address, we reuse the existing
 	// connection.
@@ -196,15 +248,25 @@ func (c *Client) connect(ctx context.Context) error {
 		//nolint:staticcheck
 		c.conn, err = grpc.DialContext(ctx, c.addresses[c.addressIndex%len(c.addresses)], c.grpcOpts...)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to dial placement: %s", err)
 		}
 	}
 
-	stream, err := v1pb.NewPlacementClient(c.conn).ReportDaprStatus(ctx)
+	client, err := v1pb.NewPlacementClient(c.conn).ReportDaprStatus(ctx)
 	if err != nil {
+		err = fmt.Errorf("failed to create placement client: %s", err)
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			// reset gRPC connenxt to reset the round robin load balancer state to
+			// ensure we connect to new hosts if all Placement hosts have been
+			// terminated.
+			log.Infof("Resetting gRPC connection to reset round robin load balancer state")
+			c.conn = nil
+		}
+
 		return err
 	}
-	c.stream.Store(&stream)
+
+	c.client = client
 
 	log.Infof("Connected to placement %s", c.addresses[c.addressIndex%len(c.addresses)])
 
@@ -215,46 +277,8 @@ func (c *Client) Recv(ctx context.Context) (*v1pb.PlacementOrder, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-c.readyCh:
-	}
-
-	for {
-		o, err := (*c.stream.Load()).Recv()
-		if err == nil {
-			return o, nil
-		}
-
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		s, ok := status.FromError(err)
-
-		if (ok &&
-			(s.Code() == codes.FailedPrecondition || s.Message() == "placement service is closed")) ||
-			errors.Is(err, io.EOF) {
-			log.Infof("Placement service is closed, reconnecting...")
-			errCh := make(chan error, 1)
-			select {
-			case <-ctx.Done():
-			case <-time.After(time.Second):
-			}
-
-			c.reconnectCh <- errCh
-
-			select {
-			case <-ctx.Done():
-				err = ctx.Err()
-			case err = <-errCh:
-			}
-			if err != nil {
-				return nil, err
-			}
-
-			continue
-		}
-
-		return nil, err
+	case order := <-c.recvQueue:
+		return order, nil
 	}
 }
 
@@ -262,22 +286,8 @@ func (c *Client) Send(ctx context.Context, host *v1pb.Host) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-c.readyCh:
-	}
-
-	for {
-		err := (*c.stream.Load()).Send(host)
-		if err == nil {
-			return nil
-		}
-
-		log.Errorf("Failed to send host report to placement, retrying: %s", err)
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Second):
-		}
+	case c.sendQueue <- host:
+		return nil
 	}
 }
 

--- a/pkg/actors/internal/placement/client/client.go
+++ b/pkg/actors/internal/placement/client/client.go
@@ -117,7 +117,6 @@ func (c *Client) Run(ctx context.Context) error {
 
 	c.htarget.Ready()
 	c.ready.Store(true)
-	log.Info("Connected to placement, ready for requests")
 
 	runner := func() *concurrency.RunnerManager {
 		return concurrency.NewRunnerManager(

--- a/pkg/actors/table/table_test.go
+++ b/pkg/actors/table/table_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package table_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/actors/internal/locker"
+	"github.com/dapr/dapr/pkg/actors/internal/reentrancystore"
+	"github.com/dapr/dapr/pkg/actors/table"
+	"github.com/dapr/dapr/pkg/actors/targets"
+	"github.com/dapr/dapr/pkg/actors/targets/fake"
+	"github.com/dapr/kit/concurrency/slice"
+	"github.com/dapr/kit/events/queue"
+)
+
+func Test_HaltAll(t *testing.T) {
+	queue := queue.NewProcessor[string, targets.Idlable](nil)
+
+	tble := table.New(table.Options{
+		IdlerQueue:      queue,
+		ReentrancyStore: reentrancystore.New(),
+		Locker: locker.New(locker.Options{
+			ConfigStore: reentrancystore.New(),
+		}),
+	})
+
+	deactivations := slice.String()
+	tble.RegisterActorTypes(table.RegisterActorTypeOptions{
+		Factories: []table.ActorTypeFactory{
+			{
+				Type: "test1",
+				Factory: fake.New("test1", func(f *fake.Fake) {
+					f.WithDeactivate(func(context.Context) error {
+						deactivations.Append(f.Key())
+						return nil
+					})
+				}),
+			},
+			{
+				Type: "test2",
+				Factory: fake.New("test2", func(f *fake.Fake) {
+					f.WithDeactivate(func(context.Context) error {
+						deactivations.Append(f.Key())
+						return nil
+					})
+				}),
+			},
+			{
+				Type: "test3",
+				Factory: fake.New("test3", func(f *fake.Fake) {
+					f.WithDeactivate(func(context.Context) error {
+						deactivations.Append(f.Key())
+						return nil
+					})
+				}),
+			},
+		},
+	})
+
+	_, _, err := tble.GetOrCreate("test1", "1")
+	require.NoError(t, err)
+	_, _, err = tble.GetOrCreate("test2", "1")
+	require.NoError(t, err)
+	_, _, err = tble.GetOrCreate("test2", "2")
+	require.NoError(t, err)
+	_, _, err = tble.GetOrCreate("test3", "312")
+	require.NoError(t, err)
+	_, _, err = tble.GetOrCreate("test3", "xyz")
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]int{
+		"test1": 1,
+		"test2": 2,
+		"test3": 2,
+	}, tble.Len())
+
+	assert.True(t, tble.IsActorTypeHosted("test1"))
+	assert.True(t, tble.IsActorTypeHosted("test2"))
+	assert.True(t, tble.IsActorTypeHosted("test3"))
+	assert.False(t, tble.IsActorTypeHosted("test4"))
+
+	require.NoError(t, tble.Halt(context.Background(), "test1", "1"))
+
+	assert.ElementsMatch(t, []string{
+		"test1/1",
+	}, deactivations.Slice())
+
+	require.NoError(t, tble.HaltAll())
+
+	assert.ElementsMatch(t, []string{
+		"test1/1", "test2/1", "test2/2", "test3/312", "test3/xyz",
+	}, deactivations.Slice())
+}

--- a/pkg/actors/targets/fake/fake.go
+++ b/pkg/actors/targets/fake/fake.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	"github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/targets"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+)
+
+type Fake struct {
+	fnKey            func() string
+	fnInvokeMethod   func(context.Context, *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error)
+	fnInvokeReminder func(context.Context, *api.Reminder) error
+	fnInvokeTimer    func(context.Context, *api.Reminder) error
+	fnInvokeStream   func(context.Context, *internalv1pb.InternalInvokeRequest, chan<- *internalv1pb.InternalInvokeResponse) error
+	fnDeactivate     func(context.Context) error
+}
+
+type Hook func(*Fake)
+
+func New(actorType string, hooks ...func(*Fake)) targets.Factory {
+	return func(actorID string) targets.Interface {
+		f := &Fake{
+			fnKey: func() string {
+				return actorType + "/" + actorID
+			},
+			fnInvokeMethod: func(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
+				return nil, nil
+			},
+			fnInvokeReminder: func(ctx context.Context, reminder *api.Reminder) error {
+				return nil
+			},
+			fnInvokeTimer: func(ctx context.Context, reminder *api.Reminder) error {
+				return nil
+			},
+			fnInvokeStream: func(ctx context.Context, req *internalv1pb.InternalInvokeRequest, stream chan<- *internalv1pb.InternalInvokeResponse) error {
+				return nil
+			},
+			fnDeactivate: func(ctx context.Context) error {
+				return nil
+			},
+		}
+
+		for _, hook := range hooks {
+			hook(f)
+		}
+
+		return f
+	}
+}
+
+func (f *Fake) WithKey(fn func() string) *Fake {
+	f.fnKey = fn
+	return f
+}
+
+func (f *Fake) WithInvokeMethod(fn func(context.Context, *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error)) *Fake {
+	f.fnInvokeMethod = fn
+	return f
+}
+
+func (f *Fake) WithInvokeReminder(fn func(context.Context, *api.Reminder) error) *Fake {
+	f.fnInvokeReminder = fn
+	return f
+}
+
+func (f *Fake) WithInvokeTimer(fn func(context.Context, *api.Reminder) error) *Fake {
+	f.fnInvokeTimer = fn
+	return f
+}
+
+func (f *Fake) WithInvokeStream(fn func(context.Context, *internalv1pb.InternalInvokeRequest, chan<- *internalv1pb.InternalInvokeResponse) error) *Fake {
+	f.fnInvokeStream = fn
+	return f
+}
+
+func (f *Fake) WithDeactivate(fn func(context.Context) error) *Fake {
+	f.fnDeactivate = fn
+	return f
+}
+
+func (f *Fake) Key() string {
+	return f.fnKey()
+}
+
+func (f *Fake) InvokeMethod(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
+	return f.fnInvokeMethod(ctx, req)
+}
+
+func (f *Fake) InvokeReminder(ctx context.Context, reminder *api.Reminder) error {
+	return f.fnInvokeReminder(ctx, reminder)
+}
+
+func (f *Fake) InvokeTimer(ctx context.Context, reminder *api.Reminder) error {
+	return f.fnInvokeTimer(ctx, reminder)
+}
+
+func (f *Fake) InvokeStream(ctx context.Context, req *internalv1pb.InternalInvokeRequest, stream chan<- *internalv1pb.InternalInvokeResponse) error {
+	return f.fnInvokeStream(ctx, req, stream)
+}
+
+func (f *Fake) Deactivate(ctx context.Context) error {
+	return f.fnDeactivate(ctx)
+}

--- a/pkg/actors/targets/fake/fake_test.go
+++ b/pkg/actors/targets/fake/fake_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake_test
+
+import (
+	"testing"
+
+	"github.com/dapr/dapr/pkg/actors/targets"
+	"github.com/dapr/dapr/pkg/actors/targets/fake"
+)
+
+func Test_Fake(t *testing.T) {
+	var _ targets.Factory = fake.New("")
+	var _ targets.Interface = fake.New("")("")
+}

--- a/pkg/actors/targets/workflow/activity.go
+++ b/pkg/actors/targets/workflow/activity.go
@@ -335,7 +335,7 @@ func (a *activity) createReliableReminder(ctx context.Context, his *backend.Hist
 
 // DeactivateActor implements actors.InternalActor
 func (a *activity) Deactivate(ctx context.Context) error {
-	log.Debugf("Activity actor '%s': deactivating", a.actorID)
+	log.Debugf("Activity actor '%s': deactivated", a.actorID)
 	return nil
 }
 

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -954,8 +954,8 @@ func (w *workflow) removeCompletedStateData(ctx context.Context, state *wfengine
 
 // DeactivateActor implements actors.InternalActor
 func (w *workflow) Deactivate(ctx context.Context) error {
-	log.Debugf("Workflow actor '%s': deactivating", w.actorID)
 	w.cleanup()
+	log.Debugf("Workflow actor '%s': deactivated", w.actorID)
 	return nil
 }
 

--- a/tests/integration/framework/process/scheduler/options.go
+++ b/tests/integration/framework/process/scheduler/options.go
@@ -29,15 +29,14 @@ type options struct {
 	namespace                string
 	etcdBackendBatchInterval string
 
-	logLevel      string
-	port          int
-	healthzPort   int
-	metricsPort   int
-	listenAddress string
-	sentry        *sentry.Sentry
-	dataDir       *string
-	kubeconfig    *string
-	mode          *string
+	logLevel    string
+	port        int
+	healthzPort int
+	metricsPort int
+	sentry      *sentry.Sentry
+	dataDir     *string
+	kubeconfig  *string
+	mode        *string
 
 	overrideBroadcastHostPort *string
 }
@@ -88,12 +87,6 @@ func WithHealthzPort(port int) Option {
 func WithMetricsPort(port int) Option {
 	return func(o *options) {
 		o.metricsPort = port
-	}
-}
-
-func WithListenAddress(address string) Option {
-	return func(o *options) {
-		o.listenAddress = address
 	}
 }
 

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -85,7 +85,6 @@ func New(t *testing.T, fopts ...Option) *Scheduler {
 
 	opts := options{
 		logLevel:                 "info",
-		listenAddress:            "127.0.0.1",
 		id:                       uids,
 		port:                     fp.Port(t),
 		healthzPort:              fp.Port(t),
@@ -115,7 +114,7 @@ func New(t *testing.T, fopts ...Option) *Scheduler {
 		"--metrics-port=" + strconv.Itoa(opts.metricsPort),
 		"--etcd-data-dir=" + dataDir,
 		"--etcd-client-port=" + strconv.Itoa(opts.etcdClientPort),
-		"--listen-address=" + opts.listenAddress,
+		"--listen-address=127.0.0.1",
 		"--identity-directory-write=" + filepath.Join(t.TempDir(), "tls"),
 		"--etcd-backend-batch-interval=" + opts.etcdBackendBatchInterval,
 	}


### PR DESCRIPTION
Fixes an issue whereby a deadlock would occur when halting all actors, which happens during shutdown or placement dissemination events. This would happen more often during workflow execution as workflow and activity actors have a short deactivation time, and the bug involved a race condition of ranging over the actor table and deleting elements from the table.

Fixes the actor placement client reconnect logic to be more robust by cancelling a placement connection when either a `Send` or `Recv` fails. Also dereferences the placement gRPC connection in the event of connection refused errors to ensure that the round robin load balance state is reset so new placement IPs can be discovered from the headless service. These errors occur when 1 or more placement pods are completely deleted.

Suppresses an EOF error when streaming workflow runtime status, as this is a normal condition when the workflow actor stream has been terminated.