### PR TITLE
[FIX 1.15] Prevent workflow cleanup process to delete activities that are not in the state

### DIFF
--- a/pkg/actors/targets/workflow/workflow.go
+++ b/pkg/actors/targets/workflow/workflow.go
@@ -534,7 +534,8 @@ func (w *workflow) runWorkflow(ctx context.Context, reminder *actorapi.Reminder)
 		activityActorID := getActivityActorID(w.actorID, taskID, state.Generation)
 
 		// Fixes 1.15 issue where it tries to delete activity state that is not present
-		res, err := w.actorState.Get(ctx, &actorapi.GetStateRequest{
+		var res *actorapi.StateResponse
+		res, err = w.actorState.Get(ctx, &actorapi.GetStateRequest{
 			ActorType: w.activityActorType,
 			ActorID:   activityActorID,
 		}, false)


### PR DESCRIPTION
# Description

This error surfaced with the Azure Cosmos DB component, reported [here](https://github.com/dapr/dapr/issues/8651).
The problem is that dapr sends a delete operation on the activity, but this actor has never been created in the database and Cosmos returns 404. Out of curiosity I compared it with Redis and MySQL and they both can handle deleting a key that doesn't exist, that's why they don't fail in the same situation.

I've added this check to not do the delete operation for missing keys.

## Issue reference

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/8651

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
