### PR TITLE
Added a command to the DaprBot to re-run failed test

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -210,7 +210,7 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
         )
 
         // #APIREF: https://octokit.github.io/rest.js/v22/#actions-list-workflow-runs-for-repo
-        await github.rest.rest.actions.reRunWorkflowFailedJobs({
+        await github.rest.actions.reRunWorkflowFailedJobs({
             owner: issue.owner,
             repo: issue.repo,
             run_id: workflow_run.id,

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -181,7 +181,7 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
 
     // Get workflow runs filtered by the pull request head-sha and status
     // #REF https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
-    const workflow_runs = await github.rest.actions.listRuns({
+    const workflow_runs = await github.rest.actions.listWorkflowRunsForRepo({
         owner: issue.owner,
         repo: issue.repo,
         head_sha: pull.data.head.sha,

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -180,10 +180,12 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
     }
 
     // Get workflow runs filtered by the pull request head-sha
-    const workflow_runs = await github.rest.actions.runs.listForRef({
+    const workflow_runs = await github.rest.actions.getWorkflowRun({
         owner: issue.owner,
         repo: issue.repo,
-        ref: pull.data.head.sha,
+        head_sha: pull.data.head.sha,
+        event: `pull_request`,
+        status: `failure`,
     })
 
     // // Find failed action in the pull request

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -181,7 +181,7 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
 
     // Get workflow runs filtered by the pull request head-sha and status
     // #REF https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
-    const workflow_runs = await github.rest.actions.listWorkflowRuns({
+    const workflow_runs = await github.rest.actions.listRuns({
         owner: issue.owner,
         repo: issue.repo,
         head_sha: pull.data.head.sha,

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -172,6 +172,13 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
         pull_number: issue.number,
     })
 
+    if (!pull || !pull.data) {
+        console.log(
+            `[cmdRetestFailed] pull request not found for ${issue.owner}/${issue.repo}#${issue.number}, skipping command execution.`
+        )
+        return
+    }
+
     // Find failed action in the pull request
     const failedActions = pull.data.statuses.filter(
         (status) => status.state === 'failure'

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -199,7 +199,7 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
     }
     else {
         console.log(
-            `[cmdRetestFailed] found ${failed_workflow_runs.data.total_count} failed workflows, triggering retest.`
+            `[cmdRetestFailed] found ${failed_workflow_runs.data.total_count} failed workflows, triggering re-run.`
 
         )
     } 

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -179,8 +179,8 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
         return
     }
 
-    // Get workflow runs filtered by the pull request head-sha
-    const workflow_runs = await github.rest.actions.getWorkflowRun({
+    // Get workflow runs filtered by the pull request head-sha and status
+    const workflow_runs = await github.rest.actions.listWorkflowRuns({
         owner: issue.owner,
         repo: issue.repo,
         head_sha: pull.data.head.sha,

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -84,7 +84,7 @@ async function handleIssueCommentCreate({ github, context }) {
     }
     
     // This command is used to re-trigger the failed tests.
-    if (command == 'retest-failed') {
+    if (command == '/retest-failed') {
         await cmdRetestFailed(github, issue, isFromPulls)
         return
     }

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -180,6 +180,7 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
     }
 
     // Get workflow runs filtered by the pull request head-sha and status
+    // #REF https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
     const workflow_runs = await github.rest.actions.listWorkflowRuns({
         owner: issue.owner,
         repo: issue.repo,

--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -180,7 +180,8 @@ async function cmdRetestFailed(github, issue, isFromPulls) {
     }
 
     // Get workflow runs filtered by the pull request head-sha and status
-    // #REF https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
+    // DOCS:   https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
+    // APIREF: https://octokit.github.io/rest.js/v22/#actions-list-workflow-runs-for-repo
     const workflow_runs = await github.rest.actions.listWorkflowRunsForRepo({
         owner: issue.owner,
         repo: issue.repo,

--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Comment analyzer
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.DAPR_BOT_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const script = require('./.github/scripts/dapr_bot.js')
             await script({github, context})
+


### PR DESCRIPTION
# Description

Added ```/retest-failed``` command to the DaprBot to re-run failed test

## Issue reference

- #8759

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
