### PR TITLE
Fix version-skew for cross-app workflow tests

### DIFF
--- a/.github/scripts/version-skew-test-patches/integration/release-1.17/dapr-sidecar-master/002-workflow-crossapp.patch
+++ b/.github/scripts/version-skew-test-patches/integration/release-1.17/dapr-sidecar-master/002-workflow-crossapp.patch
@@ -1,0 +1,156 @@
+diff --git a/tests/integration/suite/daprd/workflow/crossapp/activity/crossnamespace.go b/tests/integration/suite/daprd/workflow/crossapp/activity/crossnamespace.go
+index ea41ce2..cd4e640 100644
+--- a/tests/integration/suite/daprd/workflow/crossapp/activity/crossnamespace.go
++++ b/tests/integration/suite/daprd/workflow/crossapp/activity/crossnamespace.go
+@@ -16,10 +16,9 @@ package activity
+ import (
+ 	"context"
+ 	"fmt"
+-	"strings"
+ 	"testing"
+-	"time"
+
++	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
+
+ 	"github.com/dapr/dapr/tests/integration/framework"
+@@ -95,18 +94,15 @@ func (c *crossnamespace) Setup(t *testing.T) []framework.Option {
+ func (c *crossnamespace) Run(t *testing.T, ctx context.Context) {
+ 	c.workflow.WaitUntilRunning(t, ctx)
+
+-	// Start workflow listener for apps
+-	client0 := c.workflow.BackendClient(t, ctx)
++	client := c.workflow.BackendClient(t, ctx)
+ 	c.workflow.BackendClientN(t, ctx, 1)
+
+-	// Expect completion to hang, so timeout
+-	// dapr will log about 'did not find address for actor'
+-	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+-	defer waitCancel()
++	id, err := client.ScheduleNewOrchestration(ctx, "CrossNamespaceWorkflow", api.WithInput("Hello from app0"))
++	require.NoError(t, err)
++
++	metadata, err := client.WaitForOrchestrationStart(ctx, id)
++	require.NoError(t, err)
++	assert.Equal(t, api.RUNTIME_STATUS_RUNNING, metadata.RuntimeStatus)
+
+-	// Start workflow from app0 (default namespace)
+-	_, err := client0.ScheduleNewOrchestration(waitCtx, "CrossNamespaceWorkflow", api.WithInput("Hello from app0"))
+-	require.Error(t, err)
+-	require.True(t, strings.Contains(err.Error(), "context deadline exceeded") || strings.Contains(err.Error(), "DeadlineExceeded"))
+ 	c.actorNotFoundLogLine.EventuallyFoundAll(t)
+ }
+diff --git a/tests/integration/suite/daprd/workflow/crossapp/activity/invalidappid.go b/tests/integration/suite/daprd/workflow/crossapp/activity/invalidappid.go
+index 893196c..2a0e4b7 100644
+--- a/tests/integration/suite/daprd/workflow/crossapp/activity/invalidappid.go
++++ b/tests/integration/suite/daprd/workflow/crossapp/activity/invalidappid.go
+@@ -17,8 +17,8 @@ import (
+ 	"context"
+ 	"fmt"
+ 	"testing"
+-	"time"
+
++	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
+
+ 	"github.com/dapr/dapr/tests/integration/framework"
+@@ -78,14 +78,14 @@ func (i *invalidappid) Run(t *testing.T, ctx context.Context) {
+ 		return fmt.Sprintf("Error handled: %v", err), nil
+ 	})
+
+-	// Start workflow listener for app0
+-	client0 := i.workflow.BackendClient(t, ctx)
++	client := i.workflow.BackendClient(t, ctx)
+
+-	// ctx cancel bc it will hang
+-	wCtx, wcancel := context.WithTimeout(ctx, 5*time.Second)
+-	defer wcancel()
+-	_, err := client0.ScheduleNewOrchestration(wCtx, "InvalidAppWorkflow", api.WithInput("Hello from app0"))
+-	require.Error(t, err)
++	id, err := client.ScheduleNewOrchestration(ctx, "InvalidAppWorkflow", api.WithInput("Hello from app0"))
++	require.NoError(t, err)
++
++	metadata, err := client.WaitForOrchestrationStart(ctx, id)
++	require.NoError(t, err)
++	assert.Equal(t, api.RUNTIME_STATUS_RUNNING, metadata.RuntimeStatus)
+
+ 	i.actorNotFoundLogLine.EventuallyFoundAll(t)
+ }
+diff --git a/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/crossnamespace.go b/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/crossnamespace.go
+index ea2ba36..9a84ede 100644
+--- a/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/crossnamespace.go
++++ b/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/crossnamespace.go
+@@ -16,10 +16,9 @@ package suborchestrator
+ import (
+ 	"context"
+ 	"fmt"
+-	"strings"
+ 	"testing"
+-	"time"
+
++	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
+
+ 	"github.com/dapr/dapr/tests/integration/framework"
+@@ -95,18 +94,15 @@ func (c *crossnamespace) Setup(t *testing.T) []framework.Option {
+ func (c *crossnamespace) Run(t *testing.T, ctx context.Context) {
+ 	c.workflow.WaitUntilRunning(t, ctx)
+
+-	// Start workflow listener for apps
+-	client0 := c.workflow.BackendClient(t, ctx)
++	client := c.workflow.BackendClient(t, ctx)
+ 	c.workflow.BackendClientN(t, ctx, 1)
+
+-	// Expect completion to hang, so timeout
+-	// dapr will log about 'did not find address for actor'
+-	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+-	defer waitCancel()
++	id, err := client.ScheduleNewOrchestration(ctx, "CrossNamespaceWorkflow", api.WithInput("Hello from app0"))
++	require.NoError(t, err)
++
++	metadata, err := client.WaitForOrchestrationStart(ctx, id)
++	require.NoError(t, err)
++	assert.Equal(t, api.RUNTIME_STATUS_RUNNING, metadata.RuntimeStatus)
+
+-	// Start workflow from app0 (default namespace)
+-	_, err := client0.ScheduleNewOrchestration(waitCtx, "CrossNamespaceWorkflow", api.WithInput("Hello from app0"))
+-	require.Error(t, err)
+-	require.True(t, strings.Contains(err.Error(), "context deadline exceeded") || strings.Contains(err.Error(), "DeadlineExceeded"))
+ 	c.actorNotFoundLogLine.EventuallyFoundAll(t)
+ }
+diff --git a/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/invalidappid.go b/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/invalidappid.go
+index 70d3d6d..3d916ae 100644
+--- a/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/invalidappid.go
++++ b/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/invalidappid.go
+@@ -17,8 +17,8 @@ import (
+ 	"context"
+ 	"fmt"
+ 	"testing"
+-	"time"
+
++	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
+
+ 	"github.com/dapr/dapr/tests/integration/framework"
+@@ -78,14 +78,14 @@ func (i *invalidappid) Run(t *testing.T, ctx context.Context) {
+ 		return fmt.Sprintf("Error handled: %v", err), nil
+ 	})
+
+-	// Start workflow listener for app0
+-	client0 := i.workflow.BackendClient(t, ctx)
++	client := i.workflow.BackendClient(t, ctx)
+
+-	// ctx cancel bc it will hang
+-	wCtx, wcancel := context.WithTimeout(ctx, 5*time.Second)
+-	defer wcancel()
+-	_, err := client0.ScheduleNewOrchestration(wCtx, "InvalidAppWorkflow", api.WithInput("Hello from app0"))
+-	require.Error(t, err)
++	id, err := client.ScheduleNewOrchestration(ctx, "InvalidAppWorkflow", api.WithInput("Hello from app0"))
++	require.NoError(t, err)
++
++	metadata, err := client.WaitForOrchestrationStart(ctx, id)
++	require.NoError(t, err)
++	assert.Equal(t, api.RUNTIME_STATUS_RUNNING, metadata.RuntimeStatus)
+
+ 	i.actorNotFoundLogLine.EventuallyFoundAll(t)
+ }


### PR DESCRIPTION
PR #9738 changed daprd to no longer block on ScheduleNewOrchestration when the target app is offline, instead transitioning the workflow to RUNNING. This breaks the v1.17.3 cross-app workflow tests which expect a timeout error. Patch the release-1.17 tests to match master's behavior.