### PR TITLE
golang.org/x/image v0.25.0 -> v0.38.0

### DIFF
--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -3,6 +3,7 @@
 This update contains bug fixes and security fixes:
 - [Actor method invocation returns 200 with empty body over h2c](#actor-method-invocation-returns-200-with-empty-body-over-h2c)
 - [Security: Fixes gRPC authorization bypass - CVE-2026-33186](#security-grpc-authorization-bypass)
+- [Security: Fixes TIFF image OOM denial of service - CVE-2026-33809](#security-tiff-image-oom-denial-of-service)
 - [False positive injection failure metrics for non-Dapr pods](#false-positive-injection-failure-metrics-for-non-dapr-pods)
 - [Placement dissemination timeout cascades across all replicas](#placement-dissemination-timeout-cascades-across-all-replicas)
 - [Daprd placement reconnect hangs for 20 seconds on stale DNS](#daprd-placement-reconnect-hangs-for-20-seconds-on-stale-dns)
@@ -53,6 +54,25 @@ This release upgrades the affected dependency to a version that resolves CVE-202
 
 Users are strongly encouraged to upgrade to this release.
 
+## Security: TIFF image OOM denial of service
+
+### Problem
+
+An upstream dependency (golang.org/x/image) used by Dapr contained a vulnerability that could cause an out-of-memory crash when decoding a maliciously crafted TIFF image (CVE-2026-33809).
+
+### Impact
+
+A malicious 8-byte TIFF file with an IFD offset of 0xFFFFFFFF could cause `golang.org/x/image/tiff.Decode` to allocate up to ~4GB of memory, leading to an out-of-memory crash.
+Any Dapr component or application path that processes untrusted TIFF image input through this library could be exploited for denial of service.
+
+### Root Cause
+
+The issue originated in the upstream `golang.org/x/image/tiff` library.
+The `buffer.fill()` function did not validate the IFD offset before allocating memory, allowing a crafted offset to trigger an unbounded allocation.
+
+### Solution
+
+This release upgrades `golang.org/x/image` from v0.25.0 to v0.38.0, which resolves CVE-2026-33809.
 
 ## False positive injection failure metrics for non-Dapr pods
 

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -44,7 +44,7 @@ An upstream dependency (google.golang.org/grpc) used by Dapr introduced a vulner
 
 Users running affected versions could be exposed to unauthorized gRPC requests.
 
-### Root cause
+### Root Cause
 
 The issue originated in an upstream library.
 

--- a/go.mod
+++ b/go.mod
@@ -460,7 +460,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/image v0.25.0 // indirect
+	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1956,8 +1956,8 @@ golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5N
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.25.0 h1:Y6uW6rH1y5y/LK1J8BPWZtr6yZ7hrsy6hFrXjgsc2fQ=
-golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
+golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
+golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
Security: TIFF image OOM denial of service

Problem

An upstream dependency (golang.org/x/image) used by Dapr contained a vulnerability that could cause an out-of-memory crash when decoding a maliciously crafted TIFF image (CVE-2026-33809).

Impact

A malicious 8-byte TIFF file with an IFD offset of 0xFFFFFFFF could cause `golang.org/x/image/tiff.Decode` to allocate up to ~4GB of memory, leading to an out-of-memory crash. Any Dapr component or application path that processes untrusted TIFF image input through this library could be exploited for denial of service.

Root Cause

The issue originated in the upstream `golang.org/x/image/tiff` library. The `buffer.fill()` function did not validate the IFD offset before allocating memory, allowing a crafted offset to trigger an unbounded allocation.

Solution

This release upgrades `golang.org/x/image` from v0.25.0 to v0.38.0, which resolves CVE-2026-33809.