### PR TITLE
Scheduler: Fix client connection prune

### DIFF
--- a/docs/release_notes/v1.15.4.md
+++ b/docs/release_notes/v1.15.4.md
@@ -1,0 +1,25 @@
+# Dapr 1.15.4
+
+This update includes bug fixes:
+
+- [Fix degradation of Workflow runtime performance over time](#fix-degradation-of-workflow-runtime-performance-over-time)
+
+## Fix degradation of Workflow runtime performance over time
+
+### Problem
+
+Running a Workflow app multiple times would cause the performance of the Workflow runtime to degrade significantly over multiple runs.
+
+### Impact
+
+Workflow applications would not complete in a timely manner.
+
+### Root cause
+
+There was an issue whereby Scheduler client (daprd) connections where not properly pruned from the connection pool for a given Namespace's appID/actorTypes set.
+This would lead to jobs/actor reminders being sent to stale client connections that were no longer active.
+This caused Jobs to fail, and enter failure policy retry loops.
+
+### Solution
+
+Refactor the Scheduler connection pool logic to properly prune stale connections to prevent job execution occurring on stale connections and causing failure policy loops.

--- a/pkg/scheduler/server/internal/pool/connection/connection.go
+++ b/pkg/scheduler/server/internal/pool/connection/connection.go
@@ -11,29 +11,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pool
+package connection
 
 import (
 	"context"
-	"errors"
-	"io"
 	"sync"
 
 	"github.com/diagridio/go-etcd-cron/api"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 )
 
-// conn represents a single connection bidirectional stream between the
+// JobEvent is a triggered job event.
+type JobEvent struct {
+	Name     string
+	Data     *anypb.Any
+	Metadata *schedulerv1pb.JobMetadata
+}
+
+// Connection represents a single connection bidirectional stream between the
 // scheduler and the client (daprd). conn manages sending triggered jobs to the
 // client, and receiving job process results from the client. Jobs are sent
 // serially via a channel as gRPC does not support concurrent sends. conn
 // tracks the inflight jobs and acks them when the client sends back the
 // result, releasing the job triggering.
-type conn struct {
-	pool  *Pool
+type Connection struct {
 	jobCh chan *schedulerv1pb.WatchJobsResponse
 
 	// idx is the uuid of a triggered job. We can use a simple counter as there
@@ -49,75 +52,18 @@ type conn struct {
 	closeCh chan struct{}
 }
 
-// newConn creates a new connection and starts the goroutines to handle sending
-// jobs to the client and receiving job process results from the client.
-func (p *Pool) newConn(ctx context.Context,
-	req *schedulerv1pb.WatchJobsRequestInitial,
-	stream schedulerv1pb.Scheduler_WatchJobsServer,
-	id uint64,
-	cancel context.CancelFunc,
-) *conn {
-	conn := &conn{
-		pool:     p,
-		closeCh:  make(chan struct{}),
+func New() *Connection {
+	return &Connection{
 		inflight: make(map[uint64]chan schedulerv1pb.WatchJobsRequestResultStatus),
 		jobCh:    make(chan *schedulerv1pb.WatchJobsResponse, 10),
+		closeCh:  make(chan struct{}),
 	}
-
-	p.wg.Add(2)
-
-	go func() {
-		defer func() {
-			cancel()
-			log.Debugf("Closed send connection to %s/%s", req.GetNamespace(), req.GetAppId())
-			p.wg.Done()
-		}()
-
-		for {
-			select {
-			case job := <-conn.jobCh:
-				if err := stream.Send(job); err != nil {
-					log.Warnf("Error sending job to connection %s/%s: %s", req.GetNamespace(), req.GetAppId(), err)
-					return
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	go func() {
-		defer func() {
-			cancel()
-			log.Debugf("Closed receive connection to %s/%s", req.GetNamespace(), req.GetAppId())
-			p.wg.Done()
-		}()
-
-		for {
-			resp, err := stream.Recv()
-			if err == nil {
-				conn.handleJobProcessed(resp.GetResult())
-				continue
-			}
-
-			isEOF := errors.Is(err, io.EOF)
-			s, ok := status.FromError(err)
-			if stream.Context().Err() != nil || isEOF || (ok && s.Code() != codes.Canceled) {
-				return
-			}
-
-			log.Warnf("Error receiving from connection %s/%s: %s", req.GetNamespace(), req.GetAppId(), err)
-			return
-		}
-	}()
-
-	return conn
 }
 
-// sendWaitForResponse sends a job to the client and waits for the client to
-// send back the result. The job is acked when the client sends back the result
-// with a UUID corresponding to the job.
-func (c *conn) sendWaitForResponse(ctx context.Context, jobEvt *JobEvent) api.TriggerResponseResult {
+// Handle sends a job to the client and waits for the client to send back the
+// result. The job is acked when the client sends back the result with a UUID
+// corresponding to the job.
+func (c *Connection) Handle(ctx context.Context, jobEvt *JobEvent) api.TriggerResponseResult {
 	c.lock.Lock()
 	c.idx++
 	ackCh := make(chan schedulerv1pb.WatchJobsRequestResultStatus, 1)
@@ -138,11 +84,9 @@ func (c *conn) sendWaitForResponse(ctx context.Context, jobEvt *JobEvent) api.Tr
 
 	select {
 	case c.jobCh <- job:
-	case <-c.pool.closeCh:
+	case <-ctx.Done():
 		return api.TriggerResponseResult_FAILED
 	case <-c.closeCh:
-		return api.TriggerResponseResult_FAILED
-	case <-ctx.Done():
 		return api.TriggerResponseResult_FAILED
 	}
 
@@ -151,26 +95,39 @@ func (c *conn) sendWaitForResponse(ctx context.Context, jobEvt *JobEvent) api.Tr
 		if result == schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS {
 			return api.TriggerResponseResult_SUCCESS
 		}
-	case <-c.pool.closeCh:
-	case <-c.closeCh:
+		return api.TriggerResponseResult_FAILED
 	case <-ctx.Done():
+		return api.TriggerResponseResult_FAILED
+	case <-c.closeCh:
+		return api.TriggerResponseResult_FAILED
 	}
-	return api.TriggerResponseResult_FAILED
 }
 
-// handleJobProcessed acks the job with the given UUID. This is called when the
-// client sends back the result of the job to be acked.
-func (c *conn) handleJobProcessed(result *schedulerv1pb.WatchJobsRequestResult) {
+// Ack acks the job with the given UUID. This is called when the client
+// sends back the result of the job to be acked.
+func (c *Connection) Ack(ctx context.Context, result *schedulerv1pb.WatchJobsRequestResult) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	if ch, ok := c.inflight[result.GetId()]; ok {
 		select {
 		case ch <- result.GetStatus():
-		case <-c.closeCh:
-		case <-c.pool.closeCh:
+		case <-ctx.Done():
 		}
 	}
 
 	delete(c.inflight, result.GetId())
+}
+
+func (c *Connection) Close() {
+	close(c.closeCh)
+}
+
+func (c *Connection) Next(ctx context.Context) (*schedulerv1pb.WatchJobsResponse, error) {
+	select {
+	case job := <-c.jobCh:
+		return job, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }

--- a/pkg/scheduler/server/internal/pool/pool.go
+++ b/pkg/scheduler/server/internal/pool/pool.go
@@ -19,13 +19,12 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/diagridio/go-etcd-cron/api"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
-	"github.com/dapr/kit/concurrency/lock"
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/connection"
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/store"
 	"github.com/dapr/kit/logger"
 )
 
@@ -33,36 +32,20 @@ var log = logger.NewLogger("dapr.runtime.scheduler")
 
 // Pool represents a connection pool for namespace/appID separation of sidecars to schedulers.
 type Pool struct {
-	cron   api.Interface
-	nsPool map[string]*namespacedPool
+	cron api.Interface
 
-	lock    *lock.Context
+	nsPool *store.Namespace
+
 	wg      sync.WaitGroup
 	closeCh chan struct{}
 	running atomic.Bool
 }
 
-type namespacedPool struct {
-	connID    atomic.Uint64
-	idx       atomic.Uint64
-	appID     map[string][]uint64
-	actorType map[string][]uint64
-	conns     map[uint64]*conn
-}
-
-// JobEvent is a triggered job event.
-type JobEvent struct {
-	Name     string
-	Data     *anypb.Any
-	Metadata *schedulerv1pb.JobMetadata
-}
-
 func New(cron api.Interface) *Pool {
 	return &Pool{
 		cron:    cron,
-		nsPool:  make(map[string]*namespacedPool),
+		nsPool:  store.New(),
 		closeCh: make(chan struct{}),
-		lock:    lock.NewContext(),
 	}
 }
 
@@ -80,26 +63,8 @@ func (p *Pool) Run(ctx context.Context) error {
 
 // Add adds a connection to the pool for a given namespace/appID.
 func (p *Pool) Add(req *schedulerv1pb.WatchJobsRequestInitial, stream schedulerv1pb.Scheduler_WatchJobsServer) (context.Context, error) {
-	if err := p.lock.Lock(stream.Context()); err != nil {
-		return nil, err
-	}
-	defer p.lock.Unlock()
-
-	var id uint64
-	nsPool, ok := p.nsPool[req.GetNamespace()]
-	if ok {
-		id = nsPool.connID.Add(1)
-	} else {
-		nsPool = &namespacedPool{
-			appID:     make(map[string][]uint64),
-			actorType: make(map[string][]uint64),
-			conns:     make(map[uint64]*conn),
-		}
-
-		p.nsPool[req.GetNamespace()] = nsPool
-	}
-
 	var prefixes []string
+	var appID *string
 
 	// To account for backwards compatibility where older clients did not use
 	// this field, we assume a connected client and implement both app jobs, as
@@ -107,31 +72,34 @@ func (p *Pool) Add(req *schedulerv1pb.WatchJobsRequestInitial, stream schedulerv
 	ts := req.GetAcceptJobTypes()
 	if len(ts) == 0 || slices.Contains(ts, schedulerv1pb.JobTargetType_JOB_TARGET_TYPE_JOB) {
 		log.Infof("Adding a Sidecar connection to Scheduler for appID: %s/%s.", req.GetNamespace(), req.GetAppId())
-		nsPool.appID[req.GetAppId()] = append(nsPool.appID[req.GetAppId()], id)
+		appID = &req.AppId
 		prefixes = append(prefixes, "app||"+req.GetNamespace()+"||"+req.GetAppId()+"||")
 	}
 
 	if len(ts) == 0 || slices.Contains(ts, schedulerv1pb.JobTargetType_JOB_TARGET_TYPE_ACTOR_REMINDER) {
 		for _, actorType := range req.GetActorTypes() {
 			log.Infof("Adding a Sidecar connection to Scheduler for actor type: %s/%s.", req.GetNamespace(), actorType)
-			nsPool.actorType[actorType] = append(nsPool.actorType[actorType], id)
 			prefixes = append(prefixes, "actorreminder||"+req.GetNamespace()+"||"+actorType+"||")
 		}
 	}
 
-	ctx, cancel := context.WithCancel(stream.Context())
-	conn := p.newConn(ctx, req, stream, id, cancel)
-	nsPool.conns[id] = conn
+	ctx, conn, cancel := p.nsPool.Add(stream.Context(), store.Options{
+		Namespace:  req.GetNamespace(),
+		AppID:      appID,
+		ActorTypes: req.GetActorTypes(),
+	})
+
+	p.streamConnection(ctx, req, stream, conn)
 
 	log.Debugf("Marking deliverable prefixes for Sidecar connection: %s/%s: %v.", req.GetNamespace(), req.GetAppId(), prefixes)
 
 	dcancel, err := p.cron.DeliverablePrefixes(ctx, prefixes...)
 	if err != nil {
 		cancel()
-		close(conn.closeCh)
-		p.remove(req, id)
 		return nil, err
 	}
+
+	log.Debugf("Added a Sidecar connection to Scheduler for: %s/%s.", req.GetNamespace(), req.GetAppId())
 
 	p.wg.Add(1)
 	go func() {
@@ -143,25 +111,19 @@ func (p *Pool) Add(req *schedulerv1pb.WatchJobsRequestInitial, stream schedulerv
 		}
 
 		log.Debugf("Closing connection to %s/%s", req.GetNamespace(), req.GetAppId())
+
 		dcancel()
 		cancel()
-		close(conn.closeCh)
-
-		p.lock.Lock(context.Background())
-		p.remove(req, id)
-		p.lock.Unlock()
 
 		log.Debugf("Closed and removed connection to %s/%s", req.GetNamespace(), req.GetAppId())
 	}()
-
-	log.Debugf("Added a Sidecar connection to Scheduler for: %s/%s.", req.GetNamespace(), req.GetAppId())
 
 	return ctx, nil
 }
 
 // Send is a blocking function that sends a job trigger to a correct job
 // recipient.
-func (p *Pool) Send(ctx context.Context, job *JobEvent) api.TriggerResponseResult {
+func (p *Pool) Send(ctx context.Context, job *connection.JobEvent) api.TriggerResponseResult {
 	conn, ok := p.getConn(job.Metadata)
 	if !ok {
 		return api.TriggerResponseResult_UNDELIVERABLE
@@ -176,117 +138,20 @@ func (p *Pool) Send(ctx context.Context, job *JobEvent) api.TriggerResponseResul
 		select {
 		case <-ctx.Done():
 		case <-p.closeCh:
-		case <-conn.closeCh:
 		}
 		cancel()
 	}()
 
-	return conn.sendWaitForResponse(ctx, job)
-}
-
-// remove removes a connection from the pool with the given UUID.
-func (p *Pool) remove(req *schedulerv1pb.WatchJobsRequestInitial, id uint64) {
-	nsPool, ok := p.nsPool[req.GetNamespace()]
-	if !ok {
-		return
-	}
-
-	appIDConns, ok := nsPool.appID[req.GetAppId()]
-	if !ok {
-		return
-	}
-
-	delete(nsPool.conns, id)
-
-	// To account for backwards compatibility where older clients did not use
-	// this field, we assume a connected client and implement both app jobs, as
-	// well as actor job types. We can remove this in v1.16
-	ts := req.GetAcceptJobTypes()
-	if len(ts) == 0 || slices.Contains(ts, schedulerv1pb.JobTargetType_JOB_TARGET_TYPE_JOB) {
-		log.Infof("Removing a Sidecar connection from Scheduler for appID: %s/%s.", req.GetNamespace(), req.GetAppId())
-		for i := 0; i < len(appIDConns); i++ {
-			if appIDConns[i] == id {
-				appIDConns = append(appIDConns[:i], appIDConns[i+1:]...)
-				break
-			}
-		}
-
-		nsPool.appID[req.GetAppId()] = appIDConns
-	}
-
-	if len(ts) == 0 || slices.Contains(ts, schedulerv1pb.JobTargetType_JOB_TARGET_TYPE_ACTOR_REMINDER) {
-		for _, actorType := range req.GetActorTypes() {
-			actorTypeConns, ok := nsPool.actorType[actorType]
-			if !ok {
-				continue
-			}
-
-			log.Infof("Removing a Sidecar connection from Scheduler for actor type: %s/%s.", req.GetNamespace(), actorType)
-			for i := 0; i < len(actorTypeConns); i++ {
-				if actorTypeConns[i] == id {
-					actorTypeConns = append(actorTypeConns[:i], actorTypeConns[i+1:]...)
-					break
-				}
-			}
-
-			nsPool.actorType[actorType] = actorTypeConns
-
-			if len(nsPool.actorType[actorType]) == 0 {
-				delete(nsPool.actorType, actorType)
-			}
-		}
-	}
-
-	if len(nsPool.appID[req.GetAppId()]) == 0 {
-		delete(nsPool.appID, req.GetAppId())
-	}
-
-	if len(nsPool.appID) == 0 && len(nsPool.actorType) == 0 {
-		delete(p.nsPool, req.GetNamespace())
-	}
+	return conn.Handle(ctx, job)
 }
 
 // getConn returns a connection from the pool based on the metadata.
-func (p *Pool) getConn(meta *schedulerv1pb.JobMetadata) (*conn, bool) {
-	// If the lock times out we return false that this connection is not
-	// available.
-	// This will result in the job being put on the staging queue, which will be
-	// immediately re-delivered outside the deadlock if we actually have a
-	// connection.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second/4)
-	defer cancel()
-	if err := p.lock.RLock(ctx); err != nil {
-		return nil, false
-	}
-	defer p.lock.RUnlock()
-
-	nsPool, ok := p.nsPool[meta.GetNamespace()]
-	if !ok {
-		return nil, false
-	}
-
-	idx := nsPool.idx.Add(1)
-
+func (p *Pool) getConn(meta *schedulerv1pb.JobMetadata) (*connection.Connection, bool) {
 	switch t := meta.GetTarget(); t.GetType().(type) {
 	case *schedulerv1pb.JobTargetMetadata_Job:
-		appIDConns, ok := nsPool.appID[meta.GetAppId()]
-		if !ok || len(appIDConns) == 0 {
-			return nil, false
-		}
-		//nolint:gosec
-		conn, ok := nsPool.conns[appIDConns[int(idx)%len(appIDConns)]]
-		return conn, ok
-
+		return p.nsPool.AppID(meta.GetNamespace(), meta.GetAppId())
 	case *schedulerv1pb.JobTargetMetadata_Actor:
-		actorTypeConns, ok := nsPool.actorType[t.GetActor().GetType()]
-		if !ok || len(actorTypeConns) == 0 {
-			return nil, false
-		}
-
-		//nolint:gosec
-		conn, ok := nsPool.conns[actorTypeConns[int(idx)%len(actorTypeConns)]]
-		return conn, ok
-
+		return p.nsPool.ActorType(meta.GetNamespace(), t.GetActor().GetType())
 	default:
 		return nil, false
 	}

--- a/pkg/scheduler/server/internal/pool/store/instance.go
+++ b/pkg/scheduler/server/internal/pool/store/instance.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/connection"
+)
+
+type entry struct {
+	idx   uint64
+	conns []*connection.Connection
+}
+
+type instance struct {
+	entries map[string]*entry
+}
+
+func newInstance() *instance {
+	return &instance{
+		entries: make(map[string]*entry),
+	}
+}
+
+func (i *instance) add(name string, conn *connection.Connection) context.CancelFunc {
+	en, ok := i.entries[name]
+	if !ok {
+		en = new(entry)
+		i.entries[name] = en
+	}
+
+	en.conns = append(en.conns, conn)
+	return func() {
+		for idx, c := range en.conns {
+			if c == conn {
+				en.conns = append(en.conns[:idx], en.conns[idx+1:]...)
+				break
+			}
+		}
+
+		if len(en.conns) == 0 {
+			delete(i.entries, name)
+		}
+	}
+}
+
+func (i *instance) get(name string) (*connection.Connection, bool) {
+	en, ok := i.entries[name]
+	if !ok {
+		return nil, false
+	}
+
+	// Increase index to load balance over connections for this instance.
+	defer func() { en.idx++ }()
+	return en.conns[en.idx%uint64(len(en.conns))], true
+}

--- a/pkg/scheduler/server/internal/pool/store/namespace.go
+++ b/pkg/scheduler/server/internal/pool/store/namespace.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+	"sync"
+
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/connection"
+)
+
+type Options struct {
+	Namespace  string
+	AppID      *string
+	ActorTypes []string
+}
+
+// Namespace is a pool of connections for multiple Namespaces. Each Namespace
+// has a pool of connections for AppID and ActorType.
+type Namespace struct {
+	lock   sync.RWMutex
+	stores map[string]*store
+}
+
+func New() *Namespace {
+	return &Namespace{
+		stores: make(map[string]*store),
+	}
+}
+
+func (n *Namespace) Add(ctx context.Context, opts Options) (context.Context, *connection.Connection, context.CancelFunc) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	conn := connection.New()
+
+	store, ok := n.stores[opts.Namespace]
+	if !ok {
+		store = newStore()
+		n.stores[opts.Namespace] = store
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	remove := store.add(conn, opts)
+
+	return ctx, conn, func() {
+		n.lock.Lock()
+		defer n.lock.Unlock()
+		cancel()
+		remove()
+		conn.Close()
+
+		if len(store.appIDs.entries) == 0 &&
+			len(store.actorTypes.entries) == 0 {
+			delete(n.stores, opts.Namespace)
+		}
+	}
+}
+
+func (n *Namespace) AppID(namespace, id string) (*connection.Connection, bool) {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+
+	store, ok := n.stores[namespace]
+	if !ok {
+		return nil, false
+	}
+
+	return store.appIDs.get(id)
+}
+
+func (n *Namespace) ActorType(namespace, actorType string) (*connection.Connection, bool) {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+
+	store, ok := n.stores[namespace]
+	if !ok {
+		return nil, false
+	}
+
+	conn, ok := store.actorTypes.get(actorType)
+	return conn, ok
+}

--- a/pkg/scheduler/server/internal/pool/store/store.go
+++ b/pkg/scheduler/server/internal/pool/store/store.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/connection"
+)
+
+type store struct {
+	appIDs     *instance
+	actorTypes *instance
+}
+
+func newStore() *store {
+	return &store{
+		appIDs:     newInstance(),
+		actorTypes: newInstance(),
+	}
+}
+
+func (s *store) add(conn *connection.Connection, opts Options) context.CancelFunc {
+	// We don't know how many allocations we will have!
+	//nolint:prealloc
+	var fns []context.CancelFunc
+
+	if opts.AppID != nil {
+		fns = append(fns, s.appIDs.add(*opts.AppID, conn))
+	}
+
+	for _, actorType := range opts.ActorTypes {
+		fns = append(fns, s.actorTypes.add(actorType, conn))
+	}
+
+	return func() {
+		for _, fn := range fns {
+			fn()
+		}
+	}
+}

--- a/pkg/scheduler/server/internal/pool/stream.go
+++ b/pkg/scheduler/server/internal/pool/stream.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/connection"
+)
+
+// streamConnection run starts the goroutines to handle sending jobs to the
+// client and receiving job process results from the client.
+func (p *Pool) streamConnection(ctx context.Context,
+	req *schedulerv1pb.WatchJobsRequestInitial,
+	stream schedulerv1pb.Scheduler_WatchJobsServer,
+	conn *connection.Connection,
+) {
+	p.wg.Add(2)
+
+	go func() {
+		defer func() {
+			log.Debugf("Closed send connection to %s/%s", req.GetNamespace(), req.GetAppId())
+			p.wg.Done()
+		}()
+
+		for {
+			job, err := conn.Next(ctx)
+			if err != nil {
+				return
+			}
+
+			if err := stream.Send(job); err != nil {
+				log.Warnf("Error sending job to connection %s/%s: %s", req.GetNamespace(), req.GetAppId(), err)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer func() {
+			log.Debugf("Closed receive connection to %s/%s", req.GetNamespace(), req.GetAppId())
+			p.wg.Done()
+		}()
+
+		for {
+			resp, err := stream.Recv()
+			if err == nil {
+				conn.Ack(stream.Context(), resp.GetResult())
+				continue
+			}
+
+			isEOF := errors.Is(err, io.EOF)
+			s, ok := status.FromError(err)
+			if stream.Context().Err() != nil || isEOF || (ok && s.Code() != codes.Canceled) {
+				return
+			}
+
+			log.Warnf("Error receiving from connection %s/%s: %s", req.GetNamespace(), req.GetAppId(), err)
+			return
+		}
+	}()
+}

--- a/tests/integration/suite/daprd/workflow/restart.go
+++ b/tests/integration/suite/daprd/workflow/restart.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(restart))
+}
+
+type restart struct {
+	place     *placement.Placement
+	scheduler *scheduler.Scheduler
+}
+
+func (r *restart) Setup(t *testing.T) []framework.Option {
+	r.place = placement.New(t)
+	r.scheduler = scheduler.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(r.place, r.scheduler),
+	}
+}
+
+func (r *restart) Run(t *testing.T, ctx context.Context) {
+	r.scheduler.WaitUntilRunning(t, ctx)
+	r.place.WaitUntilRunning(t, ctx)
+
+	registry := task.NewTaskRegistry()
+	registry.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, ctx.CallActivity("bar").Await(nil)
+	})
+	registry.AddActivityN("bar", func(c task.ActivityContext) (any, error) {
+		return "", nil
+	})
+
+	appID := uuid.New().String()
+
+	timeTaken := make([]time.Duration, 0, 5)
+	for range 5 {
+		daprd := daprd.New(t,
+			daprd.WithPlacementAddresses(r.place.Address()),
+			daprd.WithInMemoryActorStateStore("mystore"),
+			daprd.WithSchedulerAddresses(r.scheduler.Address()),
+			daprd.WithAppID(appID),
+		)
+
+		daprd.Run(t, ctx)
+		daprd.WaitUntilRunning(t, ctx)
+		t.Cleanup(func() {
+			daprd.Cleanup(t)
+		})
+
+		wctx, cancel := context.WithCancel(ctx)
+		client := client.NewTaskHubGrpcClient(daprd.GRPCConn(t, wctx), logger.New(t))
+		require.NoError(t, client.StartWorkItemListener(wctx, registry))
+
+		now := time.Now()
+		id, err := client.ScheduleNewOrchestration(wctx, "foo", api.WithInstanceID("pauser"))
+		require.NoError(t, err)
+		_, err = client.WaitForOrchestrationCompletion(wctx, id)
+		require.NoError(t, err)
+		timeTaken = append(timeTaken, time.Since(now))
+		cancel()
+		daprd.Cleanup(t)
+	}
+
+	// Ensure all workflows take similar amounts of time.
+	for _, d1 := range timeTaken {
+		for _, d2 := range timeTaken {
+			assert.InDelta(t, d1.Seconds(), d2.Seconds(), float64(time.Second))
+		}
+	}
+}


### PR DESCRIPTION
Fixes an issue whereby Scheduler client (daprd) connections where not properly pruned from the connection pool for a given Namespace's appID/actorTypes set. This would lead to jobs/actor reminders being sent to stale client connections that were no longer active. This caused Jobs to fail, and enter failure policy retry loops.

This was particularly noticeable when running Workflow applications which were of single run/low number of iterations. Typically, every `dapr run` of these Workflow applications would leave a stale connection in the Scheduler pool. The end result would be Workflows which would take an artificial amount of time to complete, with longer run times the more times the application would be run.

This change refactors the Scheduler connection pool logic to properly abstract the connection instance handling, and moves logic into the connection pool store. Also fixes a bug whereby a cancelled actor reminder would be treated as a Failed trigger, rather than a Success.

This change should see more performant Workflow execution times in environments where there is any churn whatsoever.

This change should be backported to release-1.15.

Thanks to @AlbertoVPersonal for their in-depth issue report.


Fixes https://github.com/dapr/dapr/issues/8599