### PR TITLE
Workflow: Prevent panic when no actor state store is configured

### DIFF
--- a/pkg/actors/targets/workflow/invoke.go
+++ b/pkg/actors/targets/workflow/invoke.go
@@ -25,6 +25,7 @@ import (
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
+	"github.com/dapr/dapr/pkg/messages"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
@@ -71,6 +72,10 @@ func (w *workflow) handleInvoke(ctx context.Context, req *internalsv1pb.Internal
 
 func (w *workflow) executeMethod(ctx context.Context, methodName string, request []byte) ([]byte, error) {
 	log.Debugf("Workflow actor '%s': invoking method '%s'", w.actorID, methodName)
+
+	if w.actorState == nil {
+		return nil, messages.ErrActorRuntimeNotFound
+	}
 
 	switch methodName {
 	case todo.CreateWorkflowInstanceMethod:

--- a/tests/integration/suite/daprd/workflow/nostatestore/grpc.go
+++ b/tests/integration/suite/daprd/workflow/nostatestore/grpc.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nostatestore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	sched := scheduler.New(t)
+	place := placement.New(t)
+
+	g.daprd = daprd.New(t,
+		daprd.WithScheduler(sched),
+		daprd.WithPlacementAddresses(place.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sched, place, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	reg := task.NewTaskRegistry()
+	reg.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	cl := client.NewTaskHubGrpcClient(g.daprd.GRPCConn(t, ctx), logger.New(t))
+	require.NoError(t, cl.StartWorkItemListener(ctx, reg))
+
+	_, err := g.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowName: "foo",
+	})
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, s.Code())
+	assert.Contains(t, err.Error(), "the state store is not configured to use the actor runtime")
+}

--- a/tests/integration/suite/daprd/workflow/nostatestore/http.go
+++ b/tests/integration/suite/daprd/workflow/nostatestore/http.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nostatestore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	frameworkclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	sched := scheduler.New(t)
+	place := placement.New(t)
+
+	h.daprd = daprd.New(t,
+		daprd.WithScheduler(sched),
+		daprd.WithPlacementAddresses(place.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sched, place, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	reg := task.NewTaskRegistry()
+	reg.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	cl := client.NewTaskHubGrpcClient(h.daprd.GRPCConn(t, ctx), logger.New(t))
+	require.NoError(t, cl.StartWorkItemListener(ctx, reg))
+
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0-beta1/workflows/dapr/foo/start", h.daprd.HTTPPort())
+	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+
+	resp, err := frameworkclient.HTTP(t).Do(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, nethttp.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(t, string(body), "the state store is not configured to use the actor runtime")
+}

--- a/tests/integration/suite/daprd/workflow/nostatestore/workerclient.go
+++ b/tests/integration/suite/daprd/workflow/nostatestore/workerclient.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nostatestore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(workerclient))
+}
+
+type workerclient struct {
+	daprd *daprd.Daprd
+}
+
+func (w *workerclient) Setup(t *testing.T) []framework.Option {
+	sched := scheduler.New(t)
+	place := placement.New(t)
+
+	w.daprd = daprd.New(t,
+		daprd.WithScheduler(sched),
+		daprd.WithPlacementAddresses(place.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sched, place, w.daprd),
+	}
+}
+
+func (w *workerclient) Run(t *testing.T, ctx context.Context) {
+	w.daprd.WaitUntilRunning(t, ctx)
+
+	reg := task.NewTaskRegistry()
+	reg.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	cl := client.NewTaskHubGrpcClient(w.daprd.GRPCConn(t, ctx), logger.New(t))
+	require.NoError(t, cl.StartWorkItemListener(ctx, reg))
+
+	_, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, s.Code())
+	assert.Contains(t, err.Error(), "the state store is not configured to use the actor runtime")
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -16,6 +16,7 @@ package workflow
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/continueasnew"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/memory"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/nostatestore"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/rerun"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"
 )

--- a/tests/integration/suite/scheduler/authz/mtls.go
+++ b/tests/integration/suite/scheduler/authz/mtls.go
@@ -65,6 +65,7 @@ func (m *mtls) Run(t *testing.T, ctx context.Context) {
 			Name: "testJob",
 			Job: &schedulerv1pb.Job{
 				Schedule:  ptr.Of("@daily"),
+				DueTime:   ptr.Of("3h"),
 				Overwrite: true,
 			},
 			Metadata: &schedulerv1pb.JobMetadata{


### PR DESCRIPTION
Before, attempting to schedule a workflow on a daprd where no actor state store would result in a panic. This is because the workflow actor would attempt to use the actor state store, which is nil if no actor state store is configured.

Updates the workflow actor to return a typed error if no actor state store is configured.

Adds int tests.

cc @javier-aliaga