### PR TITLE
Integration: Fix workflow test race

### DIFF
--- a/tests/integration/suite/daprd/workflow/terminate/grpc.go
+++ b/tests/integration/suite/daprd/workflow/terminate/grpc.go
@@ -49,6 +49,7 @@ func (g *grpcclient) Run(t *testing.T, ctx context.Context) {
 	g.workflow.WaitUntilRunning(t, ctx)
 
 	holdCh := make(chan struct{})
+	t.Cleanup(func() { close(holdCh) })
 	var inAct atomic.Bool
 	g.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
 		require.NoError(t, ctx.CallActivity("bar").Await(nil))
@@ -70,8 +71,6 @@ func (g *grpcclient) Run(t *testing.T, ctx context.Context) {
 		InstanceId: id.String(),
 	})
 	require.NoError(t, err)
-
-	close(holdCh)
 
 	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)

--- a/tests/integration/suite/daprd/workflow/terminate/http.go
+++ b/tests/integration/suite/daprd/workflow/terminate/http.go
@@ -51,6 +51,7 @@ func (h *httpclient) Run(t *testing.T, ctx context.Context) {
 	h.workflow.WaitUntilRunning(t, ctx)
 
 	holdCh := make(chan struct{})
+	t.Cleanup(func() { close(holdCh) })
 	var inAct atomic.Bool
 	h.workflow.Registry().AddOrchestratorN("foo", func(ctx *task.OrchestrationContext) (any, error) {
 		require.NoError(t, ctx.CallActivity("bar").Await(nil))
@@ -75,8 +76,6 @@ func (h *httpclient) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
-
-	close(holdCh)
 
 	meta, err := cl.WaitForOrchestrationCompletion(ctx, id)
 	require.NoError(t, err)


### PR DESCRIPTION
The gRPC and HTTP workflow terminate tests had a race condition where close(holdCh) was called immediately after the terminate request, allowing the activity to complete normally before the termination took effect. This caused the orchestration to finish with `COMPLETED` status instead of `TERMINATED`, resulting in intermittent CI failures.
