### PR TITLE
[1.16] Update Go version to 1.25.8

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -1,6 +1,6 @@
 module build-tools
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/google/go-containerregistry v0.11.1-0.20220802162123-c1f9836a4fa9

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
-        run: govulncheck -C '.' -format text --tags=unit,allcomponents,integration ./...
+        run: GOMEMLIMIT=12GiB govulncheck -C '.' -format text --tags=unit,allcomponents,integration ./...
         shell: bash
 
   lint-slow:

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ MODFILES := $(shell find . -name go.mod)
 define modtidy-target
 .PHONY: modtidy-$(1)
 modtidy-$(1):
-	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.24.13; cd -
+	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.28.8; cd -
 endef
 
 # Generate modtidy target action for each go.mod file

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,6 +1,6 @@
 # current directory must be ./dist
 
-FROM golang:1.24.11
+FROM golang:1.25.8
 
 ARG PKG_FILES
 RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,7 +1,7 @@
 # Based on https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/go/.devcontainer/base.Dockerfile
 
-# [Choice] Go version: 1, 1.24.11, etc
-ARG GOVERSION=1.24.11
+# [Choice] Go version: 1, 1.25.8, etc
+ARG GOVERSION=1.25.8
 FROM golang:${GOVERSION}-bullseye
 
 # [Option] Install zsh

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ This includes dockerfiles to build Dapr release and debug images and development
 
 The Dev Container can be rebuilt with custom options. Relevant args (and their default values) include:
 
-* `GOVERSION` (default: `1.24.11`)
+* `GOVERSION` (default: `1.25.8`)
 * `INSTALL_ZSH` (default: `true`)
 * `KUBECTL_VERSION` (default: `latest`)
 * `HELM_VERSION` (default: `latest`)

--- a/docs/release_notes/v1.16.11.md
+++ b/docs/release_notes/v1.16.11.md
@@ -1,0 +1,20 @@
+# Dapr 1.16.11
+
+This update includes a Go version bump:
+
+- [Go version updated to 1.25.8](#go-version-updated-to-1258)
+
+## Go version updated to 1.25.8
+
+### Problem
+
+Dapr 1.16.10 was built with Go 1.25.7.
+Go 1.25.8 includes security fixes to the `html/template`, `net/url`, and `os` packages, as well as bug fixes to the `go` command, the compiler, and the `os` package.
+
+### Impact
+
+Users running Dapr built with Go 1.25.7 may be exposed to known vulnerabilities that have been patched in Go 1.25.8.
+
+### Solution
+
+Updated the Go version from 1.25.7 to 1.25.8.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr
 
-go 1.25.7
+go 1.25.8
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/tests/apps/actorload/Dockerfile
+++ b/tests/apps/actorload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.13
+FROM golang:1.25.8
 WORKDIR /actorload/
 COPY . .
 RUN make build

--- a/tests/apps/actorload/go.mod
+++ b/tests/apps/actorload/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/actorload
 
-go 1.24.13
+go 1.25.8
 
 require (
 	fortio.org/fortio v1.6.8

--- a/tests/apps/crypto/Dockerfile
+++ b/tests/apps/crypto/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.13 as build_env
+FROM golang:1.25.8 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/crypto/go.mod
+++ b/tests/apps/crypto/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/crypto
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/dapr/go-sdk v1.8.0

--- a/tests/apps/perf/actor-activation-locker/Dockerfile
+++ b/tests/apps/perf/actor-activation-locker/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.13 as build_env
+FROM golang:1.25.8 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/actor-activation-locker/go.mod
+++ b/tests/apps/perf/actor-activation-locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/actor-activation-locker
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/bsm/redislock v0.8.2

--- a/tests/apps/perf/actorfeatures/Dockerfile
+++ b/tests/apps/perf/actorfeatures/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.24.13-bookworm as build_env
+FROM golang:1.25.8-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod go.sum ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.24.13-bookworm as fortio_build_env
+FROM golang:1.25.8-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/actorfeatures/go.mod
+++ b/tests/apps/perf/actorfeatures/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/dapr/dapr v1.13.4

--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -1,5 +1,5 @@
 # Build the k6 binary with the extension
-FROM golang:1.24.13 AS builder
+FROM golang:1.25.8 AS builder
 
 WORKDIR $GOPATH/src/go.k6.io/k6
 # See https://github.com/grafana/xk6/releases for which release aligns with our go version, latest requires go 1.25.x

--- a/tests/apps/perf/service_invocation_grpc/Dockerfile
+++ b/tests/apps/perf/service_invocation_grpc/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.13 as build_env
+FROM golang:1.25.8 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_grpc/go.mod
+++ b/tests/apps/perf/service_invocation_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_grpc
 
-go 1.24.13
+go 1.25.8
 
 require github.com/dapr/go-sdk v1.8.0
 

--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.13 as build_env
+FROM golang:1.25.8 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_http/go.mod
+++ b/tests/apps/perf/service_invocation_http/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_http
 
-go 1.24.13
+go 1.25.8

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.24.13-bookworm as build_env
+FROM golang:1.25.8-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.24.13-bookworm as fortio_build_env
+FROM golang:1.25.8-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/tester/go.mod
+++ b/tests/apps/perf/tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.24.13
+go 1.25.8

--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/kafka-bindings
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-pubsub/go.mod
+++ b/tests/apps/pluggable_redis-pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-pubsub
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-statestore/go.mod
+++ b/tests/apps/pluggable_redis-statestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-statestore
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pubsub-publisher-streaming/Dockerfile
+++ b/tests/apps/pubsub-publisher-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.13 AS build_env
+FROM golang:1.25.8 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-publisher-streaming/go.mod
+++ b/tests/apps/pubsub-publisher-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-publisher-streaming
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/pubsub-subscriber-streaming/Dockerfile
+++ b/tests/apps/pubsub-subscriber-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.24.13 AS build_env
+FROM golang:1.25.8 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-subscriber-streaming/go.mod
+++ b/tests/apps/pubsub-subscriber-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-subscriber-streaming
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/resiliencyapp/go.mod
+++ b/tests/apps/resiliencyapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/dapr/dapr v0.0.0

--- a/tests/apps/resiliencyapp_grpc/go.mod
+++ b/tests/apps/resiliencyapp_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp_grpc
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/dapr/dapr v1.7.4

--- a/tests/apps/service_invocation_grpc_proxy_client/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_client/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_client
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/dapr/dapr v0.0.0-00010101000000-000000000000

--- a/tests/apps/service_invocation_grpc_proxy_server/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_server/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_server
 
-go 1.24.13
+go 1.25.8
 
 require (
 	google.golang.org/grpc v1.54.0

--- a/tests/integration/framework/binary/helpers/helmtemplate/go.mod
+++ b/tests/integration/framework/binary/helpers/helmtemplate/go.mod
@@ -1,6 +1,6 @@
 module helm
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/spf13/pflag v1.0.5

--- a/tests/perf/report/go.mod
+++ b/tests/perf/report/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/perf/report
 
-go 1.24.9
+go 1.25.8
 
 require gonum.org/v1/plot v0.16.0
 


### PR DESCRIPTION
Go 1.25.8 includes security fixes to html/template, net/url, and os packages, plus bug fixes to the go command, compiler, and os package.