### PR TITLE
Perf: Update xk6 version

### DIFF
--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.24.11 AS builder
 
 WORKDIR $GOPATH/src/go.k6.io/k6
 
-RUN go install go.k6.io/xk6/cmd/xk6@latest
+# See https://github.com/grafana/xk6/releases for which release aligns with our go version, latest requires go 1.25.x
+RUN go install go.k6.io/xk6/cmd/xk6@v1.2.3
 RUN xk6 build v0.56.0 \
     --output /k6 \
     --with github.com/grafana/xk6-output-prometheus-remote@latest \


### PR DESCRIPTION
latest for xk6 requires go 1.25.x. we need one compatible with go 1.24.11, hence this PR diff