### PR TITLE
Add http sse/streaming support to external endpoints

### DIFF
--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -365,46 +365,98 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	rw := &RWRecorder{
 		W: &bytes.Buffer{},
 	}
+
+	var sse bool
+
 	execPipeline := h.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Send request to user application
 		// (Body is closed below, but linter isn't detecting that)
 		//nolint:bodyclose
+
+		sse = isSSE(r)
+		if sse {
+			r.Header.Set("Accept", "text/event-stream")
+		}
+
 		clientResp, clientErr := h.client.Do(r)
 		if clientResp != nil {
-			copyHeader(w.Header(), clientResp.Header)
-			w.WriteHeader(clientResp.StatusCode)
-			_, _ = io.Copy(w, clientResp.Body)
+			if sse {
+				callerResponseWriter := req.HTTPResponseWriter()
+
+				callerResponseWriter.Header().Set("Content-Type", "text/event-stream")
+				callerResponseWriter.Header().Set("Cache-Control", "no-cache")
+				callerResponseWriter.Header().Set("Connection", "keep-alive")
+
+				flusher, ok := callerResponseWriter.(http.Flusher)
+				if !ok {
+					http.Error(callerResponseWriter, "Streaming not supported", http.StatusInternalServerError)
+					return
+				}
+
+				buf := make([]byte, 1024)
+				for {
+					n, err := clientResp.Body.Read(buf)
+					if n > 0 {
+						if _, writeErr := callerResponseWriter.Write(buf[:n]); writeErr != nil {
+							return
+						}
+						flusher.Flush()
+					}
+					if err != nil {
+						if err != io.EOF {
+							clientErr = err
+						}
+						break
+					}
+				}
+			} else {
+				copyHeader(w.Header(), clientResp.Header)
+				w.WriteHeader(clientResp.StatusCode)
+				_, _ = io.Copy(w, clientResp.Body)
+			}
 		}
 		if clientErr != nil {
 			err = clientErr
 		}
 	}))
 	execPipeline.ServeHTTP(rw, channelReq)
-	resp := rw.Result() //nolint:bodyclose
 
 	elapsedMs := float64(time.Since(startRequest) / time.Millisecond)
 
 	var contentLength int64
-	if resp != nil {
-		if resp.Header != nil {
-			contentLength, _ = strconv.ParseInt(resp.Header.Get("content-length"), 10, 64)
+
+	if err != nil {
+		// content-length is omitted in http streaming scenarios
+		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
+		return nil, err
+	}
+
+	if sse {
+		return nil, nil
+	} else {
+		resp := rw.Result() //nolint:bodyclose
+
+		if resp != nil {
+			if resp.Header != nil {
+				contentLength, _ = strconv.ParseInt(resp.Header.Get("content-length"), 10, 64)
+			}
 		}
+
+		rsp, err := h.parseChannelResponse(resp)
+		if err != nil {
+			diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
+			return nil, err
+		}
+
+		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(int(rsp.Status().GetCode())), contentLength, elapsedMs)
+
+		return rsp, nil
 	}
+}
 
-	if err != nil {
-		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
-		return nil, err
-	}
-
-	rsp, err := h.parseChannelResponse(resp)
-	if err != nil {
-		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
-		return nil, err
-	}
-
-	diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(int(rsp.Status().GetCode())), contentLength, elapsedMs)
-
-	return rsp, nil
+func isSSE(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	return strings.HasPrefix(accept, "text/event-stream")
 }
 
 func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMethodRequest, appID string) (*http.Request, error) {

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -54,6 +54,14 @@ const (
 	httpsScheme    = "https"
 
 	appConfigEndpoint = "/dapr/config"
+
+	headerContentType  = "Content-Type"
+	headerCacheControl = "Cache-Control"
+	headerConnection   = "Connection"
+
+	mimeEventStream     = "text/event-stream"
+	cacheNoCache        = "no-cache"
+	connectionKeepAlive = "keep-alive"
 )
 
 // Channel is an HTTP implementation of an AppChannel.
@@ -382,9 +390,9 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 			if sse {
 				callerResponseWriter := req.HTTPResponseWriter()
 
-				callerResponseWriter.Header().Set("Content-Type", "text/event-stream")
-				callerResponseWriter.Header().Set("Cache-Control", "no-cache")
-				callerResponseWriter.Header().Set("Connection", "keep-alive")
+				callerResponseWriter.Header().Set(headerContentType, mimeEventStream)
+				callerResponseWriter.Header().Set(headerCacheControl, cacheNoCache)
+				callerResponseWriter.Header().Set(headerConnection, connectionKeepAlive)
 
 				flusher, ok := callerResponseWriter.(http.Flusher)
 				if !ok {

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -58,6 +58,7 @@ const (
 	headerContentType  = "Content-Type"
 	headerCacheControl = "Cache-Control"
 	headerConnection   = "Connection"
+	headerAccept       = "Accept"
 
 	mimeEventStream     = "text/event-stream"
 	cacheNoCache        = "no-cache"
@@ -379,7 +380,7 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	execPipeline := h.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sse = isSSE(r)
 		if sse {
-			r.Header.Set("Accept", "text/event-stream")
+			r.Header.Set(headerAccept, mimeEventStream)
 		}
 
 		// Send request to user application

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -369,15 +369,14 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	var sse bool
 
 	execPipeline := h.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Send request to user application
-		// (Body is closed below, but linter isn't detecting that)
-		//nolint:bodyclose
-
 		sse = isSSE(r)
 		if sse {
 			r.Header.Set("Accept", "text/event-stream")
 		}
 
+		// Send request to user application
+		// (Body is closed below, but linter isn't detecting that)
+		//nolint:bodyclose
 		clientResp, clientErr := h.client.Do(r)
 		if clientResp != nil {
 			if sse {
@@ -395,16 +394,16 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 
 				buf := make([]byte, 1024)
 				for {
-					n, err := clientResp.Body.Read(buf)
+					n, cErr := clientResp.Body.Read(buf)
 					if n > 0 {
 						if _, writeErr := callerResponseWriter.Write(buf[:n]); writeErr != nil {
 							return
 						}
 						flusher.Flush()
 					}
-					if err != nil {
-						if err != io.EOF {
-							clientErr = err
+					if cErr != nil {
+						if cErr != io.EOF {
+							clientErr = cErr
 						}
 						break
 					}

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -38,9 +38,10 @@ const (
 type InvokeMethodRequest struct {
 	replayableRequest
 
-	r           *internalv1pb.InternalInvokeRequest
-	dataObject  any
-	dataTypeURL string
+	r                  *internalv1pb.InternalInvokeRequest
+	dataObject         any
+	dataTypeURL        string
+	httpResponseWriter http.ResponseWriter
 }
 
 // NewInvokeMethodRequest creates InvokeMethodRequest object for method.
@@ -179,6 +180,12 @@ func (imr *InvokeMethodRequest) WithReplay(enabled bool) *InvokeMethodRequest {
 	return imr
 }
 
+// WithHTTPResponseWriter enables downstream channel implementations to stream data back to the caller.
+func (imr *InvokeMethodRequest) WithHTTPResponseWriter(rw http.ResponseWriter) *InvokeMethodRequest {
+	imr.httpResponseWriter = rw
+	return imr
+}
+
 // CanReplay returns true if the data stream can be replayed.
 func (imr *InvokeMethodRequest) CanReplay() bool {
 	// We can replay if:
@@ -195,6 +202,10 @@ func (imr *InvokeMethodRequest) EncodeHTTPQueryString() string {
 	}
 
 	return m.GetHttpExtension().GetQuerystring()
+}
+
+func (imr *InvokeMethodRequest) HTTPResponseWriter() http.ResponseWriter {
+	return imr.httpResponseWriter
 }
 
 // APIVersion gets API version of InvokeMethodRequest.

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -755,6 +756,24 @@ func TestDataTypeUrl(t *testing.T) {
 
 		// Content type should be the protobuf one
 		assert.Equal(t, ProtobufContentType, req.ContentType())
+	})
+}
+
+func TestHTTPResponseWriter(t *testing.T) {
+	t.Run("response writer not nil", func(t *testing.T) {
+		pb := &commonv1pb.InvokeRequest{
+			Method: "frominvokerequestmessage",
+			Data:   &anypb.Any{},
+		}
+
+		rr := httptest.NewRecorder()
+
+		req := FromInvokeRequestMessage(pb).
+			WithContentType("text/plain").
+			WithHTTPResponseWriter(rr)
+		defer req.Close()
+
+		require.NotNil(t, req.HTTPResponseWriter())
 	})
 }
 

--- a/pkg/responsewriter/response_writer.go
+++ b/pkg/responsewriter/response_writer.go
@@ -144,3 +144,9 @@ func (rw *responseWriter) callBefore() {
 		rw.beforeFuncs[i](rw)
 	}
 }
+
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/sse.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/sse.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(sse))
+}
+
+type sse struct {
+	daprd *procdaprd.Daprd
+}
+
+func (h *sse) Setup(t *testing.T) []framework.Option {
+	newHTTPServer := func() *prochttp.HTTP {
+		handler := http.NewServeMux()
+		handler.HandleFunc("/events", sseHandler)
+
+		return prochttp.New(t, prochttp.WithHandler(handler))
+	}
+
+	srv1 := newHTTPServer()
+
+	h.daprd = procdaprd.New(t, procdaprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: HTTPEndpoint
+metadata:
+  name: myserver
+spec:
+  version: v1alpha1
+  baseUrl: http://localhost:%d
+`, srv1.Port())))
+
+	return []framework.Option{
+		framework.WithProcesses(srv1, h.daprd),
+	}
+}
+
+func (h *sse) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+	t.Run("invoke sse http endpoint", func(t *testing.T) {
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/v1.0/invoke/myserver/method/events", h.daprd.HTTPPort()), nil)
+		require.NoError(t, err)
+
+		req.Header.Set("Accept", "text/event-stream")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line != "" {
+
+			}
+		}
+
+		err = scanner.Err()
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+	})
+}
+
+func sseHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	for i := 1; i <= 10; i++ {
+		fmt.Fprintf(w, "data: %v", i)
+		flusher.Flush()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	log.Println("SSE stream finished")
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/sse.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/sse.go
@@ -69,7 +69,7 @@ func (h *sse) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 	t.Run("invoke sse http endpoint", func(t *testing.T) {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/v1.0/invoke/myserver/method/events", h.daprd.HTTPPort()), nil)
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/v1.0/invoke/myserver/method/events", h.daprd.HTTPPort()), nil)
 		require.NoError(t, err)
 
 		req.Header.Set("Accept", "text/event-stream")

--- a/tests/integration/suite/daprd/serviceinvocation/http/sse.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/sse.go
@@ -107,7 +107,7 @@ func sseHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for i := 1; i <= 10; i++ {
-		fmt.Fprintf(w, "data: %v\n\n", i)
+		fmt.Fprintf(w, "data: %d\n\n", i)
 		flusher.Flush()
 		time.Sleep(100 * time.Millisecond)
 	}


### PR DESCRIPTION
This PR adds SSE/Streaming support to HTTP external endpoints. This is a low hanging fruit that provides immediate immense value for users who want to use Dapr to talk to any external HTTP SSE/Streaming server and/or any MCP server or A2A agent, regardless of Dapr Agents.

This also sets us up towards supporting SSE fully in Dapr service invocation by taking care of the app channel side.
