### PR TITLE
[1.15] Workflow: don't wait for start when starttime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -513,3 +513,5 @@ replace (
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
+
+replace github.com/dapr/durabletask-go => github.com/joshvanl/durabletask-go v0.0.0-20250709170744-0d1187d66e53

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/dapr/components-contrib v1.15.5
-	github.com/dapr/durabletask-go v0.6.5
+	github.com/dapr/durabletask-go v0.6.6
 	github.com/dapr/kit v0.15.4
 	github.com/diagridio/go-etcd-cron v0.8.2
 	github.com/evanphx/json-patch/v5 v5.9.0
@@ -513,5 +513,3 @@ replace (
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
-
-replace github.com/dapr/durabletask-go => github.com/joshvanl/durabletask-go v0.0.0-20250709170744-0d1187d66e53

--- a/go.sum
+++ b/go.sum
@@ -495,6 +495,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.15.5 h1:rK6FEygjJkf5uXzB4tmnxDxSn7coxr6bkRzOeqzOiko=
 github.com/dapr/components-contrib v1.15.5/go.mod h1:Bm5+jJuJ6sV5+4PxVRKxWjvX+vRYFEG1TXRxEcZtzjI=
+github.com/dapr/durabletask-go v0.6.6 h1:kZ9FkWOuCO5K7fmFZVMBILj/yZOd5tsIzDmzbGBhrEQ=
+github.com/dapr/durabletask-go v0.6.6/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/dapr/kit v0.15.4 h1:29DezCR22OuZhXX4yPEc+lqcOf/PNaeAuIEx9nGv394=
 github.com/dapr/kit v0.15.4/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1099,8 +1101,6 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/joshvanl/durabletask-go v0.0.0-20250709170744-0d1187d66e53 h1:QxnAYGwMhODwHEWhW6VvmfoF1Ya/e/EQuBOW2v37/II=
-github.com/joshvanl/durabletask-go v0.0.0-20250709170744-0d1187d66e53/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -495,8 +495,6 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.15.5 h1:rK6FEygjJkf5uXzB4tmnxDxSn7coxr6bkRzOeqzOiko=
 github.com/dapr/components-contrib v1.15.5/go.mod h1:Bm5+jJuJ6sV5+4PxVRKxWjvX+vRYFEG1TXRxEcZtzjI=
-github.com/dapr/durabletask-go v0.6.5 h1:aWcxMfYudojpgRjJRdUr7yyZ7rGcvLtWXUuA4cGHBR0=
-github.com/dapr/durabletask-go v0.6.5/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/dapr/kit v0.15.4 h1:29DezCR22OuZhXX4yPEc+lqcOf/PNaeAuIEx9nGv394=
 github.com/dapr/kit v0.15.4/go.mod h1:HwFsBKEbcyLanWlDZE7u/jnaDCD/tU+n3pkFNUctQNw=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1101,6 +1099,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/durabletask-go v0.0.0-20250709170744-0d1187d66e53 h1:QxnAYGwMhODwHEWhW6VvmfoF1Ya/e/EQuBOW2v37/II=
+github.com/joshvanl/durabletask-go v0.0.0-20250709170744-0d1187d66e53/go.mod h1:nTZ5fCbJLnZbVdi6Z2YxdDF1OgQZL3LroogGuetrwuA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/tests/integration/suite/daprd/workflow/starttime/nodelay.go
+++ b/tests/integration/suite/daprd/workflow/starttime/nodelay.go
@@ -57,13 +57,12 @@ func (n *nodelay) Run(t *testing.T, ctx context.Context) {
 
 	client := n.workflow.BackendClient(t, ctx)
 
-	start := time.Now()
 	id, err := client.ScheduleNewOrchestration(ctx, "delay")
 	require.NoError(t, err)
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
 
-	start = time.Now()
+	start := time.Now()
 	id, err = client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(0)))
 	require.NoError(t, err)
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)

--- a/tests/integration/suite/daprd/workflow/starttime/nodelay.go
+++ b/tests/integration/suite/daprd/workflow/starttime/nodelay.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package starttime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(nodelay))
+}
+
+type nodelay struct {
+	workflow *workflow.Workflow
+}
+
+func (n *nodelay) Setup(t *testing.T) []framework.Option {
+	n.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(n.workflow),
+	}
+}
+
+func (n *nodelay) Run(t *testing.T, ctx context.Context) {
+	n.workflow.WaitUntilRunning(t, ctx)
+
+	var executed time.Time
+	n.workflow.Registry().AddOrchestratorN("delay", func(ctx *task.OrchestrationContext) (any, error) {
+		if !ctx.IsReplaying {
+			executed = time.Now()
+		}
+		return nil, nil
+	})
+
+	client := n.workflow.BackendClient(t, ctx)
+
+	start := time.Now()
+	id, err := client.ScheduleNewOrchestration(ctx, "delay")
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+
+	start = time.Now()
+	id, err = client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(0)))
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.InDelta(t, 0, executed.Sub(start).Seconds(), 1.0)
+}

--- a/tests/integration/suite/daprd/workflow/starttime/nowait.go
+++ b/tests/integration/suite/daprd/workflow/starttime/nowait.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package workflow
+package starttime
 
 import (
 	"context"
@@ -29,45 +29,46 @@ import (
 )
 
 func init() {
-	suite.Register(new(delaystart))
+	suite.Register(new(nowait))
 }
 
-type delaystart struct {
+type nowait struct {
 	workflow *workflow.Workflow
 }
 
-func (d *delaystart) Setup(t *testing.T) []framework.Option {
-	d.workflow = workflow.New(t)
+func (n *nowait) Setup(t *testing.T) []framework.Option {
+	n.workflow = workflow.New(t)
 
 	return []framework.Option{
-		framework.WithProcesses(d.workflow),
+		framework.WithProcesses(n.workflow),
 	}
 }
 
-func (d *delaystart) Run(t *testing.T, ctx context.Context) {
-	d.workflow.WaitUntilRunning(t, ctx)
+func (n *nowait) Run(t *testing.T, ctx context.Context) {
+	n.workflow.WaitUntilRunning(t, ctx)
 
 	var executed time.Time
-	d.workflow.Registry().AddOrchestratorN("delay", func(ctx *task.OrchestrationContext) (any, error) {
+	n.workflow.Registry().AddOrchestratorN("delay", func(ctx *task.OrchestrationContext) (any, error) {
 		if !ctx.IsReplaying {
 			executed = time.Now()
 		}
 		return nil, nil
 	})
 
-	client := d.workflow.BackendClient(t, ctx)
+	client := n.workflow.BackendClient(t, ctx)
 
 	start := time.Now()
-	id, err := client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(time.Second*7)))
+	id, err := client.ScheduleNewOrchestration(ctx, "delay")
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+
+	start = time.Now()
+	cctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	t.Cleanup(cancel)
+	id, err = client.ScheduleNewOrchestration(cctx, "delay", api.WithStartTime(start.Add(time.Second*7)))
 	require.NoError(t, err)
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
 	assert.InDelta(t, 7.0, executed.Sub(start).Seconds(), 1.0)
-
-	start = time.Now()
-	id, err = client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(0)))
-	require.NoError(t, err)
-	_, err = client.WaitForOrchestrationCompletion(ctx, id)
-	require.NoError(t, err)
-	assert.InDelta(t, 0, executed.Sub(start).Seconds(), 1.0)
 }

--- a/tests/integration/suite/daprd/workflow/starttime/nowait.go
+++ b/tests/integration/suite/daprd/workflow/starttime/nowait.go
@@ -57,13 +57,12 @@ func (n *nowait) Run(t *testing.T, ctx context.Context) {
 
 	client := n.workflow.BackendClient(t, ctx)
 
-	start := time.Now()
 	id, err := client.ScheduleNewOrchestration(ctx, "delay")
 	require.NoError(t, err)
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
 
-	start = time.Now()
+	start := time.Now()
 	cctx, cancel := context.WithTimeout(ctx, time.Second*3)
 	t.Cleanup(cancel)
 	id, err = client.ScheduleNewOrchestration(cctx, "delay", api.WithStartTime(start.Add(time.Second*7)))

--- a/tests/integration/suite/daprd/workflow/starttime/starttime.go
+++ b/tests/integration/suite/daprd/workflow/starttime/starttime.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package starttime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(starttime))
+}
+
+type starttime struct {
+	workflow *workflow.Workflow
+}
+
+func (s *starttime) Setup(t *testing.T) []framework.Option {
+	s.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *starttime) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	var executed time.Time
+	s.workflow.Registry().AddOrchestratorN("delay", func(ctx *task.OrchestrationContext) (any, error) {
+		if !ctx.IsReplaying {
+			executed = time.Now()
+		}
+		return nil, nil
+	})
+
+	client := s.workflow.BackendClient(t, ctx)
+
+	start := time.Now()
+	id, err := client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(time.Second*7)))
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.InDelta(t, 7.0, executed.Sub(start).Seconds(), 1.0)
+
+	start = time.Now()
+	id, err = client.ScheduleNewOrchestration(ctx, "delay", api.WithStartTime(start.Add(0)))
+	require.NoError(t, err)
+	_, err = client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.InDelta(t, 0, executed.Sub(start).Seconds(), 1.0)
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -19,5 +19,6 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/memory"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reconnect"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/starttime"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/timer"
 )


### PR DESCRIPTION
If start time of the workflow is defined, do not wait for the workflow
to start. This prevents timeouts of clients when scheduling workflows
which are started in the future.

Fixes https://github.com/dapr/dapr/issues/8862
