### PR TITLE
[1.15] Fix Workflow state store contention

### DIFF
--- a/docs/release_notes/v1.15.6.md
+++ b/docs/release_notes/v1.15.6.md
@@ -3,6 +3,7 @@
 This update includes bug fixes:
 
 - [Fix Actor memory leak](#fix-actor-memory-leak)
+- [Fix Workflow state store contention](#fix-workflow-state-store-contention)
 
 ## Fix Actor memory leak
 
@@ -21,3 +22,21 @@ The Actor locking mechanism would not release object memory after use, in the ca
 ### Solution
 
 Defer Actor message locking to only the daprd which is hosting that Actor ID to ensure the lock object memory is always released after use.
+
+## Fix Workflow state store contention
+
+### Problem
+
+Running Workflows in high throughput scenarios would see contention on processing or blocking Workflow state store operations.
+
+### Impact
+
+Degraded performance of Workflow operations, leading to increased latency and potential timeouts.
+
+### Root cause
+
+Circular Placement locking of Actor Workflow state operations.
+
+### Solution
+
+Remove Placement locking in Workflow state operations as it is already locked at the Actor level.

--- a/pkg/actors/state/fake/fake.go
+++ b/pkg/actors/state/fake/fake.go
@@ -20,48 +20,48 @@ import (
 )
 
 type Fake struct {
-	getFn                         func(ctx context.Context, req *api.GetStateRequest) (*api.StateResponse, error)
-	getBulkFn                     func(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error)
-	transactionalStateOperationFn func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest) error
+	getFn                         func(ctx context.Context, req *api.GetStateRequest, lock bool) (*api.StateResponse, error)
+	getBulkFn                     func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error)
+	transactionalStateOperationFn func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error
 }
 
 func New() *Fake {
 	return &Fake{
-		getFn: func(ctx context.Context, req *api.GetStateRequest) (*api.StateResponse, error) {
+		getFn: func(ctx context.Context, req *api.GetStateRequest, lock bool) (*api.StateResponse, error) {
 			return nil, nil
 		},
-		getBulkFn: func(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error) {
+		getBulkFn: func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error) {
 			return api.BulkStateResponse{}, nil
 		},
-		transactionalStateOperationFn: func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest) error {
+		transactionalStateOperationFn: func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error {
 			return nil
 		},
 	}
 }
 
-func (f *Fake) WithGetFn(fn func(ctx context.Context, req *api.GetStateRequest) (*api.StateResponse, error)) *Fake {
+func (f *Fake) WithGetFn(fn func(ctx context.Context, req *api.GetStateRequest, lock bool) (*api.StateResponse, error)) *Fake {
 	f.getFn = fn
 	return f
 }
 
-func (f *Fake) WithGetBulkFn(fn func(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error)) *Fake {
+func (f *Fake) WithGetBulkFn(fn func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error)) *Fake {
 	f.getBulkFn = fn
 	return f
 }
 
-func (f *Fake) WithTransactionalStateOperationFn(fn func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest) error) *Fake {
+func (f *Fake) WithTransactionalStateOperationFn(fn func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error) *Fake {
 	f.transactionalStateOperationFn = fn
 	return f
 }
 
-func (f *Fake) Get(ctx context.Context, req *api.GetStateRequest) (*api.StateResponse, error) {
-	return f.getFn(ctx, req)
+func (f *Fake) Get(ctx context.Context, req *api.GetStateRequest, lock bool) (*api.StateResponse, error) {
+	return f.getFn(ctx, req, lock)
 }
 
-func (f *Fake) GetBulk(ctx context.Context, req *api.GetBulkStateRequest) (api.BulkStateResponse, error) {
-	return f.getBulkFn(ctx, req)
+func (f *Fake) GetBulk(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error) {
+	return f.getBulkFn(ctx, req, lock)
 }
 
-func (f *Fake) TransactionalStateOperation(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest) error {
-	return f.transactionalStateOperationFn(ctx, ignoreHosted, req)
+func (f *Fake) TransactionalStateOperation(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error {
+	return f.transactionalStateOperationFn(ctx, ignoreHosted, req, lock)
 }

--- a/pkg/actors/targets/workflow/activity.go
+++ b/pkg/actors/targets/workflow/activity.go
@@ -308,7 +308,7 @@ func (a *activity) purgeActivityState(ctx context.Context) error {
 				Key: activityStateKey,
 			},
 		}},
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to delete activity state with error: %w", err)
 	}

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -397,7 +397,7 @@ func (w *workflow) cleanupWorkflowStateInternal(ctx context.Context, state *wfen
 		return err
 	}
 	// This will do the purging
-	err = w.actorState.TransactionalStateOperation(ctx, true, req)
+	err = w.actorState.TransactionalStateOperation(ctx, true, req, false)
 	if err != nil {
 		return err
 	}
@@ -539,7 +539,7 @@ func (w *workflow) runWorkflow(ctx context.Context, reminder *actorapi.Reminder)
 				ActorType:  w.activityActorType,
 				ActorID:    activityActorID,
 				Operations: operations,
-			})
+			}, false)
 			if aerr != nil {
 				lock.Lock()
 				errs = append(errs, fmt.Errorf("failed to delete activity state for activity actor '%s' with error: %w", activityActorID, aerr))
@@ -864,7 +864,7 @@ func (w *workflow) saveInternalState(ctx context.Context, state *wfenginestate.S
 
 	log.Debugf("Workflow actor '%s': saving %d keys to actor state store", w.actorID, len(req.Operations))
 
-	if err = w.actorState.TransactionalStateOperation(ctx, true, req); err != nil {
+	if err = w.actorState.TransactionalStateOperation(ctx, true, req, false); err != nil {
 		return err
 	}
 
@@ -953,7 +953,7 @@ func (w *workflow) removeCompletedStateData(ctx context.Context, state *wfengine
 					},
 				}},
 			}
-			if terr := w.actorState.TransactionalStateOperation(ctx, true, &req); terr != nil {
+			if terr := w.actorState.TransactionalStateOperation(ctx, true, &req, false); terr != nil {
 				lock.Lock()
 				errs = append(errs, fmt.Errorf("failed to delete activity state with error: %w", terr))
 				lock.Unlock()

--- a/pkg/api/grpc/actor_test.go
+++ b/pkg/api/grpc/actor_test.go
@@ -35,7 +35,7 @@ func TestGetActorState(t *testing.T) {
 
 		actors := actorsfake.New()
 		actors.WithState(func(context.Context) (state.Interface, error) {
-			return statefake.New().WithGetFn(func(ctx context.Context, req *actorsapi.GetStateRequest) (*actorsapi.StateResponse, error) {
+			return statefake.New().WithGetFn(func(ctx context.Context, req *actorsapi.GetStateRequest, _ bool) (*actorsapi.StateResponse, error) {
 				return &actorsapi.StateResponse{
 					Data: data,
 					Metadata: map[string]string{
@@ -80,7 +80,7 @@ func TestExecuteActorStateTransaction(t *testing.T) {
 
 		actors := actorsfake.New()
 		actors.WithState(func(context.Context) (state.Interface, error) {
-			return statefake.New().WithTransactionalStateOperationFn(func(ctx context.Context, _ bool, req *actorsapi.TransactionalRequest) error {
+			return statefake.New().WithTransactionalStateOperationFn(func(ctx context.Context, _ bool, req *actorsapi.TransactionalRequest, _ bool) error {
 				return nil
 			}), nil
 		})

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -1053,7 +1053,7 @@ func (a *api) GetActorState(ctx context.Context, in *runtimev1pb.GetActorStateRe
 		Key:       key,
 	}
 
-	resp, err := astate.Get(ctx, &req)
+	resp, err := astate.Get(ctx, &req, true)
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			apiServerLogger.Debug(err)
@@ -1125,7 +1125,7 @@ func (a *api) ExecuteActorStateTransaction(ctx context.Context, in *runtimev1pb.
 		Operations: actorOps,
 	}
 
-	err = astate.TransactionalStateOperation(ctx, false, &req)
+	err = astate.TransactionalStateOperation(ctx, false, &req, true)
 	if err != nil {
 		if _, ok := status.FromError(err); ok {
 			apiServerLogger.Debug(err)

--- a/pkg/api/http/actors.go
+++ b/pkg/api/http/actors.go
@@ -284,7 +284,7 @@ func (a *api) onActorStateTransaction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = state.TransactionalStateOperation(ctx, false, req)
+	err = state.TransactionalStateOperation(ctx, false, req, true)
 	if err != nil {
 		if errors.As(err, new(messages.APIError)) {
 			respondWithError(w, err)
@@ -449,7 +449,7 @@ func (a *api) onGetActorState(w http.ResponseWriter, r *http.Request) {
 		ActorType: actorType,
 		ActorID:   actorID,
 		Key:       key,
-	})
+	}, true)
 	if err != nil {
 		if errors.As(err, new(messages.APIError)) {
 			respondWithError(w, err)

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -1082,7 +1082,7 @@ func TestV1ActorEndpoints(t *testing.T) {
 
 	t.Run("Get actor state - 200 OK", func(t *testing.T) {
 		actors.WithState(func(context.Context) (actorsstate.Interface, error) {
-			return statefake.New().WithGetFn(func(context.Context, *actorsapi.GetStateRequest) (*actorsapi.StateResponse, error) {
+			return statefake.New().WithGetFn(func(context.Context, *actorsapi.GetStateRequest, bool) (*actorsapi.StateResponse, error) {
 				return &actorsapi.StateResponse{
 					Data: fakeData,
 					Metadata: map[string]string{
@@ -1105,7 +1105,7 @@ func TestV1ActorEndpoints(t *testing.T) {
 
 	t.Run("Get actor state - 204 No Content", func(t *testing.T) {
 		actors.WithState(func(context.Context) (actorsstate.Interface, error) {
-			return statefake.New().WithGetFn(func(context.Context, *actorsapi.GetStateRequest) (*actorsapi.StateResponse, error) {
+			return statefake.New().WithGetFn(func(context.Context, *actorsapi.GetStateRequest, bool) (*actorsapi.StateResponse, error) {
 				return nil, nil
 			}), nil
 		})
@@ -1123,7 +1123,7 @@ func TestV1ActorEndpoints(t *testing.T) {
 
 	t.Run("Get actor state - 500 on GetState failure", func(t *testing.T) {
 		actors.WithState(func(context.Context) (actorsstate.Interface, error) {
-			return statefake.New().WithGetFn(func(context.Context, *actorsapi.GetStateRequest) (*actorsapi.StateResponse, error) {
+			return statefake.New().WithGetFn(func(context.Context, *actorsapi.GetStateRequest, bool) (*actorsapi.StateResponse, error) {
 				return nil, errors.New("UPSTREAM_ERROR")
 			}), nil
 		})
@@ -1244,7 +1244,7 @@ func TestV1ActorEndpoints(t *testing.T) {
 		}
 
 		actors.WithState(func(context.Context) (actorsstate.Interface, error) {
-			return statefake.New().WithTransactionalStateOperationFn(func(context.Context, bool, *actorsapi.TransactionalRequest) error {
+			return statefake.New().WithTransactionalStateOperationFn(func(context.Context, bool, *actorsapi.TransactionalRequest, bool) error {
 				return errors.New("UPSTREAM_ERROR")
 			}), nil
 		})
@@ -1736,7 +1736,7 @@ func TestV1ActorEndpointsWithTracer(t *testing.T) {
 		buffer = ""
 		apiPath := "v1.0/actors/fakeActorType/fakeActorID/state/key1"
 		actors.WithState(func(context.Context) (actorsstate.Interface, error) {
-			return astate.WithGetFn(func(ctx context.Context, req *actorsapi.GetStateRequest) (*actorsapi.StateResponse, error) {
+			return astate.WithGetFn(func(ctx context.Context, req *actorsapi.GetStateRequest, _ bool) (*actorsapi.StateResponse, error) {
 				called.Add(1)
 				return &actorsapi.StateResponse{
 					Data: fakeData,

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -260,7 +260,7 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		ActorID:   actorID,
 		Key:       metadataKey,
 	}
-	res, err := state.Get(ctx, &req)
+	res, err := state.Get(ctx, &req, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load workflow metadata: %w", err)
 	}
@@ -308,7 +308,7 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	}
 
 	// Perform the request
-	bulkRes, err := state.GetBulk(ctx, bulkReq)
+	bulkRes, err := state.GetBulk(ctx, bulkReq, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load workflow state: %w", err)
 	}


### PR DESCRIPTION
Running Workflows in high throughput scenarios would see contention on processing or blocking Workflow state store operations.

Degraded performance of Workflow operations, leading to increased latency and potential timeouts.

Circular Placement locking of Actor Workflow state operations.

Remove Placement locking in Workflow state operations as it is already locked at the Actor level.