### PR TITLE
Placement client: force close send on shutdown

### DIFF
--- a/tests/integration/suite/daprd/workflow/fanoutthree.go
+++ b/tests/integration/suite/daprd/workflow/fanoutthree.go
@@ -17,19 +17,13 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
-	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
-	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 	"github.com/dapr/kit/concurrency/slice"
 )
@@ -39,91 +33,53 @@ func init() {
 }
 
 type fanoutthree struct {
-	called slice.Slice[int]
-	daprd1 *daprd.Daprd
-	daprd2 *daprd.Daprd
-	daprd3 *daprd.Daprd
+	called   slice.Slice[int]
+	workflow *workflow.Workflow
 }
 
 func (f *fanoutthree) Setup(t *testing.T) []framework.Option {
 	f.called = slice.New[int]()
 
-	placement := placement.New(t)
-	scheduler := scheduler.New(t)
-
-	db := sqlite.New(t,
-		sqlite.WithActorStateStore(true),
-		sqlite.WithMetadata("busyTimeout", "10s"),
-		sqlite.WithMetadata("disableWAL", "true"),
-	)
-
-	db.GetComponent(t)
-	f.daprd1 = daprd.New(t,
-		daprd.WithPlacementAddresses(placement.Address()),
-		daprd.WithScheduler(scheduler),
-		daprd.WithResourceFiles(db.GetComponent(t)),
-	)
-	f.daprd2 = daprd.New(t,
-		daprd.WithPlacementAddresses(placement.Address()),
-		daprd.WithScheduler(scheduler),
-		daprd.WithResourceFiles(db.GetComponent(t)),
-		daprd.WithAppID(f.daprd1.AppID()),
-	)
-	f.daprd3 = daprd.New(t,
-		daprd.WithPlacementAddresses(placement.Address()),
-		daprd.WithScheduler(scheduler),
-		daprd.WithResourceFiles(db.GetComponent(t)),
-		daprd.WithAppID(f.daprd1.AppID()),
+	f.workflow = workflow.New(t,
+		workflow.WithDaprds(3),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(placement, scheduler, db, f.daprd1, f.daprd2, f.daprd3),
+		framework.WithProcesses(f.workflow),
 	}
 }
 
 func (f *fanoutthree) Run(t *testing.T, ctx context.Context) {
-	f.daprd1.WaitUntilRunning(t, ctx)
-	f.daprd2.WaitUntilRunning(t, ctx)
-	f.daprd3.WaitUntilRunning(t, ctx)
+	f.workflow.WaitUntilRunning(t, ctx)
 
-	registry := task.NewTaskRegistry()
+	for r := range 3 {
+		registry := f.workflow.RegistryN(r)
 
-	registry.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
-		tasks := make([]task.Task, 5)
-		for i := range 5 {
-			tasks[i] = ctx.CallActivity("bar", task.WithActivityInput(i))
-		}
+		registry.AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+			tasks := make([]task.Task, 5)
+			for i := range 5 {
+				tasks[i] = ctx.CallActivity("bar", task.WithActivityInput(i))
+			}
 
-		var errs []error
-		for _, task := range tasks {
-			errs = append(errs, task.Await(nil))
-		}
-		return nil, errors.Join(errs...)
-	})
-	registry.AddActivityN("bar", func(ctx task.ActivityContext) (any, error) {
-		var ii int
-		if err := ctx.GetInput(&ii); err != nil {
-			return nil, err
-		}
-		f.called.Append(ii)
-		return nil, nil
-	})
+			var errs []error
+			for _, task := range tasks {
+				errs = append(errs, task.Await(nil))
+			}
+			return nil, errors.Join(errs...)
+		})
+		registry.AddActivityN("bar", func(ctx task.ActivityContext) (any, error) {
+			var ii int
+			if err := ctx.GetInput(&ii); err != nil {
+				return nil, err
+			}
+			f.called.Append(ii)
+			return nil, nil
+		})
+	}
 
-	client1 := client.NewTaskHubGrpcClient(f.daprd1.GRPCConn(t, ctx), logger.New(t))
-	require.NoError(t, client1.StartWorkItemListener(ctx, registry))
-	client2 := client.NewTaskHubGrpcClient(f.daprd2.GRPCConn(t, ctx), logger.New(t))
-	require.NoError(t, client2.StartWorkItemListener(ctx, registry))
-	client3 := client.NewTaskHubGrpcClient(f.daprd3.GRPCConn(t, ctx), logger.New(t))
-	require.NoError(t, client3.StartWorkItemListener(ctx, registry))
-
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.GreaterOrEqual(c,
-			len(f.daprd1.GetMetadata(t, ctx).ActorRuntime.ActiveActors), 3)
-		assert.GreaterOrEqual(c,
-			len(f.daprd2.GetMetadata(t, ctx).ActorRuntime.ActiveActors), 3)
-		assert.GreaterOrEqual(c,
-			len(f.daprd3.GetMetadata(t, ctx).ActorRuntime.ActiveActors), 3)
-	}, time.Second*10, time.Millisecond*10)
+	client1 := f.workflow.BackendClientN(t, ctx, 0)
+	f.workflow.BackendClientN(t, ctx, 1)
+	f.workflow.BackendClientN(t, ctx, 2)
 
 	id, err := client1.ScheduleNewOrchestration(ctx, "foo")
 	require.NoError(t, err)


### PR DESCRIPTION
Update the placement client to SendClose & close gRPC connection to ensure signal is sent immediately to placement that the client has shut down.