### PR TITLE
Use bitnamilegacy for postgres and rabbitmq

### DIFF
--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -508,6 +508,7 @@ setup-test-env-rabbitmq:
 	  --set auth.password='admin' \
 	  --namespace $(DAPR_TEST_NAMESPACE) \
 	  --set persistence.size=1Gi \
+	  --set image.repository=bitnamilegacy/rabbitmq \
 	  --timeout 10m0s
 
 # install mqtt to the cluster
@@ -541,6 +542,7 @@ setup-test-env-postgres:
 	  --version 12.8.0 \
 	  -f ./tests/config/postgres_override.yaml \
 	  --set primary.persistence.size=1Gi \
+	  --set image.repository=bitnamilegacy/postgresql \
 	  --namespace $(DAPR_TEST_NAMESPACE) \
 	  --wait \
 	  --timeout 5m0s


### PR DESCRIPTION
e2e tests are failing at the postgres step because of the missing image. Ref: https://github.com/dapr/dapr/actions/runs/17844140967/job/50740060069?pr=9071