### PR TITLE
WIP: allow actor invocation without state store requirement

### DIFF
--- a/pkg/actors/internal/reminders/storage/statestore/statestore.go
+++ b/pkg/actors/internal/reminders/storage/statestore/statestore.go
@@ -203,9 +203,11 @@ func (r *Statestore) Create(ctx context.Context, req *api.CreateReminderRequest)
 }
 
 func (r *Statestore) Close() error {
-	if r.closed.CompareAndSwap(false, true) {
-		// Close the runningCh
-		close(r.runningCh)
+	if r != nil {
+		if r.closed.CompareAndSwap(false, true) {
+			// Close the runningCh
+			close(r.runningCh)
+		}
 	}
 	return nil
 }

--- a/tests/integration/framework/process/daprd/actors/options.go
+++ b/tests/integration/framework/process/daprd/actors/options.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
@@ -40,6 +41,8 @@ type options struct {
 	entityConfig      []entityConfig
 	resources         []string
 	maxBodySize       *string
+	enableActorState  bool
+	daprdOpts         []daprd.Option
 }
 
 func WithDB(db *sqlite.SQLite) Option {
@@ -145,5 +148,17 @@ func WithResources(resources ...string) Option {
 func WithMaxBodySize(size string) Option {
 	return func(o *options) {
 		o.maxBodySize = &size
+	}
+}
+
+func WithActorStateStore(enabled bool) Option {
+	return func(o *options) {
+		o.enableActorState = enabled
+	}
+}
+
+func WithDaprdOptions(opts ...daprd.Option) Option {
+	return func(o *options) {
+		o.daprdOpts = append(o.daprdOpts, opts...)
 	}
 }

--- a/tests/integration/suite/actors/actors.go
+++ b/tests/integration/suite/actors/actors.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/http"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/lock"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/metadata"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/nostate"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/state"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/timers"

--- a/tests/integration/suite/actors/nostate/noactorstate.go
+++ b/tests/integration/suite/actors/nostate/noactorstate.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nostate
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noActorState))
+}
+
+type noActorState struct {
+	clientApp       *actors.Actors
+	hostApp         *actors.Actors
+	invocationCount atomic.Int64
+	clientLogs      *logline.LogLine
+}
+
+func (p *noActorState) Setup(t *testing.T) []framework.Option {
+	p.invocationCount.Store(0)
+
+	// Create actor host app meaning with statestore & actor types
+	p.hostApp = actors.New(t,
+		actors.WithActorTypes("testActor"),
+		actors.WithActorTypeHandler("testActor", func(_ nethttp.ResponseWriter, r *nethttp.Request) {
+			p.invocationCount.Add(1)
+		}),
+		actors.WithActorStateStore(true),
+	)
+
+	p.clientLogs = logline.New(t, logline.WithStdoutLineContains(
+		"Actor state store not configured",
+		"Connected to placement",
+	))
+
+	// Create actor client app meaning no state store & no actor types
+	p.clientApp = actors.New(t,
+		actors.WithActorStateStore(false),
+		actors.WithDaprdOptions(
+			daprd.WithExecOptions(
+				exec.WithStdout(p.clientLogs.Stdout()),
+			),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(
+			p.hostApp,
+			p.clientLogs,
+			p.clientApp,
+		),
+	}
+}
+
+func (p *noActorState) Run(t *testing.T, ctx context.Context) {
+	p.hostApp.WaitUntilRunning(t, ctx)
+	p.clientApp.WaitUntilRunning(t, ctx)
+
+	p.clientLogs.EventuallyFoundAll(t)
+
+	// test invocation from client to host for both gRPC & HTTP
+	gclient := p.clientApp.Daprd().GRPCClient(t, ctx)
+	_, err := gclient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: "testActor",
+		ActorId:   "test1",
+		Method:    "test",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), p.invocationCount.Load())
+
+	//hclient := client.HTTP(t)
+	//url := fmt.Sprintf("http://%s/v1.0/actors/testActor/test1/method/test", p.clientApp.Daprd().HTTPAddress())
+	//req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+	//require.NoError(t, err)
+	//resp, err := hclient.Do(req)
+	//require.NoError(t, err)
+	//require.NoError(t, resp.Body.Close())
+	//assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+	//assert.Equal(t, int64(2), p.invocationCount.Load())
+
+	// client app is healthy
+	//healthURL := fmt.Sprintf("http://%s/v1.0/healthz", p.clientApp.Daprd().HTTPAddress())
+	//req, err = nethttp.NewRequestWithContext(ctx, nethttp.MethodGet, healthURL, nil)
+	//require.NoError(t, err)
+	//resp, err = hclient.Do(req)
+	//require.NoError(t, err)
+	//require.NoError(t, resp.Body.Close())
+	//assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+}

--- a/tests/integration/suite/actors/nostate/noactorstate.go
+++ b/tests/integration/suite/actors/nostate/noactorstate.go
@@ -15,6 +15,7 @@ package nostate
 
 import (
 	"context"
+	"fmt"
 	nethttp "net/http"
 	"sync/atomic"
 	"testing"
@@ -24,6 +25,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -94,22 +96,13 @@ func (p *noActorState) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), p.invocationCount.Load())
 
-	//hclient := client.HTTP(t)
-	//url := fmt.Sprintf("http://%s/v1.0/actors/testActor/test1/method/test", p.clientApp.Daprd().HTTPAddress())
-	//req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
-	//require.NoError(t, err)
-	//resp, err := hclient.Do(req)
-	//require.NoError(t, err)
-	//require.NoError(t, resp.Body.Close())
-	//assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
-	//assert.Equal(t, int64(2), p.invocationCount.Load())
-
-	// client app is healthy
-	//healthURL := fmt.Sprintf("http://%s/v1.0/healthz", p.clientApp.Daprd().HTTPAddress())
-	//req, err = nethttp.NewRequestWithContext(ctx, nethttp.MethodGet, healthURL, nil)
-	//require.NoError(t, err)
-	//resp, err = hclient.Do(req)
-	//require.NoError(t, err)
-	//require.NoError(t, resp.Body.Close())
-	//assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+	hclient := client.HTTP(t)
+	url := fmt.Sprintf("http://%s/v1.0/actors/testActor/test1/method/test", p.clientApp.Daprd().HTTPAddress())
+	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+	require.NoError(t, err)
+	resp, err := hclient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(2), p.invocationCount.Load())
 }


### PR DESCRIPTION
Currently, Dapr instances without an actor state store configured are prevented from connecting to the placement service and marked as not-ready/unhealthy. This incorrectly prevents these instances from acting as actor clients, even when they only need to invoke actors on other hosts.

I still need to fix: `dapr is not becoming ready` and `dapr did not find address for actor` 