### PR TITLE
[1.16] Workflow: fix meta broadcast & no state

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -121,8 +121,6 @@ func (o *orchestrator) scheduleWorkflowStart(ctx context.Context, startEvent *ba
 		return err
 	}
 
-	defer o.ometaBroadcaster.Broadcast(o.ometa)
-
 	var start *time.Time
 	if ts := startEvent.GetExecutionStarted().GetScheduledStartTimestamp(); ts != nil {
 		start = ptr.Of(ts.AsTime())

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -144,7 +144,6 @@ func (f *factory) initOrchestrator(o any, actorID string) *orchestrator {
 		or.ometaBroadcaster.Close()
 	}
 	or.ometaBroadcaster = broadcaster.New[*backend.OrchestrationMetadata]()
-	or.closeCh = make(chan struct{})
 	or.closed.Store(false)
 
 	if f.eventSink != nil {

--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -101,8 +101,6 @@ func (o *orchestrator) handleReminder(ctx context.Context, reminder *actorapi.Re
 	completed, err := o.runWorkflow(ctx, reminder)
 	if completed == todo.RunCompletedTrue {
 		defer o.cleanup()
-	} else {
-		defer o.ometaBroadcaster.Broadcast(o.ometa)
 	}
 
 	// We delete the reminder on success and on non-recoverable errors.

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -45,7 +45,6 @@ type orchestrator struct {
 	activityResultAwaited atomic.Bool
 	completed             atomic.Bool
 	lock                  *lock.Lock
-	closeCh               chan struct{}
 	closed                atomic.Bool
 	wg                    sync.WaitGroup
 }

--- a/pkg/actors/targets/workflow/orchestrator/sink.go
+++ b/pkg/actors/targets/workflow/orchestrator/sink.go
@@ -17,14 +17,10 @@ import "github.com/dapr/durabletask-go/backend"
 
 func (o *orchestrator) runEventSink(ch chan *backend.OrchestrationMetadata, cb func(*backend.OrchestrationMetadata)) {
 	for {
-		select {
-		case <-o.closeCh:
+		val, ok := <-ch
+		if !ok {
 			return
-		case val, ok := <-ch:
-			if !ok {
-				return
-			}
-			cb(val)
 		}
+		cb(val)
 	}
 }

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -49,7 +49,6 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 	o.state = state
 	o.rstate = runtimestate.NewOrchestrationRuntimeState(o.actorID, state.CustomStatus, state.History)
 	o.ometa = o.ometaFromState(o.rstate, o.getExecutionStartedEvent(state))
-	o.ometaBroadcaster.Broadcast(o.ometa)
 
 	return state, o.ometa, nil
 }
@@ -74,6 +73,7 @@ func (o *orchestrator) saveInternalState(ctx context.Context, state *wfenginesta
 	o.state = state
 	o.rstate = runtimestate.NewOrchestrationRuntimeState(o.actorID, state.CustomStatus, state.History)
 	o.ometa = o.ometaFromState(o.rstate, o.getExecutionStartedEvent(state))
+	o.ometaBroadcaster.Broadcast(o.ometa)
 	return nil
 }
 
@@ -145,12 +145,10 @@ func (o *orchestrator) cleanup() {
 	}
 
 	o.table.Delete(o.actorID)
-	o.ometaBroadcaster.Broadcast(o.ometa)
-	close(o.closeCh)
-	o.ometaBroadcaster.Close()
 	o.state = nil
 	o.rstate = nil
 	o.ometa = nil
+	o.ometaBroadcaster.Close()
 
 	go func() {
 		o.wg.Wait()

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/state"
-	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/kit/logger"
 )
@@ -289,8 +288,8 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	// Load inbox, history, and custom status using a bulk request
 	wState := NewState(opts)
 	wState.Generation = metadata.GetGeneration()
-	wState.Inbox = make([]*backend.HistoryEvent, metadata.GetInboxLength())
-	wState.History = make([]*backend.HistoryEvent, metadata.GetHistoryLength())
+	wState.Inbox = make([]*backend.HistoryEvent, 0, metadata.GetInboxLength())
+	wState.History = make([]*backend.HistoryEvent, 0, metadata.GetHistoryLength())
 
 	bulkReq := &api.GetBulkStateRequest{
 		ActorType: opts.WorkflowActorType,
@@ -320,8 +319,8 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	defer func() {
 		// TODO: @joshvanl: remove in v1.16 where we will no longer have legacy
 		// state parsing issues.
-		if recover() != nil {
-			wfLogger.Warnf("Found legacy workflow state, ignoring and overwriting with new storage API: %s", actorID)
+		if rerr := recover(); rerr != nil {
+			wfLogger.Warnf("Found legacy workflow state, ignoring and overwriting with new storage API: %s; %v", actorID, rerr)
 		}
 	}()
 
@@ -331,23 +330,25 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		key = getMultiEntryKeyName(inboxKeyPrefix, i)
 		if bulkRes[key] == nil {
 			wfLogger.Warnf("Failed to load inbox state key '%s': not found", key)
-			return nil, nil
+			continue
 		}
-		wState.Inbox[i] = &protos.HistoryEvent{}
-		if err = proto.Unmarshal(bulkRes[key], wState.Inbox[i]); err != nil {
+		var hist backend.HistoryEvent
+		if err = proto.Unmarshal(bulkRes[key], &hist); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal history event from inbox state key '%s': %w", key, err)
 		}
+		wState.Inbox = append(wState.Inbox, &hist)
 	}
 	for i := range metadata.GetHistoryLength() {
 		key = getMultiEntryKeyName(historyKeyPrefix, i)
 		if bulkRes[key] == nil {
 			wfLogger.Warnf("Failed to load history state key '%s': not found", key)
-			return nil, nil
+			continue
 		}
-		wState.History[i] = &protos.HistoryEvent{}
-		if err = proto.Unmarshal(bulkRes[key], wState.History[i]); err != nil {
+		var hist backend.HistoryEvent
+		if err = proto.Unmarshal(bulkRes[key], &hist); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal history event from history state key '%s': %w", key, err)
 		}
+		wState.History = append(wState.History, &hist)
 	}
 
 	if len(bulkRes[customStatusKey]) > 0 {


### PR DESCRIPTION
Fix a race condition for broadcasting workflow meta stream clients to be done on only save, also saving network I/O. Remove the close channel check on state stream to ensure states are always sent. Send the current state when the orchestrator actor is deactivated.

Fix history state reading for some rerun operations.