### PR TITLE
Updates dapr/components-contrib to v1.17.1

### DIFF
--- a/docs/release_notes/v1.17.2.md
+++ b/docs/release_notes/v1.17.2.md
@@ -8,6 +8,9 @@ This update includes a breaking change and bug fixes:
 - [Scheduler fails to start due to trailing dot in cluster domain DNS lookup](#scheduler-fails-to-start-due-to-trailing-dot-in-cluster-domain-dns-lookup)
 - [Service invocation buffers entire streaming request body in memory](#service-invocation-buffers-entire-streaming-request-body-in-memory)
 - [Service invocation buffers entire streaming response body in memory](#service-invocation-buffers-entire-streaming-response-body-in-memory)
+- [Oracle Database state store BulkGet returns HTTP 500 instead of per-key errors](#oracle-database-state-store-bulkget-returns-http-500-instead-of-per-key-errors)
+- [Pulsar pub/sub publishes invalid JSON messages when Avro schema is configured](#pulsar-pubsub-publishes-invalid-json-messages-when-avro-schema-is-configured)
+- [Nil pointer dereference in conversation LangChain Go Kit LLM logger](#nil-pointer-dereference-in-conversation-langchain-go-kit-llm-logger)
 
 ## Workflow state retention policy CRD fields use incorrect type (Breaking Change)
 
@@ -165,3 +168,57 @@ When the request itself is a stream that has already been consumed, retries are 
 For streaming requests, the sidecar now forwards response bodies directly to the caller without buffering them in memory.
 Resiliency features like circuit breakers continue to track failures normally.
 Non-streaming requests continue to support retries and buffered error handling as before.
+
+## Oracle Database state store BulkGet returns HTTP 500 instead of per-key errors
+
+### Problem
+
+When using the Oracle Database state store component, a `BulkGet` request that encountered an error for one or more keys returned an HTTP 500 error for the entire request instead of returning per-key errors alongside successful results.
+
+### Impact
+
+Applications using `BulkGet` with the Oracle Database state store could not retrieve any results if even a single key encountered an error. Instead of receiving successful results for valid keys with per-key errors for failed keys, the entire operation failed with an HTTP 500 response.
+
+### Root Cause
+
+The `BulkGet` implementation in the Oracle Database state store component returned a top-level error when any individual key retrieval failed, rather than collecting the error and associating it with the specific key in the response.
+
+### Solution
+
+Updated the `BulkGet` implementation to return per-key errors in the `BulkGetResponse` items instead of returning a top-level error. Successful key retrievals are now returned alongside any per-key errors, matching the expected state store `BulkGet` contract.
+
+## Pulsar pub/sub publishes invalid JSON messages when Avro schema is configured
+
+### Problem
+
+When the Pulsar pub/sub component was configured with an Avro schema, JSON messages were published without being validated against the schema. Invalid messages that did not conform to the Avro schema were accepted and published to the topic.
+
+### Impact
+
+Applications relying on Avro schema enforcement at the Pulsar pub/sub layer could publish malformed messages that did not conform to the expected schema. Downstream consumers expecting schema-compliant messages could encounter deserialization failures or data integrity issues.
+
+### Root Cause
+
+The Pulsar pub/sub component did not validate JSON message payloads against the configured Avro schema before publishing. The schema was used only for consumer-side deserialization, not for producer-side validation.
+
+### Solution
+
+Added JSON-to-Avro schema validation in the publish path. Before publishing, the component now validates JSON message payloads against the configured Avro schema and returns an error if the message does not conform, preventing invalid messages from being published to the topic.
+
+## Nil pointer dereference in conversation LangChain Go Kit LLM logger
+
+### Problem
+
+The conversation component using the LangChain Go Kit could panic with a nil pointer dereference when the LLM logger was invoked.
+
+### Impact
+
+Applications using the conversation API with the LangChain Go Kit-based component could experience unexpected crashes due to a nil pointer dereference, causing the Dapr sidecar to restart.
+
+### Root Cause
+
+The LLM logger callback in the LangChain Go Kit conversation component was called with a nil pointer, and the logger did not perform a nil check before accessing the pointer.
+
+### Solution
+
+Added a nil pointer check in the LangChain Go Kit LLM logger to prevent the dereference, ensuring the conversation component handles the case gracefully without panicking.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/dapr/components-contrib v1.17.0
+	github.com/dapr/components-contrib v1.17.1
 	github.com/dapr/durabletask-go v0.11.1
 	github.com/dapr/kit v0.17.1-0.20260303145220-d749ae76d3c3
 	github.com/diagridio/go-etcd-cron v0.12.4

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.17.0 h1:UIra39ivC0r6Rzt8+UEtiOmyu6hZGhIZfMPW+dtGOQ0=
-github.com/dapr/components-contrib v1.17.0/go.mod h1:xA5qPPtn8FLMadoHsg9Ks32V4ScTGOBuMa/N6IK5fSc=
+github.com/dapr/components-contrib v1.17.1 h1:eTiMNGvd4E9gbmNtoERYefmrXxHOiP2UbQOd1Pci2Bs=
+github.com/dapr/components-contrib v1.17.1/go.mod h1:lVPRj9ywzkUWoKXxRTAJbvS+Vg8A882av/nynGstNE4=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
 github.com/dapr/durabletask-go v0.11.1 h1:URG8YjFqZ4dXj7gkLe3G9ZwKYuJhuF/jNyVx+jPMT8A=


### PR DESCRIPTION
Oracle Database state store BulkGet returns HTTP 500 instead of per-key errors

Problem

When using the Oracle Database state store component, a `BulkGet` request that encountered an error for one or more keys returned an HTTP 500 error for the entire request instead of returning per-key errors alongside successful results.

Impact

Applications using `BulkGet` with the Oracle Database state store could not retrieve any results if even a single key encountered an error. Instead of receiving successful results for valid keys with per-key errors for failed keys, the entire operation failed with an HTTP 500 response.

Root Cause

The `BulkGet` implementation in the Oracle Database state store component returned a top-level error when any individual key retrieval failed, rather than collecting the error and associating it with the specific key in the response.

Solution

Updated the `BulkGet` implementation to return per-key errors in the `BulkGetResponse` items instead of returning a top-level error. Successful key retrievals are now returned alongside any per-key errors, matching the expected state store `BulkGet` contract.

Pulsar pub/sub publishes invalid JSON messages when Avro schema is configured

Problem

When the Pulsar pub/sub component was configured with an Avro schema, JSON messages were published without being validated against the schema. Invalid messages that did not conform to the Avro schema were accepted and published to the topic.

### Impact

Applications relying on Avro schema enforcement at the Pulsar pub/sub layer could publish malformed messages that did not conform to the expected schema. Downstream consumers expecting schema-compliant messages could encounter deserialization failures or data integrity issues.

Root Cause

The Pulsar pub/sub component did not validate JSON message payloads against the configured Avro schema before publishing. The schema was used only for consumer-side deserialization, not for producer-side validation.

Solution

Added JSON-to-Avro schema validation in the publish path. Before publishing, the component now validates JSON message payloads against the configured Avro schema and returns an error if the message does not conform, preventing invalid messages from being published to the topic.

Nil pointer dereference in conversation LangChain Go Kit LLM logger

Problem

The conversation component using the LangChain Go Kit could panic with a nil pointer dereference when the LLM logger was invoked.

Impact

Applications using the conversation API with the LangChain Go Kit-based component could experience unexpected crashes due to a nil pointer dereference, causing the Dapr sidecar to restart.

Root Cause

The LLM logger callback in the LangChain Go Kit conversation component was called with a nil pointer, and the logger did not perform a nil check before accessing the pointer.

Solution

Added a nil pointer check in the LangChain Go Kit LLM logger to prevent the dereference, ensuring the conversation component handles the case gracefully without panicking.