### PR TITLE
Actor: transcode period string getting Scheduler reminders

### DIFF
--- a/pkg/actors/api/period.go
+++ b/pkg/actors/api/period.go
@@ -19,7 +19,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dapr/kit/cron"
 	timeutils "github.com/dapr/kit/time"
+)
+
+var cronParser = cron.NewParser(cron.Second |
+	cron.Minute |
+	cron.Hour |
+	cron.Dom |
+	cron.Month |
+	cron.Dow |
+	cron.Descriptor,
 )
 
 // ReminderPeriod contains the parsed period for a reminder.
@@ -56,6 +66,12 @@ func NewEmptyReminderPeriod() ReminderPeriod {
 func NewSchedulerReminderPeriod(val string, repeats uint32) ReminderPeriod {
 	p := NewEmptyReminderPeriod()
 	p.repeats = int(repeats)
+	period, err := cronParser.Parse(val)
+	if err == nil {
+		if c, ok := period.(cron.ConstantDelaySchedule); ok {
+			val = c.Delay.String()
+		}
+	}
 	p.value = val
 
 	return p

--- a/tests/integration/suite/actors/reminders/scheduler/get.go
+++ b/tests/integration/suite/actors/reminders/scheduler/get.go
@@ -78,5 +78,5 @@ func (g *get) Run(t *testing.T, ctx context.Context) {
 	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, `{"period":"@every 1s","data":"reminderdata","actorID":"1234","actorType":"foo","dueTime":"1s"}`, strings.TrimSpace(string(b)))
+	assert.Equal(t, `{"period":"1s","data":"reminderdata","actorID":"1234","actorType":"foo","dueTime":"1s"}`, strings.TrimSpace(string(b)))
 }


### PR DESCRIPTION
Transcode Scheduler reminder period strings on get and lists to transcode `@every` strings to the previous ISO8601 duration format to ensure backwards compatibility.