### PR TITLE
test: fix flaky placement version assertions after batched dissemination

### DIFF
--- a/tests/integration/suite/daprd/placement/multiple/actors.go
+++ b/tests/integration/suite/daprd/placement/multiple/actors.go
@@ -85,9 +85,12 @@ func (a *actors) Run(t *testing.T, ctx context.Context) {
 		},
 	}
 
+	var version1 uint64
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, expHosts, a.actors[0].Placement().PlacementTables(t, ctx).Tables["default"].Hosts)
-		assert.Equal(c, uint64(3), a.actors[0].Placement().PlacementTables(t, ctx).Tables["default"].Version)
+		tables := a.actors[0].Placement().PlacementTables(t, ctx)
+		assert.ElementsMatch(c, expHosts, tables.Tables["default"].Hosts)
+		assert.Positive(c, tables.Tables["default"].Version)
+		version1 = tables.Tables["default"].Version
 	}, time.Second*10, time.Millisecond*10)
 
 	client := dworkflow.NewClient(a.actors[0].Daprd().GRPCConn(t, ctx))
@@ -102,13 +105,15 @@ func (a *actors) Run(t *testing.T, ctx context.Context) {
 		"dapr.internal.default." + a.actors[0].Daprd().AppID() + ".workflow",
 		"def",
 	}
+	var version2 uint64
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		tables := a.actors[0].Placement().PlacementTables(t, ctx)
 		if !assert.Contains(c, tables.Tables, "default") {
 			return
 		}
 		assert.ElementsMatch(c, expHosts, tables.Tables["default"].Hosts)
-		assert.Equal(c, uint64(4), tables.Tables["default"].Version)
+		assert.Greater(c, tables.Tables["default"].Version, version1)
+		version2 = tables.Tables["default"].Version
 	}, time.Second*20, time.Millisecond*10)
 
 	cancel()
@@ -122,6 +127,6 @@ func (a *actors) Run(t *testing.T, ctx context.Context) {
 			return
 		}
 		assert.ElementsMatch(c, expHosts, tables.Tables["default"].Hosts)
-		assert.Equal(c, uint64(5), tables.Tables["default"].Version)
+		assert.Greater(c, tables.Tables["default"].Version, version2)
 	}, time.Second*10, time.Second)
 }

--- a/tests/integration/suite/daprd/placement/multiple/actors.go
+++ b/tests/integration/suite/daprd/placement/multiple/actors.go
@@ -88,6 +88,9 @@ func (a *actors) Run(t *testing.T, ctx context.Context) {
 	var version1 uint64
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		tables := a.actors[0].Placement().PlacementTables(t, ctx)
+		if !assert.Contains(c, tables.Tables, "default") {
+			return
+		}
 		assert.ElementsMatch(c, expHosts, tables.Tables["default"].Hosts)
 		assert.Positive(c, tables.Tables["default"].Version)
 		version1 = tables.Tables["default"].Version

--- a/tests/integration/suite/daprd/placement/multiple/shutdown.go
+++ b/tests/integration/suite/daprd/placement/multiple/shutdown.go
@@ -76,7 +76,7 @@ func (s *shutdown) Run(t *testing.T, ctx context.Context) {
 			return
 		}
 		assert.ElementsMatch(c, hosts, table.Tables["default"].Hosts)
-		assert.Equal(c, uint64(3), table.Tables["default"].Version)
+		assert.Positive(c, table.Tables["default"].Version)
 	}, time.Second*10, time.Millisecond*10)
 
 	for i := range s.actors[:2] {


### PR DESCRIPTION
PR #9639 introduced batched dissemination, making exact placement table version numbers non-deterministic based on connection timing. Update actors.go to use relative version checks (positive, then monotonically increasing) and shutdown.go to use assert.Positive, matching the approach already taken in basic.go by #9639.