### PR TITLE
[1.16] correctly setup CORS middleware

### DIFF
--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -156,6 +156,9 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	if opts.maxBodySize != nil {
 		args = append(args, "--max-body-size="+*opts.maxBodySize)
 	}
+	if opts.allowedOrigins != nil {
+		args = append(args, "--allowed-origins="+*opts.allowedOrigins)
+	}
 
 	ns := "default"
 	if opts.namespace != nil {

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -65,6 +65,7 @@ type options struct {
 	controlPlaneTrustDomain *string
 	schedulerAddresses      []string
 	maxBodySize             *string
+	allowedOrigins          *string
 }
 
 func WithExecOptions(execOptions ...exec.Option) Option {
@@ -309,6 +310,12 @@ func WithDaprAPIToken(t *testing.T, token string) Option {
 	return WithExecOptions(exec.WithEnvVars(t,
 		"DAPR_API_TOKEN", token,
 	))
+}
+
+func WithAllowedOrigins(t *testing.T, origins string) Option {
+	return func(o *options) {
+		o.allowedOrigins = &origins
+	}
 }
 
 func WithSentry(t *testing.T, sentry *sentry.Sentry) Option {

--- a/tests/integration/suite/daprd/httpserver/corsapitoken.go
+++ b/tests/integration/suite/daprd/httpserver/corsapitoken.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(corsapitoken))
+}
+
+type corsapitoken struct {
+	proc *procdaprd.Daprd
+}
+
+func (h *corsapitoken) Setup(t *testing.T) []framework.Option {
+	h.proc = procdaprd.New(t, procdaprd.WithDaprAPIToken(t, "test"), procdaprd.WithAllowedOrigins(t, "https://example.com"))
+	return []framework.Option{
+		framework.WithProcesses(h.proc),
+	}
+}
+
+func (h *corsapitoken) Run(t *testing.T, ctx context.Context) {
+	h.proc.WaitUntilRunning(t, ctx)
+
+	h1Client := client.HTTP(t)
+	h2cClient := &http.Client{
+		Transport: &http2.Transport{
+			// Allow http2.Transport to use protocol "http"
+			AllowHTTP: true,
+			// Pretend we are dialing a TLS endpoint
+			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+	t.Cleanup(h2cClient.CloseIdleConnections)
+
+	t.Run("OPTIONS", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://example.com")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		// OPTIONS requests usually don't include the API token
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "https://example.com", res.Header.Get("Access-Control-Allow-Origin"))
+		require.NotEmpty(t, res.Header.Get("Vary"))
+	})
+
+	t.Run("OPTIONS, error", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://foobaz.com")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		// OPTIONS requests usually don't include the API token
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Empty(t, res.Header.Get("Access-Control-Allow-Origin"))
+		require.NotEmpty(t, res.Header.Get("Vary"))
+	})
+
+	t.Run("OPTIONS, unnecessary token", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://example.com")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		req.Header.Set("dapr-api-token", "foo")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "https://example.com", res.Header.Get("Access-Control-Allow-Origin"))
+		require.NotEmpty(t, res.Header.Get("Vary"))
+	})
+
+	t.Run("GET", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("dapr-api-token", "test")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Empty(t, res.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("GET, incorrect token", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("dapr-api-token", "foo")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+		require.Empty(t, res.Header.Get("Access-Control-Allow-Origin"))
+	})
+}

--- a/tests/integration/suite/daprd/httpserver/corsdefault.go
+++ b/tests/integration/suite/daprd/httpserver/corsdefault.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(corsdefault))
+}
+
+type corsdefault struct {
+	proc *procdaprd.Daprd
+}
+
+func (h *corsdefault) Setup(t *testing.T) []framework.Option {
+	h.proc = procdaprd.New(t)
+	return []framework.Option{
+		framework.WithProcesses(h.proc),
+	}
+}
+
+func (h *corsdefault) Run(t *testing.T, ctx context.Context) {
+	h.proc.WaitUntilRunning(t, ctx)
+
+	h1Client := client.HTTP(t)
+	h2cClient := &http.Client{
+		Transport: &http2.Transport{
+			// Allow http2.Transport to use protocol "http"
+			AllowHTTP: true,
+			// Pretend we are dialing a TLS endpoint
+			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+	t.Cleanup(h2cClient.CloseIdleConnections)
+
+	t.Run("OPTIONS", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://test.com")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+		require.NotEmpty(t, res.Header.Get("Vary"))
+	})
+
+	t.Run("OPTIONS, unnecessary token", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "*")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		req.Header.Set("dapr-api-token", "foo")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+		require.NotEmpty(t, res.Header.Get("Vary"))
+	})
+
+	t.Run("GET", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Empty(t, res.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("GET, unnecessary token", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("dapr-api-token", "test")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Empty(t, res.Header.Get("Access-Control-Allow-Origin"))
+	})
+}

--- a/tests/integration/suite/daprd/httpserver/corsdefaultapitoken.go
+++ b/tests/integration/suite/daprd/httpserver/corsdefaultapitoken.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpserver
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(corsdefaultapitoken))
+}
+
+type corsdefaultapitoken struct {
+	proc *procdaprd.Daprd
+}
+
+func (h *corsdefaultapitoken) Setup(t *testing.T) []framework.Option {
+	h.proc = procdaprd.New(t, procdaprd.WithDaprAPIToken(t, "test"))
+	return []framework.Option{
+		framework.WithProcesses(h.proc),
+	}
+}
+
+func (h *corsdefaultapitoken) Run(t *testing.T, ctx context.Context) {
+	h.proc.WaitUntilRunning(t, ctx)
+
+	h1Client := client.HTTP(t)
+	h2cClient := &http.Client{
+		Transport: &http2.Transport{
+			// Allow http2.Transport to use protocol "http"
+			AllowHTTP: true,
+			// Pretend we are dialing a TLS endpoint
+			DialTLS: func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+	t.Cleanup(h2cClient.CloseIdleConnections)
+
+	t.Run("OPTIONS", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "*")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		// OPTIONS requests usually don't include the API token
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+		require.NotEmpty(t, res.Header.Get("Vary"))
+	})
+
+	t.Run("OPTIONS, unnecessary token", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodOptions, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "*")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		req.Header.Set("dapr-api-token", "foo")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+		require.NotEmpty(t, res.Header.Get("Vary"))
+	})
+
+	t.Run("GET", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("dapr-api-token", "test")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		require.Empty(t, res.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("GET, incorrect token", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/v1.0/metadata", h.proc.HTTPPort()), nil)
+		require.NoError(t, err)
+		req.Header.Set("dapr-api-token", "foo")
+
+		// Body is closed below but the linter isn't seeing that
+		//nolint:bodyclose
+		res, err := h1Client.Do(req)
+		require.NoError(t, err)
+		defer closeBody(res.Body)
+		require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+		require.Empty(t, res.Header.Get("Access-Control-Allow-Origin"))
+	})
+}


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Found this testing the default CORS support for the dapr http server

it doesn't actually support proper CORS by default, because it doesn't handle preflight requests and OPTIONS requests reach try to match all the handlers, instead of stopping into a CORS handler

even more important is the api token middleware, it must be added AFTER the CORS filter, otherwise preflight requests would never reach the CORS filter because api tokens are not usually added to OPTIONS requests

in this PR I updated the unit tests to reflect more usecases

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
