### PR TITLE
[1.15] Actors: Fix memory leak in lock goroutines

### DIFF
--- a/docs/release_notes/v1.15.6.md
+++ b/docs/release_notes/v1.15.6.md
@@ -1,0 +1,23 @@
+# Dapr 1.15.6
+
+This update includes bug fixes:
+
+- [Fix Actor memory leak](#fix-actor-memory-leak)
+
+## Fix Actor memory leak
+
+### Problem
+
+Running Actor or Workflow workloads would see the daprd process consume more and more memory over time.
+
+### Impact
+
+Running Actor or Workflow for long enough periods of time would see the daprd process consume all available memory, leading to an OOM crash.
+
+### Root cause
+
+The Actor locking mechanism would not release object memory after use, in the case where the daprd it calling a remote Actor.
+
+### Solution
+
+Defer Actor message locking to only the daprd which is hosting that Actor ID to ensure the lock object memory is always released after use.

--- a/pkg/actors/engine/engine.go
+++ b/pkg/actors/engine/engine.go
@@ -101,52 +101,36 @@ func New(opts Options) Interface {
 }
 
 func (e *engine) Call(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
-	cancel, err := e.locker.LockRequest(req)
-	if err != nil {
-		return nil, err
-	}
-	defer cancel()
-
-	var res *internalv1pb.InternalInvokeResponse
 	if e.resiliency.PolicyDefined(req.GetActor().GetActorType(), resiliency.ActorPolicy{}) {
-		res, err = e.callActor(ctx, req)
+		res, err := e.callActor(ctx, req)
 		// Don't bubble perminant errors up to the caller to interfere with top level
 		// retries.
 		if _, ok := err.(*backoff.PermanentError); ok {
 			err = errors.Unwrap(err)
 		}
+		return res, err
 	} else {
 		policyRunner := resiliency.NewRunner[*internalv1pb.InternalInvokeResponse](ctx, e.resiliency.BuiltInPolicy(resiliency.BuiltInActorNotFoundRetries))
-		res, err = policyRunner(func(ctx context.Context) (*internalv1pb.InternalInvokeResponse, error) {
+		return policyRunner(func(ctx context.Context) (*internalv1pb.InternalInvokeResponse, error) {
 			return e.callActor(ctx, req)
 		})
 	}
-
-	return res, err
 }
 
 func (e *engine) CallReminder(ctx context.Context, req *api.Reminder) error {
 	if req.SkipLock {
 		return e.callReminder(ctx, req)
-	} else {
-		cancel, err := e.locker.Lock(req.ActorType, req.ActorID)
-		if err != nil {
-			return err
-		}
-		defer cancel()
 	}
 
-	var err error
 	if e.resiliency.PolicyDefined(req.ActorType, resiliency.ActorPolicy{}) {
-		err = e.callReminder(ctx, req)
+		return e.callReminder(ctx, req)
 	} else {
 		policyRunner := resiliency.NewRunner[struct{}](ctx, e.resiliency.BuiltInPolicy(resiliency.BuiltInActorNotFoundRetries))
-		_, err = policyRunner(func(ctx context.Context) (struct{}, error) {
+		_, err := policyRunner(func(ctx context.Context) (struct{}, error) {
 			return struct{}{}, e.callReminder(ctx, req)
 		})
+		return err
 	}
-
-	return err
 }
 
 func (e *engine) CallStream(ctx context.Context, req *internalv1pb.InternalInvokeRequest, stream chan<- *internalv1pb.InternalInvokeResponse) error {
@@ -195,6 +179,13 @@ func (e *engine) callReminder(ctx context.Context, req *api.Reminder) error {
 		return err
 	}
 
+	// Only lock the request if it is a local call.
+	cancel, err := e.locker.Lock(req.ActorType, req.ActorID)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
 	target, _, err := e.table.GetOrCreate(req.ActorType, req.ActorID)
 	if err != nil {
 		return backoff.Permanent(err)
@@ -233,6 +224,14 @@ func (e *engine) callActor(ctx context.Context, req *internalv1pb.InternalInvoke
 	}
 
 	if lar.Local {
+		// Only lock the request if it is a local call.
+		var cancel context.CancelFunc
+		cancel, err = e.locker.LockRequest(req)
+		if err != nil {
+			return nil, err
+		}
+		defer cancel()
+
 		var resp *internalv1pb.InternalInvokeResponse
 		resp, err = e.callLocalActor(ctx, req)
 		if err != nil {

--- a/tests/integration/suite/actors/lock/call/remote/goroutines.go
+++ b/tests/integration/suite/actors/lock/call/remote/goroutines.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	nethttp "net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(goroutines))
+}
+
+type goroutines struct {
+	app1 *actors.Actors
+	app2 *actors.Actors
+}
+
+func (g *goroutines) Setup(t *testing.T) []framework.Option {
+	g.app1 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorIdleTimeout(time.Second),
+		actors.WithActorTypeHandler("abc", func(_ nethttp.ResponseWriter, r *nethttp.Request) {}),
+	)
+
+	g.app2 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorIdleTimeout(time.Second),
+		actors.WithPeerActor(g.app1),
+		actors.WithActorTypeHandler("abc", func(_ nethttp.ResponseWriter, r *nethttp.Request) {
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(g.app1, g.app2),
+	}
+}
+
+func (g *goroutines) Run(t *testing.T, ctx context.Context) {
+	g.app1.WaitUntilRunning(t, ctx)
+	g.app2.WaitUntilRunning(t, ctx)
+
+	client := g.app2.GRPCClient(t, ctx)
+
+	startGoRoutines1 := g.app1.Metrics(t, ctx)["go_goroutines"]
+	startGoRoutines2 := g.app2.Metrics(t, ctx)["go_goroutines"]
+
+	const n = 1000
+	for i := range n {
+		_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "abc",
+			ActorId:   strconv.Itoa(i),
+			Method:    "foo",
+		})
+		require.NoError(t, err)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.InDelta(c, startGoRoutines1, g.app1.Metrics(t, ctx)["go_goroutines"], 10)
+		assert.InDelta(c, startGoRoutines2, g.app2.Metrics(t, ctx)["go_goroutines"], 10)
+	}, time.Second*20, time.Second)
+}

--- a/tests/integration/suite/actors/lock/call/self/goroutines.go
+++ b/tests/integration/suite/actors/lock/call/self/goroutines.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package self
+
+import (
+	"context"
+	"io"
+	nethttp "net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(goroutines))
+}
+
+type goroutines struct {
+	app *actors.Actors
+}
+
+func (g *goroutines) Setup(t *testing.T) []framework.Option {
+	g.app = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorTypeHandler("abc", func(_ nethttp.ResponseWriter, r *nethttp.Request) {
+			io.ReadAll(r.Body)
+		}),
+		actors.WithActorIdleTimeout(time.Second),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(g.app),
+	}
+}
+
+func (g *goroutines) Run(t *testing.T, ctx context.Context) {
+	g.app.WaitUntilRunning(t, ctx)
+
+	client := g.app.GRPCClient(t, ctx)
+
+	startGoRoutines := g.app.Metrics(t, ctx)["go_goroutines"]
+
+	const n = 1000
+	for i := range n {
+		_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "abc",
+			ActorId:   strconv.Itoa(i),
+			Method:    "foo",
+		})
+		require.NoError(t, err)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.InDelta(c, startGoRoutines, g.app.Metrics(t, ctx)["go_goroutines"], 10)
+	}, time.Second*20, time.Second)
+}

--- a/tests/integration/suite/actors/lock/reminders/reminders.go
+++ b/tests/integration/suite/actors/lock/reminders/reminders.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/lock/reminders/remote"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/lock/reminders/self"
+)

--- a/tests/integration/suite/actors/lock/reminders/remote/goroutines.go
+++ b/tests/integration/suite/actors/lock/reminders/remote/goroutines.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	nethttp "net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(goroutines))
+}
+
+type goroutines struct {
+	app1   *actors.Actors
+	app2   *actors.Actors
+	called atomic.Int64
+}
+
+func (g *goroutines) Setup(t *testing.T) []framework.Option {
+	g.app1 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorIdleTimeout(time.Second),
+		actors.WithActorTypeHandler("abc", func(_ nethttp.ResponseWriter, r *nethttp.Request) {
+			g.called.Add(1)
+		}),
+	)
+
+	g.app2 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorIdleTimeout(time.Second),
+		actors.WithPeerActor(g.app1),
+		actors.WithActorTypeHandler("abc", func(_ nethttp.ResponseWriter, r *nethttp.Request) {
+			g.called.Add(1)
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(g.app1, g.app2),
+	}
+}
+
+func (g *goroutines) Run(t *testing.T, ctx context.Context) {
+	g.app1.WaitUntilRunning(t, ctx)
+	g.app2.WaitUntilRunning(t, ctx)
+
+	client := g.app2.GRPCClient(t, ctx)
+
+	startGoRoutines1 := g.app1.Metrics(t, ctx)["go_goroutines"]
+	startGoRoutines2 := g.app2.Metrics(t, ctx)["go_goroutines"]
+
+	const n = 1000
+	for i := range n {
+		_, err := client.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "abc",
+			ActorId:   strconv.Itoa(i),
+			Name:      "reminder",
+			DueTime:   "0s",
+		})
+		require.NoError(t, err)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(n*2), g.called.Load())
+	}, time.Second*10, time.Millisecond*10)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.InDelta(c, startGoRoutines1, g.app1.Metrics(t, ctx)["go_goroutines"], 30)
+		assert.InDelta(c, startGoRoutines2, g.app2.Metrics(t, ctx)["go_goroutines"], 30)
+	}, time.Second*20, time.Second)
+}

--- a/tests/integration/suite/actors/lock/reminders/self/goroutines.go
+++ b/tests/integration/suite/actors/lock/reminders/self/goroutines.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package self
+
+import (
+	"context"
+	nethttp "net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(goroutines))
+}
+
+type goroutines struct {
+	app    *actors.Actors
+	called atomic.Int64
+}
+
+func (g *goroutines) Setup(t *testing.T) []framework.Option {
+	g.app = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorTypeHandler("abc", func(nethttp.ResponseWriter, *nethttp.Request) {
+			g.called.Add(1)
+		}),
+		actors.WithActorIdleTimeout(time.Second),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(g.app),
+	}
+}
+
+func (g *goroutines) Run(t *testing.T, ctx context.Context) {
+	g.app.WaitUntilRunning(t, ctx)
+
+	client := g.app.GRPCClient(t, ctx)
+
+	startGoRoutines := g.app.Metrics(t, ctx)["go_goroutines"]
+
+	const n = 1000
+	for i := range n {
+		_, err := client.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "abc",
+			ActorId:   strconv.Itoa(i),
+			Name:      "reminder",
+			DueTime:   "0s",
+		})
+		require.NoError(t, err)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(n*2), g.called.Load())
+	}, time.Second*10, time.Millisecond*10)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.InDelta(c, startGoRoutines, g.app.Metrics(t, ctx)["go_goroutines"], 10)
+	}, time.Second*20, time.Second)
+}


### PR DESCRIPTION
Running Actor or Workflow workloads would see the daprd process consume more and more memory over time.

Running Actor or Workflow for long enough periods of time would see the daprd process consume all available memory, leading to an OOM crash.

The Actor locking mechanism would not release object memory after use, in the case where the daprd it calling a remote Actor.

Defer Actor message locking to only the daprd which is hosting that Actor ID to ensure the lock object memory is always released after use.