### PR TITLE
[1.16] Simplify X.509 & JWT logic

### DIFF
--- a/pkg/sentry/server/ca/bundle/bundle_test.go
+++ b/pkg/sentry/server/ca/bundle/bundle_test.go
@@ -29,88 +29,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateBundle(t *testing.T) {
+func TestGenerateX509Bundle(t *testing.T) {
 	// Create a root key for testing
 	x509RootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-
-	// Create a separate JWT key for testing
-	jwtRootKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	trustDomain := "test.example.com"
 	allowedClockSkew := 5 * time.Minute
 	overrideTTL := 24 * time.Hour
 
-	t.Run("with x509 only", func(t *testing.T) {
-		gen := MissingCredentials{
-			X509: true,
-			JWT:  false,
-		}
-
-		bundle, err := Generate(GenerateOptions{
-			X509RootKey:        x509RootKey,
-			JWTRootKey:         nil,
-			TrustDomain:        trustDomain,
-			AllowedClockSkew:   allowedClockSkew,
-			OverrideCATTL:      &overrideTTL,
-			MissingCredentials: gen,
+	t.Run("with x509", func(t *testing.T) {
+		bundle, err := GenerateX509(OptionsX509{
+			X509RootKey:      x509RootKey,
+			TrustDomain:      trustDomain,
+			AllowedClockSkew: allowedClockSkew,
+			OverrideCATTL:    &overrideTTL,
 		})
 		require.NoError(t, err)
 
 		// Verify X.509 components are present
-		require.NotEmpty(t, bundle.X509.TrustAnchors)
-		require.NotEmpty(t, bundle.X509.IssChainPEM)
-		require.NotEmpty(t, bundle.X509.IssKeyPEM)
-		require.NotNil(t, bundle.X509.IssChain)
-		require.NotNil(t, bundle.X509.IssKey)
-
-		// Verify JWT components are not present
-		require.Nil(t, bundle.JWT.SigningKey)
-		require.Empty(t, bundle.JWT.SigningKeyPEM)
-		require.Nil(t, bundle.JWT.JWKS)
-		require.Empty(t, bundle.JWT.JWKSJson)
+		require.NotEmpty(t, bundle.TrustAnchors)
+		require.NotEmpty(t, bundle.IssChainPEM)
+		require.NotEmpty(t, bundle.IssKeyPEM)
+		require.NotNil(t, bundle.IssChain)
+		require.NotNil(t, bundle.IssKey)
 
 		// Parse the generated certificates to verify them
-		rootCert, _ := decodePEM(t, bundle.X509.TrustAnchors)
+		rootCert, _ := decodePEM(t, bundle.TrustAnchors)
 		require.NotNil(t, rootCert)
 
 		// Verify TTL override was applied
 		require.WithinDuration(t, time.Now().Add(overrideTTL), rootCert.NotAfter, time.Minute)
 	})
 
-	t.Run("with jwt only", func(t *testing.T) {
-		gen := MissingCredentials{
-			X509: false,
-			JWT:  true,
-		}
-
-		bundle, err := Generate(GenerateOptions{
-			X509RootKey:        nil,
-			JWTRootKey:         jwtRootKey,
-			TrustDomain:        trustDomain,
-			AllowedClockSkew:   allowedClockSkew,
-			OverrideCATTL:      &overrideTTL,
-			MissingCredentials: gen,
+	t.Run("with nil TTL override", func(t *testing.T) {
+		bundle, err := GenerateX509(OptionsX509{
+			X509RootKey:      x509RootKey,
+			TrustDomain:      trustDomain,
+			AllowedClockSkew: allowedClockSkew,
+			OverrideCATTL:    nil,
 		})
 		require.NoError(t, err)
 
-		// Verify X.509 components are not present
-		require.Empty(t, bundle.X509.TrustAnchors)
-		require.Empty(t, bundle.X509.IssChainPEM)
-		require.Empty(t, bundle.X509.IssKeyPEM)
-		require.Nil(t, bundle.X509.IssChain)
-		require.Nil(t, bundle.X509.IssKey)
+		// Verify X.509 components are present with default TTL
+		block, _ := decodePEM(t, bundle.TrustAnchors)
+		rootCert, err := x509.ParseCertificate(block.Raw)
+		require.NoError(t, err)
+
+		// Default TTL is typically 1 year
+		expectedDefaultTTL := time.Hour * 24 * 365
+		require.WithinDuration(t, time.Now().Add(expectedDefaultTTL), rootCert.NotAfter, time.Hour*24)
+	})
+}
+
+func TestGenerateJWTBundle(t *testing.T) {
+	// Create a separate JWT key for testing
+	jwtRootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	trustDomain := "test.example.com"
+
+	t.Run("with jwt", func(t *testing.T) {
+		bundle, err := GenerateJWT(OptionsJWT{
+			JWTRootKey:  jwtRootKey,
+			TrustDomain: trustDomain,
+		})
+		require.NoError(t, err)
 
 		// Verify JWT components are present
-		require.NotNil(t, bundle.JWT.SigningKey)
-		require.NotEmpty(t, bundle.JWT.SigningKeyPEM)
-		require.NotNil(t, bundle.JWT.JWKS)
-		require.NotEmpty(t, bundle.JWT.JWKSJson)
+		require.NotNil(t, bundle.SigningKey)
+		require.NotEmpty(t, bundle.SigningKeyPEM)
+		require.NotNil(t, bundle.JWKS)
+		require.NotEmpty(t, bundle.JWKSJson)
 
 		// Parse JWKS to verify it
 		var jwksSet map[string]interface{}
-		err = json.Unmarshal(bundle.JWT.JWKSJson, &jwksSet)
+		err = json.Unmarshal(bundle.JWKSJson, &jwksSet)
 		require.NoError(t, err)
 
 		// Verify key has expected attributes
@@ -118,100 +112,13 @@ func TestGenerateBundle(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, keys, 1)
 
-		k, err := jwk.FromRaw(bundle.JWT.SigningKey)
+		k, err := jwk.FromRaw(bundle.SigningKey)
 		require.NoError(t, err)
 		tp, err := k.Thumbprint(DefaultKeyThumbprintAlgorithm)
 		require.NoError(t, err)
 		key := keys[0].(map[string]interface{})
 		require.Equal(t, base64.StdEncoding.EncodeToString(tp), key["kid"])
 		require.Equal(t, string(DefaultJWTSignatureAlgorithm), key["alg"])
-	})
-
-	t.Run("with both x509 and jwt", func(t *testing.T) {
-		gen := MissingCredentials{
-			X509: true,
-			JWT:  true,
-		}
-
-		bundle, err := Generate(GenerateOptions{
-			X509RootKey:        x509RootKey,
-			JWTRootKey:         jwtRootKey,
-			TrustDomain:        trustDomain,
-			AllowedClockSkew:   allowedClockSkew,
-			OverrideCATTL:      &overrideTTL,
-			MissingCredentials: gen,
-		})
-		require.NoError(t, err)
-
-		// Verify X.509 components are present
-		require.NotEmpty(t, bundle.X509.TrustAnchors)
-		require.NotEmpty(t, bundle.X509.IssChainPEM)
-		require.NotEmpty(t, bundle.X509.IssKeyPEM)
-		require.NotNil(t, bundle.X509.IssChain)
-		require.NotNil(t, bundle.X509.IssKey)
-
-		// Verify JWT components are present
-		require.NotNil(t, bundle.JWT.SigningKey)
-		require.NotEmpty(t, bundle.JWT.SigningKeyPEM)
-		require.NotNil(t, bundle.JWT.JWKS)
-		require.NotEmpty(t, bundle.JWT.JWKSJson)
-
-		// Verify the JWT key is the provided key
-		require.Equal(t, jwtRootKey, bundle.JWT.SigningKey)
-	})
-
-	t.Run("with neither x509 nor jwt", func(t *testing.T) {
-		gen := MissingCredentials{
-			X509: false,
-			JWT:  false,
-		}
-
-		bundle, err := Generate(GenerateOptions{
-			X509RootKey:        nil,
-			JWTRootKey:         nil,
-			TrustDomain:        trustDomain,
-			AllowedClockSkew:   allowedClockSkew,
-			OverrideCATTL:      &overrideTTL,
-			MissingCredentials: gen,
-		})
-		require.NoError(t, err)
-
-		// Verify bundle is empty
-		require.Empty(t, bundle.X509.TrustAnchors)
-		require.Empty(t, bundle.X509.IssChainPEM)
-		require.Empty(t, bundle.X509.IssKeyPEM)
-		require.Nil(t, bundle.X509.IssChain)
-		require.Nil(t, bundle.X509.IssKey)
-		require.Nil(t, bundle.JWT.SigningKey)
-		require.Empty(t, bundle.JWT.SigningKeyPEM)
-		require.Nil(t, bundle.JWT.JWKS)
-		require.Empty(t, bundle.JWT.JWKSJson)
-	})
-
-	t.Run("with nil TTL override", func(t *testing.T) {
-		gen := MissingCredentials{
-			X509: true,
-			JWT:  false,
-		}
-
-		bundle, err := Generate(GenerateOptions{
-			X509RootKey:        x509RootKey,
-			JWTRootKey:         nil,
-			TrustDomain:        trustDomain,
-			AllowedClockSkew:   allowedClockSkew,
-			OverrideCATTL:      nil,
-			MissingCredentials: gen,
-		})
-		require.NoError(t, err)
-
-		// Verify X.509 components are present with default TTL
-		block, _ := decodePEM(t, bundle.X509.TrustAnchors)
-		rootCert, err := x509.ParseCertificate(block.Raw)
-		require.NoError(t, err)
-
-		// Default TTL is typically 1 year
-		expectedDefaultTTL := time.Hour * 24 * 365
-		require.WithinDuration(t, time.Now().Add(expectedDefaultTTL), rootCert.NotAfter, time.Hour*24)
 	})
 }
 

--- a/pkg/sentry/server/ca/ca_test.go
+++ b/pkg/sentry/server/ca/ca_test.go
@@ -39,237 +39,279 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	t.Run("if no existing bundle exist, new should generate a new bundle", func(t *testing.T) {
-		t.Setenv("NAMESPACE", "dapr-test")
-		t.Cleanup(func() {
-			os.Unsetenv("NAMESPACE")
+	t.Run("if no existing bundle exist, new should generate a new bundle",
+		func(t *testing.T) {
+			t.Setenv("NAMESPACE", "dapr-test")
+			t.Cleanup(func() {
+				os.Unsetenv("NAMESPACE")
+			})
+
+			dir := t.TempDir()
+			rootCertPath := filepath.Join(dir, "root.cert")
+			issuerCertPath := filepath.Join(dir, "issuer.cert")
+			issuerKeyPath := filepath.Join(dir, "issuer.key")
+			config := config.Config{
+				RootCertPath:   rootCertPath,
+				IssuerCertPath: issuerCertPath,
+				IssuerKeyPath:  issuerKeyPath,
+				JWT: config.ConfigJWT{
+					Enabled: true,
+					TTL:     config.DefaultJWTTTL,
+				},
+				TrustDomain: "test.example.com",
+				Mode:        modes.StandaloneMode,
+			}
+
+			_, err := New(t.Context(), config)
+			require.NoError(t, err)
+
+			// Check that all certificate and key files were generated
+			require.FileExists(t, rootCertPath)
+			require.FileExists(t, issuerCertPath)
+			require.FileExists(t, issuerKeyPath)
+
+			rootCert, err := os.ReadFile(rootCertPath)
+			require.NoError(t, err)
+			issuerCert, err := os.ReadFile(issuerCertPath)
+			require.NoError(t, err)
+			issuerKey, err := os.ReadFile(issuerKeyPath)
+			require.NoError(t, err)
+
+			// Verify certificate content
+			rootCertX509, err := pem.DecodePEMCertificates(rootCert)
+			require.NoError(t, err)
+			require.Len(t, rootCertX509, 1)
+			assert.Equal(t, []string{"test.example.com"}, rootCertX509[0].Subject.Organization)
+
+			issuerCertX509, err := pem.DecodePEMCertificates(issuerCert)
+			require.NoError(t, err)
+			require.Len(t, issuerCertX509, 1)
+			assert.Equal(t, []string{"spiffe://test.example.com/ns/dapr-test/dapr-sentry"}, issuerCertX509[0].Subject.Organization)
+
+			issuerKeyPK, err := pem.DecodePEMPrivateKey(issuerKey)
+			require.NoError(t, err)
+
+			require.NoError(t, issuerCertX509[0].CheckSignatureFrom(rootCertX509[0]))
+			ok, err := pem.PublicKeysEqual(issuerCertX509[0].PublicKey, issuerKeyPK.Public())
+			require.NoError(t, err)
+			assert.True(t, ok)
 		})
 
-		dir := t.TempDir()
-		rootCertPath := filepath.Join(dir, "root.cert")
-		issuerCertPath := filepath.Join(dir, "issuer.cert")
-		issuerKeyPath := filepath.Join(dir, "issuer.key")
-		config := config.Config{
-			RootCertPath:   rootCertPath,
-			IssuerCertPath: issuerCertPath,
-			IssuerKeyPath:  issuerKeyPath,
-			JWT: config.ConfigJWT{
-				Enabled: true,
-				TTL:     config.DefaultJWTTTL,
-			},
-			TrustDomain: "test.example.com",
-			Mode:        modes.StandaloneMode,
-		}
+	t.Run("if no existing bundle exist, new should generate a new bundle with jwt",
+		func(t *testing.T) {
+			t.Setenv("NAMESPACE", "dapr-test")
+			t.Cleanup(func() {
+				os.Unsetenv("NAMESPACE")
+			})
 
-		_, err := New(t.Context(), config)
-		require.NoError(t, err)
+			dir := t.TempDir()
+			rootCertPath := filepath.Join(dir, "root.cert")
+			issuerCertPath := filepath.Join(dir, "issuer.cert")
+			issuerKeyPath := filepath.Join(dir, "issuer.key")
+			jwksPath := filepath.Join(dir, "jwks.json")
+			jwtKeyPath := filepath.Join(dir, "jwt.key")
+			config := config.Config{
+				RootCertPath:   rootCertPath,
+				IssuerCertPath: issuerCertPath,
+				IssuerKeyPath:  issuerKeyPath,
+				JWT: config.ConfigJWT{
+					Enabled:          true,
+					JWKSPath:         jwksPath,
+					SigningKeyPath:   jwtKeyPath,
+					SigningAlgorithm: ca_bundle.DefaultJWTSignatureAlgorithm.String(),
+					TTL:              config.DefaultJWTTTL,
+				},
+				TrustDomain: "test.example.com",
+				Mode:        modes.StandaloneMode,
+			}
 
-		// Check that all certificate and key files were generated
-		require.FileExists(t, rootCertPath)
-		require.FileExists(t, issuerCertPath)
-		require.FileExists(t, issuerKeyPath)
+			caObj, err := New(t.Context(), config)
+			require.NoError(t, err)
 
-		rootCert, err := os.ReadFile(rootCertPath)
-		require.NoError(t, err)
-		issuerCert, err := os.ReadFile(issuerCertPath)
-		require.NoError(t, err)
-		issuerKey, err := os.ReadFile(issuerKeyPath)
-		require.NoError(t, err)
+			// Check that all certificate and key files were generated
+			require.FileExists(t, rootCertPath)
+			require.FileExists(t, issuerCertPath)
+			require.FileExists(t, issuerKeyPath)
+			require.FileExists(t, jwksPath)
+			require.FileExists(t, jwtKeyPath)
 
-		// Verify certificate content
-		rootCertX509, err := pem.DecodePEMCertificates(rootCert)
-		require.NoError(t, err)
-		require.Len(t, rootCertX509, 1)
-		assert.Equal(t, []string{"test.example.com"}, rootCertX509[0].Subject.Organization)
+			rootCert, err := os.ReadFile(rootCertPath)
+			require.NoError(t, err)
+			issuerCert, err := os.ReadFile(issuerCertPath)
+			require.NoError(t, err)
+			require.NotEmpty(t, issuerCert)
+			issuerKey, err := os.ReadFile(issuerKeyPath)
+			require.NoError(t, err)
+			jwksData, err := os.ReadFile(jwksPath)
+			require.NoError(t, err)
+			jwtKey, err := os.ReadFile(jwtKeyPath)
+			require.NoError(t, err)
 
-		issuerCertX509, err := pem.DecodePEMCertificates(issuerCert)
-		require.NoError(t, err)
-		require.Len(t, issuerCertX509, 1)
-		assert.Equal(t, []string{"spiffe://test.example.com/ns/dapr-test/dapr-sentry"}, issuerCertX509[0].Subject.Organization)
+			// Verify certificate content
+			rootCertX509, err := pem.DecodePEMCertificates(rootCert)
+			require.NoError(t, err)
+			require.Len(t, rootCertX509, 1)
+			assert.Equal(t, []string{"test.example.com"}, rootCertX509[0].Subject.Organization)
 
-		issuerKeyPK, err := pem.DecodePEMPrivateKey(issuerKey)
-		require.NoError(t, err)
+			issuerCertX509, err := pem.DecodePEMCertificates(issuerCert)
+			require.NoError(t, err)
+			require.Len(t, issuerCertX509, 1)
+			assert.Equal(t, []string{"spiffe://test.example.com/ns/dapr-test/dapr-sentry"}, issuerCertX509[0].Subject.Organization)
 
-		require.NoError(t, issuerCertX509[0].CheckSignatureFrom(rootCertX509[0]))
-		ok, err := pem.PublicKeysEqual(issuerCertX509[0].PublicKey, issuerKeyPK.Public())
-		require.NoError(t, err)
-		assert.True(t, ok)
-	})
+			issuerKeyPK, err := pem.DecodePEMPrivateKey(issuerKey)
+			require.NoError(t, err)
 
-	t.Run("if no existing bundle exist, new should generate a new bundle with jwt", func(t *testing.T) {
-		t.Setenv("NAMESPACE", "dapr-test")
-		t.Cleanup(func() {
-			os.Unsetenv("NAMESPACE")
+			require.NoError(t, issuerCertX509[0].CheckSignatureFrom(rootCertX509[0]))
+			ok, err := pem.PublicKeysEqual(issuerCertX509[0].PublicKey, issuerKeyPK.Public())
+			require.NoError(t, err)
+			assert.True(t, ok)
+
+			// Verify JWT content
+			require.NotEmpty(t, jwksData)
+			jwks, err := jwk.Parse(jwksData)
+			require.NoError(t, err)
+			require.NotNil(t, jwks)
+
+			// JWKS should have exactly one key
+			require.Equal(t, 1, jwks.Len(), "JWKS should contain exactly one key")
+
+			// Get the first key from the jwks
+			key, ok := jwks.Key(0)
+			require.True(t, ok, "JWKS should contain a key at index 0")
+			require.NotNil(t, key)
+
+			// Key should have the expected key ID and algorithm
+			thumbprint, err := key.Thumbprint(ca_bundle.DefaultKeyThumbprintAlgorithm)
+			require.NoError(t, err)
+			kid, ok := key.Get(jwk.KeyIDKey)
+			require.True(t, ok, "Key should have a key ID")
+			require.Equal(t, base64.StdEncoding.EncodeToString(thumbprint), kid)
+
+			alg, ok := key.Get(jwk.AlgorithmKey)
+			require.True(t, ok, "Key should have an algorithm")
+			algStr := alg.(jwa.SignatureAlgorithm).String()
+			require.Equal(t, ca_bundle.DefaultJWTSignatureAlgorithm.String(), algStr)
+
+			// JWT key should be valid
+			jwtKeyPK, err := pem.DecodePEMPrivateKey(jwtKey)
+			require.NoError(t, err)
+			require.NotNil(t, jwtKeyPK)
+
+			// Verify JWT functionality by generating a token
+			caInstance := caObj.(*ca)
+			require.NotNil(t, caInstance.Issuer)
+
+			// Generate a JWT
+			jwtToken, err := caInstance.Generate(t.Context(), &jwt.Request{
+				TrustDomain: spiffeid.RequireTrustDomainFromString("test.example.com"),
+				Audiences:   []string{"test.example.com"},
+				Namespace:   "test-namespace",
+				AppID:       "test-app",
+				TTL:         time.Hour,
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, jwtToken)
+
+			// Parse and verify the token using the JWKS
+			parsedToken, err := jwx_jwt.Parse([]byte(jwtToken),
+				jwx_jwt.WithKeySet(jwks),
+				jwx_jwt.WithValidate(true))
+			require.NoError(t, err)
+
+			// Verify token claims
+			sub, ok := parsedToken.Get("sub")
+			require.True(t, ok, "subject claim should exist")
+			require.Equal(t, "spiffe://test.example.com/ns/test-namespace/test-app", sub)
 		})
 
-		dir := t.TempDir()
-		rootCertPath := filepath.Join(dir, "root.cert")
-		issuerCertPath := filepath.Join(dir, "issuer.cert")
-		issuerKeyPath := filepath.Join(dir, "issuer.key")
-		jwksPath := filepath.Join(dir, "jwks.json")
-		jwtKeyPath := filepath.Join(dir, "jwt.key")
-		config := config.Config{
-			RootCertPath:   rootCertPath,
-			IssuerCertPath: issuerCertPath,
-			IssuerKeyPath:  issuerKeyPath,
-			JWT: config.ConfigJWT{
-				Enabled:          true,
-				JWKSPath:         jwksPath,
-				SigningKeyPath:   jwtKeyPath,
-				SigningAlgorithm: ca_bundle.DefaultJWTSignatureAlgorithm.String(),
-				TTL:              config.DefaultJWTTTL,
-			},
-			TrustDomain: "test.example.com",
-			Mode:        modes.StandaloneMode,
-		}
+	t.Run("if existing pool, new should load from it",
+		func(t *testing.T) {
+			dir := t.TempDir()
+			rootCertPath := filepath.Join(dir, "root.cert")
+			issuerCertPath := filepath.Join(dir, "issuer.cert")
+			issuerKeyPath := filepath.Join(dir, "issuer.key")
+			config := config.Config{
+				RootCertPath:   rootCertPath,
+				IssuerCertPath: issuerCertPath,
+				IssuerKeyPath:  issuerKeyPath,
+				Mode:           modes.StandaloneMode,
+			}
 
-		caObj, err := New(t.Context(), config)
-		require.NoError(t, err)
+			rootPEM, rootCrt, _, rootPK := genCrt(t, "root", nil, nil)
+			rootPEM2, _, _, _ := genCrt(t, "root2", nil, nil)
+			int1PEM, int1Crt, _, int1PK := genCrt(t, "int1", rootCrt, rootPK)
+			int2PEM, int2Crt, int2PKPEM, int2PK := genCrt(t, "int2", int1Crt, int1PK)
 
-		// Check that all certificate and key files were generated
-		require.FileExists(t, rootCertPath)
-		require.FileExists(t, issuerCertPath)
-		require.FileExists(t, issuerKeyPath)
-		require.FileExists(t, jwksPath)
-		require.FileExists(t, jwtKeyPath)
+			//nolint:gocritic
+			rootFileContents := append(rootPEM, rootPEM2...)
+			//nolint:gocritic
+			issuerFileContents := append(int2PEM, int1PEM...)
+			issuerKeyFileContents := int2PKPEM
 
-		rootCert, err := os.ReadFile(rootCertPath)
-		require.NoError(t, err)
-		issuerCert, err := os.ReadFile(issuerCertPath)
-		require.NoError(t, err)
-		issuerKey, err := os.ReadFile(issuerKeyPath)
-		require.NoError(t, err)
-		jwksData, err := os.ReadFile(jwksPath)
-		require.NoError(t, err)
-		jwtKey, err := os.ReadFile(jwtKeyPath)
-		require.NoError(t, err)
+			require.NoError(t, os.WriteFile(rootCertPath, rootFileContents, 0o600))
+			require.NoError(t, os.WriteFile(issuerCertPath, issuerFileContents, 0o600))
+			require.NoError(t, os.WriteFile(issuerKeyPath, issuerKeyFileContents, 0o600))
 
-		// Verify certificate content
-		rootCertX509, err := pem.DecodePEMCertificates(rootCert)
-		require.NoError(t, err)
-		require.Len(t, rootCertX509, 1)
-		assert.Equal(t, []string{"test.example.com"}, rootCertX509[0].Subject.Organization)
+			caImp, err := New(t.Context(), config)
+			require.NoError(t, err)
 
-		issuerCertX509, err := pem.DecodePEMCertificates(issuerCert)
-		require.NoError(t, err)
-		require.Len(t, issuerCertX509, 1)
-		assert.Equal(t, []string{"spiffe://test.example.com/ns/dapr-test/dapr-sentry"}, issuerCertX509[0].Subject.Organization)
+			rootCert, err := os.ReadFile(rootCertPath)
+			require.NoError(t, err)
+			issuerCert, err := os.ReadFile(issuerCertPath)
+			require.NoError(t, err)
+			issuerKey, err := os.ReadFile(issuerKeyPath)
+			require.NoError(t, err)
 
-		issuerKeyPK, err := pem.DecodePEMPrivateKey(issuerKey)
-		require.NoError(t, err)
+			assert.Equal(t, rootFileContents, rootCert)
+			assert.Equal(t, issuerFileContents, issuerCert)
+			assert.Equal(t, issuerKeyFileContents, issuerKey)
 
-		require.NoError(t, issuerCertX509[0].CheckSignatureFrom(rootCertX509[0]))
-		ok, err := pem.PublicKeysEqual(issuerCertX509[0].PublicKey, issuerKeyPK.Public())
-		require.NoError(t, err)
-		assert.True(t, ok)
-
-		// Verify JWT content
-		require.NotEmpty(t, jwksData)
-		jwks, err := jwk.Parse(jwksData)
-		require.NoError(t, err)
-		require.NotNil(t, jwks)
-
-		// JWKS should have exactly one key
-		require.Equal(t, 1, jwks.Len(), "JWKS should contain exactly one key")
-
-		// Get the first key from the jwks
-		key, ok := jwks.Key(0)
-		require.True(t, ok, "JWKS should contain a key at index 0")
-		require.NotNil(t, key)
-
-		// Key should have the expected key ID and algorithm
-		thumbprint, err := key.Thumbprint(ca_bundle.DefaultKeyThumbprintAlgorithm)
-		require.NoError(t, err)
-		kid, ok := key.Get(jwk.KeyIDKey)
-		require.True(t, ok, "Key should have a key ID")
-		require.Equal(t, base64.StdEncoding.EncodeToString(thumbprint), kid)
-
-		alg, ok := key.Get(jwk.AlgorithmKey)
-		require.True(t, ok, "Key should have an algorithm")
-		algStr := alg.(jwa.SignatureAlgorithm).String()
-		require.Equal(t, ca_bundle.DefaultJWTSignatureAlgorithm.String(), algStr)
-
-		// JWT key should be valid
-		jwtKeyPK, err := pem.DecodePEMPrivateKey(jwtKey)
-		require.NoError(t, err)
-		require.NotNil(t, jwtKeyPK)
-
-		// Verify JWT functionality by generating a token
-		caInstance := caObj.(*ca)
-		require.NotNil(t, caInstance.Issuer)
-
-		// Generate a JWT
-		jwtToken, err := caInstance.Generate(t.Context(), &jwt.Request{
-			TrustDomain: spiffeid.RequireTrustDomainFromString("test.example.com"),
-			Audiences:   []string{"test.example.com"},
-			Namespace:   "test-namespace",
-			AppID:       "test-app",
-			TTL:         time.Hour,
+			// Only compare the X.509 certificate fields, not the JWT fields
+			bundle := caImp.(*ca).bundle
+			assert.Equal(t, rootFileContents, bundle.X509.TrustAnchors)
+			assert.Equal(t, issuerFileContents, bundle.X509.IssChainPEM)
+			assert.Equal(t, issuerKeyFileContents, bundle.X509.IssKeyPEM)
+			assert.Equal(t, []*x509.Certificate{int2Crt, int1Crt}, bundle.X509.IssChain)
+			assert.Equal(t, int2PK, bundle.X509.IssKey)
 		})
-		require.NoError(t, err)
-		require.NotEmpty(t, jwtToken)
 
-		// Parse and verify the token using the JWKS
-		parsedToken, err := jwx_jwt.Parse([]byte(jwtToken),
-			jwx_jwt.WithKeySet(jwks),
-			jwx_jwt.WithValidate(true))
-		require.NoError(t, err)
+	t.Run("if existing pool exists but root and intermediate are the same, new should fail when asked to generate JWT keys",
+		func(t *testing.T) {
+			dir := t.TempDir()
+			rootCertPath := filepath.Join(dir, "root.cert")
+			issuerCertPath := filepath.Join(dir, "issuer.cert")
+			issuerKeyPath := filepath.Join(dir, "issuer.key")
+			jwksPath := filepath.Join(dir, "jwks.json")
+			jwtKeyPath := filepath.Join(dir, "jwt.key")
+			config := config.Config{
+				RootCertPath:   rootCertPath,
+				IssuerCertPath: issuerCertPath,
+				IssuerKeyPath:  issuerKeyPath,
+				JWT: config.ConfigJWT{
+					Enabled:          true,
+					JWKSPath:         jwksPath,
+					SigningKeyPath:   jwtKeyPath,
+					SigningAlgorithm: ca_bundle.DefaultJWTSignatureAlgorithm.String(),
+					TTL:              config.DefaultJWTTTL,
+				},
+				TrustDomain: "test.example.com",
+				Mode:        modes.StandaloneMode,
+			}
 
-		// Verify token claims
-		sub, ok := parsedToken.Get("sub")
-		require.True(t, ok, "subject claim should exist")
-		require.Equal(t, "spiffe://test.example.com/ns/test-namespace/test-app", sub)
-	})
+			rootPEM, _, rootPEMKey, _ := genCrt(t, "root", nil, nil)
 
-	t.Run("if existing pool exists, new should load the existing pool", func(t *testing.T) {
-		dir := t.TempDir()
-		rootCertPath := filepath.Join(dir, "root.cert")
-		issuerCertPath := filepath.Join(dir, "issuer.cert")
-		issuerKeyPath := filepath.Join(dir, "issuer.key")
-		config := config.Config{
-			RootCertPath:   rootCertPath,
-			IssuerCertPath: issuerCertPath,
-			IssuerKeyPath:  issuerKeyPath,
-			Mode:           modes.StandaloneMode,
-		}
+			// both root and intermediate are the same document
+			rootFileContents := rootPEM
+			issuerFileContents := rootPEM
+			issuerKeyFileContents := rootPEMKey
 
-		rootPEM, rootCrt, _, rootPK := genCrt(t, "root", nil, nil)
-		rootPEM2, _, _, _ := genCrt(t, "root2", nil, nil)
-		int1PEM, int1Crt, _, int1PK := genCrt(t, "int1", rootCrt, rootPK)
-		int2PEM, int2Crt, int2PKPEM, int2PK := genCrt(t, "int2", int1Crt, int1PK)
+			require.NoError(t, os.WriteFile(rootCertPath, rootFileContents, 0o600))
+			require.NoError(t, os.WriteFile(issuerCertPath, issuerFileContents, 0o600))
+			require.NoError(t, os.WriteFile(issuerKeyPath, issuerKeyFileContents, 0o600))
 
-		//nolint:gocritic
-		rootFileContents := append(rootPEM, rootPEM2...)
-		//nolint:gocritic
-		issuerFileContents := append(int2PEM, int1PEM...)
-		issuerKeyFileContents := int2PKPEM
-
-		require.NoError(t, os.WriteFile(rootCertPath, rootFileContents, 0o600))
-		require.NoError(t, os.WriteFile(issuerCertPath, issuerFileContents, 0o600))
-		require.NoError(t, os.WriteFile(issuerKeyPath, issuerKeyFileContents, 0o600))
-
-		caImp, err := New(t.Context(), config)
-		require.NoError(t, err)
-
-		rootCert, err := os.ReadFile(rootCertPath)
-		require.NoError(t, err)
-		issuerCert, err := os.ReadFile(issuerCertPath)
-		require.NoError(t, err)
-		issuerKey, err := os.ReadFile(issuerKeyPath)
-		require.NoError(t, err)
-
-		assert.Equal(t, rootFileContents, rootCert)
-		assert.Equal(t, issuerFileContents, issuerCert)
-		assert.Equal(t, issuerKeyFileContents, issuerKey)
-
-		// Only compare the X.509 certificate fields, not the JWT fields
-		bundle := caImp.(*ca).bundle
-		assert.Equal(t, rootFileContents, bundle.X509.TrustAnchors)
-		assert.Equal(t, issuerFileContents, bundle.X509.IssChainPEM)
-		assert.Equal(t, issuerKeyFileContents, bundle.X509.IssKeyPEM)
-		assert.Equal(t, []*x509.Certificate{int2Crt, int1Crt}, bundle.X509.IssChain)
-		assert.Equal(t, int2PK, bundle.X509.IssKey)
-	})
+			_, err := New(t.Context(), config)
+			require.Error(t, err)
+		})
 }
 
 func TestSignIdentity(t *testing.T) {

--- a/pkg/sentry/server/ca/kube.go
+++ b/pkg/sentry/server/ca/kube.go
@@ -149,7 +149,10 @@ func (k *kube) store(ctx context.Context, bundle bundle.Bundle) error {
 	// If the OIDC server is enabled, clients could use that to access the JWKS
 	// to verify JWTs. However, the OIDC server is not required and so it is
 	// useful to also distribute the JWKS in the configmap.
-	configMap.Data[filepath.Base(k.config.JWT.JWKSPath)] = string(bundle.JWT.JWKSJson)
+	delete(configMap.Data, filepath.Base(k.config.JWT.JWKSPath))
+	if bundle.JWT != nil {
+		configMap.Data[filepath.Base(k.config.JWT.JWKSPath)] = string(bundle.JWT.JWKSJson)
+	}
 
 	if _, err = k.client.CoreV1().ConfigMaps(k.namespace).Update(ctx, configMap, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update trust bundle configmap: %w", err)

--- a/pkg/sentry/server/ca/kube.go
+++ b/pkg/sentry/server/ca/kube.go
@@ -120,11 +120,13 @@ func (k *kube) store(ctx context.Context, bundle bundle.Bundle) error {
 	secret.Data[filepath.Base(k.config.IssuerKeyPath)] = bundle.X509.IssKeyPEM
 
 	// Add JWT related data if available
-	if bundle.JWT.SigningKeyPEM != nil {
-		secret.Data[filepath.Base(k.config.JWT.SigningKeyPath)] = bundle.JWT.SigningKeyPEM
-	}
-	if bundle.JWT.JWKSJson != nil {
-		secret.Data[filepath.Base(k.config.JWT.JWKSPath)] = bundle.JWT.JWKSJson
+	if bundle.JWT != nil {
+		if bundle.JWT.SigningKeyPEM != nil {
+			secret.Data[filepath.Base(k.config.JWT.SigningKeyPath)] = bundle.JWT.SigningKeyPEM
+		}
+		if bundle.JWT.JWKSJson != nil {
+			secret.Data[filepath.Base(k.config.JWT.JWKSPath)] = bundle.JWT.JWKSJson
+		}
 	}
 
 	// Update the Secret

--- a/pkg/sentry/server/ca/kube_test.go
+++ b/pkg/sentry/server/ca/kube_test.go
@@ -51,34 +51,11 @@ func TestKube_get(t *testing.T) {
 	jwks, err := jwk.Parse(jwksBytes)
 	require.NoError(t, err)
 
-	shouldGenX509 := func(g ca_bundle.MissingCredentials) bool {
-		return g.X509
-	}
-	shouldNotGenX509 := func(g ca_bundle.MissingCredentials) bool {
-		return !g.X509
-	}
-	shouldGenJWT := func(g ca_bundle.MissingCredentials) bool {
-		return g.JWT
-	}
-	shouldGenX509Exclusive := func(g ca_bundle.MissingCredentials) bool {
-		return g.X509 && !g.JWT
-	}
-	shouldGenJWTExclusive := func(g ca_bundle.MissingCredentials) bool {
-		return !g.X509 && g.JWT
-	}
-	shouldGenAll := func(g ca_bundle.MissingCredentials) bool {
-		return g.X509 && g.JWT
-	}
-	shouldNotGen := func(g ca_bundle.MissingCredentials) bool {
-		return !g.X509 && !g.JWT
-	}
-
 	tests := map[string]struct {
-		sec         *corev1.Secret
-		cm          *corev1.ConfigMap
-		expBundle   ca_bundle.Bundle
-		expGenCheck func(ca_bundle.MissingCredentials) bool
-		expErr      bool
+		sec       *corev1.Secret
+		cm        *corev1.ConfigMap
+		expBundle ca_bundle.Bundle
+		expErr    bool
 	}{
 		"if secret doesn't exist, expect error": {
 			sec: nil,
@@ -89,9 +66,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: nil,
-			expErr:      true,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    true,
 		},
 		"if configmap doesn't exist, expect error": {
 			sec: &corev1.Secret{
@@ -105,10 +81,9 @@ func TestKube_get(t *testing.T) {
 					"tls.crt": intPEM,
 				},
 			},
-			cm:          nil,
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: nil,
-			expErr:      true,
+			cm:        nil,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    true,
 		},
 		"if secret doesn't include ca.crt, expect to generate x509": {
 			sec: &corev1.Secret{
@@ -128,9 +103,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: shouldGenX509,
-			expErr:      false,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    false,
 		},
 		"if secret doesn't include tls.crt, expect to generate x509": {
 			sec: &corev1.Secret{
@@ -150,9 +124,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: shouldGenX509,
-			expErr:      false,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    false,
 		},
 		"if secret doesn't include tls.key, expect to generate x509": {
 			sec: &corev1.Secret{
@@ -172,9 +145,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: shouldGenX509,
-			expErr:      false,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    false,
 		},
 		"if configmap doesn't include ca.crt, expect to generate x509": {
 			sec: &corev1.Secret{
@@ -195,9 +167,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: shouldGenX509,
-			expErr:      false,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    false,
 		},
 		"if trust anchors do not match, expect not to generate x509": {
 			sec: &corev1.Secret{
@@ -218,9 +189,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM) + "\n" + string(rootPEM2)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: shouldGenX509,
-			expErr:      false,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    false,
 		},
 		"if bundle fails to verify x509, expect error": {
 			sec: &corev1.Secret{
@@ -241,9 +211,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM2)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: nil,
-			expErr:      true,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    true,
 		},
 		"if x509 only bundle is valid, expect to not generate x509 and return bundle": {
 			sec: &corev1.Secret{
@@ -265,7 +234,7 @@ func TestKube_get(t *testing.T) {
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
 			expBundle: ca_bundle.Bundle{
-				X509: ca_bundle.X509{
+				X509: &ca_bundle.X509{
 					TrustAnchors: rootPEM,
 					IssChainPEM:  intPEM,
 					IssKeyPEM:    intPKPEM,
@@ -273,8 +242,7 @@ func TestKube_get(t *testing.T) {
 					IssKey:       intPK,
 				},
 			},
-			expGenCheck: shouldNotGenX509,
-			expErr:      false,
+			expErr: false,
 		},
 		"if secret doesn't include jwt.key, expect to generate jwt": {
 			sec: &corev1.Secret{
@@ -296,7 +264,7 @@ func TestKube_get(t *testing.T) {
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
 			expBundle: ca_bundle.Bundle{
-				X509: ca_bundle.X509{
+				X509: &ca_bundle.X509{
 					TrustAnchors: rootPEM,
 					IssChainPEM:  intPEM,
 					IssKeyPEM:    intPKPEM,
@@ -304,8 +272,7 @@ func TestKube_get(t *testing.T) {
 					IssKey:       intPK,
 				},
 			},
-			expGenCheck: shouldGenJWT,
-			expErr:      false,
+			expErr: false,
 		},
 		"if secret doesn't include jwks.json, expect to generate jwt": {
 			sec: &corev1.Secret{
@@ -328,7 +295,7 @@ func TestKube_get(t *testing.T) {
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
 			expBundle: ca_bundle.Bundle{
-				X509: ca_bundle.X509{
+				X509: &ca_bundle.X509{
 					TrustAnchors: rootPEM,
 					IssChainPEM:  intPEM,
 					IssKeyPEM:    intPKPEM,
@@ -336,8 +303,7 @@ func TestKube_get(t *testing.T) {
 					IssKey:       intPK,
 				},
 			},
-			expGenCheck: shouldGenJWT,
-			expErr:      false,
+			expErr: false,
 		},
 		"if secret doesn't include jwt.key or jwks.json, expect to generate jwt": {
 			sec: &corev1.Secret{
@@ -359,7 +325,7 @@ func TestKube_get(t *testing.T) {
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
 			expBundle: ca_bundle.Bundle{
-				X509: ca_bundle.X509{
+				X509: &ca_bundle.X509{
 					TrustAnchors: rootPEM,
 					IssChainPEM:  intPEM,
 					IssKeyPEM:    intPKPEM,
@@ -367,8 +333,7 @@ func TestKube_get(t *testing.T) {
 					IssKey:       intPK,
 				},
 			},
-			expGenCheck: shouldGenJWT,
-			expErr:      false,
+			expErr: false,
 		},
 		"if jwt.key is invalid, expect error": {
 			sec: &corev1.Secret{
@@ -391,9 +356,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: nil,
-			expErr:      true,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    true,
 		},
 		"if jwks.json is invalid, expect error": {
 			sec: &corev1.Secret{
@@ -416,9 +380,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: nil,
-			expErr:      true,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    true,
 		},
 		"valid bundle with both x509 and jwt components": {
 			sec: &corev1.Secret{
@@ -442,22 +405,21 @@ func TestKube_get(t *testing.T) {
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
 			expBundle: ca_bundle.Bundle{
-				X509: ca_bundle.X509{
+				X509: &ca_bundle.X509{
 					TrustAnchors: rootPEM,
 					IssChainPEM:  intPEM,
 					IssKeyPEM:    intPKPEM,
 					IssChain:     []*x509.Certificate{intCrt},
 					IssKey:       intPK,
 				},
-				JWT: ca_bundle.JWT{
+				JWT: &ca_bundle.JWT{
 					SigningKey:    signingKey,
 					SigningKeyPEM: signingKeyPEM,
 					JWKS:          jwks,
 					JWKSJson:      jwksBytes,
 				},
 			},
-			expGenCheck: shouldNotGen,
-			expErr:      false,
+			expErr: false,
 		},
 		"missing both x509 and jwt components": {
 			sec: &corev1.Secret{
@@ -474,9 +436,8 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
-			expBundle:   ca_bundle.Bundle{},
-			expGenCheck: shouldGenAll,
-			expErr:      false,
+			expBundle: ca_bundle.Bundle{},
+			expErr:    false,
 		},
 		"only jwt components present": {
 			sec: &corev1.Secret{
@@ -497,15 +458,14 @@ func TestKube_get(t *testing.T) {
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
 			expBundle: ca_bundle.Bundle{
-				JWT: ca_bundle.JWT{
+				JWT: &ca_bundle.JWT{
 					SigningKey:    signingKey,
 					SigningKeyPEM: signingKeyPEM,
 					JWKS:          jwks,
 					JWKSJson:      jwksBytes,
 				},
 			},
-			expGenCheck: shouldGenX509Exclusive,
-			expErr:      false,
+			expErr: false,
 		},
 		"only x509 components present with jwt keys requested": {
 			sec: &corev1.Secret{
@@ -527,7 +487,7 @@ func TestKube_get(t *testing.T) {
 				Data: map[string]string{"ca.crt": string(rootPEM)},
 			},
 			expBundle: ca_bundle.Bundle{
-				X509: ca_bundle.X509{
+				X509: &ca_bundle.X509{
 					TrustAnchors: rootPEM,
 					IssChainPEM:  intPEM,
 					IssKeyPEM:    intPKPEM,
@@ -535,8 +495,7 @@ func TestKube_get(t *testing.T) {
 					IssKey:       intPK,
 				},
 			},
-			expGenCheck: shouldGenJWTExclusive,
-			expErr:      false,
+			expErr: false,
 		},
 	}
 
@@ -567,12 +526,9 @@ func TestKube_get(t *testing.T) {
 				namespace: "dapr-system-test",
 			}
 
-			bundle, gen, err := k.get(t.Context())
+			bundle, err := k.get(t.Context())
 			assert.Equal(t, test.expErr, err != nil, "expected error: %v, but got %v", test.expErr, err)
 			bundlesEqual(t, test.expBundle, bundle)
-			if test.expGenCheck != nil {
-				assert.True(t, test.expGenCheck(gen), "generate check failed, got %v", gen)
-			}
 		})
 	}
 }
@@ -580,13 +536,15 @@ func TestKube_get(t *testing.T) {
 func bundlesEqual(t *testing.T, expected, actual ca_bundle.Bundle) {
 	t.Helper()
 
-	assert.Equal(t, expected.X509.TrustAnchors, actual.X509.TrustAnchors)
-	assert.Equal(t, expected.X509.IssChainPEM, actual.X509.IssChainPEM)
-	assert.Equal(t, expected.X509.IssKeyPEM, actual.X509.IssKeyPEM)
-	assert.Equal(t, len(expected.X509.IssChain), len(actual.X509.IssChain))
-	for i := range expected.X509.IssChain {
-		assert.Equal(t, expected.X509.IssChain[i].Subject, actual.X509.IssChain[i].Subject)
+	require.Equal(t, expected.X509 == nil, actual.X509 == nil)
+	if expected.X509 != nil {
+		assert.Equal(t, expected.X509.TrustAnchors, actual.X509.TrustAnchors)
+		assert.Equal(t, expected.X509.IssChainPEM, actual.X509.IssChainPEM)
+		assert.Equal(t, expected.X509.IssKeyPEM, actual.X509.IssKeyPEM)
+		assert.Equal(t, len(expected.X509.IssChain), len(actual.X509.IssChain))
+		for i := range expected.X509.IssChain {
+			assert.Equal(t, expected.X509.IssChain[i].Subject, actual.X509.IssChain[i].Subject)
+		}
 	}
-	assert.Equal(t, expected.JWT.SigningKeyPEM, actual.JWT.SigningKeyPEM)
-	assert.Equal(t, expected.JWT.JWKSJson, actual.JWT.JWKSJson)
+	assert.Equal(t, expected.JWT, actual.JWT)
 }

--- a/pkg/sentry/server/ca/validate_test.go
+++ b/pkg/sentry/server/ca/validate_test.go
@@ -101,91 +101,89 @@ func TestVerifyBundle(t *testing.T) {
 		issKeyPEM   []byte
 		trustBundle []byte
 		expErr      bool
-		expBundle   bundle.Bundle
+		expBundle   *bundle.X509
 	}{
 		"if issuer chain pem empty, expect error": {
 			issChainPEM: nil,
 			issKeyPEM:   int1PKPEM,
 			trustBundle: rootPEM,
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"if issuer key pem empty, expect error": {
 			issChainPEM: int1PEM,
 			issKeyPEM:   nil,
 			trustBundle: rootPEM,
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"if issuer trust bundle pem empty, expect error": {
 			issChainPEM: int1PEM,
 			issKeyPEM:   int1PKPEM,
 			trustBundle: nil,
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"invalid issuer chain PEM should error": {
 			issChainPEM: []byte("invalid"),
 			issKeyPEM:   int1PKPEM,
 			trustBundle: rootPEM,
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"invalid issuer key PEM should error": {
 			issChainPEM: int1PEM,
 			issKeyPEM:   []byte("invalid"),
 			trustBundle: rootPEM,
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"invalid trust bundle PEM should error": {
 			issChainPEM: int1PEM,
 			issKeyPEM:   int1PKPEM,
 			trustBundle: []byte("invalid"),
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"if issuer chain is in wrong order, expect error": {
 			issChainPEM: joinPEM(int1PEM, int2PEM),
 			issKeyPEM:   int2PKPEM,
 			trustBundle: joinPEM(rootPEM, rootBPEM),
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"if issuer key does not belong to issuer certificate, expect error": {
 			issChainPEM: joinPEM(int2PEM, int1PEM),
 			issKeyPEM:   int1PKPEM,
 			trustBundle: joinPEM(rootPEM, rootBPEM),
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"if trust anchors contains non root certificates, exp error": {
 			issChainPEM: joinPEM(int2PEM, int1PEM),
 			issKeyPEM:   int2PKPEM,
 			trustBundle: joinPEM(rootPEM, rootBPEM, int1PEM),
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"if issuer chain doesn't belong to trust anchors, expect error": {
 			issChainPEM: joinPEM(int2PEM, int1PEM),
 			issKeyPEM:   int2PKPEM,
 			trustBundle: joinPEM(rootBPEM),
 			expErr:      true,
-			expBundle:   bundle.Bundle{},
+			expBundle:   nil,
 		},
 		"valid chain should not error": {
 			issChainPEM: int1PEM,
 			issKeyPEM:   int1PKPEM,
 			trustBundle: rootPEM,
 			expErr:      false,
-			expBundle: bundle.Bundle{
-				X509: bundle.X509{
-					TrustAnchors: rootPEM,
-					IssChainPEM:  joinPEM(int1PEM),
-					IssKeyPEM:    int1PKPEM,
-					IssChain:     []*x509.Certificate{int1Crt},
-					IssKey:       int1PK,
-				},
+			expBundle: &bundle.X509{
+				TrustAnchors: rootPEM,
+				IssChainPEM:  joinPEM(int1PEM),
+				IssKeyPEM:    int1PKPEM,
+				IssChain:     []*x509.Certificate{int1Crt},
+				IssKey:       int1PK,
 			},
 		},
 		"valid long chain should not error": {
@@ -193,14 +191,12 @@ func TestVerifyBundle(t *testing.T) {
 			issKeyPEM:   int2PKPEM,
 			trustBundle: joinPEM(rootPEM, rootBPEM),
 			expErr:      false,
-			expBundle: bundle.Bundle{
-				X509: bundle.X509{
-					TrustAnchors: joinPEM(rootPEM, rootBPEM),
-					IssChainPEM:  joinPEM(int2PEM, int1PEM),
-					IssKeyPEM:    int2PKPEM,
-					IssChain:     []*x509.Certificate{int2Crt, int1Crt},
-					IssKey:       int2PK,
-				},
+			expBundle: &bundle.X509{
+				TrustAnchors: joinPEM(rootPEM, rootBPEM),
+				IssChainPEM:  joinPEM(int2PEM, int1PEM),
+				IssKeyPEM:    int2PKPEM,
+				IssChain:     []*x509.Certificate{int2Crt, int1Crt},
+				IssKey:       int2PK,
 			},
 		},
 		"is root certificate in chain, expect to be removed": {
@@ -208,14 +204,12 @@ func TestVerifyBundle(t *testing.T) {
 			issKeyPEM:   int2PKPEM,
 			trustBundle: joinPEM(rootPEM, rootBPEM),
 			expErr:      false,
-			expBundle: bundle.Bundle{
-				X509: bundle.X509{
-					TrustAnchors: joinPEM(rootPEM, rootBPEM),
-					IssChainPEM:  joinPEM(int2PEM, int1PEM),
-					IssKeyPEM:    int2PKPEM,
-					IssChain:     []*x509.Certificate{int2Crt, int1Crt},
-					IssKey:       int2PK,
-				},
+			expBundle: &bundle.X509{
+				TrustAnchors: joinPEM(rootPEM, rootBPEM),
+				IssChainPEM:  joinPEM(int2PEM, int1PEM),
+				IssKeyPEM:    int2PKPEM,
+				IssChain:     []*x509.Certificate{int2Crt, int1Crt},
+				IssKey:       int2PK,
 			},
 		},
 		"comments are removed from parsed issuer chain, private key and trust anchors": {
@@ -239,21 +233,19 @@ func TestVerifyBundle(t *testing.T) {
 				[]byte("# this is a comment\n"),
 			),
 			expErr: false,
-			expBundle: bundle.Bundle{
-				X509: bundle.X509{
-					TrustAnchors: joinPEM(rootPEM, rootBPEM),
-					IssChainPEM:  joinPEM(int2PEM, int1PEM),
-					IssKeyPEM:    int2PKPEM,
-					IssChain:     []*x509.Certificate{int2Crt, int1Crt},
-					IssKey:       int2PK,
-				},
+			expBundle: &bundle.X509{
+				TrustAnchors: joinPEM(rootPEM, rootBPEM),
+				IssChainPEM:  joinPEM(int2PEM, int1PEM),
+				IssKeyPEM:    int2PKPEM,
+				IssChain:     []*x509.Certificate{int2Crt, int1Crt},
+				IssKey:       int2PK,
 			},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			Bundle, err := verifyBundle(test.trustBundle, test.issChainPEM, test.issKeyPEM)
+			Bundle, err := verifyX509Bundle(test.trustBundle, test.issChainPEM, test.issKeyPEM)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)
 			require.Equal(t, test.expBundle, Bundle)
 		})

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -95,19 +95,22 @@ func New(t *testing.T, fopts ...Option) *Sentry {
 		jwtRootKey, err := rsa.GenerateKey(rand.Reader, 2048)
 		require.NoError(t, err)
 
-		bundle, err := bundle.Generate(bundle.GenerateOptions{
+		x509bundle, err := bundle.GenerateX509(bundle.OptionsX509{
 			X509RootKey:      x509RootKey,
-			JWTRootKey:       jwtRootKey,
 			TrustDomain:      td,
 			AllowedClockSkew: time.Second * 5,
 			OverrideCATTL:    nil, // Use default CA TTL
-			MissingCredentials: bundle.MissingCredentials{
-				X509: true,
-				JWT:  true,
-			},
 		})
 		require.NoError(t, err)
-		opts.bundle = &bundle
+		jwtbundle, err := bundle.GenerateJWT(bundle.OptionsJWT{
+			JWTRootKey:  jwtRootKey,
+			TrustDomain: td,
+		})
+		require.NoError(t, err)
+		opts.bundle = &bundle.Bundle{
+			X509: x509bundle,
+			JWT:  jwtbundle,
+		}
 	}
 
 	args := []string{

--- a/tests/integration/suite/sentry/usergroup/enable.go
+++ b/tests/integration/suite/sentry/usergroup/enable.go
@@ -18,6 +18,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"testing"
 	"time"
 
@@ -43,16 +44,24 @@ type enable struct {
 func (e *enable) Setup(t *testing.T) []framework.Option {
 	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-	bundle, err := bundle.Generate(bundle.GenerateOptions{
+	jwtKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	x509bundle, err := bundle.GenerateX509(bundle.OptionsX509{
 		X509RootKey:      rootKey,
 		TrustDomain:      "integration.test.dapr.io",
-		AllowedClockSkew: time.Second * 5,
+		AllowedClockSkew: time.Second * 20,
 		OverrideCATTL:    nil,
-		MissingCredentials: bundle.MissingCredentials{
-			X509: true,
-		},
 	})
 	require.NoError(t, err)
+	jwtbundle, err := bundle.GenerateJWT(bundle.OptionsJWT{
+		JWTRootKey:  jwtKey,
+		TrustDomain: "integration.test.dapr.io",
+	})
+	require.NoError(t, err)
+	bundle := bundle.Bundle{
+		X509: x509bundle,
+		JWT:  jwtbundle,
+	}
 
 	kubeAPI := utils.KubeAPI(t, utils.KubeAPIOptions{
 		Bundle:         bundle,

--- a/tests/integration/suite/sentry/validator/kubernetes/legacyid.go
+++ b/tests/integration/suite/sentry/validator/kubernetes/legacyid.go
@@ -52,21 +52,24 @@ type legacyid struct {
 func (l *legacyid) Setup(t *testing.T) []framework.Option {
 	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-
 	jwtKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
-	bundle, err := bundle.Generate(bundle.GenerateOptions{
+	x509bundle, err := bundle.GenerateX509(bundle.OptionsX509{
 		X509RootKey:      rootKey,
-		JWTRootKey:       jwtKey,
 		TrustDomain:      "integration.test.dapr.io",
-		AllowedClockSkew: time.Second * 5,
+		AllowedClockSkew: time.Second * 20,
 		OverrideCATTL:    nil,
-		MissingCredentials: bundle.MissingCredentials{
-			X509: true,
-			JWT:  true,
-		},
 	})
 	require.NoError(t, err)
+	jwtbundle, err := bundle.GenerateJWT(bundle.OptionsJWT{
+		JWTRootKey:  jwtKey,
+		TrustDomain: "integration.test.dapr.io",
+	})
+	require.NoError(t, err)
+	bundle := bundle.Bundle{
+		X509: x509bundle,
+		JWT:  jwtbundle,
+	}
 
 	kubeAPI := utils.KubeAPI(t, utils.KubeAPIOptions{
 		Bundle:         bundle,

--- a/tests/integration/suite/sentry/validator/kubernetes/longname.go
+++ b/tests/integration/suite/sentry/validator/kubernetes/longname.go
@@ -57,21 +57,24 @@ type longname struct {
 func (l *longname) Setup(t *testing.T) []framework.Option {
 	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-
 	jwtKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
-	bundle, err := bundle.Generate(bundle.GenerateOptions{
+	x509bundle, err := bundle.GenerateX509(bundle.OptionsX509{
 		X509RootKey:      rootKey,
-		JWTRootKey:       jwtKey,
 		TrustDomain:      "integration.test.dapr.io",
-		AllowedClockSkew: time.Second * 5,
+		AllowedClockSkew: time.Second * 20,
 		OverrideCATTL:    nil,
-		MissingCredentials: bundle.MissingCredentials{
-			X509: true,
-			JWT:  true,
-		},
 	})
 	require.NoError(t, err)
+	jwtbundle, err := bundle.GenerateJWT(bundle.OptionsJWT{
+		JWTRootKey:  jwtKey,
+		TrustDomain: "integration.test.dapr.io",
+	})
+	require.NoError(t, err)
+	bundle := bundle.Bundle{
+		X509: x509bundle,
+		JWT:  jwtbundle,
+	}
 
 	kubeAPI1 := utils.KubeAPI(t, utils.KubeAPIOptions{
 		Bundle:         bundle,

--- a/tests/integration/suite/sentry/validator/standalone/standalone.go
+++ b/tests/integration/suite/sentry/validator/standalone/standalone.go
@@ -47,21 +47,24 @@ type standalone struct {
 func (k *standalone) Setup(t *testing.T) []framework.Option {
 	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-
 	jwtKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
-	bundle, err := bundle.Generate(bundle.GenerateOptions{
+	x509bundle, err := bundle.GenerateX509(bundle.OptionsX509{
 		X509RootKey:      rootKey,
-		JWTRootKey:       jwtKey,
 		TrustDomain:      "integration.test.dapr.io",
-		AllowedClockSkew: time.Second * 5,
+		AllowedClockSkew: time.Second * 20,
 		OverrideCATTL:    nil,
-		MissingCredentials: bundle.MissingCredentials{
-			X509: true,
-			JWT:  true,
-		},
 	})
 	require.NoError(t, err)
+	jwtbundle, err := bundle.GenerateJWT(bundle.OptionsJWT{
+		JWTRootKey:  jwtKey,
+		TrustDomain: "integration.test.dapr.io",
+	})
+	require.NoError(t, err)
+	bundle := bundle.Bundle{
+		X509: x509bundle,
+		JWT:  jwtbundle,
+	}
 
 	kubeAPI := utils.KubeAPI(t, utils.KubeAPIOptions{
 		Bundle:         bundle,


### PR DESCRIPTION
Simplify the Sentry X.509 and JWT generation logic to compare and generate separately. Only writes when necessary.

Extends from https://github.com/dapr/dapr/pull/9012