### PR TITLE
fix(converse): add default role in runtime now in 1.16

### DIFF
--- a/pkg/api/universal/conversation.go
+++ b/pkg/api/universal/conversation.go
@@ -31,6 +31,25 @@ import (
 	kmeta "github.com/dapr/kit/metadata"
 )
 
+func mapRoleToChatMessageType(roleStr string) llms.ChatMessageType {
+	switch roleStr {
+	case "user", "human":
+		return llms.ChatMessageTypeHuman
+	case "system":
+		return llms.ChatMessageTypeSystem
+	case "assistant", "ai":
+		return llms.ChatMessageTypeAI
+	case "tool":
+		return llms.ChatMessageTypeTool
+	case "function":
+		return llms.ChatMessageTypeFunction
+	case "generic":
+		return llms.ChatMessageTypeGeneric
+	default:
+		return llms.ChatMessageTypeHuman
+	}
+}
+
 func (a *Universal) ConverseAlpha1(ctx context.Context, req *runtimev1pb.ConversationRequest) (*runtimev1pb.ConversationResponse, error) { //nolint:staticcheck
 	component, ok := a.compStore.GetConversation(req.GetName())
 	if !ok {
@@ -63,7 +82,6 @@ func (a *Universal) ConverseAlpha1(ctx context.Context, req *runtimev1pb.Convers
 	var scrubbed []string
 	for _, i := range req.GetInputs() {
 		msg := i.GetContent()
-
 		if i.GetScrubPII() {
 			scrubbed, err = scrubber.ScrubTexts([]string{i.GetContent()})
 			if err != nil {
@@ -76,7 +94,7 @@ func (a *Universal) ConverseAlpha1(ctx context.Context, req *runtimev1pb.Convers
 		}
 
 		c := llms.MessageContent{
-			Role: llms.ChatMessageType(i.GetRole()),
+			Role: mapRoleToChatMessageType(i.GetRole()),
 			Parts: []llms.ContentPart{
 				llms.TextContent{
 					Text: msg,

--- a/pkg/api/universal/conversation_test.go
+++ b/pkg/api/universal/conversation_test.go
@@ -1,0 +1,33 @@
+package universal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+)
+
+func TestMapRoleToChatMessageType(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected llms.ChatMessageType
+	}{
+		{"user", llms.ChatMessageTypeHuman},
+		{"human", llms.ChatMessageTypeHuman},
+		{"system", llms.ChatMessageTypeSystem},
+		{"assistant", llms.ChatMessageTypeAI},
+		{"ai", llms.ChatMessageTypeAI},
+		{"tool", llms.ChatMessageTypeTool},
+		{"function", llms.ChatMessageTypeFunction},
+		{"generic", llms.ChatMessageTypeGeneric},
+		{"", llms.ChatMessageTypeHuman},
+		{"unknown", llms.ChatMessageTypeHuman},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := mapRoleToChatMessageType(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Description

corresponding PR to master is here: https://github.com/dapr/dapr/pull/8934


Before the conversation api v1 had the role default setting in components contrib. With my refactoring, I cleaned things up in contrib, so need to add the default setting back to the original api on runtime side.

Found this in the quickstarts with them showing:
```

== APP - conversation == HTTP Error: 500 {"errorCode":"ERR_CONVERSATION_INVOKE","message":"failed conversing with component anthropic: anthropic: failed to process messages: anthropic: unsupported message type: "}
```

This is due to the message type role not set. This PR adds this field default setting back, and corrects the issue with my quickstart now showing:
```
 dapr run -f .
ℹ️  Validating config and starting app "conversation"
ℹ️  Started Dapr with app id "conversation". HTTP Port: 3502. gRPC Port: 56777
ℹ️  Writing log files to directory : /Users/samcoyle/go/src/github.com/forks/dapr/quickstarts/conversation/javascript/http/conversation/.dapr/logs
== APP - conversation == 
== APP - conversation == > conversation@1.0.0 start
== APP - conversation == > node index.js
== APP - conversation == 
== APP - conversation == Input sent: What is dapr?
== APP - conversation == Response status: 200
== APP - conversation == Response headers: {
== APP - conversation ==   'content-length': '1695',
== APP - conversation ==   'content-type': 'application/json',
== APP - conversation ==   date: 'Wed, 30 Jul 2025 14:16:58 GMT',
== APP - conversation ==   traceparent: '00-fc68404120a84b9c4ac290225839d419-4af907ac4bd85c93-01'
== APP - conversation == }
== APP - conversation == Full response data: {
== APP - conversation ==   "outputs": [
== APP - conversation ==     {
== APP - conversation ==       "result": "Dapr (Distributed Application Runtime) is an open-source, portable runtime for building microservices and event-driven applications. It was initially developed by Microsoft and is now part of the Cloud Native Computing Foundation (CNCF) as an incubating project.\n\nKey features and concepts of Dapr include:\n\n1. Sidecar architecture: Dapr runs alongside your application as a sidecar, providing APIs that abstract away the underlying infrastructure.\n\n2. Language agnostic: It supports multiple programming languages and frameworks, allowing developers to use their preferred tools.\n\n3. Building blocks: Dapr provides a set of building blocks for common distributed application capabilities, such as:\n   - Service invocation\n   - State management\n   - Publish/subscribe messaging\n   - Resource bindings\n   - Actors\n   - Observability\n   - Secrets management\n\n4. Cloud and edge agnostic: Dapr can run in any environment, including public clouds, on-premises, and edge devices.\n\n5. Pluggable components: It offers a pluggable design for various infrastructure services, allowing easy integration with different technologies.\n\n6. Developer-friendly: Dapr aims to simplify the development of distributed applications by providing consistent APIs and abstractions.\n\n7. Scalability and resilience: It's designed to support highly scalable and resilient microservices architectures.\n\nDapr helps developers focus on business logic while abstracting away many of the complexities associated with building distributed systems. It can be particularly useful for organizations looking to adopt microservices architectures or modernize existing applications."
== APP - conversation ==     }
== APP - conversation ==   ]
== APP - conversation == }
== APP - conversation == Output response: Dapr (Distributed Application Runtime) is an open-source, portable runtime for building microservices and event-driven applications. It was initially developed by Microsoft and is now part of the Cloud Native Computing Foundation (CNCF) as an incubating project.
== APP - conversation == 
== APP - conversation == Key features and concepts of Dapr include:
== APP - conversation == 
== APP - conversation == 1. Sidecar architecture: Dapr runs alongside your application as a sidecar, providing APIs that abstract away the underlying infrastructure.
== APP - conversation == 
== APP - conversation == 2. Language agnostic: It supports multiple programming languages and frameworks, allowing developers to use their preferred tools.
== APP - conversation == 
== APP - conversation == 3. Building blocks: Dapr provides a set of building blocks for common distributed application capabilities, such as:
== APP - conversation ==    - Service invocation
== APP - conversation ==    - State management
...
```


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
