### PR TITLE
[1.16] Optionally configure scheduler client port listen address

### DIFF
--- a/cmd/scheduler/app/app.go
+++ b/cmd/scheduler/app/app.go
@@ -108,6 +108,7 @@ func Run() {
 				EtcdName:                       opts.ID,
 				EtcdInitialCluster:             opts.EtcdInitialCluster,
 				EtcdClientPort:                 opts.EtcdClientPort,
+				EtcdClientListenAddress:        opts.EtcdClientListenAddress,
 				EtcdSpaceQuota:                 opts.EtcdSpaceQuota,
 				EtcdCompactionMode:             opts.EtcdCompactionMode,
 				EtcdCompactionRetention:        opts.EtcdCompactionRetention,

--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -53,6 +53,7 @@ type Options struct {
 	EtcdInitialCluster             []string
 	EtcdDataDir                    string
 	EtcdClientPort                 uint64
+	EtcdClientListenAddress        string
 	EtcdSpaceQuota                 int64
 	EtcdCompactionMode             string
 	EtcdCompactionRetention        string
@@ -111,6 +112,7 @@ func New(origArgs []string) (*Options, error) {
 	fs.StringSliceVar(&opts.EtcdInitialCluster, "etcd-initial-cluster", []string{"dapr-scheduler-server-0=http://localhost:2380"}, "Initial etcd cluster peers")
 	fs.StringVar(&opts.EtcdDataDir, "etcd-data-dir", "./data", "Directory to store scheduler etcd data")
 	fs.Uint64Var(&opts.EtcdClientPort, "etcd-client-port", 2379, "Port for etcd client communication")
+	fs.StringVar(&opts.EtcdClientListenAddress, "etcd-client-port", "localhost", "Address for etcd client communication")
 	fs.StringVar(&opts.etcdSpaceQuota, "etcd-space-quota", "9.2E", "Space quota for etcd")
 	fs.StringVar(&opts.EtcdCompactionMode, "etcd-compaction-mode", "periodic", "Compaction mode for etcd. Can be 'periodic' or 'revision'")
 	fs.StringVar(&opts.EtcdCompactionRetention, "etcd-compaction-retention", "10m", "Compaction retention for etcd. Can express time  or number of revisions, depending on the value of 'etcd-compaction-mode'")

--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -112,7 +112,7 @@ func New(origArgs []string) (*Options, error) {
 	fs.StringSliceVar(&opts.EtcdInitialCluster, "etcd-initial-cluster", []string{"dapr-scheduler-server-0=http://localhost:2380"}, "Initial etcd cluster peers")
 	fs.StringVar(&opts.EtcdDataDir, "etcd-data-dir", "./data", "Directory to store scheduler etcd data")
 	fs.Uint64Var(&opts.EtcdClientPort, "etcd-client-port", 2379, "Port for etcd client communication")
-	fs.StringVar(&opts.EtcdClientListenAddress, "etcd-client-port", "localhost", "Address for etcd client communication")
+	fs.StringVar(&opts.EtcdClientListenAddress, "etcd-client-listen-address", "localhost", "Listen address for etcd client communication")
 	fs.StringVar(&opts.etcdSpaceQuota, "etcd-space-quota", "9.2E", "Space quota for etcd")
 	fs.StringVar(&opts.EtcdCompactionMode, "etcd-compaction-mode", "periodic", "Compaction mode for etcd. Can be 'periodic' or 'revision'")
 	fs.StringVar(&opts.EtcdCompactionRetention, "etcd-compaction-retention", "10m", "Compaction retention for etcd. Can express time  or number of revisions, depending on the value of 'etcd-compaction-mode'")

--- a/docs/release_notes/v1.16.1.md
+++ b/docs/release_notes/v1.16.1.md
@@ -3,6 +3,8 @@
 This update includes bug fixes:
 
 - [Sidecar Injector Crash with Disabled Scheduler](#sidecar-injector-crash-with-disabled-scheduler)
+- [Workflow actors reminders stopped after Application Health check transition](#workflow-actors-reminders-stopped-after-application-health-check-transition)
+- [Fix Scheduler Etcd client port networking in standalone mode](#fix-scheduler-etcd-client-port-networking-in-standalone-mode)
 
 ## Sidecar Injector Crash with Disabled Scheduler
 
@@ -18,6 +20,7 @@ A previous change caused the `dapr-scheduler-server` StatefulSet to be removed w
 ### Solution
 Revert the behavior to scale the `dapr-scheduler-server` StatefulSet to 0 when the scheduler is disabled, instead of removing it, as implemented in the Helm chart.
 
+
 ## Workflow actors reminders stopped after Application Health check transition
 
 ### Problem
@@ -31,3 +34,21 @@ On Application Health change daprd was able to trigger an actors update for an e
 
 ### Solution
 Prevent any changes to hosted actor types if the input slice is empty
+
+## Fix Scheduler Etcd client port networking in standalone mode
+
+### Problem
+
+The Scheduler Etcd client port is not available when running in Dapr CLI standalone mode.
+
+### Impact
+
+Cannot perform Scheduler Etcd admin operations in Dapr CLI standalone mode.
+
+### Root cause
+
+The Scheduler Etcd client port is only listened on localhost.
+
+### Solution
+
+The Scheduler Etcd client listen address is now configurable via the `--scheduler-etcd-client-listen-address` CLI flag, meaning port can be exposed when running in standalone mode.

--- a/pkg/scheduler/server/internal/etcd/config.go
+++ b/pkg/scheduler/server/internal/etcd/config.go
@@ -93,7 +93,7 @@ func config(opts Options) (*embed.Config, error) {
 	config.AdvertisePeerUrls = []url.URL{etcdURL}
 	config.ListenClientUrls = []url.URL{{
 		Scheme: "http",
-		Host:   "127.0.0.1:" + strconv.FormatUint(opts.ClientPort, 10),
+		Host:   opts.ClientListenAddress + ":" + strconv.FormatUint(opts.ClientPort, 10),
 	}}
 
 	switch opts.Mode {

--- a/pkg/scheduler/server/internal/etcd/config_test.go
+++ b/pkg/scheduler/server/internal/etcd/config_test.go
@@ -35,6 +35,7 @@ func TestServerConf(t *testing.T) {
 			Name:                 "id2",
 			InitialCluster:       []string{"id1=http://localhost:5001", "id2=http://localhost:5002"},
 			ClientPort:           5001,
+			ClientListenAddress:  "127.0.0.1",
 			SpaceQuota:           0,
 			CompactionMode:       "",
 			CompactionRetention:  "",
@@ -68,6 +69,7 @@ func TestServerConf(t *testing.T) {
 			Name:                 "id2",
 			InitialCluster:       []string{"id1=http://localhost:5001", "id2=http://localhost:5002"},
 			ClientPort:           5002,
+			ClientListenAddress:  "0.0.0.0",
 			SpaceQuota:           0,
 			CompactionMode:       "",
 			CompactionRetention:  "",
@@ -89,7 +91,7 @@ func TestServerConf(t *testing.T) {
 		}
 		clientURL := url.URL{
 			Scheme: "http",
-			Host:   "127.0.0.1:5002",
+			Host:   "0.0.0.0:5002",
 		}
 
 		assert.Equal(t, listenURL, config.ListenPeerUrls[0])
@@ -106,6 +108,7 @@ func TestServerConf(t *testing.T) {
 			Name:                 "id2",
 			InitialCluster:       []string{"id1=http://hello1:5001", "id2=http://hello2:5002"},
 			ClientPort:           5002,
+			ClientListenAddress:  "localhost",
 			SpaceQuota:           0,
 			CompactionMode:       "",
 			CompactionRetention:  "",
@@ -122,7 +125,7 @@ func TestServerConf(t *testing.T) {
 		}
 		clientURL := url.URL{
 			Scheme: "http",
-			Host:   "127.0.0.1:5002",
+			Host:   "localhost:5002",
 		}
 		assert.Equal(t, listenURL, config.ListenPeerUrls[0])
 		assert.Equal(t, clientURL, config.ListenClientUrls[0])
@@ -137,6 +140,7 @@ func TestServerConf(t *testing.T) {
 			Name:                 "id2",
 			InitialCluster:       []string{"id1=http://1.2.3.4:5001", "id2=http://1.2.3.4:5002"},
 			ClientPort:           5002,
+			ClientListenAddress:  "127.0.0.1",
 			SpaceQuota:           0,
 			CompactionMode:       "",
 			CompactionRetention:  "",
@@ -168,6 +172,7 @@ func TestServerConf(t *testing.T) {
 			Name:                 "id2",
 			InitialCluster:       []string{"id1=http://1.2.3.4:5001", "id2=http://1.2.3.4:5002"},
 			ClientPort:           5002,
+			ClientListenAddress:  "127.0.0.1",
 			SpaceQuota:           0,
 			CompactionMode:       "",
 			CompactionRetention:  "",

--- a/pkg/scheduler/server/internal/etcd/etcd.go
+++ b/pkg/scheduler/server/internal/etcd/etcd.go
@@ -40,6 +40,7 @@ type Options struct {
 
 	InitialCluster             []string
 	ClientPort                 uint64
+	ClientListenAddress        string
 	SpaceQuota                 int64
 	CompactionMode             string
 	CompactionRetention        string

--- a/pkg/scheduler/server/server.go
+++ b/pkg/scheduler/server/server.go
@@ -53,6 +53,7 @@ type Options struct {
 	EtcdName                       string
 	EtcdInitialCluster             []string
 	EtcdClientPort                 uint64
+	EtcdClientListenAddress        string
 	EtcdSpaceQuota                 int64
 	EtcdCompactionMode             string
 	EtcdCompactionRetention        string
@@ -108,6 +109,7 @@ func New(opts Options) (*Server, error) {
 		Embed:                      opts.EtcdEmbed,
 		InitialCluster:             opts.EtcdInitialCluster,
 		ClientPort:                 opts.EtcdClientPort,
+		ClientListenAddress:        opts.EtcdClientListenAddress,
 		SpaceQuota:                 opts.EtcdSpaceQuota,
 		CompactionMode:             opts.EtcdCompactionMode,
 		CompactionRetention:        opts.EtcdCompactionRetention,


### PR DESCRIPTION
Fix Scheduler Etcd client port networking in standalone mode

Problem

The Scheduler Etcd client port is not available when running in Dapr CLI standalone mode.

Impact

Cannot perform Scheduler Etcd admin operations in Dapr CLI standalone mode.

Root cause

The Scheduler Etcd client port is only listened on localhost.

Solution

The Scheduler Etcd client listen address is now configurable via the `--scheduler-etcd-client-listen-address` CLI flag, meaning port can be exposed when running in standalone mode.

---

The listen address will continue to be configured as `127.0.0.1` when running in Kubernetes.