### PR TITLE
[1.15] Remove client-side rate limiter from Sentry

### DIFF
--- a/docs/release_notes/v1.15.4.md
+++ b/docs/release_notes/v1.15.4.md
@@ -6,6 +6,7 @@ This update includes bug fixes:
 - [Fix remote Actor invocation 500 retry](#fix-remote-actor-invocation-500-retry)
 - [Fix Global Actors Enabled Configuration](#fix-global-actors-enabled-configuration)
 - [Prevent panic of reminder operations on slow Actor Startup](#prevent-panic-of-reminder-operations-on-slow-actor-startup)
+- [Remove client-side rate limiter from Sentry](#remove-client-side-rate-limiter-from-sentry)
 
 ## Fix degradation of Workflow runtime performance over time
 
@@ -87,3 +88,21 @@ The Dapr runtime would attempt to use the reminder service before it was initial
 ### Solution
 
 Correctly return an errors that the actor runtime was not ready in time for the reminder operation.
+
+## Remove client-side rate limiter from Sentry
+
+### Problem
+
+A cold start of many Dapr deployments would take a long time, and even cause some crash loops.
+
+### Impact
+
+A large Dapr deployment would take a non-linear more amount of time that a smaller one to completely roll out.
+
+### Root cause
+
+The Sentry Kubernetes client was configured with a rate limiter which would be exhausted when services all new Dapr deployment at once, cause many client to wait significantly.
+
+### Solution
+
+Remove the client-side rate limiting from the Sentry Kubernetes client.

--- a/pkg/sentry/server/validator/kubernetes/kubernetes.go
+++ b/pkg/sentry/server/validator/kubernetes/kubernetes.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -88,6 +89,9 @@ func New(opts Options) (validator.Validator, error) {
 		return nil, err
 	}
 
+	opts.RestConfig.RateLimiter = nil
+	opts.RestConfig.QPS = math.MaxFloat32
+	opts.RestConfig.Burst = math.MaxInt
 	cache, err := cache.New(opts.RestConfig, cache.Options{Scheme: scheme})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION


Remove client-side rate limiter from Sentry

Problem

A cold start of many Dapr deployments would take a long time, and even cause some crash loops.

Impact

A large Dapr deployment would take a non-linear more amount of time that a smaller one to completely roll out.

Root cause

The Sentry Kubernetes client was configured with a rate limiter which would be exhausted when services all new Dapr deployment at once, cause many client to wait significantly.

Solution

Remove the client-side rate limiting from the Sentry Kubernetes client.
