### PR TITLE
1.16: Propagate trace info when rawPayload is true

### DIFF
--- a/docs/release_notes/v1.16.7.md
+++ b/docs/release_notes/v1.16.7.md
@@ -1,0 +1,42 @@
+# Dapr 1.16.7
+
+This update includes bug fixes:
+
+- [Trace information not populated in pubsub component using GPRC and raw payloads](#trace-information-not-populated-in-pubsub-component-using-gprc-and-raw-payloads)
+- [Pulsar pubsub component fails to initialize when using oauth2ClientSecretPath](#pulsar-pubsub-component-fails-to-initialize-when-using-oauth2clientsecretpath)
+
+## Trace information not populated in pubsub component using GPRC and raw payloads 
+
+### Problem
+
+The pubsub component did not correctly propagate tracing information when delivering messages over gRPC using raw payloads
+
+### Impact
+
+Distributed traces were incomplete or missing links between publishers and subscribers. This prevented users from reliably correlating pubsub messages with their originating requests and spans.
+
+### Root Cause
+
+The trace context from the incoming gRPC call was not correctly applied to the context used for the pubsub publish call, especially for raw payloads. As a result, the outgoing pubsub publish did not carry the expected tracing headers/metadata, so downstream components and tracing backends could not associate the published message with the originating span, leading to missing or broken traces for gRPC-based pubsub flows.
+
+### Solution
+
+For raw payload publishes, the same trace information is now written directly into the pubsub metadata that accompanies the raw message, ensuring that tracing works consistently regardless of payload mode.
+
+## Pulsar pubsub component fails to initialize when using oauth2ClientSecretPath
+
+### Problem
+
+Pulsar Pubsub component `oauth2ClientSecretPath` configuration looked for a token and not a client secret or json credentials.
+
+### Impact
+
+Applications using the Pulsar pubsub component with OAuth2 client credentials stored on disk via `oauth2ClientSecretPath` could not start successfully. 
+
+### Root Cause
+
+`oauth2ClientSecretPath` used an incorrect method NewAuthenticationTokenFromFile which looked for a token and not a client secret.
+
+### Solution
+
+`oauth2ClientSecretPath` configuration is now corrected to read a client secret from file. A new option, `oauth2CredentialsFile`, has been added to load `client_id`, `client_secret`, `issuer_url` , and from a JSON file with the format: `{"client_id": "...", "client_secret": "...", "issuer_url": "..."}`.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.14.1
-	github.com/dapr/components-contrib v1.16.5
+	github.com/dapr/components-contrib v1.16.6
 	github.com/dapr/durabletask-go v0.10.2
 	github.com/dapr/kit v0.16.1
 	github.com/diagridio/go-etcd-cron v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53E
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.16.5 h1:UMq48FLIidUDukwHCt1CNjQu0q/37KmNd4vCLwvJybQ=
-github.com/dapr/components-contrib v1.16.5/go.mod h1:9kKhxIcefVJtxGMKtnkgJuJzGBvAEcyvgtKRQzL/KpY=
+github.com/dapr/components-contrib v1.16.6 h1:amqLjKIKP4457hAg7J+72vUiqe+MQxoGjzUYXJFe6e0=
+github.com/dapr/components-contrib v1.16.6/go.mod h1:9kKhxIcefVJtxGMKtnkgJuJzGBvAEcyvgtKRQzL/KpY=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20251104160704-920ad8a7b958 h1:DSZgzdXlbF75fwvEkMQpPqn1jjxmWVoBNmI4Bc4dS40=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20251104160704-920ad8a7b958/go.mod h1:IUB5RJv0Gj5qxsHjjhvEBIlxPka7cD7KAn/Coa2y27M=
 github.com/dapr/durabletask-go v0.10.2 h1:LrPcfyvVC30uqfsQgV1m6NHPXlYTwFxnpuVWxt4Q8/E=

--- a/tests/integration/suite/daprd/pubsub/grpc/traceparent/raw.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/traceparent/raw.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package traceparent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+const rawPayload = "true"
+
+func init() {
+	suite.Register(new(raw))
+}
+
+type raw struct {
+	daprd *daprd.Daprd
+	ch    chan metadata.MD
+}
+
+func (a *raw) Setup(t *testing.T) []framework.Option {
+	a.ch = make(chan metadata.MD, 1)
+
+	app := app.New(t,
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			md, ok := metadata.FromIncomingContext(ctx)
+			if !ok {
+				md = metadata.MD{}
+			}
+			a.ch <- md
+			return &rtv1.TopicEventResponse{
+				Status: rtv1.TopicEventResponse_SUCCESS,
+			}, nil
+		}),
+		app.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "test-topic",
+						Metadata: map[string]string{
+							"rawPayload":   rawPayload,
+							"isRawPayload": rawPayload,
+						},
+						Routes: &rtv1.TopicRoutes{
+							Default: "/test-topic",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	a.daprd = daprd.New(t,
+		//	daprd.WithGoProcess(true),
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(app, a.daprd),
+	}
+}
+
+func (a *raw) Run(t *testing.T, ctx context.Context) {
+	t.Run("With traceparent header", func(t *testing.T) {
+		a.daprd.WaitUntilRunning(t, ctx)
+
+		client := a.daprd.GRPCClient(t, ctx)
+
+		tp := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-02"
+		ctxWithTraceInfo := metadata.AppendToOutgoingContext(ctx, "traceparent", tp)
+
+		_, err := client.PublishEvent(ctxWithTraceInfo, &rtv1.PublishEventRequest{
+			PubsubName:      "mypub",
+			Topic:           "test-topic",
+			Data:            []byte(`{"message": "hello"}`),
+			DataContentType: "application/json",
+			Metadata: map[string]string{
+				"rawPayload": rawPayload,
+			},
+		})
+		require.NoError(t, err)
+
+		select {
+		case md := <-a.ch:
+			traceparentValue := md.Get("traceparent")
+			tracebin := md.Get("grpc-trace-bin")
+			require.NotNil(t, traceparentValue)
+			assert.NotEmpty(t, traceparentValue[0])
+			assert.NotEmpty(t, tracebin[0])
+
+			assert.Equal(t, tp, traceparentValue[0])
+		case <-time.After(time.Second * 10):
+			assert.Fail(t, "Timed out waiting for pubsub event to be delivered to app")
+		}
+	})
+
+	t.Run("Without traceparent header", func(t *testing.T) {
+		a.daprd.WaitUntilRunning(t, ctx)
+
+		client := a.daprd.GRPCClient(t, ctx)
+		_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+			PubsubName:      "mypub",
+			Topic:           "test-topic",
+			Data:            []byte(`{"message": "hello"}`),
+			DataContentType: "application/json",
+			Metadata: map[string]string{
+				"rawPayload": rawPayload,
+			},
+		})
+		require.NoError(t, err)
+
+		select {
+		case md := <-a.ch:
+			traceparentValue := md.Get("traceparent")
+			require.NotNil(t, traceparentValue)
+			assert.Equal(t, "00-00000000000000000000000000000000-0000000000000000-00", traceparentValue[0])
+		case <-time.After(time.Second * 10):
+			assert.Fail(t, "Timed out waiting for pubsub event to be delivered to app")
+		}
+	})
+}


### PR DESCRIPTION
# Description

This change fixes gRPC tracing propagation when publishing messages using raw payloads by ensuring trace information is correctly added to the message metadata in that path as well.

A dedicated raw payload test was not added because the `pubsub.in-memory` implementation used in the integration tests does not currently support metadata propagation on raw payloads.

## Proof of work

Before the change the trace information was not published:
<img width="1674" height="321" alt="imagen" src="https://github.com/user-attachments/assets/58d97a3c-65c7-4d27-9a43-1286887a1974" />

Now it is propagated:
<img width="1685" height="368" alt="imagen" src="https://github.com/user-attachments/assets/bb8f0d61-9bef-4765-b856-110605df88f3" />



## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
