### PR TITLE
Subscriptions: Resiliency Integration Tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.14.1
-	github.com/dapr/components-contrib v1.16.2-0.20260119210102-64fd69899ddf
+	github.com/dapr/components-contrib v1.16.2-0.20260121142358-4d749a667028
 	github.com/dapr/durabletask-go v0.10.2-0.20260114164104-9ddc9d1ebc1f
 	github.com/dapr/kit v0.16.2-0.20251124175541-3ac186dff64d
 	github.com/diagridio/go-etcd-cron v0.10.1-0.20260105221246-ee8c118dd834

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53E
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.16.2-0.20260119210102-64fd69899ddf h1:dZyA2NFFZIej0Nra+qTaTFPYmWIPVxsGnmZRa0td+c8=
-github.com/dapr/components-contrib v1.16.2-0.20260119210102-64fd69899ddf/go.mod h1:8QF6l4FPCPxsvkI+vAINP4+mFCHaN+1xlZGJdVoNydI=
+github.com/dapr/components-contrib v1.16.2-0.20260121142358-4d749a667028 h1:+nwtsfar3A6+1dL4/qZZFHfjPgrG0oJSA3Wz9mU4XTE=
+github.com/dapr/components-contrib v1.16.2-0.20260121142358-4d749a667028/go.mod h1:8QF6l4FPCPxsvkI+vAINP4+mFCHaN+1xlZGJdVoNydI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20251104160704-920ad8a7b958 h1:DSZgzdXlbF75fwvEkMQpPqn1jjxmWVoBNmI4Bc4dS40=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20251104160704-920ad8a7b958/go.mod h1:IUB5RJv0Gj5qxsHjjhvEBIlxPka7cD7KAn/Coa2y27M=
 github.com/dapr/durabletask-go v0.10.2-0.20260114164104-9ddc9d1ebc1f h1:zRnSR4IgzhzKLTwcIV6ETcDwkuWTeGmeuJy7Jrw4Txw=

--- a/tests/integration/suite/daprd/resiliency/resiliency.go
+++ b/tests/integration/suite/daprd/resiliency/resiliency.go
@@ -16,4 +16,5 @@ package resiliency
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/apps"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/daprd"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/subscriptions"
 )

--- a/tests/integration/suite/daprd/resiliency/subscriptions/grpc.go
+++ b/tests/integration/suite/daprd/resiliency/subscriptions/grpc.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriptions
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+type grpc struct {
+	daprd *daprd.Daprd
+	app   *app.App
+
+	called atomic.Int32
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	app := app.New(t,
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			g.called.Add(1)
+			return &rtv1.TopicEventResponse{Status: rtv1.TopicEventResponse_RETRY}, nil
+		}),
+		app.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{
+						PubsubName: "mypub",
+						Topic:      "a",
+						Routes: &rtv1.TopicRoutes{
+							Default: "/a",
+						},
+					},
+				},
+			}, nil
+		}),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: dapr-resiliency
+spec:
+  policies:
+    retries:
+      retryAppCall:
+        duration: 10ms
+        maxRetries: 4
+        policy: constant
+  targets:
+    components:
+      mypub:
+        inbound:
+          retry: retryAppCall
+`,
+			`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`,
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, g.daprd),
+	}
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data:            []byte(`{"status": "completed"}`),
+		DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(5), g.called.Load())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second)
+	assert.Equal(t, int32(5), g.called.Load())
+}

--- a/tests/integration/suite/daprd/resiliency/subscriptions/grpc.go
+++ b/tests/integration/suite/daprd/resiliency/subscriptions/grpc.go
@@ -36,7 +36,6 @@ func init() {
 
 type grpc struct {
 	daprd *daprd.Daprd
-	app   *app.App
 
 	called atomic.Int32
 }

--- a/tests/integration/suite/daprd/resiliency/subscriptions/http.go
+++ b/tests/integration/suite/daprd/resiliency/subscriptions/http.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriptions
+
+import (
+	"context"
+	"encoding/json"
+	stdhttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+type http struct {
+	daprd *daprd.Daprd
+	app   *app.App
+
+	called atomic.Int32
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	app := app.New(t,
+		app.WithHandlerFunc("/a", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			h.called.Add(1)
+			w.WriteHeader(stdhttp.StatusInternalServerError)
+		}),
+		app.WithHandlerFunc("/dapr/subscribe", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+			assert.NoError(t, json.NewEncoder(w).Encode([]struct {
+				PubsubName string `json:"pubsubname"`
+				Topic      string `json:"topic"`
+				Route      string `json:"route"`
+			}{
+				{
+					PubsubName: "mypub",
+					Topic:      "a",
+					Route:      "/a",
+				},
+			}))
+		}),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: dapr-resiliency
+spec:
+  policies:
+    retries:
+      retryAppCall:
+        duration: 10ms
+        maxRetries: 4
+        policy: constant
+  targets:
+    components:
+      mypub:
+        inbound:
+          retry: retryAppCall
+`,
+			`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`,
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, h.daprd),
+	}
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	client := h.daprd.GRPCClient(t, ctx)
+	_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data:            []byte(`{"status": "completed"}`),
+		DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(5), h.called.Load())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second)
+	assert.Equal(t, int32(5), h.called.Load())
+}

--- a/tests/integration/suite/daprd/resiliency/subscriptions/http.go
+++ b/tests/integration/suite/daprd/resiliency/subscriptions/http.go
@@ -37,7 +37,6 @@ func init() {
 
 type http struct {
 	daprd *daprd.Daprd
-	app   *app.App
 
 	called atomic.Int32
 }

--- a/tests/integration/suite/daprd/resiliency/subscriptions/streaming.go
+++ b/tests/integration/suite/daprd/resiliency/subscriptions/streaming.go
@@ -36,7 +36,6 @@ type streaming struct {
 }
 
 func (s *streaming) Setup(t *testing.T) []framework.Option {
-
 	s.daprd = daprd.New(t,
 		daprd.WithResourceFiles(`
 apiVersion: dapr.io/v1alpha1

--- a/tests/integration/suite/daprd/resiliency/subscriptions/streaming.go
+++ b/tests/integration/suite/daprd/resiliency/subscriptions/streaming.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscriptions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(streaming))
+}
+
+type streaming struct {
+	daprd *daprd.Daprd
+}
+
+func (s *streaming) Setup(t *testing.T) []framework.Option {
+
+	s.daprd = daprd.New(t,
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: dapr-resiliency
+spec:
+  policies:
+    retries:
+      retryAppCall:
+        duration: 10ms
+        maxRetries: 4
+        policy: constant
+  targets:
+    components:
+      mypub:
+        inbound:
+          retry: retryAppCall
+`,
+			`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`,
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.daprd),
+	}
+}
+
+func (s *streaming) Run(t *testing.T, ctx context.Context) {
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	client := s.daprd.GRPCClient(t, ctx)
+
+	stream, err := client.SubscribeTopicEventsAlpha1(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&rtv1.SubscribeTopicEventsRequestAlpha1{
+		SubscribeTopicEventsRequestType: &rtv1.SubscribeTopicEventsRequestAlpha1_InitialRequest{
+			InitialRequest: &rtv1.SubscribeTopicEventsRequestInitialAlpha1{
+				PubsubName: "mypub", Topic: "a",
+			},
+		},
+	}))
+
+	_, err = stream.Recv()
+	require.NoError(t, err)
+
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "mypub", Topic: "a",
+		Data:            []byte(`{"status": "completed"}`),
+		DataContentType: "application/json",
+	})
+	require.NoError(t, err)
+
+	for range 5 {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		event := resp.GetEventMessage()
+		assert.Equal(t, "a", event.GetTopic())
+		assert.Equal(t, "mypub", event.GetPubsubName())
+		assert.JSONEq(t, `{"status": "completed"}`, string(event.GetData()))
+		assert.Equal(t, "/", event.GetPath())
+
+		require.NoError(t, stream.Send(&rtv1.SubscribeTopicEventsRequestAlpha1{
+			SubscribeTopicEventsRequestType: &rtv1.SubscribeTopicEventsRequestAlpha1_EventProcessed{
+				EventProcessed: &rtv1.SubscribeTopicEventsRequestProcessedAlpha1{
+					Id:     event.GetId(),
+					Status: &rtv1.TopicEventResponse{Status: rtv1.TopicEventResponse_RETRY},
+				},
+			},
+		}))
+	}
+
+	gotRecv := make(chan struct{})
+	go func() {
+		stream.Recv()
+		close(gotRecv)
+	}()
+
+	select {
+	case <-gotRecv:
+		require.Fail(t, "expected no more messages")
+	case <-time.After(time.Second):
+	}
+
+	require.NoError(t, stream.CloseSend())
+}

--- a/tests/integration/suite/daprd/subscriptions/stream/retry.go
+++ b/tests/integration/suite/daprd/subscriptions/stream/retry.go
@@ -37,7 +37,25 @@ type retry struct {
 
 func (r *retry) Setup(t *testing.T) []framework.Option {
 	r.daprd = daprd.New(t,
-		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: dapr-resiliency
+spec:
+  policies:
+    retries:
+      retryAppCall:
+        duration: 10ms
+        maxRetries: 4
+        policy: constant
+  targets:
+    components:
+      mypub:
+        inbound:
+          retry: retryAppCall
+`,
+			`apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
   name: mypub


### PR DESCRIPTION
Adds integration testing for using resiliency policy with Dapr subscriptions.

Updates components-contrib to use HEAD version where the in-memory pubsub component does not attempt to do an internal retry loop.