### PR TITLE
[1.15] Fix Workflow Start Time

### DIFF
--- a/docs/release_notes/v1.15.7.md
+++ b/docs/release_notes/v1.15.7.md
@@ -1,0 +1,23 @@
+# Dapr 1.15.6
+
+This update includes bug fixes:
+
+- [Fix Workflow Start Time](#fix-workflow-start-time)
+
+## Fix Workflow Start Time
+
+### Problem
+
+Using the Workflow "Start Time" feature would result in the Workflow starting immediately.
+
+### Impact
+
+A workflow could not be scheduled to start at some point in the future.
+
+### Root cause
+
+The "Start Time" was not being propagated to the Actor reminder responsible for executing a Workflow instance.
+
+### Solution
+
+Correctly propagate the Start Time of a Workflow to the Actor reminder responsible for executing a Workflow instance.

--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -54,6 +54,7 @@ import (
 	"github.com/dapr/durabletask-go/backend/runtimestate"
 	"github.com/dapr/kit/events/broadcaster"
 	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/ptr"
 )
 
 var log = logger.NewLogger("dapr.runtime.actors.targets.workflow")
@@ -373,10 +374,16 @@ func (w *workflow) scheduleWorkflowStart(ctx context.Context, startEvent *backen
 		return err
 	}
 
-	// Schedule a reminder to execute immediately after this operation. The reminder will trigger the actual
-	// workflow execution. This is preferable to using the current thread so that we don't block the client
-	// while the workflow logic is running.
-	if _, err := w.createReliableReminder(ctx, "start", nil, 0); err != nil {
+	var start *time.Time
+	if ts := startEvent.GetExecutionStarted().GetScheduledStartTimestamp(); ts != nil {
+		start = ptr.Of(ts.AsTime())
+	}
+
+	// Schedule a reminder to execute immediately after this operation. The
+	// reminder will trigger the actual workflow execution. This is preferable to
+	// using the current thread so that we don't block the client while the
+	// workflow logic is running.
+	if _, err := w.createReliableReminder(ctx, "start", nil, start); err != nil {
 		return err
 	}
 
@@ -448,7 +455,7 @@ func (w *workflow) addWorkflowEvent(ctx context.Context, historyEventBytes []byt
 		return err
 	}
 
-	if _, err := w.createReliableReminder(ctx, "new-event", nil, 0); err != nil {
+	if _, err := w.createReliableReminder(ctx, "new-event", nil, nil); err != nil {
 		return err
 	}
 
@@ -629,17 +636,13 @@ func (w *workflow) runWorkflow(ctx context.Context, reminder *actorapi.Reminder)
 			if tf == nil {
 				return runCompletedTrue, errors.New("invalid event in the PendingTimers list")
 			}
-			delay := time.Until(tf.GetFireAt().AsTime())
-			if delay < 0 {
-				delay = 0
-			}
 			reminderPrefix := "timer-" + strconv.Itoa(int(tf.GetTimerId()))
 			data := &backend.DurableTimer{
 				TimerEvent: t,
 				Generation: state.Generation,
 			}
 			log.Debugf("Workflow actor '%s': creating reminder '%s' for the durable timer", w.actorID, reminderPrefix)
-			if _, err = w.createReliableReminder(ctx, reminderPrefix, data, delay); err != nil {
+			if _, err = w.createReliableReminder(ctx, reminderPrefix, data, ptr.Of(tf.GetFireAt().AsTime())); err != nil {
 				executionStatus = diag.StatusRecoverable
 				return runCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("actor '%s' failed to create reminder for timer: %w", w.actorID, err))
 			}
@@ -886,15 +889,20 @@ func (w *workflow) saveInternalState(ctx context.Context, state *wfenginestate.S
 	return nil
 }
 
-func (w *workflow) createReliableReminder(ctx context.Context, namePrefix string, data proto.Message, delay time.Duration) (string, error) {
+func (w *workflow) createReliableReminder(ctx context.Context, namePrefix string, data proto.Message, start *time.Time) (string, error) {
 	b := make([]byte, 6)
 	_, err := io.ReadFull(rand.Reader, b)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate reminder ID: %w", err)
 	}
 
+	dueTime := "0s"
+	if start != nil {
+		dueTime = start.UTC().Format(time.RFC3339)
+	}
+
 	reminderName := namePrefix + "-" + base64.RawURLEncoding.EncodeToString(b)
-	log.Debugf("Workflow actor '%s||%s': creating '%s' reminder with DueTime = '%s'", w.activityActorType, w.actorID, reminderName, delay)
+	log.Debugf("Workflow actor '%s||%s': creating '%s' reminder with DueTime = '%s'", w.activityActorType, w.actorID, reminderName, dueTime)
 
 	var period string
 	var oneshot bool
@@ -916,7 +924,7 @@ func (w *workflow) createReliableReminder(ctx context.Context, namePrefix string
 		ActorType: w.actorType,
 		ActorID:   w.actorID,
 		Data:      adata,
-		DueTime:   delay.String(),
+		DueTime:   dueTime,
 		Name:      reminderName,
 		Period:    period,
 		IsOneShot: oneshot,

--- a/tests/integration/suite/daprd/workflow/delaystart.go
+++ b/tests/integration/suite/daprd/workflow/delaystart.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(delaystart))
+}
+
+type delaystart struct {
+	workflow *workflow.Workflow
+}
+
+func (d *delaystart) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *delaystart) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	var executed time.Time
+	d.workflow.Registry().AddOrchestratorN("delay", func(ctx *task.OrchestrationContext) (any, error) {
+		if !ctx.IsReplaying {
+			executed = time.Now()
+		}
+		return nil, nil
+	})
+
+	client := d.workflow.BackendClient(t, ctx)
+
+	start := time.Now()
+	id, err := client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(time.Second*7)))
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.InDelta(t, 7.0, executed.Sub(start).Seconds(), 1.0)
+
+	start = time.Now()
+	id, err = client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(0)))
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.InDelta(t, 0, executed.Sub(start).Seconds(), 1.0)
+}

--- a/tests/integration/suite/daprd/workflow/timer/resumeearly.go
+++ b/tests/integration/suite/daprd/workflow/timer/resumeearly.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(resumeearly))
+}
+
+type resumeearly struct {
+	workflow *workflow.Workflow
+}
+
+func (r *resumeearly) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *resumeearly) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	r.workflow.Registry().AddOrchestratorN("timer", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, ctx.CreateTimer(time.Second * 8).Await(nil)
+	})
+
+	client := r.workflow.BackendClient(t, ctx)
+
+	start := time.Now()
+	id, err := client.ScheduleNewOrchestration(ctx, "timer")
+	require.NoError(t, err)
+
+	time.Sleep(time.Second * 1)
+	require.NoError(t, client.SuspendOrchestration(ctx, id, "foo"))
+
+	time.Sleep(time.Second * 3)
+	require.NoError(t, client.ResumeOrchestration(ctx, id, "bar"))
+
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), time.Second*8)
+}

--- a/tests/integration/suite/daprd/workflow/timer/resumelate.go
+++ b/tests/integration/suite/daprd/workflow/timer/resumelate.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(resumelate))
+}
+
+type resumelate struct {
+	workflow *workflow.Workflow
+}
+
+func (r *resumelate) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *resumelate) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	r.workflow.Registry().AddOrchestratorN("timer", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, ctx.CreateTimer(time.Second * 8).Await(nil)
+	})
+
+	client := r.workflow.BackendClient(t, ctx)
+
+	start := time.Now()
+	id, err := client.ScheduleNewOrchestration(ctx, "timer")
+	require.NoError(t, err)
+
+	time.Sleep(time.Second * 1)
+	require.NoError(t, client.SuspendOrchestration(ctx, id, "foo"))
+
+	time.Sleep(time.Second * 10)
+	require.NoError(t, client.ResumeOrchestration(ctx, id, "bar"))
+
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), time.Second*11)
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -19,4 +19,5 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/memory"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reconnect"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/timer"
 )


### PR DESCRIPTION
Fix Workflow Start Time

Problem

Using the Workflow "Start Time" feature would result in the Workflow starting immediately.

Impact

A workflow could not be scheduled to start at some point in the future.

Root cause

The "Start Time" was not being propagated to the Actor reminder responsible for executing a Workflow instance.

Solution

Correctly propagate the Start Time of a Workflow to the Actor reminder responsible for executing a Workflow instance.

Fixes https://github.com/dapr/dapr/issues/8855