### PR TITLE
Workflows bugfix: app health check transitions stops reminders

### DIFF
--- a/docs/release_notes/v1.16.1.md
+++ b/docs/release_notes/v1.16.1.md
@@ -17,3 +17,17 @@ A previous change caused the `dapr-scheduler-server` StatefulSet to be removed w
 
 ### Solution
 Revert the behavior to scale the `dapr-scheduler-server` StatefulSet to 0 when the scheduler is disabled, instead of removing it, as implemented in the Helm chart.
+
+## Workflow actors reminders stopped after Application Health check transition
+
+### Problem
+Application Health checks transitioning from unhealthy to healthy were incorrectly configuring the scheduler clients to stop watching for actor reminder jobs.
+
+### Impact
+The misconfiguration in the scheduler clients made workflows to stop executing because reminders no longer executed.
+
+### Root cause
+On Application Health change daprd was able to trigger an actors update for an empty slice, which caused a scheduler client reconfiguration. However because there were no changes in the actor types, daprd never received a new version of the placement table which caused the scheduler clients to get misconfigured. This happens because when daprd sends an actor types update to the placement server daprd wipes out the known actor types in the scheduler client, and because daprd never received an acknowledgement from placement with a new table version then the scheduler client never got updated back with the actor types.
+
+### Solution
+Prevent any changes to hosted actor types if the input slice is empty

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -492,6 +492,10 @@ func (a *actors) UnRegisterHosted(actorTypes ...string) {
 		return
 	}
 
+	if len(actorTypes) == 0 {
+		return
+	}
+
 	a.table.UnRegisterActorTypes(actorTypes...)
 
 	a.registerDoneLock.Lock()

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -397,6 +397,10 @@ func (a *actors) RegisterHosted(cfg hostconfig.Config) error {
 		return nil
 	}
 
+	if len(cfg.HostedActorTypes) == 0 {
+		return nil
+	}
+
 	entityConfigs := make(map[string]api.EntityConfig)
 	for _, entityConfg := range cfg.EntityConfigs {
 		config := api.TranslateEntityConfig(entityConfg)

--- a/pkg/actors/table/table.go
+++ b/pkg/actors/table/table.go
@@ -166,6 +166,10 @@ func (t *table) GetOrCreate(actorType, actorID string) (targets.Interface, error
 }
 
 func (t *table) RegisterActorTypes(opts RegisterActorTypeOptions) {
+	if len(opts.Factories) == 0 {
+		return
+	}
+
 	if opts := opts.HostOptions; opts != nil {
 		t.drainRebalancedActors = opts.DrainRebalancedActors
 		t.entityConfigs = opts.EntityConfigs
@@ -180,6 +184,10 @@ func (t *table) RegisterActorTypes(opts RegisterActorTypeOptions) {
 }
 
 func (t *table) UnRegisterActorTypes(actorTypes ...string) error {
+	if len(actorTypes) == 0 {
+		return nil
+	}
+
 	errs := slice.New[error]()
 	var wg sync.WaitGroup
 	for _, actorType := range actorTypes {

--- a/pkg/apphealth/health.go
+++ b/pkg/apphealth/health.go
@@ -196,7 +196,7 @@ func (h *AppHealth) doProbe(parentCtx context.Context) {
 		log.Debug("App health probe detected status change - health probe successful: " + strconv.FormatBool(status.IsHealthy))
 		h.setResult(parentCtx, status)
 	} else {
-		log.Debug("App health probe status is unchanged - health probe successful: %v", strconv.FormatBool(status.IsHealthy))
+		log.Debug("App health probe status is unchanged - health probe successful: " + strconv.FormatBool(status.IsHealthy))
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/apphealth/apphealth.go
+++ b/tests/integration/suite/daprd/workflow/apphealth/apphealth.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apphealth
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	durabletask_client "github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+// luis case: app is unhealthy, worker is connected, app transitions to healthy
+
+func init() {
+	suite.Register(new(apphealth))
+}
+
+type apphealth struct {
+	healthy  atomic.Bool
+	app      *app.App
+	workflow *workflow.Workflow
+}
+
+func (a *apphealth) Setup(t *testing.T) []framework.Option {
+	a.healthy.Store(true)
+	a.app = app.New(t,
+		app.WithHealthCheckFn(func(context.Context, *emptypb.Empty) (*rtv1.HealthCheckResponse, error) {
+			if a.healthy.Load() {
+				return &rtv1.HealthCheckResponse{}, nil
+			}
+			return nil, errors.New("app not healthy")
+		}),
+	)
+
+	a.workflow = workflow.New(t,
+		workflow.WithDaprdOptions(0,
+			daprd.WithAppPort(a.app.Port(t)),
+			daprd.WithAppProtocol("grpc"),
+			daprd.WithAppHealthCheck(true),
+			daprd.WithAppHealthProbeInterval(1),
+			daprd.WithAppHealthProbeThreshold(1),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.app, a.workflow),
+	}
+}
+
+func (a *apphealth) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	a.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		if err := ctx.CallActivity("bar").Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.CallActivity("bar").Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	a.workflow.Registry().AddActivityN("bar", func(ctx task.ActivityContext) (any, error) {
+		return nil, nil
+	})
+
+	// app starts unhealthy
+	a.healthy.Store(false)
+	// we have no way of knowing when the sidecar detected if the app is unhealthy
+	time.Sleep(time.Second * 3)
+
+	// connect the worker
+	client := durabletask_client.NewTaskHubGrpcClient(a.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
+	require.NoError(t, client.StartWorkItemListener(ctx, a.workflow.Registry()))
+	// this sleep is the key
+	// it makes sure you get the placement tables update before the application becomes healthy
+	// the root cause of the bug we were following was that the app transitioning to healthy was wiping out the actor types
+	time.Sleep(time.Second * 10)
+
+	// app transitions to healthy
+	a.healthy.Store(true)
+	// active actors is dependant on the app health checks
+	// hence we cannot check the active actors while the app is unhealthy
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c,
+			len(a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors), 2)
+	}, time.Second*10, time.Millisecond*10)
+
+	scheduleCtx, scheduleCancel := context.WithTimeout(ctx, time.Second*10)
+	t.Cleanup(scheduleCancel)
+	id, err := client.ScheduleNewOrchestration(scheduleCtx, "foo")
+	require.NoError(t, err, "failed to schedule workflow")
+	waitCompletionCtx, waitCompletionCancel := context.WithTimeout(ctx, time.Second*10)
+	t.Cleanup(waitCompletionCancel)
+	meta, err := client.WaitForOrchestrationCompletion(waitCompletionCtx, id)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/apphealth/apphealth.go
+++ b/tests/integration/suite/daprd/workflow/apphealth/apphealth.go
@@ -94,7 +94,7 @@ func (a *apphealth) Run(t *testing.T, ctx context.Context) {
 	// this sleep could be avoided if we could inspect the watched job types from the scheduler
 	time.Sleep(time.Second * 3)
 
-	require.Empty(t, len(a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors))
+	require.Empty(t, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors)
 
 	// connect the worker
 	client := durabletask_client.NewTaskHubGrpcClient(a.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))

--- a/tests/integration/suite/daprd/workflow/apphealth/apphealth.go
+++ b/tests/integration/suite/daprd/workflow/apphealth/apphealth.go
@@ -94,7 +94,7 @@ func (a *apphealth) Run(t *testing.T, ctx context.Context) {
 	// this sleep could be avoided if we could inspect the watched job types from the scheduler
 	time.Sleep(time.Second * 3)
 
-	require.Equal(t, 0, len(a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors))
+	require.Empty(t, len(a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors))
 
 	// connect the worker
 	client := durabletask_client.NewTaskHubGrpcClient(a.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))

--- a/tests/integration/suite/daprd/workflow/apphealth/unhealthy.go
+++ b/tests/integration/suite/daprd/workflow/apphealth/unhealthy.go
@@ -93,7 +93,7 @@ func (a *unhealthy) Run(t *testing.T, ctx context.Context) {
 	// we have no way of knowing when the sidecar detected if the app is unhealthy
 	time.Sleep(time.Second * 3)
 
-	require.Empty(t, len(a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors))
+	require.Empty(t, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors)
 
 	// connect the worker
 	client := durabletask_client.NewTaskHubGrpcClient(a.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))

--- a/tests/integration/suite/daprd/workflow/apphealth/unhealthy.go
+++ b/tests/integration/suite/daprd/workflow/apphealth/unhealthy.go
@@ -93,7 +93,7 @@ func (a *unhealthy) Run(t *testing.T, ctx context.Context) {
 	// we have no way of knowing when the sidecar detected if the app is unhealthy
 	time.Sleep(time.Second * 3)
 
-	require.Equal(t, 0, len(a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors))
+	require.Empty(t, len(a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors))
 
 	// connect the worker
 	client := durabletask_client.NewTaskHubGrpcClient(a.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -14,6 +14,7 @@ limitations under the License.
 package workflow
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/apphealth"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/basic"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/continueasnew"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/crossapp"


### PR DESCRIPTION
# Description

We have found that app health checks were making the sidecar to stop watching for reminder jobs from the scheduler, resulting in workflows that suddenly stopped being executed

Adds an integration test that requires improvements, we either lack machinery, or I am not aware of it, to check the internal details that this test tries to control in order to exactly reproduce the issue

This test also showed a daprd side-effect between workflows and actors, the metadata API doesn't report the workflow actors if the app health check reports unhealthy

kudos to @lrascao for the help troubleshooting this

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
