### PR TITLE
fix flaky TestResiliencyActivationsCountMonitoring

### DIFF
--- a/pkg/diagnostics/resiliency_monitoring_test.go
+++ b/pkg/diagnostics/resiliency_monitoring_test.go
@@ -251,8 +251,8 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 						return nil, errors.New("fake error")
 					})
 				}
-				// let the circuit breaker to go to half open state (5x cb timeout)
-				time.Sleep(500 * time.Millisecond)
+				// let the circuit breaker to go to half open state (>5x cb timeout of 500ms)
+				time.Sleep(3000 * time.Millisecond)
 				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 				policyRunner := resiliency.NewRunner[any](t.Context(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (any, error) {
@@ -425,8 +425,8 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 						return nil, errors.New("fake error")
 					})
 				}
-				// let the circuit breaker to go to half open state (5x cb timeout) and then return success to close it
-				time.Sleep(1000 * time.Millisecond)
+				// let the circuit breaker to go to half open state (>5x cb timeout of 500ms) and then return success to close it
+				time.Sleep(3000 * time.Millisecond)
 				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 				policyRunner := resiliency.NewRunner[any](t.Context(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (any, error) {
@@ -590,7 +590,7 @@ func newTestResiliencyConfig(resiliencyName, resiliencyNamespace, appName, actor
 				CircuitBreakers: map[string]resiliencyV1alpha.CircuitBreaker{
 					"testCB": {
 						Interval:    "0",
-						Timeout:     "100ms",
+						Timeout:     "500ms",
 						Trip:        "consecutiveFailures > 4",
 						MaxRequests: 1,
 					},

--- a/pkg/diagnostics/resiliency_monitoring_test.go
+++ b/pkg/diagnostics/resiliency_monitoring_test.go
@@ -27,6 +27,8 @@ const (
 	testResiliencyName           = "testResiliency"
 	testResiliencyNamespace      = "testNamespace"
 	testStateStoreName           = "testStateStore"
+	testCBTimeout                = 500 * time.Millisecond
+	testCBTimeoutStr             = "500ms"
 )
 
 func TestResiliencyCountMonitoring(t *testing.T) {
@@ -251,8 +253,8 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 						return nil, errors.New("fake error")
 					})
 				}
-				// let the circuit breaker to go to half open state (>5x cb timeout of 500ms)
-				time.Sleep(3000 * time.Millisecond)
+				// let the circuit breaker go to half open state (>5x cb timeout)
+				time.Sleep(6 * testCBTimeout)
 				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 				policyRunner := resiliency.NewRunner[any](t.Context(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (any, error) {
@@ -425,8 +427,8 @@ func TestResiliencyActivationsCountMonitoring(t *testing.T) {
 						return nil, errors.New("fake error")
 					})
 				}
-				// let the circuit breaker to go to half open state (>5x cb timeout of 500ms) and then return success to close it
-				time.Sleep(3000 * time.Millisecond)
+				// let the circuit breaker go to half open state (>5x cb timeout) and then return success to close it
+				time.Sleep(6 * testCBTimeout)
 				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
 				policyRunner := resiliency.NewRunner[any](t.Context(), policyDef)
 				_, _ = policyRunner(func(ctx context.Context) (any, error) {
@@ -590,7 +592,7 @@ func newTestResiliencyConfig(resiliencyName, resiliencyNamespace, appName, actor
 				CircuitBreakers: map[string]resiliencyV1alpha.CircuitBreaker{
 					"testCB": {
 						Interval:    "0",
-						Timeout:     "500ms",
+						Timeout:     testCBTimeoutStr,
 						Trip:        "consecutiveFailures > 4",
 						MaxRequests: 1,
 					},


### PR DESCRIPTION
The circuit breaker timeout (open -> half-open transition) was 100ms, too close to the 10ms retry delay. On slow CI runners with coarser timer resolution, retries could span the half-open transition, causing extra state changes and assertion failures. Increase the CB timeout to 500ms and adjust sleep durations accordingly.