### PR TITLE
restore os.version in Windows docker image manifests

### DIFF
--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -264,66 +264,66 @@ endif
 docker-manifest-create: SHELL := $(shell which bash)
 docker-manifest-create: check-docker-env
 ifeq ($(ONLY_DAPR_IMAGE),true)
-	$(DOCKER) buildx imagetools create -t $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
-	$(DOCKER) buildx imagetools inspect $(DOCKER_IMAGE):$(DAPR_TAG)
+	$(DOCKER) manifest create $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
+	$(DOCKER) manifest push $(DOCKER_IMAGE):$(DAPR_TAG)
 else
-	$(DOCKER) buildx imagetools create -t $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
-	$(DOCKER) buildx imagetools inspect $(DOCKER_IMAGE):$(DAPR_TAG)
+	$(DOCKER) manifest create $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
+	$(DOCKER) manifest push $(DOCKER_IMAGE):$(DAPR_TAG)
 	if [[ "$(BINARIES)" == *"daprd"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"placement"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"sentry"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"operator"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"injector"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"scheduler"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 endif
 ifeq ($(LATEST_RELEASE),true)
 ifeq ($(ONLY_DAPR_IMAGE),true)
-	$(DOCKER) buildx imagetools create -t $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
-	$(DOCKER) buildx imagetools inspect $(DOCKER_IMAGE):$(LATEST_TAG)
+	$(DOCKER) manifest create $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
+	$(DOCKER) manifest push $(DOCKER_IMAGE):$(LATEST_TAG)
 else
-	$(DOCKER) buildx imagetools create -t $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
-	$(DOCKER) buildx imagetools inspect $(DOCKER_IMAGE):$(LATEST_TAG)
+	$(DOCKER) manifest create $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
+	$(DOCKER) manifest push $(DOCKER_IMAGE):$(LATEST_TAG)
 	if [[ "$(BINARIES)" == *"daprd"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"placement"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"sentry"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"operator"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"injector"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"scheduler"* ]]; then \
-	$(DOCKER) buildx imagetools create -t $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) buildx imagetools inspect $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 endif
 endif

--- a/docs/release_notes/v1.16.11.md
+++ b/docs/release_notes/v1.16.11.md
@@ -1,0 +1,31 @@
+# Dapr 1.16.11
+
+This update includes bug fixes:
+
+- [Windows sidecar container fails to start on AKS due to missing OSVersion in image manifest](#windows-sidecar-container-fails-to-start-on-aks-due-to-missing-osversion-in-image-manifest)
+
+## Windows sidecar container fails to start on AKS due to missing OSVersion in image manifest
+
+### Problem
+
+Starting with Dapr v1.16.9, the Dapr sidecar container (`daprd`) fails to start on AKS Windows nodes with the error:
+
+```
+hcs::CreateComputeSystem daprd: The container operating system does not match the host operating system.
+```
+
+### Impact
+
+All Windows-based Dapr sidecar deployments on AKS are broken from v1.16.9 onward. The `daprd` container enters `CrashLoopBackOff` and never starts. Linux deployments are unaffected.
+
+### Root Cause
+
+In v1.16.9, the `docker-manifest-create` target in `docker/docker.mk` was changed from using `docker manifest create` / `docker manifest push` to `docker buildx imagetools create`.
+
+The `docker manifest` commands automatically read `os.version` from each source image's config and include it in the manifest list entries. The `docker buildx imagetools create` command does not carry the `os.version` field through to the manifest list.
+
+Without `os.version` on the Windows manifest entries, the Windows container runtime cannot distinguish between the two `windows/amd64` images (Server 2019 and Server 2022) and pulls the wrong variant for the host OS build.
+
+### Solution
+
+Reverted the `docker-manifest-create` target to use `docker manifest create` and `docker manifest push`, restoring the `os.version` field in the manifest list entries for Windows images.

--- a/docs/release_notes/v1.17.3.md
+++ b/docs/release_notes/v1.17.3.md
@@ -8,6 +8,7 @@ This update contains bug fixes and security fixes:
 - [Placement dissemination timeout cascades across all replicas](#placement-dissemination-timeout-cascades-across-all-replicas)
 - [Daprd placement reconnect hangs for 20 seconds on stale DNS](#daprd-placement-reconnect-hangs-for-20-seconds-on-stale-dns)
 - [Scheduler instance silently stops participating after cluster scale-up](#scheduler-instance-silently-stops-participating-after-cluster-scale-up)
+- [Windows sidecar container fails to start on AKS due to missing OSVersion in image manifest](#windows-sidecar-container-fails-to-start-on-aks-due-to-missing-osversion-in-image-manifest)
 
 ## Actor method invocation returns 200 with empty body over h2c
 
@@ -205,3 +206,30 @@ This means the channel send from the cron library always completes immediately, 
 
 Since the send no longer blocks, the context cancellation race that caused the silent exit can no longer occur.
 The cron loop continues to call `Reelect` after each quorum change, leadership keys are updated with the correct partition total, and all instances converge normally.
+
+## Windows sidecar container fails to start on AKS due to missing OSVersion in image manifest
+
+### Problem
+
+Starting with Dapr v1.16.9, the Dapr sidecar container (`daprd`) fails to start on AKS Windows nodes with the error:
+
+```
+hcs::CreateComputeSystem daprd: The container operating system does not match the host operating system.
+```
+
+### Impact
+
+All Windows-based Dapr sidecar deployments on AKS are broken from v1.16.9 onward. The `daprd` container enters `CrashLoopBackOff` and never starts. Linux deployments are unaffected.
+
+### Root Cause
+
+In v1.16.9, the `docker-manifest-create` target in `docker/docker.mk` was changed from using `docker manifest create` / `docker manifest push` to `docker buildx imagetools create`.
+
+The `docker manifest` commands automatically read `os.version` from each source image's config and include it in the manifest list entries.
+The `docker buildx imagetools create` command does not carry the `os.version` field through to the manifest list.
+
+Without `os.version` on the Windows manifest entries, the Windows container runtime cannot distinguish between the two `windows/amd64` images (Server 2019 and Server 2022) and pulls the wrong variant for the host OS build.
+
+### Solution
+
+Reverted the `docker-manifest-create` target to use `docker manifest create` and `docker manifest push`, restoring the `os.version` field in the manifest list entries for Windows images.


### PR DESCRIPTION
Backport to v1.16.x and v1.17.x

The docker-manifest-create target was changed from `docker manifest create/push` to `docker buildx imagetools create` in v1.16.9, which dropped the os.version field from Windows manifest entries. Without os.version, AKS Windows nodes cannot distinguish between the Server 2019 and Server 2022 image variants, causing daprd to fail with "The container operating system does not match the host operating system".

Revert to `docker manifest create/push` which automatically preserves os.version from source image configs.

Fixes: dapr/dapr#9699