### PR TITLE
[1.15] Fix memory leak in Dapr scheduler

### DIFF
--- a/docs/release_notes/v1.15.3.md
+++ b/docs/release_notes/v1.15.3.md
@@ -3,6 +3,8 @@
 This update includes bug fixes:
 
 - [Fix Timers Deactivating after timer invocation fails](#fix-timers-deactivating-after-timer-invocation-fails)
+- [Fix Daprd continuously growing in memory](#fix-daprd-continuously-growing-in-memory)
+- [Fix Scheduler continuously growing in memory](#fix-scheduler-continuously-growing-in-memory)
 
 ## Fix Timers Deactivating after timer invocation fails
 
@@ -24,3 +26,39 @@ Regardless of whether the timer had further ticks defined in it's period schedul
 ### Solution
 
 As did before v1.15.0, treat any successful or failed timer invocation as the same, and tick the Actor timer forward allowing for future invocations.
+
+## Fix Daprd continuously growing in memory
+
+### Problem
+
+Fixes an issue where Daprd would continually grow in memory when using Workflows.
+
+### Impact
+
+Daprd would eventually use all available memory on the node or cgroup, causing an OOM crash.
+
+### Root cause
+
+An internal Actor lock object was not being released from Workflow Activities.
+
+### Solution
+
+Release lock memory during Workflow Activity completion.
+
+## Fix Scheduler continuously growing in memory
+
+### Problem
+
+Scheduler would continuously grow in memory when under heavy usage, for example using Workflows.
+
+### Impact
+
+Scheduler would eventually use all available memory on the node or cgroup, causing an OOM crash.
+
+### Root cause
+
+Etcd does not automatically Defragment after compaction, causing unused memory to not be released.
+
+### Solution
+
+Every 10 minutes, each Scheduler host will check whether the total memory is twice the size of used memory and if so, will defragment that host's Etcd database.

--- a/pkg/actors/internal/locker/lock.go
+++ b/pkg/actors/internal/locker/lock.go
@@ -83,7 +83,7 @@ func newLock(opts lockOptions) *lock {
 		reqCh:             make(chan *req),
 		maxStackDepth:     maxStackDepth,
 		reentrancyEnabled: opts.reentrancyEnabled,
-		inflights:         ring.NewBuffered[inflight](1, 64),
+		inflights:         ring.NewBuffered[inflight](2, 8),
 		lock:              fifo.New(),
 		closeCh:           make(chan struct{}),
 	}

--- a/pkg/actors/targets/workflow/activity.go
+++ b/pkg/actors/targets/workflow/activity.go
@@ -164,7 +164,7 @@ func (a *activity) InvokeReminder(ctx context.Context, reminder *actorapi.Remind
 
 	completed, err := a.executeActivity(ctx, reminder.Name, &state)
 	if completed == runCompletedTrue {
-		a.table.DeleteFromTable(a.actorType, a.actorID)
+		a.table.DeleteFromTableIn(a, 0)
 	}
 
 	// Returning nil signals that we want the execution to be retried in the next period interval

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -401,7 +401,7 @@ func (w *workflow) cleanupWorkflowStateInternal(ctx context.Context, state *wfen
 	if err != nil {
 		return err
 	}
-	w.table.DeleteFromTable(w.actorType, w.actorID)
+	w.table.DeleteFromTableIn(w, 0)
 	w.cleanup()
 	return nil
 }

--- a/pkg/scheduler/server/internal/etcd/etcd.go
+++ b/pkg/scheduler/server/internal/etcd/etcd.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -26,6 +27,7 @@ import (
 	"github.com/dapr/dapr/pkg/healthz"
 	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/security"
+	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/logger"
 )
 
@@ -118,12 +120,17 @@ func (e *etcd) Run(ctx context.Context) error {
 
 	close(e.readyCh)
 
-	select {
-	case err := <-e.etcd.Err():
-		return err
-	case <-ctx.Done():
-		return nil
-	}
+	return concurrency.NewRunnerManager(
+		e.runDefrag,
+		func(ctx context.Context) error {
+			select {
+			case err := <-e.etcd.Err():
+				return err
+			case <-ctx.Done():
+				return nil
+			}
+		},
+	).Run(ctx)
 }
 
 func (e *etcd) Client(ctx context.Context) (*clientv3.Client, error) {
@@ -132,6 +139,38 @@ func (e *etcd) Client(ctx context.Context) (*clientv3.Client, error) {
 		return nil, ctx.Err()
 	case <-e.readyCh:
 		return e.client, nil
+	}
+}
+
+func (e *etcd) runDefrag(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Minute):
+			log.Debug("Checking if Etcd needs Defragmentation")
+			resp, err := e.client.Maintenance.Status(ctx, e.config.ListenClientUrls[0].Host)
+			if err != nil {
+				return err
+			}
+
+			dbSize := fmt.Sprintf("%.2fM", float64(resp.DbSize)/(1024*1024))
+			dbSizeInUse := fmt.Sprintf("%.2fM", float64(resp.DbSizeInUse)/(1024*1024))
+
+			if resp.DbSize < resp.DbSizeInUse*2 {
+				log.Debugf("Defragmenting not needed (dbSize: %s, dbSizeInUse: %s)", dbSize, dbSizeInUse)
+				break
+			}
+
+			log.Infof("Defragmenting Etcd (dbSize: %s, dbSizeInUse: %s)", dbSize, dbSizeInUse)
+			start := time.Now()
+			_, err = e.client.Maintenance.Defragment(ctx, e.config.ListenClientUrls[0].Host)
+			if err != nil {
+				return err
+			}
+
+			log.Infof("Defragmentation completed in %s", time.Since(start))
+		}
 	}
 }
 


### PR DESCRIPTION
Fix Daprd continuously growing in memory

Problem

Fixes an issue where Daprd would continually grow in memory when using Workflows.

Impact

Daprd would eventually use all available memory on the node or cgroup, causing an OOM crash.

Root cause

An internal Actor lock object was not being released from Workflow Activities.

Solution

Release lock memory during Workflow Activity completion.

Fix Scheduler continuously growing in memory

Problem

Scheduler would continuously grow in memory when under heavy usage, for example using Workflows.

Impact

Scheduler would eventually use all available memory on the node or cgroup, causing an OOM crash.

Root cause

Etcd does not automatically Defragment after compaction, causing unused memory to not be released.

Solution

Every 10 minutes, each Scheduler host will check whether the total memory is twice the size of used memory and if so, will defragment that host's Etcd database.

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
