### PR TITLE
[1.16] Fix panic during actor deactivation

### DIFF
--- a/docs/release_notes/v1.16.2.md
+++ b/docs/release_notes/v1.16.2.md
@@ -7,6 +7,7 @@ This update includes bug fixes:
 - [Placement not cleaning internal state after host that had actors disconnects](#placement-not-cleaning-internal-state-after-host-that-had-actors-disconnects)
 - [Blocked Placement dissemination during high churn](#blocked-placement-dissemination-during-high-churn)
 - [Blocked Placement dissemination with high Scheduler dataset](#blocked-placement-dissemination-with-high-scheduler-dataset)
+- [Fix panic during actor deactivation](#fix-panic-during-actor-deactivation)
 
 ## HTTP API default CORS behavior
 
@@ -91,3 +92,21 @@ The reminder migration of state store to scheduler reminders does a full decoded
 
 Limit the maximum time spent doing the migration to 3 seconds.
 Expose a new `global.reminders.skipMigration="true"` helm chart value which will skip the migration entirely.
+
+## Fix panic during actor deactivation
+
+### Problem
+
+Daprd could panic during actor deactivation.
+
+### Impact
+
+Daprd sidecar would crash, resulting in downtime for the application.
+
+### Root Cause
+
+A race in the actor lock cached memory release and claiming logic meant a stale lock could be used during deactivation, double closing it, and causing a panic.
+
+### Solution
+
+Tie the lock's lifecycle to the actor's lifecycle, ensuring the lock is only released when the actor is fully deactivated, and claimed with the actor itself.

--- a/tests/integration/suite/actors/deactivation/idle/panic.go
+++ b/tests/integration/suite/actors/deactivation/idle/panic.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package idle
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(ppanic))
+}
+
+type ppanic struct {
+	app1 *actors.Actors
+	app2 *actors.Actors
+
+	calls atomic.Int64
+}
+
+func (p *ppanic) Setup(t *testing.T) []framework.Option {
+	p.app1 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorIdleTimeout(time.Nanosecond),
+		actors.WithActorTypeHandler("abc", func(_ http.ResponseWriter, r *http.Request) {
+			p.calls.Add(1)
+		}),
+	)
+	p.app2 = actors.New(t,
+		actors.WithActorTypes("abc"),
+		actors.WithActorIdleTimeout(time.Nanosecond),
+		actors.WithActorTypeHandler("abc", func(_ http.ResponseWriter, r *http.Request) {
+			p.calls.Add(1)
+		}),
+		actors.WithPeerActor(p.app1),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(p.app1, p.app2),
+	}
+}
+
+func (p *ppanic) Run(t *testing.T, ctx context.Context) {
+	p.app1.WaitUntilRunning(t, ctx)
+	p.app2.WaitUntilRunning(t, ctx)
+
+	const n = 1000
+	done := make(chan error, n)
+	for i := range n {
+		go func(i int) {
+			_, err := p.app1.GRPCClient(t, ctx).RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+				ActorType: "abc",
+				ActorId:   strconv.Itoa(i),
+				Name:      "xxx",
+				DueTime:   "0s",
+			})
+			done <- err
+		}(i)
+	}
+
+	for range n {
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 10):
+			require.Fail(t, "timed out waiting for reminders to be registered")
+			return
+		case <-ctx.Done():
+			require.Fail(t, "timed out waiting for reminders to be registered")
+			return
+		}
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, p.calls.Load(), int64(n*2), "expected all reminders to be fired")
+	}, time.Second*60, time.Millisecond*10)
+}

--- a/tests/integration/suite/actors/lock/call/remote/goroutines.go
+++ b/tests/integration/suite/actors/lock/call/remote/goroutines.go
@@ -78,7 +78,7 @@ func (g *goroutines) Run(t *testing.T, ctx context.Context) {
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.InDelta(c, startGoRoutines1, g.app1.Metrics(t, ctx)["go_goroutines"], 10)
-		assert.InDelta(c, startGoRoutines2, g.app2.Metrics(t, ctx)["go_goroutines"], 10)
+		assert.InDelta(c, startGoRoutines1, g.app1.Metrics(t, ctx)["go_goroutines"], 25)
+		assert.InDelta(c, startGoRoutines2, g.app2.Metrics(t, ctx)["go_goroutines"], 25)
 	}, time.Second*20, time.Second)
 }

--- a/tests/integration/suite/actors/lock/reminders/local/goroutines.go
+++ b/tests/integration/suite/actors/lock/reminders/local/goroutines.go
@@ -76,6 +76,6 @@ func (g *goroutines) Run(t *testing.T, ctx context.Context) {
 	}, time.Second*10, time.Millisecond*10)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.InDelta(c, startGoRoutines, g.app.Metrics(t, ctx)["go_goroutines"], 10)
+		assert.InDelta(c, startGoRoutines, g.app.Metrics(t, ctx)["go_goroutines"], 25)
 	}, time.Second*30, time.Second)
 }

--- a/tests/integration/suite/daprd/shutdown/graceful/invocation/http/local.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/invocation/http/local.go
@@ -59,9 +59,6 @@ func (l *local) Setup(t *testing.T) []framework.Option {
 	l.daprd = daprd.New(t,
 		daprd.WithAppPort(app.Port()),
 		daprd.WithDaprGracefulShutdownSeconds(180),
-		daprd.WithAppHealthProbeInterval(1),
-		daprd.WithAppHealthProbeThreshold(1),
-		daprd.WithAppHealthCheck(true),
 	)
 
 	return []framework.Option{


### PR DESCRIPTION
Problem

Daprd could panic during actor deactivation.

Impact

Daprd sidecar would crash, resulting in downtime for the application.

Root Cause

A race in the actor lock cached memory release and claiming logic meant a stale lock could be used during deactivation, double closing it, and causing a panic.

Solution

Tie the lock's lifecycle to the actor's lifecycle, ensuring the lock is only released when the actor is fully deactivated, and claimed with the actor itself.