### PR TITLE
[1.16] GH CI: Downgrade MacOS to 14

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -180,7 +180,8 @@ jobs:
             target_os: windows
             target_arch: amd64
             windows_version: ltsc2022
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: amd64
     env:
@@ -228,7 +229,8 @@ jobs:
             target_os: windows
             target_arch: amd64
             windows_version: ltsc2022
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: amd64
     env:
@@ -311,12 +313,14 @@ jobs:
             windows_version: ltsc2022
             job_name: "Windows LTSC 2022"
             sidecar_flavor: "allcomponents"
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: amd64
             job_name: "macOS/Intel"
             sidecar_flavor: "allcomponents"
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: arm64
             job_name: "macOS/Apple Silicon"

--- a/.github/workflows/test-tooling.yml
+++ b/.github/workflows/test-tooling.yml
@@ -17,14 +17,15 @@ permissions: {}
 jobs:
   lint:
     name: Test (${{ matrix.os}})
-    
+
     strategy:
       fail-fast: false
       matrix:
-        os: 
+        os:
           - "ubuntu-latest"
           - "windows-latest"
-          - "macos-latest"
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - "macos-14"
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -39,13 +39,12 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/binary"
 	"github.com/dapr/dapr/tests/integration/framework/client"
 	"github.com/dapr/dapr/tests/integration/framework/metrics"
-	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/ports"
 )
 
 type Daprd struct {
-	exec       process.Interface
+	exec       *exec.Exec
 	ports      *ports.Ports
 	httpClient *http.Client
 
@@ -486,4 +485,8 @@ func (d *Daprd) ActorInvokeURL(actorType, actorID, method string) string {
 
 func (d *Daprd) ActorReminderURL(actorType, actorID, method string) string {
 	return fmt.Sprintf("http://%s/v1.0/actors/%s/%s/reminders/%s", d.HTTPAddress(), actorType, actorID, method)
+}
+
+func (d *Daprd) Kill(t *testing.T) {
+	d.exec.Kill(t)
 }


### PR DESCRIPTION
Downgrades the macOS runner from `latest` (`15`) to `14`. This is
because mDNS is broken on `15` and causes the Dapr tests to fail. Once
mDNS is fixed in MacOS we can upgrade the runner back to `latest`.
