### PR TITLE
load /dapr/config on app healthy

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -765,6 +765,9 @@ func (a *DaprRuntime) appHealthChanged(ctx context.Context, status uint8) {
 				log.Warnf("Failed to complete app init: %s ", err)
 			}
 			a.appHealthReady = nil
+		} else {
+			// Load app configuration (for actors) every time app status becomes healthy
+			a.loadAppConfiguration(ctx)
 		}
 
 		if a.channels.AppChannel() != nil {


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

This simple change allows apps to "dynamically" register new hosted actors without the need to restart the dapr sidecar.

The idea is that apps using dapr app health checks they will invoke `loadAppConfiguration` (and populate `a.appConfig`) every time the app health check becomes healthy. The flow would be:
- app becomes healthy
- /dapr/config endpoint invoked and returned actors [a,b]
- actors [a,b] get registered
- app becomes unhealthy
- actors [a,b] get unregistered
- app becomes healthy again
- /dapr/config endpoint invoked and returned actors [a,b,c]
- actors [a,b,c] get registered

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
