### PR TITLE
fix(ollama): rm old workaround for ollama

### DIFF
--- a/pkg/api/universal/conversation.go
+++ b/pkg/api/universal/conversation.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dapr/components-contrib/conversation"
 	"github.com/dapr/components-contrib/conversation/langchaingokit"
 	"github.com/dapr/components-contrib/conversation/mistral"
-	"github.com/dapr/components-contrib/conversation/ollama"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/messages"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -353,11 +352,9 @@ func (a *Universal) ConverseAlpha2(ctx context.Context, req *runtimev1pb.Convers
 						},
 					}
 
-					// handle mistral and ollama edge case on handling tool call message
+					// handle mistral edge case on handling tool call message
 					// where it expects a text message instead of a tool call message
 					if _, ok := component.(*mistral.Mistral); ok {
-						langchainMsg.Parts = append(langchainMsg.Parts, langchaingokit.CreateToolCallPart(&toolCall))
-					} else if _, ok := component.(*ollama.Ollama); ok {
 						langchainMsg.Parts = append(langchainMsg.Parts, langchaingokit.CreateToolCallPart(&toolCall))
 					} else {
 						langchainMsg.Parts = append(langchainMsg.Parts, toolCall)
@@ -397,8 +394,6 @@ func (a *Universal) ConverseAlpha2(ctx context.Context, req *runtimev1pb.Convers
 				// handle mistral edge case on handling tool call response message
 				// where it expects a text message instead of a tool call response message
 				if _, ok := component.(*mistral.Mistral); ok {
-					langchainMsg = langchaingokit.CreateToolResponseMessage(parts...)
-				} else if _, ok := component.(*ollama.Ollama); ok {
 					langchainMsg = langchaingokit.CreateToolResponseMessage(parts...)
 				} else {
 					langchainMsg = llms.MessageContent{


### PR DESCRIPTION

# Description

Before components contrib implementation of ollama used the ollama langchain go client that needed tool call workarounds. Now, the ollama client in contrib has been updated to the openai client under the hood to fully support tool calls; therefore we no longer need the workaround here.

TLDR this will fix Ollama conversation components to enable them to call tools.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
