### PR TITLE
Fix stale Content-Length header forwarded

### DIFF
--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -1,12 +1,58 @@
 # Dapr 1.17.3
 
-This update contains bug fixes and security fixes:
-- [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
+This update contains security and bug fixes:
 - [Security: Fixes gRPC authorization bypass - CVE-2026-33186](#security-grpc-authorization-bypass)
 - [Security: Fixes TIFF image OOM denial of service - CVE-2026-33809](#security-tiff-image-oom-denial-of-service)
+- [Service invocation and actor responses forward stale Content-Length header](#service-invocation-and-actor-responses-forward-stale-content-length-header)
+- [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
 - [False positive injection failure metrics for non-Dapr pods](#false-positive-injection-failure-metrics-for-non-dapr-pods)
 - [Placement dissemination timeout cascades across all replicas](#placement-dissemination-timeout-cascades-across-all-replicas)
 - [Daprd placement reconnect hangs for 20 seconds on stale DNS](#daprd-placement-reconnect-hangs-for-20-seconds-on-stale-dns)
+
+## Security: gRPC authorization bypass
+
+### Problem
+
+An upstream dependency (google.golang.org/grpc) used by Dapr introduced a vulnerability that could allow gRPC authorization bypass under certain conditions (CVE-2026-33186).
+
+### Impact
+
+Users running affected versions could be exposed to unauthorized gRPC requests.
+
+### Root cause
+
+The issue originated in an upstream library.
+
+### Solution
+
+This release upgrades the affected dependency to a version that resolves CVE-2026-33186. 
+
+Users are strongly encouraged to upgrade to this release.
+
+## Service invocation and actor responses forward stale Content-Length header
+
+### Problem
+
+When a Dapr sidecar forwarded HTTP responses from service invocation or actor method calls, the `Content-Length` header from the upstream application was passed through verbatim to the caller, even though the sidecar rebuilds the response body from an internal protobuf representation.
+If the upstream application sent an incorrect `Content-Length` (or the body size changed during serialization), the caller received a `Content-Length` header that did not match the actual response body.
+
+### Impact
+
+Callers reading the response body with standard HTTP clients (such as Go's `io.ReadAll` or Python's `aiohttp`) received `unexpected EOF` errors or truncated bodies when the forwarded `Content-Length` exceeded the actual body size.
+When the forwarded `Content-Length` was smaller than the actual body, clients silently truncated the response.
+This affected both service invocation (direct messaging) and actor method invocation via HTTP.
+
+### Root Cause
+
+The `InternalMetadataToHTTPHeader` utility function converted all internal gRPC metadata headers to HTTP response headers, including `Content-Length`.
+Since the sidecar reconstructs the response body from a protobuf message (not by proxying the original HTTP stream), the original `Content-Length` from the upstream application became stale.
+Go's `http.ResponseWriter` honored this pre-set `Content-Length` header instead of computing the correct value from the data actually written.
+
+### Solution
+
+Added `Content-Length` to the skip list in `InternalMetadataToHTTPHeader`, alongside `Content-Type` which was already skipped.
+This prevents the stale upstream `Content-Length` from being forwarded to the HTTP response writer.
+Go's `http.ResponseWriter` now computes the correct `Content-Length` automatically from the actual response body. Updated the HTTP channel's `constructRequest` to read `Content-Length` directly from internal metadata for outgoing requests, since it is no longer present in the forwarded HTTP headers.
 
 ## Actor method invocation returns 200 with empty body over h2c
 

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -50,9 +50,11 @@ Go's `http.ResponseWriter` honored this pre-set `Content-Length` header instead 
 
 ### Solution
 
-Added `Content-Length` to the skip list in `InternalMetadataToHTTPHeader`, alongside `Content-Type` which was already skipped.
-This prevents the stale upstream `Content-Length` from being forwarded to the HTTP response writer.
-Go's `http.ResponseWriter` now computes the correct `Content-Length` automatically from the actual response body. Updated the HTTP channel's `constructRequest` to read `Content-Length` directly from internal metadata for outgoing requests, since it is no longer present in the forwarded HTTP headers.
+Two sets of changes prevent stale `Content-Length` headers from propagating:
+
+1. **Internal metadata path**: Added `Content-Length` to the skip list in `InternalMetadataToHTTPHeader`, alongside `Content-Type` which was already skipped. This prevents the stale upstream `Content-Length` from being forwarded to the HTTP response writer. Go's `http.ResponseWriter` now computes the correct `Content-Length` automatically from the actual response body. Updated the HTTP channel's `constructRequest` to read `Content-Length` directly from internal metadata for outgoing requests, since it is no longer present in the forwarded HTTP headers.
+
+2. **HTTP channel response path**: The HTTP app channel now strips `Content-Length` from upstream response headers before forwarding them through the response pipe. If the upstream app declared a `Content-Length` larger than the actual body, the resulting `io.ErrUnexpectedEOF` from Go's HTTP client is treated as normal completion, since the received data is valid.
 
 ## Actor method invocation returns 200 with empty body over h2c
 

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -1,13 +1,39 @@
 # Dapr 1.17.3
 
-This update contains security and bug fixes:
+This update contains bug fixes and security fixes:
+- [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
 - [Security: Fixes gRPC authorization bypass - CVE-2026-33186](#security-grpc-authorization-bypass)
 - [Security: Fixes TIFF image OOM denial of service - CVE-2026-33809](#security-tiff-image-oom-denial-of-service)
 - [Service invocation and actor responses forward stale Content-Length header](#service-invocation-and-actor-responses-forward-stale-content-length-header)
-- [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
 - [False positive injection failure metrics for non-Dapr pods](#false-positive-injection-failure-metrics-for-non-dapr-pods)
 - [Placement dissemination timeout cascades across all replicas](#placement-dissemination-timeout-cascades-across-all-replicas)
 - [Daprd placement reconnect hangs for 20 seconds on stale DNS](#daprd-placement-reconnect-hangs-for-20-seconds-on-stale-dns)
+
+## Actor method invocation returns 200 with empty body over h2c
+
+### Problem
+
+When using the h2c (HTTP/2 cleartext) app protocol, actor method invocations could return HTTP 200 with correct headers (including `Content-Length`) but an empty body.
+
+### Impact
+
+Applications using `--app-protocol h2c` with actors could receive empty response bodies from actor method calls, despite the actor handler returning data. This caused silent data loss that was difficult to diagnose because the HTTP status code and headers appeared correct.
+
+### Root Cause
+
+Dapr v1.17.2 introduced pipe-based streaming for service invocation response bodies to avoid buffering large payloads in memory. The response headers (including `Content-Length`) are captured when the pipe is ready, and the body streams lazily through an `io.Pipe` via `io.Copy`.
+
+With HTTP/2, response body reads are tied to the request context. When the context is cancelled — either by the resiliency policy runner's `defer cancel()` after `InvokeMethod` returns, or by placement dissemination cancelling actor claims — the HTTP/2 stream is reset (`RST_STREAM`). The goroutine performing `io.Copy` from the HTTP/2 response body then fails, writing 0 bytes to the pipe. The pipe closes normally (EOF), and `ProtoWithData()` reads an empty body. The caller receives 200 OK with the original `Content-Length` header but no data.
+
+HTTP/1.1 is unaffected because TCP buffer reads do not check the request context.
+
+### Solution
+
+Two changes in the HTTP app channel:
+
+1. **Pipe error propagation**: `io.Copy` errors are now captured and propagated through the pipe via `pw.CloseWithError(err)` instead of silently closing with EOF. If context cancellation causes the HTTP/2 body read to fail, callers receive an error rather than an empty body.
+
+2. **h2c context detachment**: For HTTP/2 (h2c) transports only, the HTTP request to the app now uses a context detached from the caller's context (`context.WithoutCancel`). This prevents resiliency timeout cancellation and placement dissemination from resetting the HTTP/2 stream while body data is in flight. The detached context is cancelled when the pipe reader is closed, preventing goroutine leaks. HTTP/1.1 behavior is unchanged.
 
 ## Security: gRPC authorization bypass
 
@@ -19,7 +45,7 @@ An upstream dependency (google.golang.org/grpc) used by Dapr introduced a vulner
 
 Users running affected versions could be exposed to unauthorized gRPC requests.
 
-### Root cause
+### Root Cause
 
 The issue originated in an upstream library.
 
@@ -42,7 +68,7 @@ Callers reading the response body with standard HTTP clients (such as Go's `io.R
 When the forwarded `Content-Length` was smaller than the actual body, clients silently truncated the response.
 This affected both service invocation (direct messaging) and actor method invocation via HTTP.
 
-### Root cause
+### Root Cause
 
 The `InternalMetadataToHTTPHeader` utility function converted all internal gRPC metadata headers to HTTP response headers, including `Content-Length`.
 Since the sidecar reconstructs the response body from a protobuf message (not by proxying the original HTTP stream), the original `Content-Length` from the upstream application became stale.
@@ -55,32 +81,6 @@ Two sets of changes prevent stale `Content-Length` headers from propagating:
 1. **Internal metadata path**: Added `Content-Length` to the skip list in `InternalMetadataToHTTPHeader`, alongside `Content-Type` which was already skipped. This prevents the stale upstream `Content-Length` from being forwarded to the HTTP response writer. Go's `http.ResponseWriter` now computes the correct `Content-Length` automatically from the actual response body. Updated the HTTP channel's `constructRequest` to read `Content-Length` directly from internal metadata for outgoing requests, since it is no longer present in the forwarded HTTP headers.
 
 2. **HTTP channel response path**: The HTTP app channel now strips `Content-Length` from upstream response headers before forwarding them through the response pipe. If the upstream app declared a `Content-Length` larger than the actual body, the resulting `io.ErrUnexpectedEOF` from Go's HTTP client is treated as normal completion, since the received data is valid.
-
-## Actor method invocation returns 200 with empty body over h2c
-
-### Problem
-
-When using the h2c (HTTP/2 cleartext) app protocol, actor method invocations could return HTTP 200 with correct headers (including `Content-Length`) but an empty body.
-
-### Impact
-
-Applications using `--app-protocol h2c` with actors could receive empty response bodies from actor method calls, despite the actor handler returning data. This caused silent data loss that was difficult to diagnose because the HTTP status code and headers appeared correct.
-
-### Root cause
-
-Dapr v1.17.2 introduced pipe-based streaming for service invocation response bodies to avoid buffering large payloads in memory. The response headers (including `Content-Length`) are captured when the pipe is ready, and the body streams lazily through an `io.Pipe` via `io.Copy`.
-
-With HTTP/2, response body reads are tied to the request context. When the context is cancelled — either by the resiliency policy runner's `defer cancel()` after `InvokeMethod` returns, or by placement dissemination cancelling actor claims — the HTTP/2 stream is reset (`RST_STREAM`). The goroutine performing `io.Copy` from the HTTP/2 response body then fails, writing 0 bytes to the pipe. The pipe closes normally (EOF), and `ProtoWithData()` reads an empty body. The caller receives 200 OK with the original `Content-Length` header but no data.
-
-HTTP/1.1 is unaffected because TCP buffer reads do not check the request context.
-
-### Solution
-
-Two changes in the HTTP app channel:
-
-1. **Pipe error propagation**: `io.Copy` errors are now captured and propagated through the pipe via `pw.CloseWithError(err)` instead of silently closing with EOF. If context cancellation causes the HTTP/2 body read to fail, callers receive an error rather than an empty body.
-
-2. **h2c context detachment**: For HTTP/2 (h2c) transports only, the HTTP request to the app now uses a context detached from the caller's context (`context.WithoutCancel`). This prevents resiliency timeout cancellation and placement dissemination from resetting the HTTP/2 stream while body data is in flight. The detached context is cancelled when the pipe reader is closed, preventing goroutine leaks. HTTP/1.1 behavior is unchanged.
 
 ## Security: gRPC authorization bypass
 

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -42,7 +42,7 @@ Callers reading the response body with standard HTTP clients (such as Go's `io.R
 When the forwarded `Content-Length` was smaller than the actual body, clients silently truncated the response.
 This affected both service invocation (direct messaging) and actor method invocation via HTTP.
 
-### Root Cause
+### Root cause
 
 The `InternalMetadataToHTTPHeader` utility function converted all internal gRPC metadata headers to HTTP response headers, including `Content-Length`.
 Since the sidecar reconstructs the response body from a protobuf message (not by proxying the original HTTP stream), the original `Content-Length` from the upstream application became stale.
@@ -66,7 +66,7 @@ When using the h2c (HTTP/2 cleartext) app protocol, actor method invocations cou
 
 Applications using `--app-protocol h2c` with actors could receive empty response bodies from actor method calls, despite the actor handler returning data. This caused silent data loss that was difficult to diagnose because the HTTP status code and headers appeared correct.
 
-### Root Cause
+### Root cause
 
 Dapr v1.17.2 introduced pipe-based streaming for service invocation response bodies to avoid buffering large payloads in memory. The response headers (including `Content-Length`) are captured when the pipe is ready, and the body streams lazily through an `io.Pipe` via `io.Copy`.
 

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -3,8 +3,8 @@
 This update contains bug fixes and security fixes:
 - [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
 - [Security: Fixes gRPC authorization bypass - CVE-2026-33186](#security-grpc-authorization-bypass)
-- [Security: Fixes TIFF image OOM denial of service - CVE-2026-33809](#security-tiff-image-oom-denial-of-service)
 - [Service invocation and actor responses forward stale Content-Length header](#service-invocation-and-actor-responses-forward-stale-content-length-header)
+- [Security: Fixes TIFF image OOM denial of service - CVE-2026-33809](#security-tiff-image-oom-denial-of-service)
 - [False positive injection failure metrics for non-Dapr pods](#false-positive-injection-failure-metrics-for-non-dapr-pods)
 - [Placement dissemination timeout cascades across all replicas](#placement-dissemination-timeout-cascades-across-all-replicas)
 - [Daprd placement reconnect hangs for 20 seconds on stale DNS](#daprd-placement-reconnect-hangs-for-20-seconds-on-stale-dns)

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -25,7 +25,7 @@ The issue originated in an upstream library.
 
 ### Solution
 
-This release upgrades the affected dependency to a version that resolves CVE-2026-33186. 
+This release upgrades the affected dependency to a version that resolves CVE-2026-33186.
 
 Users are strongly encouraged to upgrade to this release.
 

--- a/pkg/api/http/actors_contentlength_test.go
+++ b/pkg/api/http/actors_contentlength_test.go
@@ -1,7 +1,19 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package http
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -102,7 +114,7 @@ func TestActorResponseContentLengthBodyMatch(t *testing.T) {
 				clInt, err := strconv.Atoi(cl)
 				require.NoError(t, err)
 				assert.Equal(t, len(body), clInt,
-					fmt.Sprintf("Content-Length header (%d) must match actual body length (%d)", clInt, len(body)))
+					"Content-Length header (%d) must match actual body length (%d)", clInt, len(body))
 			}
 		})
 	}

--- a/pkg/api/http/actors_contentlength_test.go
+++ b/pkg/api/http/actors_contentlength_test.go
@@ -1,0 +1,109 @@
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+)
+
+// TestActorResponseContentLengthBodyMatch verifies that Content-Length from
+// upstream response headers is NOT blindly forwarded to the client when daprd
+// rebuilds the response body. Instead, Go's ResponseWriter should compute the
+// correct Content-Length from the actual data written.
+//
+// Regression test for https://github.com/dapr/dapr/issues/9668
+func TestActorResponseContentLengthBodyMatch(t *testing.T) {
+	tests := []struct {
+		name                  string
+		upstreamContentLength string
+		bodyToWrite           []byte
+		expectedBody          string
+	}{
+		{
+			name:                  "null body - upstream CL matches",
+			upstreamContentLength: "4",
+			bodyToWrite:           []byte("null"),
+			expectedBody:          "null",
+		},
+		{
+			name:                  "upstream CL larger than actual body",
+			upstreamContentLength: "100",
+			bodyToWrite:           []byte("short"),
+			expectedBody:          "short",
+		},
+		{
+			name:                  "upstream CL smaller than actual body",
+			upstreamContentLength: "2",
+			bodyToWrite:           []byte("much longer body"),
+			expectedBody:          "much longer body",
+		},
+		{
+			name:                  "empty body with non-zero upstream CL",
+			upstreamContentLength: "4",
+			bodyToWrite:           nil,
+			expectedBody:          "",
+		},
+		{
+			name:                  "false JSON value",
+			upstreamContentLength: "5",
+			bodyToWrite:           []byte("false"),
+			expectedBody:          "false",
+		},
+		{
+			name:                  "large body",
+			upstreamContentLength: "8192",
+			bodyToWrite:           []byte(strings.Repeat("x", 8192)),
+			expectedBody:          strings.Repeat("x", 8192),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build internal metadata simulating upstream response headers.
+			md := map[string]*internalv1pb.ListStringValue{
+				"content-length": {Values: []string{tc.upstreamContentLength}},
+				"content-type":   {Values: []string{"application/json"}},
+			}
+
+			// Simulate what onDirectActorMessage does:
+			// 1. Forward upstream headers to the ResponseWriter
+			// 2. Set content-type explicitly
+			// 3. Call respondWithData with the body
+			rec := httptest.NewRecorder()
+			h := rec.Header()
+			invokev1.InternalMetadataToHTTPHeader(t.Context(), md, h.Add)
+			h.Set("content-type", "application/json")
+
+			respondWithData(rec, http.StatusOK, tc.bodyToWrite)
+
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedBody, string(body),
+				"response body should match expected content")
+
+			// The critical check: Content-Length must match actual body
+			// length. Before the fix, Content-Length could be the stale
+			// upstream value rather than the actual body length.
+			if cl := resp.Header.Get("Content-Length"); cl != "" {
+				clInt, err := strconv.Atoi(cl)
+				require.NoError(t, err)
+				assert.Equal(t, len(body), clInt,
+					fmt.Sprintf("Content-Length header (%d) must match actual body length (%d)", clInt, len(body)))
+			}
+		})
+	}
+}

--- a/pkg/api/http/actors_contentlength_test.go
+++ b/pkg/api/http/actors_contentlength_test.go
@@ -42,10 +42,10 @@ func TestActorResponseContentLengthBodyMatch(t *testing.T) {
 		expectedBody          string
 	}{
 		{
-			name:                  "null body - upstream CL matches",
-			upstreamContentLength: "4",
-			bodyToWrite:           []byte("null"),
-			expectedBody:          "null",
+			name:                  "upstream CL matches actual body",
+			upstreamContentLength: "5",
+			bodyToWrite:           []byte("Hello"),
+			expectedBody:          "Hello",
 		},
 		{
 			name:                  "upstream CL larger than actual body",

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -604,12 +604,15 @@ func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMeth
 	// (to prevent stale values on rebuilt responses), so read it
 	// directly from the internal metadata for outgoing requests.
 	if md := req.Metadata(); md != nil {
-		if clVal, ok := md[invokev1.ContentLengthHeader]; ok && len(clVal.GetValues()) > 0 {
-			v, err := strconv.ParseInt(clVal.GetValues()[0], 10, 64)
-			if err != nil {
-				return nil, err
+		for k, clVal := range md {
+			if strings.EqualFold(k, invokev1.ContentLengthHeader) && len(clVal.GetValues()) > 0 {
+				v, err := strconv.ParseInt(clVal.GetValues()[0], 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				channelReq.ContentLength = v
+				break
 			}
-			channelReq.ContentLength = v
 		}
 	}
 

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -259,6 +259,7 @@ func (h *Channel) sendJob(ctx context.Context, name string, data *anypb.Any) (*i
 	}
 
 	var handlerErr error
+	contentLength := int64(-1)
 
 	go func() {
 		defer rw.signalReady()
@@ -279,6 +280,14 @@ func (h *Channel) sendJob(ctx context.Context, name string, data *anypb.Any) (*i
 			if clientResp != nil {
 				defer clientResp.Body.Close()
 				copyHeader(w.Header(), clientResp.Header)
+				// Capture Content-Length for metrics before removing it
+				// from forwarded headers, so that the upstream app's stale
+				// or incorrect value is not forwarded to the caller.
+				if cl := w.Header().Get("Content-Length"); cl != "" {
+					if parsed, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
+						contentLength = parsed
+					}
+				}
 				w.Header().Del("Content-Length")
 				w.WriteHeader(clientResp.StatusCode)
 				_, _ = io.Copy(w, clientResp.Body)
@@ -295,15 +304,6 @@ func (h *Channel) sendJob(ctx context.Context, name string, data *anypb.Any) (*i
 	}
 
 	elapsedMs := float64(time.Since(startRequest) / time.Millisecond)
-
-	contentLength := int64(-1)
-	if rw.h != nil {
-		if cl := rw.h.Get("content-length"); cl != "" {
-			if parsed, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
-				contentLength = parsed
-			}
-		}
-	}
 
 	if handlerErr != nil {
 		pr.Close()
@@ -431,8 +431,9 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	}
 
 	var (
-		isSse      bool
-		handlerErr error
+		isSse         bool
+		handlerErr    error
+		contentLength = int64(-1)
 	)
 
 	go func() {
@@ -482,10 +483,15 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 					}
 				} else {
 					copyHeader(w.Header(), clientResp.Header)
-					// Remove Content-Length from forwarded headers because
-					// the upstream app may have set a stale or incorrect
-					// value. The actual body length will be determined by
-					// the pipe/chunked encoding.
+					// Capture Content-Length for metrics before removing
+					// it from forwarded headers, so that the upstream
+					// app's stale or incorrect value is not forwarded to
+					// the caller.
+					if cl := w.Header().Get("Content-Length"); cl != "" {
+						if parsed, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
+							contentLength = parsed
+						}
+					}
 					w.Header().Del("Content-Length")
 					w.WriteHeader(clientResp.StatusCode)
 					_, pipeErr = io.Copy(w, clientResp.Body)
@@ -513,8 +519,6 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 
 	elapsedMs := float64(time.Since(startRequest) / time.Millisecond)
 
-	contentLength := int64(-1)
-
 	if handlerErr != nil {
 		pr.Close()
 		diag.DefaultHTTPMonitoring.ClientRequestCompleted(ctx, channelReq.Method, req.Message().GetMethod(), strconv.Itoa(http.StatusInternalServerError), contentLength, elapsedMs)
@@ -525,14 +529,6 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	if isSse && statusOK {
 		pr.Close()
 		return nil, nil
-	}
-
-	if rw.h != nil {
-		if cl := rw.h.Get("content-length"); cl != "" {
-			if parsed, parseErr := strconv.ParseInt(cl, 10, 64); parseErr == nil {
-				contentLength = parsed
-			}
-		}
 	}
 
 	// Construct the http.Response with the pipe reader as the body so data

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -278,6 +279,7 @@ func (h *Channel) sendJob(ctx context.Context, name string, data *anypb.Any) (*i
 			if clientResp != nil {
 				defer clientResp.Body.Close()
 				copyHeader(w.Header(), clientResp.Header)
+				w.Header().Del("Content-Length")
 				w.WriteHeader(clientResp.StatusCode)
 				_, _ = io.Copy(w, clientResp.Body)
 			}
@@ -480,8 +482,20 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 					}
 				} else {
 					copyHeader(w.Header(), clientResp.Header)
+					// Remove Content-Length from forwarded headers because
+					// the upstream app may have set a stale or incorrect
+					// value. The actual body length will be determined by
+					// the pipe/chunked encoding.
+					w.Header().Del("Content-Length")
 					w.WriteHeader(clientResp.StatusCode)
 					_, pipeErr = io.Copy(w, clientResp.Body)
+					// If the upstream app declared a Content-Length larger
+					// than the actual body, Go's HTTP client body reader
+					// returns io.ErrUnexpectedEOF. The data we received is
+					// still valid, so treat this as a normal completion.
+					if errors.Is(pipeErr, io.ErrUnexpectedEOF) {
+						pipeErr = nil
+					}
 				}
 			}
 		}))

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -600,13 +600,17 @@ func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMeth
 		channelReq.Header.Set(hdr.Name, hdr.Value.String())
 	}
 
-	if cl := channelReq.Header.Get(invokev1.ContentLengthHeader); cl != "" {
-		v, err := strconv.ParseInt(cl, 10, 64)
-		if err != nil {
-			return nil, err
+	// Content-Length is not forwarded by InternalMetadataToHTTPHeader
+	// (to prevent stale values on rebuilt responses), so read it
+	// directly from the internal metadata for outgoing requests.
+	if md := req.Metadata(); md != nil {
+		if clVal, ok := md[invokev1.ContentLengthHeader]; ok && len(clVal.GetValues()) > 0 {
+			v, err := strconv.ParseInt(clVal.GetValues()[0], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			channelReq.ContentLength = v
 		}
-
-		channelReq.ContentLength = v
 	}
 
 	// HTTP client needs to inject traceparent header for proper tracing stack.

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -233,7 +233,7 @@ func InternalMetadataToHTTPHeader(ctx context.Context, internalMD DaprInternalMe
 			continue
 		}
 
-		if strings.HasSuffix(keyName, gRPCBinaryMetadataSuffix) || keyName == ContentTypeHeader {
+		if strings.HasSuffix(keyName, gRPCBinaryMetadataSuffix) || keyName == ContentTypeHeader || keyName == ContentLengthHeader {
 			continue
 		}
 

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -43,6 +43,7 @@ func TestInternalMetadataToHTTPHeader(t *testing.T) {
 		":authority":     testValue,
 		"grpc-timeout":   testValue,
 		"content-type":   testValue, // skip
+		"content-length": testValue, // skip
 		"grpc-trace-bin": testValue,
 	}
 

--- a/tests/integration/suite/actors/call/responsebody.go
+++ b/tests/integration/suite/actors/call/responsebody.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/actors/call/responsebody.go
+++ b/tests/integration/suite/actors/call/responsebody.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package call
+
+import (
+	"context"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(responsebody))
+}
+
+// responsebody tests that actor method invocations correctly forward the
+// response body and that Content-Length matches the actual body.
+type responsebody struct {
+	local  *actors.Actors
+	remote *actors.Actors
+}
+
+func (r *responsebody) Setup(t *testing.T) []framework.Option {
+	handler := func(w nethttp.ResponseWriter, req *nethttp.Request) {
+		// The method name is the last path segment:
+		// /actors/{type}/{id}/method/{method}
+		parts := strings.Split(req.URL.Path, "/")
+		method := parts[len(parts)-1]
+
+		switch method {
+		case "null":
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte("null"))
+		case "empty":
+			w.WriteHeader(nethttp.StatusOK)
+		case "json-object":
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte(`{"key":"value"}`))
+		case "plain-text":
+			w.Header().Set("content-type", "text/plain")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte("hello world"))
+		case "large":
+			w.Header().Set("content-type", "application/octet-stream")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte(strings.Repeat("x", 8192)))
+		case "false":
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte("false"))
+		case "zero":
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte("0"))
+		case "empty-string":
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte(`""`))
+		case "stale-content-length":
+			// Actor app sends a WRONG Content-Length header on purpose.
+			// Before the fix, daprd blindly forwarded this stale value
+			// to the caller, causing a Content-Length / body mismatch.
+			w.Header().Set("content-type", "application/json")
+			w.Header().Set("Content-Length", "999")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte(`"ok"`))
+		default:
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte("ok"))
+		}
+	}
+
+	r.local = actors.New(t,
+		actors.WithActorTypes("rbtest"),
+		actors.WithActorTypeHandler("rbtest", handler),
+	)
+	r.remote = actors.New(t,
+		actors.WithPeerActor(r.local),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.local, r.remote),
+	}
+}
+
+func (r *responsebody) Run(t *testing.T, ctx context.Context) {
+	r.local.WaitUntilRunning(t, ctx)
+	r.remote.WaitUntilRunning(t, ctx)
+
+	tests := []struct {
+		method       string
+		expectedBody string
+	}{
+		{method: "null", expectedBody: "null"},
+		{method: "empty", expectedBody: ""},
+		{method: "json-object", expectedBody: `{"key":"value"}`},
+		{method: "plain-text", expectedBody: "hello world"},
+		{method: "large", expectedBody: strings.Repeat("x", 8192)},
+		{method: "false", expectedBody: "false"},
+		{method: "zero", expectedBody: "0"},
+		{method: "empty-string", expectedBody: `""`},
+		{method: "stale-content-length", expectedBody: `"ok"`},
+	}
+
+	// Test via HTTP from both local and remote daprd instances.
+	for _, app := range []struct {
+		name  string
+		actor *actors.Actors
+	}{
+		{name: "local", actor: r.local},
+		{name: "remote", actor: r.remote},
+	} {
+		t.Run("http-"+app.name, func(t *testing.T) {
+			httpClient := client.HTTP(t)
+			for _, tc := range tests {
+				t.Run(tc.method, func(t *testing.T) {
+					url := fmt.Sprintf("http://%s/v1.0/actors/rbtest/myactor/method/%s",
+						app.actor.Daprd().HTTPAddress(), tc.method)
+					req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+					require.NoError(t, err)
+
+					resp, err := httpClient.Do(req)
+					require.NoError(t, err)
+
+					body, err := io.ReadAll(resp.Body)
+					// io.ReadAll returns "unexpected EOF" when
+					// Content-Length exceeds the actual body.
+					require.NoError(t, err)
+					require.NoError(t, resp.Body.Close())
+
+					require.Equal(t, nethttp.StatusOK, resp.StatusCode)
+					assert.Equal(t, tc.expectedBody, string(body))
+
+					// Verify Content-Length matches actual body length
+					// when the server sets it (it may use chunked encoding).
+					if cl := resp.Header.Get("Content-Length"); cl != "" {
+						clInt, err := strconv.Atoi(cl)
+						require.NoError(t, err)
+						assert.Equal(t, len(body), clInt,
+							"Content-Length header must match actual body length")
+					}
+				})
+			}
+		})
+	}
+
+	// Test via gRPC from local daprd instance.
+	t.Run("grpc-local", func(t *testing.T) {
+		gclient := r.local.GRPCClient(t, ctx)
+		for _, tc := range tests {
+			t.Run(tc.method, func(t *testing.T) {
+				resp, err := gclient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+					ActorType: "rbtest",
+					ActorId:   "myactor",
+					Method:    tc.method,
+				})
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedBody, string(resp.GetData()))
+			})
+		}
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/contentlength.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/contentlength.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/daprd/serviceinvocation/http/contentlength.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/contentlength.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(contentlength))
+}
+
+// contentlength tests that service invocation correctly forwards response
+// bodies and that Content-Length matches the actual body.
+type contentlength struct {
+	daprd1 *procdaprd.Daprd
+	daprd2 *procdaprd.Daprd
+}
+
+func (c *contentlength) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+
+	handler.HandleFunc("/null", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("null"))
+	})
+
+	handler.HandleFunc("/empty", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler.HandleFunc("/json-object", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"key":"value"}`))
+	})
+
+	handler.HandleFunc("/plain-text", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello world"))
+	})
+
+	handler.HandleFunc("/large", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(strings.Repeat("x", 8192)))
+	})
+
+	handler.HandleFunc("/false", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("false"))
+	})
+
+	handler.HandleFunc("/zero", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("0"))
+	})
+
+	handler.HandleFunc("/empty-string", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`""`))
+	})
+
+	handler.HandleFunc("/stale-content-length", func(w http.ResponseWriter, _ *http.Request) {
+		// App sends a WRONG Content-Length header on purpose.
+		// Before the fix, daprd blindly forwarded this stale value
+		// to the caller, causing a Content-Length / body mismatch.
+		w.Header().Set("content-type", "application/json")
+		w.Header().Set("Content-Length", "999")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`"ok"`))
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	c.daprd1 = procdaprd.New(t, procdaprd.WithAppPort(srv.Port()))
+	c.daprd2 = procdaprd.New(t, procdaprd.WithAppPort(srv.Port()))
+
+	return []framework.Option{
+		framework.WithProcesses(srv, c.daprd1, c.daprd2),
+	}
+}
+
+func (c *contentlength) Run(t *testing.T, ctx context.Context) {
+	c.daprd1.WaitUntilRunning(t, ctx)
+	c.daprd2.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	tests := []struct {
+		method       string
+		expectedBody string
+	}{
+		{method: "null", expectedBody: "null"},
+		{method: "empty", expectedBody: ""},
+		{method: "json-object", expectedBody: `{"key":"value"}`},
+		{method: "plain-text", expectedBody: "hello world"},
+		{method: "large", expectedBody: strings.Repeat("x", 8192)},
+		{method: "false", expectedBody: "false"},
+		{method: "zero", expectedBody: "0"},
+		{method: "empty-string", expectedBody: `""`},
+		// The critical regression test: app sends a wrong
+		// Content-Length. Before the fix daprd forwarded it, causing
+		// io.ReadAll to return "unexpected EOF" and a short body.
+		{method: "stale-content-length", expectedBody: `"ok"`},
+	}
+
+	// Test local invocation (daprd1 -> daprd1's app).
+	t.Run("local", func(t *testing.T) {
+		for _, tc := range tests {
+			t.Run(tc.method, func(t *testing.T) {
+				url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/%s",
+					c.daprd1.HTTPAddress(), c.daprd1.AppID(), tc.method)
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				require.NoError(t, err)
+
+				resp, err := httpClient.Do(req)
+				require.NoError(t, err)
+
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				require.NoError(t, resp.Body.Close())
+
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, tc.expectedBody, string(body))
+
+				if cl := resp.Header.Get("Content-Length"); cl != "" {
+					clInt, err := strconv.Atoi(cl)
+					require.NoError(t, err)
+					assert.Equal(t, len(body), clInt,
+						"Content-Length header must match actual body length")
+				}
+			})
+		}
+	})
+
+	// Test remote invocation (daprd2 -> daprd1's app via gRPC).
+	t.Run("remote", func(t *testing.T) {
+		for _, tc := range tests {
+			t.Run(tc.method, func(t *testing.T) {
+				url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/%s",
+					c.daprd2.HTTPAddress(), c.daprd1.AppID(), tc.method)
+				req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+				require.NoError(t, err)
+
+				resp, err := httpClient.Do(req)
+				require.NoError(t, err)
+
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				require.NoError(t, resp.Body.Close())
+
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, tc.expectedBody, string(body))
+
+				if cl := resp.Header.Get("Content-Length"); cl != "" {
+					clInt, err := strconv.Atoi(cl)
+					require.NoError(t, err)
+					assert.Equal(t, len(body), clInt,
+						"Content-Length header must match actual body length")
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
When daprd rebuilds HTTP responses from internal protobuf messages, the upstream application's Content-Length header was forwarded verbatim to the caller. If the upstream sent an incorrect Content-Length, callers received unexpected EOF errors or truncated bodies.

Skip Content-Length in InternalMetadataToHTTPHeader so Go's ResponseWriter computes the correct value from the actual body written. Update http_channel's constructRequest to read Content-Length directly from internal metadata for outgoing requests.

Fixes: https://github.com/dapr/dapr/issues/9668