### PR TITLE
fix: clean up dapr services for non-enabled workloads

### DIFF
--- a/pkg/operator/handlers/dapr_handler.go
+++ b/pkg/operator/handlers/dapr_handler.go
@@ -189,6 +189,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			log.Errorf("failed to ensure dapr service present, err: %v", err)
 			return ctrl.Result{Requeue: true}, err
 		}
+	} else {
+		err := r.cleanupOwnedDaprServices(ctx, req.Namespace, req.Name, wrapper.GetObject())
+		if err != nil {
+			log.Errorf("failed to cleanup dapr services, err: %v", err)
+			return ctrl.Result{Requeue: true}, err
+		}
 	}
 
 	return ctrl.Result{}, nil
@@ -260,6 +266,45 @@ func (h *DaprHandler) createDaprService(ctx context.Context, expectedService typ
 	}
 	log.Debugf("created service: %s", expectedService)
 	monitoring.RecordServiceCreatedCount(appID)
+	return nil
+}
+
+func (h *DaprHandler) cleanupOwnedDaprServices(ctx context.Context, namespace, ownerName string, ownerObj client.Object) error {
+	ownerKind := ownerKindForObject(ownerObj)
+	if ownerKind == "" {
+		return nil
+	}
+
+	var services corev1.ServiceList
+	err := h.List(ctx, &services, client.InNamespace(namespace))
+	if err != nil {
+		return err
+	}
+
+	for i := range services.Items {
+		service := &services.Items[i]
+		if !strings.IsTruthy(service.Labels[annotations.KeyEnabled]) {
+			continue
+		}
+
+		owner := metaV1.GetControllerOf(service)
+		if owner == nil || owner.Name != ownerName || owner.Kind != ownerKind || !h.isReconciled(owner) {
+			continue
+		}
+
+		err = h.Delete(ctx, service)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		appID := service.Annotations[annotations.KeyAppID]
+		if appID == "" {
+			appID = ownerName
+		}
+		log.Debugf("deleted service: %s/%s", service.Namespace, service.Name)
+		monitoring.RecordServiceDeletedCount(appID)
+	}
+
 	return nil
 }
 
@@ -381,4 +426,17 @@ func (h *DaprHandler) isReconciled(owner *metaV1.OwnerReference) bool {
 	}
 
 	return false
+}
+
+func ownerKindForObject(obj client.Object) string {
+	switch obj.(type) {
+	case *appsv1.Deployment:
+		return "Deployment"
+	case *appsv1.StatefulSet:
+		return "StatefulSet"
+	case *argov1alpha1.Rollout:
+		return rollouts.RolloutKind
+	default:
+		return ""
+	}
 }

--- a/pkg/operator/handlers/dapr_handler_test.go
+++ b/pkg/operator/handlers/dapr_handler_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/dapr/dapr/pkg/injector/annotations"
@@ -255,6 +257,91 @@ func TestPatchDaprService(t *testing.T) {
 	assert.Len(t, actualService.OwnerReferences, 1)
 	assert.Equal(t, "Deployment", actualService.OwnerReferences[0].Kind)
 	assert.Equal(t, "app", actualService.OwnerReferences[0].Name)
+}
+
+func TestReconcileDeletesOwnedDaprServiceWhenNotAnnotated(t *testing.T) {
+	testDaprHandler := getTestDaprHandler()
+
+	s := runtime.NewScheme()
+	err := scheme.AddToScheme(s)
+	require.NoError(t, err)
+	testDaprHandler.Scheme = s
+
+	deployment := getDeployment("myapp", "false")
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(deployment.GetObject()).Build()
+	testDaprHandler.Client = cli
+
+	ctx := t.Context()
+	serviceName := types.NamespacedName{
+		Namespace: "test",
+		Name:      testDaprHandler.daprServiceName("myapp"),
+	}
+
+	err = testDaprHandler.createDaprService(ctx, serviceName, deployment)
+	require.NoError(t, err)
+
+	reconciler := &Reconciler{
+		DaprHandler: testDaprHandler,
+		newWrapper: func() ObjectWrapper {
+			return &DeploymentWrapper{}
+		},
+	}
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "test",
+			Name:      "app",
+		},
+	})
+	require.NoError(t, err)
+
+	var actualService corev1.Service
+	err = cli.Get(ctx, serviceName, &actualService)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestReconcileDeletesOwnedDaprServiceWhenOwnerMissing(t *testing.T) {
+	testDaprHandler := getTestDaprHandler()
+
+	s := runtime.NewScheme()
+	err := scheme.AddToScheme(s)
+	require.NoError(t, err)
+	testDaprHandler.Scheme = s
+
+	deployment := getDeployment("myapp", "true")
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(deployment.GetObject()).Build()
+	testDaprHandler.Client = cli
+
+	ctx := t.Context()
+	serviceName := types.NamespacedName{
+		Namespace: "test",
+		Name:      testDaprHandler.daprServiceName("myapp"),
+	}
+
+	err = testDaprHandler.createDaprService(ctx, serviceName, deployment)
+	require.NoError(t, err)
+
+	err = cli.Delete(ctx, deployment.GetObject())
+	require.NoError(t, err)
+
+	reconciler := &Reconciler{
+		DaprHandler: testDaprHandler,
+		newWrapper: func() ObjectWrapper {
+			return &DeploymentWrapper{}
+		},
+	}
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "test",
+			Name:      "app",
+		},
+	})
+	require.NoError(t, err)
+
+	var actualService corev1.Service
+	err = cli.Get(ctx, serviceName, &actualService)
+	require.True(t, apierrors.IsNotFound(err))
 }
 
 func TestGetGRPCPort(t *testing.T) {


### PR DESCRIPTION
## Description
This change deletes Dapr-managed Kubernetes Service resources when the owning workload is no longer Dapr-enabled. Without this cleanup, Services created for Dapr-enabled workloads can remain behind after the Dapr annotations are removed, and they may continue to be recreated unexpectedly.

## Issue reference
Fixes #7933

## Checklist
- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#7933
- [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#7933
- [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#7933
