### PR TITLE
fix: mark sidecar as not ready when component processing fails

### DIFF
--- a/pkg/runtime/processor/components.go
+++ b/pkg/runtime/processor/components.go
@@ -194,6 +194,7 @@ func (p *Processor) processComponents(ctx context.Context) error {
 		p.pendingComponentsWaiting.RUnlock()
 
 		if err != nil {
+			p.setProcessError(err)
 			return err
 		}
 	}

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -132,6 +132,7 @@ type Processor struct {
 	pendingComponentsWaiting   sync.RWMutex
 	pendingComponentDependents map[string][]componentsapi.Component
 	subErrCh                   chan error
+	processErr                 atomic.Pointer[error]
 
 	lock     sync.RWMutex
 	chlock   sync.RWMutex
@@ -264,6 +265,19 @@ func (p *Processor) Process(ctx context.Context) error {
 			return nil
 		},
 	).Run(ctx)
+}
+
+// setProcessError stores the first processing error encountered.
+func (p *Processor) setProcessError(err error) {
+	p.processErr.CompareAndSwap(nil, &err)
+}
+
+// ProcessError returns the first processing error encountered, or nil if no error occurred.
+func (p *Processor) ProcessError() error {
+	if err := p.processErr.Load(); err != nil {
+		return *err
+	}
+	return nil
 }
 
 // DefaultReporter is the default resource reporter for the registry. It does nothing.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -662,6 +662,11 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 
 	a.flushOutstandingComponents(ctx)
 
+	// Check if there was an error during component processing
+	if procErr := a.processor.ProcessError(); procErr != nil {
+		return fmt.Errorf("failed to process components: %s", procErr)
+	}
+
 	err = a.loadHTTPEndpoints(ctx)
 	if err != nil {
 		log.Warnf("failed to load HTTP endpoints: %s", err)


### PR DESCRIPTION
Fixes #7326

## Summary

When Dapr sidecar encounters component processing failures (e.g., due to missing secrets or invalid configurations), the sidecar was still being marked as Ready despite the failure. This happened because `initRuntime` did not check for errors that occurred during asynchronous component processing after `flushOutstandingComponents` completed.

## Changes

- Added `processErr` field to `Processor` struct to track the first processing error
- Added `setProcessError()` and `ProcessError()` methods to store and retrieve processing errors
- Modified `processComponents()` to store errors before returning
- Added check in `initRuntime()` to verify no processing errors occurred after flushing components
- If a processing error is detected, `initRuntime()` returns an error, preventing the sidecar from being marked as ready

## Testing

Verified changes compile successfully with `go build ./pkg/runtime/...`.

## Diff Stats

 pkg/runtime/processor/components.go |  1 +
 pkg/runtime/processor/processor.go | 14 ++++++++++++++
 pkg/runtime/runtime.go              |  5 +++++
 3 files changed, 20 insertions(+)