### PR TITLE
[1.15] Update Max Concurrent Workflow Operations

### DIFF
--- a/docs/release_notes/v1.15.6.md
+++ b/docs/release_notes/v1.15.6.md
@@ -4,6 +4,7 @@ This update includes bug fixes:
 
 - [Fix Actor memory leak](#fix-actor-memory-leak)
 - [Fix Workflow state store contention](#fix-workflow-state-store-contention)
+- [Update Max Concurrent Workflow Operations](#update-max-concurrent-workflow-operations)
 
 ## Fix Actor memory leak
 
@@ -40,3 +41,22 @@ Circular Placement locking of Actor Workflow state operations.
 ### Solution
 
 Remove Placement locking in Workflow state operations as it is already locked at the Actor level.
+
+## Update Max Concurrent Workflow Operations
+
+### Problem
+
+Workflows would experience degraded performance in high throughput scenarios.
+
+### Impact
+
+Workflows would be limited in the number of concurrent operations they could handle, leading to increased latency and potential timeouts.
+
+
+### Root cause
+
+The default value for `maxConcurrentWorkflowInvocations` and `maxConcurrentActivityInvocations` was set to 1000, which could lead to performance issues in high throughput scenarios.
+
+### Solution
+
+Increase the default value for `maxConcurrentWorkflowInvocations` and `maxConcurrentActivityInvocations` to max int32 value, allowing for more concurrent operations to be processed without contention.

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"sort"
@@ -69,8 +70,8 @@ const (
 	ActionPolicyApp     = "app"
 	ActionPolicyGlobal  = "global"
 
-	defaultMaxWorkflowConcurrentInvocations = 1000
-	defaultMaxActivityConcurrentInvocations = 1000
+	defaultMaxWorkflowConcurrentInvocations = math.MaxInt32
+	defaultMaxActivityConcurrentInvocations = math.MaxInt32
 )
 
 var defaultFeatures = map[Feature]bool{


### PR DESCRIPTION
Workflows would experience degraded performance in high throughput scenarios.

Workflows would be limited in the number of concurrent operations they could handle, leading to increased latency and potential timeouts.

The default value for `maxConcurrentWorkflowInvocations` and `maxConcurrentActivityInvocations` was set to 1000, which could lead to performance issues in high throughput scenarios.

Increase the default value for `maxConcurrentWorkflowInvocations` and `maxConcurrentActivityInvocations` to max int32 value, allowing for more concurrent operations to be processed without contention.