### PR TITLE
[1.15] Move Scheduler Actor Type Reload to Placement client

### DIFF
--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -213,6 +213,9 @@ func (abe *Actors) CreateOrchestrationInstance(ctx context.Context, e *backend.H
 		WithContentType(invokev1.ProtobufContentType)
 	start := time.Now()
 
+	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*15, errors.New("CreateOrchestrationInstance timeout"))
+	defer cancel()
+
 	engine, err := abe.actors.Engine(ctx)
 	if err != nil {
 		return err
@@ -243,6 +246,9 @@ func (abe *Actors) CreateOrchestrationInstance(ctx context.Context, e *backend.H
 
 // GetOrchestrationMetadata implements backend.Backend
 func (abe *Actors) GetOrchestrationMetadata(ctx context.Context, id api.InstanceID) (*backend.OrchestrationMetadata, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*15, errors.New("GetOrchestrationMetadata timeout"))
+	defer cancel()
+
 	state, err := abe.loadInternalState(ctx, id)
 	if err != nil {
 		return nil, err
@@ -356,6 +362,9 @@ func (*Actors) DeleteTaskHub(context.Context) error {
 
 // GetOrchestrationRuntimeState implements backend.Backend
 func (abe *Actors) GetOrchestrationRuntimeState(ctx context.Context, owi *backend.OrchestrationWorkItem) (*backend.OrchestrationRuntimeState, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*15, errors.New("GetOrchestrationRuntimeState timeout"))
+	defer cancel()
+
 	state, err := abe.loadInternalState(ctx, owi.InstanceID)
 	if err != nil {
 		return nil, err

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
@@ -50,7 +50,7 @@ type fuzzgrpc struct {
 }
 
 func (f *fuzzgrpc) Setup(t *testing.T) []framework.Option {
-	const numTests = 1000
+	const numTests = 500
 
 	onInvoke := func(ctx context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
 		return &commonv1.InvokeResponse{


### PR DESCRIPTION
Moves the reloading of Sheduler Actor Types from the placement package to the placement client. This fixes an issue with types being unreported during failure scenarios connecting to placement.

Updates the placement client to be more aggressive on reconnecting and on updating Actor Types.

Updates the Workflow Actor Backend to add a 15 second timeout to operations to prevent a client side deadlock.