### PR TITLE
[WIP] Implement AES-CBC-AEAD encryption scheme

### DIFF
--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -87,17 +87,18 @@ type API interface {
 
 type api struct {
 	*universal.Universal
-	logger                logger.Logger
-	directMessaging       invokev1.DirectMessaging
-	channels              *channels.Channels
-	pubsubAdapter         runtimePubsub.Adapter
-	pubsubAdapterStreamer runtimePubsub.AdapterStreamer
-	outbox                outbox.Outbox
-	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-	tracingSpec           config.TracingSpec
-	accessControlList     *config.AccessControlList
-	processor             *processor.Processor
-	wg                    sync.WaitGroup
+	logger                        logger.Logger
+	directMessaging               invokev1.DirectMessaging
+	channels                      *channels.Channels
+	pubsubAdapter                 runtimePubsub.Adapter
+	pubsubAdapterStreamer         runtimePubsub.AdapterStreamer
+	outbox                        outbox.Outbox
+	sendToOutputBindingFn         func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
+	tracingSpec                   config.TracingSpec
+	accessControlList             *config.AccessControlList
+	processor                     *processor.Processor
+	wg                            sync.WaitGroup
+	stateStoreV2EncryptionEnabled bool
 
 	closeCh chan struct{}
 	closed  atomic.Bool
@@ -105,34 +106,36 @@ type api struct {
 
 // APIOpts contains options for NewAPI.
 type APIOpts struct {
-	Universal             *universal.Universal
-	Logger                logger.Logger
-	Channels              *channels.Channels
-	PubSubAdapter         runtimePubsub.Adapter
-	PubSubAdapterStreamer runtimePubsub.AdapterStreamer
-	Outbox                outbox.Outbox
-	DirectMessaging       invokev1.DirectMessaging
-	SendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-	TracingSpec           config.TracingSpec
-	AccessControlList     *config.AccessControlList
-	Processor             *processor.Processor
+	Universal                     *universal.Universal
+	Logger                        logger.Logger
+	Channels                      *channels.Channels
+	PubSubAdapter                 runtimePubsub.Adapter
+	PubSubAdapterStreamer         runtimePubsub.AdapterStreamer
+	Outbox                        outbox.Outbox
+	DirectMessaging               invokev1.DirectMessaging
+	SendToOutputBindingFn         func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
+	TracingSpec                   config.TracingSpec
+	AccessControlList             *config.AccessControlList
+	Processor                     *processor.Processor
+	StateStoreV2EncryptionEnabled bool
 }
 
 // NewAPI returns a new gRPC API.
 func NewAPI(opts APIOpts) API {
 	return &api{
-		Universal:             opts.Universal,
-		logger:                opts.Logger,
-		directMessaging:       opts.DirectMessaging,
-		channels:              opts.Channels,
-		pubsubAdapter:         opts.PubSubAdapter,
-		pubsubAdapterStreamer: opts.PubSubAdapterStreamer,
-		outbox:                opts.Outbox,
-		sendToOutputBindingFn: opts.SendToOutputBindingFn,
-		tracingSpec:           opts.TracingSpec,
-		accessControlList:     opts.AccessControlList,
-		processor:             opts.Processor,
-		closeCh:               make(chan struct{}),
+		Universal:                     opts.Universal,
+		logger:                        opts.Logger,
+		directMessaging:               opts.DirectMessaging,
+		channels:                      opts.Channels,
+		pubsubAdapter:                 opts.PubSubAdapter,
+		pubsubAdapterStreamer:         opts.PubSubAdapterStreamer,
+		outbox:                        opts.Outbox,
+		sendToOutputBindingFn:         opts.SendToOutputBindingFn,
+		tracingSpec:                   opts.TracingSpec,
+		accessControlList:             opts.AccessControlList,
+		processor:                     opts.Processor,
+		closeCh:                       make(chan struct{}),
+		stateStoreV2EncryptionEnabled: opts.StateStoreV2EncryptionEnabled,
 	}
 }
 

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -632,7 +632,8 @@ func (a *api) GetBulkState(ctx context.Context, in *runtimev1pb.GetBulkStateRequ
 				continue
 			}
 
-			val, err := encryption.TryDecryptValue(in.GetStoreName(), bulkResp.GetItems()[i].GetData(), encryption.TryDecryptValueOpts{
+			val, err := encryption.TryDecryptValue(in.GetStoreName(), bulkResp.GetItems()[i].GetData(), encryption.TryDecryptValueOptions{
+				KeyName:                  bulkResp.GetItems()[i].GetKey(),
 				StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 			})
 			if err != nil {
@@ -694,7 +695,8 @@ func (a *api) GetState(ctx context.Context, in *runtimev1pb.GetStateRequest) (*r
 		getResponse = &state.GetResponse{}
 	}
 	if encryption.EncryptedStateStore(in.GetStoreName()) {
-		val, err := encryption.TryDecryptValue(in.GetStoreName(), getResponse.Data, encryption.TryDecryptValueOpts{
+		val, err := encryption.TryDecryptValue(in.GetStoreName(), getResponse.Data, encryption.TryDecryptValueOptions{
+			KeyName:                  key,
 			StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 		})
 		if err != nil {
@@ -764,7 +766,7 @@ func (a *api) SaveState(ctx context.Context, in *runtimev1pb.SaveStateRequest) (
 			}
 		}
 		if encryption.EncryptedStateStore(in.GetStoreName()) {
-			val, encErr := encryption.TryEncryptValue(in.GetStoreName(), s.GetValue(), encryption.TryEncryptValueOpts{
+			val, encErr := encryption.TryEncryptValue(in.GetStoreName(), s.GetValue(), encryption.TryEncryptValueOptions{
 				KeyName:                  s.Key,
 				StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 			})
@@ -1014,7 +1016,7 @@ func (a *api) ExecuteStateTransaction(ctx context.Context, in *runtimev1pb.Execu
 			switch req := op.(type) {
 			case state.SetRequest:
 				data := []byte(fmt.Sprintf("%v", req.Value))
-				val, err := encryption.TryEncryptValue(in.GetStoreName(), data, encryption.TryEncryptValueOpts{
+				val, err := encryption.TryEncryptValue(in.GetStoreName(), data, encryption.TryEncryptValueOptions{
 					KeyName:                  req.Key,
 					StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 				})

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -578,7 +578,8 @@ func (a *api) onBulkGetState(w nethttp.ResponseWriter, r *nethttp.Request) {
 				continue
 			}
 
-			val, err := encryption.TryDecryptValue(storeName, bulkResp[i].Data, encryption.TryDecryptValueOpts{
+			val, err := encryption.TryDecryptValue(storeName, bulkResp[i].Data, encryption.TryDecryptValueOptions{
+				KeyName:                  bulkResp[i].Key,
 				StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 			})
 			if err != nil {
@@ -673,7 +674,8 @@ func (a *api) onGetState(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	if encryption.EncryptedStateStore(storeName) {
-		val, err := encryption.TryDecryptValue(storeName, resp.Data, encryption.TryDecryptValueOpts{
+		val, err := encryption.TryDecryptValue(storeName, resp.Data, encryption.TryDecryptValueOptions{
+			KeyName:                  k,
 			StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 		})
 		if err != nil {
@@ -1037,7 +1039,7 @@ func (a *api) onPostState(w nethttp.ResponseWriter, r *nethttp.Request) {
 
 		if encryption.EncryptedStateStore(storeName) {
 			data := []byte(fmt.Sprintf("%v", r.Value))
-			val, encErr := encryption.TryEncryptValue(storeName, data, encryption.TryEncryptValueOpts{
+			val, encErr := encryption.TryEncryptValue(storeName, data, encryption.TryEncryptValueOptions{
 				KeyName:                  r.Key,
 				StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 			})
@@ -1610,7 +1612,7 @@ func (a *api) onPostStateTransaction(w nethttp.ResponseWriter, r *nethttp.Reques
 			switch req := op.(type) {
 			case state.SetRequest:
 				data := []byte(fmt.Sprintf("%v", req.Value))
-				val, err := encryption.TryEncryptValue(storeName, data, encryption.TryEncryptValueOpts{
+				val, err := encryption.TryEncryptValue(storeName, data, encryption.TryEncryptValueOptions{
 					KeyName:                  req.Key,
 					StateV2EncryptionEnabled: a.stateV2EncryptionEnabled,
 				})

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -65,19 +65,20 @@ type API interface {
 }
 
 type api struct {
-	universal             *universal.Universal
-	endpoints             []endpoints.Endpoint
-	publicEndpoints       []endpoints.Endpoint
-	directMessaging       invokev1.DirectMessaging
-	channels              *channels.Channels
-	pubsubAdapter         runtimePubsub.Adapter
-	outbox                outbox.Outbox
-	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-	metricSpec            *config.MetricSpec
-	tracingSpec           config.TracingSpec
-	maxRequestBodySize    int64 // In bytes
-	healthz               healthz.Healthz
-	outboundHealthz       healthz.Healthz
+	universal                     *universal.Universal
+	endpoints                     []endpoints.Endpoint
+	publicEndpoints               []endpoints.Endpoint
+	directMessaging               invokev1.DirectMessaging
+	channels                      *channels.Channels
+	pubsubAdapter                 runtimePubsub.Adapter
+	outbox                        outbox.Outbox
+	sendToOutputBindingFn         func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
+	metricSpec                    *config.MetricSpec
+	tracingSpec                   config.TracingSpec
+	maxRequestBodySize            int64 // In bytes
+	healthz                       healthz.Healthz
+	outboundHealthz               healthz.Healthz
+	stateStoreV2EncryptionEnabled bool
 }
 
 const (
@@ -111,33 +112,35 @@ const (
 
 // APIOpts contains the options for NewAPI.
 type APIOpts struct {
-	Universal             *universal.Universal
-	Channels              *channels.Channels
-	DirectMessaging       invokev1.DirectMessaging
-	PubSubAdapter         runtimePubsub.Adapter
-	Outbox                outbox.Outbox
-	SendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-	TracingSpec           config.TracingSpec
-	MetricSpec            *config.MetricSpec
-	MaxRequestBodySize    int64 // In bytes
-	Healthz               healthz.Healthz
-	OutboundHealthz       healthz.Healthz
+	Universal                     *universal.Universal
+	Channels                      *channels.Channels
+	DirectMessaging               invokev1.DirectMessaging
+	PubSubAdapter                 runtimePubsub.Adapter
+	Outbox                        outbox.Outbox
+	SendToOutputBindingFn         func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
+	TracingSpec                   config.TracingSpec
+	MetricSpec                    *config.MetricSpec
+	MaxRequestBodySize            int64 // In bytes
+	Healthz                       healthz.Healthz
+	OutboundHealthz               healthz.Healthz
+	StateStoreV2EncryptionEnabled bool
 }
 
 // NewAPI returns a new API.
 func NewAPI(opts APIOpts) API {
 	api := &api{
-		universal:             opts.Universal,
-		channels:              opts.Channels,
-		directMessaging:       opts.DirectMessaging,
-		pubsubAdapter:         opts.PubSubAdapter,
-		outbox:                opts.Outbox,
-		sendToOutputBindingFn: opts.SendToOutputBindingFn,
-		tracingSpec:           opts.TracingSpec,
-		metricSpec:            opts.MetricSpec,
-		maxRequestBodySize:    opts.MaxRequestBodySize,
-		healthz:               opts.Healthz,
-		outboundHealthz:       opts.OutboundHealthz,
+		universal:                     opts.Universal,
+		channels:                      opts.Channels,
+		directMessaging:               opts.DirectMessaging,
+		pubsubAdapter:                 opts.PubSubAdapter,
+		outbox:                        opts.Outbox,
+		sendToOutputBindingFn:         opts.SendToOutputBindingFn,
+		tracingSpec:                   opts.TracingSpec,
+		metricSpec:                    opts.MetricSpec,
+		maxRequestBodySize:            opts.MaxRequestBodySize,
+		healthz:                       opts.Healthz,
+		outboundHealthz:               opts.OutboundHealthz,
+		stateStoreV2EncryptionEnabled: opts.StateStoreV2EncryptionEnabled,
 	}
 
 	metadataEndpoints := api.constructMetadataEndpoints()

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -53,7 +53,7 @@ const (
 	HotReload Feature = "HotReload"
 
 	// Enables AES-CBC-AEAD automatic encryption for state stores.
-	StateStoreV2Encryption Feature = "StateStoreV2Encryption"
+	StateV2Encryption Feature = "StateV2Encryption"
 
 	// Enables feature to support workflows in a clustered deployment.
 	WorkflowsClusteredDeployment Feature = "WorkflowsClusteredDeployment"

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -52,6 +52,9 @@ const (
 	// Enables support for hot reloading of Daprd Components.
 	HotReload Feature = "HotReload"
 
+	// Enables AES-CBC-AEAD automatic encryption for state stores.
+	StateStoreV2Encryption Feature = "StateStoreV2Encryption"
+
 	// Enables feature to support workflows in a clustered deployment.
 	WorkflowsClusteredDeployment Feature = "WorkflowsClusteredDeployment"
 )

--- a/pkg/encryption/encryption.go
+++ b/pkg/encryption/encryption.go
@@ -56,14 +56,14 @@ type Key struct {
 
 type EncryptOpts struct {
 	// TODO: remove when feature flag is removed
-	StateStoreV2EncryptionEnabled bool
+	StateV2EncryptionEnabled bool
 }
 
 type DecryptOpts struct {
 	Tag []byte // Authentication tag
 
 	// TODO: remove when feature flag is removed
-	StateStoreV2EncryptionEnabled bool
+	StateV2EncryptionEnabled bool
 }
 
 // ComponentEncryptionKey checks if a component definition contains an encryption key and extracts it using the supplied secret store.
@@ -188,7 +188,7 @@ func tryGetEncryptionKeyFromMetadataItem(namespace string, item commonapi.NameVa
 
 // Encrypt takes a byte array and encrypts it using a supplied encryption key.
 func encrypt(value []byte, key Key, additionalData []byte, opts EncryptOpts) ([]byte, error) {
-	if opts.StateStoreV2EncryptionEnabled {
+	if opts.StateV2EncryptionEnabled {
 
 		nsize := make([]byte, key.cipherObjV2.NonceSize())
 		if _, err := io.ReadFull(rand.Reader, nsize); err != nil {
@@ -217,7 +217,7 @@ func decrypt(value []byte, key Key, additionalData []byte, opts DecryptOpts) ([]
 	}
 
 	// TODO: once feature flag is removed the old scheme needs to be detected and handled
-	if opts.StateStoreV2EncryptionEnabled {
+	if opts.StateV2EncryptionEnabled {
 		nsize := key.cipherObjV2.NonceSize()
 		nonce, ciphertext := enc[:nsize], enc[nsize:]
 

--- a/pkg/encryption/encryption.go
+++ b/pkg/encryption/encryption.go
@@ -196,7 +196,6 @@ func encrypt(value []byte, additionalData []byte, cipher cipher.AEAD) ([]byte, e
 }
 
 // Decrypt takes a byte array and decrypts it using a supplied cipher.
-// The byte array should be Base64-encoded.
 func decrypt(value []byte, additionalData []byte, cipher cipher.AEAD) ([]byte, error) {
 	nsize := cipher.NonceSize()
 	nonce, ciphertext := value[:nsize], value[nsize:]

--- a/pkg/encryption/encryption_test.go
+++ b/pkg/encryption/encryption_test.go
@@ -101,7 +101,7 @@ func TestComponentEncryptionKey(t *testing.T) {
 			},
 		}})
 
-		keys, err := ComponentEncryptionKey(component, secretStore)
+		keys, err := ComponentEncryptionKey(component, secretStore, ComponentEncryptionKeyOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, primaryKey, keys.Primary.Key)
 		assert.Equal(t, secondaryKey, keys.Secondary.Key)
@@ -130,7 +130,7 @@ func TestComponentEncryptionKey(t *testing.T) {
 			},
 		}
 
-		keys, err := ComponentEncryptionKey(component, nil)
+		keys, err := ComponentEncryptionKey(component, nil, ComponentEncryptionKeyOptions{})
 		assert.Empty(t, keys.Primary.Key)
 		assert.Empty(t, keys.Secondary.Key)
 		require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestComponentEncryptionKey(t *testing.T) {
 			},
 		}
 
-		_, err := ComponentEncryptionKey(component, nil)
+		_, err := ComponentEncryptionKey(component, nil, ComponentEncryptionKeyOptions{})
 		require.NoError(t, err)
 	})
 }
@@ -222,36 +222,36 @@ func TestCreateCipher(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("valid 256-bit key v2", func(t *testing.T) {
+	t.Run("valid 512-bit key for v2 encryption", func(t *testing.T) {
+		bytes := make([]byte, 64)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESCBCAEADAlgorithm)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 384-bit key for v2 encryption", func(t *testing.T) {
+		bytes := make([]byte, 48)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESCBCAEADAlgorithm)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 256-bit key for v2 encryption", func(t *testing.T) {
 		bytes := make([]byte, 32)
-		rand.Read(bytes)
-
-		key := hex.EncodeToString(bytes)
-
-		cipherObj, err := createCipher(Key{
-			Key: key,
-		}, AESCBCAEADAlgorithm)
-
-		assert.NotNil(t, cipherObj)
-		require.NoError(t, err)
-	})
-
-	t.Run("valid 192-bit key v2", func(t *testing.T) {
-		bytes := make([]byte, 24)
-		rand.Read(bytes)
-
-		key := hex.EncodeToString(bytes)
-
-		cipherObj, err := createCipher(Key{
-			Key: key,
-		}, AESCBCAEADAlgorithm)
-
-		assert.NotNil(t, cipherObj)
-		require.NoError(t, err)
-	})
-
-	t.Run("valid 128-bit key v2", func(t *testing.T) {
-		bytes := make([]byte, 16)
 		rand.Read(bytes)
 
 		key := hex.EncodeToString(bytes)
@@ -294,28 +294,28 @@ func TestCreateCipher(t *testing.T) {
 }
 
 func TestNewAESCBCAEAD(t *testing.T) {
+	t.Run("valid 512-bit key", func(t *testing.T) {
+		bytes := make([]byte, 64)
+		rand.Read(bytes)
+
+		cipherObj, err := newAESCBCAEAD(bytes)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 384-bit key", func(t *testing.T) {
+		bytes := make([]byte, 48)
+		rand.Read(bytes)
+
+		cipherObj, err := newAESCBCAEAD(bytes)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
 	t.Run("valid 256-bit key", func(t *testing.T) {
 		bytes := make([]byte, 32)
-		rand.Read(bytes)
-
-		cipherObj, err := newAESCBCAEAD(bytes)
-
-		assert.NotNil(t, cipherObj)
-		require.NoError(t, err)
-	})
-
-	t.Run("valid 192-bit key", func(t *testing.T) {
-		bytes := make([]byte, 24)
-		rand.Read(bytes)
-
-		cipherObj, err := newAESCBCAEAD(bytes)
-
-		assert.NotNil(t, cipherObj)
-		require.NoError(t, err)
-	})
-
-	t.Run("valid 128-bit key", func(t *testing.T) {
-		bytes := make([]byte, 16)
 		rand.Read(bytes)
 
 		cipherObj, err := newAESCBCAEAD(bytes)

--- a/pkg/encryption/encryption_test.go
+++ b/pkg/encryption/encryption_test.go
@@ -222,6 +222,48 @@ func TestCreateCipher(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("valid 256-bit key v2", func(t *testing.T) {
+		bytes := make([]byte, 32)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESCBCAEADAlgorithm)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 192-bit key v2", func(t *testing.T) {
+		bytes := make([]byte, 24)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESCBCAEADAlgorithm)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 128-bit key v2", func(t *testing.T) {
+		bytes := make([]byte, 16)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		cipherObj, err := createCipher(Key{
+			Key: key,
+		}, AESCBCAEADAlgorithm)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
 	t.Run("invalid key size", func(t *testing.T) {
 		bytes := make([]byte, 18)
 		rand.Read(bytes)
@@ -245,6 +287,48 @@ func TestCreateCipher(t *testing.T) {
 		cipherObj, err := createCipher(Key{
 			Key: key,
 		}, "3DES")
+
+		assert.Nil(t, cipherObj)
+		require.Error(t, err)
+	})
+}
+
+func TestNewAESCBCAEAD(t *testing.T) {
+	t.Run("valid 256-bit key", func(t *testing.T) {
+		bytes := make([]byte, 32)
+		rand.Read(bytes)
+
+		cipherObj, err := newAESCBCAEAD(bytes)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 192-bit key", func(t *testing.T) {
+		bytes := make([]byte, 24)
+		rand.Read(bytes)
+
+		cipherObj, err := newAESCBCAEAD(bytes)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid 128-bit key", func(t *testing.T) {
+		bytes := make([]byte, 16)
+		rand.Read(bytes)
+
+		cipherObj, err := newAESCBCAEAD(bytes)
+
+		assert.NotNil(t, cipherObj)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid key size", func(t *testing.T) {
+		bytes := make([]byte, 18)
+		rand.Read(bytes)
+
+		cipherObj, err := newAESCBCAEAD(bytes)
 
 		assert.Nil(t, cipherObj)
 		require.Error(t, err)

--- a/pkg/encryption/state.go
+++ b/pkg/encryption/state.go
@@ -44,7 +44,7 @@ type TryEncryptValueOpts struct {
 	KeyName string // The key that the value is mapped to in the store
 
 	// TODO: remove when feature flag is removed
-	StateStoreV2EncryptionEnabled bool
+	StateV2EncryptionEnabled bool
 }
 
 type TryDecryptValueOpts struct {
@@ -52,7 +52,7 @@ type TryDecryptValueOpts struct {
 	KeyName string // The key that the value is mapped to in the store
 
 	// TODO: remove when feature flag is removed
-	StateStoreV2EncryptionEnabled bool
+	StateV2EncryptionEnabled bool
 }
 
 // AddEncryptedStateStore adds an encrypted state store and an associated encryption key to a list.
@@ -77,10 +77,10 @@ func EncryptedStateStore(storeName string) bool {
 func TryEncryptValue(storeName string, value []byte, opts TryEncryptValueOpts) ([]byte, error) {
 	keys := encryptedStateStores[storeName]
 
-	if opts.StateStoreV2EncryptionEnabled {
+	if opts.StateV2EncryptionEnabled {
 		// Encrypted value is nonce || ciphertext || tag
 		enc, err := encrypt(value, keys.Primary, []byte(opts.KeyName), EncryptOpts{
-			StateStoreV2EncryptionEnabled: opts.StateStoreV2EncryptionEnabled,
+			StateV2EncryptionEnabled: opts.StateV2EncryptionEnabled,
 		})
 		if err != nil {
 			return value, err
@@ -123,7 +123,7 @@ func TryDecryptValue(storeName string, value []byte, opts TryDecryptValueOpts) (
 	keys := encryptedStateStores[storeName]
 
 	// TODO: once feature flag is removed the old scheme needs to be detected and handled
-	if opts.StateStoreV2EncryptionEnabled {
+	if opts.StateV2EncryptionEnabled {
 		// value is serialized json
 		encValue := &EncryptedValue{}
 		err := json.Unmarshal(value, encValue)
@@ -142,8 +142,8 @@ func TryDecryptValue(storeName string, value []byte, opts TryDecryptValueOpts) (
 		}
 
 		return decrypt(encValue.Ciphertext, key, []byte(opts.KeyName), DecryptOpts{
-			Tag:                           encValue.Tag,
-			StateStoreV2EncryptionEnabled: opts.StateStoreV2EncryptionEnabled,
+			Tag:                      encValue.Tag,
+			StateV2EncryptionEnabled: opts.StateV2EncryptionEnabled,
 		})
 	}
 

--- a/pkg/encryption/state.go
+++ b/pkg/encryption/state.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	b64 "encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 )
@@ -172,11 +173,22 @@ func TryDecryptValue(storeName string, value []byte, opts TryDecryptValueOptions
 	return nil, nil
 }
 
-// Returns a boolean indicating whether or not the key's SHA224 hash is equivalent to the key ID.
+// Returns a boolean indicating whether or not the key's SHA-224 hash is equivalent to the key ID.
+// The key ID must be a Base-64 encoded string.
 func keyMatchesKeyID(key Key, keyID string) bool {
-	hash := sha256.Sum224([]byte(key.Key))
+	keyIDBytes, err := b64.StdEncoding.DecodeString(keyID)
+	if err != nil {
+		return false
+	}
 
-	if subtle.ConstantTimeCompare(hash[:], []byte(keyID)) == 1 {
+	keyBytes, err := hex.DecodeString(key.Key)
+	if err != nil {
+		return false
+	}
+
+	keyHashBytes := sha256.Sum224(keyBytes)
+
+	if subtle.ConstantTimeCompare(keyHashBytes[:], keyIDBytes) == 1 {
 		return true
 	}
 

--- a/pkg/encryption/state_test.go
+++ b/pkg/encryption/state_test.go
@@ -67,6 +67,126 @@ func TestTryEncryptValue(t *testing.T) {
 		assert.False(t, ok)
 	})
 
+	t.Run("state store with AES512 primary key with v2 encryption, value encrypted and decrypted successfully", func(t *testing.T) {
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+
+		bytes := make([]byte, 64)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		pr := Key{
+			Name: "primary",
+			Key:  key,
+		}
+
+		cipherObj, _ := createCipher(pr, AESCBCAEADAlgorithm)
+		pr.cipherObjV2 = cipherObj
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Primary: pr,
+		})
+
+		v := []byte("hello")
+		r, err := TryEncryptValue("test", v, TryEncryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+
+		require.NoError(t, err)
+		assert.NotEqual(t, v, r)
+
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, v, dr)
+	})
+
+	t.Run("state store with AES512 secondary key with v2 encryption, value encrypted and decrypted successfully", func(t *testing.T) {
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+
+		bytes := make([]byte, 64)
+		rand.Read(bytes)
+
+		primaryKey := hex.EncodeToString(bytes)
+
+		pr := Key{
+			Name: "primary",
+			Key:  primaryKey,
+		}
+
+		cipherObj, _ := createCipher(pr, AESCBCAEADAlgorithm)
+		pr.cipherObjV2 = cipherObj
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Primary: pr,
+		})
+
+		v := []byte("hello")
+		r, err := TryEncryptValue("test", v, TryEncryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+
+		require.NoError(t, err)
+		assert.NotEqual(t, v, r)
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Secondary: pr,
+		})
+
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, v, dr)
+	})
+
+	t.Run("state store with AES512 primary key with v2 encryption, base64 value encrypted and decrypted successfully", func(t *testing.T) {
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+
+		bytes := make([]byte, 64)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		pr := Key{
+			Name: "primary",
+			Key:  key,
+		}
+
+		cipherObj, _ := createCipher(pr, AESCBCAEADAlgorithm)
+		pr.cipherObjV2 = cipherObj
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Primary: pr,
+		})
+
+		v := []byte("hello")
+		s := base64.StdEncoding.EncodeToString(v)
+		r, err := TryEncryptValue("test", []byte(s), TryEncryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+
+		require.NoError(t, err)
+		assert.NotEqual(t, v, r)
+
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []byte(s), dr)
+	})
+
 	t.Run("state store with AES256 primary key, value encrypted and decrypted successfully", func(t *testing.T) {
 		encryptedStateStores = map[string]ComponentEncryptionKeys{}
 
@@ -95,6 +215,44 @@ func TestTryEncryptValue(t *testing.T) {
 		assert.NotEqual(t, v, r)
 
 		dr, err := TryDecryptValue("test", r, TryDecryptValueOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, v, dr)
+	})
+
+	t.Run("state store with AES256 primary key with v2 encryption, value encrypted and decrypted successfully", func(t *testing.T) {
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+
+		bytes := make([]byte, 32)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		pr := Key{
+			Name: "primary",
+			Key:  key,
+		}
+
+		cipherObj, _ := createCipher(pr, AESCBCAEADAlgorithm)
+		pr.cipherObjV2 = cipherObj
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Primary: pr,
+		})
+
+		v := []byte("hello")
+		r, err := TryEncryptValue("test", v, TryEncryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+
+		require.NoError(t, err)
+		assert.NotEqual(t, v, r)
+
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
 		require.NoError(t, err)
 		assert.Equal(t, v, dr)
 	})

--- a/pkg/encryption/state_test.go
+++ b/pkg/encryption/state_test.go
@@ -88,12 +88,12 @@ func TestTryEncryptValue(t *testing.T) {
 		})
 
 		v := []byte("hello")
-		r, err := TryEncryptValue("test", v)
+		r, err := TryEncryptValue("test", v, TryEncryptValueOpts{})
 
 		require.NoError(t, err)
 		assert.NotEqual(t, v, r)
 
-		dr, err := TryDecryptValue("test", r)
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOpts{})
 		require.NoError(t, err)
 		assert.Equal(t, v, dr)
 	})
@@ -120,7 +120,7 @@ func TestTryEncryptValue(t *testing.T) {
 		})
 
 		v := []byte("hello")
-		r, err := TryEncryptValue("test", v)
+		r, err := TryEncryptValue("test", v, TryEncryptValueOpts{})
 
 		require.NoError(t, err)
 		assert.NotEqual(t, v, r)
@@ -130,7 +130,7 @@ func TestTryEncryptValue(t *testing.T) {
 			Secondary: pr,
 		})
 
-		dr, err := TryDecryptValue("test", r)
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOpts{})
 		require.NoError(t, err)
 		assert.Equal(t, v, dr)
 	})
@@ -158,12 +158,12 @@ func TestTryEncryptValue(t *testing.T) {
 
 		v := []byte("hello")
 		s := base64.StdEncoding.EncodeToString(v)
-		r, err := TryEncryptValue("test", []byte(s))
+		r, err := TryEncryptValue("test", []byte(s), TryEncryptValueOpts{})
 
 		require.NoError(t, err)
 		assert.NotEqual(t, v, r)
 
-		dr, err := TryDecryptValue("test", r)
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOpts{})
 		require.NoError(t, err)
 		assert.Equal(t, []byte(s), dr)
 	})
@@ -190,12 +190,12 @@ func TestTryEncryptValue(t *testing.T) {
 		})
 
 		v := []byte("hello world")
-		r, err := TryEncryptValue("test", v)
+		r, err := TryEncryptValue("test", v, TryEncryptValueOpts{})
 
 		require.NoError(t, err)
 		assert.NotEqual(t, v, r)
 
-		dr, err := TryDecryptValue("test", r)
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOpts{})
 		require.NoError(t, err)
 		assert.Equal(t, v, dr)
 	})
@@ -223,7 +223,7 @@ func TestTryDecryptValue(t *testing.T) {
 			Primary: pr,
 		})
 
-		dr, err := TryDecryptValue("test", nil)
+		dr, err := TryDecryptValue("test", nil, TryDecryptValueOpts{})
 		require.NoError(t, err)
 		assert.Empty(t, dr)
 	})

--- a/pkg/encryption/state_test.go
+++ b/pkg/encryption/state_test.go
@@ -187,6 +187,44 @@ func TestTryEncryptValue(t *testing.T) {
 		assert.Equal(t, []byte(s), dr)
 	})
 
+	t.Run("state store with AES384 primary key with v2 encryption, value encrypted and decrypted successfully", func(t *testing.T) {
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+
+		bytes := make([]byte, 48)
+		rand.Read(bytes)
+
+		key := hex.EncodeToString(bytes)
+
+		pr := Key{
+			Name: "primary",
+			Key:  key,
+		}
+
+		cipherObj, _ := createCipher(pr, AESCBCAEADAlgorithm)
+		pr.cipherObjV2 = cipherObj
+
+		encryptedStateStores = map[string]ComponentEncryptionKeys{}
+		AddEncryptedStateStore("test", ComponentEncryptionKeys{
+			Primary: pr,
+		})
+
+		v := []byte("hello")
+		r, err := TryEncryptValue("test", v, TryEncryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+
+		require.NoError(t, err)
+		assert.NotEqual(t, v, r)
+
+		dr, err := TryDecryptValue("test", r, TryDecryptValueOptions{
+			KeyName:                  "abc",
+			StateV2EncryptionEnabled: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, v, dr)
+	})
+
 	t.Run("state store with AES256 primary key, value encrypted and decrypted successfully", func(t *testing.T) {
 		encryptedStateStores = map[string]ComponentEncryptionKeys{}
 

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -152,11 +152,12 @@ func New(opts Options) *Processor {
 	})
 
 	state := state.New(state.Options{
-		ActorsEnabled:  opts.ActorsEnabled,
-		Registry:       opts.Registry.StateStores(),
-		ComponentStore: opts.ComponentStore,
-		Meta:           opts.Meta,
-		Outbox:         opts.Outbox,
+		ActorsEnabled:            opts.ActorsEnabled,
+		Registry:                 opts.Registry.StateStores(),
+		ComponentStore:           opts.ComponentStore,
+		Meta:                     opts.Meta,
+		Outbox:                   opts.Outbox,
+		StateV2EncryptionEnabled: opts.GlobalConfig.IsFeatureEnabled(config.StateV2Encryption),
 	})
 
 	secret := secret.New(secret.Options{

--- a/pkg/runtime/processor/state/state.go
+++ b/pkg/runtime/processor/state/state.go
@@ -89,7 +89,9 @@ func (s *state) Init(ctx context.Context, comp compapi.Component) error {
 	secretStoreName := s.meta.AuthSecretStoreOrDefault(&comp)
 
 	secretStore, _ := s.compStore.GetSecretStore(secretStoreName)
-	encKeys, err := encryption.ComponentEncryptionKey(comp, secretStore)
+	encKeys, err := encryption.ComponentEncryptionKey(comp, secretStore, encryption.ComponentEncryptionKeyOptions{
+		StateV2EncryptionEnabled: s.stateV2EncryptionEnabled,
+	})
 	if err != nil {
 		diag.DefaultMonitoring.ComponentInitFailed(comp.Spec.Type, "creation", comp.ObjectMeta.Name)
 		return rterrors.NewInit(rterrors.CreateComponentFailure, fName, err)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -663,17 +663,18 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 
 	// Create and start internal and external gRPC servers
 	a.daprGRPCAPI = grpc.NewAPI(grpc.APIOpts{
-		Universal:             a.daprUniversal,
-		Logger:                logger.NewLogger("dapr.grpc.api"),
-		Channels:              a.channels,
-		PubSubAdapter:         a.pubsubAdapter,
-		PubSubAdapterStreamer: a.pubsubAdapterStreamer,
-		Outbox:                a.outbox,
-		DirectMessaging:       a.directMessaging,
-		SendToOutputBindingFn: a.processor.Binding().SendToOutputBinding,
-		TracingSpec:           a.globalConfig.GetTracingSpec(),
-		AccessControlList:     a.accessControlList,
-		Processor:             a.processor,
+		Universal:                     a.daprUniversal,
+		Logger:                        logger.NewLogger("dapr.grpc.api"),
+		Channels:                      a.channels,
+		PubSubAdapter:                 a.pubsubAdapter,
+		PubSubAdapterStreamer:         a.pubsubAdapterStreamer,
+		Outbox:                        a.outbox,
+		DirectMessaging:               a.directMessaging,
+		SendToOutputBindingFn:         a.processor.Binding().SendToOutputBinding,
+		TracingSpec:                   a.globalConfig.GetTracingSpec(),
+		AccessControlList:             a.accessControlList,
+		Processor:                     a.processor,
+		StateStoreV2EncryptionEnabled: a.globalConfig.IsFeatureEnabled(config.StateStoreV2Encryption),
 	})
 
 	if err = a.runnerCloser.AddCloser(a.daprGRPCAPI); err != nil {
@@ -892,17 +893,18 @@ func (a *DaprRuntime) initProxy() {
 func (a *DaprRuntime) startHTTPServer() error {
 	getMetricSpec := a.globalConfig.GetMetricsSpec()
 	a.daprHTTPAPI = http.NewAPI(http.APIOpts{
-		Universal:             a.daprUniversal,
-		Channels:              a.channels,
-		DirectMessaging:       a.directMessaging,
-		PubSubAdapter:         a.pubsubAdapter,
-		Outbox:                a.outbox,
-		SendToOutputBindingFn: a.processor.Binding().SendToOutputBinding,
-		TracingSpec:           a.globalConfig.GetTracingSpec(),
-		MetricSpec:            &getMetricSpec,
-		MaxRequestBodySize:    int64(a.runtimeConfig.maxRequestBodySize),
-		Healthz:               a.runtimeConfig.healthz,
-		OutboundHealthz:       a.runtimeConfig.outboundHealthz,
+		Universal:                     a.daprUniversal,
+		Channels:                      a.channels,
+		DirectMessaging:               a.directMessaging,
+		PubSubAdapter:                 a.pubsubAdapter,
+		Outbox:                        a.outbox,
+		SendToOutputBindingFn:         a.processor.Binding().SendToOutputBinding,
+		TracingSpec:                   a.globalConfig.GetTracingSpec(),
+		MetricSpec:                    &getMetricSpec,
+		MaxRequestBodySize:            int64(a.runtimeConfig.maxRequestBodySize),
+		Healthz:                       a.runtimeConfig.healthz,
+		OutboundHealthz:               a.runtimeConfig.outboundHealthz,
+		StateStoreV2EncryptionEnabled: a.globalConfig.IsFeatureEnabled(config.StateStoreV2Encryption),
 	})
 
 	serverConf := http.ServerConfig{

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -663,18 +663,18 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 
 	// Create and start internal and external gRPC servers
 	a.daprGRPCAPI = grpc.NewAPI(grpc.APIOpts{
-		Universal:                     a.daprUniversal,
-		Logger:                        logger.NewLogger("dapr.grpc.api"),
-		Channels:                      a.channels,
-		PubSubAdapter:                 a.pubsubAdapter,
-		PubSubAdapterStreamer:         a.pubsubAdapterStreamer,
-		Outbox:                        a.outbox,
-		DirectMessaging:               a.directMessaging,
-		SendToOutputBindingFn:         a.processor.Binding().SendToOutputBinding,
-		TracingSpec:                   a.globalConfig.GetTracingSpec(),
-		AccessControlList:             a.accessControlList,
-		Processor:                     a.processor,
-		StateStoreV2EncryptionEnabled: a.globalConfig.IsFeatureEnabled(config.StateStoreV2Encryption),
+		Universal:                a.daprUniversal,
+		Logger:                   logger.NewLogger("dapr.grpc.api"),
+		Channels:                 a.channels,
+		PubSubAdapter:            a.pubsubAdapter,
+		PubSubAdapterStreamer:    a.pubsubAdapterStreamer,
+		Outbox:                   a.outbox,
+		DirectMessaging:          a.directMessaging,
+		SendToOutputBindingFn:    a.processor.Binding().SendToOutputBinding,
+		TracingSpec:              a.globalConfig.GetTracingSpec(),
+		AccessControlList:        a.accessControlList,
+		Processor:                a.processor,
+		StateV2EncryptionEnabled: a.globalConfig.IsFeatureEnabled(config.StateV2Encryption),
 	})
 
 	if err = a.runnerCloser.AddCloser(a.daprGRPCAPI); err != nil {
@@ -893,18 +893,18 @@ func (a *DaprRuntime) initProxy() {
 func (a *DaprRuntime) startHTTPServer() error {
 	getMetricSpec := a.globalConfig.GetMetricsSpec()
 	a.daprHTTPAPI = http.NewAPI(http.APIOpts{
-		Universal:                     a.daprUniversal,
-		Channels:                      a.channels,
-		DirectMessaging:               a.directMessaging,
-		PubSubAdapter:                 a.pubsubAdapter,
-		Outbox:                        a.outbox,
-		SendToOutputBindingFn:         a.processor.Binding().SendToOutputBinding,
-		TracingSpec:                   a.globalConfig.GetTracingSpec(),
-		MetricSpec:                    &getMetricSpec,
-		MaxRequestBodySize:            int64(a.runtimeConfig.maxRequestBodySize),
-		Healthz:                       a.runtimeConfig.healthz,
-		OutboundHealthz:               a.runtimeConfig.outboundHealthz,
-		StateStoreV2EncryptionEnabled: a.globalConfig.IsFeatureEnabled(config.StateStoreV2Encryption),
+		Universal:                a.daprUniversal,
+		Channels:                 a.channels,
+		DirectMessaging:          a.directMessaging,
+		PubSubAdapter:            a.pubsubAdapter,
+		Outbox:                   a.outbox,
+		SendToOutputBindingFn:    a.processor.Binding().SendToOutputBinding,
+		TracingSpec:              a.globalConfig.GetTracingSpec(),
+		MetricSpec:               &getMetricSpec,
+		MaxRequestBodySize:       int64(a.runtimeConfig.maxRequestBodySize),
+		Healthz:                  a.runtimeConfig.healthz,
+		OutboundHealthz:          a.runtimeConfig.outboundHealthz,
+		StateV2EncryptionEnabled: a.globalConfig.IsFeatureEnabled(config.StateV2Encryption),
 	})
 
 	serverConf := http.ServerConfig{


### PR DESCRIPTION
# Description

This PR implements an AES-CBC-AEAD encryption scheme for client-side state encryption, enabled by a `StateV2Encryption` config flag. This strengthens security for state stores when using Dapr, as having a repeated nonce won't run the risk of attackers being able to recover plaintexts.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Closes #5998, closes #6027

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_

## TODO
- [ ] Add/update integration tests
- [ ] Update docs
- [ ] Handle parsing of old encryption format when decrypting (try to parse json first, then fallback if needed?)
- [ ] Handle key size non-overlap, "master" key needs to be twice the size so it can be split into MAC and encryption keys, i.e. 128-bit keys will not be supported for v2 encryption while 384 and 512-bit keys are