### PR TITLE
durabletask-go: update to remove unused protos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -522,7 +522,8 @@ replace (
 //
 // replace github.com/dapr/components-contrib => ../components-contrib
 // replace github.com/dapr/kit => ../kit
-// replace github.com/dapr/durabletask-go => ../durabletask-go
+replace github.com/dapr/durabletask-go => github.com/joshvanl/durabletask-go v0.0.0-20260305172919-ea49a5372497
+
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,6 @@ github.com/dapr/components-contrib v1.17.0 h1:UIra39ivC0r6Rzt8+UEtiOmyu6hZGhIZfM
 github.com/dapr/components-contrib v1.17.0/go.mod h1:xA5qPPtn8FLMadoHsg9Ks32V4ScTGOBuMa/N6IK5fSc=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.11.0 h1:e9Ns/3a2b6JDKGuvksvx6gCHn7rd+nwZZyAXbg5Ley4=
-github.com/dapr/durabletask-go v0.11.0/go.mod h1:0Ts4rXp74JyG19gDWPcwNo5V6NBZzhARzHF5XynmA7Q=
 github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1 h1:3d0l10cbk5RO6ehpfvFHCcJJos+1WRitDLmEOgV+st4=
 github.com/dapr/kit v0.17.1-0.20260302165712-2d1983019aa1/go.mod h1:40ZWs5P6xfYf7O59XgwqZkIyDldTIXlhTQhGop8QoSM=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1099,6 +1097,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/durabletask-go v0.0.0-20260305172919-ea49a5372497 h1:xx0TNSPFnk1r9YMhsRKZxpax7dMIblbksEX7jxFtL5g=
+github.com/joshvanl/durabletask-go v0.0.0-20260305172919-ea49a5372497/go.mod h1:omLTzNvLQvpemgQYpKpfQGLMLVzDyUxBePRT/UlwqYI=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=


### PR DESCRIPTION
Based on https://github.com/dapr/durabletask-go/pull/70