### PR TITLE
[v1.15] Actors: Always attempt to connect to placement if configured.

### DIFF
--- a/docs/release_notes/v1.15.2.md
+++ b/docs/release_notes/v1.15.2.md
@@ -1,0 +1,24 @@
+# Dapr 1.15.2
+
+This update includes bug fixes:
+
+- [Fix Actor Invocation from non-Actor hosted Apps](#fix-actor-invocation-from-non-actor-hosted-apps)
+
+## Fix Actor Invocation from non-Actor hosted Apps
+
+### Problem
+
+When invoking an actor from an app which did not have the Actor state store configured, the actor invocation fails.
+
+### Impact
+
+Applications were unable to invoke actors if the Actor state store was not scoped for that App ID.
+
+### Root cause
+
+If daprd did not have an Actor state store configured, it did not connect to Placement.
+This meant it did not have the address for the target Actor.
+
+### Solution
+
+Daprd will always attempt to connect to Placement if a Placement address is configured.

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -175,20 +175,6 @@ func (a *actors) Init(opts InitOptions) error {
 		return nil
 	}
 
-	storeS, ok := a.compStore.GetStateStore(opts.StateStoreName)
-	if !ok {
-		var err error = messages.ErrActorRuntimeNotFound
-		a.disabled.Store(&err)
-		return nil
-	}
-
-	store, ok := storeS.(actorstate.Backend)
-	if !ok || !state.FeatureETag.IsPresent(store.Features()) || !state.FeatureTransactional.IsPresent(store.Features()) {
-		var err error = messages.ErrActorRuntimeNotFound
-		a.disabled.Store(&err)
-		return nil
-	}
-
 	a.idlerQueue = queue.NewProcessor[string, targets.Idlable](a.handleIdleActor)
 
 	rStore := reentrancystore.New()
@@ -205,13 +191,7 @@ func (a *actors) Init(opts InitOptions) error {
 
 	apiLevel := apilevel.New()
 
-	a.stateReminders = statestore.New(statestore.Options{
-		Resiliency: a.resiliency,
-		StateStore: store,
-		Table:      a.table,
-		StoreName:  opts.StateStoreName,
-		APILevel:   apiLevel,
-	})
+	storeEnabled := a.buildStateStore(opts, apiLevel)
 
 	a.reminderStore = a.stateReminders
 	if a.schedulerReminders {
@@ -222,6 +202,13 @@ func (a *actors) Init(opts InitOptions) error {
 			StateReminder: a.stateReminders,
 			Table:         a.table,
 			Healthz:       a.healthz,
+		})
+	}
+
+	if a.reminderStore != nil {
+		a.reminders = reminders.New(reminders.Options{
+			Storage: a.reminderStore,
+			Table:   a.table,
 		})
 	}
 
@@ -242,10 +229,17 @@ func (a *actors) Init(opts InitOptions) error {
 		return err
 	}
 
-	a.reminders = reminders.New(reminders.Options{
-		Storage: a.reminderStore,
-		Table:   a.table,
-	})
+	if storeEnabled {
+		a.state = actorstate.New(actorstate.Options{
+			AppID:           a.appID,
+			StoreName:       opts.StateStoreName,
+			CompStore:       a.compStore,
+			Resiliency:      a.resiliency,
+			StateTTLEnabled: a.stateTTLEnabled,
+			Table:           a.table,
+			Placement:       a.placement,
+		})
+	}
 
 	a.engine = engine.New(engine.Options{
 		Namespace:          a.namespace,
@@ -268,17 +262,9 @@ func (a *actors) Init(opts InitOptions) error {
 		Table:   a.table,
 	})
 
-	a.stateReminders.SetEngine(a.engine)
-
-	a.state = actorstate.New(actorstate.Options{
-		AppID:           a.appID,
-		StoreName:       opts.StateStoreName,
-		CompStore:       a.compStore,
-		Resiliency:      a.resiliency,
-		StateTTLEnabled: a.stateTTLEnabled,
-		Table:           a.table,
-		Placement:       a.placement,
-	})
+	if a.stateReminders != nil {
+		a.stateReminders.SetEngine(a.engine)
+	}
 
 	return nil
 }
@@ -306,10 +292,15 @@ func (a *actors) Run(ctx context.Context) error {
 
 	mngr := concurrency.NewRunnerCloserManager(nil,
 		func(ctx context.Context) error {
-			select {
-			case <-a.registerDoneCh:
-			case <-ctx.Done():
-				return ctx.Err()
+			// Only wait for host registration before starting the placement client,
+			// since registering Actor host types is dependent on the Actor state
+			// store being configured.
+			if a.state != nil {
+				select {
+				case <-a.registerDoneCh:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			}
 			return a.placement.Run(ctx)
 		},
@@ -322,12 +313,19 @@ func (a *actors) Run(ctx context.Context) error {
 
 	if err := mngr.AddCloser(
 		a.table,
-		a.stateReminders,
-		a.reminderStore,
 		a.timerStorage,
 		a.idlerQueue,
 	); err != nil {
 		return err
+	}
+
+	if a.stateReminders != nil {
+		if err := mngr.AddCloser(
+			a.stateReminders,
+			a.reminderStore,
+		); err != nil {
+			return err
+		}
 	}
 
 	defer log.Info("Actor runtime stopped")
@@ -471,10 +469,12 @@ func (a *actors) RegisterHosted(cfg hostconfig.Config) error {
 		})
 	}
 
-	a.stateReminders.SetEntityConfigsRemindersStoragePartitions(
-		entityConfigs,
-		cfg.RemindersStoragePartitions,
-	)
+	if a.stateReminders != nil {
+		a.stateReminders.SetEntityConfigsRemindersStoragePartitions(
+			entityConfigs,
+			cfg.RemindersStoragePartitions,
+		)
+	}
 
 	log.Infof("Registering hosted actors: %v", cfg.HostedActorTypes)
 	a.table.RegisterActorTypes(table.RegisterActorTypeOptions{
@@ -588,6 +588,35 @@ func (a *actors) RuntimeStatus() *runtimev1pb.ActorRuntime {
 		Placement:     statusMessage,
 		HostReady:     hostReady,
 	}
+}
+
+func (a *actors) buildStateStore(opts InitOptions, apiLevel *apilevel.APILevel) bool {
+	storeS, ok := a.compStore.GetStateStore(opts.StateStoreName)
+	if !ok {
+		log.Info("Actor state store not configured - actor hosting disabled, but invocation enabled")
+		return false
+	}
+
+	store, ok := storeS.(actorstate.Backend)
+	if !ok {
+		log.Warn("Actor state management disabled")
+		return false
+	}
+
+	if !state.FeatureETag.IsPresent(store.Features()) || !state.FeatureTransactional.IsPresent(store.Features()) {
+		log.Warnf("Actor state store %s does not support required features: %s, %s", opts.StateStoreName, state.FeatureETag, state.FeatureTransactional)
+		return false
+	}
+
+	a.stateReminders = statestore.New(statestore.Options{
+		Resiliency: a.resiliency,
+		StateStore: store,
+		Table:      a.table,
+		StoreName:  opts.StateStoreName,
+		APILevel:   apiLevel,
+	})
+
+	return true
 }
 
 // ValidateHostEnvironment validates that actors can be initialized properly given a set of parameters

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -193,18 +193,6 @@ func (a *actors) Init(opts InitOptions) error {
 
 	storeEnabled := a.buildStateStore(opts, apiLevel)
 
-	a.reminderStore = a.stateReminders
-	if a.schedulerReminders {
-		a.reminderStore = scheduler.New(scheduler.Options{
-			Namespace:     a.namespace,
-			AppID:         a.appID,
-			Clients:       opts.SchedulerClients,
-			StateReminder: a.stateReminders,
-			Table:         a.table,
-			Healthz:       a.healthz,
-		})
-	}
-
 	if a.reminderStore != nil {
 		a.reminders = reminders.New(reminders.Options{
 			Storage: a.reminderStore,
@@ -615,6 +603,18 @@ func (a *actors) buildStateStore(opts InitOptions, apiLevel *apilevel.APILevel) 
 		StoreName:  opts.StateStoreName,
 		APILevel:   apiLevel,
 	})
+
+	a.reminderStore = a.stateReminders
+	if a.schedulerReminders {
+		a.reminderStore = scheduler.New(scheduler.Options{
+			Namespace:     a.namespace,
+			AppID:         a.appID,
+			Clients:       opts.SchedulerClients,
+			StateReminder: a.stateReminders,
+			Table:         a.table,
+			Healthz:       a.healthz,
+		})
+	}
 
 	return true
 }

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -418,12 +418,17 @@ func (d *Daprd) GetMetaScheduler(t assert.TestingT, ctx context.Context) *rtv1.M
 	return d.meta(t, ctx).Scheduler
 }
 
+func (d *Daprd) GetMetaActorRuntime(t assert.TestingT, ctx context.Context) *MetadataActorRuntime {
+	return d.meta(t, ctx).ActorRuntime
+}
+
 // metaResponse is a subset of metadataResponse defined in pkg/api/http/metadata.go:160
 type metaResponse struct {
 	RegisteredComponents []*rtv1.RegisteredComponents         `json:"components,omitempty"`
 	Subscriptions        []MetadataResponsePubsubSubscription `json:"subscriptions,omitempty"`
 	HTTPEndpoints        []*rtv1.MetadataHTTPEndpoint         `json:"httpEndpoints,omitempty"`
 	Scheduler            *rtv1.MetadataScheduler              `json:"scheduler,omitempty"`
+	ActorRuntime         *MetadataActorRuntime                `json:"actorRuntime,omitempty"`
 }
 
 // MetadataResponsePubsubSubscription copied from pkg/api/http/metadata.go:172 to be able to use in integration tests until we move to Proto format
@@ -439,6 +444,18 @@ type MetadataResponsePubsubSubscription struct {
 type MetadataResponsePubsubSubscriptionRule struct {
 	Match string `json:"match,omitempty"`
 	Path  string `json:"path,omitempty"`
+}
+
+type MetadataActorRuntime struct {
+	RuntimeStatus string                             `json:"runtimeStatus"`
+	HostReady     bool                               `json:"hostReady"`
+	Placement     string                             `json:"placement"`
+	ActiveActors  []*MetadataActorRuntimeActiveActor `json:"activeActors"`
+}
+
+type MetadataActorRuntimeActiveActor struct {
+	Type  string `json:"type"`
+	Count int    `json:"count"`
 }
 
 func (d *Daprd) meta(t assert.TestingT, ctx context.Context) metaResponse {

--- a/tests/integration/suite/actors/call/nostate.go
+++ b/tests/integration/suite/actors/call/nostate.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package call
+
+import (
+	"context"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(nostate))
+}
+
+type nostate struct {
+	actors *actors.Actors
+	daprd  *daprd.Daprd
+}
+
+func (n *nostate) Setup(t *testing.T) []framework.Option {
+	n.actors = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorTypeHandler("abc", func(nethttp.ResponseWriter, *nethttp.Request) {}),
+	)
+
+	n.daprd = daprd.New(t,
+		daprd.WithPlacementAddresses(n.actors.Placement().Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(n.actors, n.daprd),
+	}
+}
+
+func (n *nostate) Run(t *testing.T, ctx context.Context) {
+	n.actors.WaitUntilRunning(t, ctx)
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	client := n.daprd.GRPCClient(t, ctx)
+
+	_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: "abc",
+		ActorId:   "1",
+		Method:    "foo",
+	})
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/actors/metadata/client.go
+++ b/tests/integration/suite/actors/metadata/client.go
@@ -70,7 +70,7 @@ func (m *client) Setup(t *testing.T) []framework.Option {
 func (m *client) Run(t *testing.T, ctx context.Context) {
 	// Test an app that is an actor client (no actor state store configured)
 	// 1. Assert that status is "INITIALIZING" before /dapr/config is called
-	// 2. After init is done, status is "DISABLED", hostReady is "false", placement doesn't report a connection, and hosted actors are empty
+	// 2. After init is done, status is "RUNNING", hostReady is "true", placement reports connection status, and no active actors
 
 	m.place.WaitUntilRunning(t, ctx)
 	m.daprd.WaitUntilTCPReady(t, ctx)
@@ -89,9 +89,9 @@ func (m *client) Run(t *testing.T, ctx context.Context) {
 	close(m.blockConfig)
 	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		res := getMetadata(t, ctx, client, m.daprd.HTTPPort())
-		assert.Equal(t, "DISABLED", res.ActorRuntime.RuntimeStatus)
-		assert.False(t, res.ActorRuntime.HostReady)
-		assert.Equal(t, "placement: disconnected", res.ActorRuntime.Placement)
+		assert.Equal(t, "RUNNING", res.ActorRuntime.RuntimeStatus)
+		assert.True(t, res.ActorRuntime.HostReady)
+		assert.Equal(t, "placement: connected", res.ActorRuntime.Placement)
 		assert.Empty(t, res.ActorRuntime.ActiveActors, 0)
 	}, 10*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/metadata/actors/noplacement.go
+++ b/tests/integration/suite/daprd/metadata/actors/noplacement.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noplacement))
+}
+
+type noplacement struct {
+	daprd *daprd.Daprd
+}
+
+func (n *noplacement) Setup(t *testing.T) []framework.Option {
+	n.daprd = daprd.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(n.daprd),
+	}
+}
+
+func (n *noplacement) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	exp := &rtv1.ActorRuntime{
+		RuntimeStatus: rtv1.ActorRuntime_DISABLED,
+		ActiveActors:  nil,
+		HostReady:     false,
+		Placement:     "placement: disconnected",
+	}
+
+	resp, err := n.daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, exp, resp.GetActorRuntime())
+	assert.Equal(t, &daprd.MetadataActorRuntime{
+		RuntimeStatus: "DISABLED",
+		HostReady:     false,
+		Placement:     "placement: disconnected",
+	}, n.daprd.GetMetaActorRuntime(t, ctx))
+}

--- a/tests/integration/suite/daprd/metadata/actors/withactors.go
+++ b/tests/integration/suite/daprd/metadata/actors/withactors.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(withactors))
+}
+
+type withactors struct {
+	actors *actors.Actors
+}
+
+func (w *withactors) Setup(t *testing.T) []framework.Option {
+	w.actors = actors.New(t,
+		actors.WithActorTypes("abc", "xyz"),
+		actors.WithActorTypeHandler("abc", func(http.ResponseWriter, *http.Request) {}),
+		actors.WithActorTypeHandler("xyz", func(http.ResponseWriter, *http.Request) {}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(w.actors),
+	}
+}
+
+func (w *withactors) Run(t *testing.T, ctx context.Context) {
+	w.actors.WaitUntilRunning(t, ctx)
+
+	exp := &rtv1.ActorRuntime{
+		RuntimeStatus: rtv1.ActorRuntime_RUNNING,
+		HostReady:     true,
+		Placement:     "placement: connected",
+		ActiveActors: []*rtv1.ActiveActorsCount{
+			{Type: "abc", Count: 0},
+			{Type: "xyz", Count: 0},
+		},
+	}
+
+	client := w.actors.GRPCClient(t, ctx)
+
+	resp, err := client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+
+	assert.Equal(t, exp.GetRuntimeStatus(), resp.GetActorRuntime().GetRuntimeStatus())
+	assert.Equal(t, exp.GetHostReady(), resp.GetActorRuntime().GetHostReady())
+	assert.Equal(t, exp.GetPlacement(), resp.GetActorRuntime().GetPlacement())
+	assert.ElementsMatch(t, exp.GetActiveActors(), resp.GetActorRuntime().GetActiveActors())
+
+	respHTTP := w.actors.Daprd().GetMetaActorRuntime(t, ctx)
+	assert.Equal(t, "RUNNING", respHTTP.RuntimeStatus)
+	assert.True(t, respHTTP.HostReady)
+	assert.Equal(t, "placement: connected", respHTTP.Placement)
+	assert.ElementsMatch(t, []*daprd.MetadataActorRuntimeActiveActor{
+		{Type: "abc", Count: 0},
+		{Type: "xyz", Count: 0},
+	}, respHTTP.ActiveActors)
+
+	_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: "abc",
+		ActorId:   "1",
+		Method:    "set",
+	})
+	require.NoError(t, err)
+	_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: "abc",
+		ActorId:   "2",
+		Method:    "set",
+	})
+	require.NoError(t, err)
+	_, err = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: "xyz",
+		ActorId:   "1",
+		Method:    "set",
+	})
+	require.NoError(t, err)
+
+	exp.ActiveActors = []*rtv1.ActiveActorsCount{
+		{Type: "abc", Count: 2},
+		{Type: "xyz", Count: 1},
+	}
+	resp, err = client.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+
+	assert.Equal(t, exp.GetRuntimeStatus(), resp.GetActorRuntime().GetRuntimeStatus())
+	assert.Equal(t, exp.GetHostReady(), resp.GetActorRuntime().GetHostReady())
+	assert.Equal(t, exp.GetPlacement(), resp.GetActorRuntime().GetPlacement())
+	assert.ElementsMatch(t, exp.GetActiveActors(), resp.GetActorRuntime().GetActiveActors())
+
+	respHTTP = w.actors.Daprd().GetMetaActorRuntime(t, ctx)
+	assert.Equal(t, "RUNNING", respHTTP.RuntimeStatus)
+	assert.True(t, respHTTP.HostReady)
+	assert.Equal(t, "placement: connected", respHTTP.Placement)
+	assert.ElementsMatch(t, []*daprd.MetadataActorRuntimeActiveActor{
+		{Type: "abc", Count: 2},
+		{Type: "xyz", Count: 1},
+	}, respHTTP.ActiveActors)
+}

--- a/tests/integration/suite/daprd/metadata/actors/withplacement.go
+++ b/tests/integration/suite/daprd/metadata/actors/withplacement.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(withplacement))
+}
+
+type withplacement struct {
+	daprd *daprd.Daprd
+}
+
+func (w *withplacement) Setup(t *testing.T) []framework.Option {
+	place := placement.New(t)
+	w.daprd = daprd.New(t,
+		daprd.WithPlacementAddresses(place.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(place, w.daprd),
+	}
+}
+
+func (w *withplacement) Run(t *testing.T, ctx context.Context) {
+	w.daprd.WaitUntilRunning(t, ctx)
+
+	exp := &rtv1.ActorRuntime{
+		RuntimeStatus: rtv1.ActorRuntime_RUNNING,
+		HostReady:     true,
+		Placement:     "placement: connected",
+	}
+
+	resp, err := w.daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+	require.NoError(t, err)
+	assert.Equal(t, exp, resp.GetActorRuntime())
+	assert.Equal(t, &daprd.MetadataActorRuntime{
+		RuntimeStatus: "RUNNING",
+		HostReady:     true,
+		Placement:     "placement: connected",
+	}, w.daprd.GetMetaActorRuntime(t, ctx))
+}

--- a/tests/integration/suite/daprd/metadata/metadata.go
+++ b/tests/integration/suite/daprd/metadata/metadata.go
@@ -14,5 +14,6 @@ limitations under the License.
 package metadata
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metadata/actors"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metadata/scheduler"
 )


### PR DESCRIPTION
Fixes a regression whereby daprd would no longer connect to placement if an Actor state store is not configured. This meant an app which did not have an actor state store configured (& host Actors), could not invoke Actors on other apps.

Update daprd to always start Placement and the Actor runtime if Placement addresses are configured.

Adds integration test for this scenario.

Adds metadatda integration tests.

Release notes for 1.15.2