### PR TITLE
Scheduler: fix silent cron exit on quorum change under load

### DIFF
--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -7,6 +7,7 @@ This update contains bug fixes and security fixes:
 - [False positive injection failure metrics for non-Dapr pods](#false-positive-injection-failure-metrics-for-non-dapr-pods)
 - [Placement dissemination timeout cascades across all replicas](#placement-dissemination-timeout-cascades-across-all-replicas)
 - [Daprd placement reconnect hangs for 20 seconds on stale DNS](#daprd-placement-reconnect-hangs-for-20-seconds-on-stale-dns)
+- [Scheduler instance silently stops participating after cluster scale-up](#scheduler-instance-silently-stops-participating-after-cluster-scale-up)
 
 ## Actor method invocation returns 200 with empty body over h2c
 
@@ -157,3 +158,50 @@ Since gRPC dials are lazy (they succeed immediately and fail on the first RPC), 
 The DNS connector now re-resolves DNS on every `Connect` call instead of caching IPs across calls.
 Kubernetes headless service DNS always returns the current set of pod IPs, so each reconnect attempt immediately gets fresh addresses.
 The round-robin index is preserved across lookups to maintain even distribution.
+
+## Scheduler instance silently stops participating after cluster scale-up
+
+### Problem
+
+After a Scheduler pod restart, rolling update, or cluster scale-up event, one or more Scheduler instances can silently stop participating in the cluster.
+The affected instance's pod remains running and passes health checks, but its cron engine exits and never restarts.
+The instance stops publishing its address to the WatchHosts API, so daprd sidecars never discover it.
+Jobs, Actor Reminders or Workflows assigned to the affected instance's partitions are never triggered.
+
+From a user's perspective, workflows, scheduled jobs, and actor reminders randomly stop firing after a Scheduler pod restart.
+The issue is intermittent and depends on the exact timing of the restart relative to other cluster activity.
+
+### Impact
+
+Any Dapr deployment running the Scheduler in a multi-instance (HA) configuration is affected.
+The issue is triggered when a Scheduler instance joins or rejoins the cluster, causing a leadership quorum change (e.g., partition count changes from 2 to 3).
+The likelihood increases with the number of connected daprd sidecars, as more WatchHosts subscribers means the host broadcast takes longer, widening the race window.
+
+When the bug is triggered:
+
+- The affected Scheduler instance owns partitions but cannot deliver jobs on them. All workflow activity timers, scheduled jobs, and actor reminders assigned to those partitions stop firing and are logged as `UNDELIVERABLE`.
+- Daprd sidecars that call `WatchHosts` may receive an incomplete host list (missing the affected instance), or may never receive a response at all — leaving the sidecar stuck on the `scheduler-watch-hosts` readiness gate indefinitely, preventing the application from becoming ready.
+- The remaining healthy instances cannot take over the affected instance's partitions because its leadership key remains in etcd (the lease keep-alive continues independently). The cluster is stuck in a state where all instances are running but quorum can never converge on the correct partition count.
+
+The only recovery is to restart all Scheduler pods simultaneously, which forces a fresh leadership election.
+
+### Root Cause
+
+When the Scheduler's internal cron module reaches leadership quorum after a partition change, it calls `runEngine` to start the cron engine.
+Before starting the engine, `runEngine` sends the updated cluster host addresses to an internal unbuffered Go channel (`WatchLeadership`) so that the WatchHosts API can broadcast them to connected sidecars.
+
+If the channel consumer is busy (for example, broadcasting a previous host update to many WatchHosts subscribers), the send blocks.
+Meanwhile, if another Scheduler instance joins and causes a second quorum change, the elected context is cancelled while the send is still blocked.
+
+Because the cron module has exited, it never calls `Reelect` to update its leadership key with the new partition total.
+The other Scheduler instances see this stale key and cannot reach quorum agreement, preventing the entire cluster from converging.
+
+### Solution
+
+The internal channel consumer in the Scheduler's cron wrapper has been replaced with a non-blocking event loop (`events/loop`).
+The loop's `Enqueue` method never blocks.
+If the current segment is full, it allocates a new one.
+This means the channel send from the cron library always completes immediately, regardless of how busy the consumer is with broadcasting.
+
+Since the send no longer blocks, the context cancellation race that caused the silent exit can no longer occur.
+The cron loop continues to call `Reelect` after each quorum change, leadership keys are updated with the correct partition total, and all instances converge normally.

--- a/pkg/scheduler/server/internal/cron/cron.go
+++ b/pkg/scheduler/server/internal/cron/cron.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool"
 	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/events/broadcaster"
+	"github.com/dapr/kit/events/loop"
 	"github.com/dapr/kit/logger"
 )
 
@@ -121,13 +122,28 @@ func (c *cron) Run(ctx context.Context) error {
 		Cron: c.etcdcron,
 	})
 
+	// Use a loop to process leadership updates. The loop's Enqueue is
+	// non-blocking, which prevents the go-etcd-cron wleaderCh send from
+	// blocking when the consumer is busy broadcasting to WatchHosts
+	// subscribers. Without this, a blocked send can race with elected context
+	// cancellation during quorum changes, causing the cron module to exit
+	// silently.
+	leaderLoop := loop.New[[]*anypb.Any](64).NewLoop(&leadership{
+		hostBroadcaster: c.hostBroadcaster,
+		lock:            &c.lock,
+		currHosts:       &c.currHosts,
+		readyCh:         c.readyCh,
+	})
+
 	return concurrency.NewRunnerManager(
 		c.connectionPool.Run,
 		c.etcdcron.Run,
+		leaderLoop.Run,
 		func(ctx context.Context) error {
 			defer log.Info("Cron shut down")
 			defer close(c.closeCh)
 			defer c.hostBroadcaster.Close()
+			defer leaderLoop.Close(nil)
 
 			for {
 				select {
@@ -137,28 +153,7 @@ func (c *cron) Run(ctx context.Context) error {
 					if !ok {
 						return nil
 					}
-
-					hosts := make([]*schedulerv1pb.Host, len(anyhosts))
-					for i, anyhost := range anyhosts {
-						var host schedulerv1pb.Host
-						if err := anyhost.UnmarshalTo(&host); err != nil {
-							return err
-						}
-						hosts[i] = &host
-					}
-
-					c.lock.Lock()
-					c.currHosts = hosts
-
-					select {
-					case <-c.readyCh:
-					default:
-						close(c.readyCh)
-						log.Info("Cron is ready")
-					}
-
-					c.hostBroadcaster.Broadcast(hosts)
-					c.lock.Unlock()
+					leaderLoop.Enqueue(anyhosts)
 				}
 			}
 		},

--- a/pkg/scheduler/server/internal/cron/cron_test.go
+++ b/pkg/scheduler/server/internal/cron/cron_test.go
@@ -62,10 +62,11 @@ func Test_quorum_convergence_after_scaleup(t *testing.T) {
 	}
 
 	errCh := make(chan error, 4)
+	started := 0
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(func() {
 		cancel()
-		for range 4 {
+		for range started {
 			select {
 			case <-time.After(time.Second * 10):
 				t.Fatal("timeout waiting for cron shutdown")
@@ -78,6 +79,7 @@ func Test_quorum_convergence_after_scaleup(t *testing.T) {
 	for i := range 2 {
 		go func() { errCh <- crs[i].Run(ctx) }()
 	}
+	started = 2
 
 	for i := range 2 {
 		_, err := crs[i].Client(ctx)
@@ -91,6 +93,7 @@ func Test_quorum_convergence_after_scaleup(t *testing.T) {
 	}, time.Second*5, time.Millisecond*10)
 
 	go func() { errCh <- crs[2].Run(ctx) }()
+	started++
 
 	_, err := crs[2].Client(ctx)
 	require.NoError(t, err, "instance 2 never became ready")
@@ -103,6 +106,7 @@ func Test_quorum_convergence_after_scaleup(t *testing.T) {
 	}, time.Second*5, time.Millisecond*10)
 
 	go func() { errCh <- crs[3].Run(ctx) }()
+	started++
 
 	_, err = crs[3].Client(ctx)
 	require.NoError(t, err, "instance 3 never became ready")

--- a/pkg/scheduler/server/internal/cron/cron_test.go
+++ b/pkg/scheduler/server/internal/cron/cron_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cron
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+)
+
+type fakeEtcd struct {
+	client *clientv3.Client
+}
+
+func (f *fakeEtcd) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (f *fakeEtcd) Client(context.Context) (*clientv3.Client, error) {
+	return f.client, nil
+}
+
+// Test_quorum_convergence_after_scaleup tests that the dapr cron wrapper
+// survives rapid quorum changes. The fix uses an events/loop to decouple the
+// WatchLeadership channel read from host broadcast processing, preventing the
+// go-etcd-cron wleaderCh send from blocking.
+func Test_quorum_convergence_after_scaleup(t *testing.T) {
+	t.Parallel()
+
+	client := embeddedEtcdClient(t)
+	etcdImpl := &fakeEtcd{client: client}
+
+	crs := make([]Interface, 4)
+	for i := range 4 {
+		crs[i] = New(Options{
+			ID:      strconv.Itoa(i),
+			Host:    &schedulerv1pb.Host{Address: "127.0.0.1:" + strconv.Itoa(50000+i)},
+			Etcd:    etcdImpl,
+			Workers: 1,
+		})
+	}
+
+	errCh := make(chan error, 4)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancel()
+		for range 4 {
+			select {
+			case <-time.After(time.Second * 10):
+				t.Fatal("timeout waiting for cron shutdown")
+			case err := <-errCh:
+				require.NoError(t, err)
+			}
+		}
+	})
+
+	for i := range 2 {
+		go func() { errCh <- crs[i].Run(ctx) }()
+	}
+
+	for i := range 2 {
+		_, err := crs[i].Client(ctx)
+		require.NoError(t, err, "instance %d never became ready", i)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := client.Get(t.Context(), "dapr/leadership", clientv3.WithPrefix())
+		require.NoError(c, err)
+		assert.Len(c, resp.Kvs, 2)
+	}, time.Second*5, time.Millisecond*10)
+
+	go func() { errCh <- crs[2].Run(ctx) }()
+
+	_, err := crs[2].Client(ctx)
+	require.NoError(t, err, "instance 2 never became ready")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var resp *clientv3.GetResponse
+		resp, err = client.Get(t.Context(), "dapr/leadership", clientv3.WithPrefix())
+		require.NoError(c, err)
+		assert.Len(c, resp.Kvs, 3)
+	}, time.Second*5, time.Millisecond*10)
+
+	go func() { errCh <- crs[3].Run(ctx) }()
+
+	_, err = crs[3].Client(ctx)
+	require.NoError(t, err, "instance 3 never became ready")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := client.Get(t.Context(), "dapr/leadership", clientv3.WithPrefix())
+		require.NoError(c, err)
+		assert.Len(c, resp.Kvs, 4)
+	}, time.Second*10, time.Millisecond*10)
+
+	for i := range 4 {
+		_, err := crs[i].Client(ctx)
+		require.NoError(t, err, "instance %d is no longer ready (cron likely exited silently)", i)
+	}
+}
+
+func embeddedEtcdClient(t *testing.T) *clientv3.Client {
+	t.Helper()
+
+	cfg := embed.NewConfig()
+	cfg.LogLevel = "error"
+	cfg.Dir = t.TempDir()
+	lurl, err := url.Parse("http://127.0.0.1:0")
+	require.NoError(t, err)
+	cfg.ListenPeerUrls = []url.URL{*lurl}
+	cfg.ListenClientUrls = []url.URL{*lurl}
+
+	etcd, err := embed.StartEtcd(cfg)
+	require.NoError(t, err)
+	t.Cleanup(etcd.Close)
+
+	cl, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{etcd.Clients[0].Addr().String()},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cl.Close()) })
+
+	select {
+	case <-etcd.Server.ReadyNotify():
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "etcd took too long to start")
+	}
+
+	return cl
+}

--- a/pkg/scheduler/server/internal/cron/leadership.go
+++ b/pkg/scheduler/server/internal/cron/leadership.go
@@ -58,9 +58,9 @@ func (h *leadership) Handle(ctx context.Context, anyhosts []*anypb.Any) error {
 		close(h.readyCh)
 		log.Info("Cron is ready")
 	}
-	h.lock.Unlock()
 
 	h.hostBroadcaster.Broadcast(hosts)
+	h.lock.Unlock()
 
 	return nil
 }

--- a/pkg/scheduler/server/internal/cron/leadership.go
+++ b/pkg/scheduler/server/internal/cron/leadership.go
@@ -58,9 +58,9 @@ func (h *leadership) Handle(ctx context.Context, anyhosts []*anypb.Any) error {
 		close(h.readyCh)
 		log.Info("Cron is ready")
 	}
+	h.lock.Unlock()
 
 	h.hostBroadcaster.Broadcast(hosts)
-	h.lock.Unlock()
 
 	return nil
 }

--- a/pkg/scheduler/server/internal/cron/leadership.go
+++ b/pkg/scheduler/server/internal/cron/leadership.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cron
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/kit/events/broadcaster"
+)
+
+// leadership processes leadership updates from go-etcd-cron. It unmarshals the
+// host addresses and broadcasts them to WatchHosts subscribers.
+type leadership struct {
+	hostBroadcaster *broadcaster.Broadcaster[[]*schedulerv1pb.Host]
+	lock            *sync.RWMutex
+	currHosts       *[]*schedulerv1pb.Host
+	readyCh         chan struct{}
+}
+
+// Handle processes a single leadership update. Called sequentially by the
+// events/loop for each enqueued event.
+func (h *leadership) Handle(ctx context.Context, anyhosts []*anypb.Any) error {
+	if ctx.Err() != nil || anyhosts == nil {
+		//nolint:nilerr
+		return nil
+	}
+
+	hosts := make([]*schedulerv1pb.Host, len(anyhosts))
+	for i, anyhost := range anyhosts {
+		var host schedulerv1pb.Host
+		if err := anyhost.UnmarshalTo(&host); err != nil {
+			return err
+		}
+		hosts[i] = &host
+	}
+
+	h.lock.Lock()
+	*h.currHosts = hosts
+
+	select {
+	case <-h.readyCh:
+	default:
+		close(h.readyCh)
+		log.Info("Cron is ready")
+	}
+
+	h.hostBroadcaster.Broadcast(hosts)
+	h.lock.Unlock()
+
+	return nil
+}

--- a/tests/integration/suite/scheduler/api/watchhosts/scaleup.go
+++ b/tests/integration/suite/scheduler/api/watchhosts/scaleup.go
@@ -93,6 +93,7 @@ func (s *scaleup) Run(t *testing.T, ctx context.Context) {
 		if !assert.NoError(c, err) {
 			return
 		}
+		defer stream.CloseSend()
 		resp, err := stream.Recv()
 		if !assert.NoError(c, err) {
 			return
@@ -153,6 +154,7 @@ func (s *scaleup) Run(t *testing.T, ctx context.Context) {
 		if !assert.NoError(c, err) {
 			return
 		}
+		defer stream.CloseSend()
 
 		resp, err := stream.Recv()
 		if !assert.NoError(c, err) {

--- a/tests/integration/suite/scheduler/api/watchhosts/scaleup.go
+++ b/tests/integration/suite/scheduler/api/watchhosts/scaleup.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchhosts
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(scaleup))
+}
+
+type scaleup struct {
+	scheduler1 *scheduler.Scheduler
+	scheduler2 *scheduler.Scheduler
+	scheduler3 *scheduler.Scheduler
+
+	s1addr string
+	s2addr string
+	s3addr string
+}
+
+func (s *scaleup) Setup(t *testing.T) []framework.Option {
+	if runtime.GOOS == "windows" {
+		t.Skip("Cleanup does not work cleanly on windows")
+	}
+
+	fp := ports.Reserve(t, 6)
+	port1, port2, port3 := fp.Port(t), fp.Port(t), fp.Port(t)
+	port4, port5, port6 := fp.Port(t), fp.Port(t), fp.Port(t)
+
+	clusterOpts := []scheduler.Option{
+		scheduler.WithInitialCluster(fmt.Sprintf(
+			"scheduler-0=http://127.0.0.1:%d,scheduler-1=http://127.0.0.1:%d,scheduler-2=http://127.0.0.1:%d",
+			port1, port2, port3),
+		),
+	}
+
+	s.scheduler1 = scheduler.New(t, append(clusterOpts,
+		scheduler.WithID("scheduler-0"),
+		scheduler.WithEtcdClientPort(port4),
+	)...)
+	s.scheduler2 = scheduler.New(t, append(clusterOpts,
+		scheduler.WithID("scheduler-1"),
+		scheduler.WithEtcdClientPort(port5),
+	)...)
+	s.scheduler3 = scheduler.New(t, append(clusterOpts,
+		scheduler.WithID("scheduler-2"),
+		scheduler.WithEtcdClientPort(port6),
+	)...)
+
+	s.s1addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(s.scheduler1.Port()))
+	s.s2addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(s.scheduler2.Port()))
+	s.s3addr = net.JoinHostPort("127.0.0.1", strconv.Itoa(s.scheduler3.Port()))
+
+	return []framework.Option{
+		framework.WithProcesses(fp, s.scheduler1, s.scheduler2),
+	}
+}
+
+func (s *scaleup) Run(t *testing.T, ctx context.Context) {
+	s.scheduler1.WaitUntilRunning(t, ctx)
+	s.scheduler2.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		stream, err := s.scheduler1.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+		if !assert.NoError(c, err) {
+			return
+		}
+		resp, err := stream.Recv()
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Len(c, resp.GetHosts(), 2)
+	}, time.Second*20, time.Millisecond*10)
+
+	const numWatchers = 500
+	for i := range numWatchers {
+		sched := s.scheduler1
+		if i%2 == 1 {
+			sched = s.scheduler2
+		}
+		stream, err := sched.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+		require.NoError(t, err, "failed to create WatchHosts stream %d", i)
+
+		_, err = stream.Recv()
+		require.NoError(t, err, "failed to recv initial WatchHosts %d", i)
+
+		t.Cleanup(func() {
+			require.NoError(t, stream.CloseSend())
+		})
+	}
+
+	const numJobs = 400
+	for i := range numJobs {
+		sched := s.scheduler1
+		if i%2 == 1 {
+			sched = s.scheduler2
+		}
+		_, err := sched.Client(t, ctx).ScheduleJob(ctx, &schedulerv1pb.ScheduleJobRequest{
+			Name: "load-" + strconv.Itoa(i),
+			Job:  &schedulerv1pb.Job{DueTime: new(time.Now().Format(time.RFC3339))},
+			Metadata: &schedulerv1pb.JobMetadata{
+				AppId: "load-app", Namespace: "default",
+				Target: &schedulerv1pb.JobTargetMetadata{
+					Type: &schedulerv1pb.JobTargetMetadata_Job{
+						Job: new(schedulerv1pb.TargetJob),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	triggered := s.scheduler1.WatchJobsSuccess(t, ctx,
+		&schedulerv1pb.WatchJobsRequestInitial{
+			AppId: "post-scaleup", Namespace: "default",
+		},
+	)
+
+	s.scheduler3.Run(t, ctx)
+	t.Cleanup(func() { s.scheduler3.Cleanup(t) })
+	s.scheduler3.WaitUntilRunning(t, ctx)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		stream, err := s.scheduler1.Client(t, ctx).WatchHosts(ctx, new(schedulerv1pb.WatchHostsRequest))
+		if !assert.NoError(c, err) {
+			return
+		}
+
+		resp, err := stream.Recv()
+		if !assert.NoError(c, err) {
+			return
+		}
+
+		got := make([]string, 0, len(resp.GetHosts()))
+		for _, host := range resp.GetHosts() {
+			got = append(got, host.GetAddress())
+		}
+
+		assert.ElementsMatch(c, []string{s.s1addr, s.s2addr, s.s3addr}, got)
+	}, time.Second*30, time.Millisecond*100)
+
+	for i := range 30 {
+		_, err := s.scheduler1.Client(t, ctx).ScheduleJob(ctx, &schedulerv1pb.ScheduleJobRequest{
+			Name: "post-" + strconv.Itoa(i),
+			Job:  &schedulerv1pb.Job{DueTime: new(time.Now().Format(time.RFC3339))},
+			Metadata: &schedulerv1pb.JobMetadata{
+				AppId: "post-scaleup", Namespace: "default",
+				Target: &schedulerv1pb.JobTargetMetadata{
+					Type: &schedulerv1pb.JobTargetMetadata_Job{
+						Job: new(schedulerv1pb.TargetJob),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case name := <-triggered:
+			assert.Contains(c, name, "post-")
+		default:
+			assert.Fail(c, "no post-scaleup job triggered")
+		}
+	}, time.Second*20, time.Millisecond*10)
+}


### PR DESCRIPTION
Marked to backport to 1.17.3 and 1.16.11.

---

When a Scheduler instance joins or rejoins the cluster, the leadership quorum changes (e.g., 2->3). The cron module's runEngine sends updated host addresses to an unbuffered WatchLeadership channel before starting the engine. If the consumer is busy broadcasting to many WatchHosts subscribers, the send blocks. A second quorum change cancels the elected context while the send is blocked, causing runEngine to return context.Canceled. The cron loop treats this as terminal and exits silently. No error is logged, no re-election is attempted, and the leadership key remains stuck at the old partition total. The other instances cannot converge, leaving the affected instance's jobs permanently undeliverable.

Replace the direct channel consumer with a non-blocking events/loop. Enqueue never blocks, so the WatchLeadership channel send always completes before the context cancellation can race with it.

---

Scheduler instance silently stops participating after cluster scale-up

Problem

After a Scheduler pod restart, rolling update, or cluster scale-up event, one or more Scheduler instances can silently stop participating in the cluster. The affected instance's pod remains running and passes health checks, but its cron engine exits and never restarts. The instance stops publishing its address to the WatchHosts API, so daprd sidecars never discover it. Jobs, Actor Reminders or Workflows assigned to the affected instance's partitions are never triggered.

From a user's perspective, workflows, scheduled jobs, and actor reminders randomly stop firing after a Scheduler pod restart. The issue is intermittent and depends on the exact timing of the restart relative to other cluster activity.

Impact

Any Dapr deployment running the Scheduler in a multi-instance (HA) configuration is affected. The issue is triggered when a Scheduler instance joins or rejoins the cluster, causing a leadership quorum change (e.g., partition count changes from 2 to 3). The likelihood increases with the number of connected daprd sidecars, as more WatchHosts subscribers means the host broadcast takes longer, widening the race window.

When the bug is triggered:

- The affected Scheduler instance owns partitions but cannot deliver jobs on them. All workflow activity timers, scheduled jobs, and actor reminders assigned to those partitions stop firing and are logged as `UNDELIVERABLE`.
- Daprd sidecars that call `WatchHosts` may receive an incomplete host list (missing the affected instance), or may never receive a response at all — leaving the sidecar stuck on the `scheduler-watch-hosts` readiness gate indefinitely, preventing the application from becoming ready.
- The remaining healthy instances cannot take over the affected instance's partitions because its leadership key remains in etcd (the lease keep-alive continues independently). The cluster is stuck in a state where all instances are running but quorum can never converge on the correct partition count.

The only recovery is to restart all Scheduler pods simultaneously, which forces a fresh leadership election.

Root Cause

When the Scheduler's internal cron module reaches leadership quorum after a partition change, it calls `runEngine` to start the cron engine. Before starting the engine, `runEngine` sends the updated cluster host addresses to an internal unbuffered Go channel (`WatchLeadership`) so that the WatchHosts API can broadcast them to connected sidecars.

If the channel consumer is busy (for example, broadcasting a previous host update to many WatchHosts subscribers), the send blocks. Meanwhile, if another Scheduler instance joins and causes a second quorum change, the elected context is cancelled while the send is still blocked.

Because the cron module has exited, it never calls `Reelect` to update its leadership key with the new partition total. The other Scheduler instances see this stale key and cannot reach quorum agreement, preventing the entire cluster from converging.

Solution

The internal channel consumer in the Scheduler's cron wrapper has been replaced with a non-blocking event loop (`events/loop`). The loop's `Enqueue` method never blocks.
If the current segment is full, it allocates a new one. This means the channel send from the cron library always completes immediately, regardless of how busy the consumer is with broadcasting.

Since the send no longer blocks, the context cancellation race that caused the silent exit can no longer occur. The cron loop continues to call `Reelect` after each quorum change, leadership keys are updated with the correct partition total, and all instances converge normally.