### PR TITLE
use latest from contrib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/dapr/components-contrib v1.16.2-0.20260212154145-4a37800d3727
+	github.com/dapr/components-contrib v1.16.2-0.20260218145013-1518e98a3100
 	github.com/dapr/durabletask-go v0.11.0
 	github.com/dapr/kit v0.16.2-0.20251124175541-3ac186dff64d
 	github.com/diagridio/go-etcd-cron v0.12.3

--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.16.2-0.20260212154145-4a37800d3727 h1:qSvkGkWPd+4bIEpVoAwxNGh76UlS5/cd1lE6FjzUJtA=
-github.com/dapr/components-contrib v1.16.2-0.20260212154145-4a37800d3727/go.mod h1:CrBOZVPMKdnblS9AjHGw02LGr9JVlNbgqiISwQeGVW8=
+github.com/dapr/components-contrib v1.16.2-0.20260218145013-1518e98a3100 h1:z6TIzoa4hRycSDz82M4S0KWoU/IEq1ZElxQPlLSQo74=
+github.com/dapr/components-contrib v1.16.2-0.20260218145013-1518e98a3100/go.mod h1:CrBOZVPMKdnblS9AjHGw02LGr9JVlNbgqiISwQeGVW8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20251104160704-920ad8a7b958 h1:DSZgzdXlbF75fwvEkMQpPqn1jjxmWVoBNmI4Bc4dS40=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20251104160704-920ad8a7b958/go.mod h1:IUB5RJv0Gj5qxsHjjhvEBIlxPka7cD7KAn/Coa2y27M=
 github.com/dapr/durabletask-go v0.11.0 h1:e9Ns/3a2b6JDKGuvksvx6gCHn7rd+nwZZyAXbg5Ley4=


### PR DESCRIPTION
[use latest from contrib to not have a regression with pulsar make issuer file credential optional](https://github.com/dapr/components-contrib/commit/1518e98a310091814b8f097eb548b0d8bbb095b3)