### PR TITLE
Fix SSE panic if service invocation is made with a streaming header

### DIFF
--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -388,7 +388,7 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 		//nolint:bodyclose
 		clientResp, clientErr := h.client.Do(r)
 		if clientResp != nil {
-			if sse {
+			if sse && req.HTTPResponseWriter() != nil {
 				callerResponseWriter := req.HTTPResponseWriter()
 
 				callerResponseWriter.Header().Set(headerContentType, mimeEventStream)


### PR DESCRIPTION
Fixes a bug where a Dapr to Dapr service invocation call will result in a panic if the caller includes a header that denotes a streaming request. This path is not yet supported.
