### PR TITLE
Metrics Path Matching Fix

### DIFF
--- a/pkg/diagnostics/http_monitoring.go
+++ b/pkg/diagnostics/http_monitoring.go
@@ -199,7 +199,7 @@ func (h *httpMetrics) ClientRequestStarted(ctx context.Context, method, path str
 	path = h.getMetricsPath(path)
 	method = h.getMetricsMethod(method)
 
-	if h.legacy || h.pathMatcher.enabled() {
+	if h.legacy {
 		stats.RecordWithOptions(
 			ctx,
 			stats.WithRecorder(h.meter),
@@ -222,7 +222,7 @@ func (h *httpMetrics) ClientRequestCompleted(ctx context.Context, method, path, 
 	path = h.getMetricsPath(path)
 	method = h.getMetricsMethod(method)
 
-	if h.legacy || h.pathMatcher.enabled() {
+	if h.legacy {
 		stats.RecordWithOptions(
 			ctx,
 			stats.WithRecorder(h.meter),
@@ -341,7 +341,9 @@ func (h *httpMetrics) HTTPMiddleware(next http.Handler) http.Handler {
 		}
 
 		var path string
-		if h.legacy || h.pathMatcher.enabled() {
+		if h.pathMatcher.enabled() {
+			path = r.URL.Path
+		} else if h.legacy {
 			path = h.convertPathToMetricLabel(r.URL.Path)
 		}
 

--- a/pkg/diagnostics/http_monitoring_path_matching_test.go
+++ b/pkg/diagnostics/http_monitoring_path_matching_test.go
@@ -1,0 +1,302 @@
+package diagnostics
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats/view"
+)
+
+func TestHTTPMetricsPathMatchingNotEnabled(t *testing.T) {
+	testHTTP := newHTTPMetrics()
+	testHTTP.enabled = false
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+	testHTTP.Init(meter, "fakeID", HTTPMonitoringConfig{}, nil)
+	matchedPath, ok := testHTTP.pathMatcher.match("/orders")
+	require.False(t, ok)
+	require.Equal(t, "", matchedPath)
+}
+
+func TestHTTPMetricsPathMatchingLegacyIncreasedCardinality(t *testing.T) {
+	testHTTP := newHTTPMetrics()
+	testHTTP.enabled = false
+	paths := []string{
+		"/v1/orders/{orderID}/items/12345",
+		"/v1/orders/{orderID}/items/{itemID}",
+		"/v1/items/{itemID}",
+		"/v1/orders/{orderID}/items/{itemID}",
+	}
+	configHTTP := NewHTTPMonitoringConfig(paths, true, false)
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+	testHTTP.Init(meter, "fakeID", configHTTP, nil)
+
+	// act & assert
+
+	// empty path
+	matchedPath, ok := testHTTP.pathMatcher.match("")
+	require.False(t, ok)
+	require.Equal(t, "", matchedPath)
+
+	// match "/v1/orders/{orderID}/items/12345"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/orders/12345/items/12345")
+	require.True(t, ok)
+	require.Equal(t, "/v1/orders/{orderID}/items/12345", matchedPath)
+
+	// match "/v1/orders/{orderID}/items/{itemID}"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/orders/12345/items/1111")
+	require.True(t, ok)
+	require.Equal(t, "/v1/orders/{orderID}/items/{itemID}", matchedPath)
+
+	// match "/v1/items/{itemID}"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/items/12345")
+	require.True(t, ok)
+	require.Equal(t, "/v1/items/{itemID}", matchedPath)
+
+	// no match so we keep the path as is
+	matchedPath, ok = testHTTP.pathMatcher.match("/v2/basket/12345")
+	require.True(t, ok)
+	require.Equal(t, "/v2/basket/12345", matchedPath)
+
+	// match "/v1/orders/{orderID}/items/{itemID}"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/orders/12345/items/1111")
+	require.True(t, ok)
+	require.Equal(t, "/v1/orders/{orderID}/items/{itemID}", matchedPath)
+}
+
+func TestHTTPMetricsPathMatchingLowCardinality(t *testing.T) {
+	testHTTP := newHTTPMetrics()
+	testHTTP.enabled = false
+	paths := []string{
+		"/v1/orders/{orderID}/items/12345",
+		"/v1/orders/{orderID}/items/{itemID}",
+		"/v1/orders/{orderID}",
+		"/v1/items/{itemID}",
+		"/dapr/config",
+		"/v1/",
+		"/",
+	}
+	configHTTP := NewHTTPMonitoringConfig(paths, false, false)
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+	testHTTP.Init(meter, "fakeID", configHTTP, nil)
+
+	// act & assert
+
+	// empty path
+	matchedPath, ok := testHTTP.pathMatcher.match("")
+	require.False(t, ok)
+	require.Equal(t, "", matchedPath)
+
+	// match "/v1/orders/{orderID}/items/12345"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/orders/12345/items/12345")
+	require.True(t, ok)
+	require.Equal(t, "/v1/orders/{orderID}/items/12345", matchedPath)
+
+	// match "/v1/orders/{orderID}"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/orders/12345")
+	require.True(t, ok)
+	require.Equal(t, "/v1/orders/{orderID}", matchedPath)
+
+	// match "/v1/items/{itemID}"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/items/12345")
+	require.True(t, ok)
+	require.Equal(t, "/v1/items/{itemID}", matchedPath)
+
+	// match "/v1/"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v1/basket")
+	require.True(t, ok)
+	assert.Equal(t, "/v1/", matchedPath)
+
+	// match "/"
+	matchedPath, ok = testHTTP.pathMatcher.match("/v2/orders/1111")
+	require.True(t, ok)
+	assert.Equal(t, "/", matchedPath)
+
+	// no match so we fallback to "/"
+	matchedPath, ok = testHTTP.pathMatcher.match("/basket/12345")
+	require.True(t, ok)
+	require.Equal(t, "/", matchedPath)
+
+	matchedPath, ok = testHTTP.pathMatcher.match("/dapr/config")
+	require.True(t, ok)
+	require.Equal(t, "/dapr/config", matchedPath)
+}
+
+func TestHTTPMetricsPathMatchingLowCardinalityRootPathRegister(t *testing.T) {
+	testHTTP := newHTTPMetrics()
+	testHTTP.enabled = false
+
+	// 1 - Root path not registered fallback to ""
+	paths1 := []string{"/v1/orders/{orderID}"}
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+	testHTTP.Init(meter, "fakeID", HTTPMonitoringConfig{paths1, false, false}, nil)
+	matchedPath, ok := testHTTP.pathMatcher.match("/thispathdoesnotexist")
+	require.True(t, ok)
+	require.Equal(t, "", matchedPath)
+
+	// 2 - Root path registered fallback to "/"
+	paths2 := []string{"/v1/orders/{orderID}", "/"}
+	meter2 := view.NewMeter()
+	meter2.Start()
+	defer meter2.Stop()
+	testHTTP.Init(meter2, "fakeID", HTTPMonitoringConfig{paths2, false, false}, nil)
+	matchedPath, ok = testHTTP.pathMatcher.match("/thispathdoesnotexist")
+	require.True(t, ok)
+	require.Equal(t, "/", matchedPath)
+}
+
+func TestHTTPMetricsPathMatchingWithRedirect(t *testing.T) {
+	const testPath = "/redirect-test"
+
+	pm := newPathMatching([]string{"/other-path"}, false)
+	pm.mux.HandleFunc(testPath, func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	})
+
+	matchedPath, ok := pm.match(testPath)
+	require.True(t, ok, "Expected path matching to succeed")
+	require.Equal(t, testPath, matchedPath, "Expected matched path to be %q", testPath)
+}
+
+func TestHTTPMetricsPathMatchingActorEndpoints(t *testing.T) {
+	testHTTP := newHTTPMetrics()
+	testHTTP.enabled = false
+	paths := []string{
+		"/v1.0/actors/{actorType}/{actorId}/method/{method}",
+		"/v1.0/actors/{actorType}/{actorId}/reminders/{name}",
+		"/v1.0/actors/{actorType}/{actorId}/timers/{name}",
+		"/v1.0/actors/{actorType}/{actorId}/state/{key}",
+		"/v1.0/actors/{actorType}/{actorId}/state",
+	}
+	configHTTP := NewHTTPMonitoringConfig(paths, false, false)
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+	testHTTP.Init(meter, "fakeID", configHTTP, nil)
+
+	tests := []struct {
+		name          string
+		path          string
+		expectedMatch string
+	}{
+		{
+			name:          "actor method invocation",
+			path:          "/v1.0/actors/WorkerActor/ActorID/method/StoreModelAndConstructRequest",
+			expectedMatch: "/v1.0/actors/{actorType}/{actorId}/method/{method}",
+		},
+		{
+			name:          "actor reminder",
+			path:          "/v1.0/actors/WorkerActor/ActorID/reminders/MyReminder",
+			expectedMatch: "/v1.0/actors/{actorType}/{actorId}/reminders/{name}",
+		},
+		{
+			name:          "actor timer",
+			path:          "/v1.0/actors/WorkerActor/ActorID/timers/MyTimer",
+			expectedMatch: "/v1.0/actors/{actorType}/{actorId}/timers/{name}",
+		},
+		{
+			name:          "actor state get specific key",
+			path:          "/v1.0/actors/RxPassResultActor/ActorID/state/stateKey",
+			expectedMatch: "/v1.0/actors/{actorType}/{actorId}/state/{key}",
+		},
+		{
+			name:          "actor state transaction",
+			path:          "/v1.0/actors/OrderActor/order-123/state",
+			expectedMatch: "/v1.0/actors/{actorType}/{actorId}/state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matchedPath, ok := testHTTP.pathMatcher.match(tt.path)
+			require.True(t, ok)
+			require.Equal(t, tt.expectedMatch, matchedPath)
+		})
+	}
+}
+
+func TestHTTPMetricsPathMatchingUnmatchedPathWithSubtreeStrictMode(t *testing.T) {
+	testHTTP := newHTTPMetrics()
+	testHTTP.enabled = false
+	paths := []string{"/"}
+	configHTTP := NewHTTPMonitoringConfig(paths, false, false)
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+	testHTTP.Init(meter, "fakeID", configHTTP, nil)
+
+	matchedPath, ok := testHTTP.pathMatcher.match("//v1.0/actors/WeatherActor/xyz/method/GetWeatherAsync")
+	require.True(t, ok)
+	require.Equal(t, "/", matchedPath, "double-slash actor path should match root '/' in strict mode")
+}
+
+func TestHTTPMetricsPathMatchingServiceInvocation(t *testing.T) {
+	testHTTP := newHTTPMetrics()
+	testHTTP.enabled = false
+
+	paths := []string{
+		"/orders/{id}",
+		"/api/v1/widget",
+	}
+	configHTTP := NewHTTPMonitoringConfig(paths, false, false)
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+	testHTTP.Init(meter, "fakeID", configHTTP, nil)
+
+	matchedPath, ok := testHTTP.pathMatcher.match("/orders/123")
+	require.True(t, ok)
+	assert.Equal(t, "/orders/{id}", matchedPath)
+
+	invokePath := "/v1.0/invoke/order-app/method/orders/123"
+	matchedPath, ok = testHTTP.pathMatcher.match(invokePath)
+	require.True(t, ok)
+	assert.Equal(t, "/v1.0/invoke/{app_id}/method/orders/{id}", matchedPath)
+}
+
+func TestHTTPMetricsPathMatchingNormalizationDedup(t *testing.T) {
+	paths := []string{
+		"/orders",
+		"//orders",
+		"orders",
+		"///orders",
+	}
+
+	configHTTP := NewHTTPMonitoringConfig(paths, false, false)
+	testHTTP := newHTTPMetrics()
+
+	meter := view.NewMeter()
+	meter.Start()
+	t.Cleanup(func() {
+		meter.Stop()
+	})
+
+	testHTTP.Init(meter, "fakeID", configHTTP, nil)
+
+	matchedPath, ok := testHTTP.pathMatcher.match("//orders")
+	require.True(t, ok)
+	assert.Equal(t, "/orders", matchedPath)
+}

--- a/tests/integration/suite/daprd/metrics/http/pathmatching/actors_high.go
+++ b/tests/integration/suite/daprd/metrics/http/pathmatching/actors_high.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pathmatching
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(highPathMatching))
+}
+
+// highPathMatching tests daprd metrics for the HTTP server configured with high cardinality AND path matching
+type highPathMatching struct {
+	daprd *daprd.Daprd
+	place *placement.Placement
+}
+
+func (h *highPathMatching) Setup(t *testing.T) []framework.Option {
+	app := app.New(t,
+		app.WithHandlerFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+		app.WithHandlerFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"entities": ["myactortype"]}`))
+		}),
+	)
+	h.place = placement.New(t)
+
+	h.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppID("myapp"),
+		daprd.WithPlacementAddresses(h.place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithConfigManifests(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: highcardinalitypathmatching
+spec:
+  metrics:
+    http:
+      increasedCardinality: true
+      pathMatching:
+        - /v1.0/actors/{actorType}/{actorId}/method/{method}
+`),
+	)
+	return []framework.Option{
+		framework.WithProcesses(app, h.daprd, h.place),
+	}
+}
+
+func (h *highPathMatching) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+	h.place.WaitUntilRunning(t, ctx)
+
+	t.Run("actor invocation matched", func(t *testing.T) {
+		h.daprd.HTTPPost2xx(t, ctx, "/v1.0/actors/myactortype/myactorid/method/foo", nil, "content-type", "application/json")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			metrics := h.daprd.Metrics(c, ctx).All()
+			// Should match the specific path matching rule
+			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:POST|path:/v1.0/actors/{actorType}/{actorId}/method/{method}|status:200"]))
+		}, time.Second*10, 10*time.Millisecond)
+	})
+
+	t.Run("unmatched path raw preservation", func(t *testing.T) {
+		// Request a path that is NOT in pathMatching
+		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/metadata")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			metrics := h.daprd.Metrics(c, ctx).All()
+			// Expect raw path
+			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/metadata|status:200"]))
+		}, time.Second*10, 10*time.Millisecond)
+	})
+}


### PR DESCRIPTION
## Description
This PR fixes a regression in HTTP metrics where Actor paths were being incorrectly normalized (truncated/masked) or dropped when `increasedCardinality` was enabled, causing loss of visibility into specific Actor methods. It also introduces comprehensive test coverage for various cardinality and path matching scenarios.

### Key Changes
1.  **Fix Path Normalization Logic:**
    - Updated `HTTPMiddleware` and client metrics functions in `pkg/diagnostics/http_monitoring.go` to respect the configured `pathMatching` rules.
    - Specifically, when `increasedCardinality: true` is set, unmatched paths now preserve their **raw** value (e.g., `/v1.0/actors/mytype/myid/method/foo`) instead of falling back to the legacy truncation logic (`/v1.0/actors/mytype/{id}/method`).
    - Matched paths continue to use the normalized template (e.g., `/v1.0/actors/mytype/{id}/method/foo`) as configured.

2.  **Test Coverage:**
    - Added a new integration test suite `tests/integration/suite/daprd/metrics/http/pathmatching/actors_high.go` to explicitly verify Actor path matching with High Cardinality.
    - Split and refactored unit tests in `pkg/diagnostics` for better organization:
        - `http_monitoring_test.go`: Middleware logic.
        - `http_monitoring_path_matching_test.go`: Specific path matching rules (Low/High cardinality, Actors, Service Invocation).


## Issue reference


## Checklist
- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
