### PR TITLE
Stop propagating service-invocation dapr-app-id header to downstream services - Backport to 1.15

### DIFF
--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -299,8 +299,11 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 // 2. Basic auth header: `http://dapr-app-id:<service-id>@localhost:3500/<method>`
 // 3. URL parameter: `http://localhost:3500/v1.0/invoke/<app-id>/method/<method>`
 func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string, method string) {
-	if appID := headers.Get(daprAppID); appID != "" {
-		return appID, strings.TrimPrefix(path.Clean(reqPath), "/")
+	if appID := headers.Get(diagConsts.GRPCProxyAppIDKey); appID != "" {
+		targetID, method = appID, strings.TrimPrefix(path.Clean(reqPath), "/")
+		// Delete the header as it should not be passed forward with the request and is only used by the Dapr API
+		headers.Del(diagConsts.GRPCProxyAppIDKey)
+		return targetID, method
 	}
 
 	if auth := headers.Get("Authorization"); strings.HasPrefix(auth, "Basic ") {

--- a/pkg/api/http/directmessaging_test.go
+++ b/pkg/api/http/directmessaging_test.go
@@ -1083,6 +1083,10 @@ func TestFindTargetIDAndMethod(t *testing.T) {
 			if gotMethod != tt.wantMethod {
 				t.Errorf("findTargetIDAndMethod() gotMethod = %v, want %v", gotMethod, tt.wantMethod)
 			}
+			appIDHeader := tt.headers.Get(daprAppID)
+			if appIDHeader != "" {
+				t.Error("dapr-app-id is present in request headers and shouldn't be")
+			}
 		})
 	}
 }

--- a/pkg/diagnostics/consts/consts.go
+++ b/pkg/diagnostics/consts/consts.go
@@ -61,6 +61,21 @@ const (
 	// Keys used in the context's metadata for streaming calls
 	// Note: these keys must always be all-lowercase
 	DaprCallLocalStreamMethodKey = "__dapr_calllocalstream_method"
+
+	// We have leveraged the code from opencensus-go plugin to adhere the w3c trace context.
+	// Reference : https://github.com/census-instrumentation/opencensus-go/blob/master/plugin/ochttp/propagation/tracecontext/propagation.go
+	// Trace context headers
+	TraceparentHeader = "traceparent"
+	TracestateHeader  = "tracestate"
+	BaggageHeader     = "baggage"
+
+	GRPCTraceContextKey  = "grpc-trace-bin"
+	GRPCProxyAppIDKey    = "dapr-app-id"
+	GRPCProxyCalleeIDKey = "dapr-callee-app-id"
+	// Trace sampling constants
+	SupportedVersion = 0
+	MaxVersion       = 254
+	MaxTracestateLen = 512
 )
 
 // GrpcAppendSpanAttributesFn is the interface that applies to gRPC requests that add span attributes.

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -129,9 +129,13 @@ func GRPCTraceStreamServerInterceptor(appID string, spec config.TracingSpec) grp
 		default:
 			isProxied = true
 			md, _ := metadata.FromIncomingContext(ctx)
-			vals := md.Get(GRPCProxyAppIDKey)
+			vals := md.Get(diagConsts.GRPCProxyCalleeIDKey)
 			if len(vals) == 0 {
-				return fmt.Errorf("cannot proxy request: missing %s metadata", GRPCProxyAppIDKey)
+				log.Debugf("cannot proxy request: missing %s metadata, fallback to %s", diagConsts.GRPCProxyCalleeIDKey, diagConsts.GRPCProxyAppIDKey)
+				vals = md.Get(diagConsts.GRPCProxyAppIDKey)
+				if len(vals) == 0 {
+					return fmt.Errorf("cannot proxy request: missing %s or %s metadata", diagConsts.GRPCProxyCalleeIDKey, diagConsts.GRPCProxyAppIDKey)
+				}
 			}
 			// vals[0] is the target app ID
 			if appID == vals[0] {

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/dapr/dapr/pkg/acl"
 	grpcProxy "github.com/dapr/dapr/pkg/api/grpc/proxy"
-	codec "github.com/dapr/dapr/pkg/api/grpc/proxy/codec"
+	"github.com/dapr/dapr/pkg/api/grpc/proxy/codec"
 	"github.com/dapr/dapr/pkg/config"
-	"github.com/dapr/dapr/pkg/diagnostics"
+	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/proto/common/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
@@ -98,9 +98,13 @@ func nopTeardown(destroy bool) {
 func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context, *grpc.ClientConn, *grpcProxy.ProxyTarget, func(destroy bool), error) {
 	md, _ := metadata.FromIncomingContext(ctx)
 
-	v := md[diagnostics.GRPCProxyAppIDKey]
+	v := md[diagConsts.GRPCProxyCalleeIDKey]
 	if len(v) == 0 {
-		return ctx, nil, nil, nopTeardown, fmt.Errorf("failed to proxy request: required metadata %s not found", diagnostics.GRPCProxyAppIDKey)
+		log.Debugf("failed to proxy request: required metadata %s not found, fallback to %s", diagConsts.GRPCProxyCalleeIDKey, diagConsts.GRPCProxyAppIDKey)
+		v = md[diagConsts.GRPCProxyAppIDKey]
+		if len(v) == 0 {
+			return ctx, nil, nil, nopTeardown, fmt.Errorf("failed to proxy request: required metadata %s or %s not found", diagConsts.GRPCProxyCalleeIDKey, diagConsts.GRPCProxyAppIDKey)
+		}
 	}
 
 	appID := v[0]

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/proxy.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/proxy.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	testpb "github.com/dapr/dapr/tests/integration/framework/process/grpc/app/proto"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(basicproxy))
+}
+
+type basicproxy struct {
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	ch     chan metadata.MD
+}
+
+func (b *basicproxy) Setup(t *testing.T) []framework.Option {
+	b.ch = make(chan metadata.MD, 1)
+
+	app := app.New(t,
+		app.WithPingFn(func(ctx context.Context, _ *testpb.PingRequest) (*testpb.PingResponse, error) {
+			md, _ := metadata.FromIncomingContext(ctx)
+			b.ch <- md
+			return new(testpb.PingResponse), nil
+		}),
+	)
+
+	b.daprd1 = daprd.New(t,
+		daprd.WithAppID("app1"),
+		daprd.WithAppProtocol("grpc"),
+	)
+
+	b.daprd2 = daprd.New(t,
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppPort(app.Port(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, b.daprd1, b.daprd2),
+	}
+}
+
+func (b *basicproxy) Run(t *testing.T, ctx context.Context) {
+	b.daprd1.WaitUntilRunning(t, ctx)
+	b.daprd2.WaitUntilRunning(t, ctx)
+
+	client := testpb.NewTestServiceClient(b.daprd1.GRPCConn(t, ctx))
+	ctx = metadata.AppendToOutgoingContext(ctx, "dapr-app-id", b.daprd2.AppID())
+	_, err := client.Ping(ctx, new(testpb.PingRequest))
+	require.NoError(t, err)
+
+	select {
+	case md := <-b.ch:
+		require.Empty(t, md.Get("dapr-app-id"))
+		require.Equal(t, md.Get("dapr-callee-app-id")[0], b.daprd2.AppID())
+		require.Equal(t, md.Get("dapr-caller-app-id")[0], b.daprd1.AppID())
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "timed out waiting for metadata")
+	}
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/basic.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/basic.go
@@ -123,6 +123,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
+			require.Empty(t, resp.Header.Get("dapr-app-id"))
 			return resp.StatusCode, string(body)
 		}
 


### PR DESCRIPTION
 remove dapr-app-id header before invoking target sidecar

---------

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
