### PR TITLE
Constrain loop event types with scoped sealed interfaces

### DIFF
--- a/pkg/actors/internal/placement/loops/disseminator/disseminator.go
+++ b/pkg/actors/internal/placement/loops/disseminator/disseminator.go
@@ -34,7 +34,7 @@ import (
 var log = logger.NewLogger("dapr.runtime.actors.placement.loops.disseminator")
 
 var (
-	LoopFactoryCache = loop.New[loops.Event](1024)
+	LoopFactoryCache = loop.New[loops.EventDiss](1024)
 	loopCache        = sync.Pool{New: func() any {
 		return new(disseminator)
 	}}
@@ -42,7 +42,7 @@ var (
 
 type Options struct {
 	Channel       v1pb.Placement_ReportDaprStatusClient
-	PlacementLoop loop.Interface[loops.Event]
+	PlacementLoop loop.Interface[loops.EventPlace]
 	ActorTable    table.Interface
 	Scheduler     schedclient.Reloader
 	IDx           uint64
@@ -60,7 +60,7 @@ type disseminator struct {
 	namespace string
 	id        string
 
-	loop         loop.Interface[loops.Event]
+	loop         loop.Interface[loops.EventDiss]
 	inflight     *inflight.Inflight
 	actorTable   table.Interface
 	scheduler    schedclient.Reloader
@@ -71,7 +71,7 @@ type disseminator struct {
 	cancel         context.CancelCauseFunc
 	timeoutVersion uint64
 
-	streamLoop loop.Interface[loops.Event]
+	streamLoop loop.Interface[loops.EventStream]
 
 	wg sync.WaitGroup
 
@@ -79,7 +79,7 @@ type disseminator struct {
 	currentVersion   uint64
 }
 
-func New(ctx context.Context, opts Options) loop.Interface[loops.Event] {
+func New(ctx context.Context, opts Options) loop.Interface[loops.EventDiss] {
 	diss := loopCache.Get().(*disseminator)
 
 	diss.namespace = opts.Namespace
@@ -117,7 +117,7 @@ func New(ctx context.Context, opts Options) loop.Interface[loops.Event] {
 	return diss.loop
 }
 
-func (d *disseminator) Handle(ctx context.Context, event loops.Event) error {
+func (d *disseminator) Handle(ctx context.Context, event loops.EventDiss) error {
 	switch e := event.(type) {
 	case *loops.LookupRequest:
 		d.handleLookupRequest(e)

--- a/pkg/actors/internal/placement/loops/disseminator/timeout/timeout.go
+++ b/pkg/actors/internal/placement/loops/disseminator/timeout/timeout.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Options struct {
-	Loop    loop.Interface[loops.Event]
+	Loop    loop.Interface[loops.EventDiss]
 	Timeout time.Duration
 }
 

--- a/pkg/actors/internal/placement/loops/loops.go
+++ b/pkg/actors/internal/placement/loops/loops.go
@@ -23,30 +23,61 @@ import (
 	"github.com/dapr/dapr/utils"
 )
 
-type Event any
+type placebase struct{}
+
+func (*placebase) isEventPlace() {}
+
+type EventPlace interface{ isEventPlace() }
+
+type dissbase struct{}
+
+func (*dissbase) isEventDiss() {}
+
+type EventDiss interface{ isEventDiss() }
+
+type streambase struct{}
+
+func (*streambase) isEventStream() {}
+
+type EventStream interface{ isEventStream() }
+
+type lookupbase struct{}
+
+func (*lookupbase) isEventLookup() {}
+
+type EventLookup interface{ isEventLookup() }
 
 type PlacementReconnect struct {
+	*placebase
 	ActorTypes *[]string
 }
 
 type UpdateTypes struct {
+	*placebase
 	ActorTypes []string
 }
 
 type ReportHost struct {
+	*dissbase
 	Host *v1pb.Host
 }
 
 type StreamOrder struct {
+	*placebase
+	*dissbase
 	Order *v1pb.PlacementOrder
 	IDx   uint64
 }
 
 type StreamSend struct {
+	*streambase
 	Host *v1pb.Host
 }
 
 type LookupRequest struct {
+	*placebase
+	*dissbase
+	*lookupbase
 	Request  *api.LookupActorRequest
 	Context  context.Context
 	Response chan<- *LookupResponse
@@ -60,6 +91,9 @@ type LookupResponse struct {
 }
 
 type LockRequest struct {
+	*placebase
+	*dissbase
+	*lookupbase
 	Context  context.Context
 	Response chan<- *LockResponse
 }
@@ -70,15 +104,20 @@ type LockResponse struct {
 }
 
 type ConnCloseStream struct {
+	*placebase
 	Error error
 	IDx   uint64
 }
 
 type Shutdown struct {
+	*placebase
+	*dissbase
+	*streambase
 	Error error
 }
 
 type DisseminationTimeout struct {
+	*dissbase
 	Version uint64
 }
 

--- a/pkg/actors/internal/placement/loops/loops.go
+++ b/pkg/actors/internal/placement/loops/loops.go
@@ -122,6 +122,7 @@ type DisseminationTimeout struct {
 }
 
 type SetDrainOngoingCallTimeout struct {
+	*placebase
 	Drain   *bool
 	Timeout *time.Duration
 }

--- a/pkg/actors/internal/placement/loops/placement/placement.go
+++ b/pkg/actors/internal/placement/loops/placement/placement.go
@@ -66,14 +66,14 @@ type placement struct {
 
 	inflight  *inflight.Inflight
 	connector connector.Interface
-	loop      loop.Interface[loops.Event]
+	loop      loop.Interface[loops.EventPlace]
 	htarget   healthz.Target
 
-	lookups []loops.Event
+	lookups []loops.EventLookup
 
 	idx uint64
 
-	dissLoop loop.Interface[loops.Event]
+	dissLoop loop.Interface[loops.EventDiss]
 	host     *v1pb.Host
 
 	dissTimeout time.Duration
@@ -82,7 +82,7 @@ type placement struct {
 	wg sync.WaitGroup
 }
 
-func New(opts Options) loop.Interface[loops.Event] {
+func New(opts Options) loop.Interface[loops.EventPlace] {
 	place := &placement{
 		id:        opts.ID,
 		ready:     opts.Ready,
@@ -99,11 +99,11 @@ func New(opts Options) loop.Interface[loops.Event] {
 		dissTimeout: opts.DisseminationTimeout,
 		cancel:      opts.Cancel,
 	}
-	place.loop = loop.New[loops.Event](8).NewLoop(place)
+	place.loop = loop.New[loops.EventPlace](8).NewLoop(place)
 	return place.loop
 }
 
-func (p *placement) Handle(ctx context.Context, event loops.Event) error {
+func (p *placement) Handle(ctx context.Context, event loops.EventPlace) error {
 	switch e := event.(type) {
 	case *loops.StreamOrder:
 		p.handleOrder(e)
@@ -216,7 +216,7 @@ func (p *placement) handleReconnect(ctx context.Context, recon *loops.PlacementR
 	})
 
 	for _, l := range p.lookups {
-		p.dissLoop.Enqueue(l)
+		p.dissLoop.Enqueue(l.(loops.EventDiss))
 	}
 	p.lookups = nil
 

--- a/pkg/actors/internal/placement/loops/stream/stream.go
+++ b/pkg/actors/internal/placement/loops/stream/stream.go
@@ -27,7 +27,7 @@ import (
 var log = logger.NewLogger("dapr.runtime.actors.placement.loops.stream")
 
 var (
-	LoopFactory = loop.New[loops.Event](8)
+	LoopFactory = loop.New[loops.EventStream](8)
 	streamCache = sync.Pool{New: func() any {
 		return new(stream)
 	}}
@@ -35,21 +35,21 @@ var (
 
 type Options struct {
 	Channel       v1pb.Placement_ReportDaprStatusClient
-	PlacementLoop loop.Interface[loops.Event]
+	PlacementLoop loop.Interface[loops.EventPlace]
 	IDx           uint64
 }
 
 type stream struct {
 	channel   v1pb.Placement_ReportDaprStatusClient
-	placeLoop loop.Interface[loops.Event]
+	placeLoop loop.Interface[loops.EventPlace]
 	idx       uint64
 
-	loop loop.Interface[loops.Event]
+	loop loop.Interface[loops.EventStream]
 
 	wg sync.WaitGroup
 }
 
-func New(ctx context.Context, opts Options) loop.Interface[loops.Event] {
+func New(ctx context.Context, opts Options) loop.Interface[loops.EventStream] {
 	stream := streamCache.Get().(*stream)
 	stream.channel = opts.Channel
 	stream.placeLoop = opts.PlacementLoop
@@ -68,7 +68,7 @@ func New(ctx context.Context, opts Options) loop.Interface[loops.Event] {
 	return stream.loop
 }
 
-func (s *stream) Handle(ctx context.Context, event loops.Event) error {
+func (s *stream) Handle(ctx context.Context, event loops.EventStream) error {
 	var err error
 	switch e := event.(type) {
 	case *loops.StreamSend:

--- a/pkg/actors/internal/placement/placement.go
+++ b/pkg/actors/internal/placement/placement.go
@@ -74,7 +74,7 @@ type placement struct {
 	ready    *atomic.Bool
 	errCh    chan error
 
-	loop loop.Interface[loops.Event]
+	loop loop.Interface[loops.EventPlace]
 }
 
 func New(opts Options) (Interface, error) {

--- a/pkg/placement/internal/loops/disseminator/timeout/timeout.go
+++ b/pkg/placement/internal/loops/disseminator/timeout/timeout.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Options struct {
-	Loop    loop.Interface[loops.Event]
+	Loop    loop.Interface[loops.EventDisseminator]
 	Timeout time.Duration
 }
 

--- a/pkg/placement/internal/loops/loops.go
+++ b/pkg/placement/internal/loops/loops.go
@@ -19,42 +19,68 @@ import (
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 )
 
-// Event is a generic interface for all events in placement.
-type Event any
+type nsbase struct{}
+
+func (*nsbase) isEventNamespace() {}
+
+type EventNamespace interface{ isEventNamespace() }
+
+type dissbase struct{}
+
+func (*dissbase) isEventDisseminator() {}
+
+type EventDisseminator interface{ isEventDisseminator() }
+
+type streambase struct{}
+
+func (*streambase) isEventStream() {}
+
+type EventStream interface{ isEventStream() }
 
 // ConnAdd is the event for adding a new connection to placement.
 type ConnAdd struct {
+	*nsbase
+	*dissbase
 	Channel     v1pb.Placement_ReportDaprStatusServer
 	Cancel      context.CancelCauseFunc
 	InitialHost *v1pb.Host
 }
 
 type ReportedHost struct {
+	*nsbase
+	*dissbase
 	Host      *v1pb.Host
 	StreamIDx uint64
 }
 
 type DisseminateLock struct {
+	*streambase
 	Version uint64
 }
 
 type DisseminateUpdate struct {
+	*streambase
 	Tables  *v1pb.PlacementTables
 	Version uint64
 }
 
 type DisseminateUnlock struct {
+	*streambase
 	Version uint64
 }
 
 // StreamShutdown is the event for shutting down the placement client stream.
 type StreamShutdown struct {
+	*nsbase
+	*streambase
 	Error error
 }
 
 // ConnCloseStream is the event for closing a connection to the placement from
 // the stream.
 type ConnCloseStream struct {
+	*nsbase
+	*dissbase
 	StreamIDx uint64
 	Namespace string
 	Error     error
@@ -62,17 +88,22 @@ type ConnCloseStream struct {
 
 // Shutdown is the event for shutting down the placement loops.
 type Shutdown struct {
+	*nsbase
+	*dissbase
 	Error error
 }
 
 type DisseminationTimeout struct {
+	*dissbase
 	Version uint64
 }
 
 type NamespaceTableRequest struct {
+	*dissbase
 	Table func(*v1pb.StatePlacementTable)
 }
 
 type StateTableRequest struct {
+	*nsbase
 	State func(*v1pb.StatePlacementTables)
 }

--- a/pkg/placement/internal/loops/namespaces/namespaces.go
+++ b/pkg/placement/internal/loops/namespaces/namespaces.go
@@ -38,7 +38,7 @@ type Options struct {
 
 type disseminatorLoop struct {
 	connections uint64
-	loop        loop.Interface[loops.Event]
+	loop        loop.Interface[loops.EventDisseminator]
 }
 
 // namespaces is the main control loop for managing stream
@@ -50,13 +50,13 @@ type namespaces struct {
 
 	// disseminators holds the active namespace connections.
 	disseminators map[string]*disseminatorLoop
-	loop          loop.Interface[loops.Event]
+	loop          loop.Interface[loops.EventNamespace]
 	authorizer    *authorizer.Authorizer
 
 	wg sync.WaitGroup
 }
 
-func New(opts Options) loop.Interface[loops.Event] {
+func New(opts Options) loop.Interface[loops.EventNamespace] {
 	ns := &namespaces{
 		cancelPool:           opts.CancelPool,
 		replicationFactor:    opts.ReplicationFactor,
@@ -65,11 +65,11 @@ func New(opts Options) loop.Interface[loops.Event] {
 		disseminationTimeout: opts.DisseminationTimeout,
 	}
 
-	ns.loop = loop.New[loops.Event](1024).NewLoop(ns)
+	ns.loop = loop.New[loops.EventNamespace](1024).NewLoop(ns)
 	return ns.loop
 }
 
-func (n *namespaces) Handle(ctx context.Context, event loops.Event) error {
+func (n *namespaces) Handle(ctx context.Context, event loops.EventNamespace) error {
 	switch e := event.(type) {
 	case *loops.ConnAdd:
 		return n.handleAdd(ctx, e)

--- a/pkg/placement/internal/loops/stream/stream.go
+++ b/pkg/placement/internal/loops/stream/stream.go
@@ -30,7 +30,7 @@ import (
 var log = logger.NewLogger("dapr.placement.server.loops.stream")
 
 var (
-	StreamLoopFactory = loop.New[loops.Event](8)
+	StreamLoopFactory = loop.New[loops.EventStream](8)
 	streamCache       = sync.Pool{New: func() any {
 		return new(stream)
 	}}
@@ -39,7 +39,7 @@ var (
 type Options struct {
 	IDx           uint64
 	Add           *loops.ConnAdd
-	NamespaceLoop loop.Interface[loops.Event]
+	NamespaceLoop loop.Interface[loops.EventNamespace]
 	Authorizer    *authorizer.Authorizer
 }
 
@@ -51,10 +51,10 @@ type stream struct {
 
 	channel v1pb.Placement_ReportDaprStatusServer
 	cancel  context.CancelCauseFunc
-	nsLoop  loop.Interface[loops.Event]
+	nsLoop  loop.Interface[loops.EventNamespace]
 	authz   *authorizer.Authorizer
 
-	loop loop.Interface[loops.Event]
+	loop loop.Interface[loops.EventStream]
 
 	currentVersion *uint64
 
@@ -62,7 +62,7 @@ type stream struct {
 	wg   sync.WaitGroup
 }
 
-func New(ctx context.Context, opts Options) loop.Interface[loops.Event] {
+func New(ctx context.Context, opts Options) loop.Interface[loops.EventStream] {
 	addr := "unknown"
 	if p, ok := peer.FromContext(opts.Add.Channel.Context()); ok {
 		addr = p.Addr.String()
@@ -95,7 +95,7 @@ func New(ctx context.Context, opts Options) loop.Interface[loops.Event] {
 	return stream.loop
 }
 
-func (s *stream) Handle(ctx context.Context, event loops.Event) error {
+func (s *stream) Handle(ctx context.Context, event loops.EventStream) error {
 	var err error
 	switch e := event.(type) {
 	case *loops.DisseminateLock:

--- a/pkg/placement/internal/server/server.go
+++ b/pkg/placement/internal/server/server.go
@@ -70,7 +70,7 @@ type Server struct {
 	disseminateTimeout time.Duration
 
 	authz *authorizer.Authorizer
-	loop  loop.Interface[loops.Event]
+	loop  loop.Interface[loops.EventNamespace]
 
 	isLeader atomic.Bool
 	shutdown atomic.Bool

--- a/pkg/runtime/scheduler/internal/loops/connector/connector.go
+++ b/pkg/runtime/scheduler/internal/loops/connector/connector.go
@@ -53,8 +53,8 @@ type connector struct {
 	closeCluster context.CancelFunc
 }
 
-func New(opts Options) loop.Interface[loops.Event] {
-	return loop.New[loops.Event](1024).NewLoop(&connector{
+func New(opts Options) loop.Interface[loops.EventConn] {
+	return loop.New[loops.EventConn](1024).NewLoop(&connector{
 		namespace: opts.Namespace,
 		appID:     opts.AppID,
 		actors:    opts.Actors,
@@ -63,7 +63,7 @@ func New(opts Options) loop.Interface[loops.Event] {
 	})
 }
 
-func (c *connector) Handle(ctx context.Context, event loops.Event) error {
+func (c *connector) Handle(ctx context.Context, event loops.EventConn) error {
 	switch e := event.(type) {
 	case *loops.Reconnect:
 		c.handleReconnect(ctx, e)

--- a/pkg/runtime/scheduler/internal/loops/hosts/hosts.go
+++ b/pkg/runtime/scheduler/internal/loops/hosts/hosts.go
@@ -26,27 +26,27 @@ import (
 
 type Options struct {
 	Security  security.Handler
-	Connector loop.Interface[loops.Event]
+	Connector loop.Interface[loops.EventConn]
 	StreamN   uint
 }
 
 type hosts struct {
 	security  security.Handler
 	streamN   uint
-	connector loop.Interface[loops.Event]
+	connector loop.Interface[loops.EventConn]
 
 	closeConns []context.CancelFunc
 }
 
-func New(opts Options) loop.Interface[loops.Event] {
-	return loop.New[loops.Event](1024).NewLoop(&hosts{
+func New(opts Options) loop.Interface[loops.EventHost] {
+	return loop.New[loops.EventHost](1024).NewLoop(&hosts{
 		streamN:   opts.StreamN,
 		security:  opts.Security,
 		connector: opts.Connector,
 	})
 }
 
-func (h *hosts) Handle(ctx context.Context, event loops.Event) error {
+func (h *hosts) Handle(ctx context.Context, event loops.EventHost) error {
 	switch e := event.(type) {
 	case *loops.ReloadClients:
 		return h.handleReloadClients(ctx, e)

--- a/pkg/runtime/scheduler/internal/loops/loops.go
+++ b/pkg/runtime/scheduler/internal/loops/loops.go
@@ -17,21 +17,39 @@ import (
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 )
 
-type Event any
+type hostbase struct{}
+
+func (*hostbase) isEventHost() {}
+
+type EventHost interface{ isEventHost() }
+
+type connbase struct{}
+
+func (*connbase) isEventConn() {}
+
+type EventConn interface{ isEventConn() }
 
 type ReloadClients struct {
+	*hostbase
 	Addresses []string
 }
 
 type Connect struct {
+	*connbase
 	Clients []schedulerv1pb.SchedulerClient
 }
 
-type Disconnect struct{}
+type Disconnect struct {
+	*connbase
+}
 
 type Reconnect struct {
+	*connbase
 	AppTarget  *bool
 	ActorTypes *[]string
 }
 
-type Close struct{}
+type Close struct {
+	*connbase
+	*hostbase
+}

--- a/pkg/runtime/scheduler/internal/watchhosts/watchhosts.go
+++ b/pkg/runtime/scheduler/internal/watchhosts/watchhosts.go
@@ -41,7 +41,7 @@ type Options struct {
 	Healthz   healthz.Healthz
 	Security  security.Handler
 	Clients   *clients.Clients
-	HostLoop  loop.Interface[loops.Event]
+	HostLoop  loop.Interface[loops.EventHost]
 }
 
 type WatchHosts struct {
@@ -50,7 +50,7 @@ type WatchHosts struct {
 	security security.Handler
 	clients  *clients.Clients
 
-	loop loop.Interface[loops.Event]
+	loop loop.Interface[loops.EventHost]
 }
 
 func New(opts Options) *WatchHosts {

--- a/pkg/runtime/scheduler/scheduler.go
+++ b/pkg/runtime/scheduler/scheduler.go
@@ -48,8 +48,8 @@ type Options struct {
 
 // Scheduler manages the connection to the cluster of schedulers.
 type Scheduler struct {
-	connector  loop.Interface[loops.Event]
-	hosts      loop.Interface[loops.Event]
+	connector  loop.Interface[loops.EventConn]
+	hosts      loop.Interface[loops.EventHost]
 	watchhosts *watchhosts.WatchHosts
 	client     client.Interface
 

--- a/pkg/scheduler/server/internal/pool/loops/connections/connections.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/connections.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	loopFactory = loop.New[loops.Event](1024)
+	loopFactory = loop.New[loops.EventConn](1024)
 	connsCache  = sync.Pool{New: func() any {
 		return &connections{
 			streams:    make(map[uint64]context.CancelFunc),
@@ -41,15 +41,15 @@ var (
 
 type Options struct {
 	Cron          api.Interface
-	NamespaceLoop loop.Interface[loops.Event]
+	NamespaceLoop loop.Interface[loops.EventNS]
 }
 
 // connections is a control loop that creates and manages stream connections,
 // piping trigger requests.
 type connections struct {
 	cron   api.Interface
-	nsLoop loop.Interface[loops.Event]
-	loop   loop.Interface[loops.Event]
+	nsLoop loop.Interface[loops.EventNS]
+	loop   loop.Interface[loops.EventConn]
 
 	streams    map[uint64]context.CancelFunc
 	streamIDx  uint64
@@ -57,7 +57,7 @@ type connections struct {
 	wg         sync.WaitGroup
 }
 
-func New(opts Options) loop.Interface[loops.Event] {
+func New(opts Options) loop.Interface[loops.EventConn] {
 	conns := connsCache.Get().(*connections)
 
 	conns.cron = opts.Cron
@@ -68,7 +68,7 @@ func New(opts Options) loop.Interface[loops.Event] {
 	return conns.loop
 }
 
-func (c *connections) Handle(ctx context.Context, event loops.Event) error {
+func (c *connections) Handle(ctx context.Context, event loops.EventConn) error {
 	switch e := event.(type) {
 	case *loops.ConnAdd:
 		return c.handleAdd(ctx, e)
@@ -158,7 +158,7 @@ func (c *connections) handleShutdown() {
 }
 
 // getStreamLoop returns a stream loop from the pool based on the metadata.
-func (c *connections) getStreamLoop(meta *schedulerv1pb.JobMetadata) (loop.Interface[loops.Event], bool) {
+func (c *connections) getStreamLoop(meta *schedulerv1pb.JobMetadata) (loop.Interface[loops.EventStream], bool) {
 	switch t := meta.GetTarget(); t.GetType().(type) {
 	case *schedulerv1pb.JobTargetMetadata_Job:
 		return c.streamPool.AppID(meta.GetAppId())

--- a/pkg/scheduler/server/internal/pool/loops/connections/store/instance.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/store/instance.go
@@ -23,7 +23,7 @@ import (
 // TODO: sync.Pool
 type entry struct {
 	nextConn uint64
-	conns    []loop.Interface[loops.Event]
+	conns    []loop.Interface[loops.EventStream]
 }
 
 // TODO: sync.Pool
@@ -37,7 +37,7 @@ func newInstance() *instance {
 	}
 }
 
-func (i *instance) add(name string, conn loop.Interface[loops.Event]) context.CancelFunc {
+func (i *instance) add(name string, conn loop.Interface[loops.EventStream]) context.CancelFunc {
 	en, ok := i.entries[name]
 	if !ok {
 		en = new(entry)
@@ -59,7 +59,7 @@ func (i *instance) add(name string, conn loop.Interface[loops.Event]) context.Ca
 	}
 }
 
-func (i *instance) get(name string) (loop.Interface[loops.Event], bool) {
+func (i *instance) get(name string) (loop.Interface[loops.EventStream], bool) {
 	en, ok := i.entries[name]
 	if !ok {
 		return nil, false

--- a/pkg/scheduler/server/internal/pool/loops/connections/store/store.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/store/store.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Options struct {
-	Loop       loop.Interface[loops.Event]
+	Loop       loop.Interface[loops.EventStream]
 	AppID      *string
 	ActorTypes []string
 }
@@ -63,10 +63,10 @@ func (s *Store) Add(opts Options) context.CancelFunc {
 	}
 }
 
-func (s *Store) AppID(id string) (loop.Interface[loops.Event], bool) {
+func (s *Store) AppID(id string) (loop.Interface[loops.EventStream], bool) {
 	return s.appIDs.get(id)
 }
 
-func (s *Store) ActorType(actorType string) (loop.Interface[loops.Event], bool) {
+func (s *Store) ActorType(actorType string) (loop.Interface[loops.EventStream], bool) {
 	return s.actorTypes.get(actorType)
 }

--- a/pkg/scheduler/server/internal/pool/loops/fake/fake.go
+++ b/pkg/scheduler/server/internal/pool/loops/fake/fake.go
@@ -25,15 +25,15 @@ import (
 )
 
 type Fake struct {
-	events chan loops.Event
-	loop   loop.Interface[loops.Event]
+	events chan loops.EventNS
+	loop   loop.Interface[loops.EventNS]
 }
 
 func New(t *testing.T) *Fake {
 	t.Helper()
 
-	f := &Fake{events: make(chan loops.Event, 10)}
-	f.loop = loop.New[loops.Event](5).NewLoop(f)
+	f := &Fake{events: make(chan loops.EventNS, 10)}
+	f.loop = loop.New[loops.EventNS](5).NewLoop(f)
 
 	errCh := make(chan error)
 	go func() { errCh <- f.loop.Run(t.Context()) }()
@@ -51,15 +51,15 @@ func New(t *testing.T) *Fake {
 	return f
 }
 
-func (f *Fake) Handle(_ context.Context, event loops.Event) error {
+func (f *Fake) Handle(_ context.Context, event loops.EventNS) error {
 	f.events <- event
 	return nil
 }
 
-func (f *Fake) Events() <-chan loops.Event {
+func (f *Fake) Events() <-chan loops.EventNS {
 	return f.events
 }
 
-func (f *Fake) Loop() loop.Interface[loops.Event] {
+func (f *Fake) Loop() loop.Interface[loops.EventNS] {
 	return f.loop
 }

--- a/pkg/scheduler/server/internal/pool/loops/loops.go
+++ b/pkg/scheduler/server/internal/pool/loops/loops.go
@@ -22,20 +22,42 @@ import (
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 )
 
-// Event is a generic interface for all events in the scheduler.
-type Event any
+type nsbase struct{}
+
+func (*nsbase) isEventNS() {}
+
+type EventNS interface{ isEventNS() }
+
+type connbase struct{}
+
+func (*connbase) isEventConn() {}
+
+type EventConn interface{ isEventConn() }
+
+type streambase struct{}
+
+func (*streambase) isEventStream() {}
+
+type EventStream interface{ isEventStream() }
 
 // TriggerRequest is the event for triggering a job in the scheduler.
 type TriggerRequest struct {
+	*nsbase
+	*connbase
+	*streambase
 	Job      *internalsv1pb.JobEvent
 	ResultFn func(api.TriggerResponseResult)
 }
 
 // StreamShutdown is the event for shutting down the scheduler stream.
-type StreamShutdown struct{}
+type StreamShutdown struct {
+	*streambase
+}
 
 // ConnAdd is the event for adding a new connection to the scheduler.
 type ConnAdd struct {
+	*nsbase
+	*connbase
 	Channel schedulerv1pb.Scheduler_WatchJobsServer
 	Request *schedulerv1pb.WatchJobsRequestInitial
 	Cancel  context.CancelCauseFunc
@@ -44,9 +66,14 @@ type ConnAdd struct {
 // ConnCloseStream is the event for closing a connection to the scheduler from
 // the stream.
 type ConnCloseStream struct {
+	*nsbase
+	*connbase
 	StreamIDx uint64
 	Namespace string
 }
 
 // Shutdown is the event for shutting down the scheduler loops.
-type Shutdown struct{}
+type Shutdown struct {
+	*nsbase
+	*connbase
+}

--- a/pkg/scheduler/server/internal/pool/loops/namespaces/namespaces.go
+++ b/pkg/scheduler/server/internal/pool/loops/namespaces/namespaces.go
@@ -36,7 +36,7 @@ type Options struct {
 
 type connectionLoop struct {
 	connections uint64
-	loop        loop.Interface[loops.Event]
+	loop        loop.Interface[loops.EventConn]
 }
 
 // namespaces is the main control loop for managing stream
@@ -47,23 +47,23 @@ type namespaces struct {
 
 	// connections holds the active namespace connections.
 	connections map[string]*connectionLoop
-	loop        loop.Interface[loops.Event]
+	loop        loop.Interface[loops.EventNS]
 
 	wg sync.WaitGroup
 }
 
-func New(opts Options) loop.Interface[loops.Event] {
+func New(opts Options) loop.Interface[loops.EventNS] {
 	ns := &namespaces{
 		cron:        opts.Cron,
 		cancelPool:  opts.CancelPool,
 		connections: make(map[string]*connectionLoop),
 	}
 
-	ns.loop = loop.New[loops.Event](1024).NewLoop(ns)
+	ns.loop = loop.New[loops.EventNS](1024).NewLoop(ns)
 	return ns.loop
 }
 
-func (n *namespaces) Handle(ctx context.Context, event loops.Event) error {
+func (n *namespaces) Handle(ctx context.Context, event loops.EventNS) error {
 	switch e := event.(type) {
 	case *loops.ConnAdd:
 		return n.handleAdd(ctx, e)

--- a/pkg/scheduler/server/internal/pool/loops/namespaces/namespaces_test.go
+++ b/pkg/scheduler/server/internal/pool/loops/namespaces/namespaces_test.go
@@ -39,7 +39,7 @@ import (
 
 type suite struct {
 	cancelCalled *atomic.Pointer[error]
-	connLoop     loop.Interface[loops.Event]
+	connLoop     loop.Interface[loops.EventNS]
 	prefixes     *[]string
 	prefixesMu   *sync.Mutex
 }

--- a/pkg/scheduler/server/internal/pool/loops/stream/stream.go
+++ b/pkg/scheduler/server/internal/pool/loops/stream/stream.go
@@ -30,7 +30,7 @@ import (
 var log = logger.NewLogger("dapr.scheduler.server.pool.loops.stream")
 
 var (
-	streamLoopFactory = loop.New[loops.Event](1024)
+	streamLoopFactory = loop.New[loops.EventStream](1024)
 	streamCache       = sync.Pool{New: func() any {
 		return new(stream)
 	}}
@@ -40,7 +40,7 @@ type Options struct {
 	IDx           uint64
 	Add           *loops.ConnAdd
 	Cron          api.Interface
-	NamespaceLoop loop.Interface[loops.Event]
+	NamespaceLoop loop.Interface[loops.EventNS]
 }
 
 // stream is a loop that handles a single stream of a connection. It handles
@@ -48,10 +48,10 @@ type Options struct {
 type stream struct {
 	idx     uint64
 	channel schedulerv1pb.Scheduler_WatchJobsServer
-	nsLoop  loop.Interface[loops.Event]
+	nsLoop  loop.Interface[loops.EventNS]
 	appID   string
 	ns      string
-	loop    loop.Interface[loops.Event]
+	loop    loop.Interface[loops.EventStream]
 	cancel  context.CancelCauseFunc
 
 	// triggerIDx is the uuid of a triggered job. We can use a simple counter as
@@ -64,7 +64,7 @@ type stream struct {
 	wg sync.WaitGroup
 }
 
-func New(ctx context.Context, opts Options) (loop.Interface[loops.Event], error) {
+func New(ctx context.Context, opts Options) (loop.Interface[loops.EventStream], error) {
 	cancel, err := handleAdd(ctx, opts.Cron, opts.Add.Request)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func New(ctx context.Context, opts Options) (loop.Interface[loops.Event], error)
 	return stream.loop, nil
 }
 
-func (s *stream) Handle(ctx context.Context, event loops.Event) error {
+func (s *stream) Handle(ctx context.Context, event loops.EventStream) error {
 	switch e := event.(type) {
 	case *loops.TriggerRequest:
 		s.handleTriggerRequest(e)

--- a/pkg/scheduler/server/internal/pool/loops/stream/stream_test.go
+++ b/pkg/scheduler/server/internal/pool/loops/stream/stream_test.go
@@ -38,7 +38,7 @@ import (
 type suite struct {
 	srv          *serverfake.Fake
 	nsLoop       *fake.Fake
-	streamLoop   loop.Interface[loops.Event]
+	streamLoop   loop.Interface[loops.EventStream]
 	clientstream schedulerv1pb.Scheduler_WatchJobsClient
 	serverstream schedulerv1pb.Scheduler_WatchJobsServer
 	closeserver  context.CancelFunc
@@ -100,7 +100,7 @@ func newSuite(t *testing.T) *suite {
 	}
 }
 
-func (s *suite) expectEvent(t *testing.T, e loops.Event) {
+func (s *suite) expectEvent(t *testing.T, e loops.EventNS) {
 	t.Helper()
 
 	select {

--- a/pkg/scheduler/server/internal/pool/pool.go
+++ b/pkg/scheduler/server/internal/pool/pool.go
@@ -38,7 +38,7 @@ type Options struct {
 type Pool struct {
 	cron api.Interface
 
-	nsLoop  loop.Interface[loops.Event]
+	nsLoop  loop.Interface[loops.EventNS]
 	readyCh chan struct{}
 }
 


### PR DESCRIPTION
Replace generic `Event`/`any`with per-loop event interfaces (placement + scheduler) so loop.Interface[T] is strongly typed.

Tag events via embedded base types to restrict which loops accept them at compile time.