### PR TITLE
fix: Proto files must have different java outer classname

### DIFF
--- a/dapr/proto/runtime/v1/actors.proto
+++ b/dapr/proto/runtime/v1/actors.proto
@@ -19,7 +19,7 @@ import "google/protobuf/any.proto";
 import "dapr/proto/common/v1/common.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprActorsProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/ai.proto
+++ b/dapr/proto/runtime/v1/ai.proto
@@ -19,7 +19,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprAiProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/binding.proto
+++ b/dapr/proto/runtime/v1/binding.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 package dapr.proto.runtime.v1;
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprBindingsProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/configuration.proto
+++ b/dapr/proto/runtime/v1/configuration.proto
@@ -18,7 +18,7 @@ package dapr.proto.runtime.v1;
 import "dapr/proto/common/v1/common.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprConfigurationProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/crypto.proto
+++ b/dapr/proto/runtime/v1/crypto.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 package dapr.proto.runtime.v1;
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprCryptoProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/invoke.proto
+++ b/dapr/proto/runtime/v1/invoke.proto
@@ -18,7 +18,7 @@ package dapr.proto.runtime.v1;
 import "dapr/proto/common/v1/common.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprInvokeProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/jobs.proto
+++ b/dapr/proto/runtime/v1/jobs.proto
@@ -19,7 +19,7 @@ import "google/protobuf/any.proto";
 import "dapr/proto/common/v1/common.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprJobsProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/lock.proto
+++ b/dapr/proto/runtime/v1/lock.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 package dapr.proto.runtime.v1;
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprLockProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/metadata.proto
+++ b/dapr/proto/runtime/v1/metadata.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 package dapr.proto.runtime.v1;
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprMetadataProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/pubsub.proto
+++ b/dapr/proto/runtime/v1/pubsub.proto
@@ -18,7 +18,7 @@ package dapr.proto.runtime.v1;
 import "dapr/proto/runtime/v1/appcallback.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprPubsubProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/secret.proto
+++ b/dapr/proto/runtime/v1/secret.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 package dapr.proto.runtime.v1;
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprSecretProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/state.proto
+++ b/dapr/proto/runtime/v1/state.proto
@@ -18,7 +18,7 @@ package dapr.proto.runtime.v1;
 import "dapr/proto/common/v1/common.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprStateProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 

--- a/dapr/proto/runtime/v1/workflow.proto
+++ b/dapr/proto/runtime/v1/workflow.proto
@@ -18,7 +18,7 @@ package dapr.proto.runtime.v1;
 import "google/protobuf/timestamp.proto";
 
 option csharp_namespace = "Dapr.Client.Autogen.Grpc.v1";
-option java_outer_classname = "DaprProtos";
+option java_outer_classname = "DaprWorkflowProtos";
 option java_package = "io.dapr.v1";
 option go_package = "github.com/dapr/dapr/pkg/proto/runtime/v1;runtime";
 


### PR DESCRIPTION
# Description

Java-sdk build fails using the old configuration as it expects each file to be in its own Java Class

<img width="1409" height="264" alt="imagen" src="https://github.com/user-attachments/assets/f7e7e9c8-b847-411a-9b99-c14a4760dc1e" />


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
