### PR TITLE
Enhance logging for component startup failures

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -602,7 +602,7 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	a.appendBuiltinSecretStore(ctx)
 	err = a.loadComponents(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to load components: %s", err)
+		return fmt.Errorf("failed to load components: %w", err)
 	}
 
 	a.flushOutstandingComponents(ctx)


### PR DESCRIPTION
# Description

This PR enhances the logging for component startup failures.  
Previously, failure logs were generic and did not provide enough context to help diagnose issues.  
Now, the logs include:
- Component type
- Component name
- The specific error message
- Startup phase (where applicable)

This makes it easier for developers and operators to identify why a component failed to initialize.

## Issue reference

Please reference the issue this PR will close: #8236

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests (added unit test to simulate a component startup failure and check log output)
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_ (not required since this is internal logging improvement)
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_ (not applicable)
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_ (not applicable)