### PR TITLE
Operator: check closed on client connect

### DIFF
--- a/pkg/diagnostics/tracing_test.go
+++ b/pkg/diagnostics/tracing_test.go
@@ -197,9 +197,9 @@ func TestStartInternalCallbackSpan(t *testing.T) {
 		require.Equal(t, numTraces, sampledCount, "Expected to sample all traces (%d) but only sampled %d", numTraces, sampledCount)
 	})
 
-	t.Run("traceparent is not provided and sampling is enabled (but almost 0 P=0.00001)", func(t *testing.T) {
+	t.Run("traceparent is not provided and sampling is enabled (but almost 0 P=0.0000001)", func(t *testing.T) {
 		const numTraces = 1000
-		sampledCount := runTraces(t, "test_trace", numTraces, "0.00001", false, 0)
+		sampledCount := runTraces(t, "test_trace", numTraces, "0.0000001", false, 0)
 		require.Less(t, sampledCount, int(numTraces*.001), "Expected to sample no traces (+/- 10%) but only sampled %d", sampledCount)
 	})
 }

--- a/pkg/operator/api/components.go
+++ b/pkg/operator/api/components.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,10 @@ type ComponentUpdateEvent struct {
 // TODO: @joshvanl: Authorize pod name and namespace matches the SPIFFE ID of
 // the caller.
 func (a *apiServer) ComponentUpdate(in *operatorv1pb.ComponentUpdateRequest, srv operatorv1pb.Operator_ComponentUpdateServer) error { //nolint:nosnakecase
+	if a.closed.Load() {
+		return errors.New("server is closed")
+	}
+
 	log.Info("sidecar connected for component updates")
 
 	ch, cancel, err := a.compInformer.WatchUpdates(srv.Context(), in.GetNamespace())

--- a/pkg/runtime/processor/subscriber/subscriber_test.go
+++ b/pkg/runtime/processor/subscriber/subscriber_test.go
@@ -439,12 +439,16 @@ func TestReloadPubSub(t *testing.T) {
 	assert.Equal(t, []string{"topic1", "topic4"}, gotTopics[0])
 	assert.Equal(t, []string{"topic2"}, gotTopics[1])
 	assert.Equal(t, []string{"topic3"}, gotTopics[2])
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 1)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 1)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 0)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 0)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 1)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 1)
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 0)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 0)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.ReloadPubSub("mockPubSub2")
 	assert.Eventually(t, func() bool {
@@ -453,12 +457,15 @@ func TestReloadPubSub(t *testing.T) {
 	assert.Equal(t, []string{"topic1", "topic4"}, gotTopics[0])
 	assert.Equal(t, []string{"topic2", "topic5"}, gotTopics[1])
 	assert.Equal(t, []string{"topic3"}, gotTopics[2])
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 1)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 0)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 1)
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 0)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.ReloadPubSub("mockPubSub3")
 	assert.Eventually(t, func() bool {
@@ -467,45 +474,57 @@ func TestReloadPubSub(t *testing.T) {
 	assert.Equal(t, []string{"topic1", "topic4"}, gotTopics[0])
 	assert.Equal(t, []string{"topic2", "topic5"}, gotTopics[1])
 	assert.Equal(t, []string{"topic3", "topic6"}, gotTopics[2])
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 1)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 1)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.StopPubSub("mockPubSub1")
 	assert.Eventually(t, func() bool {
 		return changeCalled[0].Load() == 6
 	}, time.Second, 10*time.Millisecond)
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 1)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 1)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.StopPubSub("mockPubSub2")
 	assert.Eventually(t, func() bool {
 		return changeCalled[1].Load() == 6
 	}, time.Second, 10*time.Millisecond)
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 1)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 1)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.StopPubSub("mockPubSub3")
 	assert.Eventually(t, func() bool {
 		return changeCalled[2].Load() == 6
 	}, time.Second, 10*time.Millisecond)
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 3)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 3)
+	}, time.Second*10, time.Millisecond*10)
 }
 
 func TestSubscriptionRetryMechanisms(t *testing.T) {

--- a/pkg/runtime/processor/subscriber/subscriber_test.go
+++ b/pkg/runtime/processor/subscriber/subscriber_test.go
@@ -43,6 +43,12 @@ const (
 	TestPubsubName      = "testpubsub"
 )
 
+type twithLog struct {
+	*assert.CollectT
+}
+
+func (t *twithLog) Logf(string, ...interface{}) {}
+
 func TestSubscriptionLifecycle(t *testing.T) {
 	mockPubSub1 := new(daprt.InMemoryPubsub)
 	mockPubSub2 := new(daprt.InMemoryPubsub)
@@ -145,53 +151,73 @@ func TestSubscriptionLifecycle(t *testing.T) {
 	assert.Equal(t, []string{"topic1"}, gotTopics[0])
 	assert.Equal(t, []string{"topic2"}, gotTopics[1])
 	assert.Equal(t, []string{"topic3"}, gotTopics[2])
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 1)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 1)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 1)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 1)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 1)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 1)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.StopAppSubscriptions()
 	assert.Eventually(t, func() bool {
 		return changeCalled[0].Load() == 2 && changeCalled[1].Load() == 2 && changeCalled[2].Load() == 2
 	}, time.Second, 10*time.Millisecond)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 1)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 1)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 1)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 1)
+	}, time.Second*10, time.Millisecond*10)
 
 	require.NoError(t, subs.StartAppSubscriptions())
 	assert.Equal(t, []string{"topic1"}, gotTopics[0])
 	assert.Equal(t, []string{"topic2"}, gotTopics[1])
 	assert.Equal(t, []string{"topic3"}, gotTopics[2])
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 2)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 2)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 2)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 2)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 2)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 2)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.StopAppSubscriptions()
 	assert.Eventually(t, func() bool {
 		return changeCalled[0].Load() == 4 && changeCalled[1].Load() == 4 && changeCalled[2].Load() == 4
 	}, time.Second, 10*time.Millisecond)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 2)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 2)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 2)
-
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 2)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 2)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 2)
+	}, time.Second*10, time.Millisecond*10)
 	require.NoError(t, subs.StartAppSubscriptions())
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 3)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 3)
+	}, time.Second*10, time.Millisecond*10)
 
 	subs.StopAllSubscriptionsForever()
 	assert.Eventually(t, func() bool {
 		return changeCalled[0].Load() == 6 && changeCalled[1].Load() == 6 && changeCalled[2].Load() == 6
 	}, time.Second, 10*time.Millisecond)
-	mockPubSub1.AssertNumberOfCalls(t, "unsubscribed", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "unsubscribed", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "unsubscribed", 3)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "unsubscribed", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "unsubscribed", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "unsubscribed", 3)
+	}, time.Second*10, time.Millisecond*10)
 
 	require.NoError(t, subs.StartAppSubscriptions())
 	require.NoError(t, subs.StartAppSubscriptions())
 	require.NoError(t, subs.StartAppSubscriptions())
-	mockPubSub1.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub2.AssertNumberOfCalls(t, "Subscribe", 3)
-	mockPubSub3.AssertNumberOfCalls(t, "Subscribe", 3)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		cc := &twithLog{CollectT: c}
+		mockPubSub1.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub2.AssertNumberOfCalls(cc, "Subscribe", 3)
+		mockPubSub3.AssertNumberOfCalls(cc, "Subscribe", 3)
+	}, time.Second*10, time.Millisecond*10)
 }
 
 func Test_initProgrammaticSubscriptions(t *testing.T) {

--- a/tests/integration/suite/daprd/shutdown/graceful/timein.go
+++ b/tests/integration/suite/daprd/shutdown/graceful/timein.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -77,4 +78,8 @@ func (i *timein) Run(t *testing.T, ctx context.Context) {
 		},
 	})
 	require.NoError(t, err)
+
+	// Sleep to ensure entire runtime is spun up so we hit the log line on
+	// shutdown.
+	time.Sleep(time.Millisecond * 500)
 }


### PR DESCRIPTION
Check whether operator has closed when accepting new Component watches. This prevents the operator from not gracefully shutting down when a client connects to the watch and the operator is trying to shut down.