### PR TITLE
Fix placement dissemination during high churn events

### DIFF
--- a/docs/release_notes/v1.16.2.md
+++ b/docs/release_notes/v1.16.2.md
@@ -5,6 +5,7 @@ This update includes bug fixes:
 - [HTTP API default CORS behavior](#http-api-default-cors-behavior)
 - [Scheduler External etcd with multiple client endpoints](#scheduler-external-etcd-with-multiple-client-endpoints)
 - [Placement not cleaning internal state after host that had actors disconnects](#placement-not-cleaning-internal-state-after-host-that-had-actors-disconnects)
+- [Blocked Placement dissemination during high churn](#blocked-placement-dissemination-during-high-churn)
 
 ## HTTP API default CORS behavior
 
@@ -52,3 +53,21 @@ The function `requiresUpdateInPlacementTables` sould not set `isActorHost` to fa
 ### Solution
 
 Update the logic in `requiresUpdateInPlacementTables`.
+
+## Blocked Placement dissemination during high churn
+
+### Problem
+
+Placement would fail to ever, or very slowly, disseminate the actor table in high daprd churn scenarios.
+
+### Impact
+
+Actors or workflows would fail to be activated, and existing actors or workflows would fail.
+
+### Root Cause
+
+Placement used a "small" (100) queue size which when exhausted would cause a deadlock. Placement would also wait for a fully consumed channel queue before disseminating slowing down the dissemination process.
+
+### Solution
+
+Increase the queue size to 10000 and change the dissemination logic to not wait for a fully consumed queue before disseminating.

--- a/pkg/actors/router/router.go
+++ b/pkg/actors/router/router.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/cenkalti/backoff/v4"
 	"google.golang.org/grpc"
@@ -244,10 +245,15 @@ func (r *router) callActor(ctx context.Context, req *internalv1pb.InternalInvoke
 	}
 
 	attempt := resiliency.GetAttempt(ctx)
-	code := status.Code(err)
-	if code == codes.Unavailable {
-		// Destroy the connection and force a re-connection on the next attempt
-		return res, fmt.Errorf("failed to invoke target %s after %d retries. Error: %w", lar.Address, attempt-1, err)
+	s, ok := status.FromError(err)
+	if ok {
+		if s.Code() == codes.Unavailable ||
+			(s.Code() == codes.Internal &&
+				(s.Message() == "error invoke actor method: remote actor moved" ||
+					strings.HasSuffix(s.Message(), ": placement is disseminating"))) {
+			// Destroy the connection and force a re-connection on the next attempt
+			return res, fmt.Errorf("failed to invoke target %s after %d retries. Error: %w", lar.Address, attempt-1, err)
+		}
 	}
 
 	return res, backoff.Permanent(err)

--- a/pkg/placement/leadership.go
+++ b/pkg/placement/leadership.go
@@ -176,7 +176,6 @@ func (p *Service) revokeLeadership() {
 
 	p.streamConnPool.streamIndex.Store(0)
 	p.disseminateLocks.Clear()
-	p.disseminateNextTime.Clear()
 	p.memberUpdateCount.Clear()
 	p.cleanupHeartbeats()
 }

--- a/tests/integration/suite/actors/lock/call/reentry/remote/grpc.go
+++ b/tests/integration/suite/actors/lock/call/reentry/remote/grpc.go
@@ -80,6 +80,7 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 
 func (g *grpc) Run(t *testing.T, ctx context.Context) {
 	g.app1.WaitUntilRunning(t, ctx)
+	g.app2.WaitUntilRunning(t, ctx)
 
 	client := g.app1.GRPCClient(t, ctx)
 

--- a/tests/integration/suite/daprd/workflow/timer/base.go
+++ b/tests/integration/suite/daprd/workflow/timer/base.go
@@ -59,5 +59,5 @@ func (b *base) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, time.Since(start).Seconds(), 7.0)
+	assert.GreaterOrEqual(t, time.Since(start).Seconds(), 6.0)
 }

--- a/tests/integration/suite/daprd/workflow/timer/resumeearly.go
+++ b/tests/integration/suite/daprd/workflow/timer/resumeearly.go
@@ -64,5 +64,5 @@ func (r *resumeearly) Run(t *testing.T, ctx context.Context) {
 
 	_, err = client.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, time.Since(start).Seconds(), 8.0)
+	assert.GreaterOrEqual(t, time.Since(start).Seconds(), 7.0)
 }

--- a/tests/integration/suite/placement/dissemination/streamhang.go
+++ b/tests/integration/suite/placement/dissemination/streamhang.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"sync"
 	"testing"
 	"time"
 
@@ -107,11 +106,8 @@ func (n *streamHang) Run(t *testing.T, ctx context.Context) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// Start reading from stream2
-	var wg sync.WaitGroup
-	wg.Add(1)
 	updateCh2 := make(chan *v1pb.PlacementTables, 5)
 	go func() {
-		defer wg.Done()
 		defer close(updateCh2)
 		for {
 			select {
@@ -177,10 +173,8 @@ func (n *streamHang) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err, "Failed to send host2")
 
 	// Start reading from stream3
-	wg.Add(1)
 	updateCh3 := make(chan *v1pb.PlacementTables)
 	go func() {
-		defer wg.Done()
 		defer close(updateCh3)
 		for {
 			select {
@@ -217,7 +211,6 @@ func (n *streamHang) Run(t *testing.T, ctx context.Context) {
 	streamCancel1()
 	streamCancel2()
 	streamCancel3()
-	wg.Wait()
 }
 
 func (n *streamHang) getStream(t assert.TestingT, ctx context.Context) (v1pb.Placement_ReportDaprStatusClient, func()) {


### PR DESCRIPTION
Blocked Placement dissemination during high churn

Problem

Placement would fail to ever, or very slowly, disseminate the actor table in high daprd churn scenarios.

Impact

Actors or workflows would fail to be activated, and existing actors or workflows would fail.

Root Cause

Placement used a "small" (100) queue size which when exhausted would cause a deadlock. Placement would also wait for a fully consumed channel queue before disseminating slowing down the dissemination process.

Solution

Increase the queue size to 10000 and change the dissemination logic to not wait for a fully consumed queue before disseminating.