### PR TITLE
Fix Sentry regenerating certificates when ConfigMap is out of sync

### DIFF
--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -80,7 +80,17 @@ type Signer interface {
 // store is the interface for the trust bundle backend store.
 type store interface {
 	store(context.Context, bundle.Bundle) error
-	get(context.Context) (bundle.Bundle, error)
+	// get returns the bundle and a boolean indicating whether the store is out
+	// of sync and the bundle needs to be re-persisted (e.g. ConfigMap diverged
+	// from Secret in Kubernetes mode).
+	get(context.Context) (bundle.Bundle, bool, error)
+}
+
+// configMapSyncer is an optional interface that a store can implement to
+// re-sync only the ConfigMap without rewriting the Secret. This avoids
+// unnecessary Secret updates when the certificates are already correct.
+type configMapSyncer interface {
+	syncConfigMap(context.Context, bundle.Bundle) error
 }
 
 // ca is the implementation of the CA Signer.
@@ -110,12 +120,13 @@ func New(ctx context.Context, conf config.Config) (Signer, error) {
 		castore = &selfhosted{config: conf}
 	}
 
-	bndle, err := castore.get(ctx)
+	bndle, needsSync, err := castore.get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CA bundle: %w", err)
 	}
 
 	var needsWrite bool
+
 	if bndle.X509 == nil {
 		needsWrite = true
 
@@ -162,6 +173,22 @@ func New(ctx context.Context, conf config.Config) (Signer, error) {
 
 		bndle.JWT = jwt
 		log.Info("Generating JWT signing key and persisting to store")
+	}
+
+	// When the ConfigMap is out of sync but no new certs were generated,
+	// only re-sync the ConfigMap to avoid an unnecessary Secret write.
+	if needsSync && !needsWrite {
+		if syncer, ok := castore.(configMapSyncer); ok {
+			log.Info("Trust bundle ConfigMap is out of sync; re-syncing ConfigMap only")
+			if err := syncer.syncConfigMap(ctx, bndle); err != nil {
+				return nil, fmt.Errorf("failed to sync trust bundle configmap: %w", err)
+			}
+			log.Info("Trust bundle ConfigMap re-synced successfully")
+		} else {
+			// Fallback for stores that don't support partial sync.
+			needsWrite = true
+			log.Info("Trust bundle store is out of sync; will re-persist bundle")
+		}
 	}
 
 	if needsWrite {

--- a/pkg/sentry/server/ca/kube.go
+++ b/pkg/sentry/server/ca/kube.go
@@ -41,11 +41,13 @@ type kube struct {
 }
 
 // get retrieves the existing certificate bundle from Kubernetes.
-func (k *kube) get(ctx context.Context) (bundle.Bundle, error) {
+// It returns the bundle, a boolean indicating whether the ConfigMap needs to
+// be re-synced with the Secret, and any error.
+func (k *kube) get(ctx context.Context) (bundle.Bundle, bool, error) {
 	// Get the trust bundle secret
 	secret, err := k.client.CoreV1().Secrets(k.namespace).Get(ctx, TrustBundleK8sName, metav1.GetOptions{})
 	if err != nil {
-		return bundle.Bundle{}, fmt.Errorf("failed to get trust bundle secret: %w", err)
+		return bundle.Bundle{}, false, fmt.Errorf("failed to get trust bundle secret: %w", err)
 	}
 
 	// Check if X.509 certificates need to be generated
@@ -55,14 +57,18 @@ func (k *kube) get(ctx context.Context) (bundle.Bundle, error) {
 
 	generateX509 := !hasRootCert || !hasIssuerCert || !hasIssuerKey
 
-	// Also check if the ConfigMap is in sync
+	// Check if the ConfigMap is in sync with the Secret.
+	// The Secret is the authoritative source for certificate data. A ConfigMap
+	// mismatch should trigger a re-sync, not certificate regeneration.
+	var needsSync bool
 	configMap, err := k.client.CoreV1().ConfigMaps(k.namespace).Get(ctx, TrustBundleK8sName, metav1.GetOptions{})
 	if err != nil {
-		return bundle.Bundle{}, err
+		return bundle.Bundle{}, false, fmt.Errorf("failed to get trust bundle configmap: %w", err)
 	}
 
 	if configMapRootCert, ok := configMap.Data[filepath.Base(k.config.RootCertPath)]; !ok || (hasRootCert && configMapRootCert != string(trustAnchors)) {
-		generateX509 = true
+		needsSync = true
+		log.Warn("Trust bundle ConfigMap is out of sync with Secret; will re-sync")
 	}
 
 	// Create a bundle if certificates are available
@@ -70,7 +76,7 @@ func (k *kube) get(ctx context.Context) (bundle.Bundle, error) {
 	if !generateX509 {
 		bndle.X509, err = verifyX509Bundle(trustAnchors, issChainPEM, issKeyPEM)
 		if err != nil {
-			return bundle.Bundle{}, fmt.Errorf("failed to verify CA bundle: %w", err)
+			return bundle.Bundle{}, false, fmt.Errorf("failed to verify CA bundle: %w", err)
 		}
 	}
 
@@ -81,11 +87,11 @@ func (k *kube) get(ctx context.Context) (bundle.Bundle, error) {
 	if hasJWTKey && hasJWKS {
 		jwtKey, jwtErr := loadJWTSigningKey(jwtKeyPEM)
 		if jwtErr != nil {
-			return bundle.Bundle{}, fmt.Errorf("failed to load JWT signing key: %w", jwtErr)
+			return bundle.Bundle{}, false, fmt.Errorf("failed to load JWT signing key: %w", jwtErr)
 		}
 
 		if verifyErr := verifyJWKS(jwks, jwtKey, k.config.JWT.KeyID); verifyErr != nil {
-			return bundle.Bundle{}, fmt.Errorf("failed to verify JWKS: %w", verifyErr)
+			return bundle.Bundle{}, false, fmt.Errorf("failed to verify JWKS: %w", verifyErr)
 		}
 
 		bndle.JWT = &bundle.JWT{
@@ -95,11 +101,11 @@ func (k *kube) get(ctx context.Context) (bundle.Bundle, error) {
 		}
 		bndle.JWT.JWKS, err = jwk.Parse(jwks)
 		if err != nil {
-			return bundle.Bundle{}, fmt.Errorf("failed to parse JWKS: %w", err)
+			return bundle.Bundle{}, false, fmt.Errorf("failed to parse JWKS: %w", err)
 		}
 	}
 
-	return bndle, nil
+	return bndle, needsSync, nil
 }
 
 // store saves the certificate bundle to Kubernetes.
@@ -152,6 +158,33 @@ func (k *kube) store(ctx context.Context, bundle bundle.Bundle) error {
 	delete(configMap.Data, filepath.Base(k.config.JWT.JWKSPath))
 	if bundle.JWT != nil {
 		configMap.Data[filepath.Base(k.config.JWT.JWKSPath)] = string(bundle.JWT.JWKSJson)
+	}
+
+	if _, err = k.client.CoreV1().ConfigMaps(k.namespace).Update(ctx, configMap, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update trust bundle configmap: %w", err)
+	}
+
+	return nil
+}
+
+// syncConfigMap re-syncs only the ConfigMap with the provided bundle data,
+// without touching the Secret. This is used when the Secret already has correct
+// certs but the ConfigMap has diverged.
+func (k *kube) syncConfigMap(ctx context.Context, b bundle.Bundle) error {
+	configMap, err := k.client.CoreV1().ConfigMaps(k.namespace).Get(ctx, TrustBundleK8sName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get trust bundle configmap: %w", err)
+	}
+
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+
+	configMap.Data[filepath.Base(k.config.RootCertPath)] = string(b.X509.TrustAnchors)
+
+	delete(configMap.Data, filepath.Base(k.config.JWT.JWKSPath))
+	if b.JWT != nil {
+		configMap.Data[filepath.Base(k.config.JWT.JWKSPath)] = string(b.JWT.JWKSJson)
 	}
 
 	if _, err = k.client.CoreV1().ConfigMaps(k.namespace).Update(ctx, configMap, metav1.UpdateOptions{}); err != nil {

--- a/pkg/sentry/server/ca/kube_test.go
+++ b/pkg/sentry/server/ca/kube_test.go
@@ -52,10 +52,11 @@ func TestKube_get(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := map[string]struct {
-		sec       *corev1.Secret
-		cm        *corev1.ConfigMap
-		expBundle ca_bundle.Bundle
-		expErr    bool
+		sec          *corev1.Secret
+		cm           *corev1.ConfigMap
+		expBundle    ca_bundle.Bundle
+		expNeedsSync bool
+		expErr       bool
 	}{
 		"if secret doesn't exist, expect error": {
 			sec: nil,
@@ -148,7 +149,7 @@ func TestKube_get(t *testing.T) {
 			expBundle: ca_bundle.Bundle{},
 			expErr:    false,
 		},
-		"if configmap doesn't include ca.crt, expect to generate x509": {
+		"if configmap doesn't include ca.crt, expect valid bundle with needsSync": {
 			sec: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dapr-trust-bundle",
@@ -167,10 +168,19 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{},
 			},
-			expBundle: ca_bundle.Bundle{},
-			expErr:    false,
+			expBundle: ca_bundle.Bundle{
+				X509: &ca_bundle.X509{
+					TrustAnchors: rootPEM,
+					IssChainPEM:  intPEM,
+					IssKeyPEM:    intPKPEM,
+					IssChain:     []*x509.Certificate{intCrt},
+					IssKey:       intPK,
+				},
+			},
+			expNeedsSync: true,
+			expErr:       false,
 		},
-		"if trust anchors do not match, expect not to generate x509": {
+		"if trust anchors do not match, expect valid bundle with needsSync": {
 			sec: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "dapr-trust-bundle",
@@ -189,8 +199,17 @@ func TestKube_get(t *testing.T) {
 				},
 				Data: map[string]string{"ca.crt": string(rootPEM) + "\n" + string(rootPEM2)},
 			},
-			expBundle: ca_bundle.Bundle{},
-			expErr:    false,
+			expBundle: ca_bundle.Bundle{
+				X509: &ca_bundle.X509{
+					TrustAnchors: rootPEM,
+					IssChainPEM:  intPEM,
+					IssKeyPEM:    intPKPEM,
+					IssChain:     []*x509.Certificate{intCrt},
+					IssKey:       intPK,
+				},
+			},
+			expNeedsSync: true,
+			expErr:       false,
 		},
 		"if bundle fails to verify x509, expect error": {
 			sec: &corev1.Secret{
@@ -526,8 +545,9 @@ func TestKube_get(t *testing.T) {
 				namespace: "dapr-system-test",
 			}
 
-			bundle, err := k.get(t.Context())
+			bundle, needsSync, err := k.get(t.Context())
 			assert.Equal(t, test.expErr, err != nil, "expected error: %v, but got %v", test.expErr, err)
+			assert.Equal(t, test.expNeedsSync, needsSync, "expected needsSync: %v, but got %v", test.expNeedsSync, needsSync)
 			bundlesEqual(t, test.expBundle, bundle)
 		})
 	}

--- a/pkg/sentry/server/ca/selfhosted.go
+++ b/pkg/sentry/server/ca/selfhosted.go
@@ -57,21 +57,22 @@ func (s *selfhosted) store(_ context.Context, bundle bundle.Bundle) error {
 }
 
 // get retrieves the existing certificate bundle from the filesystem.
-func (s *selfhosted) get(_ context.Context) (bundle.Bundle, error) {
+// The selfhosted store never needs a re-sync, so needsSync is always false.
+func (s *selfhosted) get(_ context.Context) (bundle.Bundle, bool, error) {
 	x509, err := s.loadAndValidateX509Bundle()
 	if err != nil {
-		return bundle.Bundle{}, err
+		return bundle.Bundle{}, false, err
 	}
 
 	jwt, err := s.loadAndValidateJWTBundle()
 	if err != nil {
-		return bundle.Bundle{}, err
+		return bundle.Bundle{}, false, err
 	}
 
 	return bundle.Bundle{
 		X509: x509,
 		JWT:  jwt,
-	}, nil
+	}, false, nil
 }
 
 // loadAndValidateX509Bundle loads the X.509 certificates and keys from disk, verifies them, and updates the bundle. Returns whether any are missing.

--- a/pkg/sentry/server/ca/selfhosted_test.go
+++ b/pkg/sentry/server/ca/selfhosted_test.go
@@ -320,8 +320,9 @@ func TestSelfhosted_get(t *testing.T) {
 				require.NoError(t, os.WriteFile(jwksFile, *test.jwksData, writePerm))
 			}
 
-			bundle, err := s.get(t.Context())
+			bundle, needsSync, err := s.get(t.Context())
 			assert.Equal(t, test.expErr, err != nil, "expected error: %v, but got %v", test.expErr, err)
+			assert.False(t, needsSync, "selfhosted store should never need sync")
 			bundlesEqual(t, test.expBundle, bundle)
 		})
 	}


### PR DESCRIPTION
# Description

When the `dapr-trust-bundle` ConfigMap is out of sync with the Secret (e.g. during certificate renewal via `dapr mtls renew-certificate -k --restart`), Sentry incorrectly regenerates new self-signed certificates instead of using the valid certificates from the Secret.

The root cause is in `kube.go`'s `get()` method: when the ConfigMap's root cert doesn't match the Secret's root cert, `generateX509` is set to `true`, causing `get()` to return a bundle with `X509 == nil`. This makes `ca.New()` generate entirely new self-signed certificates, invalidating the just-renewed ones.

The Secret is the authoritative source for certificate data. A ConfigMap mismatch should trigger a re-sync (re-persisting the bundle to update the ConfigMap), not a full certificate regeneration.

## Changes

- Changed the `store` interface's `get` method to return a `needsSync` boolean alongside the bundle
- In `kube.get()`, a ConfigMap mismatch now sets `needsSync = true` instead of `generateX509 = true`, with a warning log
- In `ca.New()`, `needsSync` is OR'd into the existing `needsWrite` flag, which triggers `store()` to re-persist the bundle and sync the ConfigMap
- Updated `selfhosted.get()` to match the new interface (always returns `false` for `needsSync`)

## Issue reference

Please reference the issue this PR will close: #9563

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_