### PR TITLE
fix: preserve trailing slash for header-based invocation

### DIFF
--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -366,7 +366,7 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 // 3. URL parameter: `http://localhost:3500/v1.0/invoke/<app-id>/method/<method>`
 func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string, method string) {
 	if appID := headers.Get(consts.DaprAppIDHeader); appID != "" {
-		targetID, method = appID, strings.TrimPrefix(path.Clean(reqPath), "/")
+		targetID, method = appID, cleanReqPathPreserveTrailingSlash(reqPath)
 		// Delete the header as it should not be passed forward with the request and is only used by the Dapr API
 		headers.Del(consts.DaprAppIDHeader)
 		return targetID, method
@@ -376,7 +376,7 @@ func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string
 		if s, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic ")); err == nil {
 			pair := strings.Split(string(s), ":")
 			if len(pair) == 2 && strings.EqualFold(pair[0], consts.DaprAppIDHeader) {
-				return pair[1], strings.TrimPrefix(path.Clean(reqPath), "/")
+				return pair[1], cleanReqPathPreserveTrailingSlash(reqPath)
 			}
 		}
 	}
@@ -405,6 +405,15 @@ func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string
 	}
 
 	return "", ""
+}
+
+func cleanReqPathPreserveTrailingSlash(reqPath string) string {
+	cleaned := path.Clean(reqPath)
+	if strings.HasSuffix(reqPath, "/") && cleaned != "/" {
+		cleaned += "/"
+	}
+
+	return strings.TrimPrefix(cleaned, "/")
 }
 
 // Returns true if a path has the parts as prefix (and a trailing slash), and returns the index of the first byte after the prefix (and after any trailing slashes).

--- a/pkg/api/http/directmessaging_test.go
+++ b/pkg/api/http/directmessaging_test.go
@@ -1062,7 +1062,9 @@ func TestFindTargetIDAndMethod(t *testing.T) {
 		wantMethod   string
 	}{
 		{name: "dapr-app-id header", path: "/foo/bar", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar"},
+		{name: "dapr-app-id header preserves trailing slash", path: "/foo/bar/", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar/"},
 		{name: "basic auth", path: "/foo/bar", headers: http.Header{"Authorization": []string{"Basic ZGFwci1hcHAtaWQ6YXV0aA=="}}, wantTargetID: "auth", wantMethod: "foo/bar"},
+		{name: "basic auth preserves trailing slash", path: "/foo/bar/", headers: http.Header{"Authorization": []string{"Basic ZGFwci1hcHAtaWQ6YXV0aA=="}}, wantTargetID: "auth", wantMethod: "foo/bar/"},
 		{name: "dapr-app-id header has priority over basic auth", path: "/foo/bar", headers: http.Header{"Dapr-App-Id": []string{"myapp"}, "Authorization": []string{"Basic ZGFwci1hcHAtaWQ6YXV0aA=="}}, wantTargetID: "myapp", wantMethod: "foo/bar"},
 		{name: "path with internal target", path: "/v1.0/invoke/myapp/method/foo", wantTargetID: "myapp", wantMethod: "foo"},
 		{name: "basic auth has priority over path", path: "/v1.0/invoke/myapp/method/foo", headers: http.Header{"Authorization": []string{"Basic ZGFwci1hcHAtaWQ6YXV0aA=="}}, wantTargetID: "auth", wantMethod: "v1.0/invoke/myapp/method/foo"},
@@ -1074,6 +1076,7 @@ func TestFindTargetIDAndMethod(t *testing.T) {
 		{name: "path with https target escaped", path: "/v1.0/invoke/https%3A%2F%2Fexample.com/method/foo", wantTargetID: "https://example.com", wantMethod: "foo"},
 		{name: "path with https target partly escaped", path: "/v1.0/invoke/https%3A/%2Fexample.com/method/foo", wantTargetID: "https://example.com", wantMethod: "foo"},
 		{name: "extra slashes are removed", path: "///foo//bar", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar"},
+		{name: "extra slashes are removed while preserving trailing slash", path: "///foo//bar/", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar/"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
