### PR TITLE
Runs prune_stale jobs only in the official repo

### DIFF
--- a/.github/workflows/dapr-bot-schedule.yml
+++ b/.github/workflows/dapr-bot-schedule.yml
@@ -39,6 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
         run: python ./.github/scripts/automerge.py
   prune_stale:
+    if: github.repository_owner == 'dapr'
     name: Prune Stale
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
I've got multiple failing runs of this job in my fork: https://github.com/acroca/dapr/actions/workflows/dapr-bot-schedule.yml

I think this cron task should run only in the main repo and not in forks.