### PR TITLE
fix workflows closing broadcaster subscriptions

### DIFF
--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -230,9 +230,6 @@ func (w *workflow) InvokeReminder(ctx context.Context, reminder *actorapi.Remind
 
 	if completed == runCompletedTrue {
 		w.table.DeleteFromTableIn(w, time.Second*10)
-		if w.closed.CompareAndSwap(false, true) {
-			close(w.closeCh)
-		}
 	}
 
 	// We delete the reminder on success and on non-recoverable errors.
@@ -1000,8 +997,10 @@ func (w *workflow) InvokeStream(ctx context.Context, req *internalsv1pb.Internal
 		return err
 	}
 
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	ch := make(chan *backend.OrchestrationMetadata)
-	w.ometaBroadcaster.Subscribe(ctx, ch)
+	w.ometaBroadcaster.Subscribe(subCtx, ch)
 
 	for {
 		select {


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

This PR changes two things:
- adds a explicit context cancel to the broadcaster subscribe in `InvokeStream`, this is to guarantee that the subscription will be closed, altough it was already being closed when the actual grpc stream call was closed... but its better to be explicit here so we don't risk blocking broadcaster.Broadcast calls
- removes the call to `close(w.closeCh)` after a workflow is completed, this was stopping the broadcaster subscriptions too early, both the event sink and the InvokeStream subscriptions were immediately prevented from consuming the last events published to the broadcaster... in fact this was a race between the last call to `Broadcast` and the subscriptions being stop because of the call to `close(w.closeCh)`. This channel will be closed when the actor is deactivated, which will happen after 10 seconds once the actor detects the workflow is completed.... we will now still have the risk that the inflight events in the broadcaster are not processed within these 10 seconds... however for now this is a good enough solution

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
