### PR TITLE
Point backport action to a specific commit

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -32,6 +32,6 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Following @mikeee [comment](https://github.com/dapr/components-contrib/pull/4223#discussion_r2811708741), pointing the backport action to a specific commit.