### PR TITLE
[backport 1.17] fix: Injector ignores non-Dapr pods before checking service account authorization

### DIFF
--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -2,6 +2,7 @@
 
 This update contains security fixes:
 - [Security: Fixes gRPC authorization bypass - CVE-2026-33186](#security-grpc-authorization-bypass)
+- [False positive injection failure metrics for non-Dapr pods](#false-positive-injection-failure-metrics-for-non-dapr-pods)
 
 ## Security: gRPC authorization bypass
 
@@ -19,8 +20,25 @@ The issue originated in an upstream library.
 
 ### Solution
 
-This release upgrades the affected dependency to a version that resolves CVE-2026-33186. 
+This release upgrades the affected dependency to a version that resolves CVE-2026-33186.
 
 Users are strongly encouraged to upgrade to this release.
 
 
+## False positive injection failure metrics for non-Dapr pods
+
+### Problem
+
+When a pod without Dapr annotations (e.g. infrastructure pods like Vault or Nginx) was created by a service account not in the injector's allowed list, the injector logged an error (`service account '...' not on the list of allowed controller accounts`) and incremented the `dapr_injector_sidecar_injection_failed_total` metric, even though the pod was never meant to be Dapr-enabled.
+
+### Impact
+
+Infrastructure and non-Dapr workloads deployed by service accounts not in the injector's `allowedServiceAccounts` list caused false-positive error logs and inflated the `sidecar_injection_failed_total` metric with `reason="pod_patch"`. This triggered spurious alerts in monitoring systems for pods that had nothing to do with Dapr.
+
+### Root Cause
+
+The injector checked service account authorization before checking whether the pod had the `dapr.io/enabled` annotation. Non-Dapr pods were rejected at the authorization step, producing error logs and failure metrics, instead of being silently allowed.
+
+### Solution
+
+The injector now checks the `dapr.io/enabled` annotation before checking service account authorization. Pods without the annotation set to `"true"` are immediately allowed with no patch, skipping all injection and authorization logic. This ensures non-Dapr pods never produce error logs or increment failure metrics regardless of which service account creates them.

--- a/pkg/injector/service/handler.go
+++ b/pkg/injector/service/handler.go
@@ -15,6 +15,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,120 +23,187 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/dapr/dapr/pkg/injector/annotations"
 	"github.com/dapr/dapr/utils"
 )
 
 func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 	RecordSidecarInjectionRequestsCount()
 
-	var body []byte
-	var err error
-	if r.Body != nil {
-		defer r.Body.Close()
-		body, err = io.ReadAll(r.Body)
-		if err != nil {
-			body = nil
-		}
-	}
-	if len(body) == 0 {
+	body, err := readRequestBody(r)
+	if err != nil {
 		log.Error("Empty body")
 		http.Error(w, "empty body", http.StatusBadRequest)
 		return
 	}
 
-	contentType := r.Header.Get("Content-Type")
-	if contentType != runtime.ContentTypeJSON {
-		log.Errorf("Content-Type=%s, expect %s", contentType, runtime.ContentTypeJSON)
-		errStr := fmt.Sprintf("invalid Content-Type, expected `%s`", runtime.ContentTypeJSON)
-		http.Error(w, errStr, http.StatusUnsupportedMediaType)
+	if ct := r.Header.Get("Content-Type"); ct != runtime.ContentTypeJSON {
+		log.Errorf("Content-Type=%s, expect %s", ct, runtime.ContentTypeJSON)
+		http.Error(w, fmt.Sprintf("invalid Content-Type, expected `%s`", runtime.ContentTypeJSON), http.StatusUnsupportedMediaType)
 		return
 	}
-
-	var patchOps jsonpatch.Patch
-	patchedSuccessfully := false
 
 	ar := admissionv1.AdmissionReview{}
 	_, gvk, err := i.deserializer.Decode(body, nil, &ar)
 	if err != nil {
 		log.Errorf("Can't decode body: %v", err)
-	} else {
-		allowServiceAccountUser := i.allowServiceAccountUser(ar.Request.UserInfo.Username)
-
-		if !(allowServiceAccountUser || utils.Contains(i.authUIDs, ar.Request.UserInfo.UID) || utils.Contains(ar.Request.UserInfo.Groups, systemGroup)) {
-			log.Errorf("service account '%s' not on the list of allowed controller accounts", ar.Request.UserInfo.Username)
-		} else if ar.Request.Kind.Kind != "Pod" {
-			log.Errorf("invalid kind for review: %s", ar.Kind)
-		} else {
-			patchOps, err = i.getPodPatchOperations(r.Context(), &ar)
-			if err == nil {
-				patchedSuccessfully = true
-			}
-		}
+		i.writeAdmissionResponse(w, ar, gvk, nil, err)
+		return
 	}
 
+	if ar.Request.Kind.Kind != "Pod" {
+		log.Errorf("invalid kind for review: %s", ar.Request.Kind.Kind)
+		diagAppID := getAppIDFromRequest(ar.Request)
+		respondWithAllowed(w, ar, gvk)
+		RecordFailedSidecarInjectionCount(diagAppID, "pod_patch")
+		return
+	}
+
+	// Non-Dapr pods are silently allowed without any metrics or logging.
+	if !podHasDaprEnabled(ar.Request) {
+		respondWithAllowed(w, ar, gvk)
+		return
+	}
+
+	if !i.isAuthorizedUser(ar.Request) {
+		log.Errorf("service account '%s' not on the list of allowed controller accounts", ar.Request.UserInfo.Username)
+		diagAppID := getAppIDFromRequest(ar.Request)
+		respondWithAllowed(w, ar, gvk)
+		RecordFailedSidecarInjectionCount(diagAppID, "pod_patch")
+		return
+	}
+
+	patchOps, err := i.getPodPatchOperations(r.Context(), &ar)
+	i.writeAdmissionResponse(w, ar, gvk, patchOps, err)
+}
+
+// readRequestBody reads the full request body and returns it. Returns an error
+// if the body is nil, unreadable, or empty.
+func readRequestBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, errors.New("empty body")
+	}
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+	if err != nil || len(body) == 0 {
+		return nil, errors.New("empty body")
+	}
+	return body, nil
+}
+
+// isAuthorizedUser checks whether the admission request was made by an
+// authorized service account, UID, or group.
+func (i *injector) isAuthorizedUser(req *admissionv1.AdmissionRequest) bool {
+	return i.allowServiceAccountUser(req.UserInfo.Username) ||
+		utils.Contains(i.authUIDs, req.UserInfo.UID) ||
+		utils.Contains(req.UserInfo.Groups, systemGroup)
+}
+
+// writeAdmissionResponse builds an AdmissionReview response from the patch
+// result, writes it to w, and records the appropriate injection metrics.
+func (i *injector) writeAdmissionResponse(w http.ResponseWriter, ar admissionv1.AdmissionReview, gvk *schema.GroupVersionKind, patchOps jsonpatch.Patch, patchErr error) {
 	diagAppID := getAppIDFromRequest(ar.Request)
 
-	var admissionResponse *admissionv1.AdmissionResponse
-	if err != nil {
-		admissionResponse = errorToAdmissionResponse(err)
-		log.Errorf("Sidecar injector failed to inject for app '%s'. Error: %s", diagAppID, err)
-		RecordFailedSidecarInjectionCount(diagAppID, "patch")
-	} else if len(patchOps) == 0 {
-		admissionResponse = &admissionv1.AdmissionResponse{
-			Allowed: true,
-		}
-	} else {
-		var patchBytes []byte
-		patchBytes, err = json.Marshal(patchOps)
-		if err != nil {
-			admissionResponse = errorToAdmissionResponse(err)
-		} else {
-			admissionResponse = &admissionv1.AdmissionResponse{
-				Allowed: true,
-				Patch:   patchBytes,
-				PatchType: func() *admissionv1.PatchType {
-					pt := admissionv1.PatchTypeJSONPatch
-					return &pt
-				}(),
-			}
-		}
+	resp, buildErr := buildAdmissionResponse(patchOps, patchErr)
+
+	review := admissionv1.AdmissionReview{Response: resp}
+	if resp != nil && ar.Request != nil {
+		review.Response.UID = ar.Request.UID
+	}
+	if gvk != nil {
+		review.SetGroupVersionKind(*gvk)
 	}
 
-	admissionReview := admissionv1.AdmissionReview{
-		Response: admissionResponse,
-	}
-	if admissionResponse != nil && ar.Request != nil {
-		admissionReview.Response.UID = ar.Request.UID
-		admissionReview.SetGroupVersionKind(*gvk)
-	}
-
-	respBytes, err := json.Marshal(admissionReview)
+	respBytes, err := json.Marshal(review)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		log.Errorf("Sidecar injector failed to inject for app '%s'. Can't serialize response: %s", diagAppID, err)
 		RecordFailedSidecarInjectionCount(diagAppID, "response")
 		return
 	}
+
 	w.Header().Set("Content-Type", runtime.ContentTypeJSON)
-	_, err = w.Write(respBytes)
-	if err != nil {
+	if _, err = w.Write(respBytes); err != nil {
 		log.Errorf("Sidecar injector failed to inject for app '%s'. Failed to write response: %v", diagAppID, err)
 		RecordFailedSidecarInjectionCount(diagAppID, "write_response")
 		return
 	}
 
-	if patchedSuccessfully {
-		// Only log and record metrics if we applied patches
-		if len(patchOps) > 0 {
-			log.Infof("Sidecar injector succeeded injection for app '%s'", diagAppID)
-			RecordSuccessfulSidecarInjectionCount(diagAppID)
-		}
-	} else {
-		log.Errorf("Admission succeeded, but pod was not patched. No sidecar injected for '%s'", diagAppID)
-		RecordFailedSidecarInjectionCount(diagAppID, "pod_patch")
+	// Record injection metrics.
+	switch {
+	case buildErr != nil:
+		log.Errorf("Sidecar injector failed to inject for app '%s'. Error: %s", diagAppID, buildErr)
+		RecordFailedSidecarInjectionCount(diagAppID, "patch")
+	case len(patchOps) > 0:
+		log.Infof("Sidecar injector succeeded injection for app '%s'", diagAppID)
+		RecordSuccessfulSidecarInjectionCount(diagAppID)
 	}
+}
+
+// buildAdmissionResponse creates an AdmissionResponse from patch operations.
+// Returns the response and any error encountered during building (including
+// patch marshaling failures).
+func buildAdmissionResponse(patchOps jsonpatch.Patch, patchErr error) (*admissionv1.AdmissionResponse, error) {
+	if patchErr != nil {
+		return errorToAdmissionResponse(patchErr), patchErr
+	}
+	if len(patchOps) == 0 {
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+	patchBytes, err := json.Marshal(patchOps)
+	if err != nil {
+		return errorToAdmissionResponse(err), err
+	}
+	pt := admissionv1.PatchTypeJSONPatch
+	return &admissionv1.AdmissionResponse{
+		Allowed:   true,
+		Patch:     patchBytes,
+		PatchType: &pt,
+	}, nil
+}
+
+// respondWithAllowed writes a minimal AdmissionReview response that allows the
+// request without any patches. Used for requests that should be silently ignored.
+func respondWithAllowed(w http.ResponseWriter, ar admissionv1.AdmissionReview, gvk *schema.GroupVersionKind) {
+	resp := admissionv1.AdmissionReview{
+		Response: &admissionv1.AdmissionResponse{
+			Allowed: true,
+		},
+	}
+	if ar.Request != nil {
+		resp.Response.UID = ar.Request.UID
+	}
+	if gvk != nil {
+		resp.SetGroupVersionKind(*gvk)
+	}
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", runtime.ContentTypeJSON)
+	if _, err = w.Write(respBytes); err != nil {
+		log.Errorf("Failed to write response for non-Dapr pod: %v", err)
+	}
+}
+
+// podHasDaprEnabled checks if the pod in the admission request has the
+// "dapr.io/enabled" annotation set to "true". If the pod cannot be
+// unmarshalled, it returns true to fall through to the normal processing path.
+func podHasDaprEnabled(req *admissionv1.AdmissionRequest) bool {
+	if req == nil || len(req.Object.Raw) == 0 {
+		return true
+	}
+	var pod corev1.Pod
+	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
+		// If we can't unmarshal the pod, let the normal flow handle the error.
+		return true
+	}
+	return strings.EqualFold(pod.Annotations[annotations.KeyEnabled], "true")
 }
 
 func (i *injector) allowServiceAccountUser(reviewRequestUserInfo string) (allowedUID bool) {

--- a/pkg/injector/service/handler_test.go
+++ b/pkg/injector/service/handler_test.go
@@ -273,6 +273,35 @@ func TestHandleRequest(t *testing.T) {
 			false,
 		},
 		{
+			"TestSidecarInjectNonDaprPodUnauthorizedServiceAccount",
+			admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					UID:       uuid.NewUUID(),
+					Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+					Name:      "non-dapr-app",
+					Namespace: "test-ns",
+					Operation: "CREATE",
+					UserInfo: authenticationv1.UserInfo{
+						Username: "system:serviceaccount:other-ns:other-sa",
+					},
+					Object: runtime.RawExtension{Raw: func() []byte {
+						var pod corev1.Pod
+						json.Unmarshal(podBytes, &pod)
+						pod.Name = "non-dapr-app"
+						pod.Labels["app"] = "non-dapr-app"
+						delete(pod.Annotations, "dapr.io/enabled")
+						delete(pod.Annotations, "dapr.io/app-id")
+						delete(pod.Annotations, "dapr.io/app-port")
+						b, _ := json.Marshal(pod)
+						return b
+					}()},
+				},
+			},
+			runtime.ContentTypeJSON,
+			http.StatusOK,
+			false,
+		},
+		{
 			"TestSidecarInjectNonDaprPod",
 			admissionv1.AdmissionReview{
 				Request: &admissionv1.AdmissionRequest{

--- a/tests/integration/framework/process/injector/injector.go
+++ b/tests/integration/framework/process/injector/injector.go
@@ -14,9 +14,12 @@ limitations under the License.
 package injector
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -25,6 +28,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -167,4 +171,40 @@ func (i *Injector) MetricsPort() int {
 
 func (i *Injector) HealthzPort() int {
 	return i.healthzPort
+}
+
+// SendAdmission posts an AdmissionReview to the injector's /mutate endpoint
+// and returns the parsed response.
+func (i *Injector) SendAdmission(t *testing.T, ctx context.Context, review admissionv1.AdmissionReview) admissionv1.AdmissionReview {
+	t.Helper()
+	body, err := json.Marshal(review)
+	require.NoError(t, err)
+
+	httpClient := &http.Client{
+		Timeout: time.Second * 10,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				//nolint:gosec
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	defer httpClient.CloseIdleConnections()
+
+	mutateURL := fmt.Sprintf("https://localhost:%d/mutate", i.port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mutateURL, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var ar admissionv1.AdmissionReview
+	require.NoError(t, json.Unmarshal(respBody, &ar))
+	return ar
 }

--- a/tests/integration/import.go
+++ b/tests/integration/import.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd"
 	_ "github.com/dapr/dapr/tests/integration/suite/healthz"
 	_ "github.com/dapr/dapr/tests/integration/suite/helm"
+	_ "github.com/dapr/dapr/tests/integration/suite/injector"
 	_ "github.com/dapr/dapr/tests/integration/suite/operator"
 	_ "github.com/dapr/dapr/tests/integration/suite/placement"
 	_ "github.com/dapr/dapr/tests/integration/suite/ports"

--- a/tests/integration/suite/injector/already_injected.go
+++ b/tests/integration/suite/injector/already_injected.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(alreadyInjected))
+}
+
+// alreadyInjected verifies that a pod which already contains a daprd container
+// is not double-injected on reinvocation.
+type alreadyInjected struct {
+	injector *procinjector.Injector
+}
+
+func (a *alreadyInjected) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	a.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, a.injector),
+	}
+}
+
+func (a *alreadyInjected) Run(t *testing.T, ctx context.Context) {
+	a.injector.WaitUntilRunning(t, ctx)
+
+	podBytes := buildPodWithContainers("already-injected", map[string]string{
+		"dapr.io/enabled":  "true",
+		"dapr.io/app-id":   "already-injected",
+		"dapr.io/app-port": "3000",
+	}, []corev1.Container{
+		{Name: "main", Image: "docker.io/app:latest"},
+		{Name: "daprd", Image: "integration.dapr.io/dapr:latest"},
+	})
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uuid.NewUUID(),
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "already-injected",
+			Namespace: "dapr-system",
+			Operation: "CREATE",
+			UserInfo:  authenticationv1.UserInfo{Groups: []string{"system:masters"}},
+			Object:    runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := a.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	assert.True(t, ar.Response.Allowed)
+	assert.Empty(t, ar.Response.Patch, "should not double-inject when daprd is present")
+}

--- a/tests/integration/suite/injector/dapr_disabled.go
+++ b/tests/integration/suite/injector/dapr_disabled.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(daprDisabled))
+}
+
+// daprDisabled verifies that a pod with dapr.io/enabled explicitly set to
+// "false" is silently allowed even when the requesting service account is not
+// whitelisted.
+type daprDisabled struct {
+	injector *procinjector.Injector
+}
+
+func (d *daprDisabled) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	d.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, d.injector),
+	}
+}
+
+func (d *daprDisabled) Run(t *testing.T, ctx context.Context) {
+	d.injector.WaitUntilRunning(t, ctx)
+
+	podBytes := buildPod("disabled-app", map[string]string{
+		"dapr.io/enabled": "false",
+	})
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uuid.NewUUID(),
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "disabled-app",
+			Namespace: "default",
+			Operation: "CREATE",
+			UserInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:some-ns:some-sa",
+			},
+			Object: runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := d.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	assert.True(t, ar.Response.Allowed, "dapr-disabled pod should be allowed")
+	assert.Empty(t, ar.Response.Patch, "dapr-disabled pod should not be patched")
+}

--- a/tests/integration/suite/injector/helpers.go
+++ b/tests/integration/suite/injector/helpers.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// buildPod returns a JSON-encoded pod with the given name and annotations.
+func buildPod(name string, annotations map[string]string) []byte {
+	return buildPodWithContainers(name, annotations, []corev1.Container{
+		{Name: "main", Image: "docker.io/app:latest"},
+	})
+}
+
+// buildPodWithContainers returns a JSON-encoded pod with custom containers.
+func buildPodWithContainers(name string, annotations map[string]string, containers []corev1.Container) []byte {
+	pod := corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Annotations: annotations,
+			Labels:      map[string]string{"app": name},
+		},
+		Spec: corev1.PodSpec{
+			Containers: containers,
+		},
+	}
+	b, _ := json.Marshal(pod)
+	return b
+}

--- a/tests/integration/suite/injector/noappid.go
+++ b/tests/integration/suite/injector/noappid.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noappid))
+}
+
+// noappid verifies that a Dapr-enabled pod without an explicit app-id
+// annotation is still injected with the sidecar.
+type noappid struct {
+	injector *procinjector.Injector
+}
+
+func (n *noappid) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	n.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, n.injector),
+	}
+}
+
+func (n *noappid) Run(t *testing.T, ctx context.Context) {
+	n.injector.WaitUntilRunning(t, ctx)
+
+	podBytes := buildPod("no-appid", map[string]string{
+		"dapr.io/enabled": "true",
+	})
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uuid.NewUUID(),
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "no-appid",
+			Namespace: "dapr-system",
+			Operation: "CREATE",
+			UserInfo:  authenticationv1.UserInfo{Groups: []string{"system:masters"}},
+			Object:    runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := n.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	assert.True(t, ar.Response.Allowed)
+	assert.NotEmpty(t, ar.Response.Patch, "should inject even without explicit app-id")
+}

--- a/tests/integration/suite/injector/nonadapr.go
+++ b/tests/integration/suite/injector/nonadapr.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(nonadapr))
+}
+
+// nonadapr verifies that non-Dapr pods (without dapr.io/enabled annotation)
+// are silently allowed even when the requesting service account is not
+// whitelisted. This is the core scenario for issue #9379.
+type nonadapr struct {
+	injector *procinjector.Injector
+}
+
+func (n *nonadapr) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	n.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, n.injector),
+	}
+}
+
+func (n *nonadapr) Run(t *testing.T, ctx context.Context) {
+	n.injector.WaitUntilRunning(t, ctx)
+
+	podBytes := buildPod("plain-app", nil)
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uuid.NewUUID(),
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "plain-app",
+			Namespace: "default",
+			Operation: "CREATE",
+			UserInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:some-ns:some-sa",
+			},
+			Object: runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := n.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	assert.True(t, ar.Response.Allowed, "non-Dapr pod should be allowed")
+	assert.Empty(t, ar.Response.Patch, "non-Dapr pod should not be patched")
+}

--- a/tests/integration/suite/injector/response_uid.go
+++ b/tests/integration/suite/injector/response_uid.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(responseUID))
+}
+
+// responseUID verifies that the admission response UID matches the request UID.
+type responseUID struct {
+	injector *procinjector.Injector
+}
+
+func (r *responseUID) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	r.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, r.injector),
+	}
+}
+
+func (r *responseUID) Run(t *testing.T, ctx context.Context) {
+	r.injector.WaitUntilRunning(t, ctx)
+
+	podBytes := buildPod("uid-test", map[string]string{
+		"dapr.io/enabled": "true",
+		"dapr.io/app-id":  "uid-test",
+	})
+	requestUID := uuid.NewUUID()
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       requestUID,
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "uid-test",
+			Namespace: "dapr-system",
+			Operation: "CREATE",
+			UserInfo:  authenticationv1.UserInfo{Groups: []string{"system:masters"}},
+			Object:    runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := r.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	assert.Equal(t, requestUID, ar.Response.UID, "response UID should match request UID")
+}

--- a/tests/integration/suite/injector/sidecar_inject.go
+++ b/tests/integration/suite/injector/sidecar_inject.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(sidecarInject))
+}
+
+// sidecarInject verifies that a Dapr-enabled pod is injected with a daprd
+// sidecar container when submitted by an authorized user.
+type sidecarInject struct {
+	injector *procinjector.Injector
+}
+
+func (s *sidecarInject) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	s.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, s.injector),
+	}
+}
+
+func (s *sidecarInject) Run(t *testing.T, ctx context.Context) {
+	s.injector.WaitUntilRunning(t, ctx)
+
+	podBytes := buildPod("dapr-app", map[string]string{
+		"dapr.io/enabled":  "true",
+		"dapr.io/app-id":   "dapr-app",
+		"dapr.io/app-port": "3000",
+	})
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uuid.NewUUID(),
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "dapr-app",
+			Namespace: "dapr-system",
+			Operation: "CREATE",
+			UserInfo:  authenticationv1.UserInfo{Groups: []string{"system:masters"}},
+			Object:    runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := s.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	assert.True(t, ar.Response.Allowed)
+	require.NotEmpty(t, ar.Response.Patch, "should contain sidecar patch")
+	var ops jsonpatch.Patch
+	require.NoError(t, json.Unmarshal(ar.Response.Patch, &ops))
+	found := false
+	for _, op := range ops {
+		b, _ := json.Marshal(op)
+		if bytes.Contains(b, []byte(`"daprd"`)) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "patch should add daprd container")
+}

--- a/tests/integration/suite/injector/unauthorized.go
+++ b/tests/integration/suite/injector/unauthorized.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(unauthorized))
+}
+
+// unauthorized verifies that a Dapr-enabled pod submitted by an unauthorized
+// service account is allowed (mutating webhook must not block) but the sidecar
+// is NOT injected.
+type unauthorized struct {
+	injector *procinjector.Injector
+}
+
+func (u *unauthorized) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	u.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, u.injector),
+	}
+}
+
+func (u *unauthorized) Run(t *testing.T, ctx context.Context) {
+	u.injector.WaitUntilRunning(t, ctx)
+
+	podBytes := buildPod("dapr-unauth", map[string]string{
+		"dapr.io/enabled":  "true",
+		"dapr.io/app-id":   "dapr-unauth",
+		"dapr.io/app-port": "3000",
+	})
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uuid.NewUUID(),
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "dapr-unauth",
+			Namespace: "default",
+			Operation: "CREATE",
+			UserInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:some-ns:some-sa",
+			},
+			Object: runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := u.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	assert.True(t, ar.Response.Allowed, "mutating webhook should allow the request")
+	assert.Empty(t, ar.Response.Patch, "unauthorized request should not inject sidecar")
+}


### PR DESCRIPTION
Cherry pick https://github.com/dapr/dapr/pull/9669 into `release-1.17`