### PR TITLE
[1.16] Scheduler External etcd with multiple client endpoints

### DIFF
--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -125,7 +125,7 @@ func New(origArgs []string) (*Options, error) {
 	fs.BoolVar(&opts.EtcdInitialElectionTickAdvance, "etcd-initial-election-tick-advance", false, "Whether to fast-forward initial election ticks on boot for faster election. When it is true, then local member fast-forwards election ticks to speed up “initial” leader election trigger. This benefits the case of larger election ticks. Disabling this would slow down initial bootstrap process for cross datacenter deployments. Make your own tradeoffs by configuring this flag at the cost of slow initial bootstrap.")
 	fs.StringVar(&opts.EtcdMetrics, "etcd-metrics", "basic", "Level of detail for exported metrics, specify ’extensive’ to include histogram metrics.")
 
-	fs.StringArrayVar(&opts.EtcdClientEndpoints, "etcd-client-endpoints", []string{}, "Comma-separated list of etcd client endpoints to connect to. Only used when --etcd-embed is false.")
+	fs.StringSliceVar(&opts.EtcdClientEndpoints, "etcd-client-endpoints", nil, "Comma-separated list of etcd client endpoints to connect to. Only used when --etcd-embed is false.")
 	fs.StringVar(&opts.EtcdClientUsername, "etcd-client-username", "", "Username for etcd client authentication. Only used when --etcd-embed is false.")
 	fs.StringVar(&opts.EtcdClientPassword, "etcd-client-password", "", "Password for etcd client authentication. Only used when --etcd-embed is false.")
 

--- a/docs/release_notes/v1.16.2.md
+++ b/docs/release_notes/v1.16.2.md
@@ -3,6 +3,7 @@
 This update includes bug fixes:
 
 - [HTTP API default CORS behavior](#http-api-default-cors-behavior)
+- [Scheduler External etcd with multiple client endpoints](#scheduler-external-etcd-with-multiple-client-endpoints)
 
 ## HTTP API default CORS behavior
 
@@ -14,3 +15,21 @@ This caused problems in scenarios where CORS is handled outside of the Dapr side
 
 ### Solution
 Revert part of the behavior introduced in this [PR](https://github.com/dapr/dapr/pull/9025) and change the default value of `allowed-origins` flag to be an empty string, and disabling the CORS filter by default.
+
+## Scheduler External etcd with multiple client endpoints
+
+### Problem
+
+Using Scheduler in non-embed mode with multiple etcd client endpoints was not working.
+
+### Impact
+
+It was not possible to use multiple etcd endpoints for high availability with an external etcd database for scheduler.
+
+### Root Cause
+
+The Scheduler etcd client endpoints CLI flag was typed as an string array, rather than a string slice, causing the given value to be parsed as a single string rather than a slice of strings.
+
+### Solution
+
+Changed the type of the etcd client endpoints CLI flag to be a string slice.

--- a/tests/integration/framework/process/scheduler/etcd/etcd.go
+++ b/tests/integration/framework/process/scheduler/etcd/etcd.go
@@ -49,8 +49,9 @@ func New(t *testing.T, fopts ...Option) *Etcd {
 	}
 
 	require.Equal(t, opts.username != nil, opts.password != nil, "username and password must be set together")
+	require.Positive(t, opts.nodes, "nodes must be greater than 0")
 
-	fp := ports.Reserve(t, int(opts.nodes*2))
+	fp := ports.Reserve(t, opts.nodes*2)
 
 	configs := make([]*embed.Config, opts.nodes)
 	endpoints := make([]string, opts.nodes)
@@ -75,7 +76,7 @@ func New(t *testing.T, fopts ...Option) *Etcd {
 
 		config.ListenMetricsUrls = nil
 
-		config.Name = "etcd" + strconv.FormatUint(i, 10)
+		config.Name = "etcd" + strconv.Itoa(i)
 
 		configs[i] = config
 		endpoints[i] = clientEndpoint

--- a/tests/integration/framework/process/scheduler/etcd/options.go
+++ b/tests/integration/framework/process/scheduler/etcd/options.go
@@ -18,6 +18,8 @@ type Option func(*options)
 type options struct {
 	username *string
 	password *string
+
+	nodes uint64
 }
 
 func WithUsername(username string) Option {
@@ -29,5 +31,11 @@ func WithUsername(username string) Option {
 func WithPassword(password string) Option {
 	return func(o *options) {
 		o.password = &password
+	}
+}
+
+func WithNodes(nodes uint64) Option {
+	return func(o *options) {
+		o.nodes = nodes
 	}
 }

--- a/tests/integration/framework/process/scheduler/etcd/options.go
+++ b/tests/integration/framework/process/scheduler/etcd/options.go
@@ -19,7 +19,7 @@ type options struct {
 	username *string
 	password *string
 
-	nodes uint64
+	nodes int
 }
 
 func WithUsername(username string) Option {
@@ -34,7 +34,7 @@ func WithPassword(password string) Option {
 	}
 }
 
-func WithNodes(nodes uint64) Option {
+func WithNodes(nodes int) Option {
 	return func(o *options) {
 		o.nodes = nodes
 	}

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -155,7 +155,7 @@ func New(t *testing.T, fopts ...Option) *Scheduler {
 		args = append(args, "--etcd-embed="+strconv.FormatBool(*opts.embed))
 	}
 	if opts.clientEndpoints != nil {
-		args = append(args, "--etcd-client-endpoints="+strings.Join(*opts.clientEndpoints, ","))
+		args = append(args, `--etcd-client-endpoints=`+strings.Join(*opts.clientEndpoints, ","))
 	}
 
 	if opts.clientUsername != nil {

--- a/tests/integration/suite/scheduler/embed/cluster.go
+++ b/tests/integration/suite/scheduler/embed/cluster.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package embed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	schedulerv1 "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/etcd"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(cluster))
+}
+
+type cluster struct {
+	scheduler *scheduler.Scheduler
+}
+
+func (c *cluster) Setup(t *testing.T) []framework.Option {
+	etcd := etcd.New(t,
+		etcd.WithNodes(3),
+	)
+
+	c.scheduler = scheduler.New(t,
+		scheduler.WithEmbed(false),
+		scheduler.WithClientEndpoints(etcd.Endpoints()...),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(etcd, c.scheduler),
+	}
+}
+
+func (c *cluster) Run(t *testing.T, ctx context.Context) {
+	c.scheduler.WaitUntilRunning(t, ctx)
+
+	client := c.scheduler.Client(t, ctx)
+
+	_, err := client.ScheduleJob(ctx, &schedulerv1.ScheduleJobRequest{
+		Name: "test",
+		Job: &schedulerv1.Job{
+			Schedule: ptr.Of("@every 20s"),
+		},
+		Metadata: &schedulerv1.JobMetadata{
+			AppId:     "appid",
+			Namespace: "namespace",
+			Target: &schedulerv1.JobTargetMetadata{
+				Type: new(schedulerv1.JobTargetMetadata_Job),
+			},
+		},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Problem

Using Scheduler in non-embed mode with multiple etcd client endpoints was not working.

Impact

It was not possible to use multiple etcd endpoints for high availability with an external etcd database for scheduler.

Root Cause

The Scheduler etcd client endpoints CLI flag was typed as an string array, rather than a string slice, causing the given value to be parsed as a single string rather than a slice of strings.

Solution

Changed the type of the etcd client endpoints CLI flag to be a string slice.