### PR TITLE
Workflow: Clear cache when stalled

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -145,9 +145,6 @@ func (f *factory) initOrchestrator(o any, actorID string) *orchestrator {
 	or.closed.Store(false)
 	or.lock.Init()
 
-	or.state = nil
-	or.rstate = nil
-	or.ometa = nil
 	if or.streamFns == nil {
 		or.streamFns = make(map[int64]*streamFn)
 	}

--- a/pkg/actors/targets/workflow/orchestrator/versioning.go
+++ b/pkg/actors/targets/workflow/orchestrator/versioning.go
@@ -94,6 +94,12 @@ func (o *orchestrator) stallWorkflow(ctx context.Context, state *wfenginestate.S
 
 	unlock := o.lock.Stall()
 	defer unlock()
+
+	// Clear in-memory state to save resources as stalling is indefinite.
+	o.state = nil
+	o.rstate = nil
+	o.ometa = nil
+
 	<-ctx.Done()
 
 	return errors.New("workflow is stalled")


### PR DESCRIPTION
Since a workflow can be stalled indefinitely, clear the memory cache of the actor to free up resources.