### PR TITLE
Unnecessary placement dissemination for daprd hosts with no actor types

### DIFF
--- a/docs/release_notes/v1.17.1.md
+++ b/docs/release_notes/v1.17.1.md
@@ -4,6 +4,7 @@ This update includes bug fixes:
 
 - [WASM binding and middleware components fail to register on non-wasm architectures](#wasm-binding-and-middleware-components-fail-to-register-on-non-wasm-architectures)
 - [Unstalled workflows cannot be deleted by state retention policy](#unstalled-workflows-cannot-be-deleted-by-state-retention-policy)
+- [Unnecessary placement dissemination for daprd hosts with no actor types](#unnecessary-placement-dissemination-for-daprd-hosts-with-no-actor-types)
 
 ## WASM binding and middleware components fail to register on non-wasm architectures
 
@@ -53,3 +54,21 @@ This prevented purge API calls from completing, even when the workflow was in a 
 ### Solution
 
 The workflow runtime metadata state tracker now removes the internal `Stalled` tracker when a workflow becomes unstalled, allowing API calls to complete successfully and enabling the state retention policy to clean up completed workflows as expected.
+
+## Unnecessary placement dissemination for daprd hosts with no actor types
+
+### Problem
+
+When a daprd sidecar with no actor types connected to or disconnected from the placement service, it triggered a full placement table dissemination across all connected sidecars. In clusters with many sidecars that do not host actors, this caused unnecessary dissemination cycles that degraded placement performance.
+
+### Impact
+
+Every daprd connection and disconnection—even from sidecars with no actor types—triggered a full 3-stage lock dissemination cycle (LOCK → UPDATE → UNLOCK) across all connected sidecars. In large clusters where many sidecars do not host actors, this created significant overhead on the placement service and caused unnecessary locking of actor invocations on all sidecars during each cycle.
+
+### Root Cause
+
+The placement service stored all connected hosts in its dissemination table regardless of whether they reported any actor types (entities). Both connecting and disconnecting these hosts triggered a cluster-wide dissemination cycle to propagate the change, even though the host was never meaningful to actor routing.
+
+### Solution
+
+The placement service no longer stores hosts with no actor types in the dissemination table, and neither their connection nor disconnection triggers a cluster-wide dissemination. Instead, when a no-types host connects, the placement service sends the current placement table directly to that single stream via a one-shot LOCK/UPDATE/UNLOCK sequence, without involving any other connected sidecars. This ensures that sidecars without actor types still receive the placement table for routing actor invocations, while avoiding the destructive cluster-wide lock cycle.

--- a/pkg/placement/internal/loops/disseminator/closeconn.go
+++ b/pkg/placement/internal/loops/disseminator/closeconn.go
@@ -43,6 +43,13 @@ func (d *disseminator) handleCloseStream(closeStream *loops.ConnCloseStream) {
 		return
 	}
 
+	// Only trigger dissemination if the host was actually in the store (had
+	// actor types). Hosts with no entities were never stored, so there is
+	// nothing to remove from the placement table.
+	if !d.store.Has(closeStream.StreamIDx) {
+		return
+	}
+
 	if d.currentOperation != v1pb.HostOperation_REPORT {
 		d.waitingToDelete = append(d.waitingToDelete, closeStream.StreamIDx)
 		return
@@ -56,6 +63,7 @@ func (d *disseminator) handleCloseStream(closeStream *loops.ConnCloseStream) {
 
 	for _, s := range d.streams {
 		s.currentState = v1pb.HostOperation_REPORT
+		s.receivingTable = nil
 		s.loop.Enqueue(&loops.DisseminateLock{
 			Version: d.currentVersion,
 		})

--- a/pkg/placement/internal/loops/disseminator/disseminator.go
+++ b/pkg/placement/internal/loops/disseminator/disseminator.go
@@ -57,6 +57,13 @@ type streamConn struct {
 	loop         loop.Interface[loops.EventStream]
 	currentState v1pb.HostOperation
 	hasActors    bool
+
+	// receivingTable is set to the version of a one-shot table push sent to
+	// this stream. Responses from the client for this version are ignored by
+	// the disseminator since they are not part of the cluster-wide
+	// dissemination protocol. It is set to nil when no table push is in
+	// progress.
+	receivingTable *uint64
 }
 
 // disseminator is a control loop that creates and manages stream connections,

--- a/pkg/placement/internal/loops/disseminator/disseminator.go
+++ b/pkg/placement/internal/loops/disseminator/disseminator.go
@@ -58,11 +58,10 @@ type streamConn struct {
 	currentState v1pb.HostOperation
 	hasActors    bool
 
-	// receivingTable is set to the version of a one-shot table push sent to
-	// this stream. Responses from the client for this version are ignored by
-	// the disseminator since they are not part of the cluster-wide
-	// dissemination protocol. It is set to nil when no table push is in
-	// progress.
+	// receivingTable is set to the version of a one-shot table push sent to this
+	// stream. Responses from the client for this version are ignored by the
+	// disseminator since they are not part of the namespace-wide dissemination
+	// protocol. It is set to nil when no table push is in progress.
 	receivingTable *uint64
 }
 

--- a/pkg/placement/internal/loops/disseminator/host.go
+++ b/pkg/placement/internal/loops/disseminator/host.go
@@ -39,8 +39,8 @@ func (d *disseminator) handleReportedHost(ctx context.Context, report *loops.Rep
 	log.Debugf("Received report from stream (idx:%d) (ns=%s) (appID=%s) (op=%s) (ver=%d)",
 		report.StreamIDx, d.namespace, report.Host.GetId(), op.String(), d.currentVersion)
 
-	// If this stream is receiving a one-shot table push, ignore responses
-	// from that push. They are not part of the cluster-wide dissemination.
+	// If this stream is receiving a one-shot table push, ignore responses from
+	// that push. They are not part of the namespace-wide dissemination.
 	if s, ok := d.streams[report.StreamIDx]; ok && s.receivingTable != nil && op != v1pb.HostOperation_REPORT {
 		//nolint:protogetter
 		if report.Host.Version != nil && *report.Host.Version == *s.receivingTable {
@@ -71,11 +71,13 @@ func (d *disseminator) doReport(streamIDx uint64, host *v1pb.Host) {
 		log.Debugf("No store changes from stream %s:%d",
 			d.namespace, streamIDx)
 
-		// No store changes so skip cluster-wide dissemination. Push the current
-		// placement table directly to this stream only so the daprd can route
-		// actor invocations. The responses from this one-shot table push are
-		// ignored by the disseminator (see receivingTable flag).
-		if s, ok := d.streams[streamIDx]; ok {
+		// No store changes so skip namespace-wide dissemination. If this stream
+		// has no entities (is not in the store), push the current placement table
+		// directly to this stream only so the daprd can route actor invocations.
+		// Streams which _are_ in the store already have the table from a previous
+		// dissemination. The responses from this one-shot table push are ignored
+		// by the disseminator (see receivingTable flag).
+		if s, ok := d.streams[streamIDx]; ok && !d.store.Has(streamIDx) {
 			version := d.currentVersion
 			s.receivingTable = &version
 			s.loop.Enqueue(&loops.DisseminateTable{

--- a/pkg/placement/internal/loops/disseminator/host.go
+++ b/pkg/placement/internal/loops/disseminator/host.go
@@ -39,6 +39,18 @@ func (d *disseminator) handleReportedHost(ctx context.Context, report *loops.Rep
 	log.Debugf("Received report from stream (idx:%d) (ns=%s) (appID=%s) (op=%s) (ver=%d)",
 		report.StreamIDx, d.namespace, report.Host.GetId(), op.String(), d.currentVersion)
 
+	// If this stream is receiving a one-shot table push, ignore responses
+	// from that push. They are not part of the cluster-wide dissemination.
+	if s, ok := d.streams[report.StreamIDx]; ok && s.receivingTable != nil && op != v1pb.HostOperation_REPORT {
+		//nolint:protogetter
+		if report.Host.Version != nil && *report.Host.Version == *s.receivingTable {
+			if op == v1pb.HostOperation_UNLOCK {
+				s.receivingTable = nil
+			}
+			return
+		}
+	}
+
 	switch op {
 	case v1pb.HostOperation_REPORT:
 		d.doReport(report.StreamIDx, report.Host)
@@ -56,8 +68,22 @@ func (d *disseminator) handleReportedHost(ctx context.Context, report *loops.Rep
 
 func (d *disseminator) doReport(streamIDx uint64, host *v1pb.Host) {
 	if !d.store.Set(streamIDx, host) {
-		log.Debugf("Ignoring report from stream %s:%d - no changes",
+		log.Debugf("No store changes from stream %s:%d",
 			d.namespace, streamIDx)
+
+		// No store changes so skip cluster-wide dissemination. Push the current
+		// placement table directly to this stream only so the daprd can route
+		// actor invocations. The responses from this one-shot table push are
+		// ignored by the disseminator (see receivingTable flag).
+		if s, ok := d.streams[streamIDx]; ok {
+			version := d.currentVersion
+			s.receivingTable = &version
+			s.loop.Enqueue(&loops.DisseminateTable{
+				Version: d.currentVersion,
+				Tables:  d.store.PlacementTables(d.currentVersion),
+			})
+		}
+
 		return
 	}
 
@@ -69,6 +95,7 @@ func (d *disseminator) doReport(streamIDx uint64, host *v1pb.Host) {
 
 	for _, s := range d.streams {
 		s.currentState = v1pb.HostOperation_REPORT
+		s.receivingTable = nil
 		s.loop.Enqueue(&loops.DisseminateLock{
 			Version: d.currentVersion,
 		})
@@ -156,6 +183,7 @@ func (d *disseminator) handleReportedUnlock(ctx context.Context, streamIDx uint6
 
 			for _, s := range d.streams {
 				s.currentState = v1pb.HostOperation_REPORT
+				s.receivingTable = nil
 				s.loop.Enqueue(&loops.DisseminateLock{
 					Version: d.currentVersion,
 				})

--- a/pkg/placement/internal/loops/disseminator/store/store.go
+++ b/pkg/placement/internal/loops/disseminator/store/store.go
@@ -87,7 +87,15 @@ func (s *Store) Set(streamIDx uint64, host *v1pb.Host) bool {
 		return false
 	}
 
-	s.hosts[streamIDx] = host
+	// If the host has no entities, it should not be stored in the placement
+	// table. If it previously had entities (i.e. it exists in the store), delete
+	// it to reflect the removal.
+	if len(host.GetEntities()) == 0 {
+		delete(s.hosts, streamIDx)
+	} else {
+		s.hosts[streamIDx] = host
+	}
+
 	return true
 }
 
@@ -96,12 +104,19 @@ func (s *Store) HostChanged(streamIDx uint64, host *v1pb.Host) bool {
 	sort.Strings(host.Entities)
 	existing, ok := s.hosts[streamIDx]
 	if !ok {
-		return true
+		// A new host with no entities has nothing to contribute to the
+		// placement table, so it is not a change.
+		return len(host.GetEntities()) > 0
 	}
 
 	return !slices.Equal(existing.GetEntities(), host.GetEntities()) ||
 		host.GetId() != existing.GetId() ||
 		host.GetNamespace() != existing.GetNamespace()
+}
+
+func (s *Store) Has(streamIDx uint64) bool {
+	_, ok := s.hosts[streamIDx]
+	return ok
 }
 
 func (s *Store) Delete(streamIDx uint64) {

--- a/pkg/placement/internal/loops/loops.go
+++ b/pkg/placement/internal/loops/loops.go
@@ -69,6 +69,16 @@ type DisseminateUnlock struct {
 	Version uint64
 }
 
+// DisseminateTable is a one-shot event that sends the current placement table
+// to a single stream via LOCK+UPDATE+UNLOCK. Unlike the 3-stage dissemination,
+// this does not participate in the cluster-wide lock protocol. It is used to
+// send the current table to newly connected streams that have no actor types.
+type DisseminateTable struct {
+	*streambase
+	Tables  *v1pb.PlacementTables
+	Version uint64
+}
+
 // StreamShutdown is the event for shutting down the placement client stream.
 type StreamShutdown struct {
 	*nsbase

--- a/pkg/placement/internal/loops/stream/dissemination.go
+++ b/pkg/placement/internal/loops/stream/dissemination.go
@@ -57,6 +57,33 @@ func (s *stream) handleUpdate(version uint64, tables *v1pb.PlacementTables) erro
 	})
 }
 
+// handleTable sends a one-shot LOCK+UPDATE+UNLOCK sequence to the stream.
+// This delivers the current placement table without participating in the
+// cluster-wide dissemination protocol.
+func (s *stream) handleTable(version uint64, tables *v1pb.PlacementTables) error {
+	log.Debugf("Sending initial table for version %d to stream %s:%d", version, s.ns, s.idx)
+
+	if err := s.channel.Send(&v1pb.PlacementOrder{
+		Operation: operationLock,
+		Version:   version,
+	}); err != nil {
+		return err
+	}
+
+	if err := s.channel.Send(&v1pb.PlacementOrder{
+		Operation: operationUpdate,
+		Version:   version,
+		Tables:    tables,
+	}); err != nil {
+		return err
+	}
+
+	return s.channel.Send(&v1pb.PlacementOrder{
+		Operation: operationUnlock,
+		Version:   version,
+	})
+}
+
 // handleUnlock sends the unlock operation to the stream.
 func (s *stream) handleUnlock(version uint64) error {
 	// Ignore unlocks for older versions.

--- a/pkg/placement/internal/loops/stream/stream.go
+++ b/pkg/placement/internal/loops/stream/stream.go
@@ -104,6 +104,8 @@ func (s *stream) Handle(ctx context.Context, event loops.EventStream) error {
 		err = s.handleUpdate(e.Version, e.Tables)
 	case *loops.DisseminateUnlock:
 		err = s.handleUnlock(e.Version)
+	case *loops.DisseminateTable:
+		err = s.handleTable(e.Version, e.Tables)
 	case *loops.StreamShutdown:
 		s.handleShutdown(e)
 	default:

--- a/tests/integration/suite/daprd/placement/cluster/basic.go
+++ b/tests/integration/suite/daprd/placement/cluster/basic.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement/cluster"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -76,24 +75,15 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		d.WaitUntilRunning(t, ctx)
 	}
 
-	hosts := make([]placement.Host, 0, len(b.daprds))
-	for _, d := range b.daprds {
-		hosts = append(hosts, placement.Host{
-			Name:      d.InternalGRPCAddress(),
-			ID:        d.AppID(),
-			APIVLevel: 20,
-			Namespace: "default",
-		})
-	}
-
 	leader := b.place.Leader(t, ctx)
 
+	// Daprds in this test have no actor types, so the placement table should
+	// have no hosts.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		table := leader.PlacementTables(t, ctx)
 		if !assert.Contains(c, table.Tables, "default") {
 			return
 		}
-		assert.ElementsMatch(c, hosts, table.Tables["default"].Hosts)
-		assert.GreaterOrEqual(c, table.Tables["default"].Version, uint64(3))
+		assert.Nil(c, table.Tables["default"].Hosts)
 	}, time.Second*30, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/placement/cluster/shutdown.go
+++ b/tests/integration/suite/daprd/placement/cluster/shutdown.go
@@ -76,40 +76,24 @@ func (s *shutdown) Run(t *testing.T, ctx context.Context) {
 		s.WaitUntilRunning(t, ctx)
 	}
 
-	hosts := make([]placement.Host, 0, len(s.daprds))
-	for _, s := range s.daprds {
-		hosts = append(hosts, placement.Host{
-			Name:      s.InternalGRPCAddress(),
-			ID:        s.AppID(),
-			APIVLevel: 20,
-			Namespace: "default",
-		})
-	}
-
 	leader := s.place.Leader(t, ctx)
 
+	// Daprds in this test have no actor types, so the placement table should
+	// have no hosts.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		table := leader.PlacementTables(t, ctx)
-		if !assert.NotNil(c, table.Tables["default"]) {
+		if !assert.Contains(c, table.Tables, "default") {
 			return
 		}
-		assert.ElementsMatch(c, hosts, table.Tables["default"].Hosts)
-		assert.Equal(c, uint64(3), table.Tables["default"].Version)
+		assert.Nil(c, table.Tables["default"].Hosts)
 	}, time.Second*10, time.Millisecond*10)
 
-	for i := range s.daprds[:2] {
-		s.daprds[i].Kill(t)
-		hosts = hosts[1:]
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			table := leader.PlacementTables(t, ctx)
-			if !assert.Contains(c, table.Tables, "default") {
-				return
-			}
-			assert.ElementsMatch(c, hosts, table.Tables["default"].Hosts)
-		}, time.Second*10, time.Millisecond*10)
+	// Kill all daprds.
+	for _, d := range s.daprds {
+		d.Kill(t)
 	}
 
-	s.daprds[2].Kill(t)
+	// After all daprds are killed, the disseminator should be removed.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		table := leader.PlacementTables(t, ctx)
 		assert.Equal(c, &placement.TableState{

--- a/tests/integration/suite/daprd/placement/cluster/workflow.go
+++ b/tests/integration/suite/daprd/placement/cluster/workflow.go
@@ -64,71 +64,116 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 	w.daprd1.WaitUntilRunning(t, ctx)
 	w.daprd2.WaitUntilRunning(t, ctx)
 
-	expTable := &placement.TableState{
-		Tables: map[string]*placement.Table{
-			"default": {
-				Version: 2,
-				Hosts: []placement.Host{
-					{
-						Name:      w.daprd1.InternalGRPCAddress(),
-						ID:        w.daprd1.AppID(),
-						APIVLevel: 20,
-						Namespace: "default",
-					},
-					{
-						Name:      w.daprd2.InternalGRPCAddress(),
-						ID:        w.daprd2.AppID(),
-						APIVLevel: 20,
-						Namespace: "default",
-					},
-				},
-			},
-		},
-	}
-
 	leader := w.place.Leader(t, ctx)
 
-	assert.Equal(t, expTable, leader.PlacementTables(t, ctx))
+	// Neither daprd has actor types registered, so the placement table should
+	// have no hosts.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := leader.PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Nil(c, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
+
+	// Record the version before starting workflow clients.
+	table := leader.PlacementTables(t, ctx)
+	versionBefore := table.Tables["default"].Version
 
 	client1 := dworkflow.NewClient(w.daprd1.GRPCConn(t, ctx))
 	cctx1, cancel1 := context.WithCancel(ctx)
 	t.Cleanup(cancel1)
 	require.NoError(t, client1.StartWorker(cctx1, dworkflow.NewRegistry()))
-	expTable.Tables["default"].Version = 3
-	expTable.Tables["default"].Hosts[0].Entities = []string{
-		"dapr.internal.default." + w.daprd1.AppID() + ".activity",
-		"dapr.internal.default." + w.daprd1.AppID() + ".retentioner",
-		"dapr.internal.default." + w.daprd1.AppID() + ".workflow",
+
+	//nolint:prealloc
+	expHosts := []placement.Host{
+		{
+			Name:      w.daprd1.InternalGRPCAddress(),
+			ID:        w.daprd1.AppID(),
+			APIVLevel: 20,
+			Namespace: "default",
+			Entities: []string{
+				"dapr.internal.default." + w.daprd1.AppID() + ".activity",
+				"dapr.internal.default." + w.daprd1.AppID() + ".retentioner",
+				"dapr.internal.default." + w.daprd1.AppID() + ".workflow",
+			},
+		},
 	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, leader.PlacementTables(t, ctx))
+		table = leader.PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Greater(c, table.Tables["default"].Version, versionBefore)
+		assert.Equal(c, expHosts, table.Tables["default"].Hosts)
 	}, time.Second*10, time.Millisecond*10)
+
+	versionAfterWf1 := table.Tables["default"].Version
 
 	client2 := dworkflow.NewClient(w.daprd2.GRPCConn(t, ctx))
 	cctx2, cancel2 := context.WithCancel(ctx)
 	t.Cleanup(cancel2)
 	require.NoError(t, client2.StartWorker(cctx2, dworkflow.NewRegistry()))
-	expTable.Tables["default"].Version = 4
-	expTable.Tables["default"].Hosts[1].Entities = []string{
-		"dapr.internal.default." + w.daprd2.AppID() + ".activity",
-		"dapr.internal.default." + w.daprd2.AppID() + ".retentioner",
-		"dapr.internal.default." + w.daprd2.AppID() + ".workflow",
-	}
+
+	expHosts = append(expHosts,
+		placement.Host{
+			Name:      w.daprd2.InternalGRPCAddress(),
+			ID:        w.daprd2.AppID(),
+			APIVLevel: 20,
+			Namespace: "default",
+			Entities: []string{
+				"dapr.internal.default." + w.daprd2.AppID() + ".activity",
+				"dapr.internal.default." + w.daprd2.AppID() + ".retentioner",
+				"dapr.internal.default." + w.daprd2.AppID() + ".workflow",
+			},
+		},
+	)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, leader.PlacementTables(t, ctx))
+		table = leader.PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Greater(c, table.Tables["default"].Version, versionAfterWf1)
+		assert.Equal(c, expHosts, table.Tables["default"].Hosts)
 	}, time.Second*10, time.Second)
 
+	versionAfterWf2 := table.Tables["default"].Version
+
+	// After workflow1 stops, daprd1 has no entities and is removed from the
+	// placement table.
 	cancel1()
-	expTable.Tables["default"].Version = 5
-	expTable.Tables["default"].Hosts[0].Entities = nil
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, leader.PlacementTables(t, ctx))
-	}, time.Second*10, time.Second)
+		table = leader.PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Greater(c, table.Tables["default"].Version, versionAfterWf2)
+		assert.Equal(c, []placement.Host{
+			{
+				Name:      w.daprd2.InternalGRPCAddress(),
+				ID:        w.daprd2.AppID(),
+				APIVLevel: 20,
+				Namespace: "default",
+				Entities: []string{
+					"dapr.internal.default." + w.daprd2.AppID() + ".activity",
+					"dapr.internal.default." + w.daprd2.AppID() + ".retentioner",
+					"dapr.internal.default." + w.daprd2.AppID() + ".workflow",
+				},
+			},
+		}, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
 
+	versionAfterCancel1 := table.Tables["default"].Version
+
+	// After workflow2 stops, daprd2 has no entities and is removed from the
+	// placement table.
 	cancel2()
-	expTable.Tables["default"].Version = 6
-	expTable.Tables["default"].Hosts[1].Entities = nil
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, leader.PlacementTables(t, ctx))
-	}, time.Second*10, time.Second)
+		table = leader.PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Greater(c, table.Tables["default"].Version, versionAfterCancel1)
+		assert.Nil(c, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/placement/multiple/basic.go
+++ b/tests/integration/suite/daprd/placement/multiple/basic.go
@@ -18,15 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -35,58 +31,47 @@ func init() {
 }
 
 type basic struct {
-	daprds []*daprd.Daprd
-	place  *placement.Placement
+	actors []*dactors.Actors
 }
 
 func (b *basic) Setup(t *testing.T) []framework.Option {
-	b.place = placement.New(t)
-	scheduler := scheduler.New(t)
-
-	appID, err := uuid.NewUUID()
-	require.NoError(t, err)
-
-	b.daprds = make([]*daprd.Daprd, 3)
-	for i := range 3 {
-		b.daprds[i] = daprd.New(t,
-			daprd.WithPlacementAddresses(b.place.Address()),
-			daprd.WithInMemoryActorStateStore("foo"),
-			daprd.WithScheduler(scheduler),
-			daprd.WithAppID(appID.String()),
-		)
-	}
-
-	procs := make([]process.Interface, 0, 2+len(b.daprds))
-	procs = append(procs,
-		b.place,
-		scheduler,
+	actor1 := dactors.New(t,
+		dactors.WithActorTypes("mytype"),
 	)
-	for _, d := range b.daprds {
-		procs = append(procs, d)
-	}
+	actor2 := dactors.New(t,
+		dactors.WithActorTypes("mytype"),
+		dactors.WithPeerActor(actor1),
+	)
+	actor3 := dactors.New(t,
+		dactors.WithActorTypes("mytype"),
+		dactors.WithPeerActor(actor1),
+	)
+
+	b.actors = []*dactors.Actors{actor1, actor2, actor3}
 
 	return []framework.Option{
-		framework.WithProcesses(procs...),
+		framework.WithProcesses(actor1, actor2, actor3),
 	}
 }
 
 func (b *basic) Run(t *testing.T, ctx context.Context) {
-	for _, d := range b.daprds {
-		d.WaitUntilRunning(t, ctx)
+	for _, a := range b.actors {
+		a.WaitUntilRunning(t, ctx)
 	}
 
-	hosts := make([]placement.Host, 0, len(b.daprds))
-	for _, d := range b.daprds {
+	hosts := make([]placement.Host, 0, len(b.actors))
+	for _, a := range b.actors {
 		hosts = append(hosts, placement.Host{
-			Name:      d.InternalGRPCAddress(),
-			ID:        d.AppID(),
+			Entities:  []string{"mytype"},
+			Name:      a.Daprd().InternalGRPCAddress(),
+			ID:        a.Daprd().AppID(),
 			APIVLevel: 20,
 			Namespace: "default",
 		})
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		table := b.place.PlacementTables(t, ctx)
+		table := b.actors[0].Placement().PlacementTables(t, ctx)
 		if !assert.NotNil(c, table.Tables["default"]) {
 			return
 		}

--- a/tests/integration/suite/daprd/placement/multiple/shutdown.go
+++ b/tests/integration/suite/daprd/placement/multiple/shutdown.go
@@ -18,15 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -35,58 +31,47 @@ func init() {
 }
 
 type shutdown struct {
-	daprds []*daprd.Daprd
-	place  *placement.Placement
+	actors []*dactors.Actors
 }
 
 func (s *shutdown) Setup(t *testing.T) []framework.Option {
-	s.place = placement.New(t)
-	scheduler := scheduler.New(t)
-
-	appID, err := uuid.NewUUID()
-	require.NoError(t, err)
-
-	s.daprds = make([]*daprd.Daprd, 3)
-	for i := range 3 {
-		s.daprds[i] = daprd.New(t,
-			daprd.WithPlacementAddresses(s.place.Address()),
-			daprd.WithInMemoryActorStateStore("foo"),
-			daprd.WithScheduler(scheduler),
-			daprd.WithAppID(appID.String()),
-		)
-	}
-
-	procs := make([]process.Interface, 0, 2+len(s.daprds))
-	procs = append(procs,
-		s.place,
-		scheduler,
+	actor1 := dactors.New(t,
+		dactors.WithActorTypes("mytype"),
 	)
-	for _, d := range s.daprds {
-		procs = append(procs, d)
-	}
+	actor2 := dactors.New(t,
+		dactors.WithActorTypes("mytype"),
+		dactors.WithPeerActor(actor1),
+	)
+	actor3 := dactors.New(t,
+		dactors.WithActorTypes("mytype"),
+		dactors.WithPeerActor(actor1),
+	)
+
+	s.actors = []*dactors.Actors{actor1, actor2, actor3}
 
 	return []framework.Option{
-		framework.WithProcesses(procs...),
+		framework.WithProcesses(actor1, actor2, actor3),
 	}
 }
 
 func (s *shutdown) Run(t *testing.T, ctx context.Context) {
-	for _, s := range s.daprds {
-		s.WaitUntilRunning(t, ctx)
+	for _, a := range s.actors {
+		a.WaitUntilRunning(t, ctx)
 	}
 
-	hosts := make([]placement.Host, 0, len(s.daprds))
-	for _, s := range s.daprds {
+	hosts := make([]placement.Host, 0, len(s.actors))
+	for _, a := range s.actors {
 		hosts = append(hosts, placement.Host{
-			Name:      s.InternalGRPCAddress(),
-			ID:        s.AppID(),
+			Entities:  []string{"mytype"},
+			Name:      a.Daprd().InternalGRPCAddress(),
+			ID:        a.Daprd().AppID(),
 			APIVLevel: 20,
 			Namespace: "default",
 		})
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		table := s.place.PlacementTables(t, ctx)
+		table := s.actors[0].Placement().PlacementTables(t, ctx)
 		if !assert.NotNil(c, table.Tables["default"]) {
 			return
 		}
@@ -94,11 +79,11 @@ func (s *shutdown) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(c, uint64(3), table.Tables["default"].Version)
 	}, time.Second*10, time.Millisecond*10)
 
-	for i := range s.daprds[:2] {
-		s.daprds[i].Cleanup(t)
+	for i := range s.actors[:2] {
+		s.actors[i].Daprd().Cleanup(t)
 		hosts = hosts[1:]
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			table := s.place.PlacementTables(t, ctx)
+			table := s.actors[0].Placement().PlacementTables(t, ctx)
 			if !assert.NotNil(c, table.Tables["default"]) {
 				return
 			}
@@ -106,9 +91,9 @@ func (s *shutdown) Run(t *testing.T, ctx context.Context) {
 		}, time.Second*20, time.Millisecond*10)
 	}
 
-	s.daprds[2].Cleanup(t)
+	s.actors[2].Daprd().Cleanup(t)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		table := s.place.PlacementTables(t, ctx)
+		table := s.actors[0].Placement().PlacementTables(t, ctx)
 		assert.Equal(c, &placement.TableState{
 			Tables: make(map[string]*placement.Table),
 		}, table)

--- a/tests/integration/suite/daprd/placement/multiple/workflow.go
+++ b/tests/integration/suite/daprd/placement/multiple/workflow.go
@@ -22,9 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -34,34 +33,27 @@ func init() {
 }
 
 type workflow struct {
-	daprd1 *daprd.Daprd
-	daprd2 *daprd.Daprd
-	place  *placement.Placement
+	actors1 *dactors.Actors
+	actors2 *dactors.Actors
 }
 
 func (w *workflow) Setup(t *testing.T) []framework.Option {
-	w.place = placement.New(t)
-	scheduler := scheduler.New(t)
-
-	w.daprd1 = daprd.New(t,
-		daprd.WithPlacementAddresses(w.place.Address()),
-		daprd.WithInMemoryActorStateStore("foo"),
-		daprd.WithScheduler(scheduler),
+	w.actors1 = dactors.New(t,
+		dactors.WithActorTypes("mytype"),
 	)
-	w.daprd2 = daprd.New(t,
-		daprd.WithPlacementAddresses(w.place.Address()),
-		daprd.WithInMemoryActorStateStore("foo"),
-		daprd.WithScheduler(scheduler),
+	w.actors2 = dactors.New(t,
+		dactors.WithActorTypes("mytype"),
+		dactors.WithPeerActor(w.actors1),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(w.place, scheduler, w.daprd1, w.daprd2),
+		framework.WithProcesses(w.actors1, w.actors2),
 	}
 }
 
 func (w *workflow) Run(t *testing.T, ctx context.Context) {
-	w.daprd1.WaitUntilRunning(t, ctx)
-	w.daprd2.WaitUntilRunning(t, ctx)
+	w.actors1.WaitUntilRunning(t, ctx)
+	w.actors2.WaitUntilRunning(t, ctx)
 
 	expTable := &placement.TableState{
 		Tables: map[string]*placement.Table{
@@ -69,14 +61,16 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 				Version: 2,
 				Hosts: []placement.Host{
 					{
-						Name:      w.daprd1.InternalGRPCAddress(),
-						ID:        w.daprd1.AppID(),
+						Entities:  []string{"mytype"},
+						Name:      w.actors1.Daprd().InternalGRPCAddress(),
+						ID:        w.actors1.Daprd().AppID(),
 						APIVLevel: 20,
 						Namespace: "default",
 					},
 					{
-						Name:      w.daprd2.InternalGRPCAddress(),
-						ID:        w.daprd2.AppID(),
+						Entities:  []string{"mytype"},
+						Name:      w.actors2.Daprd().InternalGRPCAddress(),
+						ID:        w.actors2.Daprd().AppID(),
 						APIVLevel: 20,
 						Namespace: "default",
 					},
@@ -85,47 +79,49 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 		},
 	}
 
-	assert.Equal(t, expTable, w.place.PlacementTables(t, ctx))
+	assert.Equal(t, expTable, w.actors1.Placement().PlacementTables(t, ctx))
 
-	client1 := dworkflow.NewClient(w.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClient(w.actors1.Daprd().GRPCConn(t, ctx))
 	cctx1, cancel1 := context.WithCancel(ctx)
 	t.Cleanup(cancel1)
 	require.NoError(t, client1.StartWorker(cctx1, dworkflow.NewRegistry()))
 	expTable.Tables["default"].Version = 3
 	expTable.Tables["default"].Hosts[0].Entities = []string{
-		"dapr.internal.default." + w.daprd1.AppID() + ".activity",
-		"dapr.internal.default." + w.daprd1.AppID() + ".retentioner",
-		"dapr.internal.default." + w.daprd1.AppID() + ".workflow",
+		"dapr.internal.default." + w.actors1.Daprd().AppID() + ".activity",
+		"dapr.internal.default." + w.actors1.Daprd().AppID() + ".retentioner",
+		"dapr.internal.default." + w.actors1.Daprd().AppID() + ".workflow",
+		"mytype",
 	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, w.place.PlacementTables(t, ctx))
+		assert.Equal(c, expTable, w.actors1.Placement().PlacementTables(t, ctx))
 	}, time.Second*10, time.Millisecond*10)
 
-	client2 := dworkflow.NewClient(w.daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClient(w.actors2.Daprd().GRPCConn(t, ctx))
 	cctx2, cancel2 := context.WithCancel(ctx)
 	t.Cleanup(cancel2)
 	require.NoError(t, client2.StartWorker(cctx2, dworkflow.NewRegistry()))
 	expTable.Tables["default"].Version = 4
 	expTable.Tables["default"].Hosts[1].Entities = []string{
-		"dapr.internal.default." + w.daprd2.AppID() + ".activity",
-		"dapr.internal.default." + w.daprd2.AppID() + ".retentioner",
-		"dapr.internal.default." + w.daprd2.AppID() + ".workflow",
+		"dapr.internal.default." + w.actors2.Daprd().AppID() + ".activity",
+		"dapr.internal.default." + w.actors2.Daprd().AppID() + ".retentioner",
+		"dapr.internal.default." + w.actors2.Daprd().AppID() + ".workflow",
+		"mytype",
 	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, w.place.PlacementTables(t, ctx))
+		assert.Equal(c, expTable, w.actors1.Placement().PlacementTables(t, ctx))
 	}, time.Second*20, time.Millisecond*10)
 
 	cancel1()
 	expTable.Tables["default"].Version = 5
-	expTable.Tables["default"].Hosts[0].Entities = nil
+	expTable.Tables["default"].Hosts[0].Entities = []string{"mytype"}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, w.place.PlacementTables(t, ctx))
+		assert.Equal(c, expTable, w.actors1.Placement().PlacementTables(t, ctx))
 	}, time.Second*10, time.Second)
 
 	cancel2()
 	expTable.Tables["default"].Version = 6
-	expTable.Tables["default"].Hosts[1].Entities = nil
+	expTable.Tables["default"].Hosts[1].Entities = []string{"mytype"}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, w.place.PlacementTables(t, ctx))
+		assert.Equal(c, expTable, w.actors1.Placement().PlacementTables(t, ctx))
 	}, time.Second*10, time.Second)
 }

--- a/tests/integration/suite/daprd/placement/notypes/invoke.go
+++ b/tests/integration/suite/daprd/placement/notypes/invoke.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notypes
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(invoke))
+}
+
+type invoke struct {
+	noTypes   *actors.Actors
+	withTypes *actors.Actors
+
+	called atomic.Int64
+}
+
+func (i *invoke) Setup(t *testing.T) []framework.Option {
+	i.noTypes = actors.New(t)
+
+	i.withTypes = actors.New(t,
+		actors.WithPeerActor(i.noTypes),
+		actors.WithActorTypes("mytype"),
+		actors.WithActorTypeHandler("mytype", func(nethttp.ResponseWriter, *nethttp.Request) {
+			i.called.Add(1)
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(i.noTypes, i.withTypes),
+	}
+}
+
+func (i *invoke) Run(t *testing.T, ctx context.Context) {
+	i.noTypes.WaitUntilRunning(t, ctx)
+	i.withTypes.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := i.noTypes.Placement().PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Equal(c, []placement.Host{
+			{
+				Entities:  []string{"mytype"},
+				Name:      i.withTypes.Daprd().InternalGRPCAddress(),
+				ID:        i.withTypes.Daprd().AppID(),
+				APIVLevel: 20,
+				Namespace: "default",
+			},
+		}, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
+
+	client := i.noTypes.GRPCClient(t, ctx)
+	_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: "mytype",
+		ActorId:   "1",
+		Method:    "foo",
+	})
+	require.NoError(t, err)
+
+	assert.Positive(t, i.called.Load())
+}

--- a/tests/integration/suite/daprd/placement/notypes/latejoin.go
+++ b/tests/integration/suite/daprd/placement/notypes/latejoin.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notypes
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(lateJoin))
+}
+
+type lateJoin struct {
+	withTypes *actors.Actors
+	noTypes   *actors.Actors
+
+	called atomic.Int64
+}
+
+func (l *lateJoin) Setup(t *testing.T) []framework.Option {
+	l.withTypes = actors.New(t,
+		actors.WithActorTypes("mytype"),
+		actors.WithActorTypeHandler("mytype", func(nethttp.ResponseWriter, *nethttp.Request) {
+			l.called.Add(1)
+		}),
+	)
+
+	l.noTypes = actors.New(t,
+		actors.WithPeerActor(l.withTypes),
+	)
+
+	// Only start the withTypes daprd initially.
+	return []framework.Option{
+		framework.WithProcesses(l.withTypes),
+	}
+}
+
+func (l *lateJoin) Run(t *testing.T, ctx context.Context) {
+	l.withTypes.WaitUntilRunning(t, ctx)
+
+	// Verify placement table has the typed host.
+	expHosts := []placement.Host{
+		{
+			Entities:  []string{"mytype"},
+			Name:      l.withTypes.Daprd().InternalGRPCAddress(),
+			ID:        l.withTypes.Daprd().AppID(),
+			APIVLevel: 20,
+			Namespace: "default",
+		},
+	}
+	table := l.withTypes.Placement().PlacementTables(t, ctx)
+	assert.Equal(t, expHosts, table.Tables["default"].Hosts)
+
+	// Now start the no-types daprd.
+	l.noTypes.Run(t, ctx)
+	t.Cleanup(func() { l.noTypes.Cleanup(t) })
+	l.noTypes.WaitUntilRunning(t, ctx)
+
+	// Wait for the no-types daprd to settle, then record the version.
+	time.Sleep(time.Millisecond * 500)
+	table = l.withTypes.Placement().PlacementTables(t, ctx)
+	assert.Equal(t, expHosts, table.Tables["default"].Hosts)
+	versionAfterJoin := table.Tables["default"].Version
+
+	// The no-types daprd should be able to invoke actors on the withTypes daprd.
+	client := l.noTypes.GRPCClient(t, ctx)
+	_, err := client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: "mytype",
+		ActorId:   "1",
+		Method:    "foo",
+	})
+	require.NoError(t, err)
+
+	assert.Positive(t, l.called.Load())
+
+	// Kill the no-types daprd. The version should remain unchanged since it had
+	// no entities and its disconnection should not trigger dissemination.
+	l.noTypes.Daprd().Cleanup(t)
+	time.Sleep(time.Millisecond * 500)
+	table = l.withTypes.Placement().PlacementTables(t, ctx)
+	assert.Equal(t, expHosts, table.Tables["default"].Hosts)
+	assert.Equal(t, versionAfterJoin, table.Tables["default"].Version)
+}

--- a/tests/integration/suite/daprd/placement/notypes/nodissemination.go
+++ b/tests/integration/suite/daprd/placement/notypes/nodissemination.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notypes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(nodissemination))
+}
+
+// nodissemination tests that multiple daprd instances with no actor types
+// have no hosts in the placement table and that disconnecting does not trigger
+// additional dissemination.
+type nodissemination struct {
+	actors1 *actors.Actors
+	actors2 *actors.Actors
+	actors3 *actors.Actors
+}
+
+func (n *nodissemination) Setup(t *testing.T) []framework.Option {
+	n.actors1 = actors.New(t)
+	n.actors2 = actors.New(t, actors.WithPeerActor(n.actors1))
+	n.actors3 = actors.New(t, actors.WithPeerActor(n.actors1))
+
+	return []framework.Option{
+		framework.WithProcesses(n.actors1, n.actors2, n.actors3),
+	}
+}
+
+func (n *nodissemination) Run(t *testing.T, ctx context.Context) {
+	n.actors1.WaitUntilRunning(t, ctx)
+	n.actors2.WaitUntilRunning(t, ctx)
+	n.actors3.WaitUntilRunning(t, ctx)
+
+	// No daprd has actor types, so the placement table should have no hosts.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := n.actors1.Placement().PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Nil(c, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
+
+	// Record the current version.
+	table := n.actors1.Placement().PlacementTables(t, ctx)
+	versionBefore := table.Tables["default"].Version
+
+	// Kill daprd2 and daprd3. Since they had no entities, their disconnection
+	// should not trigger dissemination and version should remain unchanged.
+	n.actors2.Daprd().Cleanup(t)
+	n.actors3.Daprd().Cleanup(t)
+
+	// Give some time for any erroneous dissemination to propagate.
+	time.Sleep(time.Millisecond * 500)
+
+	table = n.actors1.Placement().PlacementTables(t, ctx)
+	assert.Contains(t, table.Tables, "default")
+	assert.Nil(t, table.Tables["default"].Hosts)
+	assert.Equal(t, versionBefore, table.Tables["default"].Version)
+}

--- a/tests/integration/suite/daprd/placement/notypes/workflow.go
+++ b/tests/integration/suite/daprd/placement/notypes/workflow.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notypes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(workflow))
+}
+
+// workflow tests the lifecycle of a daprd that starts with no actor types,
+// gains types through a workflow client connection, and loses them when the
+// client disconnects.
+type workflow struct {
+	actors *actors.Actors
+}
+
+func (w *workflow) Setup(t *testing.T) []framework.Option {
+	// No actor types registered.
+	w.actors = actors.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(w.actors),
+	}
+}
+
+func (w *workflow) Run(t *testing.T, ctx context.Context) {
+	w.actors.WaitUntilRunning(t, ctx)
+
+	// With no entities, the placement table should have no hosts.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := w.actors.Placement().PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Nil(c, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
+
+	// Record the version after initial connection.
+	table := w.actors.Placement().PlacementTables(t, ctx)
+	initVersion := table.Tables["default"].Version
+
+	// Start a workflow client which will register workflow actor types.
+	client := dworkflow.NewClient(w.actors.GRPCConn(t, ctx))
+	cctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	require.NoError(t, client.StartWorker(cctx, dworkflow.NewRegistry()))
+
+	// Workflow entities should now be registered, triggering dissemination.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table = w.actors.Placement().PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Greater(c, table.Tables["default"].Version, initVersion)
+		assert.Equal(c, []placement.Host{
+			{
+				Name:      w.actors.Daprd().InternalGRPCAddress(),
+				ID:        w.actors.Daprd().AppID(),
+				APIVLevel: 20,
+				Namespace: "default",
+				Entities: []string{
+					"dapr.internal.default." + w.actors.Daprd().AppID() + ".activity",
+					"dapr.internal.default." + w.actors.Daprd().AppID() + ".retentioner",
+					"dapr.internal.default." + w.actors.Daprd().AppID() + ".workflow",
+				},
+			},
+		}, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
+
+	workflowVersion := table.Tables["default"].Version
+
+	// Disconnect the workflow client. The workflow entities should be removed
+	// and the host should be removed from the table since it has no remaining
+	// entities.
+	cancel()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := w.actors.Placement().PlacementTables(t, ctx)
+		if !assert.Contains(c, table.Tables, "default") {
+			return
+		}
+		assert.Greater(c, table.Tables["default"].Version, workflowVersion)
+		assert.Nil(c, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/placement/placement.go
+++ b/tests/integration/suite/daprd/placement/placement.go
@@ -16,5 +16,6 @@ package placement
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/cluster"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/multiple"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/notypes"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/single"
 )

--- a/tests/integration/suite/daprd/placement/single/basic.go
+++ b/tests/integration/suite/daprd/placement/single/basic.go
@@ -20,9 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -31,37 +30,32 @@ func init() {
 }
 
 type basic struct {
-	daprd *daprd.Daprd
-	place *placement.Placement
+	actors *dactors.Actors
 }
 
 func (b *basic) Setup(t *testing.T) []framework.Option {
-	b.place = placement.New(t)
-	scheduler := scheduler.New(t)
-
-	b.daprd = daprd.New(t,
-		daprd.WithPlacementAddresses(b.place.Address()),
-		daprd.WithInMemoryActorStateStore("foo"),
-		daprd.WithScheduler(scheduler),
+	b.actors = dactors.New(t,
+		dactors.WithActorTypes("mytype"),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(b.place, scheduler, b.daprd),
+		framework.WithProcesses(b.actors),
 	}
 }
 
 func (b *basic) Run(t *testing.T, ctx context.Context) {
-	b.daprd.WaitUntilRunning(t, ctx)
+	b.actors.WaitUntilRunning(t, ctx)
 
-	table := b.place.PlacementTables(t, ctx)
+	table := b.actors.Placement().PlacementTables(t, ctx)
 	assert.Equal(t, &placement.TableState{
 		Tables: map[string]*placement.Table{
 			"default": {
 				Version: 1,
 				Hosts: []placement.Host{
 					{
-						Name:      b.daprd.InternalGRPCAddress(),
-						ID:        b.daprd.AppID(),
+						Entities:  []string{"mytype"},
+						Name:      b.actors.Daprd().InternalGRPCAddress(),
+						ID:        b.actors.Daprd().AppID(),
 						APIVLevel: 20,
 						Namespace: "default",
 					},

--- a/tests/integration/suite/daprd/placement/single/shutdown.go
+++ b/tests/integration/suite/daprd/placement/single/shutdown.go
@@ -21,9 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
@@ -32,37 +31,32 @@ func init() {
 }
 
 type shutdown struct {
-	daprd *daprd.Daprd
-	place *placement.Placement
+	actors *dactors.Actors
 }
 
 func (s *shutdown) Setup(t *testing.T) []framework.Option {
-	s.place = placement.New(t)
-	scheduler := scheduler.New(t)
-
-	s.daprd = daprd.New(t,
-		daprd.WithPlacementAddresses(s.place.Address()),
-		daprd.WithInMemoryActorStateStore("foo"),
-		daprd.WithScheduler(scheduler),
+	s.actors = dactors.New(t,
+		dactors.WithActorTypes("mytype"),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(s.place, scheduler, s.daprd),
+		framework.WithProcesses(s.actors),
 	}
 }
 
 func (s *shutdown) Run(t *testing.T, ctx context.Context) {
-	s.daprd.WaitUntilRunning(t, ctx)
+	s.actors.WaitUntilRunning(t, ctx)
 
-	table := s.place.PlacementTables(t, ctx)
+	table := s.actors.Placement().PlacementTables(t, ctx)
 	assert.Equal(t, &placement.TableState{
 		Tables: map[string]*placement.Table{
 			"default": {
 				Version: 1,
 				Hosts: []placement.Host{
 					{
-						Name:      s.daprd.InternalGRPCAddress(),
-						ID:        s.daprd.AppID(),
+						Entities:  []string{"mytype"},
+						Name:      s.actors.Daprd().InternalGRPCAddress(),
+						ID:        s.actors.Daprd().AppID(),
 						APIVLevel: 20,
 						Namespace: "default",
 					},
@@ -71,11 +65,11 @@ func (s *shutdown) Run(t *testing.T, ctx context.Context) {
 		},
 	}, table)
 
-	s.daprd.Cleanup(t)
+	s.actors.Daprd().Cleanup(t)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		table := s.place.PlacementTables(t, ctx)
-		assert.Equal(t, &placement.TableState{
-			Tables: map[string]*placement.Table{},
+		table := s.actors.Placement().PlacementTables(t, ctx)
+		assert.Equal(c, &placement.TableState{
+			Tables: make(map[string]*placement.Table),
 		}, table)
 	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/placement/single/workflow.go
+++ b/tests/integration/suite/daprd/placement/single/workflow.go
@@ -22,9 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -34,27 +33,21 @@ func init() {
 }
 
 type workflow struct {
-	daprd *daprd.Daprd
-	place *placement.Placement
+	actors *dactors.Actors
 }
 
 func (w *workflow) Setup(t *testing.T) []framework.Option {
-	w.place = placement.New(t)
-	scheduler := scheduler.New(t)
-
-	w.daprd = daprd.New(t,
-		daprd.WithPlacementAddresses(w.place.Address()),
-		daprd.WithInMemoryActorStateStore("foo"),
-		daprd.WithScheduler(scheduler),
+	w.actors = dactors.New(t,
+		dactors.WithActorTypes("mytype"),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(w.place, scheduler, w.daprd),
+		framework.WithProcesses(w.actors),
 	}
 }
 
 func (w *workflow) Run(t *testing.T, ctx context.Context) {
-	w.daprd.WaitUntilRunning(t, ctx)
+	w.actors.WaitUntilRunning(t, ctx)
 
 	expTable := &placement.TableState{
 		Tables: map[string]*placement.Table{
@@ -62,8 +55,9 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 				Version: 1,
 				Hosts: []placement.Host{
 					{
-						Name:      w.daprd.InternalGRPCAddress(),
-						ID:        w.daprd.AppID(),
+						Entities:  []string{"mytype"},
+						Name:      w.actors.Daprd().InternalGRPCAddress(),
+						ID:        w.actors.Daprd().AppID(),
 						APIVLevel: 20,
 						Namespace: "default",
 					},
@@ -72,27 +66,28 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 		},
 	}
 
-	assert.Equal(t, expTable, w.place.PlacementTables(t, ctx))
+	assert.Equal(t, expTable, w.actors.Placement().PlacementTables(t, ctx))
 
-	client := dworkflow.NewClient(w.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClient(w.actors.Daprd().GRPCConn(t, ctx))
 	cctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 	require.NoError(t, client.StartWorker(cctx, dworkflow.NewRegistry()))
 
 	expTable.Tables["default"].Version = 2
 	expTable.Tables["default"].Hosts[0].Entities = []string{
-		"dapr.internal.default." + w.daprd.AppID() + ".activity",
-		"dapr.internal.default." + w.daprd.AppID() + ".retentioner",
-		"dapr.internal.default." + w.daprd.AppID() + ".workflow",
+		"dapr.internal.default." + w.actors.Daprd().AppID() + ".activity",
+		"dapr.internal.default." + w.actors.Daprd().AppID() + ".retentioner",
+		"dapr.internal.default." + w.actors.Daprd().AppID() + ".workflow",
+		"mytype",
 	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, w.place.PlacementTables(t, ctx))
+		assert.Equal(c, expTable, w.actors.Placement().PlacementTables(t, ctx))
 	}, time.Second*10, time.Millisecond*10)
 
 	cancel()
 	expTable.Tables["default"].Version = 3
-	expTable.Tables["default"].Hosts[0].Entities = nil
+	expTable.Tables["default"].Hosts[0].Entities = []string{"mytype"}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, expTable, w.place.PlacementTables(t, ctx))
+		assert.Equal(c, expTable, w.actors.Placement().PlacementTables(t, ctx))
 	}, time.Second*10, time.Second)
 }


### PR DESCRIPTION
When a daprd sidecar with no actor types connected to or disconnected from the placement service, it triggered a full placement table dissemination across all connected sidecars. In clusters with many sidecars that do not host actors, this caused unnecessary dissemination cycles that degraded placement performance.

Every daprd connection and disconnection—even from sidecars with no actor types—triggered a full 3-stage lock dissemination cycle (LOCK → UPDATE → UNLOCK) across all connected sidecars. In large clusters where many sidecars do not host actors, this created significant overhead on the placement service and caused unnecessary locking of actor invocations on all sidecars during each cycle.

The placement service stored all connected hosts in its dissemination table regardless of whether they reported any actor types (entities). Both connecting and disconnecting these hosts triggered a cluster-wide dissemination cycle to propagate the change, even though the host was never meaningful to actor routing.

The placement service no longer stores hosts with no actor types in the dissemination table, and neither their connection nor disconnection triggers a cluster-wide dissemination. Instead, when a no-types host connects, the placement service sends the current placement table directly to that single stream via a one-shot LOCK/UPDATE/UNLOCK sequence, without involving any other connected sidecars. This ensures that sidecars without actor types still receive the placement table for routing actor invocations, while avoiding the destructive cluster-wide lock cycle.


Hosts with no actor types (entities) are no longer stored in the
placement dissemination table. Neither their connection nor
disconnection triggers a namespace-wide dissemination cycle.

When a no-types host connects, the placement service sends the current
table directly to that single stream via a one-shot LOCK/UPDATE/UNLOCK
sequence, without involving any other connected sidecars. Responses from
this one-shot push are tracked via a `receivingTable` flag on the stream
connection and ignored by the disseminator state machine, preventing
interference with the namespace-wide lock protocol.
