### PR TITLE
Removed the scheduler's statefulset if the global.scheduler.enabled f…

### DIFF
--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if (eq .Values.global.scheduler.enabled true) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -270,4 +271,5 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName:
 {{ toYaml .Values.global.priorityClassName | indent 8 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
…lag is false

# Description

Removed the scheduler's statefulset if the global.scheduler.enabled flag is false 

## Issue reference

- https://github.com/dapr/dapr/issues/8664

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
