### PR TITLE
ci: bring back dapr alphas

### DIFF
--- a/.github/scripts/get_release_version.py
+++ b/.github/scripts/get_release_version.py
@@ -42,7 +42,6 @@ with open(os.getenv("GITHUB_ENV"), "a") as githubEnv:
         print ("Release Candidate build from {}...".format(gitRef))
     elif gitRef.find("-alpha.") > 0:
         print ("Release Alpha build from {}...".format(gitRef))
-        githubEnv.write("ALPHA_RELEASE=true\n")
     else:
         print ("Checking if {} exists".format(releaseNotePath))
         if os.path.exists(releaseNotePath):

--- a/.github/workflows/daily-alpha-release.yaml
+++ b/.github/workflows/daily-alpha-release.yaml
@@ -1,0 +1,34 @@
+name: Daily Alpha Release
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  new-alpha-release:
+    name: New Alpha Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate alpha version
+        id: version
+        run: |
+          # Fetch latest tag from git
+          latest=$(git ls-remote --tags origin | \
+            grep -o 'refs/tags/v[0-9]*\.[0-9]*\.[0-9]*$' | \
+            sed 's/refs\/tags\/v//' | sort -V | tail -n1)
+
+          echo "Latest tag: ${latest}"
+          
+          major=$(echo "$latest" | cut -d. -f1)
+          minor=$(echo "$latest" | cut -d. -f2)
+          next_minor=$((minor + 1))
+          date_str=$(date +%Y%m%d)
+          alpha_version="${major}.${next_minor}.0-alpha.${date_str}"
+
+          echo "rel_version=${alpha_version}" >> "$GITHUB_OUTPUT"
+          echo "Next alpha: ${alpha_version}"
+      - name: Create Release
+        uses: ./.github/workflows/create-release.yml
+        with:
+          rel_version: ${{ steps.version.outputs.rel_version }}

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -517,7 +517,7 @@ jobs:
       - name: lists artifacts
         run: ls -l ${{ env.ARTIFACT_DIR }}
       - name: publish binaries to github
-        if: startswith(github.ref, 'refs/tags/v') && ${{ env.ALPHA_RELEASE }} != "true"
+        if: startswith(github.ref, 'refs/tags/v')
         run: |
           echo "installing github-release-cli..."
           sudo npm install --silent --no-progress -g github-release-cli@2.1.0


### PR DESCRIPTION
# Description

Previous work:
- https://github.com/dapr/dapr/pull/8267 : Added alpha versions
- https://github.com/dapr/dapr/pull/8293 : Stopped publishing due to the CLI installing them as the latest

The motivation is the same as before: publishing earlier non-RC versions for earlier testing.

This shouldn't bring any of the issues we saw in the past with the CLI, since this is considered a pre-release version:
https://github.com/dapr/cli/blob/master/pkg/version/version.go#L122-L136

```
> sh .github/scripts/tag.sh
Latest tag: 1.15.4
Next alpha: 1.16.0-alpha.20250415

```

My main concern here is that we will be creating a new tag per day. I don't mind adding a step that clears all alpha tags except the last X ones.



## Issue reference

There is an issue for this in the 1.16 board but is in draft so I can't reference the number 🤷 

https://github.com/orgs/dapr/projects/89/views/1?pane=issue&itemId=105561623

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
