### PR TITLE
Fix workflow max body size

### DIFF
--- a/docs/release_notes/v1.17.2.md
+++ b/docs/release_notes/v1.17.2.md
@@ -11,6 +11,7 @@ This update includes a breaking change and bug fixes:
 - [Oracle Database state store BulkGet returns HTTP 500 instead of per-key errors](#oracle-database-state-store-bulkget-returns-http-500-instead-of-per-key-errors)
 - [Pulsar pub/sub publishes invalid JSON messages when Avro schema is configured](#pulsar-pubsub-publishes-invalid-json-messages-when-avro-schema-is-configured)
 - [Nil pointer dereference in conversation LangChain Go Kit LLM logger](#nil-pointer-dereference-in-conversation-langchain-go-kit-llm-logger)
+- [Workflow activities with large results fail with gRPC ResourceExhausted error](#workflow-activities-with-large-results-fail-with-grpc-resourceexhausted-error)
 
 ## Workflow state retention policy CRD fields use incorrect type (Breaking Change)
 
@@ -222,3 +223,25 @@ The LLM logger callback in the LangChain Go Kit conversation component was calle
 ### Solution
 
 Added a nil pointer check in the LangChain Go Kit LLM logger to prevent the dereference, ensuring the conversation component handles the case gracefully without panicking.
+
+## Workflow activities with large results fail with gRPC ResourceExhausted error
+
+### Problem
+
+Workflow activities that return results larger than ~2MB fail with a `ResourceExhausted` gRPC error when scheduling the activity result reminder via the scheduler:
+
+```
+Error scheduling reminder job activity-result-XXXX due to: rpc error: code = ResourceExhausted desc = trying to send message larger than max (37950104 vs. 2097152)
+```
+
+### Impact
+
+Any workflow activity returning a result larger than the default gRPC send message size limit (~2MB) fails to deliver its result back to the parent orchestration. The orchestration hangs indefinitely waiting for the activity result, eventually timing out or stalling.
+
+### Root Cause
+
+The scheduler gRPC client configured `MaxCallRecvMsgSize` to allow receiving large messages, but did not configure `MaxCallSendMsgSize`. This left the send-side limit at the gRPC default (~2MB). When an activity completes, its result is serialized into a reminder job request sent to the scheduler. If the activity result exceeds the default limit, the gRPC client rejects the outgoing message before it reaches the server.
+
+### Solution
+
+Added `MaxCallSendMsgSize` to the scheduler gRPC client dial options, matching the existing `MaxCallRecvMsgSize` configuration.

--- a/pkg/scheduler/client/client.go
+++ b/pkg/scheduler/client/client.go
@@ -46,7 +46,10 @@ func New(ctx context.Context, address string, sec security.Handler) (schedulerv1
 	}
 
 	opts := []grpc.DialOption{
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(math.MaxInt32),
+			grpc.MaxCallSendMsgSize(math.MaxInt32),
+		),
 		grpc.WithUnaryInterceptor(unaryClientInterceptor),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    time.Second * 3,

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -273,6 +274,10 @@ func (d *Daprd) GRPCConn(t *testing.T, ctx context.Context) *grpc.ClientConn {
 	conn, err := grpc.DialContext(ctx, d.GRPCAddress(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(math.MaxInt32),
+			grpc.MaxCallSendMsgSize(math.MaxInt32),
+		),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })

--- a/tests/integration/suite/daprd/workflow/largeactivityresult.go
+++ b/tests/integration/suite/daprd/workflow/largeactivityresult.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://wwb.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(largeactivityresult))
+}
+
+type largeactivityresult struct {
+	workflow *workflow.Workflow
+}
+
+func (l *largeactivityresult) Setup(t *testing.T) []framework.Option {
+	l.workflow = workflow.New(t,
+		workflow.WithDaprdOptions(0,
+			daprd.WithMaxBodySize("10M"),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(l.workflow),
+	}
+}
+
+func (l *largeactivityresult) Run(t *testing.T, ctx context.Context) {
+	l.workflow.WaitUntilRunning(t, ctx)
+
+	// Generate a payload larger than the default gRPC send limit of 4MB.
+	const payloadSize = 5 * 1024 * 1024 // 5MB
+	largePayload := strings.Repeat("x", payloadSize)
+
+	l.workflow.Registry().AddOrchestratorN("large-result", func(ctx *task.OrchestrationContext) (any, error) {
+		var result string
+		err := ctx.CallActivity("produce-large-result").Await(&result)
+		return result, err
+	})
+
+	l.workflow.Registry().AddActivityN("produce-large-result", func(ctx task.ActivityContext) (any, error) {
+		return largePayload, nil
+	})
+
+	client := l.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewOrchestration(ctx, "large-result")
+	require.NoError(t, err)
+
+	metadata, err := client.WaitForOrchestrationCompletion(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.True(t, api.OrchestrationMetadataIsComplete(metadata))
+}


### PR DESCRIPTION
Workflow activities with large results fail with gRPC ResourceExhausted error

Problem

Workflow activities that return results larger than ~2MB fail with a `ResourceExhausted` gRPC error when scheduling the activity result reminder via the scheduler:

```
Error scheduling reminder job activity-result-XXXX due to: rpc error: code = ResourceExhausted desc = trying to send message larger than max (37950104 vs. 2097152)
```

Impact

Any workflow activity returning a result larger than the default gRPC send message size limit (~2MB) fails to deliver its result back to the parent orchestration. The orchestration hangs indefinitely waiting for the activity result, eventually timing out or stalling.

Root Cause

The scheduler gRPC client configured `MaxCallRecvMsgSize` to allow receiving large messages, but did not configure `MaxCallSendMsgSize`. This left the send-side limit at the gRPC default (~2MB). When an activity completes, its result is serialized into a reminder job request sent to the scheduler. If the activity result exceeds the default limit, the gRPC client rejects the outgoing message before it reaches the server.

Solution

Added `MaxCallSendMsgSize` to the scheduler gRPC client dial options, matching the existing `MaxCallRecvMsgSize` configuration.