### PR TITLE
FIX Call Non-Dapr endpoint with redirect behavior

### DIFF
--- a/pkg/diagnostics/http_monitoring_path_matching.go
+++ b/pkg/diagnostics/http_monitoring_path_matching.go
@@ -124,6 +124,22 @@ func (pm *pathMatching) match(path string) (string, bool) {
 }
 
 type pathMatchingRW struct {
-	http.ResponseWriter
 	matchedPath string
+	header      http.Header
+}
+
+// Header returns a non-nil header map
+func (rw *pathMatchingRW) Header() http.Header {
+	if rw.header == nil {
+		rw.header = make(http.Header)
+	}
+	return rw.header
+}
+
+func (rw *pathMatchingRW) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+func (rw *pathMatchingRW) WriteHeader(statusCode int) {
+	// no-op
 }

--- a/pkg/diagnostics/http_monitoring_test.go
+++ b/pkg/diagnostics/http_monitoring_test.go
@@ -297,6 +297,19 @@ func TestGetMetricsMethodExcludeVerbs(t *testing.T) {
 	assert.Equal(t, "", testHTTP.getMetricsMethod("INVALID"))
 }
 
+func TestHTTPMetricsPathMatchingWithRedirect(t *testing.T) {
+	const testPath = "/redirect-test"
+
+	pm := newPathMatching([]string{"/other-path"}, false)
+	pm.mux.HandleFunc(testPath, func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	})
+
+	matchedPath, ok := pm.match(testPath)
+	require.True(t, ok, "Expected path matching to succeed")
+	require.Equal(t, testPath, matchedPath, "Expected matched path to be %q", testPath)
+}
+
 func fakeHTTPRequest(body string) *http.Request {
 	req, err := http.NewRequest(http.MethodPost, "http://dapr.io/invoke/method/testmethod", strings.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
**Description**

Fixes a `nil pointer dereference panic` in the HTTP metrics middleware that occurs when invoking a non-Dapr endpoint that returns an HTTP redirect. Panic was caused by an uninitialized `http.ResponseWriter` field in the `pathMatchingRW` struct. 

- Added a `Header()` implementation to `pathMatchingRW` that always returns a valid `http.Header` map.
 
- Implemented no-op `Write` and `WriteHeader` methods to satisfy the `http.ResponseWriter` interface when no underlying writer is present.

- Introduced a new unit test `TestHTTPMetricsPathMatchingWithRedirect` to simulate the scenario.

**Issue reference** - #8975

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing