### PR TITLE
Workflows: reduce go routine overhead

### DIFF
--- a/pkg/actors/router/router.go
+++ b/pkg/actors/router/router.go
@@ -172,12 +172,12 @@ func (r *router) callReminder(ctx context.Context, req *api.Reminder) error {
 		return err
 	}
 
-	target, err := r.table.GetOrCreate(req.ActorType, req.ActorID)
-	if err != nil {
-		return backoff.Permanent(err)
-	}
-
 	for {
+		target, err := r.table.GetOrCreate(req.ActorType, req.ActorID)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+
 		if req.IsTimer {
 			err = target.InvokeTimer(ctx, req)
 		} else {

--- a/pkg/actors/router/router.go
+++ b/pkg/actors/router/router.go
@@ -177,17 +177,19 @@ func (r *router) callReminder(ctx context.Context, req *api.Reminder) error {
 		return backoff.Permanent(err)
 	}
 
-	if req.IsTimer {
-		err = target.InvokeTimer(ctx, req)
-	} else {
-		err = target.InvokeReminder(ctx, req)
-	}
+	for {
+		if req.IsTimer {
+			err = target.InvokeTimer(ctx, req)
+		} else {
+			err = target.InvokeReminder(ctx, req)
+		}
 
-	if targetserrors.IsClosed(err) {
-		return err
-	}
+		if targetserrors.IsClosed(err) {
+			continue
+		}
 
-	return backoff.Permanent(err)
+		return backoff.Permanent(err)
+	}
 }
 
 func (r *router) callActor(ctx context.Context, req *internalv1pb.InternalInvokeRequest) (*internalv1pb.InternalInvokeResponse, error) {
@@ -214,15 +216,17 @@ func (r *router) callActor(ctx context.Context, req *internalv1pb.InternalInvoke
 	}
 
 	if lar.Local {
-		var resp *internalv1pb.InternalInvokeResponse
-		resp, err = r.callLocalActor(ctx, req)
-		if err != nil {
-			if targetserrors.IsClosed(err) {
-				return resp, err
+		for {
+			var resp *internalv1pb.InternalInvokeResponse
+			resp, err = r.callLocalActor(ctx, req)
+			if err != nil {
+				if targetserrors.IsClosed(err) {
+					continue
+				}
+				return resp, backoff.Permanent(err)
 			}
-			return resp, backoff.Permanent(err)
+			return resp, nil
 		}
-		return resp, nil
 	}
 
 	// If this is a dapr-dapr call and the actor didn't pass the local check
@@ -330,14 +334,16 @@ func (r *router) callStream(ctx context.Context, req *internalv1pb.InternalInvok
 		return r.callRemoteActorStream(ctx, lar, req, stream)
 	}
 
-	if err = r.callLocalActorStream(ctx, req, stream); err != nil {
-		if targetserrors.IsClosed(err) {
-			return err
+	for {
+		if err = r.callLocalActorStream(ctx, req, stream); err != nil {
+			if targetserrors.IsClosed(err) {
+				continue
+			}
+			return backoff.Permanent(err)
 		}
-		return backoff.Permanent(err)
-	}
 
-	return nil
+		return nil
+	}
 }
 
 func (r *router) callLocalActorStream(ctx context.Context,

--- a/pkg/actors/router/router.go
+++ b/pkg/actors/router/router.go
@@ -331,6 +331,9 @@ func (r *router) callStream(ctx context.Context, req *internalv1pb.InternalInvok
 	}
 
 	if err = r.callLocalActorStream(ctx, req, stream); err != nil {
+		if targetserrors.IsClosed(err) {
+			return err
+		}
 		return backoff.Permanent(err)
 	}
 

--- a/pkg/actors/targets/errors/errors.go
+++ b/pkg/actors/targets/errors/errors.go
@@ -13,6 +13,12 @@ limitations under the License.
 
 package errors
 
+import (
+	"errors"
+
+	"github.com/dapr/kit/ptr"
+)
+
 type closed struct {
 	method string
 }
@@ -21,9 +27,10 @@ func NewClosed(method string) error {
 	return &closed{method: method}
 }
 
+var cl = ptr.Of(new(closed))
+
 func IsClosed(err error) bool {
-	_, ok := err.(*closed)
-	return ok
+	return errors.As(err, cl)
 }
 
 func (c *closed) Error() string {

--- a/pkg/actors/targets/workflow/lock/lock.go
+++ b/pkg/actors/targets/workflow/lock/lock.go
@@ -13,29 +13,40 @@ limitations under the License.
 
 package lock
 
-import "context"
+import (
+	"context"
+
+	"github.com/dapr/dapr/pkg/actors/targets/errors"
+)
 
 type Lock struct {
-	ch chan struct{}
+	ch      chan struct{}
+	closeCh chan struct{}
 }
 
 func New() *Lock {
 	return &Lock{
-		ch: make(chan struct{}, 1),
+		ch:      make(chan struct{}, 1),
+		closeCh: make(chan struct{}),
 	}
-}
-
-func (l *Lock) Lock() context.CancelFunc {
-	l.ch <- struct{}{}
-	return func() { <-l.ch }
 }
 
 func (l *Lock) ContextLock(ctx context.Context) (context.CancelFunc, error) {
 	select {
 	case l.ch <- struct{}{}:
+	case <-l.closeCh:
+		return nil, errors.NewClosed("lock")
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
 
 	return func() { <-l.ch }, nil
+}
+
+func (l *Lock) Init() {
+	l.closeCh = make(chan struct{})
+}
+
+func (l *Lock) Close() {
+	close(l.closeCh)
 }

--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"google.golang.org/protobuf/proto"
 
@@ -29,29 +28,19 @@ import (
 )
 
 func (o *orchestrator) callActivities(ctx context.Context, es []*backend.HistoryEvent, generation uint64) error {
-	errs := make([]error, len(es))
-
-	var wg sync.WaitGroup
-	wg.Add(len(es))
-	for i, e := range es {
-		go func(i int, e *backend.HistoryEvent) {
-			defer wg.Done()
-
-			err := o.callActivity(ctx, e, generation)
+	for _, e := range es {
+		err := o.callActivity(ctx, e, generation)
+		if err != nil {
 			if errors.Is(err, todo.ErrDuplicateInvocation) {
 				log.Warnf("Workflow actor '%s': activity invocation '%s::%d' was flagged as a duplicate and will be skipped", o.actorID, e.GetTaskScheduled().GetName(), e.GetEventId())
-				return
+				continue
 			}
 
-			if err != nil {
-				errs[i] = err
-			}
-		}(i, e)
+			return err
+		}
 	}
 
-	wg.Wait()
-
-	return errors.Join(errs...)
+	return nil
 }
 
 func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent, generation uint64) error {

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -109,7 +109,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 	deactivateCh := make(chan *orchestrator, 10)
 	go func() {
 		for orchestrator := range deactivateCh {
-			orchestrator.cleanup()
+			orchestrator.Deactivate(ctx)
 		}
 	}()
 
@@ -149,7 +149,6 @@ func (f *factory) GetOrCreate(actorID string) targets.Interface {
 func (f *factory) initOrchestrator(o any, actorID string) *orchestrator {
 	or := o.(*orchestrator)
 
-	or.wg.Wait()
 	or.factory = f
 	or.actorID = actorID
 	if or.ometaBroadcaster != nil {

--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -100,7 +100,7 @@ func (o *orchestrator) handleReminder(ctx context.Context, reminder *actorapi.Re
 
 	completed, err := o.runWorkflow(ctx, reminder)
 	if completed == todo.RunCompletedTrue {
-		defer o.cleanup()
+		defer o.factory.deactivate(o)
 	}
 
 	// We delete the reminder on success and on non-recoverable errors.

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -16,11 +16,11 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
-	targetserrors "github.com/dapr/dapr/pkg/actors/targets/errors"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/lock"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
@@ -57,13 +57,9 @@ func (o *orchestrator) InvokeMethod(ctx context.Context, req *internalsv1pb.Inte
 
 	unlock, err := o.lock.ContextLock(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to invoke method for workflow '%s': %w", o.actorID, err)
 	}
 	defer unlock()
-
-	if err := o.checkClosed("invoke"); err != nil {
-		return nil, err
-	}
 
 	return o.handleInvoke(ctx, req)
 }
@@ -75,13 +71,9 @@ func (o *orchestrator) InvokeReminder(ctx context.Context, reminder *actorapi.Re
 
 	unlock, err := o.lock.ContextLock(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to invoke reminder for workflow '%s': %w", o.actorID, err)
 	}
 	defer unlock()
-
-	if err := o.checkClosed("reminder"); err != nil {
-		return err
-	}
 
 	return o.handleReminder(ctx, reminder)
 }
@@ -108,10 +100,9 @@ func (o *orchestrator) Deactivate(ctx context.Context) error {
 	unlock, err := o.lock.ContextLock(ctx)
 	if err != nil {
 		o.wg.Done()
-		return err
+		return fmt.Errorf("failed to deactivate workflow '%s': %w", o.actorID, err)
 	}
 	defer unlock()
-
 	o.wg.Done()
 
 	o.cleanup()
@@ -132,12 +123,4 @@ func (o *orchestrator) Type() string {
 // ID returns the ID for this unique actor.
 func (o *orchestrator) ID() string {
 	return o.actorID
-}
-
-func (o *orchestrator) checkClosed(method string) error {
-	if o.closed.Load() {
-		return targetserrors.NewClosed(method)
-	}
-
-	return nil
 }

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -104,13 +104,15 @@ func (o *orchestrator) InvokeStream(ctx context.Context, req *internalsv1pb.Inte
 // DeactivateActor implements actors.InternalActor
 func (o *orchestrator) Deactivate(ctx context.Context) error {
 	o.wg.Add(1)
-	defer o.wg.Done()
 
 	unlock, err := o.lock.ContextLock(ctx)
 	if err != nil {
+		o.wg.Done()
 		return err
 	}
 	defer unlock()
+
+	o.wg.Done()
 
 	o.cleanup()
 	log.Debugf("Workflow actor '%s': deactivated", o.actorID)

--- a/pkg/actors/targets/workflow/orchestrator/rerun.go
+++ b/pkg/actors/targets/workflow/orchestrator/rerun.go
@@ -46,7 +46,7 @@ func (o *orchestrator) forkWorkflowHistory(ctx context.Context, request []byte) 
 	}
 
 	if state == nil {
-		defer o.cleanup()
+		defer o.factory.deactivate(o)
 		return status.Errorf(codes.NotFound, "workflow instance does not exist with ID '%s'", o.actorID)
 	}
 
@@ -54,7 +54,7 @@ func (o *orchestrator) forkWorkflowHistory(ctx context.Context, request []byte) 
 		return status.Errorf(codes.InvalidArgument, "'%s' is not in a terminal state", o.actorID)
 	}
 
-	defer o.cleanup()
+	defer o.factory.deactivate(o)
 
 	fork := fork.New(fork.Options{
 		AppID:             o.appID,

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -202,10 +202,12 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			wfExecutionElapsedTime = o.calculateWorkflowExecutionLatency(state)
 		}
 	}
+
 	if runtimestate.IsCompleted(rs) {
 		log.Infof("Workflow Actor '%s': workflow completed with status '%s' workflowName '%s'", o.actorID, runtimestate.RuntimeStatus(rs).String(), workflowName)
 		return todo.RunCompletedTrue, nil
 	}
+
 	return todo.RunCompletedFalse, nil
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -139,21 +139,6 @@ func (o *orchestrator) ometaFromState(rstate *backend.OrchestrationRuntimeState,
 	}
 }
 
-func (o *orchestrator) cleanup() {
-	if !o.closed.CompareAndSwap(false, true) {
-		return
-	}
-
-	o.table.Delete(o.actorID)
-	o.state = nil
-	o.rstate = nil
-	o.ometa = nil
-	o.ometaBroadcaster.Close()
-	o.lock.Close()
-	o.wg.Wait()
-	orchestratorCache.Put(o)
-}
-
 // This method purges all the completed activity data from a workflow associated with the given actorID
 func (o *orchestrator) purgeWorkflowState(ctx context.Context) error {
 	state, _, err := o.loadInternalState(ctx)

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -97,7 +97,7 @@ func (o *orchestrator) cleanupWorkflowStateInternal(ctx context.Context, state *
 		return err
 	}
 
-	o.cleanup()
+	o.factory.deactivate(o)
 
 	return nil
 }
@@ -149,11 +149,9 @@ func (o *orchestrator) cleanup() {
 	o.rstate = nil
 	o.ometa = nil
 	o.ometaBroadcaster.Close()
-
-	go func() {
-		o.wg.Wait()
-		orchestratorCache.Put(o)
-	}()
+	o.lock.Close()
+	o.wg.Wait()
+	orchestratorCache.Put(o)
 }
 
 // This method purges all the completed activity data from a workflow associated with the given actorID

--- a/pkg/actors/targets/workflow/orchestrator/stream.go
+++ b/pkg/actors/targets/workflow/orchestrator/stream.go
@@ -143,7 +143,7 @@ func (o *orchestrator) handleStreamInitial(ctx context.Context, req *internalsv1
 	}
 
 	if api.OrchestrationMetadataIsComplete(ometa) {
-		o.cleanup()
+		o.factory.deactivate(o)
 	}
 
 	select {

--- a/pkg/actors/targets/workflow/orchestrator/timer.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer.go
@@ -18,29 +18,18 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"github.com/dapr/durabletask-go/backend"
 )
 
 func (o *orchestrator) createTimers(ctx context.Context, es []*backend.HistoryEvent, generation uint64) error {
-	errs := make([]error, len(es))
-
-	var wg sync.WaitGroup
-	wg.Add(len(es))
-	for i, e := range es {
-		go func(i int, e *backend.HistoryEvent) {
-			defer wg.Done()
-
-			if err := o.createTimer(ctx, e, generation); err != nil {
-				errs[i] = err
-			}
-		}(i, e)
+	for _, e := range es {
+		if err := o.createTimer(ctx, e, generation); err != nil {
+			return err
+		}
 	}
 
-	wg.Wait()
-
-	return errors.Join(errs...)
+	return nil
 }
 
 func (o *orchestrator) createTimer(ctx context.Context, e *backend.HistoryEvent, generation uint64) error {

--- a/tests/integration/suite/daprd/workflow/continueasnew/activity.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/activity.go
@@ -98,12 +98,11 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 		}
 
 		for range 100 {
-			ctx.CallActivity("bar").Await(nil)
+			ctx.CallActivity("bar")
 		}
 
 		if cont.CompareAndSwap(false, true) {
 			ctx.ContinueAsNew("second call", task.WithKeepUnprocessedEvents())
-			return nil, nil
 		}
 
 		return nil, nil
@@ -152,8 +151,8 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, int64(200), barCalled.Load())
+		assert.Equal(c, int64(100), barCalled.Load())
 	}, time.Second*10, time.Millisecond*10)
 	time.Sleep(time.Second)
-	assert.Equal(t, int64(200), barCalled.Load())
+	assert.Equal(t, int64(100), barCalled.Load())
 }

--- a/tests/integration/suite/daprd/workflow/continueasnew/activity.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/activity.go
@@ -98,11 +98,12 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 		}
 
 		for range 100 {
-			ctx.CallActivity("bar")
+			ctx.CallActivity("bar").Await(nil)
 		}
 
 		if cont.CompareAndSwap(false, true) {
 			ctx.ContinueAsNew("second call", task.WithKeepUnprocessedEvents())
+			return nil, nil
 		}
 
 		return nil, nil
@@ -151,8 +152,8 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, int64(100), barCalled.Load())
+		assert.Equal(c, int64(200), barCalled.Load())
 	}, time.Second*10, time.Millisecond*10)
 	time.Sleep(time.Second)
-	assert.Equal(t, int64(100), barCalled.Load())
+	assert.Equal(t, int64(200), barCalled.Load())
 }


### PR DESCRIPTION
Update the workflow orchestrator target to reduce the number of go routines which are spawned, in favour of doing work sequentially. This reduces the overhead of go rountine context thrashing.

Uses a main deactivation channel in the orchestration factory to handle cleanup of orchestration state.

Updates the workflow locker to use a `Close` to signal close of the workflow entry points.