### PR TITLE
[1.17] Fix ServiceInvocation response stream buffering

### DIFF
--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -256,7 +256,15 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 
 		if !isSSE {
 			w.WriteHeader(statusCode)
-			_, rErr = io.Copy(w, reader)
+			// Use a flushing writer to ensure each chunk is sent to the
+			// client immediately. Without this, Go's HTTP server buffers
+			// the response in a 4KB bufio.Writer, preventing true
+			// streaming for chunked responses.
+			dst := io.Writer(w)
+			if f, ok := w.(http.Flusher); ok {
+				dst = &flushWriter{w: w, f: f}
+			}
+			_, rErr = io.Copy(dst, reader)
 			if rErr != nil {
 				// Do not return rResp here, we already have a deferred `Close` call on it
 				return nil, backoff.Permanent(rErr)
@@ -454,6 +462,22 @@ type invokeError struct {
 
 func (ie invokeError) Error() string {
 	return fmt.Sprintf("invokeError (statusCode='%d') msg='%v'", ie.statusCode, string(ie.msg))
+}
+
+// flushWriter wraps an http.ResponseWriter and flushes after every Write
+// call. This ensures chunked response data is sent to the client
+// immediately rather than being buffered.
+type flushWriter struct {
+	w http.ResponseWriter
+	f http.Flusher
+}
+
+func (fw *flushWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.w.Write(p)
+	if n > 0 {
+		fw.f.Flush()
+	}
+	return
 }
 
 type codeError struct {

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -245,53 +245,83 @@ func (h *Channel) sendJob(ctx context.Context, name string, data *anypb.Any) (*i
 	if h.ch != nil {
 		h.ch <- struct{}{}
 	}
-	defer func() {
-		if h.ch != nil {
-			<-h.ch
-		}
-	}()
 
 	// Emit metric when request is sent
 	diag.DefaultHTTPMonitoring.ClientRequestStarted(ctx, channelReq.Method, channelReq.URL.Path, channelReq.ContentLength)
 	startRequest := time.Now()
 
-	rw := &RWRecorder{
-		W: &bytes.Buffer{},
+	pr, pw := io.Pipe()
+	rw := &rwRecorder{
+		pw:      pw,
+		readyCh: make(chan struct{}),
 	}
-	execPipeline := h.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Send request to user application
-		// (Body is closed below, but linter isn't detecting that)
-		//nolint:bodyclose
-		clientResp, clientErr := h.client.Do(r)
-		if clientResp != nil {
-			copyHeader(w.Header(), clientResp.Header)
-			w.WriteHeader(clientResp.StatusCode)
-			_, _ = io.Copy(w, clientResp.Body)
-		}
-		if clientErr != nil {
-			err = clientErr
-		}
-	}))
 
-	execPipeline.ServeHTTP(rw, channelReq)
-	resp := rw.Result() //nolint:bodyclose
+	var handlerErr error
+
+	go func() {
+		defer rw.signalReady()
+		defer pw.Close()
+		defer func() {
+			if h.ch != nil {
+				<-h.ch
+			}
+		}()
+
+		execPipeline := h.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Send request to user application
+			// (Body is closed below, but linter isn't detecting that)
+			clientResp, clientErr := h.client.Do(r)
+			if clientErr != nil {
+				handlerErr = clientErr
+			}
+			if clientResp != nil {
+				defer clientResp.Body.Close()
+				copyHeader(w.Header(), clientResp.Header)
+				w.WriteHeader(clientResp.StatusCode)
+				_, _ = io.Copy(w, clientResp.Body)
+			}
+		}))
+		execPipeline.ServeHTTP(rw, channelReq)
+	}()
+
+	select {
+	case <-rw.readyCh:
+	case <-ctx.Done():
+		pr.Close()
+		return nil, ctx.Err()
+	}
 
 	elapsedMs := float64(time.Since(startRequest) / time.Millisecond)
 
-	var contentLength int64
-	if resp != nil {
-		if resp.Header != nil {
-			contentLength, _ = strconv.ParseInt(resp.Header.Get("content-length"), 10, 64)
+	contentLength := int64(-1)
+	if rw.h != nil {
+		if cl := rw.h.Get("content-length"); cl != "" {
+			if parsed, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
+				contentLength = parsed
+			}
 		}
 	}
 
-	if err != nil {
+	if handlerErr != nil {
+		pr.Close()
 		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, channelReq.URL.Path, strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
-		return nil, err
+		return nil, handlerErr
 	}
+
+	resp := &http.Response{
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		StatusCode:    rw.StatusCode(),
+		Header:        rw.h,
+		ContentLength: contentLength,
+		Body:          pr,
+	}
+	resp.Status = fmt.Sprintf("%03d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 
 	rsp, err := h.parseChannelResponse(resp)
 	if err != nil {
+		pr.Close()
 		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, channelReq.URL.Path, strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
 		return nil, err
 	}
@@ -363,80 +393,118 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	if h.ch != nil {
 		h.ch <- struct{}{}
 	}
-	defer func() {
-		if h.ch != nil {
-			<-h.ch
-		}
-	}()
 
 	// Emit metric when request is sent
 	diag.DefaultHTTPMonitoring.ClientRequestStarted(ctx, channelReq.Method, req.Message().GetMethod(), int64(len(req.Message().GetData().GetValue())))
 	startRequest := time.Now()
 
-	rw := &RWRecorder{
-		W: &bytes.Buffer{},
+	pr, pw := io.Pipe()
+	rw := &rwRecorder{
+		pw:      pw,
+		readyCh: make(chan struct{}),
 	}
 
-	var isSse bool
+	var (
+		isSse      bool
+		handlerErr error
+	)
 
-	execPipeline := h.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		isSse = sse.IsSSEHttpRequest(r)
-		if isSse {
-			r.Header.Set(headerAccept, mimeEventStream)
-		}
-
-		// Send request to user application
-		// (Body is closed below, but linter isn't detecting that)
-		//nolint:bodyclose
-		clientResp, clientErr := h.client.Do(r)
-		if clientErr != nil {
-			err = clientErr
-			return
-		}
-		if clientResp != nil {
-			statusOK := clientResp.StatusCode >= 200 && clientResp.StatusCode < 300
-			if isSse && req.HTTPResponseWriter() != nil && statusOK {
-				callerResponseWriter := req.HTTPResponseWriter()
-				copyHeader(callerResponseWriter.Header(), clientResp.Header)
-				reader := bufio.NewReader(clientResp.Body)
-				err = sse.FlushSSEResponse(ctx, callerResponseWriter, reader)
-				if err != nil {
-					return
-				}
-			} else {
-				copyHeader(w.Header(), clientResp.Header)
-				w.WriteHeader(clientResp.StatusCode)
-				_, _ = io.Copy(w, clientResp.Body)
+	go func() {
+		defer rw.signalReady()
+		defer pw.Close()
+		// Release the concurrency limiter slot when the handler goroutine
+		// finishes. Because io.Pipe is synchronous (no buffer), the goroutine
+		// naturally stays alive—and holds the slot—until the caller has
+		// consumed (or closed) the response body.
+		defer func() {
+			if h.ch != nil {
+				<-h.ch
 			}
-		}
-	}))
-	execPipeline.ServeHTTP(rw, channelReq)
+		}()
+
+		execPipeline := h.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			isSse = sse.IsSSEHttpRequest(r)
+			if isSse {
+				r.Header.Set(headerAccept, mimeEventStream)
+			}
+
+			// Send request to user application
+			// (Body is closed below, but linter isn't detecting that)
+			clientResp, clientErr := h.client.Do(r)
+			if clientErr != nil {
+				handlerErr = clientErr
+				return
+			}
+			if clientResp != nil {
+				defer clientResp.Body.Close()
+				statusOK := clientResp.StatusCode >= 200 && clientResp.StatusCode < 300
+				if isSse && req.HTTPResponseWriter() != nil && statusOK {
+					callerResponseWriter := req.HTTPResponseWriter()
+					copyHeader(callerResponseWriter.Header(), clientResp.Header)
+					reader := bufio.NewReader(clientResp.Body)
+					handlerErr = sse.FlushSSEResponse(ctx, callerResponseWriter, reader)
+					if handlerErr != nil {
+						return
+					}
+				} else {
+					copyHeader(w.Header(), clientResp.Header)
+					w.WriteHeader(clientResp.StatusCode)
+					_, _ = io.Copy(w, clientResp.Body)
+				}
+			}
+		}))
+		execPipeline.ServeHTTP(rw, channelReq)
+	}()
+
+	// Wait for response headers to be available (or the handler to finish),
+	// but also honor context cancellation to avoid blocking indefinitely.
+	select {
+	case <-rw.readyCh:
+	case <-ctx.Done():
+		pr.Close()
+		return nil, ctx.Err()
+	}
 
 	elapsedMs := float64(time.Since(startRequest) / time.Millisecond)
 
-	var contentLength int64
+	contentLength := int64(-1)
 
-	if err != nil {
-		// content-length is omitted in http streaming scenarios
+	if handlerErr != nil {
+		pr.Close()
 		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
-		return nil, err
+		return nil, handlerErr
 	}
 
 	statusOK := rw.StatusCode() >= 200 && rw.StatusCode() < 300
 	if isSse && statusOK {
+		pr.Close()
 		return nil, nil
 	}
 
-	resp := rw.Result() //nolint:bodyclose
-
-	if resp != nil {
-		if resp.Header != nil {
-			contentLength, _ = strconv.ParseInt(resp.Header.Get("content-length"), 10, 64)
+	if rw.h != nil {
+		if cl := rw.h.Get("content-length"); cl != "" {
+			if parsed, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
+				contentLength = parsed
+			}
 		}
 	}
 
+	// Construct the http.Response with the pipe reader as the body so data
+	// streams through without buffering.
+	resp := &http.Response{
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		StatusCode:    rw.StatusCode(),
+		Header:        rw.h,
+		ContentLength: contentLength,
+		Body:          pr,
+	}
+	resp.Status = fmt.Sprintf("%03d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+
 	rsp, err := h.parseChannelResponse(resp)
 	if err != nil {
+		pr.Close()
 		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
 		return nil, err
 	}

--- a/pkg/channel/http/rwrecorder.go
+++ b/pkg/channel/http/rwrecorder.go
@@ -1,111 +1,50 @@
 package http
 
-/*!
-Adapted from the Go 1.19.2 source code
-Copyright 2009 The Go Authors. All rights reserved.
-License: BSD (https://github.com/golang/go/blob/go1.19.2/LICENSE)
-*/
-
 import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/textproto"
-	"strconv"
-	"strings"
-
-	"golang.org/x/net/http/httpguts"
+	"sync"
 )
 
-type RWRecorder struct {
+// rwRecorder writes response body data to an io.Writer and signals when
+// headers and status code are available.
+type rwRecorder struct {
 	statusCode int
 	h          http.Header
-	W          io.ReadWriter
+	pw         io.Writer
+	readyCh    chan struct{}
+	readyOnce  sync.Once
 }
 
-func (w *RWRecorder) StatusCode() int {
-	if w.statusCode == 0 {
+func (r *rwRecorder) signalReady() {
+	r.readyOnce.Do(func() { close(r.readyCh) })
+}
+
+func (r *rwRecorder) StatusCode() int {
+	if r.statusCode == 0 {
 		return http.StatusOK
 	}
-	return w.statusCode
+	return r.statusCode
 }
 
-func (w *RWRecorder) Header() http.Header {
-	if w.h == nil {
-		w.h = make(http.Header)
+func (r *rwRecorder) Header() http.Header {
+	if r.h == nil {
+		r.h = make(http.Header)
 	}
-	return w.h
+	return r.h
 }
 
-func (w *RWRecorder) WriteHeader(code int) {
+func (r *rwRecorder) WriteHeader(code int) {
 	if code < 100 || code > 999 {
 		panic(fmt.Sprintf("invalid WriteHeader code %v", code))
 	}
-
-	w.statusCode = code
+	r.statusCode = code
+	r.signalReady()
 }
 
-func (w *RWRecorder) Write(p []byte) (int, error) {
-	return w.W.Write(p)
-}
-
-func (w *RWRecorder) Result() *http.Response {
-	res := &http.Response{
-		Proto:      "HTTP/1.1",
-		ProtoMajor: 1,
-		ProtoMinor: 1,
-		Body:       io.NopCloser(w.W),
-		StatusCode: w.StatusCode(),
-		Header:     w.h,
-	}
-
-	res.Status = fmt.Sprintf("%03d %s", res.StatusCode, http.StatusText(res.StatusCode))
-	res.ContentLength = parseContentLength(res.Header.Get("Content-Length"))
-
-	if trailers, ok := w.h["Trailer"]; ok {
-		res.Trailer = make(http.Header, len(trailers))
-		for _, k := range trailers {
-			for _, k := range strings.Split(k, ",") {
-				k = http.CanonicalHeaderKey(textproto.TrimString(k))
-				if !httpguts.ValidTrailerHeader(k) {
-					// Ignore since forbidden by RFC 7230, section 4.1.2.
-					continue
-				}
-				vv, ok := w.h[k]
-				if !ok {
-					continue
-				}
-				vv2 := make([]string, len(vv))
-				copy(vv2, vv)
-				res.Trailer[k] = vv2
-			}
-		}
-	}
-
-	for k, vv := range w.h {
-		if !strings.HasPrefix(k, http.TrailerPrefix) {
-			continue
-		}
-		if res.Trailer == nil {
-			res.Trailer = make(http.Header)
-		}
-		for _, v := range vv {
-			res.Trailer.Add(strings.TrimPrefix(k, http.TrailerPrefix), v)
-		}
-	}
-	return res
-}
-
-// parseContentLength trims whitespace from s and returns -1 if no value
-// is set, or the value if it's >= 0.
-func parseContentLength(cl string) int64 {
-	cl = textproto.TrimString(cl)
-	if cl == "" {
-		return -1
-	}
-	n, err := strconv.ParseUint(cl, 10, 63)
-	if err != nil {
-		return -1
-	}
-	return int64(n)
+func (r *rwRecorder) Write(p []byte) (int, error) {
+	// Implicit 200 status if WriteHeader hasn't been called yet.
+	r.signalReady()
+	return r.pw.Write(p)
 }

--- a/tests/integration/framework/os/os.go
+++ b/tests/integration/framework/os/os.go
@@ -14,8 +14,12 @@ limitations under the License.
 package os
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func SkipWindows(t *testing.T) {
@@ -24,4 +28,24 @@ func SkipWindows(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on windows which relies on unix process signals")
 	}
+}
+
+func SkipMacOS(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping test on MacOS")
+	}
+}
+
+func WriteFileYaml(t *testing.T, data string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "test.yaml")
+	require.NoError(t, os.WriteFile(f, []byte(data), 0o600))
+	return f
+}
+
+func WriteFileTo(t *testing.T, name, data string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(name, []byte(data), 0o600))
 }

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/chunkedresponse.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/chunkedresponse.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(chunkedresponse))
+}
+
+// chunkedresponse tests that a chunked (streaming) HTTP response from the
+// target app is forwarded incrementally through the sidecar without being
+// buffered in memory. It verifies this by having the target app send a
+// response in two phases: the first chunk is sent immediately, and the
+// second chunk only after the test signals via a channel (after reading
+// the first chunk). The fact that the first chunk arrives before the
+// second is sent proves the response is streamed.
+type chunkedresponse struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+
+	// sendSecondCh is closed by the test after reading the first chunk,
+	// telling the app handler to send the second chunk.
+	sendSecondCh chan struct{}
+}
+
+func (c *chunkedresponse) Setup(t *testing.T) []framework.Option {
+	// Use chunks larger than Go's default HTTP server bufio.Writer buffer (4KB)
+	// so that writes are flushed to the network immediately rather than waiting
+	// for the buffer to fill or the handler to return.
+	const chunkSize = 16 * 1024
+
+	c.sendSecondCh = make(chan struct{})
+
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/chunked-response", func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			if !assert.True(t, ok, "ResponseWriter does not support flushing") {
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+
+			// Send first chunk immediately.
+			if _, werr := w.Write([]byte(strings.Repeat("A", chunkSize))); werr != nil {
+				return
+			}
+			flusher.Flush()
+
+			// Wait for the test to signal that the first chunk has been
+			// received before sending the second chunk. If the sidecar
+			// were buffering, the first chunk would never reach the test
+			// client and this would block until the context is cancelled.
+			select {
+			case <-c.sendSecondCh:
+			case <-r.Context().Done():
+				return
+			}
+
+			// Send second chunk.
+			if _, werr := w.Write([]byte(strings.Repeat("B", chunkSize))); werr != nil {
+				return
+			}
+			flusher.Flush()
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *chunkedresponse) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/chunked-response",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	const chunkSize = 16 * 1024
+
+	// Read the first chunk. If the sidecar is streaming correctly, this
+	// arrives while the app is blocked waiting on sendSecondCh. If the
+	// sidecar were buffering the full response, this read would block
+	// forever (deadlock) because the app is waiting for us to signal
+	// before sending more data.
+	firstChunk := make([]byte, chunkSize)
+	_, err = io.ReadFull(resp.Body, firstChunk)
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat("A", chunkSize), string(firstChunk))
+
+	// Signal the app to send the second chunk.
+	close(c.sendSecondCh)
+
+	// Read the second chunk.
+	secondChunk := make([]byte, chunkSize)
+	_, err = io.ReadFull(resp.Body, secondChunk)
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat("B", chunkSize), string(secondChunk))
+
+	_, err = resp.Body.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, io.EOF)
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/requestmemory.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/requestmemory.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	fos "github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(requestmemory))
+}
+
+// requestmemory verifies that streaming a large chunked HTTP request body
+// through service invocation does not cause the sidecar to buffer the entire
+// payload in memory.
+type requestmemory struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+}
+
+func (c *requestmemory) Setup(t *testing.T) []framework.Option {
+	// Don't run on very constrained CI runners.
+	fos.SkipWindows(t)
+	fos.SkipMacOS(t)
+
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/large-request-sink", func(w http.ResponseWriter, r *http.Request) {
+			n, _ := io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, "%d", n)
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+		daprd.WithMaxBodySize("512Mi"),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+		daprd.WithMaxBodySize("512Mi"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *requestmemory) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	const (
+		totalSize = 256 << 20
+		chunkSize = 1 << 20
+		numChunks = totalSize / chunkSize
+	)
+
+	// Record baseline memory for both sidecars.
+	senderBaseline := c.daprdSender.MetricResidentMemoryMi(t, ctx)
+	receiverBaseline := c.daprdReceiver.MetricResidentMemoryMi(t, ctx)
+
+	// Use io.Pipe to produce a request body with unknown Content-Length,
+	// forcing chunked transfer encoding.
+	pr, pw := io.Pipe()
+	go func() {
+		chunk := []byte(strings.Repeat("A", chunkSize))
+		for range numChunks {
+			if _, err := pw.Write(chunk); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
+		pw.Close()
+	}()
+
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/large-request-sink",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
+	require.NoError(t, err)
+
+	// Sample memory periodically during the transfer.
+	var peakReceiverMi, peakSenderMi atomic.Int64
+	storePeak := func(peak *atomic.Int64, val float64) {
+		valInt := int64(val * 1000)
+		for {
+			old := peak.Load()
+			if valInt <= old {
+				break
+			}
+			if peak.CompareAndSwap(old, valInt) {
+				break
+			}
+		}
+	}
+
+	samplerCtx, samplerCancel := context.WithCancel(ctx)
+	defer samplerCancel()
+	samplerDone := make(chan struct{})
+	go func() {
+		defer close(samplerDone)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				storePeak(&peakReceiverMi, c.daprdReceiver.MetricResidentMemoryMi(t, ctx))
+				storePeak(&peakSenderMi, c.daprdSender.MetricResidentMemoryMi(t, ctx))
+			case <-samplerCtx.Done():
+				return
+			}
+		}
+	}()
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(totalSize), string(body),
+		"target app should have received the complete request body")
+
+	// Take a final sample after the transfer.
+	storePeak(&peakReceiverMi, c.daprdReceiver.MetricResidentMemoryMi(t, ctx))
+	storePeak(&peakSenderMi, c.daprdSender.MetricResidentMemoryMi(t, ctx))
+
+	samplerCancel()
+	<-samplerDone
+
+	peakReceiverDelta := float64(peakReceiverMi.Load())/1000 - receiverBaseline
+	peakSenderDelta := float64(peakSenderMi.Load())/1000 - senderBaseline
+
+	// If the sidecar buffers the 256MB request body, its RSS would spike by
+	// ~256MB. Allow up to 80MB growth for streaming overhead (Go GC, gRPC frame
+	// buffers, pipe buffers, runtime allocations).
+	const maxDeltaMi = 80
+
+	assert.Less(t, peakReceiverDelta, float64(maxDeltaMi),
+		"receiver sidecar should not buffer the streaming request body in memory")
+	assert.Less(t, peakSenderDelta, float64(maxDeltaMi),
+		"sender sidecar should not buffer the streaming request body in memory")
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/responsememory.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/responsememory.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	fos "github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(responsememory))
+}
+
+// responsememory verifies that streaming a large HTTP response through service
+// invocation does not cause the sidecar to buffer the entire payload in memory.
+type responsememory struct {
+	daprdSender   *daprd.Daprd
+	daprdReceiver *daprd.Daprd
+}
+
+func (c *responsememory) Setup(t *testing.T) []framework.Option {
+	fos.SkipWindows(t)
+	fos.SkipMacOS(t)
+
+	const (
+		totalSize = 256 << 20
+		chunkSize = 1 << 20
+		numChunks = totalSize / chunkSize
+	)
+
+	chunk := []byte(strings.Repeat("X", chunkSize))
+
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/large-response", func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			if !assert.True(t, ok, "ResponseWriter does not support flushing") {
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+
+			for range numChunks {
+				_, werr := w.Write(chunk)
+				if werr != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *responsememory) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	const totalSize = 256 << 20
+
+	// Record baseline memory for both sidecars before the streaming call.
+	senderBaseline := c.daprdSender.MetricResidentMemoryMi(t, ctx)
+	receiverBaseline := c.daprdReceiver.MetricResidentMemoryMi(t, ctx)
+
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/large-response",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var peakReceiverMi, peakSenderMi atomic.Int64
+	storePeak := func(peak *atomic.Int64, val float64) {
+		valInt := int64(val * 1000) // Store as milli-Mi for precision.
+		for {
+			old := peak.Load()
+			if valInt <= old {
+				break
+			}
+			if peak.CompareAndSwap(old, valInt) {
+				break
+			}
+		}
+	}
+
+	samplerCtx, samplerCancel := context.WithCancel(ctx)
+	defer samplerCancel()
+	samplerDone := make(chan struct{})
+	go func() {
+		defer close(samplerDone)
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				storePeak(&peakReceiverMi, c.daprdReceiver.MetricResidentMemoryMi(t, ctx))
+				storePeak(&peakSenderMi, c.daprdSender.MetricResidentMemoryMi(t, ctx))
+			case <-samplerCtx.Done():
+				return
+			}
+		}
+	}()
+
+	n, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, int64(totalSize), n, "should receive the complete response body")
+
+	// Take a final sample after the transfer.
+	storePeak(&peakReceiverMi, c.daprdReceiver.MetricResidentMemoryMi(t, ctx))
+	storePeak(&peakSenderMi, c.daprdSender.MetricResidentMemoryMi(t, ctx))
+
+	peakReceiverDelta := float64(peakReceiverMi.Load())/1000 - receiverBaseline
+	peakSenderDelta := float64(peakSenderMi.Load())/1000 - senderBaseline
+
+	// If the sidecar buffers the 256MB response, its RSS would spike by ~256MB.
+	// Allow up to 80MB growth for streaming overhead (Go GC, gRPC frame buffers,
+	// pipe buffers, runtime allocations). This is generous enough to avoid
+	// flakes but catches a full-body buffer.
+	const maxDeltaMi = 80
+
+	assert.Less(t, peakReceiverDelta, float64(maxDeltaMi),
+		"receiver sidecar should not buffer the streaming response in memory")
+	assert.Less(t, peakSenderDelta, float64(maxDeltaMi),
+		"sender sidecar should not buffer the streaming response in memory")
+
+	// Stop the sampler goroutine.
+	samplerCancel()
+	<-samplerDone
+}


### PR DESCRIPTION
* Fix ServiceInvocation response stream buffering

The HTTP channel's response recorder (RWRecorder) buffered the entire response body in a bytes.Buffer before returning headers to the caller. For large streaming responses, this caused the receiver sidecar's memory to spike proportionally to the response size (e.g. ~750MB for a 256MB response).

Replace RWRecorder with a streaming rwRecorder backed by io.Pipe. The middleware pipeline now runs in a goroutine, writing response data to the pipe. The main goroutine waits for headers via a channel, then returns the pipe reader as the response body — data flows through without buffering.

Also flush chunked response data on the sender sidecar by wrapping the HTTP response writer with a flushWriter that calls Flush() after each Write, ensuring data reaches the client immediately instead of sitting in Go's 4KB bufio.Writer buffer.

Needs backporting but no release notes as this fix is related to the release notes already added.



* Review comments



* Review comments



* Review comment



* Fix tests



* Review comments



---------

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
