### PR TITLE
add config option for workflows event sink

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.15.0-rc.3
-	github.com/dapr/durabletask-go v0.6.3
+	github.com/dapr/durabletask-go v0.6.4
 	github.com/dapr/kit v0.15.0
 	github.com/diagridio/go-etcd-cron v0.4.3
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.sum
+++ b/go.sum
@@ -468,8 +468,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.15.0-rc.3 h1:i3BUVpJw6mia67+JRprgh73rFmYqD78KC+iiZVlG/lg=
 github.com/dapr/components-contrib v1.15.0-rc.3/go.mod h1:eFF2Jan1kZBjY4vzU1zJ4rz8q9jHwy5BOKhEWLgYi/A=
-github.com/dapr/durabletask-go v0.6.3 h1:WHhSAw1YL4xneK3Jo5nGfmMaJxfFodIIF5q1rpkDDfs=
-github.com/dapr/durabletask-go v0.6.3/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
+github.com/dapr/durabletask-go v0.6.4 h1:Mmao3JqcxVTGj87Sy/B5BcURxnr/WS8178xWSdwNjoc=
+github.com/dapr/durabletask-go v0.6.4/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/dapr/kit v0.15.0 h1:446jrEOQV/0rt6FwmoKrifP3vav5+Uh/u38DqU8q+JM=
 github.com/dapr/kit v0.15.0/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/dapr/dapr/pkg/acl"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow"
 	"github.com/dapr/dapr/pkg/config"
 	env "github.com/dapr/dapr/pkg/config/env"
 	configmodes "github.com/dapr/dapr/pkg/config/modes"
@@ -114,6 +115,7 @@ type Config struct {
 	Registry                      *registry.Options
 	Security                      security.Handler
 	Healthz                       healthz.Healthz
+	WorkflowEventSink             workflow.EventSink
 }
 
 type internalConfig struct {
@@ -149,6 +151,7 @@ type internalConfig struct {
 	metricsExporter              metrics.Exporter
 	healthz                      healthz.Healthz
 	outboundHealthz              healthz.Healthz
+	workflowEventSink            workflow.EventSink
 }
 
 func (i internalConfig) SchedulerEnabled() bool {
@@ -315,6 +318,7 @@ func (c *Config) toInternal() (*internalConfig, error) {
 		internalGRPCListenAddress: c.DaprInternalGRPCListenAddress,
 		healthz:                   c.Healthz,
 		outboundHealthz:           healthz.New(),
+		workflowEventSink:         c.WorkflowEventSink,
 	}
 
 	if len(intc.standalone.ResourcesPath) == 0 && c.ComponentsPath != "" {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -280,6 +280,7 @@ func newDaprRuntime(ctx context.Context,
 		BackendManager:     processor.WorkflowBackend(),
 		Resiliency:         resiliencyProvider,
 		SchedulerReminders: globalConfig.IsFeatureEnabled(config.SchedulerReminders),
+		EventSink:          runtimeConfig.workflowEventSink,
 	})
 
 	rt := &DaprRuntime{

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/dapr/components-contrib/workflows"
 	"github.com/dapr/dapr/pkg/actors"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow"
 	"github.com/dapr/dapr/pkg/config"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
@@ -54,6 +55,7 @@ type Options struct {
 	BackendManager     processor.WorkflowBackendManager
 	Resiliency         resiliency.Provider
 	SchedulerReminders bool
+	EventSink          workflow.EventSink
 }
 
 type engine struct {
@@ -76,6 +78,7 @@ func New(opts Options) Interface {
 		Actors:             opts.Actors,
 		Resiliency:         opts.Resiliency,
 		SchedulerReminders: opts.SchedulerReminders,
+		EventSink:          opts.EventSink,
 	})
 
 	var activeConns uint64


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

needs first https://github.com/dapr/durabletask-go/pull/17

refactors the workflow actor and changes the broadcaster to be use `backend. OrchestrationRuntimeState`
adds config option all the way up to the runtime config, so consumers of dapr as a library can use it

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
