### PR TITLE
Fix release 1.15 pipeline

### DIFF
--- a/.github/workflows/dapr-test.yml
+++ b/.github/workflows/dapr-test.yml
@@ -286,7 +286,7 @@ jobs:
       - name: Set up Go
         id: setup-go
         # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
-        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
+        uses: antontroshin/setup-go@461004e4c97225a313a997efabc35fde47d587bb
         with:
           go-version-file: "go.mod"
       - name: Login to Azure
@@ -460,7 +460,7 @@ jobs:
       - name: Set up Go
         id: setup-go
         # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
-        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
+        uses: antontroshin/setup-go@461004e4c97225a313a997efabc35fde47d587bb
         with:
           go-version-file: "go.mod"
       - uses: azure/setup-kubectl@v3

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Dependency review
         uses: actions/dependency-review-action@v4
         # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
-      - uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
+      - uses: antontroshin/setup-go@461004e4c97225a313a997efabc35fde47d587bb
         with:
           go-version-file: "go.mod"
       - name: Install govulncheck
@@ -196,7 +196,7 @@ jobs:
       - name: Set up Go
         id: setup-go
         # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
-        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
+        uses: antontroshin/setup-go@461004e4c97225a313a997efabc35fde47d587bb
         with:
           go-version-file: "go.mod"
       - name: Run make test
@@ -246,7 +246,7 @@ jobs:
       - name: Set up Go
         id: setup-go
         # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
-        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
+        uses: antontroshin/setup-go@461004e4c97225a313a997efabc35fde47d587bb
         with:
           go-version-file: "go.mod"
       - name: Override DAPR_HOST_IP for MacOS
@@ -339,7 +339,7 @@ jobs:
       - name: Set up Go
         id: setup-go
         # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
-        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
+        uses: antontroshin/setup-go@461004e4c97225a313a997efabc35fde47d587bb
         with:
           go-version-file: "go.mod"
       - name: Parse release version and set REL_VERSION and LATEST_RELEASE

--- a/.github/workflows/test-tooling.yml
+++ b/.github/workflows/test-tooling.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Setup
         # TODO: use actions/setup-go after https://github.com/actions/setup-go/pull/515 is merged and released
-        uses: antontroshin/setup-go@bda02de8887c9946189f81e7e59512914aeb9ea4
+        uses: antontroshin/setup-go@461004e4c97225a313a997efabc35fde47d587bb
         with:
           go-version-file: './.build-tools/go.mod'
 


### PR DESCRIPTION
[Fix the release pipeline](https://github.com/dapr/dapr/actions/runs/16303205437/job/46043875755)

we are still using @antontroshin's changes from [this PR](https://github.com/actions/setup-go/pull/515) - I grabbed the latest commit since on July 14 (yesterday) the D drive will no longer be accessible on GitHub-hosted Windows Server 2025 runners

TODO: fix lint issues bc theres a ton