### PR TITLE
strip hop-by-hop headers when proxying HTTP

### DIFF
--- a/docs/release_notes/v1.17.4.md
+++ b/docs/release_notes/v1.17.4.md
@@ -100,6 +100,6 @@ Similarly, the `copyHeader` function, which copies upstream response headers bac
 
 ### Solution
 
-A new filter function identifies the standard hop-by-hop headers per RFC 7230 Section 6.1: `Connection`, `Keep-Alive`, `Proxy-Connection`, `Transfer-Encoding`, `Upgrade`, `HTTP2-Settings`, `TE`, `Trailer`, and `Proxy-Authorization`.
+A new filter function identifies the standard hop-by-hop headers per RFC 7230 Section 6.1: `Connection`, `Keep-Alive`, `Proxy-Connection`, `Transfer-Encoding`, `Upgrade`, `HTTP2-Settings`, `TE`, `Trailer`, `Proxy-Authorization`, and `Proxy-Authenticate`.
 This filter is applied to request and response paths.
 End-to-end headers such as `Accept`, `Authorization`, `Content-Type`, and custom headers (`X-*`) are unaffected and continue to be forwarded normally.

--- a/docs/release_notes/v1.17.4.md
+++ b/docs/release_notes/v1.17.4.md
@@ -82,7 +82,7 @@ This violates RFC 7230 Section 6.1, which requires intermediaries (proxies) to r
 
 This affects all HTTP service invocation paths: local invocation, remote invocation, HTTPEndpoint invocation, dapr-app-id header invocation, and direct URL invocation.
 
-The most visible failure occurs when a HTTP client configured with `HTTP_2` sends `Upgrade: h2c`, `Connection: Upgrade`, and `HTTP2-Settings` headers to the Dapr sidecar.
+The most visible failure occurs when an HTTP client configured with `HTTP_2` sends `Upgrade: h2c`, `Connection: Upgrade`, and `HTTP2-Settings` headers to the Dapr sidecar.
 Dapr forwards these to the upstream HTTPS endpoint, which rejects the request with:
 
 ```

--- a/docs/release_notes/v1.17.4.md
+++ b/docs/release_notes/v1.17.4.md
@@ -3,6 +3,7 @@
 This update contains bug fixes:
 - [Pulsar pub/sub ignores processMode from component metadata and lacks async backpressure](#pulsar-pubsub-ignores-processmode-from-component-metadata-and-lacks-async-backpressure)
 - [Cross-app workflow stuck in PENDING when the first action is a remote activity or child workflow call to an offline app](#cross-app-workflow-stuck-in-pending-when-the-first-action-is-a-remote-activity-or-child-workflow-call-to-an-offline-app)
+- [Dapr forwards hop-by-hop HTTP headers when proxying service invocation requests](#dapr-forwards-hop-by-hop-http-headers-when-proxying-service-invocation-requests)
 
 ## Pulsar pub/sub ignores processMode from component metadata and lacks async backpressure
 
@@ -69,3 +70,36 @@ Two changes address this issue:
 1. **Per-dispatch timeout**: Each activity dispatch and child workflow message dispatch now uses a short timeout (2 seconds). These dispatches are one-way fire-and-forget messages to the target actor, so they complete in milliseconds when the target app is reachable. The short timeout ensures the actor lock is released quickly when an app is offline, allowing status queries and reminder retries to proceed without delay. All dispatches are attempted even if some fail, so that successfully dispatched items are not blocked by a single unreachable app.
 
 2. **Pre-save on first remote execution**: On the first execution of a workflow that contains remote activities or child workflows (detected by checking for `TargetAppId` in pending task and message routers), if any dispatch fails, the runtime saves the workflow state before returning. Events corresponding to failed dispatches (`TaskScheduled` for activities, `SubOrchestrationInstanceCreated` for child workflows) are excluded from the saved history so the retry can regenerate them. Events for successfully dispatched items are preserved to avoid re-dispatching them. The inbox is preserved so the existing reminder retries the full orchestrator execution. This transitions the workflow to `RUNNING` and releases the actor lock so that status queries are not blocked.
+
+## Dapr forwards hop-by-hop HTTP headers when proxying service invocation requests
+
+### Problem
+
+When a client sends hop-by-hop HTTP headers such as `Connection`, `Upgrade`, `HTTP2-Settings`, `TE`, `Keep-Alive`, `Trailer`, `Proxy-Authorization`, and `Proxy-Connection` to the Dapr sidecar, Dapr forwards them to the upstream application or HTTPEndpoint.
+This violates RFC 7230 Section 6.1, which requires intermediaries (proxies) to remove hop-by-hop headers before forwarding a message.
+
+### Impact
+
+This affects all HTTP service invocation paths: local invocation, remote invocation, HTTPEndpoint invocation, dapr-app-id header invocation, and direct URL invocation.
+
+The most visible failure occurs when a HTTP client configured with `HTTP_2` sends `Upgrade: h2c`, `Connection: Upgrade`, and `HTTP2-Settings` headers to the Dapr sidecar.
+Dapr forwards these to the upstream HTTPS endpoint, which rejects the request with:
+
+```
+http2: invalid Upgrade request header: ["h2c"]
+```
+
+Other upstream servers may silently accept the leaked headers, but the behavior is still incorrect per the HTTP specification and may cause subtle issues with proxies, load balancers, or HTTP/2-strict servers.
+The same issue also applied to response headers: if an upstream application set hop-by-hop headers on its response, Dapr forwarded them back to the caller.
+
+### Root Cause
+
+The `InternalMetadataToHTTPHeader` function, which converts internal metadata to outgoing HTTP request headers, did not filter out hop-by-hop headers.
+It forwarded all headers except trace headers, `Content-Type`, `Content-Length`, and gRPC binary metadata.
+Similarly, the `copyHeader` function, which copies upstream response headers back to the caller, performed a naive copy of all headers with no filtering.
+
+### Solution
+
+A new filter function identifies the standard hop-by-hop headers per RFC 7230 Section 6.1: `Connection`, `Keep-Alive`, `Proxy-Connection`, `Transfer-Encoding`, `Upgrade`, `HTTP2-Settings`, `TE`, `Trailer`, and `Proxy-Authorization`.
+This filter is applied to request and response paths.
+End-to-end headers such as `Accept`, `Authorization`, `Content-Type`, and custom headers (`X-*`) are unaffected and continue to be forwarded normally.

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -668,9 +668,24 @@ func (h *Channel) parseChannelResponse(channelResp *http.Response) (*invokev1.In
 }
 
 func copyHeader(dst http.Header, src http.Header) {
+	// Build set of headers nominated by Connection header per RFC 7230 Section 6.1.
+	connHeaders := make(map[string]struct{})
+	for _, v := range src.Values("Connection") {
+		for token := range strings.SplitSeq(v, ",") {
+			token = strings.TrimSpace(token)
+			if token != "" {
+				connHeaders[http.CanonicalHeaderKey(token)] = struct{}{}
+			}
+		}
+	}
+
 	for k, vv := range src {
-		// Strip hop-by-hop headers per RFC 7230 Section 6.1.
+		// Strip hop-by-hop headers per RFC 7230 Section 6.1,
+		// including headers nominated by the Connection header.
 		if invokev1.IsHopByHopHeader(k) {
+			continue
+		}
+		if _, ok := connHeaders[k]; ok {
 			continue
 		}
 		for _, v := range vv {

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -669,6 +669,10 @@ func (h *Channel) parseChannelResponse(channelResp *http.Response) (*invokev1.In
 
 func copyHeader(dst http.Header, src http.Header) {
 	for k, vv := range src {
+		// Strip hop-by-hop headers per RFC 7230 Section 6.1.
+		if invokev1.IsHopByHopHeader(k) {
+			continue
+		}
 		for _, v := range vv {
 			dst.Add(k, v)
 		}

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -117,11 +117,14 @@ func IsHopByHopHeader(hdr string) bool {
 // hop-by-hop by the Connection header value per RFC 7230 Section 6.1.
 func connectionHopByHopHeaders(internalMD DaprInternalMetadata) map[string]struct{} {
 	headers := make(map[string]struct{})
-	connVal, ok := internalMD["Connection"]
-	if !ok {
-		connVal, ok = internalMD["connection"]
+	var connVal *internalv1pb.ListStringValue
+	for key, val := range internalMD {
+		if strings.EqualFold(key, "Connection") {
+			connVal = val
+			break
+		}
 	}
-	if !ok || connVal == nil {
+	if connVal == nil {
 		return headers
 	}
 	for _, v := range connVal.GetValues() {

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -113,9 +113,9 @@ func IsHopByHopHeader(hdr string) bool {
 	return false
 }
 
-// ConnectionHopByHopHeaders returns the set of header names nominated as
+// connectionHopByHopHeaders returns the set of header names nominated as
 // hop-by-hop by the Connection header value per RFC 7230 Section 6.1.
-func ConnectionHopByHopHeaders(internalMD DaprInternalMetadata) map[string]struct{} {
+func connectionHopByHopHeaders(internalMD DaprInternalMetadata) map[string]struct{} {
 	headers := make(map[string]struct{})
 	connVal, ok := internalMD["Connection"]
 	if !ok {
@@ -251,7 +251,7 @@ func ReservedGRPCMetadataToDaprPrefixHeader(key string) string {
 func InternalMetadataToHTTPHeader(ctx context.Context, internalMD DaprInternalMetadata, setHeader func(string, string)) {
 	// Build the set of headers nominated by the Connection header value
 	// per RFC 7230 Section 6.1.
-	connHopByHop := ConnectionHopByHopHeaders(internalMD)
+	connHopByHop := connectionHopByHopHeaders(internalMD)
 
 	var traceparentValue, tracestateValue, grpctracebinValue string
 	for k, listVal := range internalMD {

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -106,10 +106,33 @@ func IsHopByHopHeader(hdr string) bool {
 		"http2-settings",
 		"te",
 		"trailer",
-		"proxy-authorization":
+		"proxy-authorization",
+		"proxy-authenticate":
 		return true
 	}
 	return false
+}
+
+// ConnectionHopByHopHeaders returns the set of header names nominated as
+// hop-by-hop by the Connection header value per RFC 7230 Section 6.1.
+func ConnectionHopByHopHeaders(internalMD DaprInternalMetadata) map[string]struct{} {
+	headers := make(map[string]struct{})
+	connVal, ok := internalMD["Connection"]
+	if !ok {
+		connVal, ok = internalMD["connection"]
+	}
+	if !ok || connVal == nil {
+		return headers
+	}
+	for _, v := range connVal.GetValues() {
+		for token := range strings.SplitSeq(v, ",") {
+			token = strings.TrimSpace(token)
+			if token != "" {
+				headers[strings.ToLower(token)] = struct{}{}
+			}
+		}
+	}
+	return headers
 }
 
 // isPermanentHTTPHeader checks whether hdr belongs to the list of
@@ -226,6 +249,10 @@ func ReservedGRPCMetadataToDaprPrefixHeader(key string) string {
 
 // InternalMetadataToHTTPHeader converts internal metadata pb to HTTP headers.
 func InternalMetadataToHTTPHeader(ctx context.Context, internalMD DaprInternalMetadata, setHeader func(string, string)) {
+	// Build the set of headers nominated by the Connection header value
+	// per RFC 7230 Section 6.1.
+	connHopByHop := ConnectionHopByHopHeaders(internalMD)
+
 	var traceparentValue, tracestateValue, grpctracebinValue string
 	for k, listVal := range internalMD {
 		if len(listVal.GetValues()) == 0 {
@@ -255,8 +282,12 @@ func InternalMetadataToHTTPHeader(ctx context.Context, internalMD DaprInternalMe
 			continue
 		}
 
-		// Strip hop-by-hop headers per RFC 7230 Section 6.1.
+		// Strip hop-by-hop headers per RFC 7230 Section 6.1,
+		// including headers nominated by the Connection header.
 		if IsHopByHopHeader(keyName) {
+			continue
+		}
+		if _, ok := connHopByHop[keyName]; ok {
 			continue
 		}
 

--- a/pkg/messaging/v1/util.go
+++ b/pkg/messaging/v1/util.go
@@ -94,6 +94,24 @@ func IsJSONContentType(contentType string) bool {
 	return strings.HasPrefix(strings.ToLower(contentType), JSONContentType)
 }
 
+// IsHopByHopHeader returns true if the header is a hop-by-hop header
+// that must not be forwarded by proxies per RFC 7230 Section 6.1.
+func IsHopByHopHeader(hdr string) bool {
+	switch strings.ToLower(hdr) {
+	case "connection",
+		"keep-alive",
+		"proxy-connection",
+		"transfer-encoding",
+		"upgrade",
+		"http2-settings",
+		"te",
+		"trailer",
+		"proxy-authorization":
+		return true
+	}
+	return false
+}
+
 // isPermanentHTTPHeader checks whether hdr belongs to the list of
 // permanent request headers maintained by IANA.
 // http://www.iana.org/assignments/message-headers/message-headers.xml
@@ -234,6 +252,11 @@ func InternalMetadataToHTTPHeader(ctx context.Context, internalMD DaprInternalMe
 		}
 
 		if strings.HasSuffix(keyName, gRPCBinaryMetadataSuffix) || keyName == ContentTypeHeader || keyName == ContentLengthHeader {
+			continue
+		}
+
+		// Strip hop-by-hop headers per RFC 7230 Section 6.1.
+		if IsHopByHopHeader(keyName) {
 			continue
 		}
 

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -71,6 +71,7 @@ func TestIsHopByHopHeader(t *testing.T) {
 		"TE", "te",
 		"Trailer", "trailer",
 		"Proxy-Authorization", "proxy-authorization",
+		"Proxy-Authenticate", "proxy-authenticate",
 	}
 	for _, h := range hopByHopHeaders {
 		assert.True(t, IsHopByHopHeader(h), "expected %q to be hop-by-hop", h)
@@ -105,6 +106,23 @@ func TestInternalMetadataToHTTPHeaderStripsHopByHop(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"custom-header"}, savedHeaderKeyNames)
+}
+
+func TestInternalMetadataToHTTPHeaderStripsConnectionNominated(t *testing.T) {
+	fakeMetadata := map[string]*internalv1pb.ListStringValue{
+		"Connection":      {Values: []string{"X-Foo, X-Bar"}},
+		"X-Foo":           {Values: []string{"should-be-stripped"}},
+		"X-Bar":           {Values: []string{"should-be-stripped"}},
+		"X-Custom-Header": {Values: []string{"should-survive"}},
+	}
+
+	savedHeaderKeyNames := []string{}
+	ctx := t.Context()
+	InternalMetadataToHTTPHeader(ctx, fakeMetadata, func(k, v string) {
+		savedHeaderKeyNames = append(savedHeaderKeyNames, k)
+	})
+
+	assert.Equal(t, []string{"x-custom-header"}, savedHeaderKeyNames)
 }
 
 func TestIsJSONContentType(t *testing.T) {

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -125,6 +125,22 @@ func TestInternalMetadataToHTTPHeaderStripsConnectionNominated(t *testing.T) {
 	assert.Equal(t, []string{"x-custom-header"}, savedHeaderKeyNames)
 }
 
+func TestInternalMetadataToHTTPHeaderStripsConnectionNominatedMixedCase(t *testing.T) {
+	fakeMetadata := map[string]*internalv1pb.ListStringValue{
+		"CoNnEcTiOn":      {Values: []string{"X-Foo"}},
+		"X-Foo":           {Values: []string{"should-be-stripped"}},
+		"X-Custom-Header": {Values: []string{"should-survive"}},
+	}
+
+	savedHeaderKeyNames := []string{}
+	ctx := t.Context()
+	InternalMetadataToHTTPHeader(ctx, fakeMetadata, func(k, v string) {
+		savedHeaderKeyNames = append(savedHeaderKeyNames, k)
+	})
+
+	assert.Equal(t, []string{"x-custom-header"}, savedHeaderKeyNames)
+}
+
 func TestIsJSONContentType(t *testing.T) {
 	contentTypeTests := []struct {
 		in  string

--- a/pkg/messaging/v1/util_test.go
+++ b/pkg/messaging/v1/util_test.go
@@ -60,6 +60,53 @@ func TestInternalMetadataToHTTPHeader(t *testing.T) {
 	assert.Equal(t, expectedKeyNames, savedHeaderKeyNames)
 }
 
+func TestIsHopByHopHeader(t *testing.T) {
+	hopByHopHeaders := []string{
+		"Connection", "connection",
+		"Keep-Alive", "keep-alive",
+		"Proxy-Connection", "proxy-connection",
+		"Transfer-Encoding", "transfer-encoding",
+		"Upgrade", "upgrade",
+		"HTTP2-Settings", "http2-settings",
+		"TE", "te",
+		"Trailer", "trailer",
+		"Proxy-Authorization", "proxy-authorization",
+	}
+	for _, h := range hopByHopHeaders {
+		assert.True(t, IsHopByHopHeader(h), "expected %q to be hop-by-hop", h)
+	}
+
+	endToEndHeaders := []string{
+		"Content-Type", "Accept", "Authorization", "X-Custom-Header",
+	}
+	for _, h := range endToEndHeaders {
+		assert.False(t, IsHopByHopHeader(h), "expected %q to NOT be hop-by-hop", h)
+	}
+}
+
+func TestInternalMetadataToHTTPHeaderStripsHopByHop(t *testing.T) {
+	testValue := &internalv1pb.ListStringValue{
+		Values: []string{"fakeValue"},
+	}
+
+	fakeMetadata := map[string]*internalv1pb.ListStringValue{
+		"custom-header":  testValue,
+		"Connection":     testValue,
+		"Upgrade":        testValue,
+		"HTTP2-Settings": testValue,
+		"Keep-Alive":     testValue,
+		"TE":             testValue,
+	}
+
+	savedHeaderKeyNames := []string{}
+	ctx := t.Context()
+	InternalMetadataToHTTPHeader(ctx, fakeMetadata, func(k, v string) {
+		savedHeaderKeyNames = append(savedHeaderKeyNames, k)
+	})
+
+	assert.Equal(t, []string{"custom-header"}, savedHeaderKeyNames)
+}
+
 func TestIsJSONContentType(t *testing.T) {
 	contentTypeTests := []struct {
 		in  string

--- a/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(hopbyhop))
+}
+
+type hopbyhop struct {
+	daprd1 *procdaprd.Daprd
+	daprd2 *procdaprd.Daprd
+
+	daprdEndpoint *procdaprd.Daprd
+}
+
+var hopByHopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Connection",
+	"Transfer-Encoding",
+	"Upgrade",
+	"HTTP2-Settings",
+	"TE",
+	"Trailer",
+	"Proxy-Authorization",
+}
+
+func (h *hopbyhop) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+
+	handler.HandleFunc("/echo-request-headers", func(w http.ResponseWriter, r *http.Request) {
+		var sb strings.Builder
+		for k, vals := range r.Header {
+			for _, v := range vals {
+				sb.WriteString(k + ": " + v + "\n")
+			}
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(sb.String()))
+	})
+
+	handler.HandleFunc("/respond-with-hop-by-hop", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "upgrade")
+		w.Header().Set("Upgrade", "h2c")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.Header().Set("Proxy-Connection", "keep-alive")
+		w.Header().Set("HTTP2-Settings", "AAMAAABkAAQAAP__")
+		w.Header().Set("TE", "trailers")
+		w.Header().Set("Trailer", "X-Checksum")
+		w.Header().Set("Proxy-Authorization", "Basic dGVzdDp0ZXN0")
+
+		w.Header().Set("X-Custom-Response", "should-be-forwarded")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	handler.HandleFunc("/passthrough", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Custom-Response", "present")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	handler.HandleFunc("/connection-header-values", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+
+	h.daprd1 = procdaprd.New(t, procdaprd.WithAppPort(srv.Port()))
+	h.daprd2 = procdaprd.New(t, procdaprd.WithAppPort(srv.Port()))
+
+	h.daprdEndpoint = procdaprd.New(t, procdaprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: HTTPEndpoint
+metadata:
+  name: upstream
+spec:
+  version: v1alpha1
+  baseUrl: http://localhost:%d
+`, srv.Port())))
+
+	return []framework.Option{
+		framework.WithProcesses(srv, h.daprd1, h.daprd2, h.daprdEndpoint),
+	}
+}
+
+func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
+	h.daprd1.WaitUntilRunning(t, ctx)
+	h.daprd2.WaitUntilRunning(t, ctx)
+	h.daprdEndpoint.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	doReq := func(t require.TestingT, method, url string, headers map[string]string) (int, string, http.Header) {
+		if h, ok := t.(interface{ Helper() }); ok {
+			h.Helper()
+		}
+		req, err := http.NewRequestWithContext(ctx, method, url, nil)
+		require.NoError(t, err)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		return resp.StatusCode, string(body), resp.Header
+	}
+
+	t.Run("request hop-by-hop stripped on local invocation", func(t *testing.T) {
+		// Use non-triggering values: "Connection: Upgrade" + "Upgrade: h2c" would
+		// cause Go's HTTP server to perform an actual h2c protocol switch (101
+		// Switching Protocols), so we avoid that combination.
+		reqHeaders := map[string]string{
+			"Connection":          "keep-alive",
+			"Upgrade":             "websocket",
+			"HTTP2-Settings":      "AAMAAABkAAQAAP__",
+			"Keep-Alive":          "timeout=5, max=100",
+			"TE":                  "trailers",
+			"Trailer":             "X-Checksum",
+			"Proxy-Authorization": "Basic dGVzdDp0ZXN0",
+			"Proxy-Connection":    "keep-alive",
+
+			"X-Custom-Header": "should-survive",
+			"Accept":          "application/json",
+		}
+
+		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/passthrough",
+			h.daprd1.HTTPPort(), h.daprd1.AppID())
+		status, body, respHeader := doReq(t, http.MethodGet, url, reqHeaders)
+
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "ok", body)
+
+		assert.Equal(t, "present", respHeader.Get("X-Custom-Response"))
+	})
+
+	t.Run("request hop-by-hop stripped on remote invocation", func(t *testing.T) {
+		reqHeaders := map[string]string{
+			"Connection":     "keep-alive",
+			"Upgrade":        "websocket",
+			"HTTP2-Settings": "AAMAAABkAAQAAP__",
+			"Keep-Alive":     "timeout=5",
+			"X-Custom":       "should-survive",
+		}
+
+		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/passthrough",
+			h.daprd2.HTTPPort(), h.daprd1.AppID())
+		status, body, respHeader := doReq(t, http.MethodGet, url, reqHeaders)
+
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "ok", body)
+		assert.Equal(t, "present", respHeader.Get("X-Custom-Response"))
+	})
+
+	t.Run("request hop-by-hop stripped on HTTPEndpoint invocation", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/upstream/method/passthrough",
+				h.daprdEndpoint.HTTPPort())
+			status, body, _ := doReq(c, http.MethodGet, url, map[string]string{
+				"Connection":          "keep-alive",
+				"Upgrade":             "websocket",
+				"HTTP2-Settings":      "AAMAAABkAAQAAP__",
+				"Keep-Alive":          "timeout=5",
+				"TE":                  "trailers",
+				"Trailer":             "X-Checksum",
+				"Proxy-Authorization": "Basic dGVzdDp0ZXN0",
+				"Proxy-Connection":    "keep-alive",
+				"X-Custom-Header":     "should-survive",
+			})
+			assert.Equal(c, http.StatusOK, status)
+			assert.Equal(c, "ok", body)
+		}, time.Second*20, time.Millisecond*200)
+	})
+
+	t.Run("response hop-by-hop stripped on local invocation", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/respond-with-hop-by-hop",
+			h.daprd1.HTTPPort(), h.daprd1.AppID())
+		status, body, respHeader := doReq(t, http.MethodGet, url, nil)
+
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "ok", body)
+
+		for _, hdr := range hopByHopHeaders {
+			assert.Empty(t, respHeader.Get(hdr),
+				"hop-by-hop response header %q should be stripped", hdr)
+		}
+
+		assert.Equal(t, "should-be-forwarded", respHeader.Get("X-Custom-Response"))
+	})
+
+	t.Run("response hop-by-hop stripped on remote invocation", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/respond-with-hop-by-hop",
+			h.daprd2.HTTPPort(), h.daprd1.AppID())
+		status, body, respHeader := doReq(t, http.MethodGet, url, nil)
+
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "ok", body)
+
+		for _, hdr := range hopByHopHeaders {
+			assert.Empty(t, respHeader.Get(hdr),
+				"hop-by-hop response header %q should be stripped", hdr)
+		}
+
+		assert.Equal(t, "should-be-forwarded", respHeader.Get("X-Custom-Response"))
+	})
+
+	t.Run("response hop-by-hop stripped on HTTPEndpoint invocation", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/upstream/method/respond-with-hop-by-hop",
+				h.daprdEndpoint.HTTPPort())
+			status, body, respHeader := doReq(c, http.MethodGet, url, nil)
+			assert.Equal(c, http.StatusOK, status)
+			assert.Equal(c, "ok", body)
+
+			for _, hdr := range hopByHopHeaders {
+				assert.Empty(c, respHeader.Get(hdr),
+					"hop-by-hop response header %q should be stripped", hdr)
+			}
+
+			assert.Equal(c, "should-be-forwarded", respHeader.Get("X-Custom-Response"))
+		}, time.Second*20, time.Millisecond*200)
+	})
+
+	t.Run("individual request hop-by-hop headers stripped", func(t *testing.T) {
+		for _, hdr := range hopByHopHeaders {
+			t.Run(hdr, func(t *testing.T) {
+				url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo-request-headers",
+					h.daprd1.HTTPPort(), h.daprd1.AppID())
+				status, body, _ := doReq(t, http.MethodGet, url, map[string]string{
+					hdr:            "test-value",
+					"X-End-To-End": "should-survive",
+				})
+
+				assert.Equal(t, http.StatusOK, status)
+				assert.NotContains(t, body, hdr+": test-value",
+					"hop-by-hop request header %q should not be forwarded to app", hdr)
+			})
+		}
+	})
+
+	t.Run("individual response hop-by-hop headers stripped", func(t *testing.T) {
+		for _, hdr := range hopByHopHeaders {
+			url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/respond-with-hop-by-hop",
+				h.daprd1.HTTPPort(), h.daprd1.AppID())
+			_, _, respHeader := doReq(t, http.MethodGet, url, nil)
+			assert.Empty(t, respHeader.Get(hdr),
+				"hop-by-hop response header %q should be stripped", hdr)
+		}
+	})
+
+	t.Run("end-to-end headers survive with hop-by-hop stripped", func(t *testing.T) {
+		endToEndHeaders := map[string]string{
+			"Accept":          "application/json",
+			"Authorization":   "Bearer token123",
+			"X-Request-Id":    "req-001",
+			"X-Custom-Header": "custom-value",
+		}
+		hopHeaders := map[string]string{
+			"Connection":     "keep-alive",
+			"Upgrade":        "websocket",
+			"HTTP2-Settings": "AAMAAABkAAQAAP__",
+			"Keep-Alive":     "timeout=5",
+		}
+
+		allHeaders := make(map[string]string)
+		maps.Copy(allHeaders, endToEndHeaders)
+		maps.Copy(allHeaders, hopHeaders)
+
+		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo-request-headers",
+			h.daprd1.HTTPPort(), h.daprd1.AppID())
+		status, body, _ := doReq(t, http.MethodGet, url, allHeaders)
+
+		assert.Equal(t, http.StatusOK, status)
+
+		for hdr, val := range endToEndHeaders {
+			assert.Contains(t, body, hdr+": "+val,
+				"end-to-end header %q should be forwarded to app", hdr)
+		}
+
+		for hdr := range hopHeaders {
+			assert.NotContains(t, body, hdr+": ",
+				"hop-by-hop header %q should not be forwarded to app", hdr)
+		}
+	})
+
+	t.Run("hop-by-hop stripped across HTTP methods", func(t *testing.T) {
+		methods := []string{
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodDelete,
+			http.MethodPatch,
+		}
+
+		hopHeaders := map[string]string{
+			"Connection":     "keep-alive",
+			"Upgrade":        "websocket",
+			"HTTP2-Settings": "AAMAAABkAAQAAP__",
+		}
+
+		for _, method := range methods {
+			t.Run(method, func(t *testing.T) {
+				url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo-request-headers",
+					h.daprd1.HTTPPort(), h.daprd1.AppID())
+				status, body, _ := doReq(t, method, url, hopHeaders)
+
+				assert.Equal(t, http.StatusOK, status)
+
+				for hdr := range hopHeaders {
+					assert.NotContains(t, body, hdr+": ",
+						"hop-by-hop header %q should not be forwarded for %s", hdr, method)
+				}
+			})
+		}
+	})
+
+	t.Run("hop-by-hop stripped with dapr-app-id header invocation", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/passthrough", h.daprd1.HTTPPort())
+		status, body, respHeader := doReq(t, http.MethodGet, url, map[string]string{
+			"dapr-app-id":    h.daprd2.AppID(),
+			"Connection":     "keep-alive",
+			"Upgrade":        "websocket",
+			"HTTP2-Settings": "AAMAAABkAAQAAP__",
+			"X-Custom":       "should-survive",
+		})
+
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "ok", body)
+		assert.Equal(t, "present", respHeader.Get("X-Custom-Response"))
+	})
+
+	t.Run("hop-by-hop stripped with direct URL invocation", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/http://localhost:%d/method/passthrough",
+			h.daprd1.HTTPPort(), h.daprd1.AppPort(t))
+		status, body, _ := doReq(t, http.MethodGet, url, map[string]string{
+			"Connection":     "keep-alive",
+			"Upgrade":        "websocket",
+			"HTTP2-Settings": "AAMAAABkAAQAAP__",
+		})
+
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "ok", body)
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
@@ -54,6 +54,7 @@ var hopByHopHeaders = []string{
 	"TE",
 	"Trailer",
 	"Proxy-Authorization",
+	"Proxy-Authenticate",
 }
 
 func (h *hopbyhop) Setup(t *testing.T) []framework.Option {
@@ -81,6 +82,7 @@ func (h *hopbyhop) Setup(t *testing.T) []framework.Option {
 		w.Header().Set("TE", "trailers")
 		w.Header().Set("Trailer", "X-Checksum")
 		w.Header().Set("Proxy-Authorization", "Basic dGVzdDp0ZXN0")
+		w.Header().Set("Proxy-Authenticate", "Basic realm=test")
 
 		w.Header().Set("X-Custom-Response", "should-be-forwarded")
 		w.WriteHeader(http.StatusOK)

--- a/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
@@ -269,7 +269,10 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 				})
 
 				assert.Equal(t, http.StatusOK, status)
-				assert.NotContains(t, body, hdr+": test-value",
+				// Use canonical header key since Go's HTTP server
+				// canonicalizes header names (e.g. HTTP2-Settings -> Http2-Settings).
+				canonicalHdr := http.CanonicalHeaderKey(hdr)
+				assert.NotContains(t, body, canonicalHdr+": test-value",
 					"hop-by-hop request header %q should not be forwarded to app", hdr)
 			})
 		}
@@ -315,7 +318,8 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 		}
 
 		for hdr := range hopHeaders {
-			assert.NotContains(t, body, hdr+": ",
+			canonicalHdr := http.CanonicalHeaderKey(hdr)
+			assert.NotContains(t, body, canonicalHdr+": ",
 				"hop-by-hop header %q should not be forwarded to app", hdr)
 		}
 	})
@@ -344,7 +348,8 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 				assert.Equal(t, http.StatusOK, status)
 
 				for hdr := range hopHeaders {
-					assert.NotContains(t, body, hdr+": ",
+					canonicalHdr := http.CanonicalHeaderKey(hdr)
+					assert.NotContains(t, body, canonicalHdr+": ",
 						"hop-by-hop header %q should not be forwarded for %s", hdr, method)
 				}
 			})

--- a/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
@@ -121,21 +121,24 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 
-	doReq := func(t require.TestingT, method, url string, headers map[string]string) (int, string, http.Header) {
-		if h, ok := t.(interface{ Helper() }); ok {
-			h.Helper()
-		}
+	doReq := func(method, url string, headers map[string]string) (int, string, http.Header, error) {
 		req, err := http.NewRequestWithContext(ctx, method, url, nil)
-		require.NoError(t, err)
+		if err != nil {
+			return 0, "", nil, err
+		}
 		for k, v := range headers {
 			req.Header.Set(k, v)
 		}
 		resp, err := httpClient.Do(req)
-		require.NoError(t, err)
+		if err != nil {
+			return 0, "", nil, err
+		}
 		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		require.NoError(t, resp.Body.Close())
-		return resp.StatusCode, string(body), resp.Header
+		if err != nil {
+			return 0, "", nil, err
+		}
+		resp.Body.Close()
+		return resp.StatusCode, string(body), resp.Header, nil
 	}
 
 	t.Run("request hop-by-hop stripped on local invocation", func(t *testing.T) {
@@ -158,7 +161,8 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 
 		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/passthrough",
 			h.daprd1.HTTPPort(), h.daprd1.AppID())
-		status, body, respHeader := doReq(t, http.MethodGet, url, reqHeaders)
+		status, body, respHeader, err := doReq(http.MethodGet, url, reqHeaders)
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, "ok", body)
@@ -167,47 +171,60 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("request hop-by-hop stripped on remote invocation", func(t *testing.T) {
-		reqHeaders := map[string]string{
+		hopHeaders := map[string]string{
 			"Connection":     "keep-alive",
 			"Upgrade":        "websocket",
 			"HTTP2-Settings": "AAMAAABkAAQAAP__",
 			"Keep-Alive":     "timeout=5",
-			"X-Custom":       "should-survive",
 		}
 
-		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/passthrough",
+		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo-request-headers",
 			h.daprd2.HTTPPort(), h.daprd1.AppID())
-		status, body, respHeader := doReq(t, http.MethodGet, url, reqHeaders)
+		status, body, _, err := doReq(http.MethodGet, url, hopHeaders)
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, status)
-		assert.Equal(t, "ok", body)
-		assert.Equal(t, "present", respHeader.Get("X-Custom-Response"))
+
+		for hdr := range hopHeaders {
+			canonicalHdr := http.CanonicalHeaderKey(hdr)
+			assert.NotContains(t, body, canonicalHdr+": ",
+				"hop-by-hop request header %q should not be forwarded to app via remote invocation", hdr)
+		}
 	})
 
 	t.Run("request hop-by-hop stripped on HTTPEndpoint invocation", func(t *testing.T) {
+		hopHeaders := map[string]string{
+			"Connection":          "keep-alive",
+			"Upgrade":             "websocket",
+			"HTTP2-Settings":      "AAMAAABkAAQAAP__",
+			"Keep-Alive":          "timeout=5",
+			"TE":                  "trailers",
+			"Trailer":             "X-Checksum",
+			"Proxy-Authorization": "Basic dGVzdDp0ZXN0",
+			"Proxy-Connection":    "keep-alive",
+		}
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/upstream/method/passthrough",
+			url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/upstream/method/echo-request-headers",
 				h.daprdEndpoint.HTTPPort())
-			status, body, _ := doReq(c, http.MethodGet, url, map[string]string{
-				"Connection":          "keep-alive",
-				"Upgrade":             "websocket",
-				"HTTP2-Settings":      "AAMAAABkAAQAAP__",
-				"Keep-Alive":          "timeout=5",
-				"TE":                  "trailers",
-				"Trailer":             "X-Checksum",
-				"Proxy-Authorization": "Basic dGVzdDp0ZXN0",
-				"Proxy-Connection":    "keep-alive",
-				"X-Custom-Header":     "should-survive",
-			})
+			status, body, _, err := doReq(http.MethodGet, url, hopHeaders)
+			if !assert.NoError(c, err) {
+				return
+			}
 			assert.Equal(c, http.StatusOK, status)
-			assert.Equal(c, "ok", body)
+
+			for hdr := range hopHeaders {
+				canonicalHdr := http.CanonicalHeaderKey(hdr)
+				assert.NotContains(c, body, canonicalHdr+": ",
+					"hop-by-hop request header %q should not be forwarded to app via HTTPEndpoint", hdr)
+			}
 		}, time.Second*20, time.Millisecond*200)
 	})
 
 	t.Run("response hop-by-hop stripped on local invocation", func(t *testing.T) {
 		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/respond-with-hop-by-hop",
 			h.daprd1.HTTPPort(), h.daprd1.AppID())
-		status, body, respHeader := doReq(t, http.MethodGet, url, nil)
+		status, body, respHeader, err := doReq(http.MethodGet, url, nil)
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, "ok", body)
@@ -223,7 +240,8 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 	t.Run("response hop-by-hop stripped on remote invocation", func(t *testing.T) {
 		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/respond-with-hop-by-hop",
 			h.daprd2.HTTPPort(), h.daprd1.AppID())
-		status, body, respHeader := doReq(t, http.MethodGet, url, nil)
+		status, body, respHeader, err := doReq(http.MethodGet, url, nil)
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, "ok", body)
@@ -240,7 +258,10 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/upstream/method/respond-with-hop-by-hop",
 				h.daprdEndpoint.HTTPPort())
-			status, body, respHeader := doReq(c, http.MethodGet, url, nil)
+			status, body, respHeader, err := doReq(http.MethodGet, url, nil)
+			if !assert.NoError(c, err) {
+				return
+			}
 			assert.Equal(c, http.StatusOK, status)
 			assert.Equal(c, "ok", body)
 
@@ -258,10 +279,11 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 			t.Run(hdr, func(t *testing.T) {
 				url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo-request-headers",
 					h.daprd1.HTTPPort(), h.daprd1.AppID())
-				status, body, _ := doReq(t, http.MethodGet, url, map[string]string{
+				status, body, _, err := doReq(http.MethodGet, url, map[string]string{
 					hdr:            "test-value",
 					"X-End-To-End": "should-survive",
 				})
+				require.NoError(t, err)
 
 				assert.Equal(t, http.StatusOK, status)
 				// Use canonical header key since Go's HTTP server
@@ -277,7 +299,8 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 		for _, hdr := range hopByHopHeaders {
 			url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/respond-with-hop-by-hop",
 				h.daprd1.HTTPPort(), h.daprd1.AppID())
-			_, _, respHeader := doReq(t, http.MethodGet, url, nil)
+			_, _, respHeader, err := doReq(http.MethodGet, url, nil)
+			require.NoError(t, err)
 			assert.Empty(t, respHeader.Get(hdr),
 				"hop-by-hop response header %q should be stripped", hdr)
 		}
@@ -303,7 +326,8 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 
 		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo-request-headers",
 			h.daprd1.HTTPPort(), h.daprd1.AppID())
-		status, body, _ := doReq(t, http.MethodGet, url, allHeaders)
+		status, body, _, err := doReq(http.MethodGet, url, allHeaders)
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, status)
 
@@ -338,7 +362,8 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 			t.Run(method, func(t *testing.T) {
 				url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/echo-request-headers",
 					h.daprd1.HTTPPort(), h.daprd1.AppID())
-				status, body, _ := doReq(t, method, url, hopHeaders)
+				status, body, _, err := doReq(method, url, hopHeaders)
+				require.NoError(t, err)
 
 				assert.Equal(t, http.StatusOK, status)
 
@@ -353,13 +378,14 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 
 	t.Run("hop-by-hop stripped with dapr-app-id header invocation", func(t *testing.T) {
 		url := fmt.Sprintf("http://localhost:%d/passthrough", h.daprd1.HTTPPort())
-		status, body, respHeader := doReq(t, http.MethodGet, url, map[string]string{
+		status, body, respHeader, err := doReq(http.MethodGet, url, map[string]string{
 			"dapr-app-id":    h.daprd2.AppID(),
 			"Connection":     "keep-alive",
 			"Upgrade":        "websocket",
 			"HTTP2-Settings": "AAMAAABkAAQAAP__",
 			"X-Custom":       "should-survive",
 		})
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, "ok", body)
@@ -369,11 +395,12 @@ func (h *hopbyhop) Run(t *testing.T, ctx context.Context) {
 	t.Run("hop-by-hop stripped with direct URL invocation", func(t *testing.T) {
 		url := fmt.Sprintf("http://localhost:%d/v1.0/invoke/http://localhost:%d/method/passthrough",
 			h.daprd1.HTTPPort(), h.daprd1.AppPort(t))
-		status, body, _ := doReq(t, http.MethodGet, url, map[string]string{
+		status, body, _, err := doReq(http.MethodGet, url, map[string]string{
 			"Connection":     "keep-alive",
 			"Upgrade":        "websocket",
 			"HTTP2-Settings": "AAMAAABkAAQAAP__",
 		})
+		require.NoError(t, err)
 
 		assert.Equal(t, http.StatusOK, status)
 		assert.Equal(t, "ok", body)

--- a/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/hopbyhop.go
@@ -94,11 +94,6 @@ func (h *hopbyhop) Setup(t *testing.T) []framework.Option {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))
 	})
-	handler.HandleFunc("/connection-header-values", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
-	})
-
 	srv := prochttp.New(t, prochttp.WithHandler(handler))
 
 	h.daprd1 = procdaprd.New(t, procdaprd.WithAppPort(srv.Port()))


### PR DESCRIPTION
Dapr forwarded hop-by-hop headers (Connection, Upgrade, HTTP2-Settings, TE, Keep-Alive, Trailer, Proxy-Authorization, Proxy-Connection, Transfer-Encoding) when proxying HTTP requests to upstream applications and HTTPEndpoints, violating RFC 7230 Section 6.1. This caused failures when HTTP clients sent HTTP/2 upgrade headers (Upgrade: h2c) that upstream HTTPS servers rejected.

Add IsHopByHopHeader() filter and apply it in InternalMetadataToHTTPHeader (request forwarding) and copyHeader (response forwarding).

Fixes dapr/dapr#9758

---

Dapr forwards hop-by-hop HTTP headers when proxying service invocation requests

Problem

When a client sends hop-by-hop HTTP headers such as `Connection`, `Upgrade`, `HTTP2-Settings`, `TE`, `Keep-Alive`, `Trailer`, `Proxy-Authorization`, and `Proxy-Connection` to the Dapr sidecar, Dapr forwards them to the upstream application or HTTPEndpoint. This violates RFC 7230 Section 6.1, which requires intermediaries (proxies) to remove hop-by-hop headers before forwarding a message.

Impact

This affects all HTTP service invocation paths: local invocation, remote invocation, HTTPEndpoint invocation, dapr-app-id header invocation, and direct URL invocation.

The most visible failure occurs when a HTTP client configured with `HTTP_2` sends `Upgrade: h2c`, `Connection: Upgrade`, and `HTTP2-Settings` headers to the Dapr sidecar. Dapr forwards these to the upstream HTTPS endpoint, which rejects the request with:

```
http2: invalid Upgrade request header: ["h2c"]
```

Other upstream servers may silently accept the leaked headers, but the behavior is still incorrect per the HTTP specification and may cause subtle issues with proxies, load balancers, or HTTP/2-strict servers. The same issue also applied to response headers: if an upstream application set hop-by-hop headers on its response, Dapr forwarded them back to the caller.

Root Cause

The `InternalMetadataToHTTPHeader` function, which converts internal metadata to outgoing HTTP request headers, did not filter out hop-by-hop headers. It forwarded all headers except trace headers, `Content-Type`, `Content-Length`, and gRPC binary metadata. Similarly, the `copyHeader` function, which copies upstream response headers back to the caller, performed a naive copy of all headers with no filtering.

Solution

A new filter function identifies the standard hop-by-hop headers per RFC 7230 Section 6.1: `Connection`, `Keep-Alive`, `Proxy-Connection`, `Transfer-Encoding`, `Upgrade`, `HTTP2-Settings`, `TE`, `Trailer`, and `Proxy-Authorization`. This filter is applied to request and response paths. End-to-end headers such as `Accept`, `Authorization`, `Content-Type`, and custom headers (`X-*`) are unaffected and continue to be forwarded normally.