### PR TITLE
[1.15] Fix use of DynamoDB as Workflow state store

### DIFF
--- a/docs/release_notes/v1.15.7.md
+++ b/docs/release_notes/v1.15.7.md
@@ -3,6 +3,7 @@
 This update includes bug fixes:
 
 - [Fix Workflow Start Time](#fix-workflow-start-time)
+- [Fix use of DynamoDB as Workflow state store](#fix-use-of-dynamodb-as-workflow-state-store)
 
 ## Fix Workflow Start Time
 
@@ -21,3 +22,21 @@ The "Start Time" was not being propagated to the Actor reminder responsible for 
 ### Solution
 
 Correctly propagate the Start Time of a Workflow to the Actor reminder responsible for executing a Workflow instance.
+
+## Fix use of DynamoDB as Workflow state store
+
+### Problem
+
+Using DynamoDB as the Workflow state store would result in an error when trying to run a Workflow.
+
+### Impact
+
+It would not be possible to run Workflows using DynamoDB as the state store.
+
+### Root cause
+
+The state store implementation used String (S) attributes rather than the Binary (B) attributes resulting in the state not being readable.
+
+### Solution
+
+Updated the DynamoDB state store implementation to use Binary (B) attributes for storing Workflow state.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
-	github.com/dapr/components-contrib v1.15.4
+	github.com/dapr/components-contrib v1.15.5
 	github.com/dapr/durabletask-go v0.6.5
 	github.com/dapr/kit v0.15.4
 	github.com/diagridio/go-etcd-cron v0.8.2

--- a/go.sum
+++ b/go.sum
@@ -493,8 +493,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.15.4 h1:mcCm5qienpfKT3VuF9sngSaO+KLmuoWuHtDHRd08KYo=
-github.com/dapr/components-contrib v1.15.4/go.mod h1:Bm5+jJuJ6sV5+4PxVRKxWjvX+vRYFEG1TXRxEcZtzjI=
+github.com/dapr/components-contrib v1.15.5 h1:rK6FEygjJkf5uXzB4tmnxDxSn7coxr6bkRzOeqzOiko=
+github.com/dapr/components-contrib v1.15.5/go.mod h1:Bm5+jJuJ6sV5+4PxVRKxWjvX+vRYFEG1TXRxEcZtzjI=
 github.com/dapr/durabletask-go v0.6.5 h1:aWcxMfYudojpgRjJRdUr7yyZ7rGcvLtWXUuA4cGHBR0=
 github.com/dapr/durabletask-go v0.6.5/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/dapr/kit v0.15.4 h1:29DezCR22OuZhXX4yPEc+lqcOf/PNaeAuIEx9nGv394=


### PR DESCRIPTION
Problem

Using DynamoDB as the Workflow state store would result in an error when trying to run a Workflow.

Impact

It would not be possible to run Workflows using DynamoDB as the state store.

Root cause

The state store implementation used String (S) attributes rather than the Binary (B) attributes resulting in the state not being readable.

Solution

Updated the DynamoDB state store implementation to use Binary (B) attributes for storing Workflow state.