### PR TITLE
[1.15] Scheduler: don't log excessive request stats

### DIFF
--- a/pkg/scheduler/server/internal/etcd/config.go
+++ b/pkg/scheduler/server/internal/etcd/config.go
@@ -40,7 +40,8 @@ func config(opts Options) (*embed.Config, error) {
 	config.Name = opts.Name
 	config.InitialCluster = strings.Join(opts.InitialCluster, ",")
 	config.MaxRequestBytes = math.MaxInt32
-	config.ExperimentalWarningApplyDuration = time.Second * 5
+	config.WarningApplyDuration = time.Second * 5
+	config.WarningUnaryRequestDuration = time.Second * 5
 
 	if opts.Security.MTLSEnabled() {
 		info := transport.TLSInfo{


### PR DESCRIPTION
Push excessive Etcd request stats logs to only those larger than 5 seconds. This prevents log spam from normal, non trivial usage of Scheduler.