### PR TITLE
chore: Use dapr-bot to create backport PRs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -34,4 +34,4 @@ jobs:
     steps:
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DAPR_BOT_TOKEN }}


### PR DESCRIPTION
By [design](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow?utm_source=chatgpt.com#triggering-a-workflow-from-a-workflow), workflows created from workflows don't run other workflows.
A solution is to use a user token instead of the default `GITHUB_TOKEN`.