### PR TITLE
[1.15] Workflow: Allow non-stream Workflow Schedule

### DIFF
--- a/docs/release_notes/v1.15.6.md
+++ b/docs/release_notes/v1.15.6.md
@@ -6,6 +6,7 @@ This update includes bug fixes:
 - [Fix Workflow state store contention](#fix-workflow-state-store-contention)
 - [Update Max Concurrent Workflow Operations](#update-max-concurrent-workflow-operations)
 - [Remove client-side rate limiter from injector](#remove-client-side-rate-limiter-from-injector)
+- [Allow non-stream Workflow Schedule](#allow-non-stream-workflow-schedule)
 
 ## Fix Actor memory leak
 
@@ -79,3 +80,21 @@ The client-side rate limiter in the injector was unnecessarily restricting opera
 ### Solution
 
 Remove the client-side rate limiter from the injector to allow for better performance and eliminate unnecessary throttling in production environments.
+
+## Allow non-stream Workflow Schedule
+
+### Problem
+
+Attempting to schedule a Workflow on a daprd with no Workflow listener stream would hang.
+
+### Impact
+
+Attempting to schedule a Workflow on a daprd with no Workflow listener stream would hang indefinitely.
+
+### Root cause
+
+The daprd would wait until a Workflow listener stream was established before processing the schedule request.
+
+### Solution
+
+Allow scheduling of Workflows without requiring a Workflow listener stream to be established first. This allows for immediate processing of the schedule request.

--- a/tests/integration/suite/daprd/workflow/listener/crud.go
+++ b/tests/integration/suite/daprd/workflow/listener/crud.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(crud))
+}
+
+type crud struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+}
+
+func (c *crud) Setup(t *testing.T) []framework.Option {
+	place := placement.New(t)
+	sched := scheduler.New(t)
+	db := sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithMetadata("busyTimeout", "10s"),
+		sqlite.WithMetadata("disableWAL", "true"),
+	)
+
+	c.daprd1 = daprd.New(t,
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithScheduler(sched),
+	)
+
+	c.daprd2 = daprd.New(t,
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithScheduler(sched),
+		daprd.WithAppID(c.daprd1.AppID()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(place, sched, db, c.daprd1, c.daprd2),
+	}
+}
+
+func (c *crud) Run(t *testing.T, ctx context.Context) {
+	c.daprd1.WaitUntilRunning(t, ctx)
+	c.daprd2.WaitUntilRunning(t, ctx)
+
+	r := task.NewTaskRegistry()
+	r.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, ctx.CreateTimer(time.Second * 5).Await(nil)
+	})
+	r.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	client1 := client.NewTaskHubGrpcClient(c.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, client1.StartWorkItemListener(ctx, r))
+
+	client2 := client.NewTaskHubGrpcClient(c.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+
+	_, err := client2.FetchOrchestrationMetadata(ctx, "foobar")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such instance exists")
+
+	id, err := client2.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+	_, err = client2.FetchOrchestrationMetadata(ctx, id)
+	require.NoError(t, err)
+	require.NoError(t, client2.SuspendOrchestration(ctx, id, "reason"))
+	require.NoError(t, client2.ResumeOrchestration(ctx, id, "reason"))
+	_, err = client2.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+
+	id, err = client2.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+	require.NoError(t, client2.TerminateOrchestration(ctx, id))
+}

--- a/tests/integration/suite/daprd/workflow/listener/multi.go
+++ b/tests/integration/suite/daprd/workflow/listener/multi.go
@@ -36,14 +36,14 @@ import (
 )
 
 func init() {
-	suite.Register(new(multilistener))
+	suite.Register(new(multi))
 }
 
-type multilistener struct {
+type multi struct {
 	daprd *daprd.Daprd
 }
 
-func (m *multilistener) Setup(t *testing.T) []framework.Option {
+func (m *multi) Setup(t *testing.T) []framework.Option {
 	sched := scheduler.New(t)
 	place := placement.New(t)
 	m.daprd = daprd.New(t,
@@ -57,7 +57,7 @@ func (m *multilistener) Setup(t *testing.T) []framework.Option {
 	}
 }
 
-func (m *multilistener) Run(t *testing.T, ctx context.Context) {
+func (m *multi) Run(t *testing.T, ctx context.Context) {
 	m.daprd.WaitUntilRunning(t, ctx)
 
 	t.Run("connect_multiple_workers_to_single_daprd", func(t *testing.T) {

--- a/tests/integration/suite/daprd/workflow/listener/single.go
+++ b/tests/integration/suite/daprd/workflow/listener/single.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(single))
+}
+
+type single struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+}
+
+func (s *single) Setup(t *testing.T) []framework.Option {
+	place := placement.New(t)
+	sched := scheduler.New(t)
+	db := sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithMetadata("busyTimeout", "10s"),
+		sqlite.WithMetadata("disableWAL", "true"),
+	)
+
+	s.daprd1 = daprd.New(t,
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithScheduler(sched),
+	)
+
+	s.daprd2 = daprd.New(t,
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithPlacementAddresses(place.Address()),
+		daprd.WithScheduler(sched),
+		daprd.WithAppID(s.daprd1.AppID()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(place, sched, db, s.daprd1, s.daprd2),
+	}
+}
+
+func (s *single) Run(t *testing.T, ctx context.Context) {
+	s.daprd1.WaitUntilRunning(t, ctx)
+	s.daprd2.WaitUntilRunning(t, ctx)
+
+	r := task.NewTaskRegistry()
+	r.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	client1 := client.NewTaskHubGrpcClient(s.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, client1.StartWorkItemListener(ctx, r))
+
+	client2 := client.NewTaskHubGrpcClient(s.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+
+	id, err := client2.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+	_, err = client2.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -15,6 +15,7 @@ package workflow
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/continueasnew"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/listener"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/memory"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reconnect"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"


### PR DESCRIPTION
Remove the registered actor type gate on the Scheduler workflow internal server to allow Scheduling workflows on a daprd which does not have a client listener stream.

This makes the Schedule Workflow RPC in line with the other Workflow RPCs.

Problem

Attempting to schedule a Workflow on a daprd with no Workflow listener stream would hang.

Impact

Attempting to schedule a Workflow on a daprd with no Workflow listener stream would hang indefinitely.

Root cause

The daprd would wait until a Workflow listener stream was established before processing the schedule request.

Solution

Allow scheduling of Workflows without requiring a Workflow listener stream to be established first. This allows for immediate 