### PR TITLE
Integration: build stablecomponents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 This is **dapr/dapr**, the Go implementation of the [Dapr](https://dapr.io) distributed application runtime. Dapr is a graduated CNCF project that provides APIs (state management, pub/sub, service invocation, actors, workflows, bindings, secrets, configuration, distributed lock, cryptography) as a sidecar process alongside applications.
 
 **Go module**: `github.com/dapr/dapr`  
-**Go version**: See `go.mod` (currently 1.24.x)  
+**Go version**: See `go.mod` (currently 1.26.x)  
 **License**: Apache 2.0
 
 ---

--- a/cmd/daprd/components/conversation_echo.go
+++ b/cmd/daprd/components/conversation_echo.go
@@ -1,4 +1,4 @@
-//go:build allcomponents
+//go:build allcomponents || conversation_echo
 
 /*
 Copyright 2024 The Dapr Authors

--- a/cmd/daprd/components/crypto_localstorage.go
+++ b/cmd/daprd/components/crypto_localstorage.go
@@ -1,4 +1,4 @@
-//go:build allcomponents
+//go:build allcomponents || crypto_localstorage
 
 /*
 Copyright 2023 The Dapr Authors

--- a/cmd/daprd/components/middleware_http_routeralias.go
+++ b/cmd/daprd/components/middleware_http_routeralias.go
@@ -1,4 +1,4 @@
-//go:build allcomponents
+//go:build allcomponents || middleware_http_routeralias
 
 /*
 Copyright 2021 The Dapr Authors

--- a/cmd/daprd/components/state_etcd.go
+++ b/cmd/daprd/components/state_etcd.go
@@ -1,4 +1,4 @@
-//go:build allcomponents
+//go:build allcomponents || state_etcd
 
 /*
 Copyright 2023 The Dapr Authors

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,6 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/joshvanl/kit v0.0.0-20260302171623-46ea4acf7aed h1:VyHzxzq1DOsx0XQEaZJcJusGjZdazwDMbIbufhkk2Pc=
-github.com/joshvanl/kit v0.0.0-20260302171623-46ea4acf7aed/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -1099,6 +1099,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/kit v0.0.0-20260302171623-46ea4acf7aed h1:VyHzxzq1DOsx0XQEaZJcJusGjZdazwDMbIbufhkk2Pc=
+github.com/joshvanl/kit v0.0.0-20260302171623-46ea4acf7aed/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -35,6 +35,14 @@ type options struct {
 	tags     []string
 }
 
+var buildTags = []string{
+	"stablecomponents",
+	"state_etcd",
+	"crypto_localstorage",
+	"middleware_http_routeralias",
+	"conversation_echo",
+}
+
 func BuildAll(t *testing.T) {
 	t.Helper()
 
@@ -49,7 +57,7 @@ func BuildAll(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			build(t, name, options{
 				dir:  rootDir,
-				tags: []string{"allcomponents"},
+				tags: buildTags,
 			})
 			wg.Done()
 		} else {
@@ -57,7 +65,7 @@ func BuildAll(t *testing.T) {
 				defer wg.Done()
 				build(t, name, options{
 					dir:  rootDir,
-					tags: []string{"allcomponents"},
+					tags: buildTags,
 				})
 			}(name)
 		}


### PR DESCRIPTION
Update the integration binary build to build with the `stablecomponents` build tag, rather than `allcomponents` to speed up the build process in CI.

Also adds per component build tags where needed for integration test dependencies which are not included in the `stablecomponents` build tag.