### PR TITLE
daprds: Adds SIGHUP handler reloader

### DIFF
--- a/cmd/daprd/app/app.go
+++ b/cmd/daprd/app/app.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"go.opencensus.io/stats/view"
 	"go.uber.org/automaxprocs/maxprocs"
 
 	// Register all components
@@ -167,7 +166,6 @@ func runWithContext(ctx context.Context, opts *options.Options) error {
 				return serr
 			}
 
-			meter := view.NewMeter()
 			rt, rerr := runtime.FromConfig(ctx, &runtime.Config{
 				AppID:                         opts.AppID,
 				ActorsService:                 opts.ActorsService,
@@ -214,7 +212,6 @@ func runWithContext(ctx context.Context, opts *options.Options) error {
 					Namespace:     metrics.DefaultMetricNamespace,
 					Healthz:       healthz,
 					ListenAddress: opts.Metrics.ListenAddress(),
-					Meter:         meter,
 				},
 				AppSSL:         opts.AppSSL,
 				ComponentsPath: opts.ComponentsPath,

--- a/cmd/daprd/app/app.go
+++ b/cmd/daprd/app/app.go
@@ -106,16 +106,26 @@ func Run() {
 
 	defer log.Info("Daprd shutdown gracefully")
 	for {
-		if ctx.Err() != nil {
-			return
-		}
-
 		select {
-		case hctx := <-ctxhupCh:
+		case <-ctx.Done():
+			return
+		case hctx, ok := <-ctxhupCh:
+			if !ok {
+				// Channel is closed, which means the process is shutting down. Return
+				// to exit.
+				return
+			}
+
 			if err := runWithContext(hctx, opts); err != nil {
 				log.Fatalf("Fatal error from runtime: %s", err)
 			}
-		case <-ctx.Done():
+
+			// If hctx was not cancelled, it means the runtime exited on its own
+			// (e.g. via the shutdown API), not because of a SIGHUP or SIGTERM. In
+			// that case, exit the process rather than blocking waiting for a SIGHUP.
+			if hctx.Err() == nil {
+				return
+			}
 		}
 	}
 }

--- a/cmd/daprd/app/app.go
+++ b/cmd/daprd/app/app.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"go.opencensus.io/stats/view"
 	"go.uber.org/automaxprocs/maxprocs"
 
 	// Register all components
@@ -100,6 +101,26 @@ func Run() {
 	conversationLoader.DefaultRegistry.Logger = logContrib
 	httpMiddlewareLoader.DefaultRegistry.Logger = log // Note this uses log on purpose
 
+	ctx := signals.Context()
+	ctxhupCh := signals.OnHUP(ctx)
+
+	defer log.Info("Daprd shutdown gracefully")
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		select {
+		case hctx := <-ctxhupCh:
+			if err := runWithContext(hctx, opts); err != nil {
+				log.Fatalf("Fatal error from runtime: %s", err)
+			}
+		case <-ctx.Done():
+		}
+	}
+}
+
+func runWithContext(ctx context.Context, opts *options.Options) error {
 	reg := registry.NewOptions().
 		WithSecretStores(secretstoresLoader.DefaultRegistry).
 		WithStateStores(stateLoader.DefaultRegistry).
@@ -112,7 +133,6 @@ func Run() {
 		WithHTTPMiddlewares(httpMiddlewareLoader.DefaultRegistry).
 		WithConversations(conversationLoader.DefaultRegistry)
 
-	ctx := signals.Context()
 	healthz := healthz.New()
 	secProvider, err := security.New(ctx, security.Options{
 		SentryAddress:           opts.SentryAddress,
@@ -126,7 +146,7 @@ func Run() {
 		JwtAudiences:            opts.SentryRequestJwtAudiences,
 	})
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	err = concurrency.NewRunnerManager(
@@ -137,6 +157,7 @@ func Run() {
 				return serr
 			}
 
+			meter := view.NewMeter()
 			rt, rerr := runtime.FromConfig(ctx, &runtime.Config{
 				AppID:                         opts.AppID,
 				ActorsService:                 opts.ActorsService,
@@ -183,6 +204,7 @@ func Run() {
 					Namespace:     metrics.DefaultMetricNamespace,
 					Healthz:       healthz,
 					ListenAddress: opts.Metrics.ListenAddress(),
+					Meter:         meter,
 				},
 				AppSSL:         opts.AppSSL,
 				ComponentsPath: opts.ComponentsPath,
@@ -198,7 +220,8 @@ func Run() {
 		},
 	).Run(ctx)
 	if err != nil {
-		log.Fatalf("Fatal error from runtime: %s", err)
+		return err
 	}
-	log.Info("Daprd shutdown gracefully")
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.17.0
 	github.com/dapr/durabletask-go v0.11.1
-	github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1
+	github.com/dapr/kit v0.17.1-0.20260303145220-d749ae76d3c3
 	github.com/diagridio/go-etcd-cron v0.12.4
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0c
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
 github.com/dapr/durabletask-go v0.11.1 h1:URG8YjFqZ4dXj7gkLe3G9ZwKYuJhuF/jNyVx+jPMT8A=
 github.com/dapr/durabletask-go v0.11.1/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
-github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1 h1:3d0l10cbk5RO6ehpfvFHCcJJos+1WRitDLmEOgV+st4=
-github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
+github.com/dapr/kit v0.17.1-0.20260303145220-d749ae76d3c3 h1:noPW1pCxCefI0O19Ay70TX2TwLs5OrnVhfz7aJsOKkM=
+github.com/dapr/kit v0.17.1-0.20260303145220-d749ae76d3c3/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/integration/framework/log/log.go
+++ b/tests/integration/framework/log/log.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Log struct {
-	mu  sync.Mutex
+	mu  sync.RWMutex
 	buf bytes.Buffer
 }
 
@@ -38,8 +38,8 @@ func (b *Log) Close() error {
 }
 
 func (b *Log) Contains(substr string) bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return bytes.Contains(b.buf.Bytes(), []byte(substr))
 }
 

--- a/tests/integration/framework/log/log.go
+++ b/tests/integration/framework/log/log.go
@@ -14,13 +14,13 @@ limitations under the License.
 package log
 
 import (
-	"strings"
+	"bytes"
 	"sync"
 )
 
 type Log struct {
-	mu   sync.Mutex
-	logs []string
+	mu  sync.Mutex
+	buf bytes.Buffer
 }
 
 func New() *Log {
@@ -30,8 +30,7 @@ func New() *Log {
 func (b *Log) Write(p []byte) (n int, err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.logs = append(b.logs, string(p))
-	return len(p), nil
+	return b.buf.Write(p)
 }
 
 func (b *Log) Close() error {
@@ -41,16 +40,11 @@ func (b *Log) Close() error {
 func (b *Log) Contains(substr string) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	for _, log := range b.logs {
-		if strings.Contains(log, substr) {
-			return true
-		}
-	}
-	return false
+	return bytes.Contains(b.buf.Bytes(), []byte(substr))
 }
 
 func (b *Log) Reset() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.logs = nil
+	b.buf.Reset()
 }

--- a/tests/integration/framework/log/log.go
+++ b/tests/integration/framework/log/log.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"strings"
+	"sync"
+)
+
+type Log struct {
+	mu   sync.Mutex
+	logs []string
+}
+
+func New() *Log {
+	return new(Log)
+}
+
+func (b *Log) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.logs = append(b.logs, string(p))
+	return len(p), nil
+}
+
+func (b *Log) Close() error {
+	return nil
+}
+
+func (b *Log) Contains(substr string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, log := range b.logs {
+		if strings.Contains(log, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *Log) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.logs = nil
+}

--- a/tests/integration/framework/os/os.go
+++ b/tests/integration/framework/os/os.go
@@ -32,17 +32,12 @@ func SkipWindows(t *testing.T) {
 
 func WriteFileYaml(t *testing.T, data string) string {
 	t.Helper()
-	return writeFile(t, "yaml", data)
+	f := filepath.Join(t.TempDir(), "test.yaml")
+	require.NoError(t, os.WriteFile(f, []byte(data), 0o600))
+	return f
 }
 
 func WriteFileTo(t *testing.T, name, data string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(name, []byte(data), 0o600))
-}
-
-func writeFile(t *testing.T, fileType, data string) string {
-	t.Helper()
-	f := filepath.Join(t.TempDir(), "test."+fileType)
-	require.NoError(t, os.WriteFile(f, []byte(data), 0o600))
-	return f
 }

--- a/tests/integration/framework/os/os.go
+++ b/tests/integration/framework/os/os.go
@@ -14,8 +14,12 @@ limitations under the License.
 package os
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func SkipWindows(t *testing.T) {
@@ -24,4 +28,21 @@ func SkipWindows(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on windows which relies on unix process signals")
 	}
+}
+
+func WriteFileYaml(t *testing.T, data string) string {
+	t.Helper()
+	return writeFile(t, "yaml", data)
+}
+
+func WriteFileTo(t *testing.T, name, data string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(name, []byte(data), 0o600))
+}
+
+func writeFile(t *testing.T, fileType, data string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "test."+fileType)
+	require.NoError(t, os.WriteFile(f, []byte(data), 0o600))
+	return f
 }

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -513,3 +513,8 @@ func (d *Daprd) Restart(t *testing.T, ctx context.Context) {
 	d.exec = clone
 	d.exec.Run(t, ctx)
 }
+
+func (d *Daprd) SignalHUP(t *testing.T) {
+	t.Helper()
+	d.exec.SignalHUP(t)
+}

--- a/tests/integration/framework/process/exec/exec.go
+++ b/tests/integration/framework/process/exec/exec.go
@@ -158,6 +158,15 @@ func (e *Exec) Kill(t *testing.T) {
 	kill.Kill(t, e.cmd)
 }
 
+func (e *Exec) SignalHUP(t *testing.T) {
+	t.Helper()
+
+	require.NotNil(t, e.cmd, "process should have been started before sending SIGHUP signal")
+	require.NotNil(t, e.cmd.Process, "process should have been started before sending SIGHUP signal")
+
+	kill.SignalHUP(t, e.cmd)
+}
+
 func (e *Exec) checkExit(t *testing.T) {
 	t.Helper()
 

--- a/tests/integration/framework/process/exec/kill/kill.go
+++ b/tests/integration/framework/process/exec/kill/kill.go
@@ -16,6 +16,8 @@ package kill
 import (
 	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Interrupt(t *testing.T, cmd *exec.Cmd) {
@@ -45,9 +47,8 @@ func Kill(t *testing.T, cmd *exec.Cmd) {
 func SignalHUP(t *testing.T, cmd *exec.Cmd) {
 	t.Helper()
 
-	if cmd == nil || cmd.ProcessState != nil {
-		return
-	}
+	require.NotNil(t, cmd, "cmd must not be nil when sending SIGHUP")
+	require.Nil(t, cmd.ProcessState, "process must still be running when sending SIGHUP")
 
 	t.Logf("signaling HUP to %s process", cmd.Path)
 

--- a/tests/integration/framework/process/exec/kill/kill.go
+++ b/tests/integration/framework/process/exec/kill/kill.go
@@ -41,3 +41,15 @@ func Kill(t *testing.T, cmd *exec.Cmd) {
 
 	kill(t, cmd)
 }
+
+func SignalHUP(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+
+	if cmd == nil || cmd.ProcessState != nil {
+		return
+	}
+
+	t.Logf("signaling HUP to %s process", cmd.Path)
+
+	signalHUP(t, cmd)
+}

--- a/tests/integration/framework/process/exec/kill/kill_posix.go
+++ b/tests/integration/framework/process/exec/kill/kill_posix.go
@@ -18,6 +18,7 @@ package kill
 import (
 	"os"
 	"os/exec"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,4 +30,8 @@ func interrupt(t *testing.T, cmd *exec.Cmd) {
 
 func kill(t *testing.T, cmd *exec.Cmd) {
 	require.NoError(t, cmd.Process.Signal(os.Kill))
+}
+
+func signalHUP(t *testing.T, cmd *exec.Cmd) {
+	require.NoError(t, cmd.Process.Signal(syscall.SIGHUP))
 }

--- a/tests/integration/framework/process/exec/kill/kill_windows.go
+++ b/tests/integration/framework/process/exec/kill/kill_windows.go
@@ -33,3 +33,7 @@ func kill(_ *testing.T, cmd *exec.Cmd) {
 	kill.Stderr = os.Stderr
 	kill.Run()
 }
+
+func signalHUP(_ *testing.T, cmd *exec.Cmd) {
+	// no-op on windows
+}

--- a/tests/integration/framework/process/logline/logline.go
+++ b/tests/integration/framework/process/logline/logline.go
@@ -46,6 +46,9 @@ type LogLine struct {
 	outCheck chan map[string]bool
 	done     atomic.Int32
 	doneCh   chan struct{}
+
+	// captureAll enables continuous log capture mode
+	captureAll bool
 }
 
 func New(t *testing.T, fopts ...Option) *LogLine {
@@ -79,6 +82,7 @@ func New(t *testing.T, fopts ...Option) *LogLine {
 		stderrLinContains:  stderrLineContains,
 		outCheck:           make(chan map[string]bool),
 		doneCh:             make(chan struct{}),
+		captureAll:         opts.captureAll,
 	}
 }
 
@@ -127,7 +131,8 @@ func (l *LogLine) checkOut(t *testing.T, ctx context.Context, expLines map[strin
 
 	breader := bufio.NewReader(reader)
 	for {
-		if len(expLines) == 0 {
+		// If not in captureAll mode and no expected lines remain, discard the rest
+		if !l.captureAll && len(expLines) == 0 {
 			go io.Copy(io.Discard, reader)
 			return expLines
 		}
@@ -173,4 +178,29 @@ func (l *LogLine) EventuallyFoundAll(t *testing.T) {
 
 func (l *LogLine) EventuallyFoundNone(t *testing.T) {
 	assert.Eventually(t, l.FoundNone, time.Second*15, time.Millisecond*10)
+}
+
+// Contains checks if the captured log output contains the given substring.
+// This is useful for dynamic log checking during tests.
+func (l *LogLine) Contains(substr string) bool {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return strings.Contains(l.got.String(), substr)
+}
+
+// EventuallyContains waits for the captured log output to contain the given
+// substring within the specified timeout.
+func (l *LogLine) EventuallyContains(t assert.TestingT, substr string, timeout time.Duration, tick time.Duration) bool {
+	return assert.Eventually(t, func() bool {
+		return l.Contains(substr)
+	}, timeout, tick, "expected log to contain: %s", substr)
+}
+
+// Reset clears the captured log buffer. This is useful when testing
+// configuration reloads where you want to verify new log output after
+// a reload without interference from previous log entries.
+func (l *LogLine) Reset() {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.got.Reset()
 }

--- a/tests/integration/framework/process/logline/logline.go
+++ b/tests/integration/framework/process/logline/logline.go
@@ -185,7 +185,7 @@ func (l *LogLine) EventuallyFoundNone(t *testing.T) {
 func (l *LogLine) Contains(substr string) bool {
 	l.lock.Lock()
 	defer l.lock.Unlock()
-	return strings.Contains(l.got.String(), substr)
+	return bytes.Contains(l.got.Bytes(), []byte(substr))
 }
 
 // EventuallyContains waits for the captured log output to contain the given

--- a/tests/integration/framework/process/logline/options.go
+++ b/tests/integration/framework/process/logline/options.go
@@ -17,6 +17,11 @@ package logline
 type options struct {
 	stdoutContains []string
 	stderrContains []string
+	// captureAll enables continuous log capture mode, where all logs are
+	// captured to the buffer even without specific expected lines configured.
+	// This is useful for tests that need to dynamically check log contents
+	// using Contains() or Reset().
+	captureAll bool
 }
 
 func WithStdoutLineContains(lines ...string) func(*options) {
@@ -28,5 +33,15 @@ func WithStdoutLineContains(lines ...string) func(*options) {
 func WithStderrLineContains(lines ...string) func(*options) {
 	return func(o *options) {
 		o.stderrContains = append(o.stderrContains, lines...)
+	}
+}
+
+// WithCaptureAll enables continuous log capture mode, where all logs are
+// captured to the buffer even without specific expected lines configured.
+// This is useful for tests that need to dynamically check log contents
+// using Contains() or Reset().
+func WithCaptureAll() func(*options) {
+	return func(o *options) {
+		o.captureAll = true
 	}
 }

--- a/tests/integration/suite/daprd/hotreload/hotreload.go
+++ b/tests/integration/suite/daprd/hotreload/hotreload.go
@@ -16,4 +16,5 @@ package hotreload
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/sighup"
 )

--- a/tests/integration/suite/daprd/hotreload/sighup/logging.go
+++ b/tests/integration/suite/daprd/hotreload/sighup/logging.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/tests/integration/suite/daprd/hotreload/sighup/logging.go
+++ b/tests/integration/suite/daprd/hotreload/sighup/logging.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sighup
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(logging))
+}
+
+type logging struct {
+	daprd      *daprd.Daprd
+	configFile string
+	log        *log.Log
+}
+
+func (l *logging) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	l.log = log.New()
+
+	config := `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sighup-logging
+spec:
+  logging:
+    apiLogging:
+      enabled: true
+      obfuscateURLs: false
+`
+	l.configFile = os.WriteFileYaml(t, config)
+
+	testApp := app.New(t,
+		app.WithHandlerFunc("/hi", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "OK")
+		}),
+	)
+
+	l.daprd = daprd.New(t,
+		daprd.WithAppPort(testApp.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppID("testapp"),
+		daprd.WithConfigs(l.configFile),
+		daprd.WithExecOptions(exec.WithStdout(l.log)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(testApp, l.daprd),
+	}
+}
+
+func (l *logging) Run(t *testing.T, ctx context.Context) {
+	l.daprd.WaitUntilRunning(t, ctx)
+
+	t.Run("API logs are not obfuscated before SIGHUP", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			l.daprd.HTTPGet2xx(c, ctx, "/v1.0/invoke/testapp/method/hi")
+			assert.True(c, l.log.Contains("/v1.0/invoke/testapp/method/hi"),
+				"expected logs to contain the full path when obfuscateURLs is false")
+		}, 10*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("API logs are obfuscated after SIGHUP", func(t *testing.T) {
+		config := `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sighup-logging
+spec:
+  logging:
+    apiLogging:
+      enabled: true
+      obfuscateURLs: true
+`
+		os.WriteFileTo(t, l.configFile, config)
+
+		l.log.Reset()
+		l.daprd.SignalHUP(t)
+		l.daprd.WaitUntilRunning(t, ctx)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			l.daprd.HTTPGet2xx(c, ctx, "/v1.0/invoke/testapp/method/hi")
+			assert.True(c, l.log.Contains("InvokeService/testapp"),
+				"expected logs to contain obfuscated path 'InvokeService/testapp' when obfuscateURLs is true")
+		}, 10*time.Second, 100*time.Millisecond)
+	})
+}

--- a/tests/integration/suite/daprd/hotreload/sighup/reload.go
+++ b/tests/integration/suite/daprd/hotreload/sighup/reload.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sighup
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(reload))
+}
+
+type reload struct {
+	daprd      *daprd.Daprd
+	configFile string
+	log        *log.Log
+}
+
+func (r *reload) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	r.log = log.New()
+
+	r.configFile = os.WriteFileYaml(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sighup-reload
+spec:
+  metrics:
+    http:
+      increasedCardinality: false
+`)
+
+	testApp := app.New(t,
+		app.WithHandlerFunc("/hi", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "OK")
+		}),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(testApp.Port()),
+		daprd.WithConfigs(r.configFile),
+		daprd.WithExecOptions(exec.WithStdout(r.log), exec.WithStderr(r.log)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(testApp, r.daprd),
+	}
+}
+
+func (r *reload) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, r.log.Contains(`increasedCardinality\":false`),
+			"expected log to show increasedCardinality:false")
+	}, 5*time.Second, 10*time.Millisecond)
+
+	os.WriteFileTo(t, r.configFile, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sighup-reload
+spec:
+  metrics:
+    http:
+      increasedCardinality: true
+`)
+
+	r.log.Reset()
+	r.daprd.SignalHUP(t)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, r.log.Contains(`increasedCardinality\":true`),
+			"expected log to show increasedCardinality:true after SIGHUP")
+	}, 10*time.Second, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/hotreload/sighup/reload.go
+++ b/tests/integration/suite/daprd/hotreload/sighup/reload.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/tests/integration/suite/daprd/hotreload/sighup/tracing.go
+++ b/tests/integration/suite/daprd/hotreload/sighup/tracing.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sighup
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(tracing))
+}
+
+type tracing struct {
+	daprd      *daprd.Daprd
+	configFile string
+	log        *log.Log
+}
+
+func (tr *tracing) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	tr.log = log.New()
+
+	config := `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sighup-tracing
+spec:
+  tracing:
+    samplingRate: "0"
+`
+	tr.configFile = os.WriteFileYaml(t, config)
+
+	testApp := app.New(t,
+		app.WithHandlerFunc("/hi", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "OK")
+		}),
+	)
+
+	tr.daprd = daprd.New(t,
+		daprd.WithAppPort(testApp.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppID("testapp"),
+		daprd.WithConfigs(tr.configFile),
+		daprd.WithExecOptions(exec.WithStdout(tr.log)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(testApp, tr.daprd),
+	}
+}
+
+func (tr *tracing) Run(t *testing.T, ctx context.Context) {
+	tr.daprd.WaitUntilRunning(t, ctx)
+
+	t.Run("initial configuration has sampling rate 0", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, tr.log.Contains("TraceIDRatioBased{0}"),
+				"expected log to show TraceIDRatioBased{0} for sampling rate 0")
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("configuration reloaded with sampling rate 1 after SIGHUP", func(t *testing.T) {
+		config := `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sighup-tracing
+spec:
+  tracing:
+    samplingRate: "1"
+`
+		os.WriteFileTo(t, tr.configFile, config)
+
+		tr.log.Reset()
+		tr.daprd.SignalHUP(t)
+		tr.daprd.WaitUntilRunning(t, ctx)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, tr.log.Contains("AlwaysOnSampler"),
+				"expected log to show AlwaysOnSampler for sampling rate 1 after SIGHUP")
+		}, 10*time.Second, 100*time.Millisecond)
+	})
+}

--- a/tests/integration/suite/daprd/hotreload/sighup/tracing.go
+++ b/tests/integration/suite/daprd/hotreload/sighup/tracing.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
    Adds support to daprd to handle SIGHUP posix signals which will restart
    the daprd runtime in process. This is useful for reloading Configuration
    etc.

    Linking this functionality with the HotReloading feature will be added
    in a follow-up PR.