### PR TITLE
Stalled workflow retention deletion

### DIFF
--- a/docs/release_notes/v1.17.1.md
+++ b/docs/release_notes/v1.17.1.md
@@ -3,6 +3,7 @@
 This update includes bug fixes:
 
 - [WASM binding and middleware components fail to register on non-wasm architectures](#wasm-binding-and-middleware-components-fail-to-register-on-non-wasm-architectures)
+- [Unstalled workflows cannot be deleted by state retention policy](#unstalled-workflows-cannot-be-deleted-by-state-retention-policy)
 
 ## WASM binding and middleware components fail to register on non-wasm architectures
 
@@ -33,3 +34,22 @@ Go applies an [implicit build constraint](https://pkg.go.dev/cmd/go#hdr-Build_co
 Renamed the files back to use the `_webassembly` suffix which does not match any valid `GOARCH` value:
 - `bindings_wasm.go` → `bindings_webassembly.go`
 - `middleware_http_wasm.go` → `middleware_http_webassembly.go`
+
+## Unstalled workflows cannot be deleted by state retention policy
+
+### Problem
+
+When a stalled workflow became unstalled (e.g. by re-registering the original workflow version), the completed workflow instance could not be deleted by the state retention policy or the purge API.
+
+### Impact
+
+Workflow instances that were previously stalled and then unstalled would remain in the state store indefinitely, even when a state retention policy was configured to clean up completed workflows.
+
+### Root Cause
+
+The workflow runtime metadata state tracker did not remove and internal `Stalled` tracker once a workflow became unstalled.
+This prevented pure API calls to complete, even when the workflow was in a `COMPLETED` state.
+
+### Solution
+
+The workflow runtime metadata state tracker now removes the internal `Stalled` tracker when a workflow becomes unstalled, allowing API calls to complete successfully and enabling the state retention policy to clean up completed workflows as expected.

--- a/docs/release_notes/v1.17.1.md
+++ b/docs/release_notes/v1.17.1.md
@@ -47,8 +47,8 @@ Workflow instances that were previously stalled and then unstalled would remain 
 
 ### Root Cause
 
-The workflow runtime metadata state tracker did not remove and internal `Stalled` tracker once a workflow became unstalled.
-This prevented pure API calls to complete, even when the workflow was in a `COMPLETED` state.
+The workflow runtime metadata state tracker did not remove an internal `Stalled` tracker once a workflow became unstalled.
+This prevented purge API calls from completing, even when the workflow was in a `COMPLETED` state.
 
 ### Solution
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.17.0
-	github.com/dapr/durabletask-go v0.11.0
+	github.com/dapr/durabletask-go v0.11.1
 	github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1
 	github.com/diagridio/go-etcd-cron v0.12.4
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,8 @@ github.com/dapr/components-contrib v1.17.0 h1:UIra39ivC0r6Rzt8+UEtiOmyu6hZGhIZfM
 github.com/dapr/components-contrib v1.17.0/go.mod h1:xA5qPPtn8FLMadoHsg9Ks32V4ScTGOBuMa/N6IK5fSc=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.11.0 h1:e9Ns/3a2b6JDKGuvksvx6gCHn7rd+nwZZyAXbg5Ley4=
-github.com/dapr/durabletask-go v0.11.0/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
+github.com/dapr/durabletask-go v0.11.1 h1:URG8YjFqZ4dXj7gkLe3G9ZwKYuJhuF/jNyVx+jPMT8A=
+github.com/dapr/durabletask-go v0.11.1/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
 github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1 h1:3d0l10cbk5RO6ehpfvFHCcJJos+1WRitDLmEOgV+st4=
 github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/pkg/actors/targets/workflow/orchestrator/versioning.go
+++ b/pkg/actors/targets/workflow/orchestrator/versioning.go
@@ -15,7 +15,6 @@ package orchestrator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -23,6 +22,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
@@ -101,7 +101,7 @@ func (o *orchestrator) stallWorkflow(ctx context.Context, state *wfenginestate.S
 
 	<-ctx.Done()
 
-	return errors.New("workflow is stalled")
+	return api.ErrStalled
 }
 
 func collectAllPatches(events []*protos.HistoryEvent) []string {

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
@@ -113,6 +113,6 @@ func (r *retention) Run(t *testing.T, ctx context.Context) {
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		ids, err := client.ListInstanceIDs(ctx)
 		require.NoError(c, err)
-		assert.Len(c, ids.GetInstanceIds(), 0)
+		assert.Empty(c, ids.GetInstanceIds())
 	}, time.Second*10, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
@@ -3,7 +3,7 @@ Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://wwb.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -95,7 +95,9 @@ func (r *retention) Run(t *testing.T, ctx context.Context) {
 	defer cancelClient()
 	client = r.workflow.BackendClient(t, clientCtx)
 
-	assert.NoError(t, client.RaiseEvent(ctx, id, "Continue"))
+	require.EventuallyWithT(t, func(c *require.CollectT) {
+		require.NoError(c, client.RaiseEvent(ctx, id, "Continue"))
+	}, 10*time.Second, 10*time.Millisecond)
 
 	wf.WaitForRuntimeStatus(t, ctx, client, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED)
 

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(retention))
+}
+
+type retention struct {
+	workflow *workflow.Workflow
+}
+
+func (r *retention) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t,
+		workflow.WithDaprdOptions(0, daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: wfpolicy
+spec:
+  workflow:
+    stateRetentionPolicy:
+      completed: "1s"
+`)),
+	)
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *retention) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	var runv1 atomic.Bool
+	var runv2 atomic.Bool
+
+	wf1 := func(ctx *task.OrchestrationContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		runv1.Store(true)
+		return nil, nil
+	}
+
+	r.workflow.Registry().AddVersionedOrchestratorN("workflow", "v1", true, wf1)
+
+	clientCtx, cancelClient := context.WithCancel(ctx)
+	defer cancelClient()
+	client := r.workflow.BackendClient(t, clientCtx)
+	id, err := client.ScheduleNewOrchestration(ctx, "workflow")
+	require.NoError(t, err)
+
+	wf.WaitForOrchestratorStartedEvent(t, ctx, client, id)
+
+	cancelClient()
+	r.workflow.ResetRegistry(t)
+
+	r.workflow.Registry().AddVersionedOrchestratorN("workflow", "v2", true, func(ctx *task.OrchestrationContext) (any, error) {
+		if err = ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		runv2.Store(true)
+		return nil, nil
+	})
+
+	clientCtx, cancelClient = context.WithCancel(ctx)
+	defer cancelClient()
+	client = r.workflow.BackendClient(t, clientCtx)
+
+	assert.NoError(t, client.RaiseEvent(ctx, id, "Continue"))
+
+	wf.WaitForRuntimeStatus(t, ctx, client, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED)
+
+	cancelClient()
+	r.workflow.ResetRegistry(t)
+	r.workflow.Registry().AddVersionedOrchestratorN("workflow", "v1", true, wf1)
+
+	clientCtx, cancelClient = context.WithCancel(ctx)
+	defer cancelClient()
+	client = r.workflow.BackendClient(t, clientCtx)
+	wf.WaitForRuntimeStatus(t, ctx, client, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		ids, err := client.ListInstanceIDs(ctx)
+		require.NoError(c, err)
+		assert.Len(c, ids.GetInstanceIds(), 0)
+	}, time.Second*10, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
@@ -95,7 +95,7 @@ func (r *retention) Run(t *testing.T, ctx context.Context) {
 	defer cancelClient()
 	client = r.workflow.BackendClient(t, clientCtx)
 
-	require.EventuallyWithT(t, func(c *require.CollectT) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		require.NoError(c, client.RaiseEvent(ctx, id, "Continue"))
 	}, 10*time.Second, 10*time.Millisecond)
 


### PR DESCRIPTION
Previously, when a stalled workflow became unstalled, it couldn't be eventualy deleted by the state retention policy because the workflow engine erroneously reported it as still stalled.
Un-stalled completed workflows can now be deleted by the state retention policy and API as expected.