### PR TITLE
WIP [Tracing] Adding semantic convention and pubsub producer/consumer spans

### DIFF
--- a/pkg/actors/targets/workflow/activity/factory.go
+++ b/pkg/actors/targets/workflow/activity/factory.go
@@ -58,8 +58,9 @@ type factory struct {
 
 	scheduler todo.ActivityScheduler
 
-	table sync.Map
-	lock  sync.Mutex
+	table         sync.Map
+	traceContexts sync.Map // stores trace context metadata for span linking
+	lock          sync.Mutex
 }
 
 func New(ctx context.Context, opts Options) (targets.Factory, error) {

--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -22,6 +22,8 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"go.opentelemetry.io/otel/trace"
+
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
@@ -38,7 +40,7 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 	}
 
 	for _, e := range es {
-		err := o.callActivity(ctx, e, dueTime, state.Generation)
+		err := o.callActivity(ctx, e, dueTime, state)
 		if err != nil {
 			if errors.Is(err, todo.ErrDuplicateInvocation) {
 				log.Warnf("Workflow actor '%s': activity invocation '%s::%d' was flagged as a duplicate and will be skipped", o.actorID, e.GetTaskScheduled().GetName(), e.GetEventId())
@@ -52,14 +54,40 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 	return nil
 }
 
-func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent, dueTime time.Time, generation uint64) error {
+func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent, dueTime time.Time, state *wfenginestate.State) error {
 	ts := e.GetTaskScheduled()
 	if ts == nil {
 		log.Warnf("Workflow actor '%s': unable to process task '%v'", o.actorID, e)
 		return nil
 	}
 
-	var eventData []byte
+	// Use stored trace context to continue the workflow trace
+	if state.TraceContext != nil {
+		tc := state.TraceContext
+		traceID, err1 := trace.TraceIDFromHex(tc.TraceID)
+		spanID, err2 := trace.SpanIDFromHex(tc.SpanID)
+
+		if err1 == nil && err2 == nil {
+			var flags trace.TraceFlags
+			if _, err := fmt.Sscanf(tc.TraceFlags, "%02x", &flags); err != nil {
+				log.Warnf("Workflow actor '%s': failed to parse trace flags '%s': %v", o.actorID, tc.TraceFlags, err)
+			}
+
+			var traceState trace.TraceState
+			if tc.TraceState != "" {
+				traceState, _ = trace.ParseTraceState(tc.TraceState)
+			}
+
+			ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+				TraceID:    traceID,
+				SpanID:     spanID,
+				TraceFlags: flags,
+				TraceState: traceState,
+				Remote:     true,
+			}))
+		}
+	}
+
 	eventData, err := proto.Marshal(e)
 	if err != nil {
 		return err
@@ -70,11 +98,15 @@ func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent
 		activityActorType = o.actorTypeBuilder.Activity(router.GetTargetAppID())
 	}
 
-	targetActorID := buildActivityActorID(o.actorID, e.GetEventId(), generation)
+	targetActorID := buildActivityActorID(o.actorID, e.GetEventId(), state.Generation)
 
 	o.activityResultAwaited.Store(true)
 
 	log.Debugf("Workflow actor '%s': invoking execute method on activity actor '%s||%s'", o.actorID, activityActorType, targetActorID)
+
+	metadata := map[string][]string{
+		todo.MetadataActivityReminderDueTime: {strconv.FormatInt(dueTime.UnixMilli(), 10)},
+	}
 
 	_, err = o.router.Call(ctx, internalsv1pb.
 		NewInternalInvokeRequest("Execute").
@@ -82,6 +114,7 @@ func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent
 		WithMetadata(map[string][]string{
 			todo.MetadataActivityReminderDueTime: {strconv.FormatInt(dueTime.UnixMilli(), 10)},
 		}).
+		WithMetadata(metadata).
 		WithData(eventData).
 		WithContentType(invokev1.ProtobufContentType),
 	)

--- a/pkg/diagnostics/tracing.go
+++ b/pkg/diagnostics/tracing.go
@@ -163,7 +163,7 @@ func ConstructSubscriptionSpanAttributes(topic string) map[string]string {
 	}
 }
 
-// StartInternalCallbackSpan starts trace span for internal callback such as input bindings and pubsub subscription.
+// StartInternalCallbackSpan starts trace span for internal callback such as input bindings.
 func StartInternalCallbackSpan(ctx context.Context, spanName string, parent trace.SpanContext, spec *config.TracingSpec) (context.Context, trace.Span) {
 	if spec == nil || !diagUtils.IsTracingEnabled(spec.SamplingRate) {
 		return ctx, nil
@@ -172,6 +172,21 @@ func StartInternalCallbackSpan(ctx context.Context, spanName string, parent trac
 	ctx = trace.ContextWithRemoteSpanContext(ctx, parent)
 	//nolint:spancheck
 	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
+
+	//nolint:spancheck
+	return ctx, span
+}
+
+// StartPubsubConsumerSpan starts trace span for pubsub subscription message processing.
+// Uses SpanKindConsumer per OTel semantic conventions for messaging.
+func StartPubsubConsumerSpan(ctx context.Context, spanName string, parent trace.SpanContext, spec *config.TracingSpec) (context.Context, trace.Span) {
+	if spec == nil || !diagUtils.IsTracingEnabled(spec.SamplingRate) {
+		return ctx, nil
+	}
+
+	ctx = trace.ContextWithRemoteSpanContext(ctx, parent)
+	//nolint:spancheck
+	ctx, span := tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindConsumer))
 
 	//nolint:spancheck
 	return ctx, span

--- a/pkg/runtime/pubsub/subscriptions.go
+++ b/pkg/runtime/pubsub/subscriptions.go
@@ -377,7 +377,7 @@ func GRPCEnvelopeFromSubscriptionMessage(ctx context.Context, msg *SubscribedMes
 			spanName := "pubsub/" + msg.Topic
 
 			// no ops if trace is off
-			ctx, span = diag.StartInternalCallbackSpan(ctx, spanName, sc, tracingSpec)
+			ctx, span = diag.StartPubsubConsumerSpan(ctx, spanName, sc, tracingSpec)
 			// span is nil if tracing is disabled (sampling rate is 0)
 			if span != nil {
 				ctx = diag.SpanContextToGRPCMetadata(ctx, span.SpanContext())

--- a/pkg/runtime/subscription/postman/grpc/grpc.go
+++ b/pkg/runtime/subscription/postman/grpc/grpc.go
@@ -184,7 +184,7 @@ func (g *grpc) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 
 				// no ops if trace is off
 				var span trace.Span
-				ctx, span = diag.StartInternalCallbackSpan(ctx, "pubsub/"+psm.Topic, sc, g.tracingSpec)
+				ctx, span = diag.StartPubsubConsumerSpan(ctx, "pubsub/"+psm.Topic, sc, g.tracingSpec)
 				if span != nil {
 					ctx = diag.SpanContextToGRPCMetadata(ctx, span.SpanContext())
 					spans[n] = span

--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -80,7 +80,7 @@ func (h *http) Deliver(ctx context.Context, msg *pubsub.SubscribedMessage) error
 	if iTraceID != nil {
 		traceID := iTraceID.(string)
 		sc, _ := diag.SpanContextFromW3CString(traceID)
-		ctx, span = diag.StartInternalCallbackSpan(ctx, "pubsub/"+msg.Topic, sc, h.tracingSpec)
+		ctx, span = diag.StartPubsubConsumerSpan(ctx, "pubsub/"+msg.Topic, sc, h.tracingSpec)
 	}
 
 	start := time.Now()
@@ -222,7 +222,7 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 			traceID := iTraceID.(string)
 			sc, _ := diag.SpanContextFromW3CString(traceID)
 			var span trace.Span
-			ctx, span = diag.StartInternalCallbackSpan(ctx, "pubsub/"+psm.Topic, sc, h.tracingSpec)
+			ctx, span = diag.StartPubsubConsumerSpan(ctx, "pubsub/"+psm.Topic, sc, h.tracingSpec)
 			if span != nil {
 				spans[n] = span
 				n++

--- a/semconv/README.md
+++ b/semconv/README.md
@@ -1,0 +1,53 @@
+# Dapr Semantic Conventions
+
+This directory contains Dapr-specific semantic conventions for OpenTelemetry, defined using the [OTel Weaver](https://github.com/open-telemetry/weaver) format.
+
+## Structure
+
+```
+semconv/
+├── model/
+│   └── registry.yaml          # Semantic convention definitions
+├── templates/
+│   └── registry/
+│       └── go/
+│           ├── weaver.yaml    # Weaver configuration
+│           └── workflow.go.j2 # Go code template
+└── go/
+    └── workflow.go            # Generated Go code
+```
+
+## Regenerating
+
+Prerequisites:
+- [OTel Weaver](https://github.com/open-telemetry/weaver) installed (`brew install weaver` or see weaver docs)
+
+To regenerate the Go code after modifying `model/registry.yaml`:
+
+```bash
+cd semconv
+weaver registry generate go --registry model --templates templates --skip-policies
+mv output/workflow.go go/workflow.go
+rmdir output
+```
+
+Then copy to durabletask-go:
+
+```bash
+cp go/workflow.go ../../../durabletask-go/api/semconv/workflow.go
+```
+
+## Attributes
+
+All attributes follow the `dapr.workflow.*` namespace:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `dapr.workflow.type` | enum | orchestration, activity, timer |
+| `dapr.workflow.name` | string | Workflow or activity name |
+| `dapr.workflow.instance_id` | string | Workflow instance ID |
+| `dapr.workflow.task_id` | int | Activity task ID |
+| `dapr.workflow.version` | string | Workflow version |
+| `dapr.workflow.status` | enum | Runtime status |
+| `dapr.workflow.timer.fire_at` | string | Timer fire timestamp (ISO 8601) |
+| `dapr.workflow.timer.id` | int | Timer ID |

--- a/semconv/go/workflow.go
+++ b/semconv/go/workflow.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The Dapr Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+import "go.opentelemetry.io/otel/attribute"
+
+
+// Semantic conventions for Dapr workflow engine (durabletask).
+const (
+	// DaprWorkflowTypeKey is the attribute Key conforming to the "dapr.workflow.type" semantic conventions.
+	// The type of workflow component.
+	DaprWorkflowTypeKey = attribute.Key("dapr.workflow.type")
+	// DaprWorkflowNameKey is the attribute Key conforming to the "dapr.workflow.name" semantic conventions.
+	// The name of the workflow or activity being executed.
+	DaprWorkflowNameKey = attribute.Key("dapr.workflow.name")
+	// DaprWorkflowInstanceIdKey is the attribute Key conforming to the "dapr.workflow.instance_id" semantic conventions.
+	// The unique instance ID of the workflow execution.
+	DaprWorkflowInstanceIdKey = attribute.Key("dapr.workflow.instance_id")
+	// DaprWorkflowTaskIdKey is the attribute Key conforming to the "dapr.workflow.task_id" semantic conventions.
+	// The task ID of the activity or timer within the workflow.
+	DaprWorkflowTaskIdKey = attribute.Key("dapr.workflow.task_id")
+	// DaprWorkflowVersionKey is the attribute Key conforming to the "dapr.workflow.version" semantic conventions.
+	// The version of the workflow or activity.
+	DaprWorkflowVersionKey = attribute.Key("dapr.workflow.version")
+	// DaprWorkflowStatusKey is the attribute Key conforming to the "dapr.workflow.status" semantic conventions.
+	// The runtime status of the workflow.
+	DaprWorkflowStatusKey = attribute.Key("dapr.workflow.status")
+	// DaprWorkflowParentInstanceIdKey is the attribute Key conforming to the "dapr.workflow.parent_instance_id" semantic conventions.
+	// The instance ID of the parent workflow for sub-orchestrations.
+	DaprWorkflowParentInstanceIdKey = attribute.Key("dapr.workflow.parent_instance_id")
+	// DaprWorkflowParentNameKey is the attribute Key conforming to the "dapr.workflow.parent_name" semantic conventions.
+	// The name of the parent workflow for sub-orchestrations.
+	DaprWorkflowParentNameKey = attribute.Key("dapr.workflow.parent_name")
+)
+
+// Attributes for async workflow operations like external events and timers.
+const (
+	// DaprWorkflowEventNameKey is the attribute Key conforming to the "dapr.workflow.event.name" semantic conventions.
+	// The name of the external event raised to the workflow.
+	DaprWorkflowEventNameKey = attribute.Key("dapr.workflow.event.name")
+	// DaprWorkflowTimerFireAtKey is the attribute Key conforming to the "dapr.workflow.timer.fire_at" semantic conventions.
+	// The ISO 8601 timestamp when the timer is scheduled to fire.
+	DaprWorkflowTimerFireAtKey = attribute.Key("dapr.workflow.timer.fire_at")
+	// DaprWorkflowTimerIdKey is the attribute Key conforming to the "dapr.workflow.timer.id" semantic conventions.
+	// The unique identifier of the timer within the workflow.
+	DaprWorkflowTimerIdKey = attribute.Key("dapr.workflow.timer.id")
+)
+
+// Internal attributes for workflow actor implementation.
+const (
+	// DaprWorkflowActorTypeKey is the attribute Key conforming to the "dapr.workflow.actor.type" semantic conventions.
+	// The actor type used internally for workflow execution.
+	DaprWorkflowActorTypeKey = attribute.Key("dapr.workflow.actor.type")
+	// DaprWorkflowActorIdKey is the attribute Key conforming to the "dapr.workflow.actor.id" semantic conventions.
+	// The actor ID which corresponds to the workflow or activity instance.
+	DaprWorkflowActorIdKey = attribute.Key("dapr.workflow.actor.id")
+	// DaprWorkflowActorGenerationKey is the attribute Key conforming to the "dapr.workflow.actor.generation" semantic conventions.
+	// The generation number of the workflow state.
+	DaprWorkflowActorGenerationKey = attribute.Key("dapr.workflow.actor.generation")
+)

--- a/semconv/model/registry.yaml
+++ b/semconv/model/registry.yaml
@@ -1,0 +1,142 @@
+groups:
+  # Dapr Workflow Attributes
+  - id: registry.dapr.workflow
+    type: attribute_group
+    display_name: Dapr Workflow Attributes
+    brief: 'Semantic conventions for Dapr workflow engine (durabletask).'
+    attributes:
+      - id: dapr.workflow.type
+        type:
+          members:
+            - id: orchestration
+              value: "orchestration"
+              brief: "Workflow orchestration"
+              stability: development
+            - id: activity
+              value: "activity"
+              brief: "Workflow activity"
+              stability: development
+            - id: timer
+              value: "timer"
+              brief: "Workflow timer"
+              stability: development
+        stability: development
+        brief: "The type of workflow component."
+
+      - id: dapr.workflow.name
+        type: string
+        stability: development
+        brief: "The name of the workflow or activity being executed."
+        examples: ["OrderProcessingWorkflow", "ProcessPaymentActivity"]
+
+      - id: dapr.workflow.instance_id
+        type: string
+        stability: development
+        brief: "The unique instance ID of the workflow execution."
+        examples: ["order-wf-123", "dd54fc63-082c-4f70-8dfa-ad7489d71605"]
+
+      - id: dapr.workflow.task_id
+        type: int
+        stability: development
+        brief: "The task ID of the activity or timer within the workflow."
+        examples: [0, 1, 2]
+
+      - id: dapr.workflow.version
+        type: string
+        stability: development
+        brief: "The version of the workflow or activity."
+        examples: ["1.0", "v2"]
+
+      - id: dapr.workflow.status
+        type:
+          members:
+            - id: running
+              value: "RUNNING"
+              brief: "Workflow is currently running"
+              stability: development
+            - id: completed
+              value: "COMPLETED"
+              brief: "Workflow completed successfully"
+              stability: development
+            - id: failed
+              value: "FAILED"
+              brief: "Workflow failed with an error"
+              stability: development
+            - id: terminated
+              value: "TERMINATED"
+              brief: "Workflow was terminated"
+              stability: development
+            - id: pending
+              value: "PENDING"
+              brief: "Workflow is pending execution"
+              stability: development
+            - id: suspended
+              value: "SUSPENDED"
+              brief: "Workflow is suspended"
+              stability: development
+            - id: continued_as_new
+              value: "CONTINUED_AS_NEW"
+              brief: "Workflow continued as new instance"
+              stability: development
+        stability: development
+        brief: "The runtime status of the workflow."
+
+      - id: dapr.workflow.parent_instance_id
+        type: string
+        stability: development
+        brief: "The instance ID of the parent workflow for sub-orchestrations."
+        examples: ["parent-wf-123"]
+
+      - id: dapr.workflow.parent_name
+        type: string
+        stability: development
+        brief: "The name of the parent workflow for sub-orchestrations."
+        examples: ["ParentOrderWorkflow"]
+
+  # Dapr Workflow Async Operations
+  - id: registry.dapr.workflow.async
+    type: attribute_group
+    display_name: Dapr Workflow Async Operation Attributes
+    brief: 'Attributes for async workflow operations like external events and timers.'
+    attributes:
+      - id: dapr.workflow.event.name
+        type: string
+        stability: development
+        brief: "The name of the external event raised to the workflow."
+        examples: ["OrderApproved", "PaymentReceived", "UserInput"]
+
+      - id: dapr.workflow.timer.fire_at
+        type: string
+        stability: development
+        brief: "The ISO 8601 timestamp when the timer is scheduled to fire."
+        examples: ["2024-01-15T10:30:00Z"]
+
+      - id: dapr.workflow.timer.id
+        type: int
+        stability: development
+        brief: "The unique identifier of the timer within the workflow."
+        examples: [0, 1, 2]
+
+  # Dapr Workflow Actor Attributes (internal)
+  - id: registry.dapr.workflow.actor
+    type: attribute_group
+    display_name: Dapr Workflow Actor Attributes
+    brief: 'Internal attributes for workflow actor implementation.'
+    attributes:
+      - id: dapr.workflow.actor.type
+        type: string
+        stability: development
+        brief: "The actor type used internally for workflow execution."
+        examples: ["dapr.internal.wfengine.workflow", "dapr.internal.wfengine.activity"]
+
+      - id: dapr.workflow.actor.id
+        type: string
+        stability: development
+        brief: "The actor ID which corresponds to the workflow or activity instance."
+        examples: ["order-123", "order-123::0::1"]
+
+      - id: dapr.workflow.actor.generation
+        type: int
+        stability: development
+        brief: "The generation number of the workflow state."
+        examples: [1, 2, 3]

--- a/semconv/templates/go/weaver.yaml
+++ b/semconv/templates/go/weaver.yaml
@@ -1,0 +1,4 @@
+templates:
+  - pattern: workflow.go.j2
+    filter: .
+    application_mode: single

--- a/semconv/templates/go/workflow.go.j2.go
+++ b/semconv/templates/go/workflow.go.j2.go
@@ -1,0 +1,19 @@
+// Copyright 2025 The Dapr Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+import "go.opentelemetry.io/otel/attribute"
+
+{% for group in ctx.groups %}
+// {{ group.brief }}
+const (
+{%- for attr in group.attributes %}
+// {{ attr.name | pascal_case }}Key is the attribute Key conforming to the "{{ attr.name }}" semantic conventions.
+// {{ attr.brief }}
+{{ attr.name | pascal_case }}Key = attribute.Key("{{ attr.name }}")
+{%- endfor %}
+)
+{% endfor %}


### PR DESCRIPTION
# Description

This PR adds producer and consumer spans for PubSub interactions as well as semantic conventions for Dapr workflows. This helps tooling in the observability space to group Dapr attributes together. It also help other Dapr components to align on how we define attributes for traces and spans. 

Changes created by Kasper from Dash0, but I created the PR to review and push forward. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Related to: 
- https://github.com/dapr/dapr/issues/9032
- https://github.com/dapr/durabletask-go/pull/57 
- https://github.com/dapr/durabletask-java/pull/46

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
