### PR TITLE
style: warn if too many tools provided

### DIFF
--- a/pkg/api/universal/conversation.go
+++ b/pkg/api/universal/conversation.go
@@ -467,6 +467,10 @@ func (a *Universal) ConverseAlpha2(ctx context.Context, req *runtimev1pb.Convers
 		request.ToolChoice = &toolChoice
 	}
 
+	if req.GetTools() != nil && len(req.GetTools()) > 10 {
+		a.logger.Warnf("Large tools list passed in with %d tools provided. Consider filtering tools to only those necessary for the conversation to improve performance.", len(req.GetTools()))
+	}
+
 	if tools := req.GetTools(); tools != nil {
 		availableTools := make([]llms.Tool, 0, len(tools))
 		for _, tool := range tools {


### PR DESCRIPTION
# Description

Adds a warning log in the conversation component when more than 10 tools are included in a single LLM request.

When agents pass large tool sets (e.g. all 37 tools from the GitHub MCP server), the gRPC payload from the Python SDK to the Dapr sidecar can exceed the deadline before the LLM provider is even reached. The resulting DEADLINE_EXCEEDED error gives no indication that payload size is the cause — users typically assume it's an LLM provider latency issue and try timeout configuration, which doesn't help. I will look in the Python SDK if I can capture a better error too.

This warning surfaces the actual root cause immediately. The threshold of 10 is a starting point — open to feedback on the right number or making it configurable via component metadata. Maybe in future we should have a field on the conversation components with tool count limits per request?


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
