### PR TITLE
feat(tracing): align pubsub spans with OpenTelemetry SemCov

### DIFF
--- a/pkg/diagnostics/consts/consts.go
+++ b/pkg/diagnostics/consts/consts.go
@@ -32,6 +32,12 @@ const (
 	DBConnectionStringSpanAttributeKey   = string(semconv.DBConnectionStringKey)
 	MessagingSystemSpanAttributeKey      = string(semconv.MessagingSystemKey)
 	MessagingDestinationSpanAttributeKey = string(semconv.MessagingDestinationNameKey)
+	// New semantic convention attributes for messaging
+	MessagingOperationNameSpanAttributeKey      = "messaging.operation.name"
+	MessagingMessageIDSpanAttributeKey          = "messaging.message.id"
+	MessagingMessageBodySizeSpanAttributeKey    = "messaging.message.body.size"
+	MessagingBatchMessageCountSpanAttributeKey  = "messaging.batch.message_count"
+	MessagingConsumerGroupNameSpanAttributeKey  = "messaging.consumer.group.name"
 	GrpcServiceSpanAttributeKey          = string(semconv.RPCServiceKey)
 	NetPeerNameSpanAttributeKey          = string(semconv.NetPeerNameKey)
 	RPCSystemSpanAttributeKey            = string(semconv.RPCSystemKey)

--- a/pkg/diagnostics/grpc_tracing.go
+++ b/pkg/diagnostics/grpc_tracing.go
@@ -102,8 +102,11 @@ func GRPCTraceUnaryServerInterceptor(appID string, spec config.TracingSpec) grpc
 			// For the dapr.proto.internals package, this generates ServerSpan.
 			// This is invoked by other Dapr runtimes during service invocation.
 			spanKind = trace.WithSpanKind(trace.SpanKindServer)
+		} else if strings.Contains(info.FullMethod, "PublishEvent") || strings.Contains(info.FullMethod, "BulkPublish") {
+			// For publish operations, use Producer span kind (semantic conventions)
+			spanKind = trace.WithSpanKind(trace.SpanKindProducer)
 		} else {
-			// For the dapr.proto.runtime package, this generates ClientSpan.
+			// For other dapr.proto.runtime package calls, this generates ClientSpan.
 			// This is invoked by clients (apps) while invoking Dapr APIs.
 			spanKind = trace.WithSpanKind(trace.SpanKindClient)
 		}

--- a/pkg/proto/runtime/v1/dapr_tracing.go
+++ b/pkg/proto/runtime/v1/dapr_tracing.go
@@ -14,6 +14,8 @@ limitations under the License.
 package runtime
 
 import (
+	"strconv"
+	
 	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 )
 
@@ -29,12 +31,26 @@ func (x *PublishEventRequest) AppendSpanAttributes(rpcMethod string, m map[strin
 	m[diagConsts.GrpcServiceSpanAttributeKey] = diagConsts.DaprGRPCDaprService
 	m[diagConsts.MessagingSystemSpanAttributeKey] = diagConsts.PubsubBuildingBlockType
 	m[diagConsts.MessagingDestinationSpanAttributeKey] = x.GetTopic()
+	m[diagConsts.MessagingOperationNameSpanAttributeKey] = "publish"
+	// Update span name to follow semantic conventions
+	m[diagConsts.DaprAPISpanNameInternal] = "publish " + x.GetTopic()
+	// Add message body size if data is present
+	if data := x.GetData(); data != nil {
+		m[diagConsts.MessagingMessageBodySizeSpanAttributeKey] = strconv.Itoa(len(data))
+	}
 }
 
 func (x *BulkPublishRequest) AppendSpanAttributes(rpcMethod string, m map[string]string) {
 	m[diagConsts.GrpcServiceSpanAttributeKey] = diagConsts.DaprGRPCDaprService
 	m[diagConsts.MessagingSystemSpanAttributeKey] = diagConsts.PubsubBuildingBlockType
 	m[diagConsts.MessagingDestinationSpanAttributeKey] = x.GetTopic()
+	m[diagConsts.MessagingOperationNameSpanAttributeKey] = "publish"
+	// Update span name to follow semantic conventions
+	m[diagConsts.DaprAPISpanNameInternal] = "publish " + x.GetTopic()
+	// Add batch message count
+	if entries := x.GetEntries(); entries != nil {
+		m[diagConsts.MessagingBatchMessageCountSpanAttributeKey] = strconv.Itoa(len(entries))
+	}
 }
 
 func (x *InvokeBindingRequest) AppendSpanAttributes(rpcMethod string, m map[string]string) {


### PR DESCRIPTION
# Description
This PR aligns Dapr's pubsub tracing with OpenTelemetry semantic conventions for messaging spans. See this for more information: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/ 

# Changes
- Changed publish operations to use SpanKindProducer instead of SpanKindClient
- Changed subscription processing to use SpanKindConsumer instead of SpanKindClient
- Updated span names to follow semantic conventions:
    - Publishing: publish {topic}
    - Subscriptions: process {topic}
- Added OpenTelemetry messaging attributes:
    - messaging.operation.name (publish/process)
    - messaging.message.id (CloudEvent ID)
    - messaging.message.body.size (payload size)
    - messaging.consumer.group.name (app ID)
    - messaging.batch.message_count (for bulk operations)
- Fixed consumer-side body size measurement to report actual payload size instead of
  full CloudEvent envelope size

## Issue reference

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
