### PR TITLE
[1.16] Prevent Jobs from not triggering upserting in high throughput scenarios

### DIFF
--- a/docs/release_notes/v1.15.7.md
+++ b/docs/release_notes/v1.15.7.md
@@ -3,6 +3,7 @@
 This update includes bug fixes:
 
 - [Fix Workflow Start Time](#fix-workflow-start-time)
+- [Fix use of DynamoDB as Workflow state store](#fix-use-of-dynamodb-as-workflow-state-store)
 
 ## Fix Workflow Start Time
 
@@ -21,3 +22,21 @@ The "Start Time" was not being propagated to the Actor reminder responsible for 
 ### Solution
 
 Correctly propagate the Start Time of a Workflow to the Actor reminder responsible for executing a Workflow instance.
+
+## Fix use of DynamoDB as Workflow state store
+
+### Problem
+
+Using DynamoDB as the Workflow state store would result in an error when trying to run a Workflow.
+
+### Impact
+
+It would not be possible to run Workflows using DynamoDB as the state store.
+
+### Root cause
+
+The state store implementation used String (S) attributes rather than the Binary (B) attributes resulting in the state not being readable.
+
+### Solution
+
+Updated the DynamoDB state store implementation to use Binary (B) attributes for storing Workflow state.

--- a/docs/release_notes/v1.15.8.md
+++ b/docs/release_notes/v1.15.8.md
@@ -1,0 +1,23 @@
+# Dapr 1.15.8
+
+This update includes bug fixes:
+
+- [Prevent Jobs from not triggering upserting in high throughput scenarios](#prevent-jobs-from-not-triggering-upserting-in-high-throughput-scenarios)
+
+## Prevent Jobs from not triggering upserting in high throughput scenarios
+
+### Problem
+
+Upserting a Job (or Actor reminder) in high job trigger throughput scenarios could result in the Job not being triggered.
+
+### Impact
+
+Jobs (or Actor reminders) could not be triggered in high throughput scenarios.
+
+### Root cause
+
+Scheduler would find a conflict in jobs being triggered between the old and new job state, and would result in no more jobs to be triggered on that host.
+
+### Solution
+
+Ignore the conflict in the scheduler when upserting a job (or Actor reminder) in high throughput scenarios.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dapr/components-contrib v1.15.1-0.20250701140252-bd6ea2e0f5b7
 	github.com/dapr/durabletask-go v0.7.3-0.20250711135247-7a35af6fe0e5
 	github.com/dapr/kit v0.15.3-0.20250710140356-9d4f384c5763
-	github.com/diagridio/go-etcd-cron v0.8.3-0.20250711135408-17bb34390b59
+	github.com/diagridio/go-etcd-cron v0.8.3-0.20250717040853-f73d9b003369
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-chi/cors v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.8.3-0.20250711135408-17bb34390b59 h1:vP2OR2MJLV8Zi3oCfET+TjlR1YzjH90Y85Q7TGil8Jw=
-github.com/diagridio/go-etcd-cron v0.8.3-0.20250711135408-17bb34390b59/go.mod h1:CSzuxoCDFu+Gbds0RO73GE8CnmL5t85axiPLptsej3I=
+github.com/diagridio/go-etcd-cron v0.8.3-0.20250717040853-f73d9b003369 h1:eNkhGLk53JGN6HPsizn6drCdXMNNpt32lMavoOvCq8c=
+github.com/diagridio/go-etcd-cron v0.8.3-0.20250717040853-f73d9b003369/go.mod h1:CSzuxoCDFu+Gbds0RO73GE8CnmL5t85axiPLptsej3I=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=


### PR DESCRIPTION
Problem

Upserting a Job (or Actor reminder) in high job trigger throughput scenarios could result in the Job not being triggered.

Impact

Jobs (or Actor reminders) could not be triggered in high throughput scenarios.

Root cause

Scheduler would find a conflict in jobs being triggered between the old and new job state, and would result in no more jobs to be triggered on that host.

Solution

Ignore the conflict in the scheduler when upserting a job (or Actor reminder) in high throughput scenarios.