### PR TITLE
[1.16] Workflows: (runtime) retry completing/cancelling

### DIFF
--- a/pkg/actors/targets/workflow/lock/lock.go
+++ b/pkg/actors/targets/workflow/lock/lock.go
@@ -48,5 +48,9 @@ func (l *Lock) Init() {
 }
 
 func (l *Lock) Close() {
-	close(l.closeCh)
+	select {
+	case <-l.closeCh:
+	default:
+		close(l.closeCh)
+	}
 }

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -220,9 +220,5 @@ func (f *factory) Len() int {
 }
 
 func (f *factory) deactivate(orchestrator *orchestrator) {
-	if !orchestrator.closed.CompareAndSwap(false, true) {
-		return
-	}
-
 	f.deactivateCh <- orchestrator
 }

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -220,5 +220,8 @@ func (f *factory) Len() int {
 }
 
 func (f *factory) deactivate(orchestrator *orchestrator) {
+	if !orchestrator.closed.CompareAndSwap(false, true) {
+		return
+	}
 	f.deactivateCh <- orchestrator
 }

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -109,10 +109,6 @@ func (o *orchestrator) InvokeStream(ctx context.Context, req *internalsv1pb.Inte
 
 // DeactivateActor implements actors.InternalActor
 func (o *orchestrator) Deactivate(ctx context.Context) error {
-	if !o.closed.CompareAndSwap(false, true) {
-		return nil
-	}
-
 	unlock, err := o.lock.ContextLock(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to deactivate workflow '%s': %w", o.actorID, err)

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -109,6 +109,10 @@ func (o *orchestrator) InvokeStream(ctx context.Context, req *internalsv1pb.Inte
 
 // DeactivateActor implements actors.InternalActor
 func (o *orchestrator) Deactivate(ctx context.Context) error {
+	if !orchestrator.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+
 	unlock, err := o.lock.ContextLock(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to deactivate workflow '%s': %w", o.actorID, err)

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -109,7 +109,7 @@ func (o *orchestrator) InvokeStream(ctx context.Context, req *internalsv1pb.Inte
 
 // DeactivateActor implements actors.InternalActor
 func (o *orchestrator) Deactivate(ctx context.Context) error {
-	if !orchestrator.closed.CompareAndSwap(false, true) {
+	if !o.closed.CompareAndSwap(false, true) {
 		return nil
 	}
 

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -580,22 +580,46 @@ func (abe *Actors) ActivityActorType() string {
 
 // CancelActivityTask implements backend.Backend.
 func (abe *Actors) CancelActivityTask(ctx context.Context, instanceID api.InstanceID, taskID int32) error {
-	return abe.pendingTasksBackend.CancelActivityTask(ctx, instanceID, taskID)
+	return backoff.Retry(func() error {
+		err := abe.pendingTasksBackend.CancelActivityTask(ctx, instanceID, taskID)
+		if err != nil && ctx.Err() == nil {
+			log.Warnf("error completing activity task: %v, retrying...", err)
+		}
+		return err
+	}, backoff.WithContext(backoff.NewConstantBackOff(time.Second), ctx))
 }
 
 // CancelOrchestratorTask implements backend.Backend.
 func (abe *Actors) CancelOrchestratorTask(ctx context.Context, instanceID api.InstanceID) error {
-	return abe.pendingTasksBackend.CancelOrchestratorTask(ctx, instanceID)
+	return backoff.Retry(func() error {
+		err := abe.pendingTasksBackend.CancelOrchestratorTask(ctx, instanceID)
+		if err != nil && ctx.Err() == nil {
+			log.Warnf("error completing activity task: %v, retrying...", err)
+		}
+		return err
+	}, backoff.WithContext(backoff.NewConstantBackOff(time.Second), ctx))
 }
 
 // CompleteActivityTask implements backend.Backend.
 func (abe *Actors) CompleteActivityTask(ctx context.Context, response *protos.ActivityResponse) error {
-	return abe.pendingTasksBackend.CompleteActivityTask(ctx, response)
+	return backoff.Retry(func() error {
+		err := abe.pendingTasksBackend.CompleteActivityTask(ctx, response)
+		if err != nil && ctx.Err() == nil {
+			log.Warnf("error completing activity task: %v, retrying...", err)
+		}
+		return err
+	}, backoff.WithContext(backoff.NewConstantBackOff(time.Second), ctx))
 }
 
 // CompleteOrchestratorTask implements backend.Backend.
 func (abe *Actors) CompleteOrchestratorTask(ctx context.Context, response *protos.OrchestratorResponse) error {
-	return abe.pendingTasksBackend.CompleteOrchestratorTask(ctx, response)
+	return backoff.Retry(func() error {
+		err := abe.pendingTasksBackend.CompleteOrchestratorTask(ctx, response)
+		if err != nil && ctx.Err() == nil {
+			log.Warnf("error completing activity task: %v, retrying...", err)
+		}
+		return err
+	}, backoff.WithContext(backoff.NewConstantBackOff(time.Second), ctx))
 }
 
 // WaitForActivityCompletion implements backend.Backend.

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -365,7 +365,7 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		}
 	}
 
-	wfLogger.Infof("%s: loaded %d state records in %v", actorID, 1+len(bulkRes), time.Since(loadStartTime))
+	wfLogger.Debugf("%s: loaded %d state records in %v", actorID, 1+len(bulkRes), time.Since(loadStartTime))
 	return wState, nil
 }
 

--- a/tests/integration/suite/daprd/workflow/continueasnew/activity.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/activity.go
@@ -97,7 +97,7 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 			assert.Equal(t, "first call", input)
 		}
 
-		for range 100 {
+		for range 30 {
 			ctx.CallActivity("bar")
 		}
 
@@ -151,8 +151,8 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, int64(100), barCalled.Load())
+		assert.Equal(c, int64(30), barCalled.Load())
 	}, time.Second*10, time.Millisecond*10)
 	time.Sleep(time.Second)
-	assert.Equal(t, int64(100), barCalled.Load())
+	assert.Equal(t, int64(30), barCalled.Load())
 }

--- a/tests/integration/suite/daprd/workflow/noawait.go
+++ b/tests/integration/suite/daprd/workflow/noawait.go
@@ -50,7 +50,7 @@ func (n *noawait) Run(t *testing.T, ctx context.Context) {
 
 	var barCalled atomic.Int64
 	n.workflow.Registry().AddOrchestratorN("noawait", func(ctx *task.OrchestrationContext) (any, error) {
-		for range 50 {
+		for range 30 {
 			ctx.CallActivity("bar")
 		}
 		return nil, nil
@@ -66,6 +66,6 @@ func (n *noawait) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, int64(50), barCalled.Load())
+		assert.Equal(c, int64(30), barCalled.Load())
 	}, time.Second*10, time.Millisecond*10)
 }


### PR DESCRIPTION
To account for the race between and activity/orchestration being tracked as pending in the durabletask backend, and the client reporting it as being completed/cancelled, add a backoff retry. This prevents activities and orchestrators from being stuck in a pending state forever, which can occur in high throughput scenarios.

Also changes the runtime wf runtime state to change an info to debug log for a nebulous log line.