### PR TITLE
[1.15] Add missing grpc call options when invoking actors

### DIFF
--- a/docs/release_notes/v1.15.1.md
+++ b/docs/release_notes/v1.15.1.md
@@ -1,0 +1,21 @@
+# Dapr 1.15.1
+
+This update includes a fix for https://github.com/dapr/dapr/issues/8537.
+
+## Fixes Dapr not honoring max-body-size when invoking actors
+
+### Problem
+
+When an actor client attempts to invoke an actor with a payload size larger than 4Mb, the call fails with `rpc error: code = ResourceExhausted desc = grpc: received message larger than max`.
+
+### Impact
+
+Users were unable to send actor messages with payloads larger than 4Mb.
+
+### Root cause
+
+The Dapr actor gRPC client did not honor the max-body-size parameter that is passed to `daprd`.
+
+### Solution
+
+The DApr actor gRPC client is configured with the proper gRPC call options.

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -71,7 +71,8 @@ type Options struct {
 	Healthz            healthz.Healthz
 	CompStore          *compstore.ComponentStore
 	// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
-	StateTTLEnabled bool
+	StateTTLEnabled    bool
+	MaxRequestBodySize int
 }
 
 type InitOptions struct {
@@ -110,7 +111,8 @@ type actors struct {
 	healthz            healthz.Healthz
 	compStore          *compstore.ComponentStore
 	// TODO: @joshvanl Remove in Dapr 1.12 when ActorStateTTL is finalized.
-	stateTTLEnabled bool
+	stateTTLEnabled    bool
+	maxRequestBodySize int
 
 	reminders      reminders.Interface
 	table          table.Interface
@@ -162,6 +164,7 @@ func New(opts Options) Interface {
 		closedCh:           make(chan struct{}),
 		initDoneCh:         make(chan struct{}),
 		registerDoneCh:     make(chan struct{}),
+		maxRequestBodySize: opts.MaxRequestBodySize,
 	}
 }
 
@@ -254,6 +257,7 @@ func (a *actors) Init(opts InitOptions) error {
 		IdlerQueue:         a.idlerQueue,
 		Reminders:          a.reminders,
 		Locker:             locker,
+		MaxRequestBodySize: a.maxRequestBodySize,
 	})
 
 	a.timerStorage = inmemory.New(inmemory.Options{

--- a/pkg/actors/engine/engine.go
+++ b/pkg/actors/engine/engine.go
@@ -80,10 +80,6 @@ type engine struct {
 	callOptions []grpc.CallOption
 }
 
-type actorCallOptions struct {
-	maxRequestBodySize int
-}
-
 func New(opts Options) Interface {
 	return &engine{
 		namespace:          opts.Namespace,

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -235,6 +235,7 @@ func newDaprRuntime(ctx context.Context,
 		Healthz:            runtimeConfig.healthz,
 		CompStore:          compStore,
 		StateTTLEnabled:    globalConfig.IsFeatureEnabled(config.ActorStateTTL),
+		MaxRequestBodySize: runtimeConfig.maxRequestBodySize,
 	})
 
 	processor := processor.New(processor.Options{

--- a/tests/integration/framework/process/daprd/actors/actors.go
+++ b/tests/integration/framework/process/daprd/actors/actors.go
@@ -105,6 +105,10 @@ func New(t *testing.T, fopts ...Option) *Actors {
 		daprd.WithErrorCodeMetrics(t),
 	}
 
+	if opts.maxBodySize != nil {
+		dopts = append(dopts, daprd.WithMaxBodySize(*opts.maxBodySize))
+	}
+
 	return &Actors{
 		app:   app,
 		db:    opts.db,

--- a/tests/integration/framework/process/daprd/actors/options.go
+++ b/tests/integration/framework/process/daprd/actors/options.go
@@ -39,6 +39,7 @@ type options struct {
 	actorIdleTimeout  *time.Duration
 	entityConfig      []entityConfig
 	resources         []string
+	maxBodySize       *string
 }
 
 func WithDB(db *sqlite.SQLite) Option {
@@ -138,5 +139,11 @@ func WithEntityConfig(opts ...EntityConfig) Option {
 func WithResources(resources ...string) Option {
 	return func(o *options) {
 		o.resources = append(o.resources, resources...)
+	}
+}
+
+func WithMaxBodySize(size string) Option {
+	return func(o *options) {
+		o.maxBodySize = &size
 	}
 }

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -154,6 +154,9 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	if opts.controlPlaneTrustDomain != nil {
 		args = append(args, "--control-plane-trust-domain="+*opts.controlPlaneTrustDomain)
 	}
+	if opts.maxBodySize != nil {
+		args = append(args, "--max-body-size="+*opts.maxBodySize)
+	}
 
 	ns := "default"
 	if opts.namespace != nil {

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -64,6 +64,7 @@ type options struct {
 	blockShutdownDuration   *string
 	controlPlaneTrustDomain *string
 	schedulerAddresses      []string
+	maxBodySize             *string
 }
 
 func WithExecOptions(execOptions ...exec.Option) Option {
@@ -344,5 +345,11 @@ spec:
 	return func(o *options) {
 		WithConfigs(configFile)(o)
 		WithResourcesDir(tempDir)(o)
+	}
+}
+
+func WithMaxBodySize(size string) Option {
+	return func(o *options) {
+		o.maxBodySize = &size
 	}
 }

--- a/tests/integration/suite/actors/call/maxbodysize.go
+++ b/tests/integration/suite/actors/call/maxbodysize.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package call
+
+import (
+	"context"
+	nethttp "net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(maxbodysize))
+}
+
+type maxbodysize struct {
+	actors1 *actors.Actors
+	actors2 *actors.Actors
+
+	called1 atomic.Bool
+	called2 atomic.Bool
+}
+
+func (m *maxbodysize) Setup(t *testing.T) []framework.Option {
+	m.actors1 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithMaxBodySize("1k"),
+		actors.WithActorTypeHandler("abc", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			m.called1.Store(true)
+		}),
+	)
+	m.actors2 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithPeerActor(m.actors1),
+		actors.WithMaxBodySize("1k"),
+		actors.WithActorTypeHandler("abc", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			m.called2.Store(true)
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.actors1, m.actors2),
+	}
+}
+
+func (m *maxbodysize) Run(t *testing.T, ctx context.Context) {
+	m.actors1.WaitUntilRunning(t, ctx)
+	m.actors2.WaitUntilRunning(t, ctx)
+
+	client := m.actors1.GRPCClient(t, ctx)
+
+	var host1 *int
+	var host2 *int
+
+	for i := 0; ; i++ {
+		_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "abc",
+			ActorId:   strconv.Itoa(i),
+			Method:    "foo",
+		})
+		require.NoError(t, err)
+
+		if m.called1.Load() && host1 == nil {
+			host1 = &i
+		}
+
+		if m.called2.Load() && host2 == nil {
+			host2 = &i
+		}
+
+		if m.called1.Load() && m.called2.Load() {
+			break
+		}
+	}
+
+	for i := range []int{*host1, *host2} {
+		smallBody := make([]byte, 500)
+		_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "abc",
+			ActorId:   strconv.Itoa(i),
+			Method:    "foo",
+			Data:      smallBody,
+		})
+		require.NoError(t, err)
+
+		largeBody := make([]byte, 2048)
+		_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "abc",
+			ActorId:   strconv.Itoa(i),
+			Method:    "foo",
+			Data:      largeBody,
+		})
+		require.Error(t, err)
+		status, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.ResourceExhausted, status.Code())
+		assert.Equal(t, "grpc: received message larger than max (2064 vs. 1000)", status.Message())
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/dapr/dapr/issues/8537.