### PR TITLE
Create workflow retry actor not found

### DIFF
--- a/pkg/actors/engine/engine.go
+++ b/pkg/actors/engine/engine.go
@@ -223,7 +223,7 @@ func (e *engine) callActor(ctx context.Context, req *internalv1pb.InternalInvoke
 		ActorID:   req.GetActor().GetActorId(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to lookup actor: %w", err)
 	}
 
 	if lar.Local {

--- a/pkg/actors/errors/errors.go
+++ b/pkg/actors/errors/errors.go
@@ -25,6 +25,9 @@ import (
 // ErrReminderCanceled is returned when the reminder has been canceled.
 var ErrReminderCanceled = errors.New("reminder has been canceled")
 
+// ErrCreatingActor is returned when the table cannot create an actor because its not registered.
+var ErrCreatingActor = errors.New("failed to create actor")
+
 // ActorError is an error returned by an Actor via a header + body in the method's response.
 type ActorError struct {
 	body        []byte

--- a/pkg/actors/table/table.go
+++ b/pkg/actors/table/table.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/dapr/dapr/pkg/actors/api"
+	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
 	"github.com/dapr/dapr/pkg/actors/internal/key"
 	"github.com/dapr/dapr/pkg/actors/internal/reentrancystore"
 	"github.com/dapr/dapr/pkg/actors/locker"
@@ -218,7 +219,7 @@ func (t *table) GetOrCreate(actorType, actorID string) (targets.Interface, bool,
 
 	factory, ok := t.factories.Load(actorType)
 	if !ok {
-		return nil, false, fmt.Errorf("actor type %s not registered", actorType)
+		return nil, false, fmt.Errorf("%w: actor type %s not registered", actorerrors.ErrCreatingActor, actorType)
 	}
 
 	target = factory(actorID)

--- a/pkg/actors/table/table_test.go
+++ b/pkg/actors/table/table_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
 	"github.com/dapr/dapr/pkg/actors/internal/locker"
 	"github.com/dapr/dapr/pkg/actors/internal/reentrancystore"
 	"github.com/dapr/dapr/pkg/actors/table"
@@ -116,4 +117,20 @@ func Test_HaltAll(t *testing.T) {
 	assert.ElementsMatch(t, []string{
 		"test1||1", "test2||1", "test2||2", "test3||312", "test3||xyz",
 	}, deactivations.Slice())
+}
+
+func Test_GetOrCreate_NotRegistered(t *testing.T) {
+	queue := queue.NewProcessor[string, targets.Idlable](queue.Options[string, targets.Idlable]{})
+
+	tble := table.New(table.Options{
+		IdlerQueue:      queue,
+		ReentrancyStore: reentrancystore.New(),
+		Locker: locker.New(locker.Options{
+			ConfigStore: reentrancystore.New(),
+		}),
+	})
+
+	_, _, err := tble.GetOrCreate("test1", "1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, actorerrors.ErrCreatingActor)
 }

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 
 	"github.com/dapr/dapr/pkg/actors"
+	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
 	"github.com/dapr/dapr/pkg/actors/table"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -221,6 +222,9 @@ func (abe *Actors) CreateOrchestrationInstance(ctx context.Context, e *backend.H
 		_, eerr := engine.Call(ctx, req)
 		status, ok := status.FromError(eerr)
 		if ok && status.Code() == codes.FailedPrecondition {
+			return eerr
+		}
+		if errors.Is(eerr, actorerrors.ErrCreatingActor) {
 			return eerr
 		}
 		return backoff.Permanent(eerr)


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

I've seen cases in our testing where scheduling a new workflow fails with
```
failed to start orchestrator: rpc error: code = Unknown desc = actor type dapr.internal.prj-6.workflows.workflow not registered
```

this started happening since https://github.com/dapr/dapr/pull/8771 , where if you start the workflows worker and quickly try to schedule a workflow there is a race and sometimes this error can happen

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
