### PR TITLE
Cleanup Kubernetes Dapr app services 

### DIFF
--- a/pkg/operator/cache/cache_test.go
+++ b/pkg/operator/cache/cache_test.go
@@ -152,7 +152,7 @@ func Test_deployTransformer(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, store.Add(obj))
 		}
-		require.Len(t, store.List(), 1)
+		require.Len(t, store.List(), len(deployments))
 	})
 	t.Run("allNonDaprPlusInjectorDeployment", func(t *testing.T) {
 		store := getNewTestStore()
@@ -171,7 +171,7 @@ func Test_deployTransformer(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, store.Add(obj))
 		}
-		require.Len(t, store.List(), 2)
+		require.Len(t, store.List(), len(deployments))
 	})
 }
 
@@ -217,6 +217,6 @@ func Test_stsTransformer(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, store.Add(obj))
 		}
-		require.Len(t, store.List(), 1)
+		require.Len(t, store.List(), len(statefulsets))
 	})
 }

--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -177,9 +177,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	} else {
 		if wrapper.GetObject().GetDeletionTimestamp() != nil {
 			log.Debugf("deployment is being deleted, %s", req.NamespacedName)
-			return ctrl.Result{}, nil
+		} else {
+			expectedService = r.isAnnotatedForDapr(wrapper)
 		}
-		expectedService = r.isAnnotatedForDapr(wrapper)
 	}
 
 	if expectedService {
@@ -188,6 +188,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			log.Errorf("failed to ensure dapr service present, err: %v", err)
 			return ctrl.Result{Requeue: true}, err
 		}
+	} else {
+		log.Debugf("delete service associated with %s", req.NamespacedName)
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/operator/handlers/dapr_handler_test.go
+++ b/pkg/operator/handlers/dapr_handler_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -137,7 +136,7 @@ func TestDaprServiceCleanup(t *testing.T) {
 
 	t.Run("deployment dapr service cleanup", func(t *testing.T) {
 		// Arrange
-		svcName := fmt.Sprintf("%s-dapr", d.GetObject().GetName())
+		svcName := d.GetObject().GetName() + "-dapr"
 		namespace := "test"
 		myDaprService := types.NamespacedName{
 			Namespace: namespace,
@@ -170,7 +169,7 @@ func TestDaprServiceCleanup(t *testing.T) {
 
 	t.Run("statefulset dapr service cleanup", func(t *testing.T) {
 		// Arrange
-		svcName := fmt.Sprintf("%s-dapr", s.GetObject().GetName())
+		svcName := s.GetObject().GetName() + "-dapr"
 		namespace := "test"
 		myDaprService := types.NamespacedName{
 			Namespace: namespace,
@@ -200,7 +199,6 @@ func TestDaprServiceCleanup(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, apierrors.IsNotFound(err))
 	})
-
 }
 
 func TestCreateDaprServiceAppIDAndMetricsSettings(t *testing.T) {


### PR DESCRIPTION
# Description

Performs cleanup of Dapr app services when the `dapr.io/enabled` annotation is either set to false or removed from a Deployment or StatefulSet. This cleanup is handled by the Operator component during reconciliation of non-Dapr resources that own services previously annotated with `dapr.io/enabled`.

The sinkhole mechanism introduced in https://github.com/dapr/dapr/pull/5944 was modified to use a minimal resource version for Deployments and StatefulSets. This ensures the Operator’s cache retains awareness of resources that were previously Dapr-annotated, allowing it to properly perform service cleanup.

> [!NOTE]
> Changing the sinkhole logic alone resolves the issue where the Operator would recreate the service after it was manually deleted, even when the annotation had been removed from the Deployment or StatefulSet.

Unit tests were added or updated to verify that services are created and removed as expected using the new `ensureDaprServiceAbsent` function.

## Issue reference

https://github.com/dapr/dapr/issues/7933

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
