### PR TITLE
[1.16] Workflow: fix executor panic

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -104,7 +104,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 		reminderInterval = *opts.ReminderInterval
 	}
 
-	deactivateCh := make(chan *orchestrator, 10)
+	deactivateCh := make(chan *orchestrator, 100)
 	go func() {
 		for orchestrator := range deactivateCh {
 			orchestrator.Deactivate(ctx)


### PR DESCRIPTION
Fix panic in workflow executor actor by adding a `closed` check to the Deactivator, and ensuring all funcs have returned before deleting.

Adds a deactivating channel, similar to the orchestrator actor.