### PR TITLE
Actors: h2c: actor invocation 200 with empty body

### DIFF
--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -1,7 +1,34 @@
 # Dapr 1.17.3
 
-This update contains security fixes:
+This update contains bug fixes and security fixes:
+- [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
 - [Security: Fixes gRPC authorization bypass - CVE-2026-33186](#security-grpc-authorization-bypass)
+
+## Actor method invocation returns 200 with empty body over h2c
+
+### Problem
+
+When using the h2c (HTTP/2 cleartext) app protocol, actor method invocations could return HTTP 200 with correct headers (including `Content-Length`) but an empty body.
+
+### Impact
+
+Applications using `--app-protocol h2c` with actors could receive empty response bodies from actor method calls, despite the actor handler returning data. This caused silent data loss that was difficult to diagnose because the HTTP status code and headers appeared correct.
+
+### Root Cause
+
+Dapr v1.17.2 introduced pipe-based streaming for service invocation response bodies to avoid buffering large payloads in memory. The response headers (including `Content-Length`) are captured when the pipe is ready, and the body streams lazily through an `io.Pipe` via `io.Copy`.
+
+With HTTP/2, response body reads are tied to the request context. When the context is cancelled — either by the resiliency policy runner's `defer cancel()` after `InvokeMethod` returns, or by placement dissemination cancelling actor claims — the HTTP/2 stream is reset (`RST_STREAM`). The goroutine performing `io.Copy` from the HTTP/2 response body then fails, writing 0 bytes to the pipe. The pipe closes normally (EOF), and `ProtoWithData()` reads an empty body. The caller receives 200 OK with the original `Content-Length` header but no data.
+
+HTTP/1.1 is unaffected because TCP buffer reads do not check the request context.
+
+### Solution
+
+Two changes in the HTTP app channel:
+
+1. **Pipe error propagation**: `io.Copy` errors are now captured and propagated through the pipe via `pw.CloseWithError(err)` instead of silently closing with EOF. If context cancellation causes the HTTP/2 body read to fail, callers receive an error rather than an empty body.
+
+2. **h2c context detachment**: For HTTP/2 (h2c) transports only, the HTTP request to the app now uses a context detached from the caller's context (`context.WithoutCancel`). This prevents resiliency timeout cancellation and placement dissemination from resetting the HTTP/2 stream while body data is in flight. The detached context is cancelled when the pipe reader is closed, preventing goroutine leaks. HTTP/1.1 behavior is unchanged.
 
 ## Security: gRPC authorization bypass
 

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -385,8 +386,27 @@ func (h *Channel) HealthProbe(ctx context.Context) (*apphealth.Status, error) {
 }
 
 func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethodRequest, appID string) (*invokev1.InvokeMethodResponse, error) {
-	channelReq, err := h.constructRequest(ctx, req, appID)
+	// For HTTP/2 (h2c) transports, the response body read is tied to the
+	// request context. If the caller's context is cancelled (e.g. resiliency
+	// timeout or placement dissemination) after headers are received but
+	// before the body is fully read through the pipe, the HTTP/2 stream is
+	// reset and io.Copy from the response body fails. This causes the pipe
+	// to receive 0 bytes and callers get 200 OK with empty body.
+	//
+	// To prevent this, we detach the HTTP request context from the caller's
+	// context for h2c, and instead cancel it when the pipe reader is closed.
+	// HTTP/1.1 is unaffected because TCP reads don't check the context.
+	reqCtx := ctx
+	var reqCancel context.CancelFunc
+	if _, ok := h.client.Transport.(*http2.Transport); ok {
+		reqCtx, reqCancel = context.WithCancel(context.WithoutCancel(ctx))
+	}
+
+	channelReq, err := h.constructRequest(reqCtx, req, appID)
 	if err != nil {
+		if reqCancel != nil {
+			reqCancel()
+		}
 		return nil, err
 	}
 
@@ -398,7 +418,11 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	diag.DefaultHTTPMonitoring.ClientRequestStarted(ctx, channelReq.Method, req.Message().GetMethod(), int64(len(req.Message().GetData().GetValue())))
 	startRequest := time.Now()
 
-	pr, pw := io.Pipe()
+	rawPR, pw := io.Pipe()
+	// Wrap the pipe reader so that closing it also cancels the detached
+	// request context (if any), preventing goroutine leaks from h2c
+	// requests that outlive the caller's context.
+	pr := wrapPipeReaderWithCancel(rawPR, reqCancel)
 	rw := &rwRecorder{
 		pw:      pw,
 		readyCh: make(chan struct{}),
@@ -411,7 +435,15 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 
 	go func() {
 		defer rw.signalReady()
-		defer pw.Close()
+		// Track errors from io.Copy so they propagate through the pipe
+		// instead of silently returning empty body data. With HTTP/2 (h2c),
+		// context cancellation resets the stream, causing body reads to fail.
+		// Without error propagation, the pipe closes normally (EOF) with 0
+		// bytes, and callers receive 200 OK with empty body.
+		var pipeErr error
+		defer func() {
+			pw.CloseWithError(pipeErr)
+		}()
 		// Release the concurrency limiter slot when the handler goroutine
 		// finishes. Because io.Pipe is synchronous (no buffer), the goroutine
 		// naturally stays alive—and holds the slot—until the caller has
@@ -449,7 +481,7 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 				} else {
 					copyHeader(w.Header(), clientResp.Header)
 					w.WriteHeader(clientResp.StatusCode)
-					_, _ = io.Copy(w, clientResp.Body)
+					_, pipeErr = io.Copy(w, clientResp.Body)
 				}
 			}
 		}))

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -422,7 +422,7 @@ func (h *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	// Wrap the pipe reader so that closing it also cancels the detached
 	// request context (if any), preventing goroutine leaks from h2c
 	// requests that outlive the caller's context.
-	pr := wrapPipeReaderWithCancel(rawPR, reqCancel)
+	pr := wrapReadCloserWithCancel(rawPR, reqCancel)
 	rw := &rwRecorder{
 		pw:      pw,
 		readyCh: make(chan struct{}),

--- a/pkg/channel/http/reader.go
+++ b/pkg/channel/http/reader.go
@@ -36,9 +36,9 @@ func (r *cancelOnCloseReader) Close() error {
 
 // wrapPipeReaderWithCancel wraps a pipe reader so closing it also calls cancel.
 // If cancel is nil, the reader is returned as-is.
-func wrapPipeReaderWithCancel(pr *io.PipeReader, cancel context.CancelFunc) io.ReadCloser {
+func wrapReadCloserWithCancel(rc io.ReadCloser, cancel context.CancelFunc) io.ReadCloser {
 	if cancel == nil {
-		return pr
+		return rc
 	}
-	return &cancelOnCloseReader{ReadCloser: pr, cancel: cancel}
+	return &cancelOnCloseReader{ReadCloser: rc, cancel: cancel}
 }

--- a/pkg/channel/http/reader.go
+++ b/pkg/channel/http/reader.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+// cancelOnCloseReader wraps an io.ReadCloser and calls a cancel function
+// when Close is called. This is used to cancel the detached h2c request
+// context when the pipe reader is closed, ensuring the HTTP/2 goroutine
+// does not leak.
+type cancelOnCloseReader struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *cancelOnCloseReader) Close() error {
+	r.once.Do(func() { r.cancel() })
+	return r.ReadCloser.Close()
+}
+
+// wrapPipeReaderWithCancel wraps a pipe reader so closing it also calls cancel.
+// If cancel is nil, the reader is returned as-is.
+func wrapPipeReaderWithCancel(pr *io.PipeReader, cancel context.CancelFunc) io.ReadCloser {
+	if cancel == nil {
+		return pr
+	}
+	return &cancelOnCloseReader{ReadCloser: pr, cancel: cancel}
+}

--- a/tests/integration/suite/actors/call/call.go
+++ b/tests/integration/suite/actors/call/call.go
@@ -6,7 +6,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */

--- a/tests/integration/suite/actors/call/call.go
+++ b/tests/integration/suite/actors/call/call.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieh.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package call
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/call/h2c"
+)

--- a/tests/integration/suite/actors/call/h2c/dissemination.go
+++ b/tests/integration/suite/actors/call/h2c/dissemination.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package h2c
+
+import (
+	"context"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(dissemination))
+}
+
+// dissemination tests that actor method invocations over h2c app protocol
+// correctly forward the response body when placement dissemination occurs
+// during the invocation. When a new peer daprd registers with placement,
+// placement sends a lock/update/unlock sequence. With drainRebalancedActors
+// set to false, the lock phase immediately cancels all in-flight actor claims.
+//
+// Regression test for https://github.com/dapr/dapr/issues/9672
+type dissemination struct {
+	place *placement.Placement
+	sched *scheduler.Scheduler
+	host  *daprd.Daprd
+	peer  *daprd.Daprd
+
+	inCall     atomic.Int32
+	unblockApp chan struct{}
+}
+
+func (h *dissemination) Setup(t *testing.T) []framework.Option {
+	h.unblockApp = make(chan struct{})
+
+	handler := nethttp.NewServeMux()
+
+	handler.HandleFunc("/dapr/config", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte(`{"entities":["h2cdisstest"],"drainRebalancedActors":false}`))
+	})
+	handler.HandleFunc("/healthz", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+	})
+	handler.HandleFunc("/dapr/subscribe", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte("[]"))
+	})
+
+	handler.HandleFunc("/actors/h2cdisstest/", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		h.inCall.Add(1)
+
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(nethttp.StatusOK)
+		if f, ok := w.(nethttp.Flusher); ok {
+			f.Flush()
+		}
+
+		// Block until test signals us to write the body. Dissemination
+		// will occur while we're blocked here. With the fix, the HTTP/2
+		// stream stays alive (request context is detached from claim
+		// context), so we can still write the body after dissemination.
+		<-h.unblockApp
+
+		w.Write([]byte(`{"key":"value"}`))
+	})
+
+	h2cHandler := h2c.NewHandler(handler, &http2.Server{})
+	srv := prochttp.New(t, prochttp.WithHandler(h2cHandler))
+
+	peerHandler := nethttp.NewServeMux()
+	peerHandler.HandleFunc("/dapr/config", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte(`{"entities":["h2cdisstest"],"drainRebalancedActors":false}`))
+	})
+	peerHandler.HandleFunc("/healthz", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+	})
+	peerHandler.HandleFunc("/dapr/subscribe", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte("[]"))
+	})
+	peerHandler.HandleFunc("/actors/h2cdisstest/", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		h.inCall.Add(1)
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(nethttp.StatusOK)
+		w.Write([]byte(`{"key":"value"}`))
+	})
+	peerH2cHandler := h2c.NewHandler(peerHandler, &http2.Server{})
+	peerSrv := prochttp.New(t, prochttp.WithHandler(peerH2cHandler))
+
+	h.place = placement.New(t)
+	h.sched = scheduler.New(t, scheduler.WithID("dapr-scheduler-0"))
+
+	h.host = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithAppProtocol("h2c"),
+		daprd.WithPlacementAddresses(h.place.Address()),
+		daprd.WithScheduler(h.sched),
+		daprd.WithInMemoryActorStateStore("foo"),
+	)
+
+	// Peer daprd shares placement and scheduler. When it starts, it triggers
+	// placement dissemination which cancels active claims on the host.
+	h.peer = daprd.New(t,
+		daprd.WithAppPort(peerSrv.Port()),
+		daprd.WithAppProtocol("h2c"),
+		daprd.WithPlacementAddresses(h.place.Address()),
+		daprd.WithScheduler(h.sched),
+		daprd.WithInMemoryActorStateStore("foo"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, peerSrv, h.place, h.sched, h.host),
+	}
+}
+
+func (h *dissemination) Run(t *testing.T, ctx context.Context) {
+	h.place.WaitUntilRunning(t, ctx)
+	h.sched.WaitUntilRunning(t, ctx)
+	h.host.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	// Start actor invocation in the background. The app handler blocks
+	// after sending headers until we signal it to write the body.
+	url := fmt.Sprintf("http://%s/v1.0/actors/h2cdisstest/myactor/method/test",
+		h.host.HTTPAddress())
+	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+	require.NoError(t, err)
+
+	type result struct {
+		resp *nethttp.Response
+		err  error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		//nolint:bodyclose
+		resp, rerr := httpClient.Do(req)
+		resCh <- result{resp, rerr}
+	}()
+
+	// Wait for the app handler to be called (headers sent, blocking on body).
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, h.inCall.Load(), int32(1))
+	}, time.Second*10, time.Millisecond*10)
+
+	// Start peer daprd — this triggers placement dissemination, which
+	// cancels the claim context for the in-flight actor invocation.
+	h.peer.Run(t, ctx)
+	t.Cleanup(func() { h.peer.Cleanup(t) })
+	h.peer.WaitUntilRunning(t, ctx)
+
+	// Signal handler to write the body. With the fix, the HTTP/2 stream
+	// survived dissemination, so the body data flows through normally.
+	close(h.unblockApp)
+
+	var res result
+	select {
+	case res = <-resCh:
+	case <-time.After(time.Second * 30):
+		require.Fail(t, "timed out waiting for actor invocation to complete")
+	}
+
+	t.Run("no transport error", func(t *testing.T) {
+		require.NoError(t, res.err)
+	})
+
+	// Guard remaining sub-tests; if there was a transport error there is no
+	// response to inspect.
+	require.NoError(t, res.err)
+	defer res.resp.Body.Close()
+
+	body, err := io.ReadAll(res.resp.Body)
+	require.NoError(t, err)
+
+	t.Run("status 200", func(t *testing.T) {
+		assert.Equal(t, nethttp.StatusOK, res.resp.StatusCode)
+	})
+
+	t.Run("body not empty", func(t *testing.T) {
+		assert.NotEmpty(t, string(body),
+			"response body must not be empty when status is 200 OK "+
+				"(h2c dissemination actor invocation regression)")
+	})
+
+	t.Run("body matches expected", func(t *testing.T) {
+		assert.JSONEq(t, `{"key":"value"}`, string(body))
+	})
+}

--- a/tests/integration/suite/actors/call/h2c/resiliency.go
+++ b/tests/integration/suite/actors/call/h2c/resiliency.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package h2c
+
+import (
+	"context"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(resiliency))
+}
+
+type resiliency struct {
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	host   *daprd.Daprd
+	caller *daprd.Daprd
+
+	// headersSent is signaled by the handler after headers are flushed.
+	// writeBody is signaled by the test to tell the handler to write the body.
+	// Both are buffered so the handler and test don't need to rendezvous.
+	headersSent chan struct{}
+	writeBody   chan struct{}
+}
+
+func (h *resiliency) Setup(t *testing.T) []framework.Option {
+	h.headersSent = make(chan struct{}, 1)
+	h.writeBody = make(chan struct{}, 1)
+
+	handler := nethttp.NewServeMux()
+
+	handler.HandleFunc("/dapr/config", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte(`{"entities":["h2crestest"]}`))
+	})
+	handler.HandleFunc("/healthz", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+	})
+	handler.HandleFunc("/dapr/subscribe", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte("[]"))
+	})
+
+	handler.HandleFunc("/actors/h2crestest/", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		method := parts[len(parts)-1]
+
+		var body string
+		switch method {
+		case "json-body":
+			body = `{"key":"value"}`
+			w.Header().Set("content-type", "application/json")
+		case "large-body":
+			body = strings.Repeat("x", 8192)
+			w.Header().Set("content-type", "application/octet-stream")
+		case "null":
+			body = "null"
+			w.Header().Set("content-type", "application/json")
+		default:
+			body = "ok"
+		}
+
+		// Send headers first, then wait for the test to signal before
+		// writing the body. This creates a window between readyCh firing
+		// (InvokeMethod returns) and the body data being available on the
+		// HTTP/2 stream. If the resiliency policy runner cancels the
+		// timeout context during this window, the goroutine reading from
+		// the HTTP/2 body will fail without the fix.
+		w.WriteHeader(nethttp.StatusOK)
+		if f, ok := w.(nethttp.Flusher); ok {
+			f.Flush()
+		}
+
+		// Signal that headers have been sent.
+		h.headersSent <- struct{}{}
+
+		// Wait for the test to tell us to write the body.
+		select {
+		case <-h.writeBody:
+		case <-r.Context().Done():
+			return
+		}
+
+		w.Write([]byte(body))
+	})
+
+	h2cHandler := h2c.NewHandler(handler, &http2.Server{})
+	srv := prochttp.New(t, prochttp.WithHandler(h2cHandler))
+
+	h.place = placement.New(t)
+	h.sched = scheduler.New(t, scheduler.WithID("dapr-scheduler-0"))
+
+	// The resiliency timeout is what triggers the bug: the policy runner wraps
+	// InvokeMethod with context.WithTimeout, and defer cancel() fires after
+	// InvokeMethod returns — cancelling the context before the pipe body is
+	// consumed by ProtoWithData().
+	resiliencyResource := `apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: resiliency
+spec:
+  policies:
+    timeouts:
+      actorTimeout: 30s
+  targets:
+    actors:
+      h2crestest:
+        timeout: actorTimeout
+`
+
+	h.host = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithAppProtocol("h2c"),
+		daprd.WithPlacementAddresses(h.place.Address()),
+		daprd.WithScheduler(h.sched),
+		daprd.WithInMemoryActorStateStore("foo"),
+		daprd.WithResourceFiles(resiliencyResource),
+	)
+
+	h.caller = daprd.New(t,
+		daprd.WithPlacementAddresses(h.place.Address()),
+		daprd.WithScheduler(h.sched),
+		daprd.WithInMemoryActorStateStore("foo"),
+		daprd.WithResourceFiles(resiliencyResource),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, h.place, h.sched, h.host, h.caller),
+	}
+}
+
+func (h *resiliency) Run(t *testing.T, ctx context.Context) {
+	h.place.WaitUntilRunning(t, ctx)
+	h.sched.WaitUntilRunning(t, ctx)
+	h.host.WaitUntilRunning(t, ctx)
+	h.caller.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	tests := []struct {
+		method       string
+		expectedBody string
+	}{
+		{method: "json-body", expectedBody: `{"key":"value"}`},
+		{method: "large-body", expectedBody: strings.Repeat("x", 8192)},
+		{method: "null", expectedBody: "null"},
+	}
+
+	invoke := func(t *testing.T, address, method, expectedBody string) {
+		t.Helper()
+
+		url := fmt.Sprintf("http://%s/v1.0/actors/h2crestest/myactor/method/%s",
+			address, method)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+		require.NoError(t, err)
+
+		// Start the request in the background.
+		type result struct {
+			resp *nethttp.Response
+			err  error
+		}
+		resCh := make(chan result, 1)
+		go func() {
+			//nolint:bodyclose
+			resp, rerr := httpClient.Do(req)
+			resCh <- result{resp, rerr}
+		}()
+
+		// Wait for the handler to flush headers. At this point the
+		// resiliency policy runner's InvokeMethod has returned and
+		// defer cancel() has fired, cancelling the timeout context.
+		select {
+		case <-h.headersSent:
+		case <-ctx.Done():
+			require.Fail(t, "context cancelled waiting for headers")
+		}
+
+		// Signal the handler to write the body. With the bug, the
+		// HTTP/2 stream is already reset by now and the body data
+		// is lost. With the fix, the stream is alive and body flows.
+		h.writeBody <- struct{}{}
+
+		// Collect response.
+		var res result
+		select {
+		case res = <-resCh:
+		case <-ctx.Done():
+			require.Fail(t, "context cancelled waiting for response")
+		}
+
+		require.NoError(t, res.err)
+
+		body, err := io.ReadAll(res.resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.resp.Body.Close())
+
+		require.Equal(t, nethttp.StatusOK, res.resp.StatusCode)
+		assert.Equal(t, expectedBody, string(body),
+			"response body mismatch (h2c+resiliency actor invocation regression)")
+	}
+
+	// Test via local invocation (host daprd -> own app).
+	t.Run("local", func(t *testing.T) {
+		for _, tc := range tests {
+			t.Run(tc.method, func(t *testing.T) {
+				for i := range 3 {
+					t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
+						invoke(t, h.host.HTTPAddress(), tc.method, tc.expectedBody)
+					})
+				}
+			})
+		}
+	})
+
+	// Test via remote invocation (caller daprd -> host daprd via gRPC).
+	t.Run("remote", func(t *testing.T) {
+		for _, tc := range tests {
+			t.Run(tc.method, func(t *testing.T) {
+				for i := range 3 {
+					t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
+						invoke(t, h.caller.HTTPAddress(), tc.method, tc.expectedBody)
+					})
+				}
+			})
+		}
+	})
+}

--- a/tests/integration/suite/actors/call/h2c/responsebody.go
+++ b/tests/integration/suite/actors/call/h2c/responsebody.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package h2c
+
+import (
+	"context"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(responsebody))
+}
+
+type responsebody struct {
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	host   *daprd.Daprd
+	caller *daprd.Daprd
+}
+
+func (h *responsebody) Setup(t *testing.T) []framework.Option {
+	handler := nethttp.NewServeMux()
+
+	handler.HandleFunc("/dapr/config", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte(`{"entities":["h2ctest"]}`))
+	})
+	handler.HandleFunc("/healthz", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+	})
+	handler.HandleFunc("/dapr/subscribe", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.Write([]byte("[]"))
+	})
+
+	handler.HandleFunc("/actors/h2ctest/", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		method := parts[len(parts)-1]
+
+		switch method {
+		case "json-body":
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte(`{"key":"value"}`))
+		case "large-body":
+			w.Header().Set("content-type", "application/octet-stream")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte(strings.Repeat("x", 8192)))
+		case "null":
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte("null"))
+		default:
+			w.WriteHeader(nethttp.StatusOK)
+			w.Write([]byte("ok"))
+		}
+	})
+
+	// Wrap with h2c to support HTTP/2 cleartext.
+	h2cHandler := h2c.NewHandler(handler, &http2.Server{})
+	srv := prochttp.New(t, prochttp.WithHandler(h2cHandler))
+
+	h.place = placement.New(t)
+	h.sched = scheduler.New(t, scheduler.WithID("dapr-scheduler-0"))
+
+	resiliencyResource := `apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: resiliency
+spec:
+  policies:
+    timeouts:
+      actorTimeout: 30s
+  targets:
+    actors:
+      h2ctest:
+        timeout: actorTimeout
+`
+
+	h.host = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithAppProtocol("h2c"),
+		daprd.WithPlacementAddresses(h.place.Address()),
+		daprd.WithScheduler(h.sched),
+		daprd.WithInMemoryActorStateStore("foo"),
+		daprd.WithResourceFiles(resiliencyResource),
+	)
+
+	h.caller = daprd.New(t,
+		daprd.WithPlacementAddresses(h.place.Address()),
+		daprd.WithScheduler(h.sched),
+		daprd.WithInMemoryActorStateStore("foo"),
+		daprd.WithResourceFiles(resiliencyResource),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, h.place, h.sched, h.host, h.caller),
+	}
+}
+
+func (h *responsebody) Run(t *testing.T, ctx context.Context) {
+	h.place.WaitUntilRunning(t, ctx)
+	h.sched.WaitUntilRunning(t, ctx)
+	h.host.WaitUntilRunning(t, ctx)
+	h.caller.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	tests := []struct {
+		method       string
+		expectedBody string
+	}{
+		{method: "json-body", expectedBody: `{"key":"value"}`},
+		{method: "large-body", expectedBody: strings.Repeat("x", 8192)},
+		{method: "null", expectedBody: "null"},
+	}
+
+	// Test via local invocation (host daprd -> own app).
+	t.Run("local", func(t *testing.T) {
+		for _, tc := range tests {
+			t.Run(tc.method, func(t *testing.T) {
+				for i := range 5 {
+					t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
+						url := fmt.Sprintf("http://%s/v1.0/actors/h2ctest/myactor/method/%s",
+							h.host.HTTPAddress(), tc.method)
+						req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+						require.NoError(t, err)
+
+						resp, err := httpClient.Do(req)
+						require.NoError(t, err)
+
+						body, err := io.ReadAll(resp.Body)
+						require.NoError(t, err)
+						require.NoError(t, resp.Body.Close())
+
+						require.Equal(t, nethttp.StatusOK, resp.StatusCode)
+						assert.Equal(t, tc.expectedBody, string(body),
+							"response body must not be empty (h2c actor invocation regression)")
+					})
+				}
+			})
+		}
+	})
+
+	// Test via remote invocation (caller daprd -> host daprd via gRPC).
+	t.Run("remote", func(t *testing.T) {
+		for _, tc := range tests {
+			t.Run(tc.method, func(t *testing.T) {
+				for i := range 5 {
+					t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
+						url := fmt.Sprintf("http://%s/v1.0/actors/h2ctest/myactor/method/%s",
+							h.caller.HTTPAddress(), tc.method)
+						req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+						require.NoError(t, err)
+
+						resp, err := httpClient.Do(req)
+						require.NoError(t, err)
+
+						body, err := io.ReadAll(resp.Body)
+						require.NoError(t, err)
+						require.NoError(t, resp.Body.Close())
+
+						require.Equal(t, nethttp.StatusOK, resp.StatusCode)
+						assert.Equal(t, tc.expectedBody, string(body),
+							"response body must not be empty (h2c remote actor invocation regression)")
+					})
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
With pipe-based response streaming (v1.17.2), HTTP/2 context cancellation — from resiliency timeout cleanup or placement dissemination — resets the stream before io.Copy finishes, causing the pipe to close with 0 bytes. Callers receive 200 OK with correct headers but an empty body.

Two fixes in the HTTP app channel:

1. Propagate io.Copy errors through the pipe via pw.CloseWithError instead of silently closing with EOF, so callers receive an error rather than empty body.

2. For h2c transports only, detach the HTTP request context from the caller's context (context.WithoutCancel). This prevents resiliency timeout and dissemination cancellation from resetting the HTTP/2 stream while body data is in flight. The detached context is cancelled when the pipe reader is closed to prevent goroutine leaks. HTTP/1.1 behavior is unchanged.

Fixes: https://github.com/dapr/dapr/issues/9672

---

Actor method invocation returns 200 with empty body over h2c

Problem

When using the h2c (HTTP/2 cleartext) app protocol, actor method invocations could return HTTP 200 with correct headers (including `Content-Length`) but an empty body.

Impact

Applications using `--app-protocol h2c` with actors could receive empty response bodies from actor method calls, despite the actor handler returning data. This caused silent data loss that was difficult to diagnose because the HTTP status code and headers appeared correct.

Root Cause

Dapr v1.17.2 introduced pipe-based streaming for service invocation response bodies to avoid buffering large payloads in memory. The response headers (including `Content-Length`) are captured when the pipe is ready, and the body streams lazily through an `io.Pipe` via `io.Copy`.

With HTTP/2, response body reads are tied to the request context. When the context is cancelled — either by the resiliency policy runner's `defer cancel()` after `InvokeMethod` returns, or by placement dissemination cancelling actor claims — the HTTP/2 stream is reset (`RST_STREAM`). The goroutine performing `io.Copy` from the HTTP/2 response body then fails, writing 0 bytes to the pipe. The pipe closes normally (EOF), and `ProtoWithData()` reads an empty body. The caller receives 200 OK with the original `Content-Length` header but no data.

HTTP/1.1 is unaffected because TCP buffer reads do not check the request context.

Solution

Two changes in the HTTP app channel:

1. **Pipe error propagation**: `io.Copy` errors are now captured and propagated through the pipe via `pw.CloseWithError(err)` instead of silently closing with EOF. If context cancellation causes the HTTP/2 body read to fail, callers receive an error rather than an empty body.

2. **h2c context detachment**: For HTTP/2 (h2c) transports only, the HTTP request to the app now uses a context detached from the caller's context (`context.WithoutCancel`). This prevents resiliency timeout cancellation and placement dissemination from resetting the HTTP/2 stream while body data is in flight. The detached context is cancelled when the pipe reader is closed, preventing goroutine leaks. HTTP/1.1 behavior is unchanged.