### PR TITLE
fix: actor init timing to wait for app channel readiness

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -696,15 +696,15 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	}
 	log.Infof("Internal gRPC server is running on %s:%d", a.runtimeConfig.internalGRPCListenAddress, a.runtimeConfig.internalGRPCPort)
 
+	a.runtimeConfig.outboundHealthz.AddTarget("app").Ready()
+	if err := a.blockUntilAppIsReady(ctx); err != nil {
+		return err
+	}
+
 	a.initDirectMessaging(a.nameResolver)
 
 	if err := a.initActors(ctx); err != nil {
 		return fmt.Errorf("failed to initialize actors: %w", err)
-	}
-
-	a.runtimeConfig.outboundHealthz.AddTarget("app").Ready()
-	if err := a.blockUntilAppIsReady(ctx); err != nil {
-		return err
 	}
 
 	if a.runtimeConfig.appConnectionConfig.MaxConcurrency > 0 {
@@ -1265,6 +1265,7 @@ func (a *DaprRuntime) blockUntilAppIsReady(ctx context.Context) error {
 
 	dialAddr := a.runtimeConfig.appConnectionConfig.ChannelAddress + ":" + strconv.Itoa(a.runtimeConfig.appConnectionConfig.Port)
 
+	counter := 0
 	for {
 		var (
 			conn net.Conn
@@ -1285,12 +1286,16 @@ func (a *DaprRuntime) blockUntilAppIsReady(ctx context.Context) error {
 			break
 		}
 
+		counter++
 		select {
 		// Return
 		case <-ctx.Done():
 			return ctx.Err()
 		// prevents overwhelming the OS with open connections
-		case <-a.clock.After(time.Millisecond * 100):
+		case <-a.clock.After(time.Millisecond * 100): // .1 sec
+			if counter%100 == 0 { // log to notify user every 10 sec
+				log.Infof("waiting for application to listen on port %v", a.runtimeConfig.appConnectionConfig.Port)
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR fixes actor initialization timing to wait for app channel readiness. When running Dapr with an `--app-port` specified but no application listening on that port (either due to no server or delayed server startup), the actor runtime would initialize immediately before the app channel was ready. This created a race condition where actors were trying to communicate with an application that wasn't available yet, resulting in repeated error logs:

```
`Executing task: dapr run --app-id weather --resources-path ./components --dapr-http-port 3500 --dapr-grpc-port 50001 --app-port 8001 --log-level debug 

Agent pid 88752
Identity added: /Users/samcoyle/.ssh/id_ed25519 (sam@diagrid.io)
source /Users/samcoyle/go/src/github.com/dapr-agents/quickstarts/05-multi-agent-workflows/.venv/bin/activate
WARNING: no application command found.
ℹ️  Starting Dapr with id weather. HTTP Port: 3500. gRPC Port: 50001
INFO[0000] Starting Dapr Runtime -- version 1.16.0 -- commit b68296042c975d4ede1ed93ec6b0a579c2b6a020  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Log level set to: debug                       app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
WARN[0000] mTLS is disabled. Skipping certificate request and tls validation  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.security type=log ver=1.16.0
DEBU[0000] Loading config from file(s): /Users/samcoyle/.dapr/config.yaml  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Enabled features: SchedulerReminders          app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Creating a new meter for metrics              app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] metric spec: {"enabled":true}                 app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.diagnostics type=log ver=1.16.0
INFO[0000] Using default latency distribution buckets: [1 2 3 4 5 6 8 10 13 16 20 25 30 40 50 65 80 100 130 160 200 250 300 400 500 650 800 1000 2000 5000 10000 20000 50000 100000]  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.diagnostics type=log ver=1.16.0
WARN[0000] The default value for 'spec.metric.http.increasedCardinality' will change to 'false' in Dapr 1.15 or later  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.diagnostics type=log ver=1.16.0
DEBU[0000] Found 0 resiliency configurations in resources path  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Hot reloading disabled                        app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.hotreload type=log ver=1.16.0
INFO[0000] standalone mode configured                    app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] app id: weather                               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Attempting to connect to scheduler to WatchHosts: localhost:50006  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.watchhosts type=log ver=1.16.0
INFO[0000] Dapr trace sampler initialized: ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] metrics server started on 0.0.0.0:59364/      app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] local service entry announced: weather -> 45.24.101.27:59365  app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=1.16.0
INFO[0000] Initialized name resolution to mdns           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Loading components…                           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Found component: conversationstore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Found component: openai (conversation.openai/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Loading component: conversationstore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
INFO[0000] Connected and received scheduler hosts addresses: [localhost:50006]  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.watchhosts type=log ver=1.16.0
DEBU[0000] Attempting to connect to Scheduler at address: localhost:50006  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.clients type=log ver=1.16.0
INFO[0000] Scheduler client initialized for address: localhost:50006  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.clients type=log ver=1.16.0
INFO[0000] Scheduler clients initialized                 app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.clients type=log ver=1.16.0
INFO[0000] Component loaded: conversationstore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
DEBU[0000] Loading component: openai (conversation.openai/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
INFO[0000] Component loaded: openai (conversation.openai/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
DEBU[0000] Found component: messagepubsub (pubsub.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Found component: registrystatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Loading component: messagepubsub (pubsub.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
INFO[0000] Component loaded: messagepubsub (pubsub.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
DEBU[0000] Loading component: registrystatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
DEBU[0000] Found component: workflowstatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Component loaded: registrystatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
DEBU[0000] Loading component: workflowstatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
INFO[0000] Waiting for all outstanding components to be processed…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Using 'workflowstatestore' as actor state store  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor.state type=log ver=1.16.0
INFO[0000] Component loaded: workflowstatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=1.16.0
INFO[0000] All outstanding components processed          app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Loading endpoints…                            app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Waiting for all outstanding http endpoints to be processed…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] All outstanding http endpoints processed      app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Loading Declarative Subscriptions…            app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0000] Refreshing channels                           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.channels type=log ver=1.16.0
DEBU[0000] Channels refreshed                            app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.channels type=log ver=1.16.0
INFO[0000] gRPC server listening on TCP address: :50001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=1.16.0
INFO[0000] Enabled gRPC tracing middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=1.16.0
INFO[0000] Enabled gRPC metrics middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=1.16.0
INFO[0000] Registering workflow engine for gRPC endpoint: [::]:50001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=1.16.0
INFO[0000] API gRPC server is running on port 50001      app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
WARN[0000] The default value for 'spec.metric.http.increasedCardinality' will change to 'false' in Dapr 1.15 or later  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=1.16.0
INFO[0000] Enabled max body size HTTP middleware with size 4194304 bytes  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=1.16.0
INFO[0000] Enabled tracing HTTP middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=1.16.0
INFO[0000] Enabled metrics HTTP middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=1.16.0
INFO[0000] HTTP server listening on TCP address: :3500   app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=1.16.0
INFO[0000] HTTP server is running on port 3500           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] The request body size parameter is: 4194304 bytes  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] gRPC server listening on TCP address: :59365  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.internal type=log ver=1.16.0
INFO[0000] Enabled gRPC tracing middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.internal type=log ver=1.16.0
INFO[0000] Enabled gRPC metrics middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.internal type=log ver=1.16.0
INFO[0000] Internal gRPC server is running on :59365     app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Using Scheduler service for reminders.        app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.actor.reminders.scheduler type=log ver=1.16.0
INFO[0000] application protocol: http. waiting on port 8001.  This will block until the app is listening on that port.  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0000] Actor runtime started                         app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.actor type=log ver=1.16.0
WARN[0000] Graceful shutdown timeout is infinite, will wait indefinitely to shutdown  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.actor type=log ver=1.16.0
INFO[0000] worker started with backend dapr.actors/v1    app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.wfengine.durabletask.backend type=log ver=1.16.0
INFO[0000] Workflow engine started                       app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.wfengine type=log ver=1.16.0
DEBU[0000] Actor backend is waiting for a workflow actor to schedule an invocation.  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.wfengine.backend.actors type=log ver=1.16.0
DEBU[0000] Actor backend is waiting for an activity actor to schedule an invocation.  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.wfengine.backend.actors type=log ver=1.16.0
✅  You're up and running! Dapr logs will appear here.

DEBU[0030] Refreshing all mDNS addresses.                app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=1.16.0
DEBU[0030] no mDNS apps to refresh.                      app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=1.16.0
INFO[0043] work item stream established by user-agent: [grpc-python/1.75.0 grpc-c/50.0.0 (osx; chttp2)]  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.wfengine type=log ver=1.16.0
DEBU[0043] Registering workflow actors                   app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.wfengine type=log ver=1.16.0
DEBU[0060] Refreshing all mDNS addresses.                app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=1.16.0
DEBU[0060] no mDNS apps to refresh.                      app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=1.16.0
WARN[0064] Error processing operation DaprBuiltInActorNotFoundRetries. Retrying in 1s…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0064] Error for operation DaprBuiltInActorNotFoundRetries was: failed to lookup actor: api error: code = FailedPrecondition desc = did not find address for actor  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
WARN[0070] Error processing operation DaprBuiltInActorNotFoundRetries. Retrying in 1s…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0070] Error for operation DaprBuiltInActorNotFoundRetries was: failed to lookup actor: api error: code = FailedPrecondition desc = did not find address for actor  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
WARN[0076] Error processing operation DaprBuiltInActorNotFoundRetries. Retrying in 1s…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0076] Error for operation DaprBuiltInActorNotFoundRetries was: failed to lookup actor: api error: code = FailedPrecondition desc = did not find address for actor  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
WARN[0082] Error processing operation DaprBuiltInActorNotFoundRetries. Retrying in 1s…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0082] Error for operation DaprBuiltInActorNotFoundRetries was: failed to lookup actor: api error: code = FailedPrecondition desc = did not find address for actor  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
WARN[0088] Error processing operation DaprBuiltInActorNotFoundRetries. Retrying in 1s…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0088] Error for operation DaprBuiltInActorNotFoundRetries was: failed to lookup actor: api error: code = FailedPrecondition desc = did not find address for actor  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0090] Refreshing all mDNS addresses.                app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=1.16.0
DEBU[0090] no mDNS apps to refresh.                      app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=1.16.0
WARN[0094] Error processing operation DaprBuiltInActorNotFoundRetries. Retrying in 1s…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0094] Error for operation DaprBuiltInActorNotFoundRetries was: failed to lookup actor: api error: code = FailedPrecondition desc = did not find address for actor  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
WARN[0100] Error processing operation DaprBuiltInActorNotFoundRetries. Retrying in 1s…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
DEBU[0100] Error for operation DaprBuiltInActorNotFoundRetries was: failed to lookup actor: api error: code = FailedPrecondition desc = did not find address for actor  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=1.16.0
INFO[0101] work item stream closed                       app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=
```



This creates a poor user experience with confusing error messages when the app channel is not available, whether due to no application running or delayed startup.

See here a related issue:
https://github.com/dapr/dapr/issues/8341

There are many issues out there in the ether that have this `DaprBuiltInActorNotFoundRetries` err. For example:
https://github.com/dapr/dapr/issues/9070
https://github.com/dapr/dapr/issues/9038
even here an unrelated issue but we see this err from a retry https://github.com/dapr/dapr-agents/issues/179


We see varying degrees of the retries kick in depending on the application. These are because the actor runtime initialization was occurring before the app channel was ready, creating a race condition where actors attempted to communicate with an unavailable application (at the time, or indefinitely). This PR ensures proper ordering now:

1. Defer actor runtime initialization until the application is listening on the specified port
2. Provide informative `waiting for application to listen on port XXXX` messages instead of confusing error logs that are actor specific that make us think/investigate actor/workflow internals

Now, we see just the log waiting for the application to be listening, and since the order is correct, we no longer get an actor err (and I as an end user / app dev can more easily read that log line and know what is missing):
```
Executing task: dapr run --app-id weather --resources-path ./components --dapr-http-port 3500 --dapr-grpc-port 50001 --app-port 8001 --log-level debug 

source /Users/samcoyle/go/src/github.com/dapr-agents/quickstarts/05-multi-agent-workflows/.venv/bin/activate
Agent pid 46016
Identity added: /Users/samcoyle/.ssh/id_ed25519 (sam@diagrid.io)
WARNING: no application command found.
ℹ️  Starting Dapr with id weather. HTTP Port: 3500. gRPC Port: 50001
INFO[0000] Starting Dapr Runtime -- version edge -- commit   app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Log level set to: debug                       app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
WARN[0000] mTLS is disabled. Skipping certificate request and tls validation  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.security type=log ver=unknown
DEBU[0000] Loading config from file(s): /Users/samcoyle/.dapr/config.yaml  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Enabled features: SchedulerReminders          app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Creating a new meter for metrics              app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] metric spec: {"enabled":true}                 app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.diagnostics type=log ver=unknown
INFO[0000] Using default latency distribution buckets: [1 2 3 4 5 6 8 10 13 16 20 25 30 40 50 65 80 100 130 160 200 250 300 400 500 650 800 1000 2000 5000 10000 20000 50000 100000]  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.diagnostics type=log ver=unknown
WARN[0000] The default value for 'spec.metric.http.increasedCardinality' will change to 'false' in Dapr 1.15 or later  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.diagnostics type=log ver=unknown
DEBU[0000] Found 0 resiliency configurations in resources path  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Hot reloading disabled                        app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.hotreload type=log ver=unknown
INFO[0000] standalone mode configured                    app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] app id: weather                               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Attempting to connect to scheduler to WatchHosts: localhost:50006  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.watchhosts type=log ver=unknown
INFO[0000] Dapr trace sampler initialized: ParentBased{root:AlwaysOnSampler,remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] metrics server started on 0.0.0.0:62546/      app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] local service entry announced: weather -> 45.24.101.27:62547  app_id=weather component="nr (mdns/v1)" instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.contrib type=log ver=unknown
INFO[0000] Initialized name resolution to mdns           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Loading components…                           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Found component: conversationstore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Found component: openai (conversation.openai/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Loading component: conversationstore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
INFO[0000] Connected and received scheduler hosts addresses: [localhost:50006]  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.watchhosts type=log ver=unknown
DEBU[0000] Attempting to connect to Scheduler at address: localhost:50006  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.clients type=log ver=unknown
INFO[0000] Scheduler client initialized for address: localhost:50006  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.clients type=log ver=unknown
INFO[0000] Scheduler clients initialized                 app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.scheduler.clients type=log ver=unknown
INFO[0000] Component loaded: conversationstore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
DEBU[0000] Loading component: openai (conversation.openai/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
DEBU[0000] Found component: messagepubsub (pubsub.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Component loaded: openai (conversation.openai/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
DEBU[0000] Loading component: messagepubsub (pubsub.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
DEBU[0000] Found component: registrystatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Component loaded: messagepubsub (pubsub.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
DEBU[0000] Loading component: registrystatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
DEBU[0000] Found component: workflowstatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Component loaded: registrystatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
DEBU[0000] Loading component: workflowstatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
INFO[0000] Waiting for all outstanding components to be processed…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Using 'workflowstatestore' as actor state store  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor.state type=log ver=unknown
INFO[0000] Component loaded: workflowstatestore (state.redis/v1)  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.processor type=log ver=unknown
INFO[0000] All outstanding components processed          app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Loading endpoints…                            app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Waiting for all outstanding http endpoints to be processed…  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] All outstanding http endpoints processed      app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] Loading Declarative Subscriptions…            app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Refreshing channels                           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.channels type=log ver=unknown
DEBU[0000] Channels refreshed                            app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.channels type=log ver=unknown
INFO[0000] gRPC server listening on TCP address: :50001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=unknown
INFO[0000] Enabled gRPC tracing middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=unknown
INFO[0000] Enabled gRPC metrics middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=unknown
INFO[0000] Registering workflow engine for gRPC endpoint: [::]:50001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.api type=log ver=unknown
INFO[0000] API gRPC server is running on port 50001      app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
WARN[0000] The default value for 'spec.metric.http.increasedCardinality' will change to 'false' in Dapr 1.15 or later  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=unknown
INFO[0000] Enabled max body size HTTP middleware with size 4194304 bytes  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=unknown
INFO[0000] Enabled tracing HTTP middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=unknown
INFO[0000] Enabled metrics HTTP middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=unknown
INFO[0000] HTTP server listening on TCP address: :3500   app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.http type=log ver=unknown
INFO[0000] HTTP server is running on port 3500           app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] The request body size parameter is: 4194304 bytes  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] gRPC server listening on TCP address: :62547  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.internal type=log ver=unknown
INFO[0000] Enabled gRPC tracing middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.internal type=log ver=unknown
INFO[0000] Enabled gRPC metrics middleware               app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime.grpc.internal type=log ver=unknown
INFO[0000] Internal gRPC server is running on :62547     app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
DEBU[0000] Sam sanity check                              app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] application protocol: http. waiting on port 8001.  This will block until the app is listening on that port.  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] waiting for application to listen on port 8001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] waiting for application to listen on port 8001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] waiting for application to listen on port 8001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] waiting for application to listen on port 8001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
INFO[0000] waiting for application to listen on port 8001  app_id=weather instance=45-24-101-27.lightspeed.ltrkar.sbcglobal.net scope=dapr.runtime type=log ver=unknown
```


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
