### PR TITLE
fix: Preserve trailing slash in service invocation via dapr-app-id header

### DIFF
--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -360,13 +360,23 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// cleanPathPreserveTrailingSlash normalizes a path while preserving a single trailing slash.
+func cleanPathPreserveTrailingSlash(reqPath string) string {
+	cleaned := path.Clean(reqPath)
+	if len(reqPath) > 1 && strings.HasSuffix(reqPath, "/") && cleaned != "/" {
+		cleaned += "/"
+	}
+	return cleaned
+}
+
 // findTargetIDAndMethod finds ID of the target service and method from the following three places:
 // 1. HTTP header 'dapr-app-id' (path is method)
 // 2. Basic auth header: `http://dapr-app-id:<service-id>@localhost:3500/<method>`
 // 3. URL parameter: `http://localhost:3500/v1.0/invoke/<app-id>/method/<method>`
 func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string, method string) {
 	if appID := headers.Get(consts.DaprAppIDHeader); appID != "" {
-		targetID, method = appID, strings.TrimPrefix(path.Clean(reqPath), "/")
+		cleaned := cleanPathPreserveTrailingSlash(reqPath)
+		targetID, method = appID, strings.TrimPrefix(cleaned, "/")
 		// Delete the header as it should not be passed forward with the request and is only used by the Dapr API
 		headers.Del(consts.DaprAppIDHeader)
 		return targetID, method
@@ -376,7 +386,8 @@ func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string
 		if s, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic ")); err == nil {
 			pair := strings.Split(string(s), ":")
 			if len(pair) == 2 && strings.EqualFold(pair[0], consts.DaprAppIDHeader) {
-				return pair[1], strings.TrimPrefix(path.Clean(reqPath), "/")
+				cleaned := cleanPathPreserveTrailingSlash(reqPath)
+				return pair[1], strings.TrimPrefix(cleaned, "/")
 			}
 		}
 	}

--- a/pkg/api/http/directmessaging_test.go
+++ b/pkg/api/http/directmessaging_test.go
@@ -1074,6 +1074,14 @@ func TestFindTargetIDAndMethod(t *testing.T) {
 		{name: "path with https target escaped", path: "/v1.0/invoke/https%3A%2F%2Fexample.com/method/foo", wantTargetID: "https://example.com", wantMethod: "foo"},
 		{name: "path with https target partly escaped", path: "/v1.0/invoke/https%3A/%2Fexample.com/method/foo", wantTargetID: "https://example.com", wantMethod: "foo"},
 		{name: "extra slashes are removed", path: "///foo//bar", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar"},
+		{name: "dapr-app-id header preserves trailing slash", path: "/foo/bar/", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar/"},
+		{name: "dapr-app-id header preserves trailing slash on nested path", path: "/api/v1/resource/", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "api/v1/resource/"},
+		{name: "basic auth preserves trailing slash", path: "/foo/bar/", headers: http.Header{"Authorization": []string{"Basic ZGFwci1hcHAtaWQ6YXV0aA=="}}, wantTargetID: "auth", wantMethod: "foo/bar/"},
+		{name: "dapr-app-id header without trailing slash unchanged", path: "/foo/bar", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar"},
+		{name: "dapr-app-id header normalizes multiple trailing slashes", path: "/foo/bar///", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar/"},
+		{name: "basic auth normalizes multiple trailing slashes", path: "/foo/bar///", headers: http.Header{"Authorization": []string{"Basic ZGFwci1hcHAtaWQ6YXV0aA=="}}, wantTargetID: "auth", wantMethod: "foo/bar/"},
+		{name: "dapr-app-id header with root-collapsing path", path: "//", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: ""},
+
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

When using the `dapr-app-id` header for service invocation, trailing slashes
are stripped from the request path due to `path.Clean()` in
`findTargetIDAndMethod()`. This causes 404 errors for services that
distinguish `/endpoint` from `/endpoint/`.

The fix preserves trailing slashes after path normalization, making the
behavior consistent with URL-based invocation (`/v1.0/invoke/{appId}/method/{method}/`).

Fixes: #7686

## Changes

- Modified `findTargetIDAndMethod()` in `pkg/api/http/directmessaging.go`
  to preserve trailing slashes after `path.Clean()`
- Added test cases for trailing slash preservation

## Testing

- Added unit tests for trailing slash scenarios (header, basic auth, nested paths)
- All existing tests pass
- `make lint` passes