### PR TITLE
[1.16] Integration: fix scheduler cluster wait for ready

### DIFF
--- a/tests/integration/framework/process/scheduler/cluster/cluster.go
+++ b/tests/integration/framework/process/scheduler/cluster/cluster.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	clientv3 "go.etcd.io/etcd/client/v3"
 
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 	"github.com/dapr/dapr/tests/integration/framework/process/ports"
@@ -122,12 +121,16 @@ func (c *Cluster) WaitUntilRunning(t *testing.T, ctx context.Context) {
 		s.WaitUntilRunning(t, ctx)
 	}
 
-	require.EventuallyWithT(t, func(col *assert.CollectT) {
-		resp, err := c.schedulers[0].ETCDClient(t, ctx).Get(ctx, "dapr/leadership", clientv3.WithPrefix())
-		if assert.NoError(col, err) {
-			_ = assert.NotNil(col, resp) && assert.Len(col, resp.Kvs, len(c.schedulers))
-		}
-	}, 10*time.Second, 10*time.Millisecond)
+	for _, sched := range c.schedulers {
+		assert.EventuallyWithT(t, func(col *assert.CollectT) {
+			stream, err := sched.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+			require.NoError(t, err)
+			resp, err := stream.Recv()
+			stream.CloseSend()
+			require.NoError(t, err)
+			assert.Len(col, resp.GetHosts(), len(c.schedulers))
+		}, 10*time.Second, 10*time.Millisecond)
+	}
 }
 
 func (c *Cluster) Client(t *testing.T, ctx context.Context) schedulerv1pb.SchedulerClient {


### PR DESCRIPTION
Update the scheduler cluster framework "wait for ready" to check that all of the schedulers have seen one another, and have settled leadership. This prevents a race in scheduler cluster tests whereby scheduler leaders are still trying to re-shuffle whilst the test has already started. This manifests by "Job Already Exists" errors, as the Job PUT call has it's context cancelled, but the key was successfully written to the Etcd database disk.d-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
