### PR TITLE
Enable OpenSSF Scorecard GitHub Action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Weekly on Saturdays.
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Description

Add the [OpenSSF Scorecard](https://github.com/ossf/scorecard) GitHub Action to automatically evaluate the project's security posture, as requested in #7893.

## Changes

- Add `.github/workflows/scorecard.yml` with:
  - **Trigger:** Push to `master` + weekly schedule (Saturdays)
  - **Permissions:** `security-events: write` + `id-token: write` (minimum required)
  - **Steps:** Checkout → Scorecard analysis → Upload SARIF artifact → Upload to code-scanning dashboard
  - **Publish results:** Enabled (contributes to OpenSSF public dataset)
  - All action versions pinned to full SHA hashes

## Configuration

The workflow follows the [official template](https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml) from ossf/scorecard. Results will appear in:
- **GitHub Security tab** → Code scanning alerts (SARIF upload)
- **OpenSSF API** → Public scorecard data (publish_results: true)
- **Actions tab** → SARIF artifact retained for 5 days

Addresses #7893