### PR TITLE
set timestamp to timer fired event

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
@@ -55,7 +57,11 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			return todo.RunCompletedFalse, nil
 		}
 
-		state.Inbox = append(state.Inbox, durableTimer.GetTimerEvent())
+		timerEvent := durableTimer.GetTimerEvent()
+		// timer fired event is precreated at the moment of creating the timer
+		// set the timestamp to now so it is accurately recorded in the history
+		timerEvent.Timestamp = timestamppb.Now()
+		state.Inbox = append(state.Inbox, timerEvent)
 	}
 
 	if len(state.Inbox) == 0 {


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Small tweak so the TimerFired event timestamp (notice this is different than the timer fire_at timestamp) is updated to the moment where the event is actually produced from the user POV

This change is just cosmetic so the TimerFired event is better recorded in the workflow history

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
