### PR TITLE
[1.16] Fix e2e tests (state store reminders)

### DIFF
--- a/pkg/actors/api/track.go
+++ b/pkg/actors/api/track.go
@@ -38,7 +38,7 @@ func (r *ReminderTrack) MarshalJSON() ([]byte, error) {
 	}
 
 	if !r.LastFiredTime.IsZero() {
-		m.LastFiredTime = r.LastFiredTime.Format(time.RFC3339Nano)
+		m.LastFiredTime = r.LastFiredTime.Format(time.RFC3339)
 	}
 
 	return json.Marshal(m)
@@ -60,11 +60,12 @@ func (r *ReminderTrack) UnmarshalJSON(data []byte) error {
 	}
 
 	if m.LastFiredTime != "" {
-		// Try RFC3339Nano
-		r.LastFiredTime, err = time.Parse(time.RFC3339Nano, m.LastFiredTime)
+		r.LastFiredTime, err = time.Parse(time.RFC3339, m.LastFiredTime)
 		if err != nil {
 			return fmt.Errorf("failed to parse LastFiredTime: %w", err)
 		}
+		r.LastFiredTime = r.LastFiredTime.Truncate(time.Second)
 	}
+
 	return nil
 }

--- a/pkg/actors/internal/reminders/storage/statestore/statestore.go
+++ b/pkg/actors/internal/reminders/storage/statestore/statestore.go
@@ -137,7 +137,7 @@ func (r *Statestore) DrainRebalancedReminders() {
 
 func (r *Statestore) Create(ctx context.Context, req *api.CreateReminderRequest) error {
 	// Create the new reminder object
-	reminder, err := req.NewReminder(r.clock.Now())
+	reminder, err := req.NewReminder(r.clock.Now(), true)
 	if err != nil {
 		return err
 	}

--- a/pkg/actors/timers/timers.go
+++ b/pkg/actors/timers/timers.go
@@ -54,7 +54,7 @@ func (t *timers) Create(ctx context.Context, req *api.CreateTimerRequest) error 
 		return fmt.Errorf("can't create timer for actor %s: actor type not registered", req.ActorKey())
 	}
 
-	reminder, err := req.NewReminder(t.clock.Now())
+	reminder, err := req.NewReminder(t.clock.Now(), false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes the state store reminders by adding back the second precision truncation which the state store implementation relies upon. Scheduler based reminders continue to have any duration precision duration and times.

Fixes e2e tests.