### PR TITLE
[1.15] Prevent panic of reminder operations on slow Actor Startup

### DIFF
--- a/docs/release_notes/v1.15.4.md
+++ b/docs/release_notes/v1.15.4.md
@@ -5,6 +5,7 @@ This update includes bug fixes:
 - [Fix degradation of Workflow runtime performance over time](#fix-degradation-of-workflow-runtime-performance-over-time)
 - [Fix remote Actor invocation 500 retry](#fix-remote-actor-invocation-500-retry)
 - [Fix Global Actors Enabled Configuration](#fix-global-actors-enabled-configuration)
+- [Prevent panic of reminder operations on slow Actor Startup](#prevent-panic-of-reminder-operations-on-slow-actor-startup)
 
 ## Fix degradation of Workflow runtime performance over time
 
@@ -67,3 +68,22 @@ The sidecar injector was not properly respecting the global actors enabled confi
 ### Solution
 
 The sidecar injector now properly respects the `global.actors.enabled` helm configuration and `ACTORS_ENABLED` environment variable. When set to `false`, it will not attempt to connect to the placement service, allowing the sidecar to start successfully without actor functionality.
+
+
+## Prevent panic of reminder operations on slow Actor Startup
+
+### Problem
+
+The Dapr runtime HTTP server would panic if a reminder operation timed out while an Actor was starting up.
+
+### Impact
+
+The HTTP server would panic, causing degraded performance.
+
+### Root cause
+
+The Dapr runtime would attempt to use the reminder service before it was initialized.
+
+### Solution
+
+Correctly return an errors that the actor runtime was not ready in time for the reminder operation.

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -193,12 +193,10 @@ func (a *actors) Init(opts InitOptions) error {
 
 	storeEnabled := a.buildStateStore(opts, apiLevel)
 
-	if a.reminderStore != nil {
-		a.reminders = reminders.New(reminders.Options{
-			Storage: a.reminderStore,
-			Table:   a.table,
-		})
-	}
+	a.reminders = reminders.New(reminders.Options{
+		Storage: a.reminderStore,
+		Table:   a.table,
+	})
 
 	var err error
 	a.placement, err = placement.New(placement.Options{
@@ -357,6 +355,10 @@ func (a *actors) Reminders(ctx context.Context) (reminders.Interface, error) {
 		return nil, err
 	}
 
+	if a.reminders == nil {
+		return nil, messages.ErrActorRuntimeNotFound
+	}
+
 	return a.reminders, nil
 }
 
@@ -374,7 +376,7 @@ func (a *actors) waitForReady(ctx context.Context) error {
 		}
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return messages.ErrActorRuntimeNotFound
 	}
 }
 


### PR DESCRIPTION
Prevent panic of reminder operations on slow Actor Startup

Problem

The Dapr runtime HTTP server would panic if a reminder operation timed out while an Actor was starting up.

Impact

The HTTP server would panic, causing degraded performance.

Root cause

The Dapr runtime would attempt to use the reminder service before it was initialized.

Solution

Correctly return an errors that the actor runtime was not ready in time for the reminder operation.

Should be back-ported to release-1.15