### PR TITLE
Update github action runner windows-2019 to windows-2025

### DIFF
--- a/.github/workflows/dapr-base-containers.yaml
+++ b/.github/workflows/dapr-base-containers.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: "windows-2019"
+          - os: "windows-2025"
             windows-version: "1809"
           - os: "windows-2022"
             windows-version: "ltsc2022"

--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -271,7 +271,7 @@ jobs:
                 `PR_NUMBER=${testPayload.issue.number}`
               );
             }
-      # In windows-2019 images, WSL comes with bash.exe (but no distribution) and that causes issues
+      # In windows-2025 images, WSL comes with bash.exe (but no distribution) and that causes issues
       # See: https://github.community/t/wsl-not-available-for-hosted-windows-machine/124389
       - name: Remove bash.exe from WSL
         if: runner.os == 'Windows'

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -299,7 +299,7 @@ jobs:
             target_arch: arm
             job_name: "Linux/arm"
             sidecar_flavor: "stablecomponents"
-          - os: windows-2019
+          - os: windows-2025
             target_os: windows
             target_arch: amd64
             windows_version: "1809"


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/12045