### PR TITLE
Workflow: Delete orphan timer reminders

### DIFF
--- a/docs/release_notes/v1.17.2.md
+++ b/docs/release_notes/v1.17.2.md
@@ -14,6 +14,7 @@ This update includes a breaking change and bug fixes:
 - [Nil pointer dereference in conversation LangChain Go Kit LLM logger](#nil-pointer-dereference-in-conversation-langchain-go-kit-llm-logger)
 - [Workflow activities with large results fail with gRPC ResourceExhausted error](#workflow-activities-with-large-results-fail-with-grpc-resourceexhausted-error)
 - [Bulk publish does not apply namespace prefix to topic](#bulk-publish-does-not-apply-namespace-prefix-to-topic)
+- [Workflow timer reminders not deleted when external event is received before timeout](#workflow-timer-reminders-not-deleted-when-external-event-is-received-before-timeout)
 
 ## Workflow state retention policy CRD fields use incorrect type (Breaking Change)
 
@@ -289,3 +290,28 @@ The `Publish` method in `publisher.go` prepends the namespace to `req.Topic` whe
 ### Solution
 
 Added the namespace prefix guard to `BulkPublish` in `publisher.go`, immediately after scope validation and before either the native `BulkPublisher` or `defaultBulkPublisher` fallback path is invoked. This ensures bulk-published messages are routed to the same namespace-prefixed topic as regular published messages.
+
+## Workflow timer reminders not deleted when external event is received before timeout
+
+### Problem
+
+When a workflow used `WaitForSingleEvent` with a timeout, a timer reminder was created in the scheduler. If the external event was raised before the timer fired, the timer reminder was never deleted and remained as an orphan in the scheduler until it eventually fired unnecessarily.
+Additionally, when a workflow completed while timers were still pending (e.g. a `CreateTimer` that had not yet fired), those timer reminders were also left behind.
+
+### Impact
+
+Workflows using `WaitForSingleEvent` with timeouts accumulated orphan timer reminders in the scheduler. These timers would eventually fire and trigger unnecessary workflow actor invocations that were silently ignored, wasting scheduler and actor resources.
+For long-running workflows with many `WaitForSingleEvent` calls or long timeouts, the number of orphan reminders could grow significantly.
+
+### Root Cause
+
+The durable task SDK completes the event task when an external event is received, but does not signal the Dapr runtime to delete the associated timer reminder. The runtime had no mechanism to detect that a timer was no longer needed because its associated event had already been received.
+Similarly, when a workflow completed, there was no cleanup of pending timer reminders that had not yet fired.
+
+### Solution
+
+Added two timer cleanup mechanisms to the workflow orchestrator:
+
+1. **Mid-execution cleanup** (`deleteCancelledEventTimers`): After each workflow execution step, the runtime scans the history for `TimerCreated` events associated with `WaitForSingleEvent` calls (identified by the `Name` field on `TimerCreated`). When a matching `EventRaised` event is found in the new events, the corresponding timer reminder is deleted from the scheduler. Event name matching is case-insensitive, and already-deleted timers (e.g. from a crash recovery) are handled gracefully by ignoring `NotFound` errors.
+
+2. **Completion cleanup** (`deleteAllReminders`): When a workflow completes and has unfired timers (detected by comparing `TimerCreated` vs `TimerFired` event counts), all reminders for the workflow and its activities are bulk-deleted via `DeleteByActorID`. This handles timers without a `Name` field (e.g. `CreateTimer`) that cannot be matched to specific events.

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -75,3 +75,26 @@ func (o *orchestrator) createReminderWithType(ctx context.Context, namePrefix st
 		},
 	})
 }
+
+// deleteAllReminders deletes all reminders for the workflow and its
+// activities. This is called when the workflow completes to ensure no orphan
+// reminders (e.g. unfired timers) remain in the scheduler.
+func (o *orchestrator) deleteAllReminders(ctx context.Context) error {
+	actorType := o.actorTypeBuilder.Workflow(o.appID)
+
+	log.Debugf("Workflow actor '%s': deleting all reminders for completed workflow", o.actorID)
+
+	if err := o.reminders.DeleteByActorID(ctx, &actorapi.DeleteRemindersByActorIDRequest{
+		ActorType:       actorType,
+		ActorID:         o.actorID,
+		MatchIDAsPrefix: false,
+	}); err != nil {
+		return fmt.Errorf("actor '%s' failed to delete reminders on completion: %w", o.actorID, err)
+	}
+
+	return o.reminders.DeleteByActorID(ctx, &actorapi.DeleteRemindersByActorIDRequest{
+		ActorType:       o.activityActorType,
+		ActorID:         o.actorID + "::",
+		MatchIDAsPrefix: true,
+	})
+}

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -92,9 +92,13 @@ func (o *orchestrator) deleteAllReminders(ctx context.Context) error {
 		return fmt.Errorf("actor '%s' failed to delete reminders on completion: %w", o.actorID, err)
 	}
 
-	return o.reminders.DeleteByActorID(ctx, &actorapi.DeleteRemindersByActorIDRequest{
+	if err := o.reminders.DeleteByActorID(ctx, &actorapi.DeleteRemindersByActorIDRequest{
 		ActorType:       o.activityActorType,
 		ActorID:         o.actorID + "::",
 		MatchIDAsPrefix: true,
-	})
+	}); err != nil {
+		return fmt.Errorf("actor '%s' failed to delete activity reminders on completion: %w", o.actorID, err)
+	}
+
+	return nil
 }

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -158,6 +158,13 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	}
 
 	if !runtimestate.IsCompleted(rs) {
+		// Delete timer reminders for WaitForSingleEvent timers where the event has
+		// been received before the timer fired.
+		if err = o.deleteCancelledEventTimers(ctx, rs); err != nil {
+			executionStatus = diag.StatusRecoverable
+			return todo.RunCompletedFalse, wferrors.NewRecoverable(err)
+		}
+
 		if err = o.createTimers(ctx, rs.GetPendingTimers(), state.Generation); err != nil {
 			executionStatus = diag.StatusRecoverable
 			return todo.RunCompletedFalse, wferrors.NewRecoverable(err)
@@ -220,6 +227,11 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 
 	if runtimestate.IsCompleted(rs) {
 		log.Infof("Workflow Actor '%s': workflow completed with status '%s' workflowName '%s'", o.actorID, rstatus, workflowName)
+		if hasUnfiredTimers(rs) {
+			if err = o.deleteAllReminders(ctx); err != nil {
+				return todo.RunCompletedFalse, err
+			}
+		}
 		if err = o.handleRetention(ctx, rstatus); err != nil {
 			return todo.RunCompletedFalse, err
 		}

--- a/pkg/actors/targets/workflow/orchestrator/timer.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer.go
@@ -18,7 +18,18 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
+	"time"
 
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 )
 
@@ -32,6 +43,32 @@ func (o *orchestrator) createTimers(ctx context.Context, es []*backend.HistoryEv
 	return nil
 }
 
+// hasUnfiredTimers returns true if the runtime state contains TimerCreated
+// events that do not have a corresponding TimerFired event.
+func hasUnfiredTimers(rs *protos.OrchestrationRuntimeState) bool {
+	var created, fired int
+	for _, events := range [2][]*protos.HistoryEvent{
+		([]*protos.HistoryEvent)(rs.GetOldEvents()),
+		([]*protos.HistoryEvent)(rs.GetNewEvents()),
+	} {
+		for _, e := range events {
+			if e.GetTimerCreated() != nil {
+				created++
+			} else if e.GetTimerFired() != nil {
+				fired++
+			}
+		}
+	}
+	return created > fired
+}
+
+// timerReminderName returns the deterministic reminder name for a timer with
+// the given ID. Timer reminders use deterministic names (no random suffix) so
+// they can be reliably deleted when no longer needed.
+func timerReminderName(timerID int32) string {
+	return reminderPrefixTimer + strconv.Itoa(int(timerID))
+}
+
 func (o *orchestrator) createTimer(ctx context.Context, e *backend.HistoryEvent, generation uint64) error {
 	ts := e.GetTimerFired()
 	if ts == nil {
@@ -39,13 +76,145 @@ func (o *orchestrator) createTimer(ctx context.Context, e *backend.HistoryEvent,
 	}
 
 	start := e.GetTimerFired().GetFireAt().AsTime()
-	reminderPrefix := reminderPrefixTimer + strconv.Itoa(int(e.GetTimerFired().GetTimerId()))
+	reminderName := timerReminderName(e.GetTimerFired().GetTimerId())
 	data := &backend.DurableTimer{TimerEvent: e, Generation: generation}
 
-	log.Debugf("Workflow actor '%s': creating reminder '%s' for the durable timer, duetime=%s", o.actorID, reminderPrefix, start)
+	log.Debugf("Workflow actor '%s': creating reminder '%s' for the durable timer, duetime=%s", o.actorID, reminderName, start)
 
-	if _, err := o.createWorkflowReminder(ctx, reminderPrefix, data, start, o.appID); err != nil {
+	if err := o.createTimerReminder(ctx, reminderName, data, start); err != nil {
 		return fmt.Errorf("actor '%s' failed to create reminder for timer: %w", o.actorID, err)
+	}
+
+	return nil
+}
+
+func (o *orchestrator) createTimerReminder(ctx context.Context, name string, data proto.Message, start time.Time) error {
+	actorType := o.actorTypeBuilder.Workflow(o.appID)
+	dueTime := start.UTC().Format(time.RFC3339)
+
+	adata, err := anypb.New(data)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Workflow actor '%s||%s': creating '%s' reminder with DueTime = '%s'", actorType, o.actorID, name, dueTime)
+
+	return o.reminders.Create(ctx, &actorapi.CreateReminderRequest{
+		ActorType: actorType,
+		ActorID:   o.actorID,
+		Data:      adata,
+		DueTime:   dueTime,
+		Name:      name,
+		// One shot, retry forever, every second.
+		FailurePolicy: &commonv1pb.JobFailurePolicy{
+			Policy: &commonv1pb.JobFailurePolicy_Constant{
+				Constant: &commonv1pb.JobFailurePolicyConstant{
+					Interval:   durationpb.New(time.Second),
+					MaxRetries: nil,
+				},
+			},
+		},
+	})
+}
+
+// deleteCancelledEventTimers scans the workflow history to find timer reminders
+// associated with WaitForSingleEvent calls where the event has been received
+// before the timer fired, and deletes those now-unnecessary timer reminders.
+// 1. Find all TimerCreated events with a Name (i.e., event-associated timers)
+// 2. Remove any that have already fired (matching TimerFired events)
+// 3. For each new EventRaised, consume one matching unfired timer (FIFO order)
+// 4. Delete the timer reminders for consumed timers
+//
+// Only EventRaised events in NewEvents are considered as triggers for
+// cancellation, since events in OldEvents were already processed in a
+// previous execution. TimerCreated and TimerFired are scanned across both
+// OldEvents and NewEvents.
+func (o *orchestrator) deleteCancelledEventTimers(ctx context.Context, rs *protos.OrchestrationRuntimeState) error {
+	newEvents := rs.GetNewEvents()
+
+	// Quick check: if there are no new events that could contain an
+	// EventRaised, there's nothing to cancel.
+	hasEventRaised := false
+	for _, e := range newEvents {
+		if e.GetEventRaised() != nil {
+			hasEventRaised = true
+			break
+		}
+	}
+	if !hasEventRaised {
+		return nil
+	}
+
+	// Build the set of unfired event-associated timers from full history.
+	// pendingEventTimers: event name (uppercase) -> list of timer IDs (creation order)
+	pendingEventTimers := make(map[string][]int32)
+	firedTimerIDs := make(map[int32]bool)
+
+	for _, events := range [2][]*protos.HistoryEvent{
+		([]*protos.HistoryEvent)(rs.GetOldEvents()),
+		([]*protos.HistoryEvent)(newEvents),
+	} {
+		for _, e := range events {
+			if tc := e.GetTimerCreated(); tc != nil && tc.Name != nil {
+				key := strings.ToUpper(*tc.Name)
+				pendingEventTimers[key] = append(pendingEventTimers[key], e.EventId)
+			} else if tf := e.GetTimerFired(); tf != nil {
+				firedTimerIDs[tf.TimerId] = true
+			}
+		}
+	}
+
+	// Remove already-fired timers from the pending map.
+	for key, timerIDs := range pendingEventTimers {
+		filtered := timerIDs[:0]
+		for _, id := range timerIDs {
+			if !firedTimerIDs[id] {
+				filtered = append(filtered, id)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(pendingEventTimers, key)
+		} else {
+			pendingEventTimers[key] = filtered
+		}
+	}
+
+	// For each new EventRaised, consume one matching unfired timer (FIFO).
+	var cancelledTimerIDs []int32
+	for _, e := range newEvents {
+		if er := e.GetEventRaised(); er != nil {
+			key := strings.ToUpper(er.GetName())
+			if timerIDs, ok := pendingEventTimers[key]; ok && len(timerIDs) > 0 {
+				cancelledTimerIDs = append(cancelledTimerIDs, timerIDs[0])
+				if len(timerIDs) == 1 {
+					delete(pendingEventTimers, key)
+				} else {
+					pendingEventTimers[key] = timerIDs[1:]
+				}
+			}
+		}
+	}
+
+	if len(cancelledTimerIDs) == 0 {
+		return nil
+	}
+
+	// Delete the timer reminders.
+	actorType := o.actorTypeBuilder.Workflow(o.appID)
+	for _, timerID := range cancelledTimerIDs {
+		name := timerReminderName(timerID)
+		log.Debugf("Workflow actor '%s': deleting cancelled event timer reminder '%s'", o.actorID, name)
+		if err := o.reminders.Delete(ctx, &actorapi.DeleteReminderRequest{
+			Name:      name,
+			ActorType: actorType,
+			ActorID:   o.actorID,
+		}); err != nil {
+			if s, ok := grpcstatus.FromError(err); ok && s.Code() == codes.NotFound {
+				log.Debugf("Workflow actor '%s': timer reminder '%s' already deleted, ignoring", o.actorID, name)
+				continue
+			}
+			return fmt.Errorf("actor '%s' failed to delete cancelled timer reminder '%s': %w", o.actorID, name, err)
+		}
 	}
 
 	return nil

--- a/pkg/actors/targets/workflow/orchestrator/timer.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer.go
@@ -48,8 +48,8 @@ func (o *orchestrator) createTimers(ctx context.Context, es []*backend.HistoryEv
 func hasUnfiredTimers(rs *protos.OrchestrationRuntimeState) bool {
 	var created, fired int
 	for _, events := range [2][]*protos.HistoryEvent{
-		([]*protos.HistoryEvent)(rs.GetOldEvents()),
-		([]*protos.HistoryEvent)(rs.GetNewEvents()),
+		(rs.GetOldEvents()),
+		(rs.GetNewEvents()),
 	} {
 		for _, e := range events {
 			if e.GetTimerCreated() != nil {
@@ -151,15 +151,15 @@ func (o *orchestrator) deleteCancelledEventTimers(ctx context.Context, rs *proto
 	firedTimerIDs := make(map[int32]bool)
 
 	for _, events := range [2][]*protos.HistoryEvent{
-		([]*protos.HistoryEvent)(rs.GetOldEvents()),
-		([]*protos.HistoryEvent)(newEvents),
+		rs.GetOldEvents(),
+		newEvents,
 	} {
 		for _, e := range events {
 			if tc := e.GetTimerCreated(); tc != nil && tc.Name != nil {
-				key := strings.ToUpper(*tc.Name)
-				pendingEventTimers[key] = append(pendingEventTimers[key], e.EventId)
+				key := strings.ToUpper(tc.GetName())
+				pendingEventTimers[key] = append(pendingEventTimers[key], e.GetEventId())
 			} else if tf := e.GetTimerFired(); tf != nil {
-				firedTimerIDs[tf.TimerId] = true
+				firedTimerIDs[tf.GetTimerId()] = true
 			}
 		}
 	}

--- a/pkg/actors/targets/workflow/orchestrator/timer_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer_test.go
@@ -1,0 +1,659 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	remindersfake "github.com/dapr/dapr/pkg/actors/reminders/fake"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+func Test_timerReminderName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		timerID int32
+		want    string
+	}{
+		{0, "timer-0"},
+		{1, "timer-1"},
+		{42, "timer-42"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, timerReminderName(tt.timerID))
+	}
+}
+
+func Test_hasUnfiredTimers(t *testing.T) {
+	t.Parallel()
+
+	timerCreated := func(eventID int32) *protos.HistoryEvent {
+		return &protos.HistoryEvent{
+			EventId: eventID,
+			EventType: &protos.HistoryEvent_TimerCreated{
+				TimerCreated: &protos.TimerCreatedEvent{},
+			},
+		}
+	}
+
+	timerFired := func(timerID int32) *protos.HistoryEvent {
+		return &protos.HistoryEvent{
+			EventId: -1,
+			EventType: &protos.HistoryEvent_TimerFired{
+				TimerFired: &protos.TimerFiredEvent{
+					TimerId: timerID,
+				},
+			},
+		}
+	}
+
+	t.Run("empty state returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, hasUnfiredTimers(&protos.OrchestrationRuntimeState{}))
+	})
+
+	t.Run("no timers returns false", func(t *testing.T) {
+		t.Parallel()
+		rs := &protos.OrchestrationRuntimeState{
+			NewEvents: []*protos.HistoryEvent{
+				{EventType: &protos.HistoryEvent_EventRaised{
+					EventRaised: &protos.EventRaisedEvent{Name: "foo"},
+				}},
+			},
+		}
+		assert.False(t, hasUnfiredTimers(rs))
+	})
+
+	t.Run("created without fired returns true", func(t *testing.T) {
+		t.Parallel()
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{timerCreated(0)},
+		}
+		assert.True(t, hasUnfiredTimers(rs))
+	})
+
+	t.Run("created and fired returns false", func(t *testing.T) {
+		t.Parallel()
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{timerCreated(0), timerFired(0)},
+		}
+		assert.False(t, hasUnfiredTimers(rs))
+	})
+
+	t.Run("two created one fired returns true", func(t *testing.T) {
+		t.Parallel()
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{timerCreated(0), timerCreated(1)},
+			NewEvents: []*protos.HistoryEvent{timerFired(0)},
+		}
+		assert.True(t, hasUnfiredTimers(rs))
+	})
+
+	t.Run("all fired returns false", func(t *testing.T) {
+		t.Parallel()
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{timerCreated(0), timerCreated(1), timerFired(0)},
+			NewEvents: []*protos.HistoryEvent{timerFired(1)},
+		}
+		assert.False(t, hasUnfiredTimers(rs))
+	})
+
+	t.Run("timer in NewEvents only returns true", func(t *testing.T) {
+		t.Parallel()
+		rs := &protos.OrchestrationRuntimeState{
+			NewEvents: []*protos.HistoryEvent{timerCreated(0)},
+		}
+		assert.True(t, hasUnfiredTimers(rs))
+	})
+}
+
+func Test_deleteAllReminders(t *testing.T) {
+	t.Parallel()
+
+	newOrchestrator := func(reminders *remindersfake.Fake) *orchestrator {
+		return &orchestrator{
+			factory: &factory{
+				appID:             "testapp",
+				activityActorType: "dapr.internal.default.testapp.activity",
+				reminders:         reminders,
+				actorTypeBuilder:  common.NewActorTypeBuilder("default"),
+			},
+			actorID: "wf-123",
+		}
+	}
+
+	t.Run("deletes workflow and activity reminders", func(t *testing.T) {
+		t.Parallel()
+		var gotReqs []*actorapi.DeleteRemindersByActorIDRequest
+		reminders := remindersfake.New().WithDeleteByActorID(func(_ context.Context, req *actorapi.DeleteRemindersByActorIDRequest) error {
+			gotReqs = append(gotReqs, req)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		err := o.deleteAllReminders(t.Context())
+		require.NoError(t, err)
+		require.Len(t, gotReqs, 2)
+
+		assert.Equal(t, "dapr.internal.default.testapp.workflow", gotReqs[0].ActorType)
+		assert.Equal(t, "wf-123", gotReqs[0].ActorID)
+		assert.False(t, gotReqs[0].MatchIDAsPrefix)
+
+		assert.Equal(t, "dapr.internal.default.testapp.activity", gotReqs[1].ActorType)
+		assert.Equal(t, "wf-123::", gotReqs[1].ActorID)
+		assert.True(t, gotReqs[1].MatchIDAsPrefix)
+	})
+
+	t.Run("workflow reminder delete error stops and returns", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		reminders := remindersfake.New().WithDeleteByActorID(func(_ context.Context, _ *actorapi.DeleteRemindersByActorIDRequest) error {
+			callCount++
+			return fmt.Errorf("scheduler unavailable")
+		})
+		o := newOrchestrator(reminders)
+
+		err := o.deleteAllReminders(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scheduler unavailable")
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("activity reminder delete error is returned", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		reminders := remindersfake.New().WithDeleteByActorID(func(_ context.Context, _ *actorapi.DeleteRemindersByActorIDRequest) error {
+			callCount++
+			if callCount == 1 {
+				return nil
+			}
+			return fmt.Errorf("activity delete failed")
+		})
+		o := newOrchestrator(reminders)
+
+		err := o.deleteAllReminders(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "activity delete failed")
+		assert.Equal(t, 2, callCount)
+	})
+}
+
+func Test_deleteCancelledEventTimers(t *testing.T) {
+	t.Parallel()
+
+	eventName := func(name string) *string { return &name }
+
+	timerCreated := func(eventID int32, name *string) *protos.HistoryEvent {
+		return &protos.HistoryEvent{
+			EventId: eventID,
+			EventType: &protos.HistoryEvent_TimerCreated{
+				TimerCreated: &protos.TimerCreatedEvent{
+					Name: name,
+				},
+			},
+		}
+	}
+
+	timerFired := func(timerID int32) *protos.HistoryEvent {
+		return &protos.HistoryEvent{
+			EventId: -1,
+			EventType: &protos.HistoryEvent_TimerFired{
+				TimerFired: &protos.TimerFiredEvent{
+					TimerId: timerID,
+				},
+			},
+		}
+	}
+
+	eventRaised := func(name string) *protos.HistoryEvent {
+		return &protos.HistoryEvent{
+			EventId: -1,
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{
+					Name: name,
+				},
+			},
+		}
+	}
+
+	newOrchestrator := func(reminders *remindersfake.Fake) *orchestrator {
+		return &orchestrator{
+			factory: &factory{
+				appID:            "testapp",
+				reminders:        reminders,
+				actorTypeBuilder: common.NewActorTypeBuilder("default"),
+			},
+			actorID: "wf-123",
+		}
+	}
+
+	t.Run("no new events returns nil", func(t *testing.T) {
+		t.Parallel()
+		o := newOrchestrator(remindersfake.New())
+
+		err := o.deleteCancelledEventTimers(t.Context(), &protos.OrchestrationRuntimeState{})
+		require.NoError(t, err)
+	})
+
+	t.Run("no EventRaised in new events returns nil", func(t *testing.T) {
+		t.Parallel()
+		o := newOrchestrator(remindersfake.New())
+
+		rs := &protos.OrchestrationRuntimeState{
+			NewEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+	})
+
+	t.Run("EventRaised with no matching timer does not delete", func(t *testing.T) {
+		t.Parallel()
+		deleteCalled := false
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			deleteCalled = true
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+	})
+
+	t.Run("EventRaised matches timer in OldEvents and deletes it", func(t *testing.T) {
+		t.Parallel()
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timer-0"}, deletedNames)
+	})
+
+	t.Run("EventRaised matches timer in NewEvents and deletes it", func(t *testing.T) {
+		t.Parallel()
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			NewEvents: []*protos.HistoryEvent{
+				timerCreated(5, eventName("bar")),
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timer-5"}, deletedNames)
+	})
+
+	t.Run("event name matching is case insensitive", func(t *testing.T) {
+		t.Parallel()
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("MyEvent")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("MYEVENT"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timer-0"}, deletedNames)
+	})
+
+	t.Run("already fired timer is not cancelled", func(t *testing.T) {
+		t.Parallel()
+		deleteCalled := false
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			deleteCalled = true
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+				timerFired(0),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+	})
+
+	t.Run("timer without Name field is ignored", func(t *testing.T) {
+		t.Parallel()
+		deleteCalled := false
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			deleteCalled = true
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, nil), // plain timer, not from WaitForSingleEvent
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+	})
+
+	t.Run("FIFO: one EventRaised consumes only the first matching timer", func(t *testing.T) {
+		t.Parallel()
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+				timerCreated(1, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timer-0"}, deletedNames)
+	})
+
+	t.Run("multiple EventRaised consume multiple timers FIFO", func(t *testing.T) {
+		t.Parallel()
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+				timerCreated(1, eventName("bar")),
+				timerCreated(2, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timer-0", "timer-1"}, deletedNames)
+	})
+
+	t.Run("multiple event names handled independently", func(t *testing.T) {
+		t.Parallel()
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("foo")),
+				timerCreated(1, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("foo"),
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Len(t, deletedNames, 2)
+		assert.Contains(t, deletedNames, "timer-0")
+		assert.Contains(t, deletedNames, "timer-1")
+	})
+
+	t.Run("delete request uses correct actor type and ID", func(t *testing.T) {
+		t.Parallel()
+		var gotReq *actorapi.DeleteReminderRequest
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			gotReq = req
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		require.NotNil(t, gotReq)
+		assert.Equal(t, "timer-0", gotReq.Name)
+		assert.Equal(t, "dapr.internal.default.testapp.workflow", gotReq.ActorType)
+		assert.Equal(t, "wf-123", gotReq.ActorID)
+	})
+
+	t.Run("NotFound error from delete is ignored", func(t *testing.T) {
+		t.Parallel()
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			return status.Error(codes.NotFound, "job not found")
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-NotFound error from delete is returned", func(t *testing.T) {
+		t.Parallel()
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			return fmt.Errorf("connection refused")
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("gRPC error other than NotFound is returned", func(t *testing.T) {
+		t.Parallel()
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			return status.Error(codes.Internal, "internal error")
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "internal error")
+	})
+
+	t.Run("NotFound on first delete does not prevent second delete", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			callCount++
+			if callCount == 1 {
+				return status.Error(codes.NotFound, "job not found")
+			}
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+				timerCreated(1, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, 2, callCount)
+		assert.Equal(t, []string{"timer-1"}, deletedNames)
+	})
+
+	t.Run("error on first delete stops processing", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			callCount++
+			if callCount == 1 {
+				return fmt.Errorf("connection refused")
+			}
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("foo")),
+				timerCreated(1, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("foo"),
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.Error(t, err)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("EventRaised in OldEvents does not trigger deletion", func(t *testing.T) {
+		t.Parallel()
+		deleteCalled := false
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			deleteCalled = true
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		// Both the timer and event are in OldEvents (already processed).
+		// No new EventRaised in NewEvents, so nothing should be deleted.
+		rs := &protos.OrchestrationRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+				eventRaised("bar"),
+			},
+			NewEvents: []*protos.HistoryEvent{},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+	})
+
+	t.Run("fired timer in NewEvents is excluded", func(t *testing.T) {
+		t.Parallel()
+		deleteCalled := false
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			deleteCalled = true
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.OrchestrationRuntimeState{
+			NewEvents: []*protos.HistoryEvent{
+				timerCreated(0, eventName("bar")),
+				timerFired(0),
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+	})
+}

--- a/pkg/actors/targets/workflow/orchestrator/timer_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer_test.go
@@ -15,7 +15,7 @@ package orchestrator
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,7 +171,7 @@ func Test_deleteAllReminders(t *testing.T) {
 		callCount := 0
 		reminders := remindersfake.New().WithDeleteByActorID(func(_ context.Context, _ *actorapi.DeleteRemindersByActorIDRequest) error {
 			callCount++
-			return fmt.Errorf("scheduler unavailable")
+			return errors.New("scheduler unavailable")
 		})
 		o := newOrchestrator(reminders)
 
@@ -189,7 +189,7 @@ func Test_deleteAllReminders(t *testing.T) {
 			if callCount == 1 {
 				return nil
 			}
-			return fmt.Errorf("activity delete failed")
+			return errors.New("activity delete failed")
 		})
 		o := newOrchestrator(reminders)
 
@@ -519,7 +519,7 @@ func Test_deleteCancelledEventTimers(t *testing.T) {
 	t.Run("non-NotFound error from delete is returned", func(t *testing.T) {
 		t.Parallel()
 		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
-			return fmt.Errorf("connection refused")
+			return errors.New("connection refused")
 		})
 		o := newOrchestrator(reminders)
 
@@ -592,7 +592,7 @@ func Test_deleteCancelledEventTimers(t *testing.T) {
 		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
 			callCount++
 			if callCount == 1 {
-				return fmt.Errorf("connection refused")
+				return errors.New("connection refused")
 			}
 			return nil
 		})

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/activity.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/activity.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(activity))
+}
+
+type activity struct {
+	workflow *workflow.Workflow
+}
+
+func (d *activity) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *activity) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		require.NoError(t, ctx.CallActivity("noop").Await(nil))
+		require.NoError(t, ctx.WaitForSingleEvent("bar", time.Minute).Await(nil))
+		return nil, nil
+	})
+	d.workflow.Registry().AddActivityN("noop", func(ctx task.ActivityContext) (any, error) {
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "bar"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/alreadydeleted.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/alreadydeleted.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(alreadydeleted))
+}
+
+type alreadydeleted struct {
+	workflow *workflow.Workflow
+}
+
+func (d *alreadydeleted) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *alreadydeleted) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		require.NoError(t, ctx.WaitForSingleEvent("bar", time.Minute).Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	var timerKey string
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-0")
+			timerKey = keys[0]
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NotEmpty(t, timerKey)
+	etcdClient := d.workflow.Scheduler().ETCDClient(t, ctx)
+	_, err = etcdClient.Delete(ctx, timerKey)
+	require.NoError(t, err)
+
+	assert.Empty(t, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "bar"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/base.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/base.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(base))
+}
+
+type base struct {
+	workflow *workflow.Workflow
+}
+
+func (d *base) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *base) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		require.NoError(t, ctx.WaitForSingleEvent("bar", time.Minute).Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-0")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "bar"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/caseinsensitive.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/caseinsensitive.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(caseinsensitive))
+}
+
+type caseinsensitive struct {
+	workflow *workflow.Workflow
+}
+
+func (d *caseinsensitive) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *caseinsensitive) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		require.NoError(t, ctx.WaitForSingleEvent("MyEvent", time.Minute).Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-0")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "MYEVENT"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/completioncleanup.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/completioncleanup.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(completioncleanup))
+}
+
+type completioncleanup struct {
+	workflow *workflow.Workflow
+}
+
+func (d *completioncleanup) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *completioncleanup) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		t1 := ctx.WaitForSingleEvent("event1", time.Minute)
+		t2 := ctx.WaitForSingleEvent("event2", time.Minute)
+		require.NoError(t, t1.Await(nil))
+		require.NoError(t, t2.Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		assert.Len(c, keys, 2)
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "event1"))
+	require.NoError(t, cl.RaiseEvent(ctx, id, "event2"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/createtimer.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/createtimer.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(createtimer))
+}
+
+type createtimer struct {
+	workflow *workflow.Workflow
+}
+
+func (d *createtimer) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *createtimer) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		_ = ctx.CreateTimer(time.Hour)
+		require.NoError(t, ctx.WaitForSingleEvent("done", -1).Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-0")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "done"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/fanout.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/fanout.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(fanout))
+}
+
+type fanout struct {
+	workflow *workflow.Workflow
+}
+
+func (d *fanout) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *fanout) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		t1 := ctx.WaitForSingleEvent("event1", time.Minute)
+		t2 := ctx.WaitForSingleEvent("event2", time.Minute)
+		t3 := ctx.WaitForSingleEvent("event3", time.Minute)
+
+		require.NoError(t, t1.Await(nil))
+		require.NoError(t, t2.Await(nil))
+		require.NoError(t, t3.Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		assert.Len(c, keys, 3)
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "event1"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		assert.Len(c, keys, 2)
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "event2"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		assert.Len(c, keys, 1)
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "event3"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/multiple.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/multiple.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(multiple))
+}
+
+type multiple struct {
+	workflow *workflow.Workflow
+}
+
+func (d *multiple) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *multiple) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		require.NoError(t, ctx.WaitForSingleEvent("event1", time.Minute).Await(nil))
+		require.NoError(t, ctx.WaitForSingleEvent("event2", time.Minute).Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-0")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "event1"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-1")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "event2"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/notimeout.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/notimeout.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(notimeout))
+}
+
+// notimeout tests that WaitForSingleEvent without a timeout (no timer created)
+// still completes correctly when the event is raised. This verifies the timer
+// deletion logic does not interfere when there is no timer to delete.
+type notimeout struct {
+	workflow *workflow.Workflow
+}
+
+func (d *notimeout) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *notimeout) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		require.NoError(t, ctx.WaitForSingleEvent("bar", -1).Await(nil))
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		assert.Empty(c, keys)
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "bar"))
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/timerfired.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/timerfired.go
@@ -47,7 +47,8 @@ func (d *timerfired) Run(t *testing.T, ctx context.Context) {
 	d.workflow.WaitUntilRunning(t, ctx)
 
 	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
-		if err := ctx.WaitForSingleEvent("bar", time.Second).Await(nil); err != nil {
+		//nolint:nilerr
+		if err := ctx.WaitForSingleEvent("bar", time.Second*5).Await(nil); err != nil {
 			// ErrTaskCanceled is expected when the timer fires.
 			return "timed_out", nil
 		}
@@ -55,8 +56,19 @@ func (d *timerfired) Run(t *testing.T, ctx context.Context) {
 	})
 
 	cl := d.workflow.BackendClient(t, ctx)
-	_, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	id, err := cl.ScheduleNewOrchestration(ctx, "foo")
 	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.NotEmpty(c, keys) {
+			assert.Contains(c, keys[0], "timer-0")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.RuntimeStatus.String())
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/timerfired.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/timerfired.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(timerfired))
+}
+
+type timerfired struct {
+	workflow *workflow.Workflow
+}
+
+func (d *timerfired) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *timerfired) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("bar", time.Second).Await(nil); err != nil {
+			// ErrTaskCanceled is expected when the timer fires.
+			return "timed_out", nil
+		}
+		return "event_received", nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	_, err := cl.ScheduleNewOrchestration(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/nostatestore"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/patching"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/purge"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/raise/deletetimer"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reconnect"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/records"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/rerun"


### PR DESCRIPTION
`WaitForSingleEvent` with a timeout creates a timer reminder in the scheduler. When the external event arrives before the timer fires, the timer reminder was never cleaned up, leaving orphan reminders that would eventually fire unnecessarily.

Add two cleanup mechanisms:

1. Mid-execution: `deleteCancelledEventTimers` scans history to match TimerCreated events (with a Name field) against new EventRaised events, and deletes the corresponding timer reminders. Matching is case-insensitive and NotFound errors are ignored for idempotency.

2. On completion: deleteAllReminders bulk-deletes all workflow and activity reminders via DeleteByActorID when hasUnfiredTimers detects pending timers. This handles plain CreateTimer timers that have no associated event name.

---

Should be backported to 1.17

---

Workflow timer reminders not deleted when external event is received before timeout

Problem

When a workflow used `WaitForSingleEvent` with a timeout, a timer reminder was created in the scheduler. If the external event was raised before the timer fired, the timer reminder was never deleted and remained as an orphan in the scheduler until it eventually fired unnecessarily. Additionally, when a workflow completed while timers were still pending (e.g. a `CreateTimer` that had not yet fired), those timer reminders were also left behind.

Impact

Workflows using `WaitForSingleEvent` with timeouts accumulated orphan timer reminders in the scheduler. These timers would eventually fire and trigger unnecessary workflow actor invocations that were silently ignored, wasting scheduler and actor resources. For long-running workflows with many `WaitForSingleEvent` calls or long timeouts, the number of orphan reminders could grow significantly.

Root Cause

The durable task SDK completes the event task when an external event is received, but does not signal the Dapr runtime to delete the associated timer reminder. The runtime had no mechanism to detect that a timer was no longer needed because its associated event had already been received. Similarly, when a workflow completed, there was no cleanup of pending timer reminders that had not yet fired.

Solution

Added two timer cleanup mechanisms to the workflow orchestrator:

1. **Mid-execution cleanup** (`deleteCancelledEventTimers`): After each workflow execution step, the runtime scans the history for `TimerCreated` events associated with `WaitForSingleEvent` calls (identified by the `Name` field on `TimerCreated`). When a matching `EventRaised` event is found in the new events, the corresponding timer reminder is deleted from the scheduler. Event name matching is case-insensitive, and already-deleted timers (e.g. from a crash recovery) are handled gracefully by ignoring `NotFound` errors.

2. **Completion cleanup** (`deleteAllReminders`): When a workflow completes and has unfired timers (detected by comparing `TimerCreated` vs `TimerFired` event counts), all reminders for the workflow and its activities are bulk-deleted via `DeleteByActorID`. This handles timers without a `Name` field (e.g. `CreateTimer`) that cannot be matched to specific events.