### PR TITLE
[1.16] Fix 1.16.5 release notes format

### DIFF
--- a/docs/release_notes/v1.16.5.md
+++ b/docs/release_notes/v1.16.5.md
@@ -26,15 +26,19 @@ The trace context is now explicitly added to the outgoing gRPC metadata for pubs
 ## Allow for OIDC clientSecret to be rotated when token is refreshed in the Pulsar PubSub component
 
 ### Problem
+
 The Pulsar OAuth2 client in the Go SDK only loads the client secret once at startup, and the Dapr Pulsar component only supports providing the clientSecret as a static value. 
 This combination prevents rotating the OAuth2 client secret via a file path and breaks authentication when the clientSecret is changed.
 
 ### Impact
+
 Environments with strict security policies that require periodic rotation of the Pulsar OAuth2 client secret cannot safely rotate secrets. 
 Once the clientSecret file is updated, token refresh operations may fail because the running client continues using the old secret, leading to authentication errors and potential message flow interruption.
 
 ### Root Cause
+
 The Dapr Pulsar component exposes clientSecret only as a literal value in metadata, not as a file path, so it cannot take advantage of secret rotation mechanisms based on files.
 
 ### Solution
+
 The Dapr Pulsar component will add support for specifying clientSecret (privateKey) via a file path in its metadata.


### PR DESCRIPTION
rm `-` from release notes - I already manually edited it.