### PR TITLE
Fix scheduler/placement empty address handling to prevent errors

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -138,7 +138,7 @@ type actors struct {
 func New(opts Options) Interface {
 	var disabled atomic.Pointer[error]
 	if len(opts.PlacementAddresses) == 0 ||
-		(len(opts.PlacementAddresses) == 1 && strings.TrimSpace(opts.PlacementAddresses[0]) == "") {
+		(len(opts.PlacementAddresses) == 1 && strings.TrimSpace(strings.Trim(opts.PlacementAddresses[0], `"'`)) == "") {
 		var err error = messages.ErrActorNoPlacement
 		log.Warnf("Actor runtime disabled: %s. Actors and Workflow APIs will be unavailable", err)
 		disabled.Store(&err)

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cast"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/dapr/dapr/pkg/injector/annotations"
 	injectorConsts "github.com/dapr/dapr/pkg/injector/consts"
 	"github.com/dapr/kit/utils"
 )
@@ -165,6 +166,12 @@ func (c *SidecarConfig) setFromAnnotations(an map[string]string) {
 		// Skip annotations that are not defined, respect user defined "" for fields to disable them
 		if _, exists := an[key]; !exists {
 			continue
+		}
+
+		// Special cleanup for placement and scheduler addresses defined by annotations being empty
+		if key == annotations.KeyPlacementHostAddresses || key == annotations.KeySchedulerHostAddresses {
+			trimmed := strings.TrimSpace(strings.Trim(an[key], `"'`))
+			an[key] = trimmed
 		}
 
 		// Assign the value

--- a/pkg/injector/patcher/sidecar_test.go
+++ b/pkg/injector/patcher/sidecar_test.go
@@ -84,4 +84,31 @@ func TestSidecarConfigSetFromAnnotations(t *testing.T) {
 		assert.Equal(t, int32(0), c.AppPort)
 		assert.Nil(t, c.HTTPMaxRequestSize)
 	})
+
+	t.Run("host addresses with various empty string formats", func(t *testing.T) {
+		testCases := []struct {
+			name  string
+			value string
+		}{
+			{"empty string", ""},
+			{"single-quoted empty string", `'""'`},
+			{"single quotes", `''`},
+			{"double quotes", `""`},
+			{"spaces", "   "},
+			{"quoted spaces", `"   "`},
+			{"single-quoted spaces", `'   '`},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				c := NewSidecarConfig(&corev1.Pod{})
+				c.setFromAnnotations(map[string]string{
+					annotations.KeySchedulerHostAddresses: tc.value,
+					annotations.KeyPlacementHostAddresses: tc.value,
+				})
+				assert.Equal(t, "", c.PlacementAddress, "PlacementAddress should be empty for input: %q", tc.value)
+				assert.Equal(t, "", c.SchedulerAddress, "SchedulerAddress should be empty for input: %q", tc.value)
+			})
+		}
+	})
 }

--- a/pkg/runtime/scheduler/scheduler.go
+++ b/pkg/runtime/scheduler/scheduler.go
@@ -84,7 +84,7 @@ func New(opts Options) *Scheduler {
 
 func (s *Scheduler) Run(ctx context.Context) error {
 	if len(s.addresses) == 0 ||
-		(len(s.addresses) == 1 && strings.TrimSpace(s.addresses[0]) == "") {
+		(len(s.addresses) == 1 && strings.TrimSpace(strings.Trim(s.addresses[0], `"'`)) == "") {
 		s.htarget.Ready()
 		log.Warn("Scheduler disabled, not connecting...")
 		close(s.disabled)

--- a/tests/integration/suite/daprd/actors/emptyaddress.go
+++ b/tests/integration/suite/daprd/actors/emptyaddress.go
@@ -29,9 +29,16 @@ func init() {
 }
 
 type emptyaddress struct {
-	daprdNoPlace          *daprd.Daprd
-	daprdPlaceEmptyAddr   *daprd.Daprd
-	daprdPlaceSpaceAddr   *daprd.Daprd
+	daprdNoPlace                         *daprd.Daprd
+	daprdPlaceEmptyAddr                  *daprd.Daprd
+	daprdPlaceSpaceAddr                  *daprd.Daprd
+	daprdPlaceExtraSpaceAddr             *daprd.Daprd
+	daprdPlaceSingleQuoteAddr            *daprd.Daprd
+	daprdPlaceSingleQuoteExtraSpaceAddr  *daprd.Daprd
+	daprdPlaceSingleQuoteEmtpyStringAddr *daprd.Daprd
+	daprdPlaceDoubleQuoteAddr            *daprd.Daprd
+	daprdPlaceDoubleQuoteSpaceAddr       *daprd.Daprd
+
 	loglineActorsDisabled *logline.LogLine
 }
 
@@ -57,15 +64,60 @@ func (a *emptyaddress) Setup(t *testing.T) []framework.Option {
 		daprd.WithInMemoryActorStateStore("mystore"),
 	)
 
+	a.daprdPlaceExtraSpaceAddr = daprd.New(t,
+		daprd.WithPlacementAddresses("       "),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineActorsDisabled.Stdout())),
+		daprd.WithInMemoryActorStateStore("mystore"),
+	)
+
+	a.daprdPlaceSingleQuoteAddr = daprd.New(t,
+		daprd.WithPlacementAddresses("''"),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineActorsDisabled.Stdout())),
+		daprd.WithInMemoryActorStateStore("mystore"),
+	)
+
+	a.daprdPlaceSingleQuoteExtraSpaceAddr = daprd.New(t,
+		daprd.WithPlacementAddresses("'      '"),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineActorsDisabled.Stdout())),
+		daprd.WithInMemoryActorStateStore("mystore"),
+	)
+
+	a.daprdPlaceSingleQuoteEmtpyStringAddr = daprd.New(t,
+		daprd.WithPlacementAddresses(`'""'`),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineActorsDisabled.Stdout())),
+		daprd.WithInMemoryActorStateStore("mystore"),
+	)
+
+	a.daprdPlaceDoubleQuoteAddr = daprd.New(t,
+		daprd.WithPlacementAddresses(`""`),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineActorsDisabled.Stdout())),
+		daprd.WithInMemoryActorStateStore("mystore"),
+	)
+
+	a.daprdPlaceDoubleQuoteSpaceAddr = daprd.New(t,
+		daprd.WithPlacementAddresses(`"   "`),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineActorsDisabled.Stdout())),
+		daprd.WithInMemoryActorStateStore("mystore"),
+	)
+
 	return []framework.Option{
-		framework.WithProcesses(a.loglineActorsDisabled, a.daprdNoPlace, a.daprdPlaceEmptyAddr, a.daprdPlaceSpaceAddr),
+		framework.WithProcesses(a.loglineActorsDisabled, a.daprdNoPlace, a.daprdPlaceEmptyAddr,
+			a.daprdPlaceSpaceAddr, a.daprdPlaceExtraSpaceAddr, a.daprdPlaceSingleQuoteAddr,
+			a.daprdPlaceSingleQuoteExtraSpaceAddr, a.daprdPlaceSingleQuoteEmtpyStringAddr,
+			a.daprdPlaceDoubleQuoteAddr, a.daprdPlaceDoubleQuoteSpaceAddr),
 	}
 }
 
 func (a *emptyaddress) Run(t *testing.T, ctx context.Context) {
 	a.daprdNoPlace.WaitUntilRunning(t, ctx)
 	a.daprdPlaceSpaceAddr.WaitUntilRunning(t, ctx)
+	a.daprdPlaceExtraSpaceAddr.WaitUntilRunning(t, ctx)
 	a.daprdPlaceEmptyAddr.WaitUntilRunning(t, ctx)
+	a.daprdPlaceSingleQuoteAddr.WaitUntilRunning(t, ctx)
+	a.daprdPlaceSingleQuoteExtraSpaceAddr.WaitUntilRunning(t, ctx)
+	a.daprdPlaceSingleQuoteEmtpyStringAddr.WaitUntilRunning(t, ctx)
+	a.daprdPlaceDoubleQuoteAddr.WaitUntilRunning(t, ctx)
+	a.daprdPlaceDoubleQuoteSpaceAddr.WaitUntilRunning(t, ctx)
 
 	a.loglineActorsDisabled.EventuallyFoundAll(t)
 }

--- a/tests/integration/suite/daprd/daprd.go
+++ b/tests/integration/suite/daprd/daprd.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/pubsub"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resources"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/scheduler"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/secret"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown"

--- a/tests/integration/suite/daprd/scheduler/emptyaddress.go
+++ b/tests/integration/suite/daprd/scheduler/emptyaddress.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(emptyaddress))
+}
+
+type emptyaddress struct {
+	daprdNoSched                        *daprd.Daprd
+	daprdSchedEmptyAddr                 *daprd.Daprd
+	daprdSchedSpaceAddr                 *daprd.Daprd
+	daprdSchedExtraSpaceAddr            *daprd.Daprd
+	daprdSchedSingleQuoteAddr           *daprd.Daprd
+	daprdSchedSingleQuoteExtraSpaceAddr *daprd.Daprd
+	daprdSchedDoubleQuoteAddr           *daprd.Daprd
+	daprdSchedDoubleQuoteSpaceAddr      *daprd.Daprd
+
+	loglineSchedDisabled *logline.LogLine
+}
+
+func (a *emptyaddress) Setup(t *testing.T) []framework.Option {
+	a.loglineSchedDisabled = logline.New(t, logline.WithStdoutLineContains(
+		"Scheduler disabled",
+	))
+
+	a.daprdNoSched = daprd.New(t,
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	a.daprdSchedEmptyAddr = daprd.New(t,
+		daprd.WithSchedulerAddresses(""),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	a.daprdSchedSpaceAddr = daprd.New(t,
+		daprd.WithSchedulerAddresses(" "),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	a.daprdSchedExtraSpaceAddr = daprd.New(t,
+		daprd.WithSchedulerAddresses("       "),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	a.daprdSchedSingleQuoteAddr = daprd.New(t,
+		daprd.WithSchedulerAddresses("''"),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	a.daprdSchedSingleQuoteExtraSpaceAddr = daprd.New(t,
+		daprd.WithSchedulerAddresses("'      '"),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	a.daprdSchedDoubleQuoteAddr = daprd.New(t,
+		daprd.WithSchedulerAddresses(`""`),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	a.daprdSchedDoubleQuoteSpaceAddr = daprd.New(t,
+		daprd.WithSchedulerAddresses(`"   "`),
+		daprd.WithExecOptions(exec.WithStdout(a.loglineSchedDisabled.Stdout())),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.loglineSchedDisabled, a.daprdNoSched,
+			a.daprdSchedEmptyAddr, a.daprdSchedSpaceAddr, a.daprdSchedExtraSpaceAddr,
+			a.daprdSchedSingleQuoteAddr, a.daprdSchedSingleQuoteExtraSpaceAddr,
+			a.daprdSchedDoubleQuoteAddr, a.daprdSchedDoubleQuoteSpaceAddr),
+	}
+}
+
+func (a *emptyaddress) Run(t *testing.T, ctx context.Context) {
+	a.daprdNoSched.WaitUntilRunning(t, ctx)
+	a.daprdSchedEmptyAddr.WaitUntilRunning(t, ctx)
+	a.daprdSchedSpaceAddr.WaitUntilRunning(t, ctx)
+	a.daprdSchedExtraSpaceAddr.WaitUntilRunning(t, ctx)
+	a.daprdSchedSingleQuoteAddr.WaitUntilRunning(t, ctx)
+	a.daprdSchedSingleQuoteExtraSpaceAddr.WaitUntilRunning(t, ctx)
+	a.daprdSchedDoubleQuoteAddr.WaitUntilRunning(t, ctx)
+	a.daprdSchedDoubleQuoteSpaceAddr.WaitUntilRunning(t, ctx)
+
+	a.loglineSchedDisabled.EventuallyFoundAll(t)
+}


### PR DESCRIPTION
This PR improves the robustness of scheduler/placement address handling by adding proper validation for empty addresses and preventing potential panics or errors. The changes ensure that dapr safely handles various forms of empty address inputs that users might pass in via the cli or annotations to disable scheduler or placement connections.

The initial error that prompted this was a user passing in `'""'` via an annotation and seeing this error:
```
{"app_id":"tst-order-model","instance":"tst-order-model-c768656c5-cfk5f","level":"error","msg":"Failed to connect to placement \"\": rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp: address \\\"\\\": missing port in address\"","scope":"dapr.runtime.actors.placement.client","time":"2025-02-17T12:36:10.679293225Z","type":"log","ver":"1.15.0-rc.12"}
```

In v1.14, the user reported that `""` did not work to disable the connection, so they tried `'""'` which they claimed worked (though this might have been a false positive). Now in v1.15, the `'""'` syntax results in the above error. This PR ensures consistent and safe handling of empty address inputs across versions. 