### PR TITLE
fix: improve component startup failure logging

### DIFF
--- a/pkg/runtime/processor/components.go
+++ b/pkg/runtime/processor/components.go
@@ -208,7 +208,7 @@ func (p *Processor) WaitForEmptyComponentQueue() {
 }
 
 func (p *Processor) processComponentAndDependents(ctx context.Context, comp componentsapi.Component) error {
-	log.Debug("Loading component: " + comp.LogName())
+	log.Info("Loading component: " + comp.LogName())
 
 	res := p.preprocessOneComponent(ctx, &comp)
 	if res.unreadyDependency != "" {

--- a/pkg/runtime/processor/processor_test.go
+++ b/pkg/runtime/processor/processor_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package processor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -503,6 +504,47 @@ func TestProcessNoWorkflow(t *testing.T) {
 	proc, _ := newTestProc()
 	_, ok := proc.managers[components.CategoryWorkflow]
 	require.False(t, ok, "workflow cannot be registered as user facing component")
+}
+
+func TestProcessComponentLogsBeforeInitFailure(t *testing.T) {
+	prev := log
+	testLog := logger.NewLogger("test-runtime-processor")
+	logDest := &bytes.Buffer{}
+	testLog.SetOutput(logDest)
+	testLog.SetOutputLevel(logger.InfoLevel)
+	log = testLog
+	t.Cleanup(func() {
+		log = prev
+	})
+
+	proc, reg := newTestProc()
+	mockPubSub := new(daprt.MockPubSub)
+
+	reg.PubSubs().RegisterComponent(
+		func(_ logger.Logger) pubsub.PubSub {
+			return mockPubSub
+		},
+		"mockPubSub",
+	)
+
+	comp := componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpubsub",
+		},
+		Spec: componentsapi.ComponentSpec{
+			Type:        "pubsub.mockPubSub",
+			Version:     "v1",
+			Metadata:    daprt.GetFakeMetadataItems(),
+			InitTimeout: "2",
+		},
+	}
+
+	mockPubSub.On("Init", mock.Anything).Return(errors.New("error"))
+
+	err := proc.processComponentAndDependents(t.Context(), comp)
+	require.Error(t, err)
+	assert.Contains(t, logDest.String(), "Loading component: "+comp.LogName())
+	assert.Contains(t, logDest.String(), "Failed to init component "+comp.LogName()+":")
 }
 
 func TestReporter(t *testing.T) {


### PR DESCRIPTION
## Description
This change makes component startup logs more descriptive by emitting the "Loading component" message at info level. Without this, a startup failure can show the init error but still hide the component currently being processed in normal log output unless debug logging is enabled.

## Issue reference
Fixes #8236

## Checklist
- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#8236
- [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#8236
- [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#8236