### PR TITLE
scheduler helm: fix default storage class name

### DIFF
--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       name: dapr-scheduler-data-dir
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      {{- if Values.cluster.storageClassName }}
+      {{- if .Values.cluster.storageClassName }}
       storageClassName: {{ .Values.cluster.storageClassName }}
       {{- end }}
       resources:

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -27,7 +27,9 @@ spec:
       name: dapr-scheduler-data-dir
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if Values.cluster.storageClassName }}
       storageClassName: {{ .Values.cluster.storageClassName }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.cluster.storageSize }}


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

for kubernetes to use its default storage class name the field needs to be absent

noticed the storage class name in the scheduler server is hardcoded to empty, unlike the placement server where if it is absent it doesn't set it

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
