### PR TITLE
Release notes for #9606

### DIFF
--- a/docs/release_notes/v1.17.2.md
+++ b/docs/release_notes/v1.17.2.md
@@ -13,6 +13,7 @@ This update includes a breaking change and bug fixes:
 - [Actor placement dissemination failures with many replicas](#actor-placement-dissemination-failures-with-many-replicas)
 - [Nil pointer dereference in conversation LangChain Go Kit LLM logger](#nil-pointer-dereference-in-conversation-langchain-go-kit-llm-logger)
 - [Workflow activities with large results fail with gRPC ResourceExhausted error](#workflow-activities-with-large-results-fail-with-grpc-resourceexhausted-error)
+- [Bulk publish does not apply namespace prefix to topic](#bulk-publish-does-not-apply-namespace-prefix-to-topic)
 
 ## Workflow state retention policy CRD fields use incorrect type (Breaking Change)
 
@@ -270,3 +271,21 @@ The scheduler gRPC client configured `MaxCallRecvMsgSize` to allow receiving lar
 ### Solution
 
 Added `MaxCallSendMsgSize` to the scheduler gRPC client dial options, matching the existing `MaxCallRecvMsgSize` configuration.
+
+## Bulk publish does not apply namespace prefix to topic
+
+### Problem
+
+When using the Bulk Publish API with a pub/sub component that has `NamespaceScoped` enabled, messages were published to the un-namespaced topic instead of the namespace-prefixed topic.
+
+### Impact
+
+Applications using namespace-scoped pub/sub components with the Bulk Publish API experienced silent message loss. Bulk-published messages were routed to the wrong topic (e.g. the un-namespaced exchange), while subscribers were listening on the namespace-prefixed topic. The regular `Publish` API was not affected, so only bulk publish users encountered this issue.
+
+### Root Cause
+
+The `Publish` method in `publisher.go` prepends the namespace to `req.Topic` when `NamespaceScoped` is true, but the `BulkPublish` method did not include this same namespace-prefixing step. This caused bulk-published messages to bypass the namespace scoping entirely.
+
+### Solution
+
+Added the namespace prefix guard to `BulkPublish` in `publisher.go`, immediately after scope validation and before either the native `BulkPublisher` or `defaultBulkPublisher` fallback path is invoked. This ensures bulk-published messages are routed to the same namespace-prefixed topic as regular published messages.


### PR DESCRIPTION
Release notes for https://github.com/dapr/dapr/pull/9606

---

Bulk publish does not apply namespace prefix to topic

Problem

When using the Bulk Publish API with a pub/sub component that has `NamespaceScoped` enabled, messages were published to the un-namespaced topic instead of the namespace-prefixed topic.

Impact

Applications using namespace-scoped pub/sub components with the Bulk Publish API experienced silent message loss. Bulk-published messages were routed to the wrong topic (e.g. the un-namespaced exchange), while subscribers were listening on the namespace-prefixed topic. The regular `Publish` API was not affected, so only bulk publish users encountered this issue.

Root Cause

The `Publish` method in `publisher.go` prepends the namespace to `req.Topic` when `NamespaceScoped` is true, but the `BulkPublish` method did not include this same namespace-prefixing step. This caused bulk-published messages to bypass the namespace scoping entirely.

Solution

Added the namespace prefix guard to `BulkPublish` in `publisher.go`, immediately after scope validation and before either the native `BulkPublisher` or `defaultBulkPublisher` fallback path is invoked. This ensures bulk-published messages are routed to the same namespace-prefixed topic as regular published messages.