### PR TITLE
Graceful shutdown: don't cancel in-flight input binding events

### DIFF
--- a/pkg/components/bindings/input_pluggable.go
+++ b/pkg/components/bindings/input_pluggable.go
@@ -29,7 +29,6 @@ import (
 // grpcInputBinding is a implementation of a inputbinding over a gRPC Protocol.
 type grpcInputBinding struct {
 	*pluggable.GRPCConnector[proto.InputBindingClient]
-	bindings.InputBinding
 	logger logger.Logger
 
 	closed  atomic.Bool
@@ -130,7 +129,7 @@ func (b *grpcInputBinding) Read(ctx context.Context, handler bindings.Handler) e
 
 			// TODO reconnect on error
 			if err != nil {
-				b.logger.Errorf("failed to receive message: %v", err)
+				b.logger.Errorf("failed to receive binding message: %v", err)
 				return
 			}
 			b.wg.Add(1)
@@ -149,7 +148,7 @@ func (b *grpcInputBinding) Close() error {
 	if b.closed.CompareAndSwap(false, true) {
 		close(b.closeCh)
 	}
-	return b.InputBinding.Close()
+	return nil
 }
 
 // inputFromConnector creates a new GRPC inputbinding using the given underlying connector.

--- a/pkg/components/pubsub/pluggable.go
+++ b/pkg/components/pubsub/pluggable.go
@@ -159,10 +159,8 @@ func (p *grpcPubSub) adaptHandler(ctx context.Context, streamingPull proto.PubSu
 func (p *grpcPubSub) pullMessages(parentCtx context.Context, topic *proto.Topic, handler pubsub.Handler) error {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var wg sync.WaitGroup
 	go func() {
 		<-parentCtx.Done()
-		wg.Wait()
 		cancel()
 	}()
 
@@ -207,11 +205,7 @@ func (p *grpcPubSub) pullMessages(parentCtx context.Context, topic *proto.Topic,
 
 			p.logger.Debugf("Received message from stream on topic %s", msg.GetTopicName())
 
-			wg.Add(1)
-			go func() {
-				handle(msg)
-				wg.Done()
-			}()
+			handle(msg)
 		}
 	}()
 

--- a/pkg/components/pubsub/pluggable.go
+++ b/pkg/components/pubsub/pluggable.go
@@ -156,7 +156,16 @@ func (p *grpcPubSub) adaptHandler(ctx context.Context, streamingPull proto.PubSu
 }
 
 // pullMessages pull messages of the given subscription and execute the handler for that messages.
-func (p *grpcPubSub) pullMessages(ctx context.Context, topic *proto.Topic, handler pubsub.Handler) error {
+func (p *grpcPubSub) pullMessages(parentCtx context.Context, topic *proto.Topic, handler pubsub.Handler) error {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	go func() {
+		<-parentCtx.Done()
+		wg.Wait()
+		cancel()
+	}()
+
 	// first pull should be sync and subsequent connections can be made in background if necessary
 	pull, err := p.Client.PullMessages(ctx)
 	if err != nil {
@@ -192,13 +201,17 @@ func (p *grpcPubSub) pullMessages(ctx context.Context, topic *proto.Topic, handl
 
 			// TODO reconnect on error
 			if err != nil {
-				p.logger.Errorf("failed to receive message: %v", err)
+				p.logger.Errorf("Failed to receive pubsub message: %v", err)
 				return
 			}
 
-			p.logger.Debugf("received message from stream on topic %s", msg.GetTopicName())
+			p.logger.Debugf("Received message from stream on topic %s", msg.GetTopicName())
 
-			go handle(msg)
+			wg.Add(1)
+			go func() {
+				handle(msg)
+				wg.Done()
+			}()
 		}
 	}()
 

--- a/pkg/components/pubsub/pluggable.go
+++ b/pkg/components/pubsub/pluggable.go
@@ -172,7 +172,7 @@ func (p *grpcPubSub) pullMessages(parentCtx context.Context, topic *proto.Topic,
 		return fmt.Errorf("unable to subscribe: %w", err)
 	}
 
-	streamCtx, cancel := context.WithCancel(pull.Context())
+	streamCtx, streamCancel := context.WithCancel(pull.Context())
 
 	err = pull.Send(&proto.PullMessagesRequest{
 		Topic: topic,
@@ -182,7 +182,7 @@ func (p *grpcPubSub) pullMessages(parentCtx context.Context, topic *proto.Topic,
 		if closeErr := pull.CloseSend(); closeErr != nil {
 			p.logger.Warnf("could not close pull stream of topic %s: %v", topic.GetName(), closeErr)
 		}
-		cancel()
+		streamCancel()
 	}
 
 	if err != nil {

--- a/pkg/runtime/processor/binding/input/input.go
+++ b/pkg/runtime/processor/binding/input/input.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package input
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dapr/components-contrib/bindings"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/kit/logger"
+)
+
+var log = logger.NewLogger("dapr.runtime.processor.binding.input")
+
+type Options struct {
+	Name    string
+	Binding bindings.InputBinding
+	Handler func(context.Context, string, []byte, map[string]string) ([]byte, error)
+}
+
+type Input struct {
+	name    string
+	binding bindings.InputBinding
+	handler func(context.Context, string, []byte, map[string]string) ([]byte, error)
+
+	cancel   func()
+	closed   atomic.Bool
+	wg       sync.WaitGroup
+	inflight atomic.Int64
+}
+
+func Run(opts Options) (*Input, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	i := &Input{
+		name:    opts.Name,
+		binding: opts.Binding,
+		handler: opts.Handler,
+		cancel:  cancel,
+	}
+
+	return i, i.read(ctx)
+}
+
+func (i *Input) Stop() {
+	i.closed.Store(true)
+	inflight := i.inflight.Load() > 0
+
+	i.wg.Wait()
+
+	// If there were in-flight requests then wait some time for the result to be
+	// sent to the binding. This is because the message result context is
+	// disparate.
+	if inflight {
+		time.Sleep(time.Millisecond * 400)
+	}
+	i.cancel()
+}
+
+func (i *Input) read(ctx context.Context) error {
+	return i.binding.Read(ctx, func(ctx context.Context, resp *bindings.ReadResponse) ([]byte, error) {
+		i.wg.Add(1)
+		i.inflight.Add(1)
+		defer func() {
+			i.wg.Done()
+			i.inflight.Add(-1)
+		}()
+
+		if i.closed.Load() {
+			return nil, errors.New("input binding is closed")
+		}
+
+		if resp == nil {
+			return nil, nil
+		}
+
+		start := time.Now()
+		b, err := i.handler(ctx, i.name, resp.Data, resp.Metadata)
+		elapsed := diag.ElapsedSince(start)
+
+		diag.DefaultComponentMonitoring.InputBindingEvent(context.Background(), i.name, err == nil, elapsed)
+
+		if err != nil {
+			log.Debugf("error from app consumer for binding [%s]: %s", i.name, err)
+			return nil, err
+		}
+
+		return b, nil
+	})
+}

--- a/pkg/runtime/processor/binding/send_test.go
+++ b/pkg/runtime/processor/binding/send_test.go
@@ -272,11 +272,14 @@ func TestReadInputBindings(t *testing.T) {
 		b.compStore.AddInputBindingRoute(testInputBindingName, testInputBindingName)
 
 		mockBinding := rtmock.Binding{}
-		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		ch := make(chan bool, 1)
 		mockBinding.ReadErrorCh = ch
-		b.readFromBinding(ctx, testInputBindingName, &mockBinding)
-		cancel()
+		comp := componentsV1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testInputBindingName,
+			},
+		}
+		b.startInputBinding(comp, &mockBinding)
 
 		assert.False(t, <-ch)
 	})
@@ -318,11 +321,14 @@ func TestReadInputBindings(t *testing.T) {
 		b.compStore.AddInputBindingRoute(testInputBindingName, testInputBindingName)
 
 		mockBinding := rtmock.Binding{}
-		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		ch := make(chan bool, 1)
 		mockBinding.ReadErrorCh = ch
-		b.readFromBinding(ctx, testInputBindingName, &mockBinding)
-		cancel()
+		comp := componentsV1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testInputBindingName,
+			},
+		}
+		b.startInputBinding(comp, &mockBinding)
 
 		assert.True(t, <-ch)
 	})
@@ -364,11 +370,15 @@ func TestReadInputBindings(t *testing.T) {
 		b.compStore.AddInputBindingRoute(testInputBindingName, testInputBindingName)
 
 		mockBinding := rtmock.Binding{Metadata: map[string]string{"bindings": "input"}}
-		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		ch := make(chan bool, 1)
 		mockBinding.ReadErrorCh = ch
-		b.readFromBinding(ctx, testInputBindingName, &mockBinding)
-		cancel()
+
+		comp := componentsV1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testInputBindingName,
+			},
+		}
+		b.startInputBinding(comp, &mockBinding)
 
 		assert.Equal(t, string(rtmock.TestInputBindingData), mockBinding.Data)
 	})
@@ -383,6 +393,18 @@ func TestReadInputBindings(t *testing.T) {
 		})
 		b.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
 
+		fakeReq := invokev1.NewInvokeMethodRequest("").
+			WithHTTPExtension(http.MethodOptions, "").
+			WithContentType("application/json")
+		defer fakeReq.Close()
+
+		// User App subscribes 1 topics via http app channel
+		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
+			WithContentType("application/json")
+		defer fakeResp.Close()
+
+		mockAppChannel.On("InvokeMethod", mock.MatchedBy(daprt.MatchContextInterface), fakeReq).Return(fakeResp, nil)
+
 		closeCh := make(chan struct{})
 		defer close(closeCh)
 
@@ -390,10 +412,18 @@ func TestReadInputBindings(t *testing.T) {
 		mockBinding.SetOnReadCloseCh(closeCh)
 		mockBinding.On("Read", mock.MatchedBy(daprt.MatchContextInterface), mock.Anything).Return(nil).Once()
 
-		ctx, cancel := context.WithCancel(t.Context())
-		b.readFromBinding(ctx, testInputBindingName, mockBinding)
+		comp := componentsV1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testInputBindingName,
+			},
+		}
+		b.compStore.AddInputBinding(testInputBindingName, mockBinding)
+		b.startInputBinding(comp, mockBinding)
+
 		time.Sleep(80 * time.Millisecond)
-		cancel()
+
+		b.Close(comp)
+
 		select {
 		case <-closeCh:
 			// All good

--- a/pkg/runtime/processor/subscriber/subscriber.go
+++ b/pkg/runtime/processor/subscriber/subscriber.go
@@ -64,8 +64,7 @@ type Subscriber struct {
 	appSubActive bool
 	hasInitProg  bool
 	lock         sync.RWMutex
-	running      atomic.Bool
-	closed       bool
+	closed       atomic.Bool
 }
 
 type namedSubscription struct {
@@ -93,22 +92,49 @@ func New(opts Options) *Subscriber {
 }
 
 func (s *Subscriber) Run(ctx context.Context) error {
-	if !s.running.CompareAndSwap(false, true) {
-		return errors.New("subscriber is already running")
+	<-ctx.Done()
+	s.closed.Store(true)
+	return nil
+}
+
+func (s *Subscriber) StopAllSubscriptionsForever() {
+	s.lock.Lock()
+
+	s.closed.Store(true)
+
+	var wg sync.WaitGroup
+	for _, psubs := range s.appSubs {
+		wg.Add(len(psubs))
+		for _, sub := range psubs {
+			go func(sub *namedSubscription) {
+				sub.Stop()
+				wg.Done()
+			}(sub)
+		}
 	}
 
-	<-ctx.Done()
+	for _, psubs := range s.streamSubs {
+		wg.Add(len(psubs))
+		for _, sub := range psubs {
+			go func() {
+				sub.Stop()
+				wg.Done()
+			}()
+		}
+	}
 
-	s.StopAllSubscriptionsForever()
+	s.appSubs = make(map[string][]*namedSubscription)
+	s.streamSubs = make(map[string][]*namedSubscription)
+	s.lock.Unlock()
 
-	return nil
+	wg.Wait()
 }
 
 func (s *Subscriber) ReloadPubSub(name string) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if s.closed {
+	if s.closed.Load() {
 		return nil
 	}
 
@@ -130,7 +156,7 @@ func (s *Subscriber) StartStreamerSubscription(key string) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if s.closed {
+	if s.closed.Load() {
 		return apierrors.PubSub("").WithMetadata(nil).DeserializeError(errors.New("subscriber is closed"))
 	}
 
@@ -162,14 +188,10 @@ func (s *Subscriber) StopStreamerSubscription(pubsubName, key string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if s.closed {
-		return
-	}
-
 	for i, sub := range s.streamSubs[pubsubName] {
 		if sub.name != nil && *sub.name == key {
-			sub.Stop()
 			s.streamSubs[pubsubName] = append(s.streamSubs[pubsubName][:i], s.streamSubs[pubsubName][i+1:]...)
+			sub.Stop()
 			return
 		}
 	}
@@ -179,7 +201,7 @@ func (s *Subscriber) ReloadDeclaredAppSubscription(name, pubsubName string) erro
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if !s.appSubActive || s.closed {
+	if !s.appSubActive || s.closed.Load() {
 		return nil
 	}
 
@@ -222,12 +244,21 @@ func (s *Subscriber) StopPubSub(name string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	var wg sync.WaitGroup
+	wg.Add(len(s.appSubs[name]) + len(s.streamSubs[name]))
 	for _, sub := range s.appSubs[name] {
-		sub.Stop()
+		go func(sub *namedSubscription) {
+			sub.Stop()
+			wg.Done()
+		}(sub)
 	}
 	for _, sub := range s.streamSubs[name] {
-		sub.Stop()
+		go func(sub *namedSubscription) {
+			sub.Stop()
+			wg.Done()
+		}(sub)
 	}
+	wg.Wait()
 
 	s.appSubs[name] = nil
 	s.streamSubs[name] = nil
@@ -237,7 +268,7 @@ func (s *Subscriber) StartAppSubscriptions() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if s.appSubActive || s.closed {
+	if s.appSubActive || s.closed.Load() {
 		return nil
 	}
 
@@ -247,11 +278,19 @@ func (s *Subscriber) StartAppSubscriptions() error {
 
 	s.appSubActive = true
 
+	var wg sync.WaitGroup
 	for _, subs := range s.appSubs {
+		wg.Add(len(subs))
 		for _, sub := range subs {
-			sub.Stop()
+			go func(sub *namedSubscription) {
+				sub.Stop()
+				wg.Done()
+			}(sub)
 		}
 	}
+
+	wg.Wait()
+
 	s.appSubs = make(map[string][]*namedSubscription)
 
 	var errs []error
@@ -283,34 +322,19 @@ func (s *Subscriber) StopAppSubscriptions() {
 
 	s.appSubActive = false
 
+	var wg sync.WaitGroup
 	for _, psub := range s.appSubs {
+		wg.Add(len(psub))
 		for _, sub := range psub {
-			sub.Stop()
+			go func(sub *namedSubscription) {
+				sub.Stop()
+				wg.Done()
+			}(sub)
 		}
 	}
+	wg.Wait()
 
 	s.appSubs = make(map[string][]*namedSubscription)
-}
-
-func (s *Subscriber) StopAllSubscriptionsForever() {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.closed = true
-
-	for _, psubs := range s.appSubs {
-		for _, sub := range psubs {
-			sub.Stop()
-		}
-	}
-	for _, psubs := range s.streamSubs {
-		for _, sub := range psubs {
-			sub.Stop()
-		}
-	}
-
-	s.appSubs = make(map[string][]*namedSubscription)
-	s.streamSubs = make(map[string][]*namedSubscription)
 }
 
 func (s *Subscriber) InitProgramaticSubscriptions(ctx context.Context) error {
@@ -320,12 +344,19 @@ func (s *Subscriber) InitProgramaticSubscriptions(ctx context.Context) error {
 }
 
 func (s *Subscriber) reloadPubSubStream(name string, pubsub *rtpubsub.PubsubItem) error {
+	var wg sync.WaitGroup
+	wg.Add(len(s.streamSubs[name]))
 	for _, sub := range s.streamSubs[name] {
-		sub.Stop()
+		go func(sub *namedSubscription) {
+			sub.Stop()
+			wg.Done()
+		}(sub)
 	}
+	wg.Wait()
+
 	s.streamSubs[name] = nil
 
-	if s.closed || pubsub == nil {
+	if s.closed.Load() || pubsub == nil {
 		return nil
 	}
 
@@ -350,13 +381,19 @@ func (s *Subscriber) reloadPubSubStream(name string, pubsub *rtpubsub.PubsubItem
 }
 
 func (s *Subscriber) reloadPubSubApp(name string, pubsub *rtpubsub.PubsubItem) error {
+	var wg sync.WaitGroup
+	wg.Add(len(s.appSubs[name]))
 	for _, sub := range s.appSubs[name] {
-		sub.Stop()
+		go func(sub *namedSubscription) {
+			sub.Stop()
+			wg.Done()
+		}(sub)
 	}
+	wg.Wait()
 
 	s.appSubs[name] = nil
 
-	if !s.appSubActive || s.closed || pubsub == nil {
+	if !s.appSubActive || s.closed.Load() || pubsub == nil {
 		return nil
 	}
 

--- a/pkg/runtime/pubsub/streamer/conn.go
+++ b/pkg/runtime/pubsub/streamer/conn.go
@@ -15,7 +15,6 @@ package streamer
 
 import (
 	"sync"
-	"sync/atomic"
 
 	rtv1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 )
@@ -26,7 +25,6 @@ type conn struct {
 	stream           rtv1pb.Dapr_SubscribeTopicEventsAlpha1Server
 	publishResponses map[string]chan *rtv1pb.SubscribeTopicEventsRequestProcessedAlpha1
 	closeCh          chan struct{}
-	closed           atomic.Bool
 }
 
 func (c *conn) registerPublishResponse(id string) (chan *rtv1pb.SubscribeTopicEventsRequestProcessedAlpha1, func()) {

--- a/pkg/runtime/pubsub/streamer/streamer.go
+++ b/pkg/runtime/pubsub/streamer/streamer.go
@@ -74,58 +74,63 @@ func (s *streamer) Subscribe(stream rtv1pb.Dapr_SubscribeTopicEventsAlpha1Server
 
 	defer func() {
 		s.lock.Lock()
+		defer s.lock.Unlock()
+		select {
+		case <-conn.closeCh:
+		default:
+			close(conn.closeCh)
+		}
 		delete(s.subscribers, key)
-		s.lock.Unlock()
 	}()
 
 	errCh := make(chan error, 2)
-
 	go func() {
+		var err error
 		select {
 		case <-conn.closeCh:
+			err = errors.New("stream closed")
 		case <-stream.Context().Done():
+			err = stream.Context().Err()
 		}
-		errCh <- nil
+		errCh <- err
 	}()
 
 	go func() {
-		for {
-			resp, err := stream.Recv()
-
-			s, ok := status.FromError(err)
-
-			if (ok && s.Code() == codes.Canceled) ||
-				errors.Is(err, context.Canceled) ||
-				errors.Is(err, io.EOF) {
-				log.Infof("Unsubscribed from pubsub '%s' topic '%s'", req.GetPubsubName(), req.GetTopic())
-				errCh <- err
-				return
-			}
-
-			if err != nil {
-				log.Errorf("error receiving message from client stream: %s", err)
-				errCh <- err
-				return
-			}
-
-			eventResp := resp.GetEventProcessed()
-			if eventResp == nil {
-				errCh <- errors.New("duplicate initial request received")
-				return
-			}
-
-			conn.notifyPublishResponse(eventResp)
-		}
+		errCh <- s.recvLoop(stream, req, conn)
 	}()
 
-	// TODO: @joshvanl: add global wait group here to wait during shutdown.
-	err := <-errCh
-	go func() {
-		if eerr := <-errCh; eerr != nil {
-			log.Errorf("Error subscribing to pubsub '%s' topic '%s': %s", req.GetPubsubName(), req.GetTopic(), eerr)
+	return <-errCh
+}
+
+func (s *streamer) recvLoop(
+	stream rtv1pb.Dapr_SubscribeTopicEventsAlpha1Server,
+	req *rtv1pb.SubscribeTopicEventsRequestInitialAlpha1,
+	conn *conn,
+) error {
+	for {
+		resp, err := stream.Recv()
+
+		stat, ok := status.FromError(err)
+
+		if (ok && stat.Code() == codes.Canceled) ||
+			errors.Is(err, context.Canceled) ||
+			errors.Is(err, io.EOF) {
+			log.Infof("Unsubscribed from pubsub '%s' topic '%s'", req.GetPubsubName(), req.GetTopic())
+			return err
 		}
-	}()
-	return err
+
+		if err != nil {
+			log.Errorf("Error receiving message from client stream: %s", err)
+			return err
+		}
+
+		eventResp := resp.GetEventProcessed()
+		if eventResp == nil {
+			return errors.New("duplicate initial request received")
+		}
+
+		conn.notifyPublishResponse(eventResp)
+	}
 }
 
 func (s *streamer) Publish(ctx context.Context, msg *rtpubsub.SubscribedMessage) error {
@@ -173,6 +178,7 @@ func (s *streamer) Publish(ctx context.Context, msg *rtpubsub.SubscribedMessage)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-conn.closeCh:
 	case resp = <-ch:
 	}
 
@@ -202,12 +208,11 @@ func (s *streamer) StreamerKey(pubsub, topic string) string {
 }
 
 func (s *streamer) Close(key string) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	if conn, ok := s.subscribers[key]; ok {
-		if conn.closed.CompareAndSwap(false, true) {
-			close(conn.closeCh)
-		}
+	conn, ok := s.subscribers[key]
+	if ok {
+		close(conn.closeCh)
 	}
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -427,9 +427,6 @@ func (a *DaprRuntime) Run(parentCtx context.Context) error {
 			log.Infof("Blocking graceful shutdown for %s or until app reports unhealthy...", *a.runtimeConfig.blockShutdownDuration)
 
 			a.processor.Subscriber().StopAllSubscriptionsForever()
-
-			// TODO: @joshvanl: gracefully shutdown bindings without disrupting
-			// in-flight requests.
 			a.processor.Binding().StopReadingFromBindings(true)
 
 			select {
@@ -899,12 +896,6 @@ func (a *DaprRuntime) startHTTPServer() error {
 		return err
 	}
 	if err := a.runnerCloser.AddCloser(server); err != nil {
-		return err
-	}
-
-	if err := a.runnerCloser.AddCloser(func() {
-		a.processor.Binding().StopReadingFromBindings(true)
-	}); err != nil {
 		return err
 	}
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -426,10 +426,10 @@ func (a *DaprRuntime) Run(parentCtx context.Context) error {
 
 			log.Infof("Blocking graceful shutdown for %s or until app reports unhealthy...", *a.runtimeConfig.blockShutdownDuration)
 
-			// Stop reading from subscriptions and input bindings forever while
-			// blocking graceful shutdown. This will prevent incoming messages from
-			// being processed, but allow outgoing APIs to be processed.
 			a.processor.Subscriber().StopAllSubscriptionsForever()
+
+			// TODO: @joshvanl: gracefully shutdown bindings without disrupting
+			// in-flight requests.
 			a.processor.Binding().StopReadingFromBindings(true)
 
 			select {
@@ -902,9 +902,6 @@ func (a *DaprRuntime) startHTTPServer() error {
 		return err
 	}
 
-	if err := a.runnerCloser.AddCloser(a.processor.Subscriber().StopAllSubscriptionsForever); err != nil {
-		return err
-	}
 	if err := a.runnerCloser.AddCloser(func() {
 		a.processor.Binding().StopReadingFromBindings(true)
 	}); err != nil {

--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -19,6 +19,9 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/dapr/components-contrib/metadata"
 	contribpubsub "github.com/dapr/components-contrib/pubsub"
@@ -63,7 +66,10 @@ type Subscription struct {
 	adapter         rtpubsub.Adapter
 	adapterStreamer rtpubsub.AdapterStreamer
 
-	cancel func()
+	cancel   func()
+	closed   atomic.Bool
+	wg       sync.WaitGroup
+	inflight atomic.Int64
 }
 
 var log = logger.NewLogger("dapr.runtime.processor.pubsub.subscription")
@@ -119,6 +125,17 @@ func New(opts Options) (*Subscription, error) {
 		Topic:    subscribeTopic,
 		Metadata: routeMetadata,
 	}, func(ctx context.Context, msg *contribpubsub.NewMessage) error {
+		s.wg.Add(1)
+		s.inflight.Add(1)
+		defer func() {
+			s.wg.Done()
+			s.inflight.Add(-1)
+		}()
+
+		if s.closed.Load() {
+			return errors.New("subscription is closed")
+		}
+
 		if msg.Metadata == nil {
 			msg.Metadata = make(map[string]string, 1)
 		}
@@ -306,10 +323,20 @@ func New(opts Options) (*Subscription, error) {
 }
 
 func (s *Subscription) Stop() {
-	s.cancel()
+	s.closed.Store(true)
+	inflight := s.inflight.Load() > 0
+
+	s.wg.Wait()
 	if s.adapterStreamer != nil {
 		s.adapterStreamer.Close(s.adapterStreamer.StreamerKey(s.pubsubName, s.topic))
 	}
+	// If there were in-flight requests then wait some time for the result to be
+	// sent to the broker. This is because the message result context is
+	// disparate.
+	if inflight {
+		time.Sleep(time.Millisecond * 400)
+	}
+	s.cancel()
 }
 
 func (s *Subscription) sendToDeadLetter(ctx context.Context, name string, msg *contribpubsub.NewMessage, deadLetterTopic string) error {

--- a/tests/integration/framework/process/binding/binding.go
+++ b/tests/integration/framework/process/binding/binding.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	compv1pb "github.com/dapr/dapr/pkg/proto/components/v1"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+)
+
+type Binding struct {
+	listener   net.Listener
+	socketName string
+	component  *component
+	socket     *socket.Socket
+	srvErrCh   chan error
+	stopCh     chan struct{}
+}
+
+func New(t *testing.T, fopts ...Option) *Binding {
+	t.Helper()
+
+	os.SkipWindows(t)
+
+	opts := options{
+		socket: socket.New(t),
+	}
+	for _, fopts := range fopts {
+		fopts(&opts)
+	}
+
+	require.NotNil(t, opts.socket)
+
+	comp := newComponent(t, opts)
+
+	// Start the listener in New, so we can sit on the path immediately, and
+	// keep it for the entire test case.
+	socketFile := opts.socket.File(t)
+	listener, err := net.Listen("unix", socketFile.Filename())
+	require.NoError(t, err)
+
+	return &Binding{
+		listener:   listener,
+		component:  comp,
+		socketName: socketFile.Name(),
+		socket:     opts.socket,
+		srvErrCh:   make(chan error),
+		stopCh:     make(chan struct{}),
+	}
+}
+
+func (b *Binding) Run(t *testing.T, ctx context.Context) {
+	b.component.Init(ctx, new(compv1pb.InputBindingInitRequest))
+
+	server := grpc.NewServer()
+	compv1pb.RegisterInputBindingServer(server, b.component)
+	reflection.Register(server)
+
+	go func() {
+		b.srvErrCh <- server.Serve(b.listener)
+	}()
+
+	go func() {
+		<-b.stopCh
+		server.GracefulStop()
+	}()
+}
+
+func (b *Binding) Cleanup(t *testing.T) {
+	close(b.stopCh)
+	require.NoError(t, <-b.srvErrCh)
+}
+
+func (b *Binding) SocketName() string {
+	return b.socketName
+}
+
+func (b *Binding) Socket() *socket.Socket {
+	return b.socket
+}
+
+func (b *Binding) SendMessage(r *compv1pb.ReadResponse) <-chan *compv1pb.ReadRequest {
+	b.component.msgCh <- r
+	return b.component.respCh
+}

--- a/tests/integration/framework/process/binding/component.go
+++ b/tests/integration/framework/process/binding/component.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"context"
+	"testing"
+
+	compv1pb "github.com/dapr/dapr/pkg/proto/components/v1"
+)
+
+type component struct {
+	msgCh  chan *compv1pb.ReadResponse
+	respCh chan *compv1pb.ReadRequest
+}
+
+func newComponent(t *testing.T, opts options) *component {
+	t.Helper()
+
+	return &component{
+		msgCh:  make(chan *compv1pb.ReadResponse, 1),
+		respCh: make(chan *compv1pb.ReadRequest, 1),
+	}
+}
+
+func (c *component) Init(ctx context.Context, req *compv1pb.InputBindingInitRequest) (*compv1pb.InputBindingInitResponse, error) {
+	return new(compv1pb.InputBindingInitResponse), nil
+}
+
+func (c *component) Read(stream compv1pb.InputBinding_ReadServer) error {
+	for {
+		select {
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		case msg := <-c.msgCh:
+			if err := stream.Send(msg); err != nil {
+				return err
+			}
+
+			resp, err := stream.Recv()
+			if err != nil {
+				return err
+			}
+
+			c.respCh <- resp
+		}
+	}
+}
+
+func (c *component) Ping(context.Context, *compv1pb.PingRequest) (*compv1pb.PingResponse, error) {
+	return new(compv1pb.PingResponse), nil
+}

--- a/tests/integration/framework/process/binding/options.go
+++ b/tests/integration/framework/process/binding/options.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Dapr Authors
+Copyright 2025 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,10 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package binding
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/block/app/binding"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/block/app/invocation"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/block/app/pubsub"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 )
+
+type Option func(*options)
+
+type options struct {
+	socket *socket.Socket
+}
+
+func WithSocket(socket *socket.Socket) Option {
+	return func(o *options) {
+		o.socket = socket
+	}
+}

--- a/tests/integration/framework/process/pubsub/broker/broker.go
+++ b/tests/integration/framework/process/pubsub/broker/broker.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	compv1 "github.com/dapr/dapr/pkg/proto/components/v1"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub"
+	inmemory "github.com/dapr/dapr/tests/integration/framework/process/pubsub/in-memory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+)
+
+type Broker struct {
+	pmrReqCh  chan *compv1.PullMessagesRequest
+	pmrRespCh chan *compv1.PullMessagesResponse
+
+	inmem  *pubsub.PubSub
+	socket *socket.Socket
+}
+
+func New(t *testing.T) *Broker {
+	pmrReqCh := make(chan *compv1.PullMessagesRequest, 1)
+	pmrRespCh := make(chan *compv1.PullMessagesResponse, 1)
+
+	socket := socket.New(t)
+	inmem := pubsub.New(t,
+		pubsub.WithSocket(socket),
+		pubsub.WithPullMessagesChannel(pmrReqCh, pmrRespCh),
+		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
+	)
+
+	return &Broker{
+		pmrReqCh:  pmrReqCh,
+		pmrRespCh: pmrRespCh,
+		inmem:     inmem,
+		socket:    socket,
+	}
+}
+
+func (b *Broker) Run(t *testing.T, ctx context.Context) {
+	t.Helper()
+	b.inmem.Run(t, ctx)
+}
+
+func (b *Broker) Cleanup(t *testing.T) {
+	t.Helper()
+	b.inmem.Cleanup(t)
+}
+
+func (b *Broker) DaprdOptions(t *testing.T, componentName string, opts ...daprd.Option) []daprd.Option {
+	return append(opts,
+		daprd.WithSocket(t, b.socket),
+		daprd.WithResourceFiles(fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: %s
+spec:
+  type: pubsub.%s
+  version: v1
+`,
+			componentName,
+			b.inmem.SocketName())),
+	)
+}
+
+func (b *Broker) Socket() *socket.Socket {
+	return b.socket
+}
+
+func (b *Broker) PubSub() *pubsub.PubSub {
+	return b.inmem
+}
+
+func (b *Broker) PublishHelloWorld(topic string) <-chan *compv1.PullMessagesRequest {
+	b.pmrRespCh <- &compv1.PullMessagesResponse{
+		Data:      []byte(`{"data":{"foo": "helloworld"},"datacontenttype":"application/json","id":"b959cd5a-29e5-42ca-89e2-c66f4402f273","pubsubname":"mypub","source":"foo","specversion":"1.0","time":"2024-03-27T23:47:53Z","topic":"a","traceid":"00-00000000000000000000000000000000-0000000000000000-00","traceparent":"00-00000000000000000000000000000000-0000000000000000-00","tracestate":"","type":"com.dapr.event.sent"}`),
+		Id:        "foo",
+		TopicName: topic,
+	}
+
+	return b.pmrReqCh
+}

--- a/tests/integration/framework/process/pubsub/options.go
+++ b/tests/integration/framework/process/pubsub/options.go
@@ -20,9 +20,10 @@ import (
 )
 
 type options struct {
-	socket *socket.Socket
-	pubsub pubsub.PubSub
-	pmrCh  <-chan *compv1pb.PullMessagesResponse
+	socket    *socket.Socket
+	pubsub    pubsub.PubSub
+	pmrReqCh  chan<- *compv1pb.PullMessagesRequest
+	pmrRespCh <-chan *compv1pb.PullMessagesResponse
 }
 
 func WithSocket(socket *socket.Socket) Option {
@@ -37,8 +38,9 @@ func WithPubSub(pubsub pubsub.PubSub) Option {
 	}
 }
 
-func WithPullMessagesChannel(ch <-chan *compv1pb.PullMessagesResponse) Option {
+func WithPullMessagesChannel(reqCh chan<- *compv1pb.PullMessagesRequest, resCh <-chan *compv1pb.PullMessagesResponse) Option {
 	return func(o *options) {
-		o.pmrCh = ch
+		o.pmrReqCh = reqCh
+		o.pmrRespCh = resCh
 	}
 }

--- a/tests/integration/framework/process/pubsub/pubsub.go
+++ b/tests/integration/framework/process/pubsub/pubsub.go
@@ -43,7 +43,8 @@ func New(t *testing.T, fopts ...Option) *PubSub {
 	t.Helper()
 
 	opts := options{
-		pmrCh: make(chan *compv1pb.PullMessagesResponse),
+		pmrRespCh: make(chan *compv1pb.PullMessagesResponse),
+		pmrReqCh:  make(chan *compv1pb.PullMessagesRequest),
 	}
 	for _, fopts := range fopts {
 		fopts(&opts)

--- a/tests/integration/suite/daprd/binding/input/pluggable.go
+++ b/tests/integration/suite/daprd/binding/input/pluggable.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package input
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compv1pb "github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/binding"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(pluggable))
+}
+
+type pluggable struct {
+	daprd   *daprd.Daprd
+	binding *binding.Binding
+
+	bindingCalled atomic.Int64
+}
+
+func (p *pluggable) Setup(t *testing.T) []framework.Option {
+	app := app.New(t,
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			p.bindingCalled.Add(1)
+			return &rtv1.BindingEventResponse{
+				Data: []byte("world hello"),
+			}, nil
+		}),
+	)
+
+	p.binding = binding.New(t)
+
+	p.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithSocket(t, p.binding.Socket()),
+		daprd.WithResourceFiles(fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mybinding'
+spec:
+  type: bindings.%s
+  version: v1
+  metadata:
+  - name: direction
+    value: "input"
+`, p.binding.SocketName())),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, p.binding, p.daprd),
+	}
+}
+
+func (p *pluggable) Run(t *testing.T, ctx context.Context) {
+	p.daprd.WaitUntilRunning(t, ctx)
+
+	require.Len(t, p.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+
+	resp := <-p.binding.SendMessage(&compv1pb.ReadResponse{
+		Data: []byte("hello world"),
+	})
+	assert.Equal(t, "world hello", string(resp.GetResponseData()))
+	assert.Nil(t, resp.GetResponseError())
+	assert.Equal(t, int64(1), p.bindingCalled.Load())
+}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/closing.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/closing.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compv1 "github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/binding"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(closing))
+}
+
+type closing struct {
+	daprd   *daprd.Daprd
+	binding *binding.Binding
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+	dir         string
+}
+
+func (c *closing) Setup(t *testing.T) []framework.Option {
+	c.dir = t.TempDir()
+
+	c.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			c.inInvoke.Store(true)
+			<-c.closeInvoke
+			return &rtv1.BindingEventResponse{
+				Data: []byte("hello world"),
+			}, nil
+		}),
+	)
+
+	c.binding = binding.New(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(c.dir, "comp.yaml"), []byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mybinding'
+spec:
+  type: bindings.%s
+  version: v1
+  metadata:
+  - name: direction
+    value: "input"
+`, c.binding.SocketName())), 0o600))
+
+	c.daprd = daprd.New(t,
+		daprd.WithSocket(t, c.binding.Socket()),
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(c.dir),
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configun
+metadata:
+  name: hotreloading
+spec:
+  features:
+  - name: HotReload
+    enabled: true`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, c.binding, c.daprd),
+	}
+}
+
+func (c *closing) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Len(t, c.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+
+	ch := c.binding.SendMessage(new(compv1.ReadResponse))
+
+	require.Eventually(t, c.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, os.WriteFile(filepath.Join(c.dir, "comp.yaml"), nil, 0o600))
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(c.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Equal(t, "hello world", string(req.GetResponseData()))
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = c.binding.SendMessage(new(compv1.ReadResponse))
+	select {
+	case req := <-ch:
+		assert.Empty(t, req.GetResponseData())
+		assert.Equal(t, &compv1.AckResponseError{Message: "input binding is closed"}, req.GetResponseError())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	// The Binding should eventually be completely removed.
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		ch = c.binding.SendMessage(new(compv1.ReadResponse))
+		select {
+		case req := <-ch:
+			assert.Fail(col, "unexpected request returned", req)
+		case <-time.After(time.Second):
+		}
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/closing.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/closing.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriptions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(closing))
+}
+
+type closing struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+	dir         string
+}
+
+func (c *closing) Setup(t *testing.T) []framework.Option {
+	c.dir = t.TempDir()
+
+	c.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{PubsubName: "mypub", Topic: "a", Routes: &rtv1.TopicRoutes{Default: "/a"}},
+				},
+			}, nil
+		}),
+		app.WithOnTopicEventFn(func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			c.inInvoke.Store(true)
+			<-c.closeInvoke
+			return nil, nil
+		}),
+	)
+
+	c.broker = broker.New(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(c.dir, "comp.yaml"), []byte(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+ name: 'mypub'
+spec:
+ type: pubsub.%s
+ version: v1
+`, c.broker.PubSub().SocketName())), 0o600))
+
+	c.daprd = daprd.New(t,
+		daprd.WithSocket(t, c.broker.Socket()),
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourcesDir(c.dir),
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configun
+metadata:
+  name: hotreloading
+spec:
+  features:
+  - name: HotReload
+    enabled: true`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, c.broker, c.daprd),
+	}
+}
+
+func (c *closing) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+	assert.Len(t, c.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	ch := c.broker.PublishHelloWorld("a")
+
+	require.Eventually(t, c.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, os.WriteFile(filepath.Join(c.dir, "comp.yaml"), nil, 0o600))
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(c.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = c.broker.PublishHelloWorld("a")
+	select {
+	case req := <-ch:
+		assert.Equal(t, &components.AckMessageError{Message: "subscription is closed"}, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	// The Subscription should eventually be completely removed.
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		ch = c.broker.PublishHelloWorld("a")
+		select {
+		case req := <-ch:
+			assert.Fail(col, "unexpected request returned", req)
+		case <-time.After(time.Second):
+		}
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/pubsub/contentlength/bulk.go
+++ b/tests/integration/suite/daprd/pubsub/contentlength/bulk.go
@@ -54,7 +54,7 @@ func (b *bulk) Setup(t *testing.T) []framework.Option {
 	socket1 := socket.New(t)
 	inmem1 := pubsub.New(t,
 		pubsub.WithSocket(socket1),
-		pubsub.WithPullMessagesChannel(b.pmrChHTTP),
+		pubsub.WithPullMessagesChannel(nil, b.pmrChHTTP),
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
 	)
 
@@ -86,7 +86,7 @@ spec:
 	socket2 := socket.New(t)
 	inmem2 := pubsub.New(t,
 		pubsub.WithSocket(socket2),
-		pubsub.WithPullMessagesChannel(b.pmrChGRPC),
+		pubsub.WithPullMessagesChannel(nil, b.pmrChGRPC),
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
 	)
 

--- a/tests/integration/suite/daprd/pubsub/contentlength/singular.go
+++ b/tests/integration/suite/daprd/pubsub/contentlength/singular.go
@@ -54,7 +54,7 @@ func (s *singular) Setup(t *testing.T) []framework.Option {
 	socket1 := socket.New(t)
 	inmem1 := pubsub.New(t,
 		pubsub.WithSocket(socket1),
-		pubsub.WithPullMessagesChannel(s.pmrChHTTP),
+		pubsub.WithPullMessagesChannel(nil, s.pmrChHTTP),
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
 	)
 
@@ -84,7 +84,7 @@ spec:
 	socket2 := socket.New(t)
 	inmem2 := pubsub.New(t,
 		pubsub.WithSocket(socket2),
-		pubsub.WithPullMessagesChannel(s.pmrChGRPC),
+		pubsub.WithPullMessagesChannel(nil, s.pmrChGRPC),
 		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t)),
 	)
 

--- a/tests/integration/suite/daprd/shutdown/block/app/binding/inflight.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/binding/inflight.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	compv1 "github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/binding"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(inflight))
+}
+
+type inflight struct {
+	daprd   *daprd.Daprd
+	binding *binding.Binding
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+	healthz     atomic.Bool
+}
+
+func (i *inflight) Setup(t *testing.T) []framework.Option {
+	i.closeInvoke = make(chan struct{})
+
+	i.healthz.Store(true)
+
+	app := app.New(t,
+		app.WithHealthCheckFn(func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error) {
+			if i.healthz.Load() {
+				return new(rtv1.HealthCheckResponse), nil
+			}
+			return nil, errors.New("not healthy")
+		}),
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			i.inInvoke.Store(true)
+			<-i.closeInvoke
+			return &rtv1.BindingEventResponse{
+				Data: []byte("hello world"),
+			}, nil
+		}),
+	)
+
+	i.binding = binding.New(t)
+
+	i.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithDaprBlockShutdownDuration("180s"),
+		daprd.WithAppHealthProbeInterval(1),
+		daprd.WithAppHealthProbeThreshold(1),
+		daprd.WithAppHealthCheck(true),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithSocket(t, i.binding.Socket()),
+		daprd.WithResourceFiles(fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mybinding'
+spec:
+  type: bindings.%s
+  version: v1
+  metadata:
+  - name: direction
+    value: "input"
+`, i.binding.SocketName())),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, i.binding),
+	}
+}
+
+func (i *inflight) Run(t *testing.T, ctx context.Context) {
+	i.daprd.Run(t, ctx)
+	i.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { i.daprd.Cleanup(t) })
+
+	assert.Len(t, i.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+
+	ch := i.binding.SendMessage(new(compv1.ReadResponse))
+
+	require.Eventually(t, i.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go i.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(i.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Equal(t, "hello world", string(req.GetResponseData()))
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = i.binding.SendMessage(new(compv1.ReadResponse))
+	select {
+	case req := <-ch:
+		assert.Empty(t, req.GetResponseData())
+		assert.Equal(t, &compv1.AckResponseError{Message: "input binding is closed"}, req.GetResponseError())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	client := i.daprd.GRPCClient(t, ctx)
+	req := &rtv1.InvokeServiceRequest{
+		Id: i.daprd.AppID(),
+		Message: &commonv1.InvokeRequest{
+			Method:        "foo",
+			HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_POST},
+		},
+	}
+	_, err := client.InvokeService(ctx, req)
+	require.NoError(t, err)
+
+	i.healthz.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err = client.InvokeService(ctx, req)
+		assert.NoError(c, err)
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/shutdown/block/app/pubsub/inflight.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/pubsub/inflight.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	"github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(inflight))
+}
+
+type inflight struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+	healthz     atomic.Bool
+}
+
+func (i *inflight) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	i.closeInvoke = make(chan struct{})
+	i.healthz.Store(true)
+
+	app := app.New(t,
+		app.WithHealthCheckFn(func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error) {
+			if i.healthz.Load() {
+				return new(rtv1.HealthCheckResponse), nil
+			}
+			return nil, errors.New("not healthy")
+		}),
+		app.WithOnTopicEventFn(func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			i.inInvoke.Store(true)
+			<-i.closeInvoke
+			return nil, nil
+		}),
+	)
+
+	i.broker = broker.New(t)
+
+	i.daprd = daprd.New(t,
+		i.broker.DaprdOptions(t, "mypub",
+			daprd.WithDaprBlockShutdownDuration("180s"),
+			daprd.WithAppHealthProbeInterval(1),
+			daprd.WithAppHealthProbeThreshold(1),
+			daprd.WithAppHealthCheck(true),
+			daprd.WithAppPort(app.Port(t)),
+			daprd.WithAppProtocol("grpc"),
+			daprd.WithResourceFiles(`
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  routes:
+    default: /a
+`),
+		)...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, i.broker),
+	}
+}
+
+func (i *inflight) Run(t *testing.T, ctx context.Context) {
+	i.daprd.Run(t, ctx)
+	i.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { i.daprd.Cleanup(t) })
+
+	assert.Len(t, i.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	ch := i.broker.PublishHelloWorld("a")
+
+	require.Eventually(t, i.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go i.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(i.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = i.broker.PublishHelloWorld("a")
+	select {
+	case req := <-ch:
+		assert.Equal(t, &components.AckMessageError{Message: "subscription is closed"}, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	client := i.daprd.GRPCClient(t, ctx)
+	req := &rtv1.InvokeServiceRequest{
+		Id: i.daprd.AppID(),
+		Message: &commonv1.InvokeRequest{
+			Method:        "foo",
+			HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_POST},
+		},
+	}
+	_, err := client.InvokeService(ctx, req)
+	require.NoError(t, err)
+
+	i.healthz.Store(false)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err = client.InvokeService(ctx, req)
+		assert.NoError(c, err)
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/binding/binding.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/binding/binding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Dapr Authors
+Copyright 2025 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,10 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package binding
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/block/app/binding"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/block/app/invocation"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/block/app/pubsub"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/binding/declarative"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/binding/programmatic"
 )

--- a/tests/integration/suite/daprd/shutdown/graceful/binding/declarative/grpc.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/binding/declarative/grpc.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package declarative
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compv1 "github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/binding"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd   *daprd.Daprd
+	binding *binding.Binding
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			g.inInvoke.Store(true)
+			<-g.closeInvoke
+			return &rtv1.BindingEventResponse{
+				Data: []byte("hello world"),
+			}, nil
+		}),
+	)
+
+	g.binding = binding.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithSocket(t, g.binding.Socket()),
+		daprd.WithResourceFiles(fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mybinding'
+spec:
+  type: bindings.%s
+  version: v1
+  metadata:
+  - name: direction
+    value: "input"
+`, g.binding.SocketName())),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, g.binding),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.Run(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { g.daprd.Cleanup(t) })
+
+	assert.Len(t, g.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+
+	ch := g.binding.SendMessage(new(compv1.ReadResponse))
+
+	require.Eventually(t, g.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go g.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(g.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Equal(t, "hello world", string(req.GetResponseData()))
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = g.binding.SendMessage(new(compv1.ReadResponse))
+	select {
+	case req := <-ch:
+		assert.Empty(t, req.GetResponseData())
+		assert.Equal(t, &compv1.AckResponseError{Message: "input binding is closed"}, req.GetResponseError())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/binding/declarative/http.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/binding/declarative/http.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package declarative
+
+import (
+	"context"
+	"fmt"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compv1 "github.com/dapr/dapr/pkg/proto/components/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/binding"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd   *daprd.Daprd
+	binding *binding.Binding
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	h.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithHandlerFunc("/healthz", func(w nethttp.ResponseWriter, r *nethttp.Request) {}),
+		app.WithHandlerFunc("/mybinding", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			h.inInvoke.Store(true)
+			<-h.closeInvoke
+			w.Write([]byte("hello world"))
+		}),
+	)
+
+	h.binding = binding.New(t)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithSocket(t, h.binding.Socket()),
+		daprd.WithResourceFiles(fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mybinding'
+spec:
+  type: bindings.%s
+  version: v1
+  metadata:
+  - name: direction
+    value: "input"
+`, h.binding.SocketName())),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, h.binding),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.Run(t, ctx)
+	h.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { h.daprd.Cleanup(t) })
+
+	assert.Len(t, h.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+
+	ch := h.binding.SendMessage(new(compv1.ReadResponse))
+
+	require.Eventually(t, h.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go h.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(h.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Equal(t, "hello world", string(req.GetResponseData()))
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = h.binding.SendMessage(new(compv1.ReadResponse))
+	select {
+	case req := <-ch:
+		assert.Empty(t, req.GetResponseData())
+		assert.Equal(t, &compv1.AckResponseError{Message: "input binding is closed"}, req.GetResponseError())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/binding/programmatic/grpc.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/binding/programmatic/grpc.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package programmatic
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	compv1 "github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/binding"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd   *daprd.Daprd
+	binding *binding.Binding
+
+	closeInvoke chan struct{}
+	inInvoke    atomic.Bool
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	g.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithHealthCheckFn(func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error) {
+			return new(rtv1.HealthCheckResponse), nil
+		}),
+		app.WithListInputBindings(func(context.Context, *emptypb.Empty) (*rtv1.ListInputBindingsResponse, error) {
+			return &rtv1.ListInputBindingsResponse{
+				Bindings: []string{"mybinding"},
+			}, nil
+		}),
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			g.inInvoke.Store(true)
+			<-g.closeInvoke
+			return &rtv1.BindingEventResponse{
+				Data: []byte("hello world"),
+			}, nil
+		}),
+	)
+
+	g.binding = binding.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithSocket(t, g.binding.Socket()),
+		daprd.WithResourceFiles(fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mybinding
+spec:
+  type: bindings.%s
+  version: v1
+  metadata:
+  - name: direction
+    value: "input"
+`, g.binding.SocketName())),
+	)
+	return []framework.Option{
+		framework.WithProcesses(app, g.binding),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.Run(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { g.daprd.Cleanup(t) })
+
+	assert.Len(t, g.daprd.GetMetaRegisteredComponents(t, ctx), 1)
+
+	ch := g.binding.SendMessage(new(compv1.ReadResponse))
+
+	require.Eventually(t, g.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go g.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(g.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Equal(t, "hello world", string(req.GetResponseData()))
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = g.binding.SendMessage(new(compv1.ReadResponse))
+	select {
+	case req := <-ch:
+		assert.Empty(t, req.GetResponseData())
+		assert.Equal(t, &compv1.AckResponseError{Message: "input binding is closed"}, req.GetResponseError())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/graceful.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/graceful.go
@@ -14,6 +14,7 @@ limitations under the License.
 package graceful
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/binding"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/invocation"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/subscription"
 )

--- a/tests/integration/suite/daprd/shutdown/graceful/httpendpoints.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/httpendpoints.go
@@ -6,12 +6,12 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package http
+package graceful
 
 import (
 	"context"
@@ -26,57 +26,56 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/client"
-	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
 func init() {
-	suite.Register(new(self))
+	suite.Register(new(httpendpoints))
 }
 
-type self struct {
+type httpendpoints struct {
 	daprd *daprd.Daprd
 
 	inInvoke    atomic.Bool
 	closeInvoke chan struct{}
 }
 
-func (s *self) Setup(t *testing.T) []framework.Option {
-	os.SkipWindows(t)
-
-	s.closeInvoke = make(chan struct{})
+func (h *httpendpoints) Setup(t *testing.T) []framework.Option {
+	h.closeInvoke = make(chan struct{})
 
 	app := app.New(t,
 		app.WithHandlerFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {}),
 		app.WithHandlerFunc("/foo", func(w http.ResponseWriter, r *http.Request) {
-			s.inInvoke.Store(true)
-			<-s.closeInvoke
+			h.inInvoke.Store(true)
+			<-h.closeInvoke
 		}),
 	)
 
-	s.daprd = daprd.New(t,
-		daprd.WithAppPort(app.Port()),
-		daprd.WithDaprGracefulShutdownSeconds(180),
-		daprd.WithAppHealthProbeInterval(1),
-		daprd.WithAppHealthProbeThreshold(1),
-		daprd.WithAppHealthCheck(true),
-	)
+	h.daprd = daprd.New(t, daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: HTTPEndpoint
+metadata:
+  name: mywebsite
+spec:
+  version: v1alpha1
+  baseUrl: http://localhost:%d
+`, app.Port())))
 
 	return []framework.Option{
 		framework.WithProcesses(app),
 	}
 }
 
-func (s *self) Run(t *testing.T, ctx context.Context) {
-	s.daprd.Run(t, ctx)
-	s.daprd.WaitUntilRunning(t, ctx)
-	t.Cleanup(func() { s.daprd.Cleanup(t) })
+func (h *httpendpoints) Run(t *testing.T, ctx context.Context) {
+	h.daprd.Run(t, ctx)
+	h.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { h.daprd.Cleanup(t) })
 
 	client := client.HTTP(t)
 
-	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/foo", s.daprd.HTTPAddress(), s.daprd.AppID())
+	url := fmt.Sprintf("http://%s/v1.0/invoke/mywebsite/method/foo", h.daprd.HTTPAddress())
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	require.NoError(t, err)
 
@@ -92,9 +91,9 @@ func (s *self) Run(t *testing.T, ctx context.Context) {
 		respCh <- resp
 	}()
 
-	require.Eventually(t, s.inInvoke.Load, time.Second*10, time.Millisecond*10)
+	require.Eventually(t, h.inInvoke.Load, time.Second*10, time.Millisecond*10)
 
-	go s.daprd.Cleanup(t)
+	go h.daprd.Cleanup(t)
 
 	select {
 	case err = <-errCh:
@@ -102,7 +101,7 @@ func (s *self) Run(t *testing.T, ctx context.Context) {
 	case <-time.After(time.Second * 3):
 	}
 
-	close(s.closeInvoke)
+	close(h.closeInvoke)
 
 	select {
 	case err = <-errCh:

--- a/tests/integration/suite/daprd/shutdown/graceful/httpendpoints.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/httpendpoints.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -43,6 +44,8 @@ type httpendpoints struct {
 }
 
 func (h *httpendpoints) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
 	h.closeInvoke = make(chan struct{})
 
 	app := app.New(t,

--- a/tests/integration/suite/daprd/shutdown/graceful/invocation/http/caller.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/invocation/http/caller.go
@@ -86,12 +86,15 @@ func (c *caller) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 
 	errCh := make(chan error)
+	respCh := make(chan *http.Response)
 	go func() {
-		resp, err := client.Do(req)
+		var resp *http.Response
+		resp, err = client.Do(req)
 		if resp != nil {
 			assert.NoError(t, resp.Body.Close())
 		}
 		errCh <- err
+		respCh <- resp
 	}()
 
 	require.Eventually(t, c.inInvoke.Load, time.Second*10, time.Millisecond*10)
@@ -99,7 +102,7 @@ func (c *caller) Run(t *testing.T, ctx context.Context) {
 	go c.daprd2.Cleanup(t)
 
 	select {
-	case err := <-errCh:
+	case err = <-errCh:
 		assert.Fail(t, "unexpected error returned", err)
 	case <-time.After(time.Second * 3):
 	}
@@ -107,9 +110,22 @@ func (c *caller) Run(t *testing.T, ctx context.Context) {
 	close(c.closeInvoke)
 
 	select {
-	case err := <-errCh:
+	case err = <-errCh:
 		require.NoError(t, err)
 	case <-time.After(time.Second * 10):
 		assert.Fail(t, "timeout")
+	}
+
+	select {
+	case resp := <-respCh:
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	resp, err := client.Do(req)
+	require.Error(t, err)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
 	}
 }

--- a/tests/integration/suite/daprd/shutdown/graceful/subscription/declarative/grpc.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/subscription/declarative/grpc.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package declarative
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	g.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithOnTopicEventFn(func(context.Context, *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			g.inInvoke.Store(true)
+			<-g.closeInvoke
+			return nil, nil
+		}),
+	)
+
+	g.broker = broker.New(t)
+
+	g.daprd = daprd.New(t,
+		g.broker.DaprdOptions(t, "mypub",
+			daprd.WithAppPort(app.Port(t)),
+			daprd.WithAppProtocol("grpc"),
+			daprd.WithResourceFiles(`
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  routes:
+    default: /a
+`),
+		)...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, g.broker),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.Run(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { g.daprd.Cleanup(t) })
+
+	assert.Len(t, g.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	ch := g.broker.PublishHelloWorld("a")
+
+	require.Eventually(t, g.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go g.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(g.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = g.broker.PublishHelloWorld("a")
+	select {
+	case req := <-ch:
+		assert.Equal(t, &components.AckMessageError{Message: "subscription is closed"}, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/subscription/declarative/http.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/subscription/declarative/http.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package declarative
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/proto/components/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	h.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithHandlerFunc("/healthz", func(w nethttp.ResponseWriter, r *nethttp.Request) {}),
+		app.WithHandlerFunc("/a", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			h.inInvoke.Store(true)
+			<-h.closeInvoke
+		}),
+	)
+
+	h.broker = broker.New(t)
+
+	h.daprd = daprd.New(t,
+		h.broker.DaprdOptions(t, "mypub",
+			daprd.WithAppPort(app.Port()),
+			daprd.WithResourceFiles(`
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: mysub
+spec:
+  pubsubname: mypub
+  topic: a
+  routes:
+    default: /a
+`),
+		)...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, h.broker),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.Run(t, ctx)
+	h.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { h.daprd.Cleanup(t) })
+
+	assert.Len(t, h.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	ch := h.broker.PublishHelloWorld("a")
+
+	require.Eventually(t, h.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go h.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(h.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = h.broker.PublishHelloWorld("a")
+	select {
+	case req := <-ch:
+		assert.Equal(t, &components.AckMessageError{Message: "subscription is closed"}, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/subscription/programmatic/grpc.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/subscription/programmatic/grpc.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package programmatic
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+
+	closeInvoke chan struct{}
+	inInvoke    atomic.Bool
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	g.closeInvoke = make(chan struct{})
+
+	app := app.New(t,
+		app.WithHealthCheckFn(func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error) {
+			return new(rtv1.HealthCheckResponse), nil
+		}),
+		app.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+					},
+				},
+			}, nil
+		}),
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			g.inInvoke.Store(true)
+			<-g.closeInvoke
+			return new(rtv1.TopicEventResponse), nil
+		}),
+	)
+
+	g.broker = broker.New(t)
+
+	g.daprd = daprd.New(t,
+		g.broker.DaprdOptions(t, "mypub",
+			daprd.WithAppProtocol("grpc"),
+			daprd.WithAppPort(app.Port(t)),
+		)...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, g.broker),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.Run(t, ctx)
+	g.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { g.daprd.Cleanup(t) })
+
+	assert.Len(t, g.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	ch := g.broker.PublishHelloWorld("a")
+
+	require.Eventually(t, g.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go g.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(g.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = g.broker.PublishHelloWorld("a")
+	select {
+	case req := <-ch:
+		assert.Equal(t, &components.AckMessageError{Message: "subscription is closed"}, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/subscription/programmatic/http.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/subscription/programmatic/http.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package programmatic
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/proto/components/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+
+	inInvoke    atomic.Bool
+	closeInvoke chan struct{}
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	app := app.New(t,
+		app.WithSubscribe(`[{"pubsubname":"mypub","topic":"a","route":"/a"}]`),
+		app.WithHandlerFunc("/a", func(nethttp.ResponseWriter, *nethttp.Request) {
+			h.inInvoke.Store(true)
+			<-h.closeInvoke
+		}),
+	)
+
+	h.closeInvoke = make(chan struct{})
+
+	h.broker = broker.New(t)
+
+	h.daprd = daprd.New(t,
+		h.broker.DaprdOptions(t, "mypub",
+			daprd.WithAppPort(app.Port()),
+		)...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, h.broker),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.Run(t, ctx)
+	h.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { h.daprd.Cleanup(t) })
+
+	assert.Len(t, h.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	ch := h.broker.PublishHelloWorld("a")
+
+	require.Eventually(t, h.inInvoke.Load, time.Second*10, time.Millisecond*10)
+
+	go h.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	close(h.closeInvoke)
+
+	select {
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = h.broker.PublishHelloWorld("a")
+	select {
+	case req := <-ch:
+		assert.Equal(t, &components.AckMessageError{Message: "subscription is closed"}, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/subscription/streaming.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/subscription/streaming.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscription
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/proto/components/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(streaming))
+}
+
+type streaming struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+}
+
+func (s *streaming) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	s.broker = broker.New(t)
+
+	s.daprd = daprd.New(t,
+		s.broker.DaprdOptions(t, "mypub")...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.broker),
+	}
+}
+
+func (s *streaming) Run(t *testing.T, ctx context.Context) {
+	s.daprd.Run(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { s.daprd.Cleanup(t) })
+
+	stream, err := s.daprd.GRPCClient(t, ctx).SubscribeTopicEventsAlpha1(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&rtv1.SubscribeTopicEventsRequestAlpha1{
+		SubscribeTopicEventsRequestType: &rtv1.SubscribeTopicEventsRequestAlpha1_InitialRequest{
+			InitialRequest: &rtv1.SubscribeTopicEventsRequestInitialAlpha1{
+				PubsubName: "mypub", Topic: "a",
+			},
+		},
+	}))
+
+	_, err = stream.Recv()
+	require.NoError(t, err)
+
+	assert.Len(t, s.daprd.GetMetaSubscriptions(t, ctx), 1)
+
+	ch := s.broker.PublishHelloWorld("a")
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+
+	assert.Equal(t, "a", resp.GetEventMessage().GetTopic())
+
+	go s.daprd.Cleanup(t)
+
+	select {
+	case req := <-ch:
+		assert.Fail(t, "unexpected request returned", req)
+	case <-time.After(time.Second * 3):
+	}
+
+	require.NoError(t, stream.Send(&rtv1.SubscribeTopicEventsRequestAlpha1{
+		SubscribeTopicEventsRequestType: &rtv1.SubscribeTopicEventsRequestAlpha1_EventProcessed{
+			EventProcessed: &rtv1.SubscribeTopicEventsRequestProcessedAlpha1{
+				Id:     resp.GetEventMessage().GetId(),
+				Status: &rtv1.TopicEventResponse{Status: rtv1.TopicEventResponse_SUCCESS},
+			},
+		},
+	}))
+
+	select {
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+
+	ch = s.broker.PublishHelloWorld("a")
+	select {
+	case req := <-ch:
+		assert.Equal(t, &components.AckMessageError{Message: "subscription is closed"}, req.GetAckError())
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout")
+	}
+}

--- a/tests/integration/suite/daprd/shutdown/graceful/subscription/subscription.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/subscription/subscription.go
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package graceful
+package subscription
 
 import (
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/invocation"
-	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/subscription"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/subscription/declarative"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/shutdown/graceful/subscription/programmatic"
 )


### PR DESCRIPTION
Do not cancel in-flight input binding requests during graceful shutdown
procedure, instead wait for them to complete or until the grace period
expires. Also ensures in-flight requests are resolved during hot-reload
events. New requests while the shutdown is in progress are errors to the
input binding Component.

Fixes: https://github.com/dapr/dapr/issues/8332

Branched from https://github.com/dapr/dapr/pull/8628 which should be merged first.

cc @alicejgibbons 