### PR TITLE
Feat scheduler actor reminder metrics

### DIFF
--- a/tests/integration/suite/daprd/metrics/actors/actors.go
+++ b/tests/integration/suite/daprd/metrics/actors/actors.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(actors))
+}
+
+type actors struct {
+	place     *placement.Placement
+	scheduler *scheduler.Scheduler
+	triggered atomic.Int64
+
+	daprd *daprd.Daprd
+}
+
+func (a *actors) Setup(t *testing.T) []framework.Option {
+	a.scheduler = scheduler.New(t)
+
+	app := app.New(t,
+		app.WithHandlerFunc("/actors/myactortype/myactorid", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/actors/myactortype/myactorid/method/remind/remindermethod", func(http.ResponseWriter, *http.Request) {
+			a.triggered.Add(1)
+		}),
+		app.WithHandlerFunc("/actors/myactortype/myactorid/method/foo", func(http.ResponseWriter, *http.Request) {}),
+		app.WithConfig(`{"entities": ["myactortype"]}`),
+	)
+
+	a.place = placement.New(t)
+	a.daprd = daprd.New(t,
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+ name: schedulerreminders
+spec:
+ features:
+ - name: SchedulerReminders
+   enabled: true
+`),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithSchedulerAddresses(a.scheduler.Address()),
+		daprd.WithAppPort(app.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, a.scheduler, a.place, a.daprd),
+	}
+}
+
+func (a *actors) Run(t *testing.T, ctx context.Context) {
+	a.scheduler.WaitUntilRunning(t, ctx)
+	a.place.WaitUntilRunning(t, ctx)
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	grpcClient := a.daprd.GRPCClient(t, ctx)
+
+	_, err := grpcClient.RegisterActorReminder(ctx, &runtimev1pb.RegisterActorReminderRequest{
+		ActorType: "myactortype",
+		ActorId:   "myactorid",
+		Name:      "remindermethod",
+		DueTime:   "0s",
+		Period:    "R1/PT1S",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), a.triggered.Load())
+	}, 5*time.Second, 10*time.Millisecond, "failed to wait for 'triggered' to be greater or equal 1, actual value %d", a.triggered.Load())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		a.daprd.Metrics(c, ctx).MatchMetricAndSum(c, 1, "dapr_runtime_actor_reminders_fired_total")
+	}, 5*time.Second, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/metrics/metrics.go
+++ b/tests/integration/suite/daprd/metrics/metrics.go
@@ -14,6 +14,7 @@ limitations under the License.
 package metrics
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metrics/actors"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metrics/grpc"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metrics/http"
 )


### PR DESCRIPTION
Add the `dapr_runtime_actor_reminders_fired_total` metric when using scheduler reminders. This is needed for supporting the metric when using the scheduler, as it was previously being supported with statestore reminders.

I removed the `actorerrors.ErrReminderCanceled` check bc that was prior to one shot wf reminders, so I think we should be able to remove it now - will confirm with IT tests.

There is no way to support the prior actor reminder metrics:
-`ActorTimerFired`
-`ActorReminders`
-`ActorTimers`
As the timer logic was from the `inmemory` code land previously and we don't really have a distinction btw timer and reminder anymore. The `ActorReminders` one isn't really feasible since we don't keep a global inmemory map anymore with scheduler since that logic is managed by scheduler + etcd and not in dapr runtime.

As a follow up, I think it would be easy to add CRUD actor reminder metrics, but that is out of scope for this PR. We should also go thru the IT suite and see what other metrics are in the wrong place and move them here tests/integration/suite/daprd/metrics, also, we should really have IT tests for metrics for all the APIs... Maybe a good opportunity for community support with good first issues. I can take note of which ones do/don't and open issues accordingly.