### PR TITLE
Fix placement connection and dissemination chrun

### DIFF
--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -4,6 +4,8 @@ This update contains bug fixes and security fixes:
 - [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
 - [Security: Fixes gRPC authorization bypass - CVE-2026-33186](#security-grpc-authorization-bypass)
 - [False positive injection failure metrics for non-Dapr pods](#false-positive-injection-failure-metrics-for-non-dapr-pods)
+- [Placement dissemination timeout cascades across all replicas](#placement-dissemination-timeout-cascades-across-all-replicas)
+- [Daprd placement reconnect hangs for 20 seconds on stale DNS](#daprd-placement-reconnect-hangs-for-20-seconds-on-stale-dns)
 
 ## Actor method invocation returns 200 with empty body over h2c
 
@@ -69,3 +71,69 @@ The injector checked service account authorization before checking whether the p
 ### Solution
 
 The injector now checks the `dapr.io/enabled` annotation before checking service account authorization. Pods without the annotation set to `"true"` are immediately allowed with no patch, skipping all injection and authorization logic. This ensures non-Dapr pods never produce error logs or increment failure metrics regardless of which service account creates them.
+
+## Placement dissemination timeout cascades across all replicas
+
+### Problem
+
+When a single slow or unresponsive daprd sidecar fails to respond during placement table dissemination, the dissemination timeout disconnects **all** connected sidecars in the namespace,  not just the slow one.
+This causes a cascading failure where healthy replicas lose their placement tables and must reconnect and re-disseminate.
+
+During rolling updates, rapid sequential connect/disconnect cycles generate a "version storm" where the placement server churns through many dissemination versions faster than sidecars can process them, leading to repeated timeouts that affect all replicas.
+
+### Impact
+
+Any deployment with multiple replicas using actors or workflows is affected.
+A single slow sidecar (due to GC pressure, network latency, or resource contention) can cause all replicas in the namespace to lose actor routing for the duration of the timeout cycle.
+During rolling updates, the version storm can prevent new replicas from receiving placement tables for extended periods, causing actor invocations to fail.
+
+### Root Cause
+
+Three issues in the placement server's dissemination logic:
+
+1. **Nuclear timeout**: `handleTimeout` closed ALL streams on timeout, regardless of whether they had responded to the current dissemination phase.
+Healthy streams that had already acknowledged LOCK/UPDATE were disconnected alongside the slow one.
+
+2. **No phase advancement on disconnect**: When a stream disconnected during an active dissemination round, the `streamsInTargetState` counter was not adjusted.
+If the disconnected stream was the last one that hadn't responded, the round would stall until the timeout fired, even though all remaining streams had already responded.
+
+3. **Orphaned store entries**: During rolling updates, stream close events could arrive at the disseminator after the dissemination round had already completed, leaving stale host entries in the placement table.
+
+### Solution
+
+- **Selective timeout**: `handleTimeout` now only closes streams that have NOT reached the current dissemination phase.
+Streams that responded successfully survive the timeout and participate in the next round.
+Waiting connections that were queued during the timed-out round are added to the new round instead of being cancelled.
+
+- **Phase advancement on disconnect**: `handleCloseStream` now decrements `streamsInTargetState` when a counted stream disconnects and calls `advancePhase()` if removing the stream completes the current phase.
+This prevents rounds from stalling when a slow stream disconnects.
+
+- **Delete batching**: Stream deletions during active dissemination are queued and processed when the round completes, combining multiple deletes into a single dissemination round.
+`handleAdd` also processes pending deletes before adding new streams, coalescing delete+add pairs during rolling updates.
+
+- **Orphan cleanup**: After each dissemination round completes, the store is scanned for entries whose streams are no longer active.
+These orphaned entries are cleaned up in the next round.
+
+## Daprd placement reconnect hangs for 20 seconds on stale DNS
+
+### Problem
+
+When a placement server pod is restarted (due to rolling update, eviction, or crash), daprd sidecars that were connected to the old pod attempt to reconnect using cached DNS entries.
+The cached IP address points to the terminated pod, and each connection attempt hangs for 20 seconds (TCP dial timeout) before trying the next address.
+
+### Impact
+
+With a 3-node placement cluster, daprd can try up to 3 stale IPs sequentially, causing a **60-second reconnect delay** in the worst case.
+During this time, actor invocations and workflow operations fail because the sidecar has no placement table.
+
+### Root Cause
+
+The DNS round-robin connector cached the IP addresses from the initial DNS lookup and only re-resolved when the cache was exhausted (all IPs tried).
+After a placement pod restart, the old IP remained in the cache.
+Since gRPC dials are lazy (they succeed immediately and fail on the first RPC), the stale IP was not detected until the sidecar tried to open a placement stream, which then hung for the full TCP dial timeout.
+
+### Solution
+
+The DNS connector now re-resolves DNS on every `Connect` call instead of caching IPs across calls.
+Kubernetes headless service DNS always returns the current set of pod IPs, so each reconnect attempt immediately gets fresh addresses.
+The round-robin index is preserved across lookups to maintain even distribution.

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -76,7 +76,7 @@ The injector now checks the `dapr.io/enabled` annotation before checking service
 
 ### Problem
 
-When a single slow or unresponsive daprd sidecar fails to respond during placement table dissemination, the dissemination timeout disconnects **all** connected sidecars in the namespace,  not just the slow one.
+When a single slow or unresponsive daprd sidecar fails to respond during placement table dissemination, the dissemination timeout disconnects **all** connected sidecars in the namespace, not just the slow one.
 This causes a cascading failure where healthy replicas lose their placement tables and must reconnect and re-disseminate.
 
 During rolling updates, rapid sequential connect/disconnect cycles generate a "version storm" where the placement server churns through many dissemination versions faster than sidecars can process them, leading to repeated timeouts that affect all replicas.

--- a/pkg/actors/internal/placement/connector/dnslookup/dnslookup.go
+++ b/pkg/actors/internal/placement/connector/dnslookup/dnslookup.go
@@ -26,18 +26,27 @@ import (
 	"github.com/dapr/kit/logger"
 )
 
+var log = logger.NewLogger("dapr.runtime.actors.placement.manager.connector.dnslookup")
+
 type lookupFunc func(ctx context.Context, host string) (addrs []string, err error)
 
 type dnsLookUpConnector struct {
-	dnsEntries []string
-	current    string
-	host       string
-	port       string
-	gOpts      []grpc.DialOption
-	resolver   lookupFunc
+	// rrIndex tracks the round-robin position across DNS lookups so that
+	// successive Connect calls cycle through available placement pods even
+	// when DNS returns the same set.
+	rrIndex  int
+	current  string
+	host     string
+	port     string
+	gOpts    []grpc.DialOption
+	resolver lookupFunc
 }
 
-var log = logger.NewLogger("dapr.runtime.actors.placement.manager.connector.dnslookup")
+type Options struct {
+	GRPCOptions []grpc.DialOption
+	Address     string
+	resolver    lookupFunc
+}
 
 func New(opts Options) (connector.Interface, error) {
 	host, port, err := net.SplitHostPort(opts.Address)
@@ -58,22 +67,25 @@ func New(opts Options) (connector.Interface, error) {
 	}, nil
 }
 
-type Options struct {
-	GRPCOptions []grpc.DialOption
-	Address     string
-	resolver    lookupFunc
-}
-
 func (r *dnsLookUpConnector) Connect(ctx context.Context) (*grpc.ClientConn, error) {
-	if len(r.dnsEntries) == 0 {
-		if err := r.refreshEntries(ctx); err != nil {
-			return nil, fmt.Errorf("failed to refresh DNS addresses: %w", err)
-		}
+	// Re-resolve DNS on every connect attempt. Kubernetes headless services
+	// return the current set of pod IPs. Previously, stale cached IPs from
+	// terminated pods would cause 20-second dial timeouts during placement
+	// pod restarts. DNS lookups are ~1ms and always return fresh IPs.
+	addrs, err := r.resolver(ctx, r.host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup addresses: %w", err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no addresses found for %s", r.host)
 	}
 
-	hostPort := net.JoinHostPort(r.dnsEntries[0], r.port)
+	// Round-robin across the resolved addresses.
+	addr := addrs[r.rrIndex%len(addrs)]
+	r.rrIndex++
+
+	hostPort := net.JoinHostPort(addr, r.port)
 	r.current = hostPort
-	r.dnsEntries = r.dnsEntries[1:]
 
 	log.Debugf("Attempting to connect to placement %s", hostPort)
 
@@ -90,17 +102,4 @@ func (r *dnsLookUpConnector) Connect(ctx context.Context) (*grpc.ClientConn, err
 
 func (r *dnsLookUpConnector) Address() string {
 	return r.current
-}
-
-func (r *dnsLookUpConnector) refreshEntries(ctx context.Context) error {
-	addrs, err := r.resolver(ctx, r.host)
-	if err != nil {
-		return fmt.Errorf("failed to lookup addresses: %w", err)
-	}
-	if len(addrs) == 0 {
-		return fmt.Errorf("no addresses found for %s", r.host)
-	}
-
-	r.dnsEntries = addrs
-	return nil
 }

--- a/pkg/actors/internal/placement/connector/dnslookup/dnslookup.go
+++ b/pkg/actors/internal/placement/connector/dnslookup/dnslookup.go
@@ -80,9 +80,9 @@ func (r *dnsLookUpConnector) Connect(ctx context.Context) (*grpc.ClientConn, err
 		return nil, fmt.Errorf("no addresses found for %s", r.host)
 	}
 
-	// Round-robin across the resolved addresses. Use modulo assignment to
-	// keep rrIndex bounded and avoid negative index from int overflow.
-	r.rrIndex = r.rrIndex % len(addrs)
+	// Round-robin across the resolved addresses. The modulo assignment keeps
+	// rrIndex in [0, len(addrs)), so it never grows unbounded.
+	r.rrIndex %= len(addrs)
 	addr := addrs[r.rrIndex]
 	r.rrIndex++
 

--- a/pkg/actors/internal/placement/connector/dnslookup/dnslookup.go
+++ b/pkg/actors/internal/placement/connector/dnslookup/dnslookup.go
@@ -80,8 +80,10 @@ func (r *dnsLookUpConnector) Connect(ctx context.Context) (*grpc.ClientConn, err
 		return nil, fmt.Errorf("no addresses found for %s", r.host)
 	}
 
-	// Round-robin across the resolved addresses.
-	addr := addrs[r.rrIndex%len(addrs)]
+	// Round-robin across the resolved addresses. Use modulo assignment to
+	// keep rrIndex bounded and avoid negative index from int overflow.
+	r.rrIndex = r.rrIndex % len(addrs)
+	addr := addrs[r.rrIndex]
 	r.rrIndex++
 
 	hostPort := net.JoinHostPort(addr, r.port)

--- a/pkg/actors/internal/placement/connector/dnslookup/dnslookup_integration_test.go
+++ b/pkg/actors/internal/placement/connector/dnslookup/dnslookup_integration_test.go
@@ -44,13 +44,22 @@ func startGRPCServerOn(t *testing.T, addr string) (actualAddr string, stop func(
 }
 
 func TestIntegration_ReconnectAfterServerRestart(t *testing.T) {
+	// Start server 1 on 127.0.0.1 with a random port.
 	srv1Addr, stopSrv1 := startGRPCServerOn(t, "127.0.0.1:0")
 	_, port, err := net.SplitHostPort(srv1Addr)
 	require.NoError(t, err)
 
+	// Start server 2 on [::1] (IPv6 loopback) with the same port. We use ::1
+	// instead of 127.0.0.2 because macOS only binds 127.0.0.1 to the loopback
+	// interface (Linux routes all of 127.0.0.0/8). IPv6 loopback is available
+	// on both platforms and binds the same port without conflict since it's a
+	// different address family.
+	_, stopSrv2 := startGRPCServerOn(t, net.JoinHostPort("::1", port))
+	defer stopSrv2()
+
 	var resolveCount atomic.Int32
-	var currentAddrs atomic.Value
-	currentAddrs.Store([]string{"127.0.0.1"})
+	var currentAddr atomic.Value
+	currentAddr.Store("127.0.0.1")
 
 	conn, err := New(Options{
 		Address: net.JoinHostPort("placement.local", port),
@@ -59,7 +68,7 @@ func TestIntegration_ReconnectAfterServerRestart(t *testing.T) {
 		},
 		resolver: func(ctx context.Context, host string) ([]string, error) {
 			resolveCount.Add(1)
-			return currentAddrs.Load().([]string), nil
+			return []string{currentAddr.Load().(string)}, nil
 		},
 	})
 	require.NoError(t, err)
@@ -74,13 +83,11 @@ func TestIntegration_ReconnectAfterServerRestart(t *testing.T) {
 	require.NoError(t, err)
 	grpcConn.Close()
 
+	// Simulate server restart: stop server 1 and update DNS to return the new
+	// IP (::1). The connector should re-resolve DNS and connect to server 2
+	// immediately without hanging on the stale 127.0.0.1 address.
 	stopSrv1()
-
-	srv2Addr, stopSrv2 := startGRPCServerOn(t, net.JoinHostPort("127.0.0.2", port))
-	defer stopSrv2()
-	_ = srv2Addr
-
-	currentAddrs.Store([]string{"127.0.0.2"})
+	currentAddr.Store("::1")
 
 	startTime := time.Now()
 	grpcConn, err = conn.Connect(t.Context())
@@ -89,7 +96,7 @@ func TestIntegration_ReconnectAfterServerRestart(t *testing.T) {
 
 	assert.Less(t, elapsed, 2*time.Second,
 		"reconnect should be fast after DNS re-resolve, not hang on stale IP")
-	assert.Equal(t, net.JoinHostPort("127.0.0.2", port), conn.Address())
+	assert.Equal(t, net.JoinHostPort("::1", port), conn.Address())
 
 	healthClient = healthpb.NewHealthClient(grpcConn)
 	ctx2, cancel2 := context.WithTimeout(t.Context(), time.Second)

--- a/pkg/actors/internal/placement/connector/dnslookup/dnslookup_integration_test.go
+++ b/pkg/actors/internal/placement/connector/dnslookup/dnslookup_integration_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package dnslookup
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func startGRPCServerOn(t *testing.T, addr string) (actualAddr string, stop func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+
+	go srv.Serve(lis)
+
+	return lis.Addr().String(), func() { srv.Stop() }
+}
+
+func TestIntegration_ReconnectAfterServerRestart(t *testing.T) {
+	srv1Addr, stopSrv1 := startGRPCServerOn(t, "127.0.0.1:0")
+	_, port, err := net.SplitHostPort(srv1Addr)
+	require.NoError(t, err)
+
+	var resolveCount atomic.Int32
+	var currentAddrs atomic.Value
+	currentAddrs.Store([]string{"127.0.0.1"})
+
+	conn, err := New(Options{
+		Address: net.JoinHostPort("placement.local", port),
+		GRPCOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			resolveCount.Add(1)
+			return currentAddrs.Load().([]string), nil
+		},
+	})
+	require.NoError(t, err)
+
+	grpcConn, err := conn.Connect(t.Context())
+	require.NoError(t, err)
+
+	healthClient := healthpb.NewHealthClient(grpcConn)
+	ctx1, cancel1 := context.WithTimeout(t.Context(), time.Second)
+	defer cancel1()
+	_, err = healthClient.Check(ctx1, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	grpcConn.Close()
+
+	stopSrv1()
+
+	srv2Addr, stopSrv2 := startGRPCServerOn(t, net.JoinHostPort("127.0.0.2", port))
+	defer stopSrv2()
+	_ = srv2Addr
+
+	currentAddrs.Store([]string{"127.0.0.2"})
+
+	startTime := time.Now()
+	grpcConn, err = conn.Connect(t.Context())
+	elapsed := time.Since(startTime)
+	require.NoError(t, err)
+
+	assert.Less(t, elapsed, 2*time.Second,
+		"reconnect should be fast after DNS re-resolve, not hang on stale IP")
+	assert.Equal(t, net.JoinHostPort("127.0.0.2", port), conn.Address())
+
+	healthClient = healthpb.NewHealthClient(grpcConn)
+	ctx2, cancel2 := context.WithTimeout(t.Context(), time.Second)
+	defer cancel2()
+	_, err = healthClient.Check(ctx2, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	grpcConn.Close()
+
+	assert.Equal(t, int32(2), resolveCount.Load())
+}
+
+func TestIntegration_AlwaysResolvesOnConnect(t *testing.T) {
+	srvAddr, stopSrv := startGRPCServerOn(t, "127.0.0.1:0")
+	defer stopSrv()
+	_, port, err := net.SplitHostPort(srvAddr)
+	require.NoError(t, err)
+
+	var resolveCount atomic.Int32
+
+	conn, err := New(Options{
+		Address: net.JoinHostPort("placement.local", port),
+		GRPCOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			resolveCount.Add(1)
+			return []string{"127.0.0.1"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	for range 5 {
+		grpcConn, cerr := conn.Connect(t.Context())
+		require.NoError(t, cerr)
+		grpcConn.Close()
+	}
+
+	assert.Equal(t, int32(5), resolveCount.Load())
+}

--- a/pkg/actors/internal/placement/connector/dnslookup/dnslookup_test.go
+++ b/pkg/actors/internal/placement/connector/dnslookup/dnslookup_test.go
@@ -16,36 +16,156 @@ package dnslookup
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func lookupHost(addrs []string) lookupFunc {
-	return func(ctx context.Context, host string) ([]string, error) {
-		return addrs, nil
-	}
-}
-
-func TestNewDNSConnector(t *testing.T) {
+func TestRoundRobinAcrossAddresses(t *testing.T) {
 	conn, err := New(Options{
-		Address:  "dapr-placement-server.dapr-tests.svc.cluster.local:50005",
-		resolver: lookupHost([]string{"add1", "add2", "add3"}),
+		Address: "placement.svc:50005",
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			return []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, nil
+		},
 	})
 	require.NoError(t, err)
 
 	_, _ = conn.Connect(t.Context())
-	assert.Equal(t, "add1:50005", conn.Address())
+	assert.Equal(t, "10.0.0.1:50005", conn.Address())
 
 	_, _ = conn.Connect(t.Context())
-	assert.Equal(t, "add2:50005", conn.Address())
+	assert.Equal(t, "10.0.0.2:50005", conn.Address())
 
 	_, _ = conn.Connect(t.Context())
-	assert.Equal(t, "add3:50005", conn.Address())
+	assert.Equal(t, "10.0.0.3:50005", conn.Address())
 
 	_, _ = conn.Connect(t.Context())
-	assert.Equal(t, "add1:50005", conn.Address())
+	assert.Equal(t, "10.0.0.1:50005", conn.Address())
+}
+
+func TestResolvesOnEveryConnect(t *testing.T) {
+	var lookupCount atomic.Int32
+	conn, err := New(Options{
+		Address: "placement.svc:50005",
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			lookupCount.Add(1)
+			return []string{"10.0.0.1"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, int32(1), lookupCount.Load())
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, int32(2), lookupCount.Load())
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, int32(3), lookupCount.Load())
+}
+
+func TestPicksUpNewIPsImmediately(t *testing.T) {
+	var callCount atomic.Int32
+	conn, err := New(Options{
+		Address: "placement.svc:50005",
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			n := callCount.Add(1)
+			if n <= 2 {
+				return []string{"10.0.0.1", "10.0.0.2"}, nil
+			}
+			return []string{"10.0.0.3", "10.0.0.4"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.1:50005", conn.Address())
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.2:50005", conn.Address())
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.3:50005", conn.Address())
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.4:50005", conn.Address())
+}
+
+func TestDNSFailureReturnsError(t *testing.T) {
+	conn, err := New(Options{
+		Address: "placement.svc:50005",
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			return nil, errors.New("dns: no such host")
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = conn.Connect(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dns: no such host")
+}
+
+func TestDNSReturnsEmptyList(t *testing.T) {
+	conn, err := New(Options{
+		Address: "placement.svc:50005",
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			return []string{}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = conn.Connect(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no addresses found")
+}
+
+func TestDNSFailureThenRecovery(t *testing.T) {
+	var callCount atomic.Int32
+	conn, err := New(Options{
+		Address: "placement.svc:50005",
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return nil, errors.New("temporary DNS failure")
+			}
+			return []string{"10.0.0.1"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = conn.Connect(t.Context())
+	require.Error(t, err)
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.1:50005", conn.Address())
+}
+
+func TestRoundRobinWrapsWhenDNSResultsShrink(t *testing.T) {
+	var callCount atomic.Int32
+	conn, err := New(Options{
+		Address: "placement.svc:50005",
+		resolver: func(ctx context.Context, host string) ([]string, error) {
+			n := callCount.Add(1)
+			if n <= 3 {
+				return []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, nil
+			}
+			return []string{"10.0.0.4"}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.1:50005", conn.Address())
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.2:50005", conn.Address())
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.3:50005", conn.Address())
+
+	_, _ = conn.Connect(t.Context())
+	assert.Equal(t, "10.0.0.4:50005", conn.Address())
 }
 
 func TestNewDNSConnectorErrors(t *testing.T) {

--- a/pkg/placement/internal/loops/disseminator/closeconn.go
+++ b/pkg/placement/internal/loops/disseminator/closeconn.go
@@ -33,6 +33,14 @@ func (d *disseminator) handleCloseStream(closeStream *loops.ConnCloseStream) {
 		monitoring.RecordActorRuntimesCount(d.actorConnCount.Add(-1), d.namespace)
 	}
 
+	// If this stream was already counted towards the current dissemination
+	// phase, decrement the counter so the round can still complete without it.
+	// Without this, streamsInTargetState would exceed len(d.streams) after
+	// deletion.
+	if s.currentState == d.currentOperation && d.currentOperation != v1pb.HostOperation_REPORT {
+		d.streamsInTargetState--
+	}
+
 	delete(d.streams, closeStream.StreamIDx)
 	s.loop.Close(&loops.StreamShutdown{
 		Error: closeStream.Error,
@@ -43,19 +51,89 @@ func (d *disseminator) handleCloseStream(closeStream *loops.ConnCloseStream) {
 		return
 	}
 
-	// Only trigger dissemination if the host was actually in the store (had
-	// actor types). Hosts with no entities were never stored, so there is
-	// nothing to remove from the placement table.
+	// Hosts with no entities were never stored, so there is nothing to remove
+	// from the placement table.
 	if !d.store.Has(closeStream.StreamIDx) {
 		return
 	}
 
+	// Always queue the deletion rather than immediately starting a new
+	// dissemination round. This allows rapid sequential disconnections (as
+	// happen during a rolling update) to be batched together. The queued
+	// deletions will be processed when the current dissemination round
+	// completes, or when a new connection triggers a round via handleAdd.
+	d.waitingToDelete = append(d.waitingToDelete, closeStream.StreamIDx)
+
 	if d.currentOperation != v1pb.HostOperation_REPORT {
-		d.waitingToDelete = append(d.waitingToDelete, closeStream.StreamIDx)
+		// We're currently disseminating. The store deletion is queued above. Check
+		// if removing this stream completes the current phase, this happens when
+		// this was the last stream that hadn't responded yet.
+		if d.streamsInTargetState >= len(d.streams) {
+			d.advancePhase()
+		}
 		return
 	}
 
-	d.store.Delete(closeStream.StreamIDx)
+	// In REPORT state, process accumulated deletions now. Multiple closes
+	// arriving in rapid succession (during a rolling update) will be batched
+	// naturally because handleAdd processes waitingToDelete before starting a
+	// new round, combining deletes and adds into a single dissemination.
+	d.processWaitingDeletes()
+}
+
+// advancePhase checks if all streams have reached the target state and
+// advances to the next dissemination phase. This is called from
+// handleCloseStream when removing a stream during active dissemination may
+// have completed the current phase.
+func (d *disseminator) advancePhase() {
+	if d.streamsInTargetState < len(d.streams) {
+		return
+	}
+
+	switch d.currentOperation {
+	case v1pb.HostOperation_LOCK:
+		d.currentOperation = v1pb.HostOperation_UPDATE
+		d.streamsInTargetState = 0
+		for _, s := range d.streams {
+			s.loop.Enqueue(&loops.DisseminateUpdate{
+				Version: d.currentVersion,
+				Tables:  d.store.PlacementTables(d.currentVersion),
+			})
+		}
+
+	case v1pb.HostOperation_UPDATE:
+		d.currentOperation = v1pb.HostOperation_UNLOCK
+		d.streamsInTargetState = 0
+		for _, s := range d.streams {
+			s.loop.Enqueue(&loops.DisseminateUnlock{
+				Version: d.currentVersion,
+			})
+		}
+
+	case v1pb.HostOperation_UNLOCK:
+		d.currentOperation = v1pb.HostOperation_REPORT
+		d.streamsInTargetState = 0
+		d.timeoutQ.Dequeue(d.currentVersion)
+		log.Debugf("Dissemination of version %d in %s complete (via stream close)", d.currentVersion, d.namespace)
+
+		if len(d.waitingToDelete) > 0 {
+			d.processWaitingDeletes()
+		}
+	}
+}
+
+// processWaitingDeletes processes all queued stream deletions in a single
+// dissemination round. Must only be called when currentOperation is REPORT.
+func (d *disseminator) processWaitingDeletes() {
+	if len(d.waitingToDelete) == 0 || len(d.streams) == 0 {
+		return
+	}
+
+	for _, toDelete := range d.waitingToDelete {
+		d.store.Delete(toDelete)
+	}
+	d.waitingToDelete = nil
+
 	d.currentVersion++
 	d.timeoutQ.Enqueue(d.currentVersion)
 	d.currentOperation = v1pb.HostOperation_LOCK

--- a/pkg/placement/internal/loops/disseminator/disseminator.go
+++ b/pkg/placement/internal/loops/disseminator/disseminator.go
@@ -192,6 +192,31 @@ func (d *disseminator) handleAdd(ctx context.Context, add *loops.ConnAdd) {
 		return
 	}
 
+	// Process any queued deletions before adding the new stream. During a
+	// rolling update, disconnects (queued as waitingToDelete) and new
+	// connections arrive in rapid succession. Processing deletions here lets the
+	// subsequent doReport include both the removal and addition in a single
+	// dissemination round instead of alternating delete-round → add-round
+	// cycles.
+	for _, toDelete := range d.waitingToDelete {
+		d.store.Delete(toDelete)
+	}
+	d.waitingToDelete = nil
+
+	// Also clean up orphaned store entries,  store entries whose streams have
+	// already been removed from d.streams but whose ConnCloseStream event hasn't
+	// arrived at the disseminator loop yet. This happens during rolling updates
+	// where CloseSend + new connection arrive faster than the close event
+	// propagates through the stream -> namespace -> disseminator queues.
+	d.store.CollectOrphans(func(idx uint64) bool {
+		_, ok := d.streams[idx]
+		return ok
+	}, &d.waitingToDelete)
+	for _, toDelete := range d.waitingToDelete {
+		d.store.Delete(toDelete)
+	}
+	d.waitingToDelete = nil
+
 	streamIDx := d.addStream(ctx, add)
 	d.handleReportedHost(ctx, &loops.ReportedHost{
 		Host:      add.InitialHost,
@@ -243,25 +268,72 @@ func (d *disseminator) handleTimeout(ctx context.Context, timeout *loops.Dissemi
 	)
 
 	log.Warnf("Dissemination timeout for version %d", timeout.Version)
+
+	// Only close streams that have NOT reached the current target state. Streams
+	// that responded successfully to the current dissemination phase are healthy
+	// and should not be punished for another stream's slowness.
 	for idx, s := range d.streams {
+		if s.currentState == d.currentOperation {
+			// This stream already responded to the current phase, it's healthy.
+			continue
+		}
+
+		log.Warnf("Closing non-responding stream %s:%d (state=%s, expected=%s)",
+			d.namespace, idx, s.currentState.String(), d.currentOperation.String())
+
 		d.store.Delete(idx)
+		monitoring.RecordRuntimesCount(d.connCount.Add(-1), d.namespace)
+		if s.hasActors {
+			monitoring.RecordActorRuntimesCount(d.actorConnCount.Add(-1), d.namespace)
+		}
 		s.loop.Close(&loops.StreamShutdown{
 			Error: err,
 		})
 		stream.StreamLoopFactory.CacheLoop(s.loop)
+		delete(d.streams, idx)
 	}
 
-	monitoring.RecordRuntimesCount(0, d.namespace)
-	monitoring.RecordActorRuntimesCount(0, d.namespace)
+	// Reset dissemination state. Process any deletions that were queued during
+	// the round (from streams that disconnected while we were disseminating).
+	// These must be applied to the store before starting the next round,
+	// otherwise the deleted hosts remain in the table.
+	for _, toDelete := range d.waitingToDelete {
+		d.store.Delete(toDelete)
+	}
+	d.waitingToDelete = nil
 
-	clear(d.streams)
 	d.currentVersion++
 	d.currentOperation = v1pb.HostOperation_REPORT
+	d.streamsInTargetState = 0
 
-	for _, add := range d.waitingToDisseminate {
-		add.Cancel(err)
+	// Add any waiting connections- they should not be punished for another
+	// stream's slowness. They are added regardless of whether surviving streams
+	// exist, because the waiting connections themselves become the new stream
+	// set.
+	if len(d.waitingToDisseminate) > 0 {
+		waiting := d.waitingToDisseminate
+		d.waitingToDisseminate = nil
+
+		for _, add := range waiting {
+			streamIDx := d.addStream(ctx, add)
+			d.store.Set(streamIDx, add.InitialHost)
+		}
 	}
 
-	d.waitingToDisseminate = nil
-	d.waitingToDelete = nil
+	if len(d.streams) > 0 {
+		// Start a new dissemination round with all remaining + newly added
+		// streams.
+		d.timeoutQ.Enqueue(d.currentVersion)
+		d.currentOperation = v1pb.HostOperation_LOCK
+		for _, s := range d.streams {
+			s.currentState = v1pb.HostOperation_REPORT
+			s.receivingTable = nil
+			s.loop.Enqueue(&loops.DisseminateLock{
+				Version: d.currentVersion,
+			})
+		}
+	} else {
+		monitoring.RecordRuntimesCount(0, d.namespace)
+		monitoring.RecordActorRuntimesCount(0, d.namespace)
+	}
 }

--- a/pkg/placement/internal/loops/disseminator/disseminator_test.go
+++ b/pkg/placement/internal/loops/disseminator/disseminator_test.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disseminator
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/pkg/placement/internal/loops"
+	"github.com/dapr/dapr/pkg/placement/internal/loops/disseminator/store"
+	"github.com/dapr/dapr/pkg/placement/internal/loops/disseminator/timeout"
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/kit/events/loop/fake"
+)
+
+func newTestDisseminator(t *testing.T) *disseminator {
+	t.Helper()
+
+	dissLoop := fake.New[loops.EventDisseminator]()
+
+	d := &disseminator{
+		nsLoop:           fake.New[loops.EventNamespace](),
+		loop:             dissLoop,
+		timeout:          5 * time.Second,
+		namespace:        "default",
+		streams:          make(map[uint64]*streamConn),
+		store:            store.New(store.Options{ReplicationFactor: 1}),
+		currentOperation: v1pb.HostOperation_REPORT,
+		timeoutQ: timeout.New(timeout.Options{
+			Loop:    dissLoop,
+			Timeout: 5 * time.Second,
+		}),
+	}
+
+	t.Cleanup(func() { d.timeoutQ.Close() })
+
+	return d
+}
+
+type fakeStreamLoop struct {
+	loop     *fake.Fake[loops.EventStream]
+	enqueued atomic.Int32
+	closeCh  chan struct{}
+}
+
+func addFakeStream(d *disseminator, idx uint64, entities []string) *fakeStreamLoop {
+	fs := &fakeStreamLoop{closeCh: make(chan struct{}, 1)}
+	fs.loop = fake.New[loops.EventStream]().
+		WithEnqueue(func(loops.EventStream) { fs.enqueued.Add(1) }).
+		WithClose(func(loops.EventStream) {
+			select {
+			case fs.closeCh <- struct{}{}:
+			default:
+			}
+		})
+
+	d.streams[idx] = &streamConn{
+		loop:         fs.loop,
+		currentState: v1pb.HostOperation_REPORT,
+		hasActors:    len(entities) > 0,
+	}
+	if len(entities) > 0 {
+		//nolint:gosec
+		d.store.Set(idx, &v1pb.Host{
+			Name:      "app-" + string(rune('0'+idx)),
+			Id:        "app-" + string(rune('0'+idx)),
+			Namespace: "default",
+			Entities:  entities,
+		})
+	}
+	d.connCount.Add(1)
+	if len(entities) > 0 {
+		d.actorConnCount.Add(1)
+	}
+	if idx >= d.streamIDx {
+		d.streamIDx = idx + 1
+	}
+	return fs
+}
+
+func host(id string, entities ...string) *v1pb.Host {
+	return &v1pb.Host{
+		Name:      id,
+		Id:        id,
+		Namespace: "default",
+		Entities:  entities,
+	}
+}
+
+func TestHandleTimeout_IgnoresStaleVersion(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 5
+
+	d.handleTimeout(t.Context(), &loops.DisseminationTimeout{Version: 3})
+
+	assert.Len(t, d.streams, 1)
+	assert.True(t, d.store.Has(0))
+}
+
+func TestHandleTimeout_ClosesOnlyNonRespondingStreams(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+	d.streams[0].currentState = v1pb.HostOperation_LOCK
+	d.streams[1].currentState = v1pb.HostOperation_REPORT
+
+	d.handleTimeout(t.Context(), &loops.DisseminationTimeout{Version: 1})
+
+	assert.Contains(t, d.streams, uint64(0))
+	assert.NotContains(t, d.streams, uint64(1))
+	assert.False(t, d.store.Has(1))
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+	assert.Equal(t, uint64(2), d.currentVersion)
+}
+
+func TestHandleTimeout_AllStreamsRemoved_NoStreamsLeft(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+	d.streams[0].currentState = v1pb.HostOperation_REPORT
+
+	d.handleTimeout(t.Context(), &loops.DisseminationTimeout{Version: 1})
+
+	assert.Empty(t, d.streams)
+	assert.Equal(t, v1pb.HostOperation_REPORT, d.currentOperation)
+}
+
+func TestHandleTimeout_WaitingConnectionsSurvive(t *testing.T) {
+	t.Skip("requires real gRPC stream for addStream — covered by integration test waitingcancel")
+}
+
+func TestHandleTimeout_ProcessesWaitingDeletes(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+	d.streams[0].currentState = v1pb.HostOperation_LOCK
+	d.streams[1].currentState = v1pb.HostOperation_REPORT
+	d.waitingToDelete = []uint64{99}
+	d.store.Set(99, host("departed", "actorA"))
+
+	d.handleTimeout(t.Context(), &loops.DisseminationTimeout{Version: 1})
+
+	assert.False(t, d.store.Has(99))
+	assert.Nil(t, d.waitingToDelete)
+}
+
+func TestHandleCloseStream_RemovesFromStreams(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+
+	d.handleCloseStream(&loops.ConnCloseStream{StreamIDx: 0, Namespace: "default"})
+
+	assert.NotContains(t, d.streams, uint64(0))
+	assert.Equal(t, int64(0), d.connCount.Load())
+}
+
+func TestHandleCloseStream_QueuesDeleteDuringRound(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentOperation = v1pb.HostOperation_LOCK
+
+	d.handleCloseStream(&loops.ConnCloseStream{StreamIDx: 0, Namespace: "default"})
+
+	assert.NotContains(t, d.streams, uint64(0))
+	assert.Contains(t, d.waitingToDelete, uint64(0))
+	assert.True(t, d.store.Has(0))
+}
+
+func TestHandleCloseStream_ProcessesImmediatelyInReportState(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentOperation = v1pb.HostOperation_REPORT
+
+	d.handleCloseStream(&loops.ConnCloseStream{StreamIDx: 0, Namespace: "default"})
+
+	assert.False(t, d.store.Has(0))
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+}
+
+func TestHandleCloseStream_DecrementsTargetState(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+	d.streamsInTargetState = 1
+	d.streams[0].currentState = v1pb.HostOperation_LOCK
+
+	d.handleCloseStream(&loops.ConnCloseStream{StreamIDx: 0, Namespace: "default"})
+
+	assert.Equal(t, 0, d.streamsInTargetState)
+}
+
+func TestHandleCloseStream_AdvancesPhaseWhenLastNonResponder(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+	d.streamsInTargetState = 1
+	d.streams[0].currentState = v1pb.HostOperation_LOCK
+	d.streams[1].currentState = v1pb.HostOperation_REPORT
+
+	d.handleCloseStream(&loops.ConnCloseStream{StreamIDx: 1, Namespace: "default"})
+
+	assert.Equal(t, v1pb.HostOperation_UPDATE, d.currentOperation)
+}
+
+func TestHandleCloseStream_NoActorsSkipsDissemination(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, nil)
+	addFakeStream(d, 1, []string{"actorA"})
+
+	d.handleCloseStream(&loops.ConnCloseStream{StreamIDx: 0, Namespace: "default"})
+
+	assert.Equal(t, v1pb.HostOperation_REPORT, d.currentOperation)
+}
+
+func TestHandleCloseStream_IgnoresUnknownStream(t *testing.T) {
+	d := newTestDisseminator(t)
+	d.handleCloseStream(&loops.ConnCloseStream{StreamIDx: 999, Namespace: "default"})
+}
+
+func TestAdvancePhase_LockToUpdate(t *testing.T) {
+	d := newTestDisseminator(t)
+	fakeLoop := addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+	d.streamsInTargetState = 1
+
+	d.advancePhase()
+
+	assert.Equal(t, v1pb.HostOperation_UPDATE, d.currentOperation)
+	assert.Equal(t, 0, d.streamsInTargetState)
+	assert.Equal(t, int32(1), fakeLoop.enqueued.Load())
+}
+
+func TestAdvancePhase_UpdateToUnlock(t *testing.T) {
+	d := newTestDisseminator(t)
+	fakeLoop := addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_UPDATE
+	d.streamsInTargetState = 1
+
+	d.advancePhase()
+
+	assert.Equal(t, v1pb.HostOperation_UNLOCK, d.currentOperation)
+	assert.Equal(t, 0, d.streamsInTargetState)
+	assert.Equal(t, int32(1), fakeLoop.enqueued.Load())
+}
+
+func TestAdvancePhase_UnlockToReport(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_UNLOCK
+	d.streamsInTargetState = 1
+
+	d.advancePhase()
+
+	assert.Equal(t, v1pb.HostOperation_REPORT, d.currentOperation)
+}
+
+func TestAdvancePhase_UnlockProcessesWaitingDeletes(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_UNLOCK
+	d.streamsInTargetState = 1
+	d.waitingToDelete = []uint64{99}
+	d.store.Set(99, host("gone", "actorA"))
+
+	d.advancePhase()
+
+	assert.False(t, d.store.Has(99))
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+}
+
+func TestAdvancePhase_NoAdvanceIfNotAllResponded(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+	d.streamsInTargetState = 1
+
+	d.advancePhase()
+
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+}
+
+func TestHandleAdd_QueuesDuringActiveRound(t *testing.T) {
+	d := newTestDisseminator(t)
+	d.currentOperation = v1pb.HostOperation_LOCK
+
+	d.handleAdd(t.Context(), &loops.ConnAdd{
+		InitialHost: host("queued-app", "actorA"),
+		Cancel:      func(error) {},
+	})
+
+	assert.Len(t, d.waitingToDisseminate, 1)
+	assert.Empty(t, d.streams)
+}
+
+func TestHandleAdd_ProcessesPendingDeletesFirst(t *testing.T) {
+	t.Skip("requires real gRPC stream for addStream — covered by integration tests")
+}
+
+func TestProcessWaitingDeletes_DeletesFromStoreAndStartsRound(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.store.Set(99, host("old", "actorA"))
+	d.waitingToDelete = []uint64{99}
+
+	d.processWaitingDeletes()
+
+	assert.False(t, d.store.Has(99))
+	assert.Nil(t, d.waitingToDelete)
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+}
+
+func TestProcessWaitingDeletes_NoopIfEmpty(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+
+	d.processWaitingDeletes()
+
+	assert.Equal(t, v1pb.HostOperation_REPORT, d.currentOperation)
+}
+
+func TestProcessWaitingDeletes_NoopIfNoStreams(t *testing.T) {
+	d := newTestDisseminator(t)
+	d.store.Set(99, host("old", "actorA"))
+	d.waitingToDelete = []uint64{99}
+
+	d.processWaitingDeletes()
+
+	assert.Equal(t, v1pb.HostOperation_REPORT, d.currentOperation)
+}
+
+func TestReportedLock_AdvancesToUpdate(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+
+	d.handleReportedLock(0)
+
+	assert.Equal(t, v1pb.HostOperation_UPDATE, d.currentOperation)
+	assert.Equal(t, 0, d.streamsInTargetState)
+}
+
+func TestReportedLock_WaitsForAllStreams(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	addFakeStream(d, 1, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_LOCK
+
+	d.handleReportedLock(0)
+
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+	assert.Equal(t, 1, d.streamsInTargetState)
+}
+
+func TestReportedUpdate_AdvancesToUnlock(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_UPDATE
+
+	d.handleReportedUpdate(0)
+
+	assert.Equal(t, v1pb.HostOperation_UNLOCK, d.currentOperation)
+}
+
+func TestReportedUnlock_CompletesRound(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_UNLOCK
+
+	d.handleReportedUnlock(t.Context(), 0)
+
+	assert.Equal(t, v1pb.HostOperation_REPORT, d.currentOperation)
+}
+
+func TestReportedUnlock_ProcessesWaitingDeletes(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_UNLOCK
+	d.waitingToDelete = []uint64{99}
+	d.store.Set(99, host("departed", "actorA"))
+
+	d.handleReportedUnlock(t.Context(), 0)
+
+	assert.False(t, d.store.Has(99))
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+}
+
+func TestReportedUnlock_CollectsOrphans(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+	d.currentVersion = 1
+	d.currentOperation = v1pb.HostOperation_UNLOCK
+	d.store.Set(99, host("orphan", "actorA"))
+
+	d.handleReportedUnlock(t.Context(), 0)
+
+	assert.False(t, d.store.Has(99))
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+}
+
+func TestDoReport_NoStoreChange_NoRound(t *testing.T) {
+	d := newTestDisseminator(t)
+	addFakeStream(d, 0, []string{"actorA"})
+
+	d.doReport(0, host("app-0", "actorA"))
+
+	assert.Equal(t, v1pb.HostOperation_REPORT, d.currentOperation)
+}
+
+func TestDoReport_StoreChange_StartsLockRound(t *testing.T) {
+	d := newTestDisseminator(t)
+	fakeLoop := addFakeStream(d, 0, []string{"actorA"})
+
+	d.doReport(0, host("app-0", "actorA", "actorB"))
+
+	assert.Equal(t, v1pb.HostOperation_LOCK, d.currentOperation)
+	assert.Equal(t, uint64(1), d.currentVersion)
+	assert.Equal(t, int32(1), fakeLoop.enqueued.Load())
+}
+
+func TestStoreCollectOrphans(t *testing.T) {
+	s := store.New(store.Options{ReplicationFactor: 1})
+	s.Set(0, host("alive", "actorA"))
+	s.Set(1, host("orphan", "actorA"))
+	s.Set(2, host("also-alive", "actorA"))
+
+	activeStreams := map[uint64]bool{0: true, 2: true}
+
+	var orphans []uint64
+	s.CollectOrphans(func(idx uint64) bool {
+		return activeStreams[idx]
+	}, &orphans)
+
+	assert.Equal(t, []uint64{uint64(1)}, orphans)
+}
+
+func TestStoreCollectOrphans_NoOrphans(t *testing.T) {
+	s := store.New(store.Options{ReplicationFactor: 1})
+	s.Set(0, host("alive", "actorA"))
+
+	activeStreams := map[uint64]bool{0: true}
+
+	var orphans []uint64
+	s.CollectOrphans(func(idx uint64) bool {
+		return activeStreams[idx]
+	}, &orphans)
+
+	assert.Empty(t, orphans)
+}

--- a/pkg/placement/internal/loops/disseminator/disseminator_test.go
+++ b/pkg/placement/internal/loops/disseminator/disseminator_test.go
@@ -467,7 +467,7 @@ func TestStoreCollectOrphans(t *testing.T) {
 		return activeStreams[idx]
 	}, &orphans)
 
-	assert.Equal(t, []uint64{uint64(1)}, orphans)
+	assert.ElementsMatch(t, []uint64{uint64(1)}, orphans)
 }
 
 func TestStoreCollectOrphans_NoOrphans(t *testing.T) {

--- a/pkg/placement/internal/loops/disseminator/host.go
+++ b/pkg/placement/internal/loops/disseminator/host.go
@@ -171,33 +171,25 @@ func (d *disseminator) handleReportedUnlock(ctx context.Context, streamIDx uint6
 		d.timeoutQ.Dequeue(d.currentVersion)
 		log.Debugf("Dissemination of version %d in %s complete", d.currentVersion, d.namespace)
 
-		// If there were connections deleted while we were disseminating, delete
-		// them now in a new dissemination cycle.
+		// Clean up orphaned store entries- store entries whose streams are no
+		// longer in d.streams. This handles the case where a stream's
+		// ConnCloseStream event hasn't propagated to the disseminator yet but the
+		// stream was already removed from d.streams by a prior handleCloseStream
+		// or handleTimeout call.
+		d.store.CollectOrphans(func(idx uint64) bool {
+			_, ok := d.streams[idx]
+			return ok
+		}, &d.waitingToDelete)
+
 		if len(d.waitingToDelete) > 0 {
-			for _, toDelete := range d.waitingToDelete {
-				d.store.Delete(toDelete)
-			}
-
-			d.waitingToDelete = nil
-			d.currentVersion++
-			d.timeoutQ.Enqueue(d.currentVersion)
-			d.currentOperation = v1pb.HostOperation_LOCK
-
-			for _, s := range d.streams {
-				s.currentState = v1pb.HostOperation_REPORT
-				s.receivingTable = nil
-				s.loop.Enqueue(&loops.DisseminateLock{
-					Version: d.currentVersion,
-				})
-			}
-
+			d.processWaitingDeletes()
 			return
 		}
 
-		// Batch all waiting connections: create their streams and update the
-		// store for all of them, then start a single dissemination round if any
-		// store change occurred. This avoids O(n) sequential dissemination
-		// rounds when many replicas connect at once.
+		// Batch all waiting connections: create their streams and update the store
+		// for all of them, then start a single dissemination round if any store
+		// change occurred. This avoids O(n) sequential dissemination rounds when
+		// many replicas connect at once.
 		if len(d.waitingToDisseminate) > 0 {
 			waiting := d.waitingToDisseminate
 			d.waitingToDisseminate = nil

--- a/pkg/placement/internal/loops/disseminator/store/store.go
+++ b/pkg/placement/internal/loops/disseminator/store/store.go
@@ -123,6 +123,16 @@ func (s *Store) Delete(streamIDx uint64) {
 	delete(s.hosts, streamIDx)
 }
 
+// CollectOrphans appends orphaned store entry indices to the given slice. An
+// orphan is a store entry whose streamIDx is not in the active set.
+func (s *Store) CollectOrphans(isActive func(uint64) bool, orphans *[]uint64) {
+	for idx := range s.hosts {
+		if !isActive(idx) {
+			*orphans = append(*orphans, idx)
+		}
+	}
+}
+
 func (s *Store) DeleteAll() {
 	clear(s.hosts)
 }

--- a/tests/integration/suite/placement/dissemination/manyreplicas.go
+++ b/tests/integration/suite/placement/dissemination/manyreplicas.go
@@ -108,7 +108,7 @@ func (m *manyreplicas) Run(t *testing.T, ctx context.Context) {
 
 	// Close all streams gracefully.
 	for _, s := range streams {
-		s.CloseSend()
+		require.NoError(t, s.CloseSend())
 	}
 	wg.Wait()
 

--- a/tests/integration/suite/placement/dissemination/manyreplicas.go
+++ b/tests/integration/suite/placement/dissemination/manyreplicas.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dissemination
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(manyreplicas))
+}
+
+type manyreplicas struct {
+	place *placement.Placement
+}
+
+func (m *manyreplicas) Setup(t *testing.T) []framework.Option {
+	m.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*5),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.place),
+	}
+}
+
+func (m *manyreplicas) Run(t *testing.T, ctx context.Context) {
+	m.place.WaitUntilRunning(t, ctx)
+
+	assert.Eventually(t, func() bool {
+		return m.place.IsLeader(t, ctx)
+	}, time.Second*10, time.Millisecond*10)
+
+	client := m.place.Client(t, ctx)
+
+	const numReplicas = 15
+
+	streams := make([]v1pb.Placement_ReportDaprStatusClient, numReplicas)
+	for i := range numReplicas {
+		s, err := client.ReportDaprStatus(ctx)
+		require.NoError(t, err)
+		id := "replica-" + strconv.Itoa(i)
+		require.NoError(t, s.Send(&v1pb.Host{
+			Name:      id,
+			Port:      int64(3000 + i),
+			Entities:  []string{"myactor"},
+			Id:        id,
+			Namespace: "default",
+		}))
+		streams[i] = s
+	}
+
+	var wg sync.WaitGroup
+	for i, s := range streams {
+		wg.Go(func() {
+			id := "replica-" + strconv.Itoa(i)
+			for {
+				resp, err := s.Recv()
+				if err != nil {
+					return
+				}
+				op := resp.GetOperation()
+				if op == "lock" || op == "update" || op == "unlock" {
+					_ = s.Send(&v1pb.Host{
+						Name: id, Port: int64(3000 + i),
+						Entities:  []string{"myactor"},
+						Id:        id,
+						Namespace: "default",
+						Operation: hostOpFromString(op),
+						Version:   &resp.Version,
+					})
+				}
+			}
+		})
+	}
+
+	// All 15 replicas should appear in the placement table.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := m.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, numReplicas)
+	}, time.Second*30, time.Millisecond*10)
+
+	// Close all streams gracefully.
+	for _, s := range streams {
+		s.CloseSend()
+	}
+	wg.Wait()
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := m.place.PlacementTables(t, ctx)
+		if table.Tables["default"] == nil {
+			return
+		}
+		assert.Empty(c, table.Tables["default"].Hosts)
+	}, time.Second*15, time.Millisecond*10)
+}

--- a/tests/integration/suite/placement/dissemination/rollout.go
+++ b/tests/integration/suite/placement/dissemination/rollout.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dissemination
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(rollout))
+}
+
+type rollout struct {
+	place *placement.Placement
+}
+
+func (r *rollout) Setup(t *testing.T) []framework.Option {
+	r.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.place),
+	}
+}
+
+func (r *rollout) Run(t *testing.T, ctx context.Context) {
+	r.place.WaitUntilRunning(t, ctx)
+
+	assert.Eventually(t, func() bool {
+		return r.place.IsLeader(t, ctx)
+	}, time.Second*10, time.Millisecond*10)
+
+	client := r.place.Client(t, ctx)
+
+	// Phase 1: Establish a stable cluster of 5 "old" pods by adding them one at
+	// a time, completing each dissemination round before adding the next. This
+	// ensures a clean baseline before the rollout churn.
+	const numPods = 5
+	oldStreams := make([]v1pb.Placement_ReportDaprStatusClient, numPods)
+	for i := range numPods {
+		s, err := client.ReportDaprStatus(ctx)
+		require.NoError(t, err)
+		id := "old-" + strconv.Itoa(i)
+		require.NoError(t, s.Send(&v1pb.Host{
+			Name:      id,
+			Port:      int64(2000 + i),
+			Entities:  []string{"myactor"},
+			Id:        id,
+			Namespace: "default",
+		}))
+		oldStreams[i] = s
+
+		allCurrent := oldStreams[:i+1]
+		for j, cs := range allCurrent {
+			resp, rerr := cs.Recv()
+			require.NoError(t, rerr, "stream old-%d lock (round %d)", j, i)
+			require.Equal(t, "lock", resp.GetOperation())
+		}
+		for j, cs := range allCurrent {
+			cid := "old-" + strconv.Itoa(j)
+			require.NoError(t, cs.Send(&v1pb.Host{
+				Name: cid, Port: int64(2000 + j),
+				Entities: []string{"myactor"}, Id: cid, Namespace: "default",
+			}))
+		}
+		for j, cs := range allCurrent {
+			resp, rerr := cs.Recv()
+			require.NoError(t, rerr, "stream old-%d update (round %d)", j, i)
+			require.Equal(t, "update", resp.GetOperation())
+		}
+		for j, cs := range allCurrent {
+			cid := "old-" + strconv.Itoa(j)
+			require.NoError(t, cs.Send(&v1pb.Host{
+				Name: cid, Port: int64(2000 + j),
+				Entities: []string{"myactor"}, Id: cid, Namespace: "default",
+			}))
+		}
+		for j, cs := range allCurrent {
+			resp, rerr := cs.Recv()
+			require.NoError(t, rerr, "stream old-%d unlock (round %d)", j, i)
+			require.Equal(t, "unlock", resp.GetOperation())
+		}
+		for j, cs := range allCurrent {
+			cid := "old-" + strconv.Itoa(j)
+			require.NoError(t, cs.Send(&v1pb.Host{
+				Name: cid, Port: int64(2000 + j),
+				Entities: []string{"myactor"}, Id: cid, Namespace: "default",
+			}))
+		}
+	}
+
+	// Phase 2: Simulate a rolling update. One by one, close an old stream and
+	// open a new one. Each close and open changes the store, triggering a new
+	// dissemination version.
+	newStreams := make([]v1pb.Placement_ReportDaprStatusClient, numPods)
+	for i := range numPods {
+		require.NoError(t, oldStreams[i].CloseSend())
+
+		s, err := client.ReportDaprStatus(ctx)
+		require.NoError(t, err)
+		id := "new-" + strconv.Itoa(i)
+		require.NoError(t, s.Send(&v1pb.Host{
+			Name:      id,
+			Port:      int64(3000 + i),
+			Entities:  []string{"myactor"},
+			Id:        id,
+			Namespace: "default",
+		}))
+		newStreams[i] = s
+	}
+
+	// Phase 3: Drive the new streams through dissemination. Each stream needs
+	// to respond to LOCK→UPDATE→UNLOCK messages. Run a goroutine per stream
+	// that auto-responds to dissemination messages.
+	for i, s := range newStreams {
+		go func() {
+			id := "new-" + strconv.Itoa(i)
+			for {
+				resp, err := s.Recv()
+				if err != nil {
+					return
+				}
+				op := resp.GetOperation()
+				if op == "lock" || op == "update" || op == "unlock" {
+					_ = s.Send(&v1pb.Host{
+						Name: id, Port: int64(3000 + i),
+						Entities: []string{"myactor"}, Id: id, Namespace: "default",
+						Operation: hostOpFromString(op),
+						Version:   &resp.Version,
+					})
+				}
+			}
+		}()
+	}
+
+	// After driving the protocol, the placement tables should stabilize
+	// with all 5 new pods.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := r.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		hosts := table.Tables["default"].Hosts
+		names := make([]string, len(hosts))
+		for i, h := range hosts {
+			names[i] = h.Name
+		}
+		t.Logf("Table hosts (%d): %v (version=%d)", len(names), names, table.Tables["default"].Version)
+		if !assert.Len(c, names, numPods) {
+			return
+		}
+		for i := range numPods {
+			assert.Contains(c, names, "new-"+strconv.Itoa(i))
+		}
+	}, time.Second*30, time.Millisecond*500)
+}
+
+func hostOpFromString(op string) v1pb.HostOperation {
+	switch op {
+	case "lock":
+		return v1pb.HostOperation_LOCK
+	case "update":
+		return v1pb.HostOperation_UPDATE
+	case "unlock":
+		return v1pb.HostOperation_UNLOCK
+	default:
+		return v1pb.HostOperation_REPORT
+	}
+}

--- a/tests/integration/suite/placement/timeout/closemidround.go
+++ b/tests/integration/suite/placement/timeout/closemidround.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timeout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(closemidround))
+}
+
+type closemidround struct {
+	place *placement.Placement
+}
+
+func (c *closemidround) Setup(t *testing.T) []framework.Option {
+	c.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*10),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.place),
+	}
+}
+
+func (c *closemidround) Run(t *testing.T, ctx context.Context) {
+	c.place.WaitUntilRunning(t, ctx)
+
+	assert.Eventually(t, func() bool {
+		return c.place.IsLeader(t, ctx)
+	}, time.Second*10, time.Millisecond*10)
+
+	client := c.place.Client(t, ctx)
+
+	// Connect stream1 (healthy) and complete the first round.
+	stream1, err := client.ReportDaprStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "app1", Port: 1001, Entities: []string{"actorA"},
+		Id: "app1", Namespace: "default",
+	}))
+
+	resp, err := stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "lock", resp.GetOperation())
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "app1", Port: 1001, Entities: []string{"actorA"},
+		Id: "app1", Namespace: "default",
+	}))
+	resp, err = stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "update", resp.GetOperation())
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "app1", Port: 1001, Entities: []string{"actorA"},
+		Id: "app1", Namespace: "default",
+	}))
+	resp, err = stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "unlock", resp.GetOperation())
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "app1", Port: 1001, Entities: []string{"actorA"},
+		Id: "app1", Namespace: "default",
+	}))
+
+	// Connect stream2 (will disconnect mid-round).
+	stream2, err := client.ReportDaprStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream2.Send(&v1pb.Host{
+		Name: "app2", Port: 1002, Entities: []string{"actorA"},
+		Id: "app2", Namespace: "default",
+	}))
+
+	// Both streams receive LOCK for the new round.
+	resp1, err := stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "lock", resp1.GetOperation())
+
+	resp2, err := stream2.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "lock", resp2.GetOperation())
+
+	// Both respond to LOCK.
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "app1", Port: 1001, Entities: []string{"actorA"},
+		Id: "app1", Namespace: "default",
+	}))
+	require.NoError(t, stream2.Send(&v1pb.Host{
+		Name: "app2", Port: 1002, Entities: []string{"actorA"},
+		Id: "app2", Namespace: "default",
+	}))
+
+	// Both receive UPDATE.
+	resp1, err = stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "update", resp1.GetOperation())
+
+	resp2, err = stream2.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "update", resp2.GetOperation())
+
+	// stream1 responds to UPDATE. stream2 disconnects mid-round.
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "app1", Port: 1001, Entities: []string{"actorA"},
+		Id: "app1", Namespace: "default",
+	}))
+	require.NoError(t, stream2.CloseSend())
+
+	// stream1 should receive UNLOCK quickly (via advancePhase, not after the 10s
+	// timeout). If advancePhase doesn't work, this would hang for 10 seconds and
+	// the test would be slow.
+	startTime := time.Now()
+	resp1, err = stream1.Recv()
+	elapsed := time.Since(startTime)
+	require.NoError(t, err)
+	require.Equal(t, "unlock", resp1.GetOperation())
+
+	assert.Less(t, elapsed, 5*time.Second,
+		"UNLOCK should arrive quickly via advancePhase, not after timeout")
+
+	// Complete the round.
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "app1", Port: 1001, Entities: []string{"actorA"},
+		Id: "app1", Namespace: "default",
+	}))
+
+	// Placement table should show only app1.
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		table := c.place.PlacementTables(t, ctx)
+		if !assert.NotNil(col, table.Tables["default"]) {
+			return
+		}
+		assert.Len(col, table.Tables["default"].Hosts, 1)
+		if len(table.Tables["default"].Hosts) > 0 {
+			assert.Equal(col, "app1", table.Tables["default"].Hosts[0].Name)
+		}
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/placement/timeout/slowreplica.go
+++ b/tests/integration/suite/placement/timeout/slowreplica.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timeout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(slowreplica))
+}
+
+type slowreplica struct {
+	place *placement.Placement
+}
+
+func (s *slowreplica) Setup(t *testing.T) []framework.Option {
+	s.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*2),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.place),
+	}
+}
+
+func (s *slowreplica) Run(t *testing.T, ctx context.Context) {
+	s.place.WaitUntilRunning(t, ctx)
+
+	assert.Eventually(t, func() bool {
+		return s.place.IsLeader(t, ctx)
+	}, time.Second*10, time.Millisecond*10)
+
+	client := s.place.Client(t, ctx)
+
+	stream1, err := client.ReportDaprStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name:      "healthy-app",
+		Port:      1001,
+		Entities:  []string{"actorA"},
+		Id:        "healthy-app",
+		Namespace: "default",
+	}))
+
+	// stream1 receives LOCK for version 1.
+	resp, err := stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "lock", resp.GetOperation())
+	version1 := resp.GetVersion()
+
+	// stream1 responds to advance to UPDATE.
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name:      "healthy-app",
+		Port:      1001,
+		Entities:  []string{"actorA"},
+		Id:        "healthy-app",
+		Namespace: "default",
+	}))
+	resp, err = stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "update", resp.GetOperation())
+
+	// stream1 responds to advance to UNLOCK.
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name:      "healthy-app",
+		Port:      1001,
+		Entities:  []string{"actorA"},
+		Id:        "healthy-app",
+		Namespace: "default",
+	}))
+	resp, err = stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "unlock", resp.GetOperation())
+	require.Equal(t, version1, resp.GetVersion())
+
+	// stream1 acknowledges UNLOCK.
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name:      "healthy-app",
+		Port:      1001,
+		Entities:  []string{"actorA"},
+		Id:        "healthy-app",
+		Namespace: "default",
+	}))
+
+	// Now connect stream2 (the "slow" replica) which triggers a new
+	// dissemination round.
+	stream2, err := client.ReportDaprStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream2.Send(&v1pb.Host{
+		Name:      "slow-app",
+		Port:      1002,
+		Entities:  []string{"actorA"},
+		Id:        "slow-app",
+		Namespace: "default",
+	}))
+
+	// Both streams should receive LOCK for version 2.
+	resp1, err := stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "lock", resp1.GetOperation())
+	version2 := resp1.GetVersion()
+	require.Greater(t, version2, version1)
+
+	resp2, err := stream2.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "lock", resp2.GetOperation())
+	require.Equal(t, version2, resp2.GetVersion())
+
+	// stream1 (healthy) responds immediately.
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name:      "healthy-app",
+		Port:      1001,
+		Entities:  []string{"actorA"},
+		Id:        "healthy-app",
+		Namespace: "default",
+	}))
+
+	// stream2 (slow) does NOT respond. It hangs in the LOCK phase.
+	// The dissemination timeout will fire after 2 seconds.
+
+	// Collect the error from stream2.
+	stream2ErrCh := make(chan error, 1)
+	go func() {
+		_, serr := stream2.Recv()
+		stream2ErrCh <- serr
+	}()
+
+	// stream2 (the slow one) MUST be disconnected with DeadlineExceeded.
+	select {
+	case serr := <-stream2ErrCh:
+		require.Error(t, serr)
+		st, ok := status.FromError(serr)
+		require.True(t, ok)
+		assert.Equal(t, codes.DeadlineExceeded, st.Code())
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "stream2 (slow) was not disconnected")
+	}
+
+	// stream1 (healthy) should survive the timeout. The server starts a new
+	// dissemination round with only stream1. Complete the round to prove
+	// stream1 is still alive and functional.
+	resp1, err = stream1.Recv()
+	require.NoError(t, err, "stream1 should receive new LOCK after timeout kills stream2")
+	require.Equal(t, "lock", resp1.GetOperation())
+
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "healthy-app", Port: 1001,
+		Entities: []string{"actorA"}, Id: "healthy-app", Namespace: "default",
+	}))
+	resp1, err = stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "update", resp1.GetOperation())
+
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name: "healthy-app", Port: 1001,
+		Entities: []string{"actorA"}, Id: "healthy-app", Namespace: "default",
+	}))
+	resp1, err = stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "unlock", resp1.GetOperation())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := s.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+		if len(table.Tables["default"].Hosts) > 0 {
+			assert.Equal(c, "healthy-app", table.Tables["default"].Hosts[0].Name)
+		}
+	}, time.Second*5, time.Millisecond*100)
+}

--- a/tests/integration/suite/placement/timeout/waitingcancel.go
+++ b/tests/integration/suite/placement/timeout/waitingcancel.go
@@ -92,8 +92,8 @@ func (w *waitingcancel) Run(t *testing.T, ctx context.Context) {
 		waitingStreams[i] = s
 	}
 
-	// Wait for the timeout to fire. It should disconnect stream1 AND cancel all
-	// waiting connections.
+	// Wait for the timeout to fire. It should disconnect stream1, while the
+	// waiting connections remain queued and are not cancelled by the timeout.
 
 	// stream1 should be disconnected with DeadlineExceeded.
 	stream1ErrCh := make(chan error, 1)

--- a/tests/integration/suite/placement/timeout/waitingcancel.go
+++ b/tests/integration/suite/placement/timeout/waitingcancel.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timeout
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(waitingcancel))
+}
+
+type waitingcancel struct {
+	place *placement.Placement
+}
+
+func (w *waitingcancel) Setup(t *testing.T) []framework.Option {
+	w.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*2),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(w.place),
+	}
+}
+
+func (w *waitingcancel) Run(t *testing.T, ctx context.Context) {
+	w.place.WaitUntilRunning(t, ctx)
+
+	assert.Eventually(t, func() bool {
+		return w.place.IsLeader(t, ctx)
+	}, time.Second*10, time.Millisecond*10)
+
+	client := w.place.Client(t, ctx)
+
+	// Stream1 connects and starts a dissemination round, but never responds past
+	// LOCK (simulating a slow or crashing sidecar).
+	stream1, err := client.ReportDaprStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream1.Send(&v1pb.Host{
+		Name:      "blocker",
+		Port:      1001,
+		Entities:  []string{"actorA"},
+		Id:        "blocker",
+		Namespace: "default",
+	}))
+
+	// stream1 receives LOCK but does NOT respond.
+	resp, err := stream1.Recv()
+	require.NoError(t, err)
+	require.Equal(t, "lock", resp.GetOperation())
+
+	// While stream1 is blocking dissemination, connect 4 more replicas. These
+	// should be queued in waitingToDisseminate.
+	const numWaiting = 4
+	waitingStreams := make([]v1pb.Placement_ReportDaprStatusClient, numWaiting)
+	for i := range numWaiting {
+		s, serr := client.ReportDaprStatus(ctx)
+		require.NoError(t, serr)
+		id := "waiter-" + strconv.Itoa(i)
+		require.NoError(t, s.Send(&v1pb.Host{
+			Name:      id,
+			Port:      int64(2001 + i),
+			Entities:  []string{"actorA"},
+			Id:        id,
+			Namespace: "default",
+		}))
+		waitingStreams[i] = s
+	}
+
+	// Wait for the timeout to fire. It should disconnect stream1 AND cancel all
+	// waiting connections.
+
+	// stream1 should be disconnected with DeadlineExceeded.
+	stream1ErrCh := make(chan error, 1)
+	go func() {
+		_, serr := stream1.Recv()
+		stream1ErrCh <- serr
+	}()
+
+	select {
+	case serr := <-stream1ErrCh:
+		require.Error(t, serr)
+		st, ok := status.FromError(serr)
+		require.True(t, ok)
+		assert.Equal(t, codes.DeadlineExceeded, st.Code())
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "stream1 (blocker) was not disconnected by timeout")
+	}
+
+	// After the fix: waiting streams are NOT cancelled. They are added to the
+	// new dissemination round started after the timeout. Each waiting stream
+	// should receive LOCK from the new round. Complete the round by responding.
+	for i, s := range waitingStreams {
+		resp, rerr := s.Recv()
+		require.NoError(t, rerr, "waiter-%d should receive LOCK (not be cancelled)", i)
+		require.Equal(t, "lock", resp.GetOperation(), "waiter-%d should get lock", i)
+	}
+
+	// Respond to LOCK on all waiting streams.
+	for i, s := range waitingStreams {
+		id := "waiter-" + strconv.Itoa(i)
+		require.NoError(t, s.Send(&v1pb.Host{
+			Name: id, Port: int64(2001 + i),
+			Entities: []string{"actorA"}, Id: id, Namespace: "default",
+		}))
+	}
+
+	// All should receive UPDATE.
+	for i, s := range waitingStreams {
+		resp, rerr := s.Recv()
+		require.NoError(t, rerr, "waiter-%d update", i)
+		require.Equal(t, "update", resp.GetOperation())
+	}
+
+	for i, s := range waitingStreams {
+		id := "waiter-" + strconv.Itoa(i)
+		require.NoError(t, s.Send(&v1pb.Host{
+			Name: id, Port: int64(2001 + i),
+			Entities: []string{"actorA"}, Id: id, Namespace: "default",
+		}))
+	}
+
+	// All should receive UNLOCK.
+	for i, s := range waitingStreams {
+		resp, rerr := s.Recv()
+		require.NoError(t, rerr, "waiter-%d unlock", i)
+		require.Equal(t, "unlock", resp.GetOperation())
+	}
+
+	// Verify placement table contains all 4 waiting apps (blocker is gone).
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := w.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, numWaiting)
+	}, time.Second*10, time.Millisecond*100)
+}


### PR DESCRIPTION
Marked for backport to 1.17.3

---

Placement dissemination timeout cascades across all replicas:

When a single slow daprd sidecar fails to respond during placement table dissemination, the timeout previously disconnected ALL connected sidecars in the namespace,  not just the slow one. This caused a cascading failure where healthy replicas lost their placement tables. During rolling updates, rapid connect/disconnect cycles generated a version storm where the placement server churned through dissemination versions faster than sidecars could process them.

The fix makes timeouts selective (only closes non-responding streams), adds phase advancement when streams disconnect mid-round, batches store deletions during rolling updates, and cleans up orphaned store entries after each round completes.

---

Daprd placement reconnect hangs for 20 seconds on stale DNS:

The DNS round-robin connector cached IP addresses from the initial DNS lookup and only re-resolved when all cached IPs were exhausted. After a placement pod restart, the old IP remained in the cache and each connection attempt hung for 20 seconds on TCP dial timeout before trying the next address, up to 60 seconds worst case with a 3-node cluster.

The DNS connector now re-resolves on every Connect call. Kubernetes headless service DNS returns current pod IPs, so reconnects immediately find new placement pods.

---

Placement dissemination timeout cascades across all replicas

Problem

When a single slow or unresponsive daprd sidecar fails to respond during placement table dissemination, the dissemination timeout disconnects **all** connected sidecars in the namespace,  not just the slow one. This causes a cascading failure where healthy replicas lose their placement tables and must reconnect and re-disseminate.

During rolling updates, rapid sequential connect/disconnect cycles generate a "version storm" where the placement server churns through many dissemination versions faster than sidecars can process them, leading to repeated timeouts that affect all replicas.

Impact

Any deployment with multiple replicas using actors or workflows is affected. A single slow sidecar (due to GC pressure, network latency, or resource contention) can cause all replicas in the namespace to lose actor routing for the duration of the timeout cycle. During rolling updates, the version storm can prevent new replicas from receiving placement tables for extended periods, causing actor invocations to fail.

Root Cause

Three issues in the placement server's dissemination logic:

1. **Nuclear timeout**: `handleTimeout` closed ALL streams on timeout, regardless of whether they had responded to the current dissemination phase. Healthy streams that had already acknowledged LOCK/UPDATE were disconnected alongside the slow one.

2. **No phase advancement on disconnect**: When a stream disconnected during an active dissemination round, the `streamsInTargetState` counter was not adjusted. If the disconnected stream was the last one that hadn't responded, the round would stall until the timeout fired, even though all remaining streams had already responded.

3. **Orphaned store entries**: During rolling updates, stream close events could arrive at the disseminator after the dissemination round had already completed, leaving stale host entries in the placement table.

Solution

- **Selective timeout**: `handleTimeout` now only closes streams that have NOT reached the current dissemination phase. Streams that responded successfully survive the timeout and participate in the next round. Waiting connections that were queued during the timed-out round are added to the new round instead of being cancelled.

- **Phase advancement on disconnect**: `handleCloseStream` now decrements `streamsInTargetState` when a counted stream disconnects and calls `advancePhase()` if removing the stream completes the current phase. This prevents rounds from stalling when a slow stream disconnects.

- **Delete batching**: Stream deletions during active dissemination are queued and processed when the round completes, combining multiple deletes into a single dissemination round. `handleAdd` also processes pending deletes before adding new streams, coalescing delete+add pairs during rolling updates.

- **Orphan cleanup**: After each dissemination round completes, the store is scanned for entries whose streams are no longer active. These orphaned entries are cleaned up in the next round.

Daprd placement reconnect hangs for 20 seconds on stale DNS

Problem

When a placement server pod is restarted (due to rolling update, eviction, or crash), daprd sidecars that were connected to the old pod attempt to reconnect using cached DNS entries. The cached IP address points to the terminated pod, and each connection attempt hangs for 20 seconds (TCP dial timeout) before trying the next address.

Impact

With a 3-node placement cluster, daprd can try up to 3 stale IPs sequentially, causing a **60-second reconnect delay** in the worst case. During this time, actor invocations and workflow operations fail because the sidecar has no placement table.

Root Cause

The DNS round-robin connector cached the IP addresses from the initial DNS lookup and only re-resolved when the cache was exhausted (all IPs tried). After a placement pod restart, the old IP remained in the cache. Since gRPC dials are lazy (they succeed immediately and fail on the first RPC), the stale IP was not detected until the sidecar tried to open a placement stream, which then hung for the full TCP dial timeout.

Solution

The DNS connector now re-resolves DNS on every `Connect` call instead of caching IPs across calls. Kubernetes headless service DNS always returns the current set of pod IPs, so each reconnect attempt immediately gets fresh addresses. The round-robin index is preserved across lookups to maintain even distribution.