### PR TITLE
fix(ci): fix gh api command in update-longhauls workflow

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -776,5 +776,6 @@ jobs:
       - name: Parse release version and set REL_VERSION and LATEST_RELEASE
         run: python ./.github/scripts/get_release_version.py ${{ github.event_name }}
       - name: Trigger GitHub workflow
-        run: gh api repos/dapr/test-infra/actions/workflows/version-update.yml/dispatches \
-             -X POST -f ref="master" -f inputs[rel_version]="${{ env.REL_VERSION }}"
+        run: |
+          gh api repos/dapr/test-infra/actions/workflows/version-update.yml/dispatches \
+            -X POST -f ref="master" -f 'inputs[rel_version]=${{ env.REL_VERSION }}'


### PR DESCRIPTION
## Summary
- Fixes the `update-longhauls` job failing with `accepts 1 arg(s), received 3` during the 1.17.0 release workflow
- The `gh api` command used a YAML plain scalar with a `\` line continuation, but YAML replaces newlines with spaces in plain scalars — so the `\` no longer acts as a line continuation and `gh api` receives 3 positional args instead of 1
- Fix uses a YAML block scalar (`|`) to preserve newlines, and quotes `inputs[rel_version]` to prevent shell glob expansion

## Failed run
https://github.com/dapr/dapr/actions/runs/22492749233/job/65162442451

## Test plan
- [x] Verified the YAML block scalar preserves newlines correctly
- [x] The `gh api` command will now receive exactly 1 positional arg (the endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)