### PR TITLE
[1.16] Upgrade go 1.24.13

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -1,6 +1,6 @@
 module build-tools
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/google/go-containerregistry v0.11.1-0.20220802162123-c1f9836a4fa9

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ MODFILES := $(shell find . -name go.mod)
 define modtidy-target
 .PHONY: modtidy-$(1)
 modtidy-$(1):
-	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.24.11; cd -
+	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.24.13; cd -
 endef
 
 # Generate modtidy target action for each go.mod file

--- a/docs/development/setup-dapr-development-env.md
+++ b/docs/development/setup-dapr-development-env.md
@@ -23,7 +23,7 @@ This document helps you get started developing Dapr. If you find any problems wh
 
 ## Go (Golang)
 
-1. Download and install [Go 1.24.11 or later](https://golang.org/doc/install#tarball).
+1. Download and install [Go 1.24.13 or later](https://golang.org/doc/install#tarball).
 
 2. Install [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation) for Go debugging, if desired.
 

--- a/docs/release_notes/v1.16.9.md
+++ b/docs/release_notes/v1.16.9.md
@@ -1,0 +1,24 @@
+# Dapr 1.16.9
+
+This update includes bug fixes:
+
+- [Upgade Go to 1.24.13](#upgade-go-to-1-24-13)
+
+## Upgade Go to 1.24.13
+
+### Problem
+
+- Vulnerability #1: GO-2026-4341
+- Vulnerability #2: GO-2026-4340
+
+### Impact
+
+-
+
+### Root Cause
+
+-
+
+### Solution
+
+- Upgrade Go to 1.24.13 ### References - [Go 1.24.13 Release Notes](https://go.dev/doc/devel/release#go1.24.minor)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr
 
-go 1.24.11
+go 1.24.13
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/tests/apps/actorload/Dockerfile
+++ b/tests/apps/actorload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.11
+FROM golang:1.24.13
 WORKDIR /actorload/
 COPY . .
 RUN make build

--- a/tests/apps/actorload/go.mod
+++ b/tests/apps/actorload/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/actorload
 
-go 1.24.11
+go 1.24.13
 
 require (
 	fortio.org/fortio v1.6.8

--- a/tests/apps/crypto/Dockerfile
+++ b/tests/apps/crypto/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.11 as build_env
+FROM golang:1.24.13 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/crypto/go.mod
+++ b/tests/apps/crypto/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/crypto
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr/go-sdk v1.8.0

--- a/tests/apps/perf/actor-activation-locker/Dockerfile
+++ b/tests/apps/perf/actor-activation-locker/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.11 as build_env
+FROM golang:1.24.13 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/actor-activation-locker/go.mod
+++ b/tests/apps/perf/actor-activation-locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/actor-activation-locker
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/bsm/redislock v0.8.2

--- a/tests/apps/perf/actorfeatures/Dockerfile
+++ b/tests/apps/perf/actorfeatures/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.24.11-bookworm as build_env
+FROM golang:1.24.13-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod go.sum ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.24.11-bookworm as fortio_build_env
+FROM golang:1.24.13-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/actorfeatures/go.mod
+++ b/tests/apps/perf/actorfeatures/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr/dapr v1.13.4

--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -1,5 +1,5 @@
 # Build the k6 binary with the extension
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 WORKDIR $GOPATH/src/go.k6.io/k6
 # See https://github.com/grafana/xk6/releases for which release aligns with our go version, latest requires go 1.25.x

--- a/tests/apps/perf/service_invocation_grpc/Dockerfile
+++ b/tests/apps/perf/service_invocation_grpc/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.11 as build_env
+FROM golang:1.24.13 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_grpc/go.mod
+++ b/tests/apps/perf/service_invocation_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_grpc
 
-go 1.24.11
+go 1.24.13
 
 require github.com/dapr/go-sdk v1.8.0
 

--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.11 as build_env
+FROM golang:1.24.13 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_http/go.mod
+++ b/tests/apps/perf/service_invocation_http/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_http
 
-go 1.24.11
+go 1.24.13

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.24.11-bookworm as build_env
+FROM golang:1.24.13-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.24.11-bookworm as fortio_build_env
+FROM golang:1.24.13-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/tester/go.mod
+++ b/tests/apps/perf/tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.24.11
+go 1.24.13

--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/kafka-bindings
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-pubsub/go.mod
+++ b/tests/apps/pluggable_redis-pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-pubsub
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-statestore/go.mod
+++ b/tests/apps/pluggable_redis-statestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-statestore
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pubsub-publisher-streaming/Dockerfile
+++ b/tests/apps/pubsub-publisher-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.11 AS build_env
+FROM golang:1.24.13 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-publisher-streaming/go.mod
+++ b/tests/apps/pubsub-publisher-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-publisher-streaming
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/pubsub-subscriber-streaming/Dockerfile
+++ b/tests/apps/pubsub-subscriber-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.11 AS build_env
+FROM golang:1.24.13 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-subscriber-streaming/go.mod
+++ b/tests/apps/pubsub-subscriber-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-subscriber-streaming
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/resiliencyapp/go.mod
+++ b/tests/apps/resiliencyapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr/dapr v0.0.0

--- a/tests/apps/resiliencyapp_grpc/go.mod
+++ b/tests/apps/resiliencyapp_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp_grpc
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr/dapr v1.7.4

--- a/tests/apps/service_invocation_grpc_proxy_client/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_client/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_client
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/dapr/dapr v0.0.0-00010101000000-000000000000

--- a/tests/apps/service_invocation_grpc_proxy_server/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_server/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_server
 
-go 1.24.11
+go 1.24.13
 
 require (
 	google.golang.org/grpc v1.54.0

--- a/tests/integration/framework/binary/helpers/helmtemplate/go.mod
+++ b/tests/integration/framework/binary/helpers/helmtemplate/go.mod
@@ -1,6 +1,6 @@
 module helm
 
-go 1.24.11
+go 1.24.13
 
 require (
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
- [Upgade Go to 1.24.13](#upgade-go-to-1-24-13)
Upgade Go to 1.24.13

Problem

- Vulnerability #1: GO-2026-4341
- Vulnerability #2: GO-2026-4340

Impact

-

Root Cause

-

Solution

- Upgrade Go to 1.24.13 ### References - [Go 1.24.13 Release Notes](https://go.dev/doc/devel/release#go1.24.minor)