### PR TITLE
Add --amend and --purge flags to docker manifest commands

### DIFF
--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -264,66 +264,66 @@ endif
 docker-manifest-create: SHELL := $(shell which bash)
 docker-manifest-create: check-docker-env
 ifeq ($(ONLY_DAPR_IMAGE),true)
-	$(DOCKER) manifest create $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
-	$(DOCKER) manifest push $(DOCKER_IMAGE):$(DAPR_TAG)
+	$(DOCKER) manifest create --amend $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
+	$(DOCKER) manifest push --purge $(DOCKER_IMAGE):$(DAPR_TAG)
 else
-	$(DOCKER) manifest create $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
-	$(DOCKER) manifest push $(DOCKER_IMAGE):$(DAPR_TAG)
+	$(DOCKER) manifest create --amend $(DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_TAG)-%)
+	$(DOCKER) manifest push --purge $(DOCKER_IMAGE):$(DAPR_TAG)
 	if [[ "$(BINARIES)" == *"daprd"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_RUNTIME_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"placement"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_PLACEMENT_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"sentry"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_SENTRY_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"operator"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_OPERATOR_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"injector"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_INJECTOR_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"scheduler"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_SCHEDULER_DOCKER_IMAGE):$(DAPR_TAG); \
 	fi
 endif
 ifeq ($(LATEST_RELEASE),true)
 ifeq ($(ONLY_DAPR_IMAGE),true)
-	$(DOCKER) manifest create $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
-	$(DOCKER) manifest push $(DOCKER_IMAGE):$(LATEST_TAG)
+	$(DOCKER) manifest create --amend $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
+	$(DOCKER) manifest push --purge $(DOCKER_IMAGE):$(LATEST_TAG)
 else
-	$(DOCKER) manifest create $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
-	$(DOCKER) manifest push $(DOCKER_IMAGE):$(LATEST_TAG)
+	$(DOCKER) manifest create --amend $(DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%)
+	$(DOCKER) manifest push --purge $(DOCKER_IMAGE):$(LATEST_TAG)
 	if [[ "$(BINARIES)" == *"daprd"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_RUNTIME_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_RUNTIME_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"placement"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_PLACEMENT_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_PLACEMENT_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"sentry"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SENTRY_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_SENTRY_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"operator"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_OPERATOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_OPERATOR_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"injector"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_INJECTOR_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_INJECTOR_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 	if [[ "$(BINARIES)" == *"scheduler"* ]]; then \
-	$(DOCKER) manifest create $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
-	$(DOCKER) manifest push $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG); \
+	$(DOCKER) manifest create --amend $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG) $(DOCKER_MULTI_ARCH:%=$(DAPR_SCHEDULER_DOCKER_IMAGE):$(MANIFEST_LATEST_TAG)-%); \
+	$(DOCKER) manifest push --purge $(DAPR_SCHEDULER_DOCKER_IMAGE):$(LATEST_TAG); \
 	fi
 endif
 endif


### PR DESCRIPTION
docker manifest create fails if a local manifest already exists from a previous run. Add --amend so it updates in place, and --purge on push to clean up local state afterward. This makes docker-manifest-create idempotent for CI retries.