### PR TITLE
Integration: fix flaky stalled/retention workflow

### DIFF
--- a/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/retention.go
@@ -108,7 +108,6 @@ func (r *retention) Run(t *testing.T, ctx context.Context) {
 	clientCtx, cancelClient = context.WithCancel(ctx)
 	defer cancelClient()
 	client = r.workflow.BackendClient(t, clientCtx)
-	wf.WaitForRuntimeStatus(t, ctx, client, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		ids, err := client.ListInstanceIDs(ctx)


### PR DESCRIPTION
Remove WaitForRuntimeStatus(COMPLETED) call which races with the 1s state retention policy—the instance can be purged before the poll observes COMPLETED, causing "no such instance exists". The subsequent ListInstanceIDs empty check already validates both completion and retention purge.