### PR TITLE
ci: add repository dispatch to version skew

### DIFF
--- a/.github/workflows/version-skew.yaml
+++ b/.github/workflows/version-skew.yaml
@@ -18,6 +18,8 @@ on:
   push:
     branches:
       - master
+      - release-*
+  workflow_dispatch:
   # Dispatch on external events
   repository_dispatch:
     types:


### PR DESCRIPTION
This pull request updates the workflow triggers in `.github/workflows/version-skew.yaml` to ensure CI runs on additional branches and can be manually dispatched.

Workflow trigger improvements:

* Added the `release-*` branch pattern to the `push` trigger, so the workflow runs for release branches as well as `master`.
* Enabled `workflow_dispatch` to allow manual triggering of the workflow from the GitHub UI.