### PR TITLE
[v1.15] Actors: Always tick timer invocations forwards.

### DIFF
--- a/docs/release_notes/v1.15.3.md
+++ b/docs/release_notes/v1.15.3.md
@@ -1,0 +1,26 @@
+# Dapr 1.15.3
+
+This update includes bug fixes:
+
+- [Fix Timers Deactivating after timer invocation fails](#fix-timers-deactivating-after-timer-invocation-fails)
+
+## Fix Timers Deactivating after timer invocation fails
+
+### Problem
+
+Fixes this [issue](https://github.com/dapr/dapr/issues/8548).
+An app returning a non-2xx status code from a timer invocation would cause a periodic timer to no longer trigger.
+
+### Impact
+
+An Actor app which restarted/crashed, or was otherwise busy, would cause a timer to no longer trigger.
+This breaks backwards compatibility where a periodic Actor timer would continue to trigger at the defined period, even if the actor was busy or had an error.
+
+### Root cause
+
+The Actor timer handle logic deactivates the timer if _any_ timer invocation failed.
+Regardless of whether the timer had further ticks defined in it's period schedule.
+
+### Solution
+
+As did before v1.15.0, treat any successful or failed timer invocation as the same, and tick the Actor timer forward allowing for future invocations.

--- a/pkg/actors/internal/timers/inmemory/inmemory.go
+++ b/pkg/actors/internal/timers/inmemory/inmemory.go
@@ -73,11 +73,9 @@ func (i *inmemory) processorExecuteFn(reminder *api.Reminder) {
 	err := i.engine.CallReminder(context.TODO(), reminder)
 	diag.DefaultMonitoring.ActorTimerFired(reminder.ActorType, err == nil)
 	if err != nil {
+		// Successful and non-successful executions are treated as the same in
+		// terms of ticking forward, so we log the error and continue.
 		log.Errorf("Error executing timer: %s", err)
-		if i.activeTimers.CompareAndDelete(reminder.Key(), reminder) {
-			i.updateActiveTimersCount(reminder.ActorType, -1)
-		}
-		return
 	}
 
 	// If TickExecuted returns true, it means the timer has no more repetitions left

--- a/tests/integration/suite/actors/timers/period/complete.go
+++ b/tests/integration/suite/actors/timers/period/complete.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package period
+
+import (
+	"context"
+	nethttp "net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+)
+
+func init() {
+	suite.Register(new(complete))
+}
+
+type complete struct {
+	actors    *actors.Actors
+	triggered slice.Slice[string]
+}
+
+func (c *complete) Setup(t *testing.T) []framework.Option {
+	c.triggered = slice.String()
+
+	c.actors = actors.New(t,
+		actors.WithActorTypes("helloworld"),
+		actors.WithActorTypeHandler("helloworld", func(w nethttp.ResponseWriter, req *nethttp.Request) {
+			if req.Method == nethttp.MethodDelete {
+				return
+			}
+			c.triggered.Append(path.Base(req.URL.Path))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.actors),
+	}
+}
+
+func (c *complete) Run(t *testing.T, ctx context.Context) {
+	c.actors.WaitUntilRunning(t, ctx)
+
+	_, err := c.actors.GRPCClient(t, ctx).RegisterActorTimer(ctx, &rtv1.RegisterActorTimerRequest{
+		ActorType: "helloworld",
+		ActorId:   "1234",
+		Name:      "test",
+		DueTime:   "0s",
+		Period:    "R3/PT1S",
+	})
+	require.NoError(t, err)
+
+	exp := []string{"test", "test", "test"}
+
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		assert.ElementsMatch(col, exp, c.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, exp, c.triggered.Slice())
+}

--- a/tests/integration/suite/actors/timers/period/fail.go
+++ b/tests/integration/suite/actors/timers/period/fail.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package period
+
+import (
+	"context"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/concurrency/slice"
+)
+
+func init() {
+	suite.Register(new(fail))
+}
+
+type fail struct {
+	actors    *actors.Actors
+	triggered slice.Slice[string]
+}
+
+func (f *fail) Setup(t *testing.T) []framework.Option {
+	f.triggered = slice.String()
+
+	f.actors = actors.New(t,
+		actors.WithActorTypes("helloworld"),
+		actors.WithActorTypeHandler("helloworld", func(w http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodDelete {
+				return
+			}
+			f.triggered.Append(path.Base(req.URL.Path))
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(f.actors),
+	}
+}
+
+func (f *fail) Run(t *testing.T, ctx context.Context) {
+	f.actors.WaitUntilRunning(t, ctx)
+
+	_, err := f.actors.GRPCClient(t, ctx).RegisterActorTimer(ctx, &rtv1.RegisterActorTimerRequest{
+		ActorType: "helloworld",
+		ActorId:   "1234",
+		Name:      "test",
+		DueTime:   "0s",
+		Period:    "R3/PT1S",
+	})
+	require.NoError(t, err)
+
+	exp := []string{"test", "test", "test"}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, exp, f.triggered.Slice())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.ElementsMatch(t, exp, f.triggered.Slice())
+}

--- a/tests/integration/suite/actors/timers/timers.go
+++ b/tests/integration/suite/actors/timers/timers.go
@@ -15,5 +15,6 @@ package timers
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/timers/callback"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/timers/period"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/timers/remote"
 )


### PR DESCRIPTION
Dapr 1.15.3

This update includes bug fixes:

- [Fix Timers Deactivating after timer invocation fails](#fix-timers-deactivating-after-timer-invocation-fails)

Fix Timers Deactivating after timer invocation fails

Problem

An app returning a non-2xx status code from a timer invocation would cause a periodic timer to no longer trigger.

Impact

An Actor app which restarted/crashed, or was otherwise busy, would cause a timer to no longer trigger.
This breaks backwards compatibility where a periodic Actor timer would continue to trigger at the defined period, even if the actor was busy or had an error.

Root cause

The Actor timer handle logic deactivates the timer if _any_ timer invocation failed.
Regardless of whether the timer had further ticks defined in it's period schedule.

Solution

As did before v1.15.0, treat any successful or failed timer invocation as the same, and tick the Actor timer forward allowing for future invocations.


Closes https://github.com/dapr/dapr/issues/8548