### PR TITLE
fix flaky crossactivity workflow integration test

### DIFF
--- a/tests/integration/suite/daprd/workflow/get/crossactivity.go
+++ b/tests/integration/suite/daprd/workflow/get/crossactivity.go
@@ -74,34 +74,52 @@ func (c *crossactivity) Run(t *testing.T, ctx context.Context) {
 
 	evs := resp.Events
 
-	// Can have 1 or 2 `GetOrchestratorStarted` events depending on timing.
-	require.True(t, len(evs) == 7 || len(evs) == 6)
+	// OrchestratorStarted events can appear at varying positions depending on
+	// timing, so find the non-OrchestratorStarted events by scanning rather
+	// than assuming fixed indices.
+	require.True(t, len(evs) >= 6 && len(evs) <= 8,
+		"expected 6-8 events, got %d", len(evs))
 
 	assert.NotNil(t, evs[0].GetOrchestratorStarted())
-	assert.NotNil(t, evs[1].GetExecutionStarted())
-	assert.Equal(t, "foo", evs[1].GetExecutionStarted().GetName())
-	assert.Equal(t, "abc", evs[1].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
-	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[1].GetRouter().GetSourceAppID())
 
-	assert.NotNil(t, evs[2].GetTaskScheduled())
-	assert.Equal(t, "a", evs[2].GetTaskScheduled().GetName())
-	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[2].GetRouter().GetSourceAppID())
-	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[2].GetRouter().GetTargetAppID())
-
-	assert.NotNil(t, evs[3].GetOrchestratorStarted())
-
-	// The index of the next events depends on whether there are 6 or 7 events
-	// total.
-	i := 4
-	if len(evs) == 7 {
-		i = 5
-		assert.NotNil(t, evs[4].GetOrchestratorStarted())
+	// Find ExecutionStarted (first non-OrchestratorStarted event).
+	i := 1
+	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+		i++
 	}
+	require.Less(t, i, len(evs), "ExecutionStarted event not found")
+	assert.NotNil(t, evs[i].GetExecutionStarted())
+	assert.Equal(t, "foo", evs[i].GetExecutionStarted().GetName())
+	assert.Equal(t, "abc", evs[i].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[i].GetRouter().GetSourceAppID())
 
+	// Find TaskScheduled (skip any OrchestratorStarted events).
+	i++
+	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+		i++
+	}
+	require.Less(t, i, len(evs), "TaskScheduled event not found")
+	assert.NotNil(t, evs[i].GetTaskScheduled())
+	assert.Equal(t, "a", evs[i].GetTaskScheduled().GetName())
+	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[i].GetRouter().GetSourceAppID())
+	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[i].GetRouter().GetTargetAppID())
+
+	// Find TaskCompleted (skip any OrchestratorStarted events).
+	i++
+	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+		i++
+	}
+	require.Less(t, i, len(evs), "TaskCompleted event not found")
 	assert.NotNil(t, evs[i].GetTaskCompleted())
 	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[i].GetRouter().GetSourceAppID())
 	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[i].GetRouter().GetTargetAppID())
 
-	assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", evs[i+1].GetExecutionCompleted().GetOrchestrationStatus().String())
-	assert.Equal(t, c.workflow.Dapr().AppID(), evs[i+1].GetRouter().GetSourceAppID())
+	// Find ExecutionCompleted (skip any OrchestratorStarted events).
+	i++
+	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+		i++
+	}
+	require.Less(t, i, len(evs), "ExecutionCompleted event not found")
+	assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", evs[i].GetExecutionCompleted().GetOrchestrationStatus().String())
+	assert.Equal(t, c.workflow.Dapr().AppID(), evs[i].GetRouter().GetSourceAppID())
 }

--- a/tests/integration/suite/daprd/workflow/get/crossactivity.go
+++ b/tests/integration/suite/daprd/workflow/get/crossactivity.go
@@ -75,38 +75,39 @@ func (c *crossactivity) Run(t *testing.T, ctx context.Context) {
 	evs := resp.Events
 
 	// OrchestratorStarted events can appear at varying positions depending on
-	// timing, so find the non-OrchestratorStarted events by scanning rather
-	// than assuming fixed indices.
-	require.True(t, len(evs) >= 6 && len(evs) <= 8,
-		"expected 6-8 events, got %d", len(evs))
+	// timing, so find each meaningful event by type rather than by index.
+	require.GreaterOrEqual(t, len(evs), 6,
+		"expected at least 6 events, got %d", len(evs))
 
 	assert.NotNil(t, evs[0].GetOrchestratorStarted())
 
-	// Find ExecutionStarted (first non-OrchestratorStarted event).
+	// Find ExecutionStarted.
 	i := 1
-	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+	for i < len(evs) && evs[i].GetExecutionStarted() == nil {
 		i++
 	}
 	require.Less(t, i, len(evs), "ExecutionStarted event not found")
-	assert.NotNil(t, evs[i].GetExecutionStarted())
-	assert.Equal(t, "foo", evs[i].GetExecutionStarted().GetName())
-	assert.Equal(t, "abc", evs[i].GetExecutionStarted().GetOrchestrationInstance().GetInstanceId())
+	es := evs[i].GetExecutionStarted()
+	assert.NotNil(t, es)
+	assert.Equal(t, "foo", es.GetName())
+	assert.Equal(t, "abc", es.GetOrchestrationInstance().GetInstanceId())
 	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[i].GetRouter().GetSourceAppID())
 
-	// Find TaskScheduled (skip any OrchestratorStarted events).
+	// Find TaskScheduled.
 	i++
-	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+	for i < len(evs) && evs[i].GetTaskScheduled() == nil {
 		i++
 	}
 	require.Less(t, i, len(evs), "TaskScheduled event not found")
-	assert.NotNil(t, evs[i].GetTaskScheduled())
-	assert.Equal(t, "a", evs[i].GetTaskScheduled().GetName())
+	ts := evs[i].GetTaskScheduled()
+	assert.NotNil(t, ts)
+	assert.Equal(t, "a", ts.GetName())
 	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[i].GetRouter().GetSourceAppID())
 	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[i].GetRouter().GetTargetAppID())
 
-	// Find TaskCompleted (skip any OrchestratorStarted events).
+	// Find TaskCompleted.
 	i++
-	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+	for i < len(evs) && evs[i].GetTaskCompleted() == nil {
 		i++
 	}
 	require.Less(t, i, len(evs), "TaskCompleted event not found")
@@ -114,9 +115,9 @@ func (c *crossactivity) Run(t *testing.T, ctx context.Context) {
 	assert.Equal(t, c.workflow.DaprN(0).AppID(), evs[i].GetRouter().GetSourceAppID())
 	assert.Equal(t, c.workflow.DaprN(1).AppID(), evs[i].GetRouter().GetTargetAppID())
 
-	// Find ExecutionCompleted (skip any OrchestratorStarted events).
+	// Find ExecutionCompleted.
 	i++
-	for i < len(evs) && evs[i].GetOrchestratorStarted() != nil {
+	for i < len(evs) && evs[i].GetExecutionCompleted() == nil {
 		i++
 	}
 	require.Less(t, i, len(evs), "ExecutionCompleted event not found")


### PR DESCRIPTION
OrchestratorStarted events can appear at varying positions in the workflow history depending on timing. The test assumed these events only appeared at fixed indices, but on slow CI runners, an extra OrchestratorStarted could be interleaved before TaskScheduled (at index 2), shifting all subsequent events and causing assertion failures. Scan past OrchestratorStarted events to find each meaningful event by type rather than by hardcoded index.vided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
