### PR TITLE
fix - only record logs/metrics if we applied patch

### DIFF
--- a/pkg/injector/service/handler.go
+++ b/pkg/injector/service/handler.go
@@ -127,8 +127,11 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if patchedSuccessfully {
-		log.Infof("Sidecar injector succeeded injection for app '%s'", diagAppID)
-		RecordSuccessfulSidecarInjectionCount(diagAppID)
+		// Only log and record metrics if we applied patches
+		if len(patchOps) > 0 {
+			log.Infof("Sidecar injector succeeded injection for app '%s'", diagAppID)
+			RecordSuccessfulSidecarInjectionCount(diagAppID)
+		}
 	} else {
 		log.Errorf("Admission succeeded, but pod was not patched. No sidecar injected for '%s'", diagAppID)
 		RecordFailedSidecarInjectionCount(diagAppID, "pod_patch")


### PR DESCRIPTION
# Description

Fixes a bug where the Dapr sidecar injector was incorrectly logging "succeeded injection" and recording metrics for non-Dapr applications (pods without `dapr.io/enabled: "true"` annotation).

- `getPodPatchOperations()` correctly returned an empty patch (no error)
- `patchedSuccessfully` was set to `true` because there was no error
- The code logged success and recorded metrics even though `len(patchOps) == 0` (no actual injection occurred)

**Fix:**
- Updated the success condition to check both `patchedSuccessfully && len(patchOps) > 0`
- Added test case `TestSidecarInjectNonDaprPod` to verify non-Dapr pods don't generate false success logs/metrics

## Issue reference

Fixes https://github.com/dapr/dapr/issues/9267

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing 