### PR TITLE
hotreload: simplify disk loader triggers and move reconciler to event loop

### DIFF
--- a/pkg/operator/api/loops/loops.go
+++ b/pkg/operator/api/loops/loops.go
@@ -25,12 +25,12 @@ type clientbase struct{}
 
 func (*clientbase) isEventClient() {}
 
+// EventStream is the marker interface for events handled by the stream loop.
+type EventStream interface{ isEventStream() }
+
 type streambase struct{}
 
 func (*streambase) isEventStream() {}
-
-// EventStream is the marker interface for events handled by the stream loop.
-type EventStream interface{ isEventStream() }
 
 // ResourceUpdate is an event for a component update from the informer.
 type ResourceUpdate[T meta.Resource] struct {

--- a/pkg/runtime/hotreload/loader/disk/disk.go
+++ b/pkg/runtime/hotreload/loader/disk/disk.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/hotreload/loader"
 	"github.com/dapr/dapr/pkg/runtime/hotreload/loader/store"
 	"github.com/dapr/kit/concurrency"
-	"github.com/dapr/kit/events/batcher"
 	"github.com/dapr/kit/fswatcher"
 	"github.com/dapr/kit/logger"
 	"github.com/dapr/kit/ptr"
@@ -44,7 +43,6 @@ type disk struct {
 	components    *resource[compapi.Component]
 	subscriptions *resource[subapi.Subscription]
 	fs            *fswatcher.FSWatcher
-	batcher       *batcher.Batcher[int, struct{}]
 }
 
 func New(opts Options) (loader.Interface, error) {
@@ -58,10 +56,6 @@ func New(opts Options) (loader.Interface, error) {
 		return nil, fmt.Errorf("failed to create watcher: %w", err)
 	}
 
-	batcher := batcher.New[int, struct{}](batcher.Options{
-		Interval: 0,
-	})
-
 	return &disk{
 		fs: fs,
 		components: newResource[compapi.Component](
@@ -70,8 +64,7 @@ func New(opts Options) (loader.Interface, error) {
 					AppID: opts.AppID,
 					Paths: opts.Dirs,
 				}),
-				store:   store.NewComponents(opts.ComponentStore),
-				batcher: batcher,
+				store: store.NewComponents(opts.ComponentStore),
 			},
 		),
 		subscriptions: newResource[subapi.Subscription](
@@ -80,11 +73,9 @@ func New(opts Options) (loader.Interface, error) {
 					AppID: opts.AppID,
 					Paths: opts.Dirs,
 				}),
-				store:   store.NewSubscriptions(opts.ComponentStore),
-				batcher: batcher,
+				store: store.NewSubscriptions(opts.ComponentStore),
 			},
 		),
-		batcher: batcher,
 	}, nil
 }
 
@@ -98,19 +89,17 @@ func (d *disk) Run(ctx context.Context) error {
 			return d.fs.Run(ctx, eventCh)
 		},
 		func(ctx context.Context) error {
-			defer d.batcher.Close()
-
-			var i int
-
 			for {
 				select {
 				case <-ctx.Done():
 					return nil
 				case <-eventCh:
-					// Use a separate: index every batch to prevent deduplicates of separate
-					// file updates happening at the same time.
-					i++
-					d.batcher.Batch(i, struct{}{})
+					if err := d.components.trigger(ctx); err != nil {
+						return err
+					}
+					if err := d.subscriptions.trigger(ctx); err != nil {
+						return err
+					}
 				}
 			}
 		},

--- a/pkg/runtime/hotreload/loader/disk/resource.go
+++ b/pkg/runtime/hotreload/loader/disk/resource.go
@@ -78,11 +78,9 @@ func (r *resource[T]) Stream(ctx context.Context) (*loader.StreamConn[T], error)
 		ReconcileCh: make(chan struct{}),
 	}
 
-	r.wg.Add(1)
-	go func() {
-		defer r.wg.Done()
+	r.wg.Go(func() {
 		r.streamLoop(ctx, conn)
-	}()
+	})
 
 	return conn, nil
 }

--- a/pkg/runtime/hotreload/loader/disk/resource.go
+++ b/pkg/runtime/hotreload/loader/disk/resource.go
@@ -24,42 +24,36 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/hotreload/differ"
 	"github.com/dapr/dapr/pkg/runtime/hotreload/loader"
 	"github.com/dapr/dapr/pkg/runtime/hotreload/loader/store"
-	"github.com/dapr/kit/events/batcher"
 )
 
 // resource is a generic implementation of a disk resource loader. resource
 // will watch and load resources from disk.
 type resource[T differ.Resource] struct {
-	sourceBatcher *batcher.Batcher[int, struct{}]
-	streamBatcher *batcher.Batcher[int, struct{}]
-	store         store.Store[T]
-	diskLoader    internalloader.Loader[T]
+	store      store.Store[T]
+	diskLoader internalloader.Loader[T]
 
-	lock          sync.RWMutex
-	currentResult *differ.Result[T]
+	triggerCh chan struct{}
+	closeCh   chan struct{}
+	closed    atomic.Bool
+	wg        sync.WaitGroup
 
-	wg      sync.WaitGroup
-	running chan struct{}
-	closeCh chan struct{}
-	closed  atomic.Bool
+	lock       sync.RWMutex
+	diffResult *differ.Result[T]
+	resultCh   chan struct{}
 }
 
 type resourceOptions[T differ.Resource] struct {
-	loader  internalloader.Loader[T]
-	store   store.Store[T]
-	batcher *batcher.Batcher[int, struct{}]
+	loader internalloader.Loader[T]
+	store  store.Store[T]
 }
 
 func newResource[T differ.Resource](opts resourceOptions[T]) *resource[T] {
 	return &resource[T]{
-		sourceBatcher: opts.batcher,
-		store:         opts.store,
-		diskLoader:    opts.loader,
-		streamBatcher: batcher.New[int, struct{}](batcher.Options{
-			Interval: 0,
-		}),
-		running: make(chan struct{}),
-		closeCh: make(chan struct{}),
+		store:      opts.store,
+		diskLoader: opts.loader,
+		triggerCh:  make(chan struct{}, 1),
+		closeCh:    make(chan struct{}),
+		resultCh:   make(chan struct{}, 1),
 	}
 }
 
@@ -84,29 +78,37 @@ func (r *resource[T]) Stream(ctx context.Context) (*loader.StreamConn[T], error)
 		ReconcileCh: make(chan struct{}),
 	}
 
-	batchCh := make(chan struct{})
-	r.streamBatcher.Subscribe(ctx, batchCh)
-
-	r.wg.Go(func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-r.closeCh:
-				return
-			case <-batchCh:
-				r.triggerDiff(ctx, conn)
-			}
-		}
-	})
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		r.streamLoop(ctx, conn)
+	}()
 
 	return conn, nil
 }
 
-func (r *resource[T]) triggerDiff(ctx context.Context, conn *loader.StreamConn[T]) {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
+func (r *resource[T]) streamLoop(ctx context.Context, conn *loader.StreamConn[T]) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.closeCh:
+			return
+		case <-r.resultCh:
+		}
 
+		r.lock.Lock()
+		result := r.diffResult
+		r.diffResult = nil
+		r.lock.Unlock()
+
+		if result != nil {
+			r.sendEvents(ctx, conn, result)
+		}
+	}
+}
+
+func (r *resource[T]) sendEvents(ctx context.Context, conn *loader.StreamConn[T], result *differ.Result[T]) {
 	// Each group is a list of resources which have been created, updated, or
 	// deleted. It is critical that we send the events in the order of deleted,
 	// updated, and created. This ensures we close before initing a resource
@@ -115,9 +117,9 @@ func (r *resource[T]) triggerDiff(ctx context.Context, conn *loader.StreamConn[T
 		resources []T
 		eventType operatorpb.ResourceEventType
 	}{
-		{r.currentResult.Deleted, operatorpb.ResourceEventType_DELETED},
-		{r.currentResult.Updated, operatorpb.ResourceEventType_UPDATED},
-		{r.currentResult.Created, operatorpb.ResourceEventType_CREATED},
+		{result.Deleted, operatorpb.ResourceEventType_DELETED},
+		{result.Updated, operatorpb.ResourceEventType_UPDATED},
+		{result.Created, operatorpb.ResourceEventType_CREATED},
 	} {
 		for _, resource := range group.resources {
 			select {
@@ -134,21 +136,23 @@ func (r *resource[T]) triggerDiff(ctx context.Context, conn *loader.StreamConn[T
 	}
 }
 
+// trigger sends a trigger signal to process file changes.
+func (r *resource[T]) trigger(ctx context.Context) error {
+	select {
+	case r.triggerCh <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (r *resource[T]) run(ctx context.Context) error {
 	defer func() {
 		if r.closed.CompareAndSwap(false, true) {
 			close(r.closeCh)
 		}
-
-		r.streamBatcher.Close()
 		r.wg.Wait()
 	}()
-
-	updateCh := make(chan struct{})
-	r.sourceBatcher.Subscribe(ctx, updateCh)
-	close(r.running)
-
-	var i int
 
 	for {
 		select {
@@ -156,7 +160,7 @@ func (r *resource[T]) run(ctx context.Context) error {
 			return nil
 		case <-r.closeCh:
 			return nil
-		case <-updateCh:
+		case <-r.triggerCh:
 		}
 
 		// List the resources which exist locally (those loaded already), and those
@@ -167,20 +171,20 @@ func (r *resource[T]) run(ctx context.Context) error {
 		}
 
 		// Reconcile the differences between what we have loaded locally, and what
-		// exists on disk.k
+		// exists on disk.
 		result := differ.Diff(resources)
-
-		r.lock.Lock()
-		r.currentResult = result
-		r.lock.Unlock()
-
 		if result == nil {
 			continue
 		}
 
-		// Use a separate: index every batch to prevent deduplicates of separate
-		// file updates happening at the same time.
-		i++
-		r.streamBatcher.Batch(i, struct{}{})
+		r.lock.Lock()
+		r.diffResult = result
+		r.lock.Unlock()
+
+		// Signal that a new result is available
+		select {
+		case r.resultCh <- struct{}{}:
+		default:
+		}
 	}
 }

--- a/pkg/runtime/hotreload/loader/disk/resource_test.go
+++ b/pkg/runtime/hotreload/loader/disk/resource_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	"github.com/dapr/dapr/pkg/runtime/hotreload/loader"
 	loadercompstore "github.com/dapr/dapr/pkg/runtime/hotreload/loader/store"
-	"github.com/dapr/kit/events/batcher"
 )
 
 const (
@@ -145,12 +144,10 @@ func Test_Stream(t *testing.T) {
 		err := os.WriteFile(filepath.Join(dir, "f.yaml"), []byte(strings.Join([]string{comp1, comp2, comp3}, "\n---\n")), 0o600)
 		require.NoError(t, err)
 
-		batcher := batcher.New[int, struct{}](batcher.Options{Interval: 0})
 		store := compstore.New()
 
 		r := newResource[componentsapi.Component](resourceOptions[componentsapi.Component]{
-			store:   loadercompstore.NewComponents(store),
-			batcher: batcher,
+			store: loadercompstore.NewComponents(store),
 			loader: loaderdisk.NewComponents(loaderdisk.Options{
 				Paths: []string{dir},
 			}),
@@ -167,16 +164,11 @@ func Test_Stream(t *testing.T) {
 			errCh <- r.run(ctx)
 		}()
 
-		select {
-		case <-r.running:
-		case <-time.After(time.Second * 3):
-			assert.Fail(t, "expected to be running")
-		}
-
-		batcher.Batch(0, struct{}{})
-
 		conn, err := r.Stream(t.Context())
 		require.NoError(t, err)
+
+		// Send a trigger event to process the files
+		r.trigger(t.Context())
 
 		var events []*loader.Event[componentsapi.Component]
 
@@ -224,7 +216,6 @@ func Test_Stream(t *testing.T) {
 		err := os.WriteFile(filepath.Join(dir, "f.yaml"), []byte(strings.Join([]string{comp1, comp2, comp3}, "\n---\n")), 0o600)
 		require.NoError(t, err)
 
-		batcher := batcher.New[int, struct{}](batcher.Options{Interval: 0})
 		store := compstore.New()
 		require.NoError(t, store.AddPendingComponentForCommit(componentsapi.Component{
 			ObjectMeta: metav1.ObjectMeta{Name: "comp1"},
@@ -234,8 +225,7 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, store.CommitPendingComponent())
 
 		r := newResource[componentsapi.Component](resourceOptions[componentsapi.Component]{
-			store:   loadercompstore.NewComponents(store),
-			batcher: batcher,
+			store: loadercompstore.NewComponents(store),
 			loader: loaderdisk.NewComponents(loaderdisk.Options{
 				Paths: []string{dir},
 			}),
@@ -252,16 +242,11 @@ func Test_Stream(t *testing.T) {
 			errCh <- r.run(ctx)
 		}()
 
-		select {
-		case <-r.running:
-		case <-time.After(time.Second * 3):
-			assert.Fail(t, "expected to be running")
-		}
-
-		batcher.Batch(0, struct{}{})
-
 		conn, err := r.Stream(t.Context())
 		require.NoError(t, err)
+
+		// Send a trigger event to process the files
+		r.trigger(t.Context())
 
 		var events []*loader.Event[componentsapi.Component]
 
@@ -301,7 +286,6 @@ func Test_Stream(t *testing.T) {
 		err := os.WriteFile(filepath.Join(dir, "f.yaml"), []byte(strings.Join([]string{comp2, comp3}, "\n---\n")), 0o600)
 		require.NoError(t, err)
 
-		batcher := batcher.New[int, struct{}](batcher.Options{Interval: 0})
 		store := compstore.New()
 		require.NoError(t, store.AddPendingComponentForCommit(componentsapi.Component{
 			ObjectMeta: metav1.ObjectMeta{Name: "comp1"},
@@ -320,8 +304,7 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, store.CommitPendingComponent())
 
 		r := newResource[componentsapi.Component](resourceOptions[componentsapi.Component]{
-			store:   loadercompstore.NewComponents(store),
-			batcher: batcher,
+			store: loadercompstore.NewComponents(store),
 			loader: loaderdisk.NewComponents(loaderdisk.Options{
 				Paths: []string{dir},
 			}),
@@ -338,16 +321,11 @@ func Test_Stream(t *testing.T) {
 			errCh <- r.run(ctx)
 		}()
 
-		select {
-		case <-r.running:
-		case <-time.After(time.Second * 3):
-			assert.Fail(t, "expected to be running")
-		}
-
-		batcher.Batch(0, struct{}{})
-
 		conn, err := r.Stream(t.Context())
 		require.NoError(t, err)
+
+		// Send a trigger event to process the files
+		r.trigger(t.Context())
 
 		var events []*loader.Event[componentsapi.Component]
 

--- a/pkg/runtime/hotreload/loader/disk/resource_test.go
+++ b/pkg/runtime/hotreload/loader/disk/resource_test.go
@@ -168,7 +168,7 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, err)
 
 		// Send a trigger event to process the files
-		r.trigger(t.Context())
+		require.NoError(t, r.trigger(t.Context()))
 
 		var events []*loader.Event[componentsapi.Component]
 
@@ -246,7 +246,8 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, err)
 
 		// Send a trigger event to process the files
-		r.trigger(t.Context())
+		err = r.trigger(t.Context())
+		require.NoError(t, err)
 
 		var events []*loader.Event[componentsapi.Component]
 
@@ -325,7 +326,7 @@ func Test_Stream(t *testing.T) {
 		require.NoError(t, err)
 
 		// Send a trigger event to process the files
-		r.trigger(t.Context())
+		require.NoError(t, r.trigger(t.Context()))
 
 		var events []*loader.Event[componentsapi.Component]
 

--- a/pkg/runtime/hotreload/reconciler/loops.go
+++ b/pkg/runtime/hotreload/reconciler/loops.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"github.com/dapr/dapr/pkg/runtime/hotreload/differ"
+	"github.com/dapr/dapr/pkg/runtime/hotreload/loader"
+)
+
+type eventbase struct{}
+
+func (*eventbase) isEvent() {}
+
+// Event is a marker interface for reconciler loop events.
+type Event interface{ isEvent() }
+
+// tick signals a periodic reconciliation.
+type tick struct {
+	*eventbase
+}
+
+// reconcile signals a full reconciliation (e.g., after reconnect).
+type reconcile struct {
+	*eventbase
+}
+
+// resourceEvent represents a single resource event from the loader.
+type resourceEvent[T differ.Resource] struct {
+	*eventbase
+	Event *loader.Event[T]
+}
+
+// shutdown signals graceful shutdown.
+type shutdown struct {
+	*eventbase
+	Error error
+}

--- a/pkg/runtime/hotreload/reconciler/reconciler.go
+++ b/pkg/runtime/hotreload/reconciler/reconciler.go
@@ -30,10 +30,15 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/hotreload/differ"
 	"github.com/dapr/dapr/pkg/runtime/hotreload/loader"
 	"github.com/dapr/dapr/pkg/runtime/processor"
+	"github.com/dapr/kit/concurrency"
+	"github.com/dapr/kit/events/loop"
 	"github.com/dapr/kit/logger"
 )
 
-var log = logger.NewLogger("dapr.runtime.hotreload.reconciler")
+var (
+	log         = logger.NewLogger("dapr.runtime.hotreload.reconciler")
+	loopFactory = loop.New[Event](16)
+)
 
 type Options[T differ.Resource] struct {
 	Loader     loader.Interface
@@ -49,6 +54,7 @@ type Reconciler[T differ.Resource] struct {
 	htarget healthz.Target
 
 	clock clock.WithTicker
+	loop  loop.Interface[Event]
 }
 
 type manager[T differ.Resource] interface {
@@ -58,10 +64,10 @@ type manager[T differ.Resource] interface {
 }
 
 func NewComponents(opts Options[compapi.Component]) *Reconciler[compapi.Component] {
-	return &Reconciler[compapi.Component]{
-		clock:   clock.RealClock{},
+	r := &Reconciler[compapi.Component]{
 		kind:    compapi.Kind,
 		htarget: opts.Healthz.AddTarget("component-reconciler"),
+		clock:   clock.RealClock{},
 		manager: &components{
 			Loader: opts.Loader.Components(),
 			store:  opts.CompStore,
@@ -69,19 +75,23 @@ func NewComponents(opts Options[compapi.Component]) *Reconciler[compapi.Componen
 			auth:   opts.Authorizer,
 		},
 	}
+	r.loop = loopFactory.NewLoop(r)
+	return r
 }
 
 func NewSubscriptions(opts Options[subapi.Subscription]) *Reconciler[subapi.Subscription] {
-	return &Reconciler[subapi.Subscription]{
-		clock:   clock.RealClock{},
+	r := &Reconciler[subapi.Subscription]{
 		kind:    subapi.Kind,
 		htarget: opts.Healthz.AddTarget("subscription-reconciler"),
+		clock:   clock.RealClock{},
 		manager: &subscriptions{
 			Loader: opts.Loader.Subscriptions(),
 			store:  opts.CompStore,
 			proc:   opts.Processor,
 		},
 	}
+	r.loop = loopFactory.NewLoop(r)
+	return r
 }
 
 func (r *Reconciler[T]) Run(ctx context.Context) error {
@@ -92,46 +102,102 @@ func (r *Reconciler[T]) Run(ctx context.Context) error {
 
 	r.htarget.Ready()
 
-	return r.watchForEvents(ctx, conn)
-}
-
-func (r *Reconciler[T]) watchForEvents(ctx context.Context, conn *loader.StreamConn[T]) error {
 	log.Infof("Starting to watch %s updates", r.kind)
 
+	defer loopFactory.CacheLoop(r.loop)
+
+	return concurrency.NewRunnerManager(
+		r.loop.Run,
+		r.watchTicker,
+		func(ctx context.Context) error {
+			return r.watchConn(ctx, conn)
+		},
+	).Run(ctx)
+}
+
+func (r *Reconciler[T]) watchTicker(ctx context.Context) error {
 	ticker := r.clock.NewTicker(time.Second * 60)
 	defer ticker.Stop()
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	for {
 		select {
 		case <-ctx.Done():
+			r.loop.Close(&shutdown{Error: ctx.Err()})
 			return nil
 		case <-ticker.C():
-			log.Debugf("Running scheduled %s reconcile", r.kind)
-
-			resources, err := r.manager.List(ctx)
-			if err != nil {
-				log.Errorf("Error listing %s: %s", r.kind, err)
-				continue
-			}
-
-			r.reconcile(ctx, differ.Diff(resources))
-		case <-conn.ReconcileCh:
-			log.Debugf("Reconciling all %s", r.kind)
-
-			resources, err := r.manager.List(ctx)
-			if err != nil {
-				log.Errorf("Error listing %s: %s", r.kind, err)
-				continue
-			}
-
-			r.reconcile(ctx, differ.Diff(resources))
-		case event := <-conn.EventCh:
-			r.handleEvent(ctx, event)
+			r.loop.Enqueue(new(tick))
 		}
 	}
+}
+
+func (r *Reconciler[T]) watchConn(ctx context.Context, conn *loader.StreamConn[T]) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-conn.ReconcileCh:
+			r.loop.Enqueue(new(reconcile))
+		case event := <-conn.EventCh:
+			r.loop.Enqueue(&resourceEvent[T]{Event: event})
+		}
+	}
+}
+
+func (r *Reconciler[T]) Handle(ctx context.Context, event Event) error {
+	switch e := event.(type) {
+	case *tick:
+		r.handleTick(ctx)
+	case *reconcile:
+		r.handleReconcile(ctx)
+	case *resourceEvent[T]:
+		r.handleResourceEvent(ctx, e.Event)
+	case *shutdown:
+		r.handleShutdown(e)
+	default:
+		panic(fmt.Sprintf("unknown reconciler event type: %T", e))
+	}
+
+	return nil
+}
+
+func (r *Reconciler[T]) handleTick(ctx context.Context) {
+	log.Debugf("Running scheduled %s reconcile", r.kind)
+	r.doReconcile(ctx)
+}
+
+func (r *Reconciler[T]) handleReconcile(ctx context.Context) {
+	log.Debugf("Reconciling all %s", r.kind)
+	r.doReconcile(ctx)
+}
+
+func (r *Reconciler[T]) doReconcile(ctx context.Context) {
+	resources, err := r.manager.List(ctx)
+	if err != nil {
+		log.Errorf("Error listing %s: %s", r.kind, err)
+		return
+	}
+
+	r.reconcile(ctx, differ.Diff(resources))
+}
+
+func (r *Reconciler[T]) handleResourceEvent(ctx context.Context, event *loader.Event[T]) {
+	log.Debugf("Received %s event %s: %s", event.Resource.Kind(), event.Type, event.Resource.LogName())
+
+	switch event.Type {
+	case operatorpb.ResourceEventType_CREATED:
+		log.Debugf("Received %s creation: %s", r.kind, event.Resource.LogName())
+		r.manager.update(ctx, event.Resource)
+	case operatorpb.ResourceEventType_UPDATED:
+		log.Debugf("Received %s update: %s", r.kind, event.Resource.LogName())
+		r.manager.update(ctx, event.Resource)
+	case operatorpb.ResourceEventType_DELETED:
+		log.Debugf("Received %s deletion, closing: %s", r.kind, event.Resource.LogName())
+		r.manager.delete(ctx, event.Resource)
+	}
+}
+
+func (r *Reconciler[T]) handleShutdown(e *shutdown) {
+	log.Debugf("reconciler loop shutdown: %v", e.Error)
 }
 
 func (r *Reconciler[T]) reconcile(ctx context.Context, result *differ.Result[T]) {
@@ -153,8 +219,7 @@ func (r *Reconciler[T]) reconcile(ctx context.Context, result *differ.Result[T])
 		for _, resource := range group.resources {
 			go func(resource T, eventType operatorpb.ResourceEventType) {
 				defer wg.Done()
-
-				r.handleEvent(ctx, &loader.Event[T]{
+				r.handleResourceEvent(ctx, &loader.Event[T]{
 					Type:     eventType,
 					Resource: resource,
 				})
@@ -162,21 +227,5 @@ func (r *Reconciler[T]) reconcile(ctx context.Context, result *differ.Result[T])
 		}
 
 		wg.Wait()
-	}
-}
-
-func (r *Reconciler[T]) handleEvent(ctx context.Context, event *loader.Event[T]) {
-	log.Debugf("Received %s event %s: %s", event.Resource.Kind(), event.Type, event.Resource.LogName())
-
-	switch event.Type {
-	case operatorpb.ResourceEventType_CREATED:
-		log.Debugf("Received %s creation: %s", r.kind, event.Resource.LogName())
-		r.manager.update(ctx, event.Resource)
-	case operatorpb.ResourceEventType_UPDATED:
-		log.Debugf("Received %s update: %s", r.kind, event.Resource.LogName())
-		r.manager.update(ctx, event.Resource)
-	case operatorpb.ResourceEventType_DELETED:
-		log.Debugf("Received %s deletion, closing: %s", r.kind, event.Resource.LogName())
-		r.manager.delete(ctx, event.Resource)
 	}
 }

--- a/pkg/runtime/hotreload/reconciler/reconciler_test.go
+++ b/pkg/runtime/hotreload/reconciler/reconciler_test.go
@@ -406,21 +406,21 @@ func Test_handleEvent(t *testing.T) {
 	assert.Equal(t, 0, updateCalled)
 	assert.Equal(t, 0, deleteCalled)
 
-	r.handleEvent(t.Context(), &loader.Event[componentsapi.Component]{
+	r.handleResourceEvent(t.Context(), &loader.Event[componentsapi.Component]{
 		Type:     operator.ResourceEventType_CREATED,
 		Resource: comp1,
 	})
 	assert.Equal(t, 1, updateCalled)
 	assert.Equal(t, 0, deleteCalled)
 
-	r.handleEvent(t.Context(), &loader.Event[componentsapi.Component]{
+	r.handleResourceEvent(t.Context(), &loader.Event[componentsapi.Component]{
 		Type:     operator.ResourceEventType_UPDATED,
 		Resource: comp1,
 	})
 	assert.Equal(t, 2, updateCalled)
 	assert.Equal(t, 0, deleteCalled)
 
-	r.handleEvent(t.Context(), &loader.Event[componentsapi.Component]{
+	r.handleResourceEvent(t.Context(), &loader.Event[componentsapi.Component]{
 		Type:     operator.ResourceEventType_DELETED,
 		Resource: comp1,
 	})


### PR DESCRIPTION
Branched from https://github.com/dapr/dapr/pull/9570

Remove batcher usage from disk hotreload loader and resource pipeline

Trigger component/subscription reload directly on filesystem events

Refactor resource to use trigger/result channels (coalesced signals)
instead of batchers

Split ticker/stream watchers into loop-enqueued events; add graceful
shutdown handling.