### PR TITLE
Perf: Use bookworm base image

### DIFF
--- a/tests/apps/perf/actorfeatures/Dockerfile
+++ b/tests/apps/perf/actorfeatures/Dockerfile
@@ -12,8 +12,8 @@ ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache
 RUN git clone https://github.com/dapr/fortio.git
 RUN cd fortio && git checkout v1.38.4-dapr && go build
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 WORKDIR /
 COPY --from=build_env /app/tester /
-COPY --from=fortio_build_env /fortio/fortio/fortio /usr/local/bin
+COPY --from=fortio_build_env /fortio/fortio/fortio /usr/local/bin/fortio
 CMD ["/tester"]

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -12,8 +12,8 @@ ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache
 RUN git clone https://github.com/dapr/fortio.git
 RUN cd fortio && git checkout v1.38.4-dapr && go build
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 WORKDIR /
 COPY --from=build_env /app/tester /
-COPY --from=fortio_build_env /fortio/fortio/fortio /usr/local/bin
+COPY --from=fortio_build_env /fortio/fortio/fortio /usr/local/bin/fortio
 CMD ["/tester"]


### PR DESCRIPTION
Update golang base image to use `bookworm` for debian-based images.
