### PR TITLE
[1.16] fix(diagnostics): redirect

### DIFF
--- a/pkg/diagnostics/http_monitoring_path_matching.go
+++ b/pkg/diagnostics/http_monitoring_path_matching.go
@@ -124,6 +124,22 @@ func (pm *pathMatching) match(path string) (string, bool) {
 }
 
 type pathMatchingRW struct {
-	http.ResponseWriter
 	matchedPath string
+	header      http.Header
+}
+
+// Header returns a non-nil header map
+func (rw *pathMatchingRW) Header() http.Header {
+	if rw.header == nil {
+		rw.header = make(http.Header)
+	}
+	return rw.header
+}
+
+func (rw *pathMatchingRW) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+func (rw *pathMatchingRW) WriteHeader(statusCode int) {
+	// no-op
 }

--- a/pkg/diagnostics/http_monitoring_path_matching.go
+++ b/pkg/diagnostics/http_monitoring_path_matching.go
@@ -137,7 +137,7 @@ func (rw *pathMatchingRW) Header() http.Header {
 }
 
 func (rw *pathMatchingRW) Write(b []byte) (int, error) {
-	return 0, nil
+	return len(b), nil
 }
 
 func (rw *pathMatchingRW) WriteHeader(statusCode int) {

--- a/pkg/diagnostics/http_monitoring_test.go
+++ b/pkg/diagnostics/http_monitoring_test.go
@@ -297,6 +297,19 @@ func TestGetMetricsMethodExcludeVerbs(t *testing.T) {
 	assert.Equal(t, "", testHTTP.getMetricsMethod("INVALID"))
 }
 
+func TestHTTPMetricsPathMatchingWithRedirect(t *testing.T) {
+	const testPath = "/redirect-test"
+
+	pm := newPathMatching([]string{"/other-path"}, false)
+	pm.mux.HandleFunc(testPath, func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	})
+
+	matchedPath, ok := pm.match(testPath)
+	require.True(t, ok, "Expected path matching to succeed")
+	require.Equal(t, testPath, matchedPath, "Expected matched path to be %q", testPath)
+}
+
 func fakeHTTPRequest(body string) *http.Request {
 	req, err := http.NewRequest(http.MethodPost, "http://dapr.io/invoke/method/testmethod", strings.NewReader(body))
 	if err != nil {

--- a/tests/integration/framework/process/http/http.go
+++ b/tests/integration/framework/process/http/http.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -56,10 +57,17 @@ func New(t *testing.T, fopts ...Option) *HTTP {
 		opts.handler = handler
 	}
 
-	fp := ports.Reserve(t, 1)
+	var lis net.Listener
+	if opts.port != nil {
+		var err error
+		lis, err = net.Listen("tcp", "localhost:"+strconv.Itoa(*opts.port))
+		require.NoError(t, err)
+	} else {
+		lis = ports.Reserve(t, 1).Listener(t)
+	}
 
 	return &HTTP{
-		listener: fp.Listener(t),
+		listener: lis,
 		srvErrCh: make(chan error, 1),
 		server: &http.Server{
 			ReadHeaderTimeout: time.Second,

--- a/tests/integration/framework/process/http/options.go
+++ b/tests/integration/framework/process/http/options.go
@@ -27,11 +27,18 @@ type options struct {
 	handler      http.Handler
 	handlerFuncs map[string]http.HandlerFunc
 	tlsConfig    *tls.Config
+	port         *int
 }
 
 func WithHandler(handler http.Handler) Option {
 	return func(o *options) {
 		o.handler = handler
+	}
+}
+
+func WithPort(port int) Option {
+	return func(o *options) {
+		o.port = &port
 	}
 }
 

--- a/tests/integration/suite/daprd/serviceinvocation/http/redirect.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/redirect.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(redirect))
+}
+
+type redirect struct {
+	daprd  *daprd.Daprd
+	port   int
+	called atomic.Bool
+}
+
+func (r *redirect) Setup(t *testing.T) []framework.Option {
+	fp := ports.Reserve(t, 1)
+	r.port = fp.Port(t)
+
+	redirectHandler := func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, fmt.Sprintf("http://localhost:%d/helloworld", r.port), http.StatusMovedPermanently)
+	}
+
+	fp.Free(t)
+	srv1 := prochttp.New(t,
+		prochttp.WithPort(r.port),
+		prochttp.WithHandlerFunc("/events", redirectHandler),
+		prochttp.WithHandlerFunc("/helloworld", func(http.ResponseWriter, *http.Request) {
+			r.called.Store(true)
+		}),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: hello
+spec:
+  metrics:
+    enabled: true
+    rules: []
+    latencyDistributionBuckets: []
+    http:
+      increasedCardinality: true
+      pathMatching:
+        - /events
+        - /helloworld
+      excludeVerbs: false
+    recordErrorCodes: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(fp, srv1, r.daprd),
+	}
+}
+
+func (r *redirect) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/http://localhost:%d/method/events", r.daprd.HTTPPort(), r.port)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := client.HTTP(t).Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	assert.True(t, r.called.Load())
+}


### PR DESCRIPTION
**Description**

Fixes a `nil pointer dereference panic` in the HTTP metrics middleware that occurs when invoking a non-Dapr endpoint that returns an HTTP redirect. Panic was caused by an uninitialized `http.ResponseWriter` field in the `pathMatchingRW` struct. 

- Added a `Header()` implementation to `pathMatchingRW` that always returns a valid `http.Header` map.
 
- Implemented no-op `Write` and `WriteHeader` methods to satisfy the `http.ResponseWriter` interface when no underlying writer is present.

- Introduced a new unit test `TestHTTPMetricsPathMatchingWithRedirect` to simulate the scenario.

**Issue reference** - #8975

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing