### PR TITLE
[1.15] Scheduler: Fix go routine memory leak

### DIFF
--- a/docs/release_notes/v1.15.2.md
+++ b/docs/release_notes/v1.15.2.md
@@ -3,6 +3,7 @@
 This update includes bug fixes:
 
 - [Fix Actor Invocation from non-Actor hosted Apps](#fix-actor-invocation-from-non-actor-hosted-apps)
+- [Fix Scheduler memory leak](#fix-scheduler-memory-leak)
 
 ## Fix Actor Invocation from non-Actor hosted Apps
 
@@ -22,3 +23,21 @@ This meant it did not have the address for the target Actor.
 ### Solution
 
 Daprd will always attempt to connect to Placement if a Placement address is configured.
+
+## Fix Scheduler memory leak
+
+### Problem
+
+Scheduler would continually grow in memory during usage.
+
+### Impact
+
+Scheduler would consume the entirety of memory on the host machine, or to it's cgroup limit, then OOM crash.
+
+### Root cause
+
+A Go routine was doing being closed on connection sends.
+
+### Solution
+
+Correctly close the Go routine on completion of the connection send.

--- a/pkg/scheduler/server/internal/pool/pool.go
+++ b/pkg/scheduler/server/internal/pool/pool.go
@@ -168,6 +168,8 @@ func (p *Pool) Send(ctx context.Context, job *JobEvent) api.TriggerResponseResul
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()


### PR DESCRIPTION
This update includes bug fixes:

- [Fix Scheduler memory leak](#fix-scheduler-memory-leak)

Fix Scheduler memory leak

Problem

Scheduler would continually grow in memory during usage.

Impact

Scheduler would consume the entirety of memory on the host machine, or to it's cgroup limit, then OOM crash.

Root cause

A Go routine was doing being closed on connection sends.

Solution

Correctly close the Go routine on completion of the connection send.