### PR TITLE
fix use the raw request path (normalized) for path matching

### DIFF
--- a/pkg/diagnostics/http_monitoring_path_matching.go
+++ b/pkg/diagnostics/http_monitoring_path_matching.go
@@ -93,6 +93,9 @@ func (pm *pathMatching) match(path string) (string, bool) {
 
 	cleanPath := NormalizeHTTPPath(path)
 	req, _ := http.NewRequest(http.MethodGet, cleanPath, nil)
+	if req.URL != nil {
+		req.URL.Path = cleanPath
+	}
 
 	_, pattern := pm.mux.Handler(req)
 

--- a/tests/integration/suite/daprd/metrics/http/pathmatching/low.go
+++ b/tests/integration/suite/daprd/metrics/http/pathmatching/low.go
@@ -83,6 +83,15 @@ spec:
 func (h *lowCardinality) Run(t *testing.T, ctx context.Context) {
 	h.daprd.WaitUntilRunning(t, ctx)
 
+	t.Run("increasedCardinality false and pathMatching: metric path label is matched path not empty", func(t *testing.T) {
+		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/1234")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			metrics := h.daprd.Metrics(c, ctx).All()
+			matchedKey := "dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/1234|status:200"
+			assert.Equal(c, 1, int(metrics[matchedKey]), "expected: request recorded with path=/v1.0/.../orders/1234")
+		}, time.Second*10, time.Millisecond*10)
+	})
+
 	t.Run("service invocation - matches ingres/egress", func(t *testing.T) {
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/1111")
 		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/1234")
@@ -93,7 +102,7 @@ func (h *lowCardinality) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			metrics := h.daprd.Metrics(c, ctx).All()
 			assert.Equal(c, 2, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/{orderID}|status:200"]))
-			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/1234|status:200"]))
+			assert.Equal(c, 2, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/1234|status:200"]))
 			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders|status:200"]))
 			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/basket|status:200"]))
 			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:|status:200"]))

--- a/tests/integration/suite/daprd/metrics/http/pathmatching/low.go
+++ b/tests/integration/suite/daprd/metrics/http/pathmatching/low.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -72,6 +73,7 @@ spec:
         - /v1.0/invoke/myapp/method/orders/1234
         - /v1.0/invoke/myapp/method/orders/{orderID}
         - /v1.0/invoke/myapp/method/orders
+        - /v1.0/state/mystore/{key}
 `),
 	)
 
@@ -84,11 +86,13 @@ func (h *lowCardinality) Run(t *testing.T, ctx context.Context) {
 	h.daprd.WaitUntilRunning(t, ctx)
 
 	t.Run("increasedCardinality false and pathMatching: metric path label is matched path not empty", func(t *testing.T) {
-		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/invoke/myapp/method/orders/1234")
+		body := `[{"key": "foo", "value": "v1"}]`
+		h.daprd.HTTPPost2xx(t, ctx, "/v1.0/state/mystore", strings.NewReader(body), "content-type", "application/json")
+		h.daprd.HTTPGet2xx(t, ctx, "/v1.0/state/mystore/foo")
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			metrics := h.daprd.Metrics(c, ctx).All()
-			matchedKey := "dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/1234|status:200"
-			assert.Equal(c, 1, int(metrics[matchedKey]), "expected: request recorded with path=/v1.0/.../orders/1234")
+			matchedKey := "dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/state/mystore/{key}|status:200"
+			assert.Equal(c, 1, int(metrics[matchedKey]), "expected: GET state/key under matched path")
 		}, time.Second*10, time.Millisecond*10)
 	})
 
@@ -102,7 +106,7 @@ func (h *lowCardinality) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			metrics := h.daprd.Metrics(c, ctx).All()
 			assert.Equal(c, 2, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/{orderID}|status:200"]))
-			assert.Equal(c, 2, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/1234|status:200"]))
+			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders/1234|status:200"]))
 			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/orders|status:200"]))
 			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:/v1.0/invoke/myapp/method/basket|status:200"]))
 			assert.Equal(c, 1, int(metrics["dapr_http_server_request_count|app_id:myapp|method:GET|path:|status:200"]))


### PR DESCRIPTION
# Description

Use the raw request path for HTTP metrics path matching instead of the converted metric label which would drop valid matched paths, and fix handling of root/empty matches 


- Modified HTTPMiddleware to pass normalized raw path to matcher when path matching is enabled
- Enhanced getMetricsPath()  raw path first, then fallback to converted path

## Issue reference 

Addresses unfixed bug https://github.com/dapr/dapr/issues/9188

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
