### PR TITLE
Fixes workflows getting in an invalid state

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -103,6 +103,14 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Orches
 	// We block (re)creation of existing workflows unless they are in a completed state
 	// Or if they still have any pending activity result awaited.
 	if !runtimestate.IsCompleted(rs) {
+		// This happens when the parent's runWorkflow created the child workflow
+		// successfully but crashed before persisting its own state, causing it to
+		// re-execute and attempt the child creation again.
+		if o.isSameParentCreation(state, startEvent) {
+			log.Warnf("Workflow actor '%s': ignoring duplicate child workflow creation from parent '%s'",
+				o.actorID, startEvent.GetExecutionStarted().GetParentInstance().GetOrchestrationInstance().GetInstanceId())
+			return nil
+		}
 		return fmt.Errorf("an active workflow with ID '%s' already exists", o.actorID)
 	}
 	if o.activityResultAwaited.Load() {
@@ -114,11 +122,6 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Orches
 }
 
 func (o *orchestrator) scheduleWorkflowStart(ctx context.Context, startEvent *backend.HistoryEvent, state *wfenginestate.State) error {
-	state.AddToInbox(startEvent)
-	if err := o.saveInternalState(ctx, state); err != nil {
-		return err
-	}
-
 	start := startEvent.GetTimestamp().AsTime()
 	if ts := startEvent.GetExecutionStarted().GetScheduledStartTimestamp(); ts != nil {
 		start = ts.AsTime()
@@ -130,8 +133,27 @@ func (o *orchestrator) scheduleWorkflowStart(ctx context.Context, startEvent *ba
 	if _, err := o.createWorkflowReminder(ctx, reminderPrefixStart, nil, start, o.appID); err != nil {
 		return err
 	}
+	state.AddToInbox(startEvent)
+	if err := o.saveInternalState(ctx, state); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+func (o *orchestrator) isSameParentCreation(state *wfenginestate.State, startEvent *backend.HistoryEvent) bool {
+	newParent := startEvent.GetExecutionStarted().GetParentInstance()
+	if newParent == nil {
+		return false
+	}
+
+	existingParent := o.getExecutionStartedEvent(state).GetParentInstance()
+	if existingParent == nil {
+		return false
+	}
+
+	return existingParent.GetOrchestrationInstance().GetInstanceId() == newParent.GetOrchestrationInstance().GetInstanceId() &&
+		existingParent.GetTaskScheduledId() == newParent.GetTaskScheduledId()
 }
 
 func isStatusMatch(statuses []api.OrchestrationStatus, runtimeStatus api.OrchestrationStatus) bool {

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -107,7 +107,7 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Orches
 		// successfully but crashed before persisting its own state, causing it to
 		// re-execute and attempt the child creation again.
 		if o.isSameParentCreation(state, startEvent) {
-			log.Warnf("Workflow actor '%s': ignoring duplicate child workflow creation from parent '%s'",
+			log.Debugf("Workflow actor '%s': ignoring duplicate child workflow creation from parent '%s'",
 				o.actorID, startEvent.GetExecutionStarted().GetParentInstance().GetOrchestrationInstance().GetInstanceId())
 			return nil
 		}

--- a/tests/integration/framework/process/statestore/component.go
+++ b/tests/integration/framework/process/statestore/component.go
@@ -303,6 +303,7 @@ func (c *component) Transact(ctx context.Context, req *compv1pb.TransactionalSta
 			if v.Set.GetEtag() != nil && v.Set.GetEtag().GetValue() != "" {
 				setReq.ETag = &v.Set.GetEtag().Value
 			}
+			operations = append(operations, setReq)
 		default:
 			return nil, fmt.Errorf("unknown operation type %T", v)
 		}

--- a/tests/integration/suite/daprd/workflow/basic/childidempotent.go
+++ b/tests/integration/suite/daprd/workflow/basic/childidempotent.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,6 +31,7 @@ import (
 	"github.com/dapr/durabletask-go/task"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"

--- a/tests/integration/suite/daprd/workflow/basic/childidempotent.go
+++ b/tests/integration/suite/daprd/workflow/basic/childidempotent.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(childidempotent))
+}
+
+// childidempotent verifies duplicate child creation is treated idempotently
+// when a parent crashes after creating the child but before saving its own state.
+type childidempotent struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *failOnceMultiStore
+}
+
+const (
+	parentID = "parent-crash-test"
+	childID  = "parent-crash-test:child"
+)
+
+func (c *childidempotent) Setup(t *testing.T) []framework.Option {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping unix socket based test on windows")
+	}
+
+	c.store = &failOnceMultiStore{Wrapped: inmemory.New(t).(*inmemory.Wrapped)}
+
+	sock := socket.New(t)
+	c.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(c.store),
+	)
+
+	c.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, c.ss.SocketName())),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.ss, c.workflow),
+	}
+}
+
+func (c *childidempotent) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	gclient := c.workflow.GRPCClient(t, ctx)
+
+	blockedCh := make(chan struct{})
+	failedCh := make(chan struct{})
+
+	r := c.workflow.Registry()
+
+	require.NoError(t, r.AddActivityN("blocking", func(actx task.ActivityContext) (any, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-blockedCh:
+			return "activity done", nil
+		}
+	}))
+
+	require.NoError(t, r.AddOrchestratorN("child", func(octx *task.OrchestrationContext) (any, error) {
+		var result string
+		if err := octx.CallActivity("blocking").Await(&result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}))
+
+	require.NoError(t, r.AddOrchestratorN("parent", func(octx *task.OrchestrationContext) (any, error) {
+		var output string
+		err := octx.CallSubOrchestrator("child",
+			task.WithSubOrchestrationInstanceID(childID),
+		).Await(&output)
+		return output, err
+	}))
+
+	c.workflow.BackendClient(t, ctx)
+
+	c.store.ArmFailureForKey(parentID+"||history-", failedCh)
+
+	// Uses StartWorkflowBeta1 instead of ScheduleNewOrchestration because it returns immediately
+	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "parent",
+		InstanceId:        parentID,
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-failedCh:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "injected save failure did not fire")
+	}
+
+	savedCh := make(chan struct{})
+	c.store.WatchForSuccessfulSave(parentID+"||history-", savedCh)
+
+	startReminderPrefix := fmt.Sprintf(
+		"dapr/jobs/actorreminder||default||dapr.internal.default.%s.workflow||%s||start-",
+		c.workflow.Dapr().AppID(),
+		parentID,
+	)
+	assert.EventuallyWithT(t, func(ac *assert.CollectT) {
+		keys := c.workflow.Scheduler().ListAllKeys(t, ctx, startReminderPrefix)
+		assert.Empty(ac, keys)
+	}, 15*time.Second, 200*time.Millisecond)
+
+	_, err = gclient.RaiseEventWorkflowBeta1(ctx, &rtv1.RaiseEventWorkflowRequest{
+		InstanceId:        parentID,
+		WorkflowComponent: "dapr",
+		EventName:         "wakeup",
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-savedCh:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "parent did not save state after re-execution (fix may not be active)")
+	}
+
+	close(blockedCh)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        parentID,
+			WorkflowComponent: "dapr",
+		})
+		if assert.NoError(c, err) {
+			assert.Equal(c, "COMPLETED", resp.GetRuntimeStatus())
+		}
+	}, 30*time.Second, 500*time.Millisecond)
+
+	assert.True(t, c.store.DidFail(), "injected save failure should have triggered")
+}
+
+type failOnceMultiStore struct {
+	*inmemory.Wrapped
+
+	mu sync.Mutex
+
+	failKeySubstring string
+	failNotifyCh     chan struct{}
+	didFail          atomic.Bool
+
+	watchKeySubstring string
+	watchNotifyCh     chan struct{}
+}
+
+func (s *failOnceMultiStore) Multi(ctx context.Context, req *state.TransactionalStateRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// In-memory state store mutates req.Operations, so capture keys first.
+	keys := make([]string, len(req.Operations))
+	for i, op := range req.Operations {
+		switch v := op.(type) {
+		case state.SetRequest:
+			keys[i] = v.Key
+		case state.DeleteRequest:
+			keys[i] = v.Key
+		}
+	}
+
+	if s.failKeySubstring != "" && containsAny(keys, s.failKeySubstring) {
+		s.didFail.Store(true)
+		if s.failNotifyCh != nil {
+			close(s.failNotifyCh)
+		}
+		s.failKeySubstring = ""
+		s.failNotifyCh = nil
+		return errors.New("injected transient failure for testing")
+	}
+
+	err := s.Wrapped.Store.(state.TransactionalStore).Multi(ctx, req)
+	if err == nil {
+		if s.watchKeySubstring != "" && containsAny(keys, s.watchKeySubstring) {
+			if s.watchNotifyCh != nil {
+				close(s.watchNotifyCh)
+			}
+			s.watchKeySubstring = ""
+			s.watchNotifyCh = nil
+		}
+	}
+
+	return err
+}
+
+func (s *failOnceMultiStore) MultiMaxSize() int {
+	return -1
+}
+
+func (s *failOnceMultiStore) ArmFailureForKey(substring string, failedCh chan struct{}) {
+	s.mu.Lock()
+	s.failNotifyCh = failedCh
+	s.failKeySubstring = substring
+	s.mu.Unlock()
+}
+
+func (s *failOnceMultiStore) WatchForSuccessfulSave(substring string, savedCh chan struct{}) {
+	s.mu.Lock()
+	s.watchNotifyCh = savedCh
+	s.watchKeySubstring = substring
+	s.mu.Unlock()
+}
+
+func (s *failOnceMultiStore) DidFail() bool {
+	return s.didFail.Load()
+}
+
+func containsAny(keys []string, substr string) bool {
+	for _, key := range keys {
+		if strings.Contains(key, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/integration/suite/daprd/workflow/basic/childidempotent.go
+++ b/tests/integration/suite/daprd/workflow/basic/childidempotent.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -58,9 +58,7 @@ const (
 )
 
 func (c *childidempotent) Setup(t *testing.T) []framework.Option {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping unix socket based test on windows")
-	}
+	os.SkipWindows(t)
 
 	c.store = &failOnceMultiStore{Wrapped: inmemory.New(t).(*inmemory.Wrapped)}
 
@@ -158,7 +156,7 @@ func (c *childidempotent) Run(t *testing.T, ctx context.Context) {
 	assert.EventuallyWithT(t, func(ac *assert.CollectT) {
 		keys := c.workflow.Scheduler().ListAllKeys(t, ctx, startReminderPrefix)
 		assert.Empty(ac, keys)
-	}, 15*time.Second, 200*time.Millisecond)
+	}, 15*time.Second, 10*time.Millisecond)
 
 	_, err = gclient.RaiseEventWorkflowBeta1(ctx, &rtv1.RaiseEventWorkflowRequest{
 		InstanceId:        parentID,
@@ -183,7 +181,7 @@ func (c *childidempotent) Run(t *testing.T, ctx context.Context) {
 		if assert.NoError(c, err) {
 			assert.Equal(c, "COMPLETED", resp.GetRuntimeStatus())
 		}
-	}, 30*time.Second, 500*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 
 	assert.True(t, c.store.DidFail(), "injected save failure should have triggered")
 }


### PR DESCRIPTION
Ref: https://github.com/dapr/dapr/issues/9258

When a parent workflow creates a child workflow, `runWorkflow` performs these steps sequentially with no atomicity guarantee. If the pod dies between `callCreateWorkflowStateMessage` and `saveInternalState(parent)`, the child is created successfully in the state store, but the parent's state is never updated to reflect this.

When the parent's reminder retries (every 1 second via the failure policy), it replays the workflow code deterministically and produces the same child creation task again. It then calls `createWorkflowInstance` on the child actor — which finds the child already exists and is active, and returns an error. This error propagates up and causes the reminder to retry indefinitely, and the parent gets permanently stuck. 