### PR TITLE
[1.15] Fixed Kafka PubSub intermittently dropping messages while retrying

### DIFF
--- a/docs/release_notes/v1.15.6.md
+++ b/docs/release_notes/v1.15.6.md
@@ -10,6 +10,7 @@ This update includes bug fixes:
 - [Scheduler connect after Placement dissemination](#scheduler-connect-after-placement-dissemination)
 - [Fix Scheduler Deadlock under high load](#fix-scheduler-deadlock-under-high-load)
 - [Fix Placement reconnection during leader shutdown](#fix-placement-reconnection-during-leader-shutdown)
+- [Fixed Kafka PubSub intermittently dropping messages while retrying](#fixed-kafka-pubsub-intermittently-dropping-messages-while-retrying)
 
 ## Fix Actor memory leak
 
@@ -155,3 +156,21 @@ The daprd DNS record set used to round robin the Placement hosts would not be re
 ### Solution
 
 Add a retry mechanism to the daprd to refresh the DNS record set for the Placement hosts, ensuring that it can always find the current leader host even during leader shutdown events.
+
+## Fixed Kafka PubSub intermittently dropping messages while retrying
+
+### Problem
+
+Kafka PubSub would intermittently drop messages while retrying during rebalance or any other event requiring re-initialization of the consumer.
+
+### Impact
+
+Messages sent to Kafka PubSub could be lost during retries, leading to potential data loss and inconsistencies in message processing.
+
+### Root cause
+
+The processing loop for messages was continued in the consumer even after re-initialization, causing messages to no be processed if the consumer was not ready to process them.
+
+### Solution
+
+Correctly breaking out of the processing loop in the Kafka consumer in the event of rebalancing or other re-initialization events.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
-	github.com/dapr/components-contrib v1.15.3
+	github.com/dapr/components-contrib v1.15.4
 	github.com/dapr/durabletask-go v0.6.5
 	github.com/dapr/kit v0.15.4
 	github.com/diagridio/go-etcd-cron v0.8.2

--- a/go.sum
+++ b/go.sum
@@ -493,8 +493,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.15.3 h1:BGBAfrt4raj/MF9J+9nFCe38ls193ft2COvKOBvrK/Q=
-github.com/dapr/components-contrib v1.15.3/go.mod h1:Bm5+jJuJ6sV5+4PxVRKxWjvX+vRYFEG1TXRxEcZtzjI=
+github.com/dapr/components-contrib v1.15.4 h1:mcCm5qienpfKT3VuF9sngSaO+KLmuoWuHtDHRd08KYo=
+github.com/dapr/components-contrib v1.15.4/go.mod h1:Bm5+jJuJ6sV5+4PxVRKxWjvX+vRYFEG1TXRxEcZtzjI=
 github.com/dapr/durabletask-go v0.6.5 h1:aWcxMfYudojpgRjJRdUr7yyZ7rGcvLtWXUuA4cGHBR0=
 github.com/dapr/durabletask-go v0.6.5/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/dapr/kit v0.15.4 h1:29DezCR22OuZhXX4yPEc+lqcOf/PNaeAuIEx9nGv394=


### PR DESCRIPTION
Problem

Kafka PubSub would intermittently drop messages while retrying during rebalance or any other event requiring re-initialization of the consumer.

Impact

Messages sent to Kafka PubSub could be lost during retries, leading to potential data loss and inconsistencies in message processing.

Root cause

The processing loop for messages was continued in the consumer even after re-initialization, causing messages to no be processed if the consumer was not ready to process them.

Solution

Correctly breaking out of the processing loop in the Kafka consumer in the event of rebalancing or other re-initialization events.

# Description
