### PR TITLE
WIP

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -58,7 +58,11 @@ jobs:
       # TODO: Make this auto-populated based on GitHub's releases.
       DAPR_TEST_N_MINUS_1_IMAGE: "ghcr.io/dapr/daprd:1.16.8"
       DAPR_TEST_N_MINUS_2_IMAGE: "ghcr.io/dapr/daprd:1.15.13"
-      # Container registry where to cache e2e test images
+      # Container registry where to cache e2e test images.
+      # The prebuild-test-apps workflow keeps this cache warm by
+      # pre-building all e2e app images on pushes to master and on a
+      # nightly schedule, so build-push-e2e-app-all gets reliable
+      # cache hits here and avoids redundant image builds.
       DAPR_CACHE_REGISTRY: "dapre2eacr.azurecr.io"
       PULL_POLICY: IfNotPresent
     strategy:
@@ -103,19 +107,33 @@ jobs:
       #     https://github.com/kubernetes-sigs/kind/issues/1165, using
       #     a local repository speeds up the image pushes into KinD
       #     significantly.
+      # Uses pre-baked node image (ghcr.io/dapr/kind-node) if available,
+      # which has 3rd-party images pre-pulled to skip Helm install pull time.
+      # Falls back to stock kindest/node if the pre-baked image doesn't exist.
       run: |
+        PREBAKED_IMAGE="ghcr.io/dapr/kind-node:${{ matrix.k8s-version }}"
+        STOCK_IMAGE="kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}"
+
+        if docker pull "${PREBAKED_IMAGE}" 2>/dev/null; then
+          echo "Using pre-baked KinD node image: ${PREBAKED_IMAGE}"
+          KIND_IMAGE="${PREBAKED_IMAGE}"
+        else
+          echo "Pre-baked image not available, using stock: ${STOCK_IMAGE}"
+          KIND_IMAGE="${STOCK_IMAGE}"
+        fi
+
         cat > kind.yaml <<EOF
         apiVersion: kind.x-k8s.io/v1alpha4
         kind: Cluster
         nodes:
         - role: control-plane
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+          image: ${KIND_IMAGE}
         - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+          image: ${KIND_IMAGE}
         - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+          image: ${KIND_IMAGE}
         - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+          image: ${KIND_IMAGE}
         containerdConfigPatches:
         - |-
           [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:$REGISTRY_PORT"]

--- a/.github/workflows/prebake-kind-node.yml
+++ b/.github/workflows/prebake-kind-node.yml
@@ -1,0 +1,155 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Build pre-baked KinD node images
+
+on:
+  # Manual trigger with optional K8s version override
+  workflow_dispatch:
+    inputs:
+      k8s_version:
+        description: 'Kubernetes version to build (leave empty for all matrix versions)'
+        required: false
+        type: string
+
+  # Rebuild when Dockerfile or Helm override configs change
+  push:
+    branches:
+      - master
+      - 'release-*'
+    paths:
+      - 'tests/config/kind-node-image/**'
+      - 'tests/config/redis_override.yaml'
+      - 'tests/config/kafka_override.yaml'
+      - 'tests/config/postgres_override.yaml'
+      - 'tests/config/zipkin.yaml'
+
+  # Monthly rebuild to keep images fresh (first day of month at 06:00 UTC)
+  schedule:
+    - cron: '0 6 1 * *'
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-node-image:
+    name: Build KinD node (${{ matrix.k8s-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # These K8s versions must match the kind-e2e.yaml matrix.
+        # See: .github/workflows/kind-e2e.yaml
+        k8s-version:
+          - v1.34.0
+          - v1.33.4
+          - v1.32.8
+    steps:
+      - name: Check version filter
+        # Skip matrix entries that don't match the requested version (if specified)
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          inputs.k8s_version != '' &&
+          matrix.k8s-version != inputs.k8s_version
+        run: |
+          echo "Skipping ${{ matrix.k8s-version }} (requested: ${{ inputs.k8s_version }})"
+          exit 0
+
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve 3rd-party image references from Helm charts
+        id: resolve-images
+        run: |
+          # Redis — explicit in override file
+          REDIS_REPO=$(grep 'repository:' tests/config/redis_override.yaml | head -1 | awk '{print $2}')
+          REDIS_TAG=$(grep 'tag:' tests/config/redis_override.yaml | head -1 | awk '{print $2}')
+          echo "redis_image=docker.io/${REDIS_REPO}:${REDIS_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Zipkin — explicit in manifest
+          ZIPKIN_IMAGE=$(grep 'image:' tests/config/zipkin.yaml | head -1 | awk '{print $2}')
+          echo "zipkin_image=${ZIPKIN_IMAGE}" >> "$GITHUB_OUTPUT"
+
+          # Kafka + Zookeeper — resolve from Helm chart
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update bitnami
+
+          KAFKA_TEMPLATE=$(helm template dapr-kafka bitnami/kafka \
+            --version 23.0.7 \
+            -f tests/config/kafka_override.yaml \
+            --set image.repository=bitnamilegacy/kafka)
+
+          KAFKA_IMAGE=$(echo "${KAFKA_TEMPLATE}" | grep 'image:' | grep 'kafka' | head -1 | awk '{print $2}' | tr -d '"')
+          [[ "${KAFKA_IMAGE}" != docker.io/* ]] && KAFKA_IMAGE="docker.io/${KAFKA_IMAGE}"
+          echo "kafka_image=${KAFKA_IMAGE}" >> "$GITHUB_OUTPUT"
+
+          ZK_IMAGE=$(echo "${KAFKA_TEMPLATE}" | grep 'image:' | grep 'zookeeper' | head -1 | awk '{print $2}' | tr -d '"')
+          [[ "${ZK_IMAGE}" != docker.io/* ]] && ZK_IMAGE="docker.io/${ZK_IMAGE}"
+          echo "zookeeper_image=${ZK_IMAGE}" >> "$GITHUB_OUTPUT"
+
+          # PostgreSQL — resolve from Helm chart
+          POSTGRES_TEMPLATE=$(helm template dapr-postgres bitnami/postgresql \
+            --version 12.8.0 \
+            -f tests/config/postgres_override.yaml \
+            --set image.repository=bitnamilegacy/postgresql)
+
+          PG_IMAGE=$(echo "${POSTGRES_TEMPLATE}" | grep 'image:' | grep 'postgresql' | head -1 | awk '{print $2}' | tr -d '"')
+          [[ "${PG_IMAGE}" != docker.io/* ]] && PG_IMAGE="docker.io/${PG_IMAGE}"
+          echo "postgresql_image=${PG_IMAGE}" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved images:"
+          echo "  Redis:      docker.io/${REDIS_REPO}:${REDIS_TAG}"
+          echo "  Kafka:      ${KAFKA_IMAGE}"
+          echo "  Zookeeper:  ${ZK_IMAGE}"
+          echo "  PostgreSQL: ${PG_IMAGE}"
+          echo "  Zipkin:     ${ZIPKIN_IMAGE}"
+
+      - name: Build and push pre-baked KinD node image
+        uses: docker/build-push-action@v6
+        with:
+          context: tests/config/kind-node-image
+          file: tests/config/kind-node-image/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/kind-node:${{ matrix.k8s-version }}
+          build-args: |
+            K8S_VERSION=${{ matrix.k8s-version }}
+            REDIS_IMAGE=${{ steps.resolve-images.outputs.redis_image }}
+            KAFKA_IMAGE=${{ steps.resolve-images.outputs.kafka_image }}
+            ZOOKEEPER_IMAGE=${{ steps.resolve-images.outputs.zookeeper_image }}
+            POSTGRESQL_IMAGE=${{ steps.resolve-images.outputs.postgresql_image }}
+            ZIPKIN_IMAGE=${{ steps.resolve-images.outputs.zipkin_image }}
+          # Cache layers to speed up rebuilds
+          cache-from: type=gha,scope=kind-node-${{ matrix.k8s-version }}
+          cache-to: type=gha,mode=max,scope=kind-node-${{ matrix.k8s-version }}
+
+      - name: Verify image
+        run: |
+          docker pull ghcr.io/${{ github.repository_owner }}/kind-node:${{ matrix.k8s-version }}
+          echo "Image size:"
+          docker images ghcr.io/${{ github.repository_owner }}/kind-node:${{ matrix.k8s-version }} --format '{{.Size}}'

--- a/.github/workflows/prebuild-test-apps.yml
+++ b/.github/workflows/prebuild-test-apps.yml
@@ -1,0 +1,85 @@
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Pre-build E2E test app images
+
+on:
+  # Push to master when test apps or build tools change
+  push:
+    branches:
+      - master
+    paths:
+      - 'tests/apps/**'
+      - 'tests/e2e/utils/**'
+      - '.build-tools/**'
+  # Nightly schedule to keep cache warm
+  schedule:
+    - cron: "0 4 * * *"
+  # Manual trigger
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  prebuild:
+    name: Pre-build e2e test app images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # Container registry where to cache e2e test images
+      DAPR_CACHE_REGISTRY: "dapre2eacr.azurecr.io"
+      # The pre-build pushes images to the cache registry itself,
+      # so dest and cache registries are the same.
+      DAPR_REGISTRY: "dapre2eacr.azurecr.io"
+      DAPR_TAG: "cache"
+      DAPR_NAMESPACE: "dapr-tests"
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      id: setup-go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Login to Azure
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Login to cache registry
+      run: |
+        az acr login --name ${{ env.DAPR_CACHE_REGISTRY }}
+
+    - name: Free disk space
+      run: |
+        df -h
+        docker system prune -af || true
+        docker volume prune -f || true
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/* || true
+        df -h
+
+    - name: Build and push all e2e test app images to cache
+      run: |
+        make build-push-e2e-app-all

--- a/tests/config/kind-node-image/Dockerfile
+++ b/tests/config/kind-node-image/Dockerfile
@@ -1,0 +1,71 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Custom KinD node image with pre-baked 3rd-party container images.
+#
+# Pre-pulling these images into the node image eliminates container pull time
+# during E2E test setup, saving ~15-20 minutes per test run.
+#
+# Pre-baked images (update these when Helm chart versions change):
+#   - Redis:      redislabs/rejson:2.0.11          (tests/config/redis_override.yaml)
+#   - Kafka:      bitnamilegacy/kafka               (tests/dapr_tests.mk, chart 23.0.7)
+#   - Zookeeper:  bitnami/zookeeper                 (kafka chart 23.0.7 dependency)
+#   - PostgreSQL: bitnamilegacy/postgresql           (tests/dapr_tests.mk, chart 12.8.0)
+#   - Zipkin:     ghcr.io/dapr/3rdparty/zipkin      (tests/config/zipkin.yaml)
+
+ARG K8S_VERSION=v1.34.0
+FROM kindest/node:${K8S_VERSION} AS base
+
+# Image references for pre-pulling.
+# These must match what the Helm charts and manifests actually deploy.
+#
+# Redis and Zipkin tags are explicit in config files. Kafka, Zookeeper, and
+# PostgreSQL tags come from Helm chart defaults — run build.sh which uses
+# "helm template" to extract the actual image references automatically.
+#
+# Sources:
+#   Redis:      tests/config/redis_override.yaml
+#   Kafka:      tests/dapr_tests.mk (chart bitnami/kafka 23.0.7)
+#   Zookeeper:  tests/dapr_tests.mk (kafka chart 23.0.7 dependency)
+#   PostgreSQL: tests/dapr_tests.mk (chart bitnami/postgresql 12.8.0)
+#   Zipkin:     tests/config/zipkin.yaml
+#
+# All images are required build args — there are no defaults, to avoid
+# silently pulling wrong versions. Use build.sh to resolve them automatically.
+ARG REDIS_IMAGE
+ARG KAFKA_IMAGE
+ARG ZOOKEEPER_IMAGE
+ARG POSTGRESQL_IMAGE
+ARG ZIPKIN_IMAGE
+
+# Start containerd, pull all required images into the k8s.io namespace
+# (which is where Kubernetes/CRI looks for images), then stop containerd.
+# Using tmpfs mounts for /run and /tmp since containerd needs them for runtime
+# state but we don't want to persist that in the image layer.
+RUN --mount=type=tmpfs,target=/run \
+    --mount=type=tmpfs,target=/tmp \
+    containerd -log-level warn & \
+    while ! ctr version >/dev/null 2>&1; do sleep 0.1; done && \
+    echo "Pulling Redis image: ${REDIS_IMAGE}" && \
+    ctr -n k8s.io images pull ${REDIS_IMAGE} && \
+    echo "Pulling Kafka image: ${KAFKA_IMAGE}" && \
+    ctr -n k8s.io images pull ${KAFKA_IMAGE} && \
+    echo "Pulling Zookeeper image: ${ZOOKEEPER_IMAGE}" && \
+    ctr -n k8s.io images pull ${ZOOKEEPER_IMAGE} && \
+    echo "Pulling PostgreSQL image: ${POSTGRESQL_IMAGE}" && \
+    ctr -n k8s.io images pull ${POSTGRESQL_IMAGE} && \
+    echo "Pulling Zipkin image: ${ZIPKIN_IMAGE}" && \
+    ctr -n k8s.io images pull ${ZIPKIN_IMAGE} && \
+    echo "All images pulled successfully." && \
+    kill $(pidof containerd) && \
+    wait

--- a/tests/config/kind-node-image/build.sh
+++ b/tests/config/kind-node-image/build.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Build custom KinD node image with pre-baked 3rd-party container images.
+#
+# Uses "helm template" to resolve the actual container images that the Helm
+# charts deploy, so the pre-baked images always match what tests expect.
+#
+# Usage:
+#   ./build.sh [K8S_VERSION] [IMAGE_TAG]
+#
+# Arguments:
+#   K8S_VERSION  Kubernetes version for the base kindest/node image (default: v1.34.0)
+#   IMAGE_TAG    Tag for the output image (default: ghcr.io/dapr/kind-node:${K8S_VERSION})
+#
+# Examples:
+#   ./build.sh                           # Build for default K8s version
+#   ./build.sh v1.33.4                   # Build for K8s 1.33.4
+#   ./build.sh v1.34.0 my-image:latest   # Build with custom output tag
+#
+# Environment variables (optional, override resolved image references):
+#   REDIS_IMAGE       Redis image (default: resolved from redis_override.yaml)
+#   KAFKA_IMAGE       Kafka image (default: resolved from helm template)
+#   ZOOKEEPER_IMAGE   Zookeeper image (default: resolved from helm template)
+#   POSTGRESQL_IMAGE  PostgreSQL image (default: resolved from helm template)
+#   ZIPKIN_IMAGE      Zipkin image (default: resolved from zipkin.yaml)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+K8S_VERSION="${1:-v1.34.0}"
+IMAGE_TAG="${2:-ghcr.io/dapr/kind-node:${K8S_VERSION}}"
+
+# Resolve image references from config files and Helm charts if not overridden.
+
+if [[ -z "${REDIS_IMAGE:-}" ]]; then
+  # Redis image is explicit in the override file.
+  REDIS_REPO=$(grep 'repository:' "${REPO_ROOT}/tests/config/redis_override.yaml" | head -1 | awk '{print $2}')
+  REDIS_TAG=$(grep 'tag:' "${REPO_ROOT}/tests/config/redis_override.yaml" | head -1 | awk '{print $2}')
+  REDIS_IMAGE="docker.io/${REDIS_REPO}:${REDIS_TAG}"
+fi
+
+if [[ -z "${ZIPKIN_IMAGE:-}" ]]; then
+  # Zipkin image is explicit in the manifest.
+  ZIPKIN_IMAGE=$(grep 'image:' "${REPO_ROOT}/tests/config/zipkin.yaml" | head -1 | awk '{print $2}')
+fi
+
+if [[ -z "${KAFKA_IMAGE:-}" ]] || [[ -z "${ZOOKEEPER_IMAGE:-}" ]]; then
+  echo "Resolving Kafka/Zookeeper images from Helm chart bitnami/kafka 23.0.7..."
+  helm repo add bitnami https://charts.bitnami.com/bitnami 2>/dev/null || true
+  helm repo update bitnami 2>/dev/null
+
+  KAFKA_TEMPLATE=$(helm template dapr-kafka bitnami/kafka \
+    --version 23.0.7 \
+    -f "${REPO_ROOT}/tests/config/kafka_override.yaml" \
+    --set image.repository=bitnamilegacy/kafka 2>/dev/null)
+
+  if [[ -z "${KAFKA_IMAGE:-}" ]]; then
+    KAFKA_IMAGE=$(echo "${KAFKA_TEMPLATE}" | grep 'image:' | grep 'kafka' | head -1 | awk '{print $2}' | tr -d '"')
+    # Ensure docker.io prefix for containerd
+    [[ "${KAFKA_IMAGE}" != docker.io/* ]] && KAFKA_IMAGE="docker.io/${KAFKA_IMAGE}"
+  fi
+  if [[ -z "${ZOOKEEPER_IMAGE:-}" ]]; then
+    ZOOKEEPER_IMAGE=$(echo "${KAFKA_TEMPLATE}" | grep 'image:' | grep 'zookeeper' | head -1 | awk '{print $2}' | tr -d '"')
+    [[ "${ZOOKEEPER_IMAGE}" != docker.io/* ]] && ZOOKEEPER_IMAGE="docker.io/${ZOOKEEPER_IMAGE}"
+  fi
+fi
+
+if [[ -z "${POSTGRESQL_IMAGE:-}" ]]; then
+  echo "Resolving PostgreSQL image from Helm chart bitnami/postgresql 12.8.0..."
+  helm repo add bitnami https://charts.bitnami.com/bitnami 2>/dev/null || true
+
+  POSTGRES_TEMPLATE=$(helm template dapr-postgres bitnami/postgresql \
+    --version 12.8.0 \
+    -f "${REPO_ROOT}/tests/config/postgres_override.yaml" \
+    --set image.repository=bitnamilegacy/postgresql 2>/dev/null)
+
+  POSTGRESQL_IMAGE=$(echo "${POSTGRES_TEMPLATE}" | grep 'image:' | grep 'postgresql' | head -1 | awk '{print $2}' | tr -d '"')
+  [[ "${POSTGRESQL_IMAGE}" != docker.io/* ]] && POSTGRESQL_IMAGE="docker.io/${POSTGRESQL_IMAGE}"
+fi
+
+echo "Building custom KinD node image"
+echo "  Base K8s version: ${K8S_VERSION}"
+echo "  Output image:     ${IMAGE_TAG}"
+echo "  Redis:            ${REDIS_IMAGE}"
+echo "  Kafka:            ${KAFKA_IMAGE}"
+echo "  Zookeeper:        ${ZOOKEEPER_IMAGE}"
+echo "  PostgreSQL:       ${POSTGRESQL_IMAGE}"
+echo "  Zipkin:           ${ZIPKIN_IMAGE}"
+
+docker build \
+  --build-arg "K8S_VERSION=${K8S_VERSION}" \
+  --build-arg "REDIS_IMAGE=${REDIS_IMAGE}" \
+  --build-arg "KAFKA_IMAGE=${KAFKA_IMAGE}" \
+  --build-arg "ZOOKEEPER_IMAGE=${ZOOKEEPER_IMAGE}" \
+  --build-arg "POSTGRESQL_IMAGE=${POSTGRESQL_IMAGE}" \
+  --build-arg "ZIPKIN_IMAGE=${ZIPKIN_IMAGE}" \
+  -t "${IMAGE_TAG}" \
+  -f "${SCRIPT_DIR}/Dockerfile" \
+  "${SCRIPT_DIR}"
+
+echo ""
+echo "Successfully built: ${IMAGE_TAG}"
+echo "To push: docker push ${IMAGE_TAG}"

--- a/tests/dapr_tests.mk
+++ b/tests/dapr_tests.mk
@@ -318,6 +318,13 @@ push-e2e-app-all: $(PUSH_E2E_APPS_TARGETS)
 # can be faster because it uses cache and copies images directly
 build-push-e2e-app-all: $(BUILD_PUSH_E2E_APPS_TARGETS)
 
+# Pull all e2e test app images from the cache registry.
+# This is the same as build-push-e2e-app-all but requires DAPR_CACHE_REGISTRY
+# to be set. The build-and-push command tries the cache first and only builds
+# on a cache miss. The prebuild-test-apps workflow keeps the cache warm so
+# this target reliably gets cache hits during CI.
+pull-cache-e2e-app-all: check-e2e-cache $(BUILD_PUSH_E2E_APPS_TARGETS)
+
 # push test app image to kind cluster
 push-kind-e2e-app-all: $(PUSH_KIND_E2E_APPS_TARGETS)
 


### PR DESCRIPTION
Add pre-build workflow for e2e test app images

Adds a new workflow that pre-builds all e2e test app images and pushes them to the cache registry on master pushes and nightly, so the KinD E2E workflow gets reliable cache hits and avoids redundant image builds.

---

Add pre-baked KinD node images with 3rd-party services

Adds a Dockerfile, build script, and workflow for building custom KinD node images that pre-pull Redis, Kafka, Zookeeper, PostgreSQL, and Zipkin container images. Eliminates ~15-20 minutes of image pull time per KinD E2E test run. Image references are resolved from Helm charts via helm template to ensure they always match what tests deploy.
