### PR TITLE
Fix ServiceInvocation stream buffering

### DIFF
--- a/docs/release_notes/v1.17.2.md
+++ b/docs/release_notes/v1.17.2.md
@@ -6,6 +6,8 @@ This update includes a breaking change and bug fixes:
 - [Pub/sub messages incorrectly routed to dead-letter queue during graceful shutdown](#pubsub-messages-incorrectly-routed-to-dead-letter-queue-during-graceful-shutdown)
 - [Scheduler jobs with Drop failure policy may fire more than once during host reconnection](#scheduler-jobs-with-drop-failure-policy-may-fire-more-than-once-during-host-reconnection)
 - [Scheduler fails to start due to trailing dot in cluster domain DNS lookup](#scheduler-fails-to-start-due-to-trailing-dot-in-cluster-domain-dns-lookup)
+- [Service invocation buffers entire streaming request body in memory](#service-invocation-buffers-entire-streaming-request-body-in-memory)
+- [Service invocation buffers entire streaming error response in memory](#service-invocation-buffers-entire-streaming-error-response-in-memory)
 
 ## Workflow state retention policy CRD fields use incorrect type (Breaking Change)
 
@@ -117,3 +119,48 @@ This caused the etcd peer TLS server name to end with an extra dot, which did no
 ### Solution
 
 Changed `strings.TrimLeft` to `strings.Trim` to strip dots from both ends of the parsed cluster domain, ensuring the trailing dot from DNS CNAME responses is removed.
+
+## Service invocation buffers entire streaming request body in memory
+
+### Problem
+
+When sending a request with a streaming body (chunked transfer encoding) through Dapr HTTP service invocation, the sidecar buffered the entire request body in memory before forwarding it.
+For large payloads—such as file uploads or long-running data streams—this caused excessive memory usage and potential out-of-memory crashes.
+
+### Impact
+
+Any HTTP service invocation request without a known `Content-Length` (e.g. chunked uploads, streamed data, piped bodies) had its entire body buffered in memory by the sending sidecar.
+This made Dapr unsuitable for streaming large payloads between services and could cause sidecar OOM kills in production.
+
+### Root Cause
+
+The sidecar's retry mechanism unconditionally buffered the request body into memory so it could replay the body on retry.
+For streaming requests, the body cannot be replayed because it is consumed as it is read, making the buffering both unnecessary and harmful.
+
+### Solution
+
+The sidecar now detects streaming requests (those with no known content length) and skips request body buffering entirely.
+Both the built-in retry logic and any user-configured resiliency retry policies are automatically bypassed for streaming requests, since retrying would require re-reading a body that has already been consumed.
+Non-streaming requests with a known `Content-Length` continue to support retries as before.
+
+## Service invocation buffers entire streaming error response in memory
+
+### Problem
+
+When a target app returned a non-2xx error response with a large or streaming body through HTTP service invocation, the sidecar read the entire response body into memory before forwarding it to the caller.
+This caused excessive memory usage for large error responses and defeated streaming semantics.
+
+### Impact
+
+Applications returning large error responses (e.g. detailed diagnostic payloads or streaming error bodies) through service invocation could trigger high memory usage or OOM crashes in the receiving sidecar, even though the response only needed to be forwarded through to the caller.
+
+### Root Cause
+
+The sidecar buffered non-2xx response bodies in memory so the resiliency policy could evaluate whether to retry the request.
+When the request itself is a non-replayable stream, retries are impossible regardless of the response, making the buffering unnecessary.
+
+### Solution
+
+For streaming requests where retries are not possible, the sidecar now streams non-2xx error responses directly to the caller without buffering the body in memory.
+The caller receives both the correct HTTP status code and the full response body.
+For non-streaming requests where retries are still possible, the existing buffered error handling behavior is preserved.

--- a/docs/release_notes/v1.17.2.md
+++ b/docs/release_notes/v1.17.2.md
@@ -7,7 +7,7 @@ This update includes a breaking change and bug fixes:
 - [Scheduler jobs with Drop failure policy may fire more than once during host reconnection](#scheduler-jobs-with-drop-failure-policy-may-fire-more-than-once-during-host-reconnection)
 - [Scheduler fails to start due to trailing dot in cluster domain DNS lookup](#scheduler-fails-to-start-due-to-trailing-dot-in-cluster-domain-dns-lookup)
 - [Service invocation buffers entire streaming request body in memory](#service-invocation-buffers-entire-streaming-request-body-in-memory)
-- [Service invocation buffers entire streaming error response in memory](#service-invocation-buffers-entire-streaming-error-response-in-memory)
+- [Service invocation buffers entire streaming response body in memory](#service-invocation-buffers-entire-streaming-response-body-in-memory)
 
 ## Workflow state retention policy CRD fields use incorrect type (Breaking Change)
 
@@ -143,24 +143,25 @@ The sidecar now detects streaming requests (those with no known content length) 
 Both the built-in retry logic and any user-configured resiliency retry policies are automatically bypassed for streaming requests, since retrying would require re-reading a body that has already been consumed.
 Non-streaming requests with a known `Content-Length` continue to support retries as before.
 
-## Service invocation buffers entire streaming error response in memory
+## Service invocation buffers entire streaming response body in memory
 
 ### Problem
 
-When a target app returned a non-2xx error response with a large or streaming body through HTTP service invocation, the sidecar read the entire response body into memory before forwarding it to the caller.
-This caused excessive memory usage for large error responses and defeated streaming semantics.
+When proxying HTTP responses through service invocation, the sidecar buffered the entire response body in memory before forwarding it to the caller.
+For large or unbounded streaming responses, this caused excessive memory usage and potential out-of-memory crashes.
 
 ### Impact
 
-Applications returning large error responses (e.g. detailed diagnostic payloads or streaming error bodies) through service invocation could trigger high memory usage or OOM crashes in the receiving sidecar, even though the response only needed to be forwarded through to the caller.
+Any service invocation response with a large or streaming body could cause sidecar OOM kills, regardless of HTTP status code.
+This made Dapr unsuitable for proxying streaming responses such as server-sent events, file downloads, or long-running data streams between services.
 
 ### Root Cause
 
-The sidecar buffered non-2xx response bodies in memory so the resiliency policy could evaluate whether to retry the request.
-When the request itself is a non-replayable stream, retries are impossible regardless of the response, making the buffering unnecessary.
+The sidecar's resiliency mechanism read the full response body into memory so it could evaluate whether to retry the request.
+When the request itself is a stream that has already been consumed, retries are impossible regardless of the response, making the buffering unnecessary.
 
 ### Solution
 
-For streaming requests where retries are not possible, the sidecar now streams non-2xx error responses directly to the caller without buffering the body in memory.
-The caller receives both the correct HTTP status code and the full response body.
-For non-streaming requests where retries are still possible, the existing buffered error handling behavior is preserved.
+For streaming requests, the sidecar now forwards response bodies directly to the caller without buffering them in memory.
+Resiliency features like circuit breakers continue to track failures normally.
+Non-streaming requests continue to support retries and buffered error handling as before.

--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -177,6 +177,14 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 			if status.Code(rErr) == codes.PermissionDenied {
 				invokeErr.statusCode = invokev1.HTTPStatusFromCode(codes.PermissionDenied)
 			}
+
+			// For streaming requests, wrap transport errors as permanent
+			// to prevent the resiliency policy from retrying with a
+			// consumed (empty) request body.
+			if req.IsStreamingRequest() {
+				return rResp, backoff.Permanent(invokeErr)
+			}
+
 			return rResp, invokeErr
 		}
 
@@ -294,8 +302,17 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 	// If success is true, it means that headers have already been sent, so we can't send the error to the user, because:
 	// headers cannot be re-sent, and adding to response body may cause corrupted data to be sent
 	if success.Load() {
-		// Use Warn log here because it's the only way users are notified of the error
-		log.Warnf("HTTP service invocation failed to complete with error: %v", err)
+		// For streaming requests with non-2xx responses, a CodeError is
+		// returned solely for circuit breaker accounting after the
+		// response was already successfully forwarded. Use debug level
+		// since this is expected behavior, not a failure.
+		var resCodeErr resiliency.CodeError
+		if errors.As(err, &resCodeErr) {
+			log.Debugf("HTTP service invocation completed with non-success status: %v", err)
+		} else {
+			// Use Warn log here because it's the only way users are notified of the error
+			log.Warnf("HTTP service invocation failed to complete with error: %v", err)
+		}
 
 		// Do nothing else, as at least some data was already sent to the client
 		return

--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -144,6 +144,12 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 		// Save headers to internal metadata
 		WithHTTPHeaders(r.Header).
 		WithHTTPResponseWriter(w)
+	// For streaming requests (chunked transfer / unknown content length),
+	// disable replay to prevent buffering the entire body in memory.
+	// ContentLength is -1 when Transfer-Encoding is chunked or Content-Length is absent.
+	if r.ContentLength < 0 {
+		req.SetStreamingRequest()
+	}
 	if policyDef != nil {
 		req.WithReplay(policyDef.HasRetries())
 	}
@@ -202,14 +208,25 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 				resStatus.Code = statusCode
 			}
 		} else if resStatus.GetCode() < 200 || resStatus.GetCode() > 399 {
-			msg, _ := rResp.RawDataFull()
-			// Returning a `codeError` here will cause Resiliency to retry the request (if retries are enabled), but if the request continues to fail, the response is sent to the user with whatever status code the app returned.
-			return rResp, resiliency.NewCodeError(resStatus.GetCode(), codeError{
-				headers:     rResp.Headers(),
-				statusCode:  int(resStatus.GetCode()),
-				msg:         msg,
-				contentType: rResp.ContentType(),
-			})
+			if !req.IsStreamingRequest() {
+				// For non-streaming requests, buffer the error response body
+				// so the resiliency policy can retry and, if retries are
+				// exhausted, return the error to the caller.
+				msg, _ := rResp.RawDataFull()
+				return rResp, resiliency.NewCodeError(resStatus.GetCode(), codeError{
+					headers:     rResp.Headers(),
+					statusCode:  int(resStatus.GetCode()),
+					msg:         msg,
+					contentType: rResp.ContentType(),
+				})
+			}
+
+			// For streaming requests, we can't buffer the response body
+			// (it may be arbitrarily large) and can't retry (request body
+			// already consumed). Stream the error response directly to
+			// the caller, then return a permanent CodeError so circuit
+			// breakers still count the failure without triggering retries.
+			// Fall through to the streaming response path below.
 		}
 
 		// If we get to this point, we must consider the operation as successful, so we invoke this only once and we consider all errors returned by this to be permanent (so the policy function doesn't retry)
@@ -233,23 +250,35 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 		reader := rResp.RawData()
 		isSSE := sse.IsSSEHttpRequest(r)
 
+		statusCode := int(rResp.Status().GetCode())
+
 		if !isSSE {
-			w.WriteHeader(int(rResp.Status().GetCode()))
-			// Use regular io.Copy for non-streaming responses
+			w.WriteHeader(statusCode)
 			_, rErr = io.Copy(w, reader)
 			if rErr != nil {
 				// Do not return rResp here, we already have a deferred `Close` call on it
 				return nil, backoff.Permanent(rErr)
 			}
-
-			return nil, nil
+		} else {
+			sse.AddSSEHeaders(w)
+			w.WriteHeader(statusCode)
+			sseErr := sse.FlushSSEResponse(r.Context(), w, reader)
+			if sseErr != nil {
+				return nil, backoff.Permanent(sseErr)
+			}
 		}
 
-		sse.AddSSEHeaders(w)
-		w.WriteHeader(int(rResp.Status().GetCode()))
-		err := sse.FlushSSEResponse(r.Context(), w, reader)
-		if err != nil {
-			return nil, backoff.Permanent(err)
+		// For streaming requests with non-2xx responses, return a
+		// permanent CodeError so circuit breakers count the failure.
+		// The response has already been written to the caller above.
+		// "Permanent" prevents retries (which are impossible for
+		// streaming requests anyway), and the error handler sees
+		// success==true so it won't try to write the response again.
+		if req.IsStreamingRequest() && (statusCode < 200 || statusCode > 399) {
+			return nil, backoff.Permanent(
+				//nolint:gosec
+				resiliency.NewCodeError(int32(statusCode), errors.New("streaming request received non-2xx response")),
+			)
 		}
 
 		// Do not return rResp here, we already have a deferred `Close` call on it

--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -193,6 +193,8 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 			return nil, nil
 		}
 
+		defer rResp.Close()
+
 		// Construct response if not HTTP
 		resStatus := rResp.Status()
 		if !rResp.IsHTTPResponse() {
@@ -215,26 +217,21 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 			} else {
 				resStatus.Code = statusCode
 			}
-		} else if resStatus.GetCode() < 200 || resStatus.GetCode() > 399 {
-			if !req.IsStreamingRequest() {
-				// Non-streaming request: buffer the error response body
-				// for the resiliency policy to evaluate and potentially
-				// retry.
-				msg, _ := rResp.RawDataFull()
-				return rResp, resiliency.NewCodeError(resStatus.GetCode(), codeError{
-					headers:     rResp.Headers(),
-					statusCode:  int(resStatus.GetCode()),
-					msg:         msg,
-					contentType: rResp.ContentType(),
-				})
-			}
-
-			// Streaming request: retries are impossible. Stream the
-			// error response directly to the caller, then return a
-			// permanent CodeError so circuit breakers still count the
-			// failure.
-			// Fall through to the streaming response path below.
+		} else if !req.IsStreamingRequest() && (resStatus.GetCode() < 200 || resStatus.GetCode() > 399) {
+			// Non-streaming request with non-2xx response: buffer the
+			// error response body for the resiliency policy to evaluate
+			// and potentially retry.
+			msg, _ := rResp.RawDataFull()
+			return rResp, resiliency.NewCodeError(resStatus.GetCode(), codeError{
+				headers:     rResp.Headers(),
+				statusCode:  int(resStatus.GetCode()),
+				msg:         msg,
+				contentType: rResp.ContentType(),
+			})
 		}
+		// For streaming requests with non-2xx responses, retries are
+		// impossible so we fall through to stream the response directly
+		// to the caller.
 
 		// If we get to this point, we must consider the operation as successful, so we invoke this only once and we consider all errors returned by this to be permanent (so the policy function doesn't retry)
 		// We still need to be within the policy function because if we return, the context passed to `Invoke` is canceled, so the `Copy` operation below can fail with a ContextCanceled error
@@ -247,8 +244,6 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 		if len(headers) > 0 {
 			invokev1.InternalMetadataToHTTPHeader(r.Context(), headers, w.Header().Add)
 		}
-
-		defer rResp.Close()
 
 		if ct := rResp.ContentType(); ct != "" {
 			w.Header().Set("content-type", ct)

--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -178,9 +178,9 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 				invokeErr.statusCode = invokev1.HTTPStatusFromCode(codes.PermissionDenied)
 			}
 
-			// For streaming requests, wrap transport errors as permanent
-			// to prevent the resiliency policy from retrying with a
-			// consumed (empty) request body.
+			// If this is a streaming request, wrap transport errors as
+			// permanent to prevent the resiliency policy from retrying
+			// with a consumed (empty) request body.
 			if req.IsStreamingRequest() {
 				return rResp, backoff.Permanent(invokeErr)
 			}
@@ -217,9 +217,9 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 			}
 		} else if resStatus.GetCode() < 200 || resStatus.GetCode() > 399 {
 			if !req.IsStreamingRequest() {
-				// For non-streaming requests, buffer the error response body
-				// so the resiliency policy can retry and, if retries are
-				// exhausted, return the error to the caller.
+				// Non-streaming request: buffer the error response body
+				// for the resiliency policy to evaluate and potentially
+				// retry.
 				msg, _ := rResp.RawDataFull()
 				return rResp, resiliency.NewCodeError(resStatus.GetCode(), codeError{
 					headers:     rResp.Headers(),
@@ -229,11 +229,10 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 				})
 			}
 
-			// For streaming requests, we can't buffer the response body
-			// (it may be arbitrarily large) and can't retry (request body
-			// already consumed). Stream the error response directly to
-			// the caller, then return a permanent CodeError so circuit
-			// breakers still count the failure without triggering retries.
+			// Streaming request: retries are impossible. Stream the
+			// error response directly to the caller, then return a
+			// permanent CodeError so circuit breakers still count the
+			// failure.
 			// Fall through to the streaming response path below.
 		}
 

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -212,7 +212,16 @@ func (d *directMessaging) invokeWithRetry(
 	req *invokev1.InvokeMethodRequest,
 ) (*invokev1.InvokeMethodResponse, error) {
 	if !d.resiliency.PolicyDefined(app.id, resiliency.EndpointPolicy{}) {
-		// This policy has built-in retries so enable replay in the request
+		// Streaming requests cannot be retried since the body has already
+		// been consumed, so invoke once and return immediately.
+		if req.IsStreamingRequest() {
+			log.Debugf("Skipping built-in retries for streaming request to app '%s' as request body cannot be replayed", app.id)
+			resp, teardown, err := fn(ctx, app.id, app.namespace, app.address, req)
+			teardown(false)
+			return resp, err
+		}
+
+		// Enable body buffering so the request can be replayed on retry.
 		req.WithReplay(true)
 
 		policyRunner := resiliency.NewRunnerWithOptions(ctx,

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -211,16 +211,7 @@ func (d *directMessaging) invokeWithRetry(
 	fn func(ctx context.Context, appID, namespace, appAddress string, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, func(destroy bool), error),
 	req *invokev1.InvokeMethodRequest,
 ) (*invokev1.InvokeMethodResponse, error) {
-	if !d.resiliency.PolicyDefined(app.id, resiliency.EndpointPolicy{}) {
-		// Streaming requests cannot be retried since the body has already
-		// been consumed, so invoke once and return immediately.
-		if req.IsStreamingRequest() {
-			log.Debugf("Skipping built-in retries for streaming request to app '%s' as request body cannot be replayed", app.id)
-			resp, teardown, err := fn(ctx, app.id, app.namespace, app.address, req)
-			teardown(false)
-			return resp, err
-		}
-
+	if !d.resiliency.PolicyDefined(app.id, resiliency.EndpointPolicy{}) && !req.IsStreamingRequest() {
 		// Enable body buffering so the request can be replayed on retry.
 		req.WithReplay(true)
 

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -41,6 +41,11 @@ type InvokeMethodRequest struct {
 	dataObject         any
 	dataTypeURL        string
 	httpResponseWriter http.ResponseWriter
+	// streamingRequest is set when the request body is a stream that cannot be
+	// replayed (e.g. chunked-transfer / unknown content-length).
+	// When true, WithReplay becomes a no-op to prevent the entire body
+	// from being buffered into memory for retry purposes.
+	streamingRequest bool
 }
 
 // NewInvokeMethodRequest creates InvokeMethodRequest object for method.
@@ -171,12 +176,31 @@ func (imr *InvokeMethodRequest) WithCustomHTTPMetadata(md map[string]string) *In
 }
 
 // WithReplay enables replaying for the data stream.
+// If the request is a streaming request, this is a no-op to prevent
+// buffering the entire body in memory.
 func (imr *InvokeMethodRequest) WithReplay(enabled bool) *InvokeMethodRequest {
+	if imr.streamingRequest {
+		return imr
+	}
 	// If the object has data in-memory, WithReplay is a nop
 	if !imr.HasMessageData() {
 		imr.SetReplay(enabled)
 	}
 	return imr
+}
+
+// SetStreamingRequest marks the request body as a stream that cannot be
+// replayed. This prevents WithReplay from buffering the entire body in
+// memory, which is critical for chunked-transfer requests to avoid OOM.
+func (imr *InvokeMethodRequest) SetStreamingRequest() *InvokeMethodRequest {
+	imr.streamingRequest = true
+	return imr
+}
+
+// IsStreamingRequest returns true if the request body is a stream that
+// cannot be replayed.
+func (imr *InvokeMethodRequest) IsStreamingRequest() bool {
+	return imr.streamingRequest
 }
 
 // WithHTTPResponseWriter enables downstream channel implementations to stream data back to the caller.

--- a/pkg/messaging/v1/invoke_method_request.go
+++ b/pkg/messaging/v1/invoke_method_request.go
@@ -176,8 +176,8 @@ func (imr *InvokeMethodRequest) WithCustomHTTPMetadata(md map[string]string) *In
 }
 
 // WithReplay enables replaying for the data stream.
-// If the request is a streaming request, this is a no-op to prevent
-// buffering the entire body in memory.
+// If the request is streaming, this is a no-op to prevent buffering the
+// entire body in memory.
 func (imr *InvokeMethodRequest) WithReplay(enabled bool) *InvokeMethodRequest {
 	if imr.streamingRequest {
 		return imr
@@ -191,7 +191,7 @@ func (imr *InvokeMethodRequest) WithReplay(enabled bool) *InvokeMethodRequest {
 
 // SetStreamingRequest marks the request body as a stream that cannot be
 // replayed. This prevents WithReplay from buffering the entire body in
-// memory, which is critical for chunked-transfer requests to avoid OOM.
+// memory, and causes built-in and user-configured retries to be skipped.
 func (imr *InvokeMethodRequest) SetStreamingRequest() *InvokeMethodRequest {
 	imr.streamingRequest = true
 	return imr

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -759,6 +759,73 @@ func TestDataTypeUrl(t *testing.T) {
 	})
 }
 
+func TestStreamingRequest(t *testing.T) {
+	const message = "streaming data that should not be buffered"
+
+	t.Run("streaming request prevents WithReplay from enabling replay", func(t *testing.T) {
+		req := NewInvokeMethodRequest("test_method").
+			WithRawData(strings.NewReader(message)).
+			SetStreamingRequest()
+		defer req.Close()
+
+		assert.True(t, req.IsStreamingRequest())
+
+		// WithReplay should be a no-op
+		req.WithReplay(true)
+		assert.False(t, req.CanReplay())
+	})
+
+	t.Run("streaming request does not affect in-memory proto data", func(t *testing.T) {
+		pb := &commonv1pb.InvokeRequest{
+			Method: "test_method",
+			Data:   &anypb.Any{Value: []byte(message)},
+		}
+		req := FromInvokeRequestMessage(pb).
+			SetStreamingRequest()
+		defer req.Close()
+
+		assert.True(t, req.IsStreamingRequest())
+		// CanReplay is true because data is in-memory (HasMessageData)
+		assert.True(t, req.CanReplay())
+	})
+
+	t.Run("non-streaming request WithReplay works normally", func(t *testing.T) {
+		req := NewInvokeMethodRequest("test_method").
+			WithRawData(strings.NewReader(message)).
+			WithReplay(true)
+		defer req.Close()
+
+		assert.False(t, req.IsStreamingRequest())
+		assert.True(t, req.CanReplay())
+
+		// Data can be read and replayed
+		read, err := io.ReadAll(req.RawData())
+		require.NoError(t, err)
+		assert.Equal(t, message, string(read))
+
+		read, err = io.ReadAll(req.RawData())
+		require.NoError(t, err)
+		assert.Equal(t, message, string(read))
+	})
+
+	t.Run("streaming request data is read once only", func(t *testing.T) {
+		req := NewInvokeMethodRequest("test_method").
+			WithRawData(strings.NewReader(message)).
+			SetStreamingRequest()
+		defer req.Close()
+
+		// First read succeeds
+		read, err := io.ReadAll(req.RawData())
+		require.NoError(t, err)
+		assert.Equal(t, message, string(read))
+
+		// Second read returns empty (stream consumed, no replay buffer)
+		read, err = io.ReadAll(req.RawData())
+		require.NoError(t, err)
+		assert.Empty(t, read)
+	})
+}
+
 func TestHTTPResponseWriter(t *testing.T) {
 	t.Run("response writer not nil", func(t *testing.T) {
 		pb := &commonv1pb.InvokeRequest{

--- a/pkg/messaging/v1/invoke_method_request_test.go
+++ b/pkg/messaging/v1/invoke_method_request_test.go
@@ -762,16 +762,26 @@ func TestDataTypeUrl(t *testing.T) {
 func TestStreamingRequest(t *testing.T) {
 	const message = "streaming data that should not be buffered"
 
-	t.Run("streaming request prevents WithReplay from enabling replay", func(t *testing.T) {
+	t.Run("streaming request without WithReplay cannot replay", func(t *testing.T) {
 		req := NewInvokeMethodRequest("test_method").
 			WithRawData(strings.NewReader(message)).
 			SetStreamingRequest()
 		defer req.Close()
 
 		assert.True(t, req.IsStreamingRequest())
+		assert.False(t, req.CanReplay())
+	})
 
-		// WithReplay should be a no-op
-		req.WithReplay(true)
+	t.Run("streaming request prevents WithReplay from enabling replay", func(t *testing.T) {
+		req := NewInvokeMethodRequest("test_method").
+			WithRawData(strings.NewReader(message)).
+			SetStreamingRequest().
+			WithReplay(true)
+		defer req.Close()
+
+		assert.True(t, req.IsStreamingRequest())
+		// WithReplay is a no-op when streamingRequest is set,
+		// preventing the body from being buffered in memory.
 		assert.False(t, req.CanReplay())
 	})
 

--- a/tests/apps/resiliencyapp/app.go
+++ b/tests/apps/resiliencyapp/app.go
@@ -14,6 +14,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -439,8 +440,12 @@ func TestInvokeService(w http.ResponseWriter, r *http.Request) {
 		}
 		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/%s", daprHttpPort, targetApp, targetMethod)
 
-		req, _ := http.NewRequest("POST", url, r.Body)
-		defer r.Body.Close()
+		// Read body into a buffer so the outgoing request has a known
+		// Content-Length, avoiding chunked-transfer which would be
+		// treated as a streaming request by the sidecar.
+		bodyBytes, _ := io.ReadAll(r.Body)
+		r.Body.Close()
+		req, _ := http.NewRequest("POST", url, bytes.NewReader(bodyBytes))
 
 		resp, err := httpClient.Do(req)
 		if err != nil {

--- a/tests/integration/suite/daprd/serviceinvocation/http/http.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/http.go
@@ -15,4 +15,5 @@ package http
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/http/appapitoken"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/http/streaming"
 )

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/chunkednoretry.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/chunkednoretry.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(chunkednoretry))
+}
+
+// chunkednoretry tests that a chunked-transfer request which receives an error
+// response is NOT retried, since the streaming body cannot be replayed.
+type chunkednoretry struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+
+	errorSinkCalls atomic.Int32
+}
+
+func (c *chunkednoretry) Setup(t *testing.T) []framework.Option {
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/error-sink", func(w http.ResponseWriter, r *http.Request) {
+			c.errorSinkCalls.Add(1)
+			io.Copy(io.Discard, r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"intentional error"}`))
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *chunkednoretry) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	pr, pw := io.Pipe()
+	go func() {
+		pw.Write([]byte("streaming data"))
+		pw.Close()
+	}()
+
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/error-sink",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Should get the 500 status from the target app
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	// Should only be called once - no retries for streaming requests
+	assert.Equal(t, int32(1), c.errorSinkCalls.Load())
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/chunkedrequest.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/chunkedrequest.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(chunkedrequest))
+}
+
+// chunkedrequest tests that a chunked-transfer (streaming) request body
+// flows through the sidecar without being fully buffered in memory.
+type chunkedrequest struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+
+	sinkCalls atomic.Int32
+}
+
+func (c *chunkedrequest) Setup(t *testing.T) []framework.Option {
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/sink", func(w http.ResponseWriter, r *http.Request) {
+			c.sinkCalls.Add(1)
+			n, _ := io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, "%d", n)
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *chunkedrequest) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	// Send a 1MB chunked request through service invocation.
+	// Using io.Pipe ensures the body has no known Content-Length (-1),
+	// which triggers chunked transfer encoding.
+	// With the fix, the sidecar should NOT buffer this in memory for retries.
+	const dataSize = 1 << 20
+
+	pr, pw := io.Pipe()
+	go func() {
+		chunk := []byte(strings.Repeat("A", 1024))
+		for range dataSize / 1024 {
+			pw.Write(chunk)
+		}
+		pw.Close()
+	}()
+
+	c.sinkCalls.Store(0)
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/sink",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	// The sink returns the byte count received
+	assert.Equal(t, strconv.Itoa(dataSize), string(respBody))
+	// Should only be called once (no retries for streaming requests)
+	assert.Equal(t, int32(1), c.sinkCalls.Load())
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/circuitbreaker.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/circuitbreaker.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(circuitbreaker))
+}
+
+// circuitbreaker tests that circuit breakers correctly trip for streaming
+// requests. Even though streaming requests cannot be retried, the circuit
+// breaker should still count consecutive failures and open the circuit.
+type circuitbreaker struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+
+	endpointCalls atomic.Int32
+}
+
+func (c *circuitbreaker) Setup(t *testing.T) []framework.Option {
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/always-fail", func(w http.ResponseWriter, r *http.Request) {
+			c.endpointCalls.Add(1)
+			io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	resiliency := fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: streamingcb
+spec:
+  policies:
+    circuitBreakers:
+      cbpolicy:
+        maxRequests: 1
+        interval: 0
+        timeout: 5s
+        trip: consecutiveFailures >= 3
+  targets:
+    apps:
+      %s:
+        circuitBreaker: cbpolicy
+`, c.daprdReceiver.AppID())
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+		daprd.WithResourceFiles(resiliency),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *circuitbreaker) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	// Send 3 streaming requests that all fail with 500.
+	// The circuit breaker should count these failures.
+	for i := range 3 {
+		pr, pw := io.Pipe()
+		go func() {
+			fmt.Fprintf(pw, "streaming data %d", i)
+			pw.Close()
+		}()
+
+		url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/always-fail",
+			c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	// All 3 requests should have reached the endpoint (no retries for
+	// streaming, but each request is a separate call).
+	assert.Equal(t, int32(3), c.endpointCalls.Load())
+
+	// 4th streaming request: the circuit breaker should be open, so the
+	// request should fail without reaching the endpoint.
+	pr, pw := io.Pipe()
+	go func() {
+		pw.Write([]byte("this should be blocked"))
+		pw.Close()
+	}()
+
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/always-fail",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Circuit is open — request should fail without reaching the endpoint
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	// Endpoint call count should still be 3 (4th request was blocked)
+	assert.Equal(t, int32(3), c.endpointCalls.Load())
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/fixedlengthrequest.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/fixedlengthrequest.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(fixedlengthrequest))
+}
+
+// fixedlengthrequest tests that a normal (known Content-Length) request
+// body still supports retries through service invocation.
+// Regression test to ensure the chunked-transfer fix doesn't break
+// normal request handling.
+type fixedlengthrequest struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+}
+
+func (c *fixedlengthrequest) Setup(t *testing.T) []framework.Option {
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/sink", func(w http.ResponseWriter, r *http.Request) {
+			n, _ := io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, "%d", n)
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *fixedlengthrequest) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	// Normal request (with Content-Length) should still support retries
+	body := "hello world"
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/sink",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(len(body)), string(respBody))
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/resiliencynoretry.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/resiliencynoretry.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(resiliencynoretry))
+}
+
+// resiliencynoretry tests that a resiliency policy with retries configured
+// is correctly ignored for streaming (chunked-transfer) requests, while
+// still being applied for normal fixed-length requests.
+type resiliencynoretry struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+
+	endpointCalls atomic.Int32
+}
+
+func (c *resiliencynoretry) Setup(t *testing.T) []framework.Option {
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/always-fail", func(w http.ResponseWriter, r *http.Request) {
+			c.endpointCalls.Add(1)
+			io.Copy(io.Discard, r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"always fails"}`))
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	resiliency := fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: myresiliency
+spec:
+  policies:
+    retries:
+      retrypolicy:
+        policy: constant
+        duration: 1ms
+        maxRetries: 3
+  targets:
+    apps:
+      %s:
+        retry: retrypolicy
+`, c.daprdReceiver.AppID())
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+		daprd.WithResourceFiles(resiliency),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *resiliencynoretry) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	t.Run("streaming request skips resiliency retries", func(t *testing.T) {
+		// Streaming request (chunked, unknown Content-Length) should NOT be
+		// retried even though a resiliency policy with retries is configured.
+		pr, pw := io.Pipe()
+		go func() {
+			pw.Write([]byte("streaming data"))
+			pw.Close()
+		}()
+
+		c.endpointCalls.Store(0)
+		url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/always-fail",
+			c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		// Should only be called once despite maxRetries: 3
+		assert.Equal(t, int32(1), c.endpointCalls.Load())
+	})
+
+	t.Run("fixed-length request uses resiliency retries", func(t *testing.T) {
+		// Normal request (known Content-Length) should be retried per the
+		// resiliency policy (1 initial + 3 retries = 4 total calls).
+		c.endpointCalls.Store(0)
+		url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/always-fail",
+			c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("fixed body"))
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		// Should be called 4 times: 1 initial + 3 retries
+		assert.Equal(t, int32(4), c.endpointCalls.Load())
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/resiliencyrecovery.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/resiliencyrecovery.go
@@ -33,28 +33,30 @@ import (
 )
 
 func init() {
-	suite.Register(new(resiliencynoretry))
+	suite.Register(new(resiliencyrecovery))
 }
 
-// resiliencynoretry tests that streaming requests (chunked-transfer) are NOT
-// retried even when a resiliency policy with retries is configured, because
-// the streaming body cannot be buffered for replay.
-type resiliencynoretry struct {
+type resiliencyrecovery struct {
 	daprdSender   *daprd.Daprd
 	daprdReceiver *daprd.Daprd
 
 	endpointCalls atomic.Int32
 }
 
-func (c *resiliencynoretry) Setup(t *testing.T) []framework.Option {
+func (c *resiliencyrecovery) Setup(t *testing.T) []framework.Option {
 	receiverApp := app.New(t,
 		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
-		app.WithHandlerFunc("/always-fail", func(w http.ResponseWriter, r *http.Request) {
-			c.endpointCalls.Add(1)
+		app.WithHandlerFunc("/flaky", func(w http.ResponseWriter, r *http.Request) {
+			n := c.endpointCalls.Add(1)
 			io.Copy(io.Discard, r.Body)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"error":"always fails"}`))
+			// Fail the first 3 calls, succeed on the 4th
+			if n <= 3 {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"error":"transient failure"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"recovered"}`))
 		}),
 	)
 
@@ -73,7 +75,7 @@ spec:
       retrypolicy:
         policy: constant
         duration: 1ms
-        maxRetries: 3
+        maxRetries: 5
   targets:
     apps:
       %s:
@@ -93,52 +95,31 @@ spec:
 	}
 }
 
-func (c *resiliencynoretry) Run(t *testing.T, ctx context.Context) {
+func (c *resiliencyrecovery) Run(t *testing.T, ctx context.Context) {
 	c.daprdSender.WaitUntilRunning(t, ctx)
 	c.daprdReceiver.WaitUntilRunning(t, ctx)
 
 	httpClient := client.HTTP(t)
 
-	t.Run("streaming request is not retried despite resiliency policy", func(t *testing.T) {
-		// Streaming requests (unknown Content-Length) must not be retried
-		// because the body cannot be buffered for replay. The request
-		// should be attempted exactly once.
-		pr, pw := io.Pipe()
-		go func() {
-			pw.Write([]byte("streaming data"))
-			pw.Close()
-		}()
-
+	t.Run("fixed-length request recovers from transient failure", func(t *testing.T) {
 		c.endpointCalls.Store(0)
-		url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/always-fail",
+
+		url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/flaky",
 			c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`{"message":"hello"}`))
 		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := httpClient.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		// Should be called exactly once — no retries for streaming requests
-		assert.Equal(t, int32(1), c.endpointCalls.Load())
-	})
-
-	t.Run("fixed-length request is retried per resiliency policy", func(t *testing.T) {
-		// Contrast: fixed-length (known Content-Length) requests ARE retried
-		// per the resiliency policy (1 initial + 3 retries = 4 total calls).
-		c.endpointCalls.Store(0)
-		url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/always-fail",
-			c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("fixed body"))
+		// Should recover: 3 failures + 1 success = 200
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-
-		resp, err := httpClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		// Should be called 4 times: 1 initial + 3 retries
+		assert.JSONEq(t, `{"status":"recovered"}`, string(body))
+		// 3 failed + 1 successful = 4 total calls
 		assert.Equal(t, int32(4), c.endpointCalls.Load())
 	})
 }

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/smallerror.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/smallerror.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(smallerror))
+}
+
+// smallerror tests that a non-streaming request receiving a small error
+// response still returns the correct status code and body.
+// Regression test to ensure the chunked-transfer fix doesn't break
+// normal error response handling.
+type smallerror struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+}
+
+func (c *smallerror) Setup(t *testing.T) []framework.Option {
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/small-error", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"bad request"}`))
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *smallerror) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	// Non-streaming request with small error response should work normally
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/small-error",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("test"))
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"error":"bad request"}`, string(respBody))
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/streamerror.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/streamerror.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(streamerror))
+}
+
+// streamerror tests that a non-2xx streaming error response is streamed
+// through to the caller without being buffered in memory.
+type streamerror struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+
+	streamErrorCalls atomic.Int32
+}
+
+func (c *streamerror) Setup(t *testing.T) []framework.Option {
+	const dataSize = 1 << 20
+
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/stream-error", func(w http.ResponseWriter, r *http.Request) {
+			c.streamErrorCalls.Add(1)
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusInternalServerError)
+			// Write 1MB error body in chunks
+			chunk := strings.Repeat("E", 1024)
+			for range dataSize / 1024 {
+				w.Write([]byte(chunk))
+				flusher.Flush()
+			}
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *streamerror) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	// Non-2xx responses with streaming bodies should be streamed directly to the
+	// caller without buffering via RawDataFull(). Send as chunked (streaming)
+	// request via pipe, so the error response body is streamed through without
+	// being buffered in memory.
+	pr, pw := io.Pipe()
+	go func() {
+		pw.Write([]byte("trigger"))
+		pw.Close()
+	}()
+
+	c.streamErrorCalls.Store(0)
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/stream-error",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Should get the 500 status from the target app
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	// Should receive the full 1MB error body streamed through
+	assert.Len(t, respBody, 1<<20)
+	// Should only be called once (no retries for streaming requests)
+	assert.Equal(t, int32(1), c.streamErrorCalls.Load())
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/streamresponse.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/streamresponse.go
@@ -35,8 +35,9 @@ func init() {
 	suite.Register(new(streamresponse))
 }
 
-// streamresponse tests that a chunked (streaming) response flows through
-// the sidecar without being fully buffered in memory.
+// streamresponse tests that a streaming request receiving a chunked
+// (streaming) 2xx response gets the full response body forwarded without
+// it being buffered in memory.
 type streamresponse struct {
 	daprdSender   *daprd.Daprd
 	daprdReceiver *daprd.Daprd
@@ -85,10 +86,18 @@ func (c *streamresponse) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 
-	// Streamed responses should flow through without buffering
+	// Send a streaming request (pipe body, unknown Content-Length) that
+	// receives a streaming 2xx response. Both directions should flow
+	// through without buffering.
+	pr, pw := io.Pipe()
+	go func() {
+		pw.Write([]byte("streaming request body"))
+		pw.Close()
+	}()
+
 	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/stream-response",
 		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
 	require.NoError(t, err)
 
 	resp, err := httpClient.Do(req)

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/streamresponse.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/streamresponse.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(streamresponse))
+}
+
+// streamresponse tests that a chunked (streaming) response flows through
+// the sidecar without being fully buffered in memory.
+type streamresponse struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+}
+
+func (c *streamresponse) Setup(t *testing.T) []framework.Option {
+	const dataSize = 1 << 20
+
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/stream-response", func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			if !assert.True(t, ok, "ResponseWriter does not support flushing") {
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			// Write 1MB in 1KB chunks
+			chunk := strings.Repeat("X", 1024)
+			for range dataSize / 1024 {
+				w.Write([]byte(chunk))
+				flusher.Flush()
+			}
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *streamresponse) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	// Streamed responses should flow through without buffering
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/stream-response",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Len(t, respBody, 1<<20)
+}


### PR DESCRIPTION
Service invocation buffers entire streaming request body in memory

Problem

When sending a request with a streaming body (chunked transfer encoding) through Dapr HTTP service invocation, the sidecar buffered the entire request body in memory before forwarding it. For large payloads—such as file uploads or long-running data streams—this caused excessive memory usage and potential out-of-memory crashes.

Impact

Any HTTP service invocation request without a known `Content-Length` (e.g. chunked uploads, streamed data, piped bodies) had its entire body buffered in memory by the sending sidecar. This made Dapr unsuitable for streaming large payloads between services and could cause sidecar OOM kills in production.

Root Cause

The sidecar's retry mechanism unconditionally buffered the request body into memory so it could replay the body on retry. For streaming requests, the body cannot be replayed because it is consumed as it is read, making the buffering both unnecessary and harmful.

Solution

The sidecar now detects streaming requests (those with no known content length) and skips request body buffering entirely. Both the built-in retry logic and any user-configured resiliency retry policies are automatically bypassed for streaming requests, since retrying would require re-reading a body that has already been consumed. Non-streaming requests with a known `Content-Length` continue to support retries as before.

---

Service invocation buffers entire streaming response body in memory

Problem

When proxying HTTP responses through service invocation, the sidecar buffered the entire response body in memory before forwarding it to the caller.
For large or unbounded streaming responses, this caused excessive memory usage and potential out-of-memory crashes.

Impact

Any service invocation response with a large or streaming body could cause sidecar OOM kills, regardless of HTTP status code.
This made Dapr unsuitable for proxying streaming responses such as server-sent events, file downloads, or long-running data streams between services.

Root Cause

The sidecar's resiliency mechanism read the full response body into memory so it could evaluate whether to retry the request.
When the request itself is a stream that has already been consumed, retries are impossible regardless of the response, making the buffering unnecessary.

Solution

For streaming requests, the sidecar now forwards response bodies directly to the caller without buffering them in memory.
Resiliency features like circuit breakers continue to track failures normally.
Non-streaming requests continue to support retries and buffered error handling as before.

---

Fixes https://github.com/dapr/dapr/issues/9626 https://github.com/dapr/dapr/issues/9625