### PR TITLE
Implements durabletask `ListInstanceIDs` & `GetInstanceHistory`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.14.1
-	github.com/dapr/components-contrib v1.16.1
+	github.com/dapr/components-contrib v1.16.2-0.20251113171451-b78f056c8491
 	github.com/dapr/durabletask-go v0.10.2-0.20251113171253-87ecdf8f0547
 	github.com/dapr/kit v0.16.2-0.20251117143824-2fd5d0c93524
 	github.com/diagridio/go-etcd-cron v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjm
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/dapr/components-contrib v1.16.1 h1:EpntHk5qUXTbB55kec97cMQbC2QXBwbBU6QMI3ljV8g=
-github.com/dapr/components-contrib v1.16.1/go.mod h1:1AufCWqZwBj//UkyS7FesOEmp5/E6Xgy1tyCn8peiR4=
+github.com/dapr/components-contrib v1.16.2-0.20251113171451-b78f056c8491 h1:ms0IhiGK6Mow+e1DZgIxD3qo7xqOPjpxeFkhahBo+Tg=
+github.com/dapr/components-contrib v1.16.2-0.20251113171451-b78f056c8491/go.mod h1:1AufCWqZwBj//UkyS7FesOEmp5/E6Xgy1tyCn8peiR4=
 github.com/dapr/durabletask-go v0.10.2-0.20251113171253-87ecdf8f0547 h1:bD4JBlXDHURsgvhIB1HQ1q0k8kYfVo/iNSBi0guSoe0=
 github.com/dapr/durabletask-go v0.10.2-0.20251113171253-87ecdf8f0547/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
 github.com/dapr/kit v0.16.2-0.20251117143824-2fd5d0c93524 h1:SQ7VeWGnypENpGjsL94wN2IgH+oYHx9ULpYrpFoRExQ=

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -307,6 +307,7 @@ func newDaprRuntime(ctx context.Context,
 		Resiliency:                resiliencyProvider,
 		EventSink:                 runtimeConfig.workflowEventSink,
 		EnableClusteredDeployment: globalConfig.IsFeatureEnabled(config.WorkflowsClusteredDeployment),
+		ComponentStore:            compStore,
 	})
 
 	jobsManager, err := scheduler.New(scheduler.Options{

--- a/pkg/runtime/wfengine/state/list/list.go
+++ b/pkg/runtime/wfengine/state/list/list.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+)
+
+type ListOptions struct {
+	ComponentStore *compstore.ComponentStore
+	Namespace      string
+	AppID          string
+
+	PageSize          *uint32
+	ContinuationToken *string
+}
+
+type ListInstanceIDsResult struct {
+	Keys              []string
+	ContinuationToken *string
+}
+
+func ListInstanceIDs(ctx context.Context, opts ListOptions) (*ListInstanceIDsResult, error) {
+	store, _, ok := opts.ComponentStore.GetStateStoreActor()
+	if !ok {
+		return nil, errors.New("no state store with actor support found")
+	}
+
+	ks, ok := store.(state.KeysLiker)
+	if !ok {
+		return nil, fmt.Errorf("state store %T does not support listing keys", store)
+	}
+
+	like := opts.AppID + "||" + todo.ActorTypePrefix + opts.Namespace + "." + opts.AppID + ".workflow||%||metadata"
+
+	resp, err := ks.KeysLike(ctx, &state.KeysLikeRequest{
+		Pattern:           like,
+		ContinuationToken: opts.ContinuationToken,
+		PageSize:          opts.PageSize,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(resp.Keys))
+	for _, key := range resp.Keys {
+		split := strings.Split(key, "||")
+		if len(split) != 4 {
+			return nil, fmt.Errorf("invalid key format: %s", key)
+		}
+
+		keys = append(keys, split[2])
+	}
+
+	return &ListInstanceIDsResult{
+		Keys:              keys,
+		ContinuationToken: resp.ContinuationToken,
+	}, nil
+}

--- a/pkg/runtime/wfengine/todo/todo.go
+++ b/pkg/runtime/wfengine/todo/todo.go
@@ -32,6 +32,8 @@ const (
 	RerunWorkflowInstance        = "RerunWorkflowInstance"
 
 	MetadataActivityReminderDueTime = "dueTime"
+
+	ActorTypePrefix = "dapr.internal."
 )
 
 var (

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dapr/dapr/pkg/config"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
 	"github.com/dapr/dapr/pkg/runtime/processor"
 	backendactors "github.com/dapr/dapr/pkg/runtime/wfengine/backends/actors"
 	"github.com/dapr/durabletask-go/backend"
@@ -59,6 +60,7 @@ type Options struct {
 	Resiliency                resiliency.Provider
 	EventSink                 orchestrator.EventSink
 	EnableClusteredDeployment bool
+	ComponentStore            *compstore.ComponentStore
 }
 
 type engine struct {
@@ -83,6 +85,7 @@ func New(opts Options) Interface {
 		Resiliency:                opts.Resiliency,
 		EventSink:                 opts.EventSink,
 		EnableClusteredDeployment: opts.EnableClusteredDeployment,
+		ComponentStore:            opts.ComponentStore,
 	})
 
 	var getWorkItemsCount atomic.Int32

--- a/tests/integration/suite/daprd/hotreload/operator/actorstate.go
+++ b/tests/integration/suite/daprd/hotreload/operator/actorstate.go
@@ -176,7 +176,7 @@ func (a *actorstate) Run(t *testing.T, ctx context.Context) {
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 	}, comps)
 	inmemStore.Spec.Metadata = []common.NameValuePair{}
@@ -188,7 +188,7 @@ func (a *actorstate) Run(t *testing.T, ctx context.Context) {
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 	}, comps)
 	a.operatorDelete.SetComponents()

--- a/tests/integration/suite/daprd/hotreload/operator/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/operator/crypto.go
@@ -217,7 +217,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 				{Name: "crypto3", Type: "crypto.dapr.localstorage", Version: "v1"},
 				{
 					Name: "crypto2", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp.GetRegisteredComponents())
 		}, time.Second*10, time.Millisecond*10)
@@ -255,7 +255,7 @@ func (c *crypto) Run(t *testing.T, ctx context.Context) {
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
 					Name: "crypto3", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp.GetRegisteredComponents())
 		}, time.Second*10, time.Millisecond*10)

--- a/tests/integration/suite/daprd/hotreload/operator/informer/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/components.go
@@ -141,7 +141,7 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 		exp := []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -179,7 +179,7 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 			exp := []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 			}
 			assert.ElementsMatch(ct, exp, c.daprd1.GetMetaRegisteredComponents(ct, ctx))

--- a/tests/integration/suite/daprd/hotreload/operator/secret.go
+++ b/tests/integration/suite/daprd/hotreload/operator/secret.go
@@ -403,7 +403,7 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 					{Name: "foo", Type: "secretstores.local.env", Version: "v1"},
 					{
 						Name: "bar", Type: "state.in-memory", Version: "v1",
-						Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+						Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 					},
 				}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -438,7 +438,7 @@ func (s *secret) Run(t *testing.T, ctx context.Context) {
 			assert.ElementsMatch(c, resp, []*rtpbv1.RegisteredComponents{
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			})
 		}, time.Second*5, time.Millisecond*10)

--- a/tests/integration/suite/daprd/hotreload/operator/state.go
+++ b/tests/integration/suite/daprd/hotreload/operator/state.go
@@ -119,6 +119,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 					"TRANSACTIONAL",
 					"TTL",
 					"DELETE_WITH_PREFIX",
+					"KEYS_LIKE",
 					"ACTOR",
 				},
 			},
@@ -162,15 +163,15 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 		assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 			{
 				Name: "abc", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 			{
 				Name: "xyz", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, resp)
 
@@ -209,15 +210,15 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "abc", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -282,19 +283,19 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "abc", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "foo", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -344,19 +345,19 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "foo", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -399,15 +400,15 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "foo", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/actorstate.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/actorstate.go
@@ -161,7 +161,7 @@ spec:
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 	}, comps)
 
@@ -183,7 +183,7 @@ spec:
 	require.ElementsMatch(t, []*rtv1.RegisteredComponents{
 		{
 			Name: "mystore", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 	}, comps)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/crypto.go
@@ -212,7 +212,7 @@ spec:
 				{Name: "crypto3", Type: "crypto.dapr.localstorage", Version: "v1"},
 				{
 					Name: "crypto2", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp.GetRegisteredComponents())
 		}, time.Second*5, time.Millisecond*10)
@@ -245,7 +245,7 @@ spec:
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
 					Name: "crypto1", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp.GetRegisteredComponents())
 		}, time.Second*5, time.Millisecond*10)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/namespace/set.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/namespace/set.go
@@ -90,7 +90,7 @@ func (s *set) Run(t *testing.T, ctx context.Context) {
 		assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, s.daprd.GetMetaRegisteredComponents(t, ctx))
 	}, 5*time.Second, 10*time.Millisecond)
@@ -141,7 +141,7 @@ spec:
 		assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, s.daprd.GetMetaRegisteredComponents(t, ctx))
 	}, 5*time.Second, 10*time.Millisecond)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/namespace/unset.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/namespace/unset.go
@@ -89,7 +89,7 @@ func (u *unset) Run(t *testing.T, ctx context.Context) {
 		assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, u.daprd.GetMetaRegisteredComponents(t, ctx))
 	}, 5*time.Second, 10*time.Millisecond)
@@ -129,7 +129,7 @@ spec:
 		assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, u.daprd.GetMetaRegisteredComponents(t, ctx))
 	}, 5*time.Second, 10*time.Millisecond)
@@ -158,11 +158,11 @@ spec:
 		assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 			{
 				Name: "foo", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, u.daprd.GetMetaRegisteredComponents(t, ctx))
 	}, 5*time.Second, 10*time.Millisecond)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/secret.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/secret.go
@@ -346,7 +346,7 @@ spec:
 					{Name: "foo", Type: "secretstores.local.env", Version: "v1"},
 					{
 						Name: "bar", Type: "state.in-memory", Version: "v1",
-						Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+						Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 					},
 				}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -374,7 +374,7 @@ spec:
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/state.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/state.go
@@ -100,7 +100,7 @@ spec:
 		assert.ElementsMatch(t, []*rtpbv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, resp)
 
@@ -143,15 +143,15 @@ spec:
 		assert.ElementsMatch(t, []*rtpbv1.RegisteredComponents{
 			{
 				Name: "123", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 			{
 				Name: "abc", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 			{
 				Name: "xyz", Type: "state.in-memory", Version: "v1",
-				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 			},
 		}, resp)
 
@@ -184,15 +184,15 @@ spec:
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "abc", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -246,19 +246,19 @@ spec:
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "abc", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "foo", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -291,19 +291,19 @@ spec:
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "foo", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)
@@ -342,15 +342,15 @@ spec:
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 				{
 					Name: "foo", Type: "state.in-memory", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 				},
 			}, resp)
 		}, time.Second*5, time.Millisecond*10)

--- a/tests/integration/suite/daprd/resources/namespace/set/name.go
+++ b/tests/integration/suite/daprd/resources/namespace/set/name.go
@@ -88,11 +88,11 @@ func (n *name) Run(t *testing.T, ctx context.Context) {
 	assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 		{
 			Name: "123", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 		{
 			Name: "789", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 	}, resp.GetRegisteredComponents())
 }

--- a/tests/integration/suite/daprd/resources/namespace/unset/name.go
+++ b/tests/integration/suite/daprd/resources/namespace/unset/name.go
@@ -87,19 +87,19 @@ func (n *name) Run(t *testing.T, ctx context.Context) {
 	assert.ElementsMatch(t, []*rtv1.RegisteredComponents{
 		{
 			Name: "abc", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 		{
 			Name: "123", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 		{
 			Name: "456", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 		{
 			Name: "789", Type: "state.in-memory", Version: "v1",
-			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "ACTOR"},
+			Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
 		},
 	}, resp.GetRegisteredComponents())
 }

--- a/tests/integration/suite/daprd/workflow/get/activities.go
+++ b/tests/integration/suite/daprd/workflow/get/activities.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(activities))
+}
+
+type activities struct {
+	workflow *workflow.Workflow
+}
+
+func (a *activities) Setup(t *testing.T) []framework.Option {
+	a.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *activities) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("foo", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		require.NoError(t, ctx.CallActivity("a").Await(nil))
+		require.NoError(t, ctx.CallActivity("b").Await(nil))
+		require.NoError(t, ctx.CallActivity("c").Await(nil))
+		return nil, nil
+	})
+	reg.AddActivityN("a", func(ctx dworkflow.ActivityContext) (any, error) { return "1", nil })
+	reg.AddActivityN("b", func(ctx dworkflow.ActivityContext) (any, error) { return "2", nil })
+	reg.AddActivityN("c", func(ctx dworkflow.ActivityContext) (any, error) { return "3", nil })
+
+	wf := a.workflow.WorkflowClient(t, ctx)
+	wf.StartWorker(ctx, reg)
+
+	id, err := wf.ScheduleWorkflow(ctx, "foo", dworkflow.WithInstanceID("abc"))
+	require.NoError(t, err)
+
+	_, err = wf.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	resp, err := wf.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	evs := resp.Events
+
+	require.Len(t, evs, 12)
+
+	assert.NotNil(t, evs[0].GetOrchestratorStarted())
+	assert.NotNil(t, evs[1].GetExecutionStarted())
+	assert.Equal(t, "foo", evs[1].GetExecutionStarted().GetName())
+	assert.Equal(t, "abc", evs[1].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
+
+	assert.NotNil(t, evs[2].GetTaskScheduled())
+	assert.Equal(t, "a", evs[2].GetTaskScheduled().GetName())
+	assert.Equal(t, a.workflow.Dapr().AppID(), evs[2].GetRouter().GetSourceAppID())
+	assert.NotNil(t, evs[3].GetOrchestratorStarted())
+	assert.NotNil(t, evs[4].GetTaskCompleted())
+	assert.Equal(t, `"1"`, evs[4].GetTaskCompleted().GetResult().GetValue())
+	assert.Equal(t, a.workflow.Dapr().AppID(), evs[4].GetRouter().GetSourceAppID())
+
+	assert.NotNil(t, evs[5].GetTaskScheduled())
+	assert.Equal(t, "b", evs[5].GetTaskScheduled().GetName())
+	assert.Equal(t, a.workflow.Dapr().AppID(), evs[5].GetRouter().GetSourceAppID())
+	assert.NotNil(t, evs[6].GetOrchestratorStarted())
+	assert.NotNil(t, evs[7].GetTaskCompleted())
+	assert.Equal(t, `"2"`, evs[7].GetTaskCompleted().GetResult().GetValue())
+	assert.Equal(t, a.workflow.Dapr().AppID(), evs[7].GetRouter().GetSourceAppID())
+
+	assert.NotNil(t, evs[8].GetTaskScheduled())
+	assert.Equal(t, "c", evs[8].GetTaskScheduled().GetName())
+	assert.Equal(t, a.workflow.Dapr().AppID(), evs[8].GetRouter().GetSourceAppID())
+	assert.NotNil(t, evs[9].GetOrchestratorStarted())
+	assert.NotNil(t, evs[10].GetTaskCompleted())
+	assert.Equal(t, `"3"`, evs[10].GetTaskCompleted().GetResult().GetValue())
+	assert.Equal(t, a.workflow.Dapr().AppID(), evs[10].GetRouter().GetSourceAppID())
+
+	assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", evs[11].GetExecutionCompleted().GetOrchestrationStatus().String())
+	assert.Equal(t, a.workflow.Dapr().AppID(), evs[11].GetRouter().GetSourceAppID())
+}

--- a/tests/integration/suite/daprd/workflow/get/base.go
+++ b/tests/integration/suite/daprd/workflow/get/base.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(base))
+}
+
+type base struct {
+	workflow *workflow.Workflow
+}
+
+func (b *base) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *base) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("foo", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	wf := b.workflow.WorkflowClient(t, ctx)
+	wf.StartWorker(ctx, reg)
+
+	id, err := wf.ScheduleWorkflow(ctx, "foo", dworkflow.WithInstanceID("abc"))
+	require.NoError(t, err)
+
+	_, err = wf.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	resp, err := wf.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	evs := resp.Events
+	require.Len(t, evs, 3)
+
+	assert.NotNil(t, evs[0].GetOrchestratorStarted())
+	assert.Nil(t, evs[0].GetExecutionStarted())
+	assert.NotNil(t, evs[1].GetExecutionStarted())
+	assert.Equal(t, "foo", evs[1].GetExecutionStarted().GetName())
+	assert.Equal(t, "abc", evs[1].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
+	assert.Equal(t, b.workflow.Dapr().AppID(), evs[1].GetRouter().GetSourceAppID())
+	assert.NotNil(t, evs[2].GetExecutionCompleted())
+	assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", evs[2].GetExecutionCompleted().GetOrchestrationStatus().String())
+	assert.Equal(t, b.workflow.Dapr().AppID(), evs[2].GetRouter().GetSourceAppID())
+}

--- a/tests/integration/suite/daprd/workflow/get/childwf.go
+++ b/tests/integration/suite/daprd/workflow/get/childwf.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(childwf))
+}
+
+type childwf struct {
+	workflow *workflow.Workflow
+}
+
+func (c *childwf) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *childwf) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("foo", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		require.NoError(t, ctx.CallChildWorkflow("bar").Await(nil))
+		return nil, nil
+	})
+	reg.AddWorkflowN("bar", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	wf := c.workflow.WorkflowClient(t, ctx)
+	wf.StartWorker(ctx, reg)
+
+	id, err := wf.ScheduleWorkflow(ctx, "foo", dworkflow.WithInstanceID("abc"))
+	require.NoError(t, err)
+
+	_, err = wf.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	resp, err := wf.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	evs := resp.Events
+
+	require.Len(t, evs, 6)
+
+	assert.NotNil(t, evs[0].GetOrchestratorStarted())
+	assert.Nil(t, evs[0].GetExecutionStarted())
+	assert.NotNil(t, evs[1].GetExecutionStarted())
+	assert.Equal(t, "foo", evs[1].GetExecutionStarted().GetName())
+	assert.Equal(t, "abc", evs[1].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
+	assert.Equal(t, c.workflow.Dapr().AppID(), evs[1].GetRouter().GetSourceAppID())
+
+	assert.NotNil(t, evs[2].GetSubOrchestrationInstanceCreated())
+	assert.Equal(t, "abc:0000", evs[2].GetSubOrchestrationInstanceCreated().GetInstanceId())
+	assert.Equal(t, "bar", evs[2].GetSubOrchestrationInstanceCreated().GetName())
+	assert.Equal(t, c.workflow.Dapr().AppID(), evs[2].GetRouter().GetSourceAppID())
+
+	assert.NotNil(t, evs[3].GetOrchestratorStarted())
+
+	assert.NotNil(t, evs[4].GetSubOrchestrationInstanceCompleted())
+
+	assert.NotNil(t, evs[5].GetExecutionCompleted())
+	assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", evs[5].GetExecutionCompleted().GetOrchestrationStatus().String())
+	assert.Equal(t, c.workflow.Dapr().AppID(), evs[5].GetRouter().GetSourceAppID())
+}

--- a/tests/integration/suite/daprd/workflow/get/crossactivity.go
+++ b/tests/integration/suite/daprd/workflow/get/crossactivity.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(crossactivity))
+}
+
+type crossactivity struct {
+	workflow *workflow.Workflow
+}
+
+func (c *crossactivity) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t,
+		workflow.WithDaprds(2),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *crossactivity) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	reg1 := dworkflow.NewRegistry()
+	reg2 := dworkflow.NewRegistry()
+
+	reg1.AddWorkflowN("foo", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		require.NoError(t, ctx.CallActivity("a", dworkflow.WithActivityAppID(c.workflow.DaprN(1).AppID())).Await(nil))
+		return nil, nil
+	})
+	reg2.AddActivityN("a", func(ctx dworkflow.ActivityContext) (any, error) {
+		return nil, nil
+	})
+
+	wf1 := c.workflow.WorkflowClientN(t, ctx, 0)
+	wf1.StartWorker(ctx, reg1)
+	wf2 := c.workflow.WorkflowClientN(t, ctx, 1)
+	wf2.StartWorker(ctx, reg2)
+
+	id, err := wf1.ScheduleWorkflow(ctx, "foo", dworkflow.WithInstanceID("abc"))
+	require.NoError(t, err)
+
+	_, err = wf1.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	resp, err := wf1.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	evs := resp.Events
+
+	require.Len(t, evs, 6)
+
+	assert.NotNil(t, evs[0].GetOrchestratorStarted())
+	assert.NotNil(t, evs[1].GetExecutionStarted())
+	assert.Equal(t, "foo", evs[1].GetExecutionStarted().GetName())
+	assert.Equal(t, "abc", evs[1].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[1].GetRouter().GetSourceAppID())
+
+	assert.NotNil(t, evs[2].GetTaskScheduled())
+	assert.Equal(t, "a", evs[2].GetTaskScheduled().GetName())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[2].GetRouter().GetSourceAppID())
+	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[2].GetRouter().GetTargetAppID())
+
+	assert.NotNil(t, evs[3].GetOrchestratorStarted())
+
+	assert.NotNil(t, evs[4].GetTaskCompleted())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[4].GetRouter().GetSourceAppID())
+	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[4].GetRouter().GetTargetAppID())
+
+	assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", evs[5].GetExecutionCompleted().GetOrchestrationStatus().String())
+	assert.Equal(t, c.workflow.Dapr().AppID(), evs[5].GetRouter().GetSourceAppID())
+}

--- a/tests/integration/suite/daprd/workflow/get/crossworkflow.go
+++ b/tests/integration/suite/daprd/workflow/get/crossworkflow.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(crossworkflow))
+}
+
+type crossworkflow struct {
+	workflow *workflow.Workflow
+}
+
+func (c *crossworkflow) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t,
+		workflow.WithDaprds(2),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *crossworkflow) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	reg1 := dworkflow.NewRegistry()
+	reg2 := dworkflow.NewRegistry()
+
+	reg1.AddWorkflowN("foo", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		require.NoError(t, ctx.CallChildWorkflow("bar", dworkflow.WithChildWorkflowAppID(c.workflow.DaprN(1).AppID())).Await(nil))
+		return nil, nil
+	})
+	reg2.AddWorkflowN("bar", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	wf1 := c.workflow.WorkflowClientN(t, ctx, 0)
+	wf1.StartWorker(ctx, reg1)
+	wf2 := c.workflow.WorkflowClientN(t, ctx, 1)
+	wf2.StartWorker(ctx, reg2)
+
+	id, err := wf1.ScheduleWorkflow(ctx, "foo", dworkflow.WithInstanceID("abc"))
+	require.NoError(t, err)
+
+	_, err = wf1.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	resp, err := wf1.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	evs := resp.Events
+
+	require.Len(t, evs, 6)
+
+	assert.NotNil(t, evs[0].GetOrchestratorStarted())
+	assert.NotNil(t, evs[1].GetExecutionStarted())
+	assert.Equal(t, "foo", evs[1].GetExecutionStarted().GetName())
+	assert.Equal(t, "abc", evs[1].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[1].GetRouter().GetSourceAppID())
+
+	assert.NotNil(t, evs[2].GetSubOrchestrationInstanceCreated())
+	assert.Equal(t, "abc:0000", evs[2].GetSubOrchestrationInstanceCreated().GetInstanceId())
+	assert.Equal(t, "bar", evs[2].GetSubOrchestrationInstanceCreated().GetName())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[2].GetRouter().GetSourceAppID())
+	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[2].GetRouter().GetTargetAppID())
+
+	assert.NotNil(t, evs[3].GetOrchestratorStarted())
+
+	assert.NotNil(t, evs[4].GetSubOrchestrationInstanceCompleted())
+	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[4].GetRouter().GetSourceAppID())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[4].GetRouter().GetTargetAppID())
+
+	assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", evs[5].GetExecutionCompleted().GetOrchestrationStatus().String())
+	assert.Equal(t, c.workflow.Dapr().AppID(), evs[5].GetRouter().GetSourceAppID())
+}

--- a/tests/integration/suite/daprd/workflow/list/base.go
+++ b/tests/integration/suite/daprd/workflow/list/base.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(base))
+}
+
+type base struct {
+	workflow *workflow.Workflow
+}
+
+func (b *base) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *base) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	b.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	client := b.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	resp, err := b.workflow.WorkflowClient(t, ctx).ListInstanceIDs(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{id.String()}, resp.InstanceIds)
+	assert.Nil(t, resp.ContinuationToken)
+}

--- a/tests/integration/suite/daprd/workflow/list/escape.go
+++ b/tests/integration/suite/daprd/workflow/list/escape.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(escape))
+}
+
+type escape struct {
+	workflow *workflow.Workflow
+}
+
+func (e *escape) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *escape) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	e.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	e.workflow.BackendClient(t, ctx)
+
+	ids := []string{
+		"hello_workflow",
+		"workflow_",
+		"hello_",
+		"_hello",
+		"hello_workflow_yoyo",
+	}
+
+	wf := e.workflow.WorkflowClient(t, ctx)
+	for _, id := range ids {
+		_, err := wf.ScheduleWorkflow(ctx, "foo", dworkflow.WithInstanceID(id))
+		require.NoError(t, err)
+	}
+
+	resp, err := wf.ListInstanceIDs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, ids, resp.InstanceIds)
+	assert.Nil(t, resp.ContinuationToken)
+}

--- a/tests/integration/suite/daprd/workflow/list/multiple.go
+++ b/tests/integration/suite/daprd/workflow/list/multiple.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(multipule))
+}
+
+type multipule struct {
+	workflow *workflow.Workflow
+}
+
+func (m *multipule) Setup(t *testing.T) []framework.Option {
+	uuid := uuid.NewString()
+	m.workflow = workflow.New(t,
+		workflow.WithDaprds(5),
+		workflow.WithDaprdOptions(0, daprd.WithAppID(uuid)),
+		workflow.WithDaprdOptions(1, daprd.WithAppID(uuid)),
+		workflow.WithDaprdOptions(2, daprd.WithAppID(uuid)),
+		workflow.WithDaprdOptions(3, daprd.WithAppID(uuid)),
+		workflow.WithDaprdOptions(4, daprd.WithAppID(uuid)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.workflow),
+	}
+}
+
+func (m *multipule) Run(t *testing.T, ctx context.Context) {
+	m.workflow.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("foo", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	const numWf = 5
+
+	wfs := make([]*dworkflow.Client, 0, numWf)
+	for i := range numWf {
+		wfs = append(wfs, m.workflow.WorkflowClientN(t, ctx, i))
+		require.NoError(t, wfs[i].StartWorker(ctx, reg))
+	}
+
+	ids := make([]string, 0, 100)
+	for range 100 {
+		id, err := wfs[0].ScheduleWorkflow(ctx, "foo")
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+
+	for i := range numWf {
+		resp, err := wfs[i].ListInstanceIDs(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, ids, resp.InstanceIds)
+		assert.Nil(t, resp.ContinuationToken)
+	}
+}

--- a/tests/integration/suite/daprd/workflow/list/pagination.go
+++ b/tests/integration/suite/daprd/workflow/list/pagination.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(pagination))
+}
+
+type pagination struct {
+	workflow *workflow.Workflow
+}
+
+func (p *pagination) Setup(t *testing.T) []framework.Option {
+	p.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(p.workflow),
+	}
+}
+
+func (p *pagination) Run(t *testing.T, ctx context.Context) {
+	p.workflow.WaitUntilRunning(t, ctx)
+
+	p.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	client := p.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, 0, 1030)
+	for range 1030 {
+		id, err := client.ScheduleNewOrchestration(ctx, "foo")
+		require.NoError(t, err)
+		ids = append(ids, id.String())
+	}
+
+	resp, err := p.workflow.WorkflowClient(t, ctx).ListInstanceIDs(ctx)
+	require.NoError(t, err)
+	require.Len(t, resp.InstanceIds, 1024)
+	assert.Equal(t, ids[:1024], resp.InstanceIds)
+	require.NotNil(t, resp.ContinuationToken)
+
+	resp, err = p.workflow.WorkflowClient(t, ctx).ListInstanceIDs(ctx, dworkflow.WithListInstanceIDsContinuationToken(*resp.ContinuationToken))
+	require.NoError(t, err)
+	require.Len(t, resp.InstanceIds, 6)
+	assert.Equal(t, ids[1024:], resp.InstanceIds)
+	require.Nil(t, resp.ContinuationToken)
+}

--- a/tests/integration/suite/daprd/workflow/list/purge.go
+++ b/tests/integration/suite/daprd/workflow/list/purge.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(purge))
+}
+
+type purge struct {
+	workflow *workflow.Workflow
+}
+
+func (p *purge) Setup(t *testing.T) []framework.Option {
+	p.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(p.workflow),
+	}
+}
+
+func (p *purge) Run(t *testing.T, ctx context.Context) {
+	p.workflow.WaitUntilRunning(t, ctx)
+
+	p.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		return nil, nil
+	})
+
+	client := p.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, 0, 5)
+	for range 5 {
+		id, err := client.ScheduleNewOrchestration(ctx, "foo")
+		require.NoError(t, err)
+		ids = append(ids, id.String())
+	}
+
+	wf := p.workflow.WorkflowClient(t, ctx)
+	for range 5 {
+		resp, err := wf.ListInstanceIDs(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, ids, resp.InstanceIds)
+		assert.Nil(t, resp.ContinuationToken)
+		require.NoError(t, wf.PurgeWorkflowState(ctx, ids[0]))
+		ids = ids[1:]
+	}
+
+	resp, err := wf.ListInstanceIDs(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, resp.InstanceIds)
+	assert.Nil(t, resp.ContinuationToken)
+
+	ids = make([]string, 0, 5)
+	for range 5 {
+		var id api.InstanceID
+		id, err = client.ScheduleNewOrchestration(ctx, "foo")
+		require.NoError(t, err)
+		ids = append(ids, id.String())
+	}
+
+	for range 5 {
+		resp, err = wf.ListInstanceIDs(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, ids, resp.InstanceIds)
+		assert.Nil(t, resp.ContinuationToken)
+		require.NoError(t, wf.PurgeWorkflowState(ctx, ids[0]))
+		ids = ids[1:]
+	}
+
+	resp, err = wf.ListInstanceIDs(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, resp.InstanceIds)
+	assert.Nil(t, resp.ContinuationToken)
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -18,6 +18,8 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/basic"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/continueasnew"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/crossapp"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/get"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/list"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/listener"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/loadbalance"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/maxconcurrent"


### PR DESCRIPTION
Today, there is no ways of discovering the list of workflow instances that are currently running or have completed in the past without using external storage queries. The Dapr CLI [introduced list and workflow history commands](https://github.com/dapr/cli/pull/1560) to get information about running and completed workflows, however these commands rely on direct queries to the underlying storage provider. By introducing this functionality into the durabletask framework itself, these commands need only talk to Daprd, removing the requirement for direct access to the storage provider as well as authentication. Daprd can make these queries itself, and use the Actor State Store component to access the underlying storage.

Implements the new durabletask APIs according to https://github.com/dapr/proposals/pull/93