### PR TITLE
tests: add placement process options

### DIFF
--- a/tests/integration/framework/process/placement/options.go
+++ b/tests/integration/framework/process/placement/options.go
@@ -37,10 +37,13 @@ type options struct {
 	initialClusterPorts []int
 	tlsEnabled          bool
 	sentryAddress       *string
+	trustDomain         *string
 	trustAnchorsFile    *string
 	maxAPILevel         *int
 	minAPILevel         *int
 	metadataEnabled     bool
+	mode                *string
+	namespace           string
 }
 
 func WithExecOptions(execOptions ...exec.Option) Option {
@@ -102,6 +105,7 @@ func WithSentry(t *testing.T, sentry *sentry.Sentry) Option {
 		o.tlsEnabled = true
 		o.sentryAddress = ptr.Of(sentry.Address())
 		o.trustAnchorsFile = ptr.Of(sentry.TrustAnchorsFile(t))
+		o.trustDomain = ptr.Of(sentry.TrustDomain(t))
 	}
 }
 
@@ -132,5 +136,17 @@ func WithMinAPILevel(val int) Option {
 func WithMetadataEnabled(enabled bool) Option {
 	return func(o *options) {
 		o.metadataEnabled = enabled
+	}
+}
+
+func WithMode(mode string) Option {
+	return func(o *options) {
+		o.mode = &mode
+	}
+}
+
+func WithNamespace(namespace string) Option {
+	return func(o *options) {
+		o.namespace = namespace
 	}
 }

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -74,6 +74,7 @@ func New(t *testing.T, fopts ...Option) *Placement {
 		initialCluster:      uid.String() + "=127.0.0.1:" + strconv.Itoa(port),
 		initialClusterPorts: []int{port},
 		metadataEnabled:     false,
+		namespace:           "default",
 	}
 
 	for _, fopt := range fopts {
@@ -105,9 +106,19 @@ func New(t *testing.T, fopts ...Option) *Placement {
 	if opts.trustAnchorsFile != nil {
 		args = append(args, "--trust-anchors-file="+*opts.trustAnchorsFile)
 	}
+	if opts.trustDomain != nil {
+		args = append(args, "--trust-domain="+*opts.trustDomain)
+	}
+	if opts.mode != nil {
+		args = append(args, "--mode="+*opts.mode)
+	}
 
 	return &Placement{
-		exec:                exec.New(t, binary.EnvValue("placement"), args, opts.execOpts...),
+		exec: exec.New(t, binary.EnvValue("placement"), args,
+			append(opts.execOpts, exec.WithEnvVars(t,
+				"NAMESPACE", opts.namespace,
+			))...,
+		),
 		ports:               fp,
 		id:                  opts.id,
 		port:                opts.port,

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -120,8 +120,7 @@ func New(t *testing.T, fopts ...Option) *Scheduler {
 	}
 
 	if opts.sentry != nil {
-		taFile := filepath.Join(t.TempDir(), "ca.pem")
-		require.NoError(t, os.WriteFile(taFile, opts.sentry.CABundle().TrustAnchors, 0o600))
+		taFile := opts.sentry.TrustAnchorsFile(t)
 		args = append(args,
 			"--tls-enabled=true",
 			"--sentry-address="+opts.sentry.Address(),


### PR DESCRIPTION
# Description

Missing options to be able to run placement in kubernetes mode in integration tests

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
