### PR TITLE
fix: make DeliverBulk fallthru consistent with Deliver for empty status

### DIFF
--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -303,8 +303,12 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 			if _, ok := (*bscData.EntryIdIndexMap)[response.EntryId]; ok {
 				switch response.Status {
 				case "":
-					// When statusCode 2xx, Consider empty status field OR not receiving status for an item as retry
+					// Consider empty status field as success, consistent with Deliver
 					fallthrough
+				case contribpubsub.Success:
+					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Success)]++
+					entryRespReceived[response.EntryId] = true
+					todo.AddBulkResponseEntry(&bsrr.Entries, response.EntryId, nil)
 				case contribpubsub.Retry:
 					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Retry)]++
 					entryRespReceived[response.EntryId] = true
@@ -312,10 +316,6 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 						fmt.Errorf("RETRY required while processing bulk subscribe event for entry id: %v", response.EntryId))
 
 					hasAnyError = true
-				case contribpubsub.Success:
-					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Success)]++
-					entryRespReceived[response.EntryId] = true
-					todo.AddBulkResponseEntry(&bsrr.Entries, response.EntryId, nil)
 				case contribpubsub.Drop:
 					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Drop)]++
 					entryRespReceived[response.EntryId] = true


### PR DESCRIPTION
## Description

Fixes #8737.

`DeliverBulk` in the HTTP postman treated an empty response status (`""`) as a retry, while `Deliver` treated it as success. This inconsistency meant bulk subscriptions would unnecessarily retry messages that the app considered successful (2xx response with no explicit status field).

This PR aligns `DeliverBulk` with `Deliver` by changing the `case ""` fallthrough target from `Retry` to `Success`.

### Before (inconsistent)

| Function | Empty status `""` behavior |
|---|---|
| `Deliver` | Falls through to **Success** |
| `DeliverBulk` | Falls through to **Retry** |

### After (consistent)

| Function | Empty status `""` behavior |
|---|---|
| `Deliver` | Falls through to **Success** |
| `DeliverBulk` | Falls through to **Success** |

## Issue reference

Per [this discussion](https://github.com/dapr/dapr/pull/8692#discussion_r2099378669), the `Deliver` and `DeliverBulk` switch cases handle `""` differently. One falls through to retry, the other to success. This change makes them consistent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage

Existing unit tests pass (`go test -tags=unit ./pkg/runtime/subscription/postman/http/ -v`). The `Deliver` tests already validate that empty status returns no error (success), confirming the intended behavior.