### PR TITLE
[1.15] GH CI: Downgrade MacOS to 14

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -181,7 +181,8 @@ jobs:
             target_os: windows
             target_arch: amd64
             windows_version: ltsc2022
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: amd64
     env:
@@ -229,7 +230,8 @@ jobs:
             target_os: windows
             target_arch: amd64
             windows_version: ltsc2022
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: amd64
     env:
@@ -312,12 +314,14 @@ jobs:
             windows_version: ltsc2022
             job_name: "Windows LTSC 2022"
             sidecar_flavor: "allcomponents"
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: amd64
             job_name: "macOS/Intel"
             sidecar_flavor: "allcomponents"
-          - os: macOS-latest
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - os: macos-14
             target_os: darwin
             target_arch: arm64
             job_name: "macOS/Apple Silicon"

--- a/.github/workflows/test-tooling.yml
+++ b/.github/workflows/test-tooling.yml
@@ -17,14 +17,15 @@ permissions: {}
 jobs:
   lint:
     name: Test (${{ matrix.os}})
-    
+
     strategy:
       fail-fast: false
       matrix:
-        os: 
+        os:
           - "ubuntu-latest"
           - "windows-latest"
-          - "macos-latest"
+          # TODO: @joshvanl Upgrade to latest once dns is fixed.
+          - "macos-14"
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
Downgrades the macOS runner from `latest` (`15`) to `14`. This is because mDNS is broken on `15` and causes the Dapr tests to fail. Once mDNS is fixed in MacOS we can upgrade the runner back to `latest`.
