### PR TITLE
fix workflow name empty on first event

### DIFF
--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -48,6 +48,7 @@ import (
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
 	"github.com/dapr/kit/events/broadcaster"
@@ -273,28 +274,8 @@ func (w *workflow) InvokeTimer(ctx context.Context, reminder *actorapi.Reminder)
 }
 
 func (w *workflow) createWorkflowInstance(ctx context.Context, request []byte) error {
-	// create a new state entry if one doesn't already exist
-	state, _, err := w.loadInternalState(ctx)
-	if err != nil {
-		return err
-	}
-
-	created := false
-	if state == nil {
-		state = wfenginestate.NewState(wfenginestate.Options{
-			AppID:             w.appID,
-			WorkflowActorType: w.actorType,
-			ActivityActorType: w.activityActorType,
-		})
-		w.lock.Lock()
-		w.rstate = runtimestate.NewOrchestrationRuntimeState(w.actorID, state.CustomStatus, state.History)
-		w.setOrchestrationMetadata(w.rstate)
-		created = true
-		w.lock.Unlock()
-	}
-
 	var createWorkflowInstanceRequest backend.CreateWorkflowInstanceRequest
-	if err = proto.Unmarshal(request, &createWorkflowInstanceRequest); err != nil {
+	if err := proto.Unmarshal(request, &createWorkflowInstanceRequest); err != nil {
 		return fmt.Errorf("failed to unmarshal createWorkflowInstanceRequest: %w", err)
 	}
 	reuseIDPolicy := createWorkflowInstanceRequest.GetPolicy()
@@ -310,8 +291,23 @@ func (w *workflow) createWorkflowInstance(ctx context.Context, request []byte) e
 		}
 	}
 
-	// orchestration didn't exist and was just created
-	if created {
+	state, _, err := w.loadInternalState(ctx)
+	if err != nil {
+		return err
+	}
+
+	// orchestration didn't exist
+	// create a new state entry if one doesn't already exist
+	if state == nil {
+		state = wfenginestate.NewState(wfenginestate.Options{
+			AppID:             w.appID,
+			WorkflowActorType: w.actorType,
+			ActivityActorType: w.activityActorType,
+		})
+		w.lock.Lock()
+		w.rstate = runtimestate.NewOrchestrationRuntimeState(w.actorID, state.CustomStatus, state.History)
+		w.setOrchestrationMetadata(w.rstate, startEvent.GetExecutionStarted())
+		w.lock.Unlock()
 		return w.scheduleWorkflowStart(ctx, startEvent, state)
 	}
 
@@ -457,18 +453,18 @@ func (w *workflow) addWorkflowEvent(ctx context.Context, historyEventBytes []byt
 	return nil
 }
 
-func (w *workflow) getWorkflowName(oldEvents, newEvents []*backend.HistoryEvent) string {
-	for _, e := range oldEvents {
+func (w *workflow) getExecutionStartedEvent(state *wfenginestate.State) *protos.ExecutionStartedEvent {
+	for _, e := range state.History {
 		if es := e.GetExecutionStarted(); es != nil {
-			return es.GetName()
+			return es
 		}
 	}
-	for _, e := range newEvents {
+	for _, e := range state.Inbox {
 		if es := e.GetExecutionStarted(); es != nil {
-			return es.GetName()
+			return es
 		}
 	}
-	return ""
+	return &protos.ExecutionStartedEvent{}
 }
 
 func (w *workflow) runWorkflow(ctx context.Context, reminder *actorapi.Reminder) (runCompleted, error) {
@@ -580,7 +576,7 @@ func (w *workflow) runWorkflow(ctx context.Context, reminder *actorapi.Reminder)
 		// which will skip recording metrics for this execution.
 		executionStatus = ""
 	}
-	workflowName := w.getWorkflowName(state.History, state.Inbox)
+	workflowName := w.getExecutionStartedEvent(state).GetName()
 	// Request to execute workflow
 	log.Debugf("Workflow actor '%s': scheduling workflow execution with instanceId '%s'", w.actorID, wi.InstanceID)
 	// Schedule the workflow execution by signaling the backend
@@ -856,7 +852,7 @@ func (w *workflow) loadInternalState(ctx context.Context) (*wfenginestate.State,
 	defer w.lock.Unlock()
 	w.state = state
 	w.rstate = runtimestate.NewOrchestrationRuntimeState(w.actorID, state.CustomStatus, state.History)
-	w.setOrchestrationMetadata(w.rstate)
+	w.setOrchestrationMetadata(w.rstate, w.getExecutionStartedEvent(state))
 	w.ometaBroadcaster.Broadcast(w.ometa)
 
 	return state, w.ometa, nil
@@ -883,7 +879,7 @@ func (w *workflow) saveInternalState(ctx context.Context, state *wfenginestate.S
 	defer w.lock.Unlock()
 	w.state = state
 	w.rstate = runtimestate.NewOrchestrationRuntimeState(w.actorID, state.CustomStatus, state.History)
-	w.setOrchestrationMetadata(w.rstate)
+	w.setOrchestrationMetadata(w.rstate, w.getExecutionStartedEvent(state))
 	w.ometaBroadcaster.Broadcast(w.ometa)
 	return nil
 }
@@ -1063,8 +1059,18 @@ func (w *workflow) handleStreamInitial(ctx context.Context, req *internalsv1pb.I
 	return nil
 }
 
-func (w *workflow) setOrchestrationMetadata(rstate *backend.OrchestrationRuntimeState) {
+func (w *workflow) setOrchestrationMetadata(rstate *backend.OrchestrationRuntimeState, startEvent *protos.ExecutionStartedEvent) {
+	var se *protos.ExecutionStartedEvent = nil
+	if rstate.GetStartEvent() != nil {
+		se = rstate.GetStartEvent()
+	} else if startEvent != nil {
+		se = startEvent
+	}
+
 	name, _ := runtimestate.Name(rstate)
+	if name == "" && se != nil {
+		name = se.GetName()
+	}
 	createdAt, _ := runtimestate.CreatedTime(rstate)
 	lastUpdated, _ := runtimestate.LastUpdatedTime(rstate)
 	completedAt, _ := runtimestate.CompletedTime(rstate)
@@ -1072,8 +1078,8 @@ func (w *workflow) setOrchestrationMetadata(rstate *backend.OrchestrationRuntime
 	output, _ := runtimestate.Output(rstate)
 	failureDetails, _ := runtimestate.FailureDetails(rstate)
 	var parentInstanceID string
-	if rstate.GetStartEvent() != nil && rstate.GetStartEvent().GetParentInstance() != nil && rstate.GetStartEvent().GetParentInstance().GetOrchestrationInstance() != nil {
-		parentInstanceID = rstate.GetStartEvent().GetParentInstance().GetOrchestrationInstance().GetInstanceId()
+	if se != nil && se.GetParentInstance() != nil && se.GetParentInstance().GetOrchestrationInstance() != nil {
+		parentInstanceID = se.GetParentInstance().GetOrchestrationInstance().GetInstanceId()
 	}
 	w.ometa = &backend.OrchestrationMetadata{
 		InstanceId:       rstate.GetInstanceId(),


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Testing the event sink functionality, it happens that the first event when a workflow is created has an empty workflow name
This PR fixes it

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
