### PR TITLE
[1.16] Update dapr/durabletask-go & contrib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/dapr/components-contrib v1.16.0-rc.4
-	github.com/dapr/durabletask-go v0.8.2
+	github.com/dapr/durabletask-go v0.8.3
 	github.com/dapr/kit v0.16.0
 	github.com/diagridio/go-etcd-cron v0.9.1
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.14.1
-	github.com/dapr/components-contrib v1.16.0-rc.4
+	github.com/dapr/components-contrib v1.16.0-rc.5
 	github.com/dapr/durabletask-go v0.8.3
 	github.com/dapr/kit v0.16.0
 	github.com/diagridio/go-etcd-cron v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.16.0-rc.4 h1:RvK4qxONm6lrAZnDubTVvEFk07lbHig00rjKoaTIRIg=
-github.com/dapr/components-contrib v1.16.0-rc.4/go.mod h1:mPT6lNeoQxJoJ0y9HyOGWozscSmTdf4yVJTTJMjSOJE=
+github.com/dapr/components-contrib v1.16.0-rc.5 h1:wlenzFiSW+XUQpAkiC2/LIc4aTjAEjukaBMXaWQSDUE=
+github.com/dapr/components-contrib v1.16.0-rc.5/go.mod h1:mPT6lNeoQxJoJ0y9HyOGWozscSmTdf4yVJTTJMjSOJE=
 github.com/dapr/durabletask-go v0.8.3 h1:ntcaUOigNtDLCvQ0pFqxJTziibU1q/ItrCh89Jyrw3E=
 github.com/dapr/durabletask-go v0.8.3/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
 github.com/dapr/kit v0.16.0 h1:I2sMBzndw5XTjsaH0J/hbKK6WNbuT0AHxIY5M9OhzGI=

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/dapr/components-contrib v1.16.0-rc.4 h1:RvK4qxONm6lrAZnDubTVvEFk07lbHig00rjKoaTIRIg=
 github.com/dapr/components-contrib v1.16.0-rc.4/go.mod h1:mPT6lNeoQxJoJ0y9HyOGWozscSmTdf4yVJTTJMjSOJE=
-github.com/dapr/durabletask-go v0.8.2 h1:nBoJ73CEuRRIsivzr8in+0BoryS0ZXG6UO3jpIgMOto=
-github.com/dapr/durabletask-go v0.8.2/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
+github.com/dapr/durabletask-go v0.8.3 h1:ntcaUOigNtDLCvQ0pFqxJTziibU1q/ItrCh89Jyrw3E=
+github.com/dapr/durabletask-go v0.8.3/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
 github.com/dapr/kit v0.16.0 h1:I2sMBzndw5XTjsaH0J/hbKK6WNbuT0AHxIY5M9OhzGI=
 github.com/dapr/kit v0.16.0/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
Updates dapr/durabletask-go to v0.8.3
dapr/components-crontrib v1.16.0-rc.5