### PR TITLE
Only retry cancelled requests for non-mutating operations

### DIFF
--- a/pkg/runtime/scheduler/internal/clients/wrapper/wrapper.go
+++ b/pkg/runtime/scheduler/internal/clients/wrapper/wrapper.go
@@ -67,7 +67,7 @@ func (w *wrapper) DeleteByMetadata(ctx context.Context, req *v1pb.DeleteByMetada
 
 func (w *wrapper) GetJob(ctx context.Context, req *v1pb.GetJobRequest, opts ...grpc.CallOption) (*v1pb.GetJobResponse, error) {
 	var resp *v1pb.GetJobResponse
-	err := w.call(ctx, func(client v1pb.SchedulerClient) error {
+	err := w.callWithRetry(ctx, func(client v1pb.SchedulerClient) error {
 		var err error
 		resp, err = client.GetJob(ctx, req, opts...)
 		return err
@@ -77,7 +77,7 @@ func (w *wrapper) GetJob(ctx context.Context, req *v1pb.GetJobRequest, opts ...g
 
 func (w *wrapper) ListJobs(ctx context.Context, req *v1pb.ListJobsRequest, opts ...grpc.CallOption) (*v1pb.ListJobsResponse, error) {
 	var resp *v1pb.ListJobsResponse
-	err := w.call(ctx, func(client v1pb.SchedulerClient) error {
+	err := w.callWithRetry(ctx, func(client v1pb.SchedulerClient) error {
 		var err error
 		resp, err = client.ListJobs(ctx, req, opts...)
 		return err
@@ -97,7 +97,7 @@ func (w *wrapper) ScheduleJob(ctx context.Context, req *v1pb.ScheduleJobRequest,
 
 func (w *wrapper) WatchJobs(ctx context.Context, opts ...grpc.CallOption) (v1pb.Scheduler_WatchJobsClient, error) {
 	var resp v1pb.Scheduler_WatchJobsClient
-	err := w.call(ctx, func(client v1pb.SchedulerClient) error {
+	err := w.callWithRetry(ctx, func(client v1pb.SchedulerClient) error {
 		var err error
 		resp, err = client.WatchJobs(ctx, opts...)
 		return err
@@ -107,7 +107,7 @@ func (w *wrapper) WatchJobs(ctx context.Context, opts ...grpc.CallOption) (v1pb.
 
 func (w *wrapper) WatchHosts(ctx context.Context, req *v1pb.WatchHostsRequest, opts ...grpc.CallOption) (v1pb.Scheduler_WatchHostsClient, error) {
 	var resp v1pb.Scheduler_WatchHostsClient
-	err := w.call(ctx, func(client v1pb.SchedulerClient) error {
+	err := w.callWithRetry(ctx, func(client v1pb.SchedulerClient) error {
 		var err error
 		resp, err = client.WatchHosts(ctx, req, opts...)
 		return err
@@ -128,6 +128,14 @@ func (w *wrapper) DeleteByNamePrefix(ctx context.Context, req *v1pb.DeleteByName
 type apiFn func(client v1pb.SchedulerClient) error
 
 func (w *wrapper) call(ctx context.Context, fn apiFn) error {
+	client, err := w.clients.Next(ctx)
+	if err != nil {
+		return err
+	}
+	return fn(client)
+}
+
+func (w *wrapper) callWithRetry(ctx context.Context, fn apiFn) error {
 	for {
 		client, err := w.clients.Next(ctx)
 		if err != nil {


### PR DESCRIPTION
# Description

We've got this failed build: https://github.com/dapr/dapr/actions/runs/22149568249/job/64037619020

In that run, the job creation gets a `409`, but it's a single HTTP request. The problem is the retry, it received a `Cancel` but the job was created successfully, so the retry (because of the error being a `Cancel`) found the job already existed and returned a `409`.
