### PR TITLE
Tolerate missing CRDs in operator informers

### DIFF
--- a/pkg/operator/api/informer/informer.go
+++ b/pkg/operator/api/informer/informer.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/tools/cache"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 
@@ -85,6 +86,17 @@ func (i *informer[T]) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return nil
 		}
+
+		// If the CRD for this resource type is not installed, log a warning and
+		// run as a no-op rather than crashing the operator. This supports
+		// version-skew scenarios where newer control plane binaries run against a
+		// cluster that doesn't yet have all CRDs.
+		if apimeta.IsNoMatchError(err) {
+			i.log.Warnf("CRD for %s not found, skipping informer", zero.Kind())
+			<-ctx.Done()
+			return nil
+		}
+
 		return fmt.Errorf("unable to get setup %s informer: %w", zero.Kind(), err)
 	}
 

--- a/pkg/operator/api/informer/informer.go
+++ b/pkg/operator/api/informer/informer.go
@@ -92,7 +92,7 @@ func (i *informer[T]) Run(ctx context.Context) error {
 		// version-skew scenarios where newer control plane binaries run against a
 		// cluster that doesn't yet have all CRDs.
 		if apimeta.IsNoMatchError(err) {
-			i.log.Warnf("CRD for %s not found, skipping informer", zero.Kind())
+			i.log.Warnf("CRD for %s/%s not found, skipping informer: %v", zero.APIVersion(), zero.Kind(), err)
 			<-ctx.Done()
 			return nil
 		}

--- a/pkg/operator/api/informer/informer_test.go
+++ b/pkg/operator/api/informer/informer_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package informer
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -22,8 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/dapr/dapr/pkg/apis/common"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
@@ -31,6 +37,16 @@ import (
 	"github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/dapr/kit/crypto/test"
 )
+
+// fakeCache is a minimal ctrlcache.Cache stub that only implements GetInformer.
+type fakeCache struct {
+	ctrlcache.Cache
+	getInformerErr error
+}
+
+func (f *fakeCache) GetInformer(ctx context.Context, obj client.Object, opts ...ctrlcache.InformerGetOption) (ctrlcache.Informer, error) {
+	return nil, f.getInformerErr
+}
 
 func Test_WatchUpdates(t *testing.T) {
 	t.Run("bad authz should error", func(t *testing.T) {
@@ -127,6 +143,55 @@ func Test_WatchUpdates(t *testing.T) {
 				}
 			}
 		}
+	})
+}
+
+func Test_Run(t *testing.T) {
+	t.Run("NoKindMatchError should not return error", func(t *testing.T) {
+		i := New[compapi.Component](Options{
+			Cache: &fakeCache{
+				getInformerErr: &apimeta.NoKindMatchError{
+					GroupKind:        schema.GroupKind{Group: "dapr.io", Kind: "Component"},
+					SearchedVersions: []string{"v1alpha1"},
+				},
+			},
+		})
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- i.Run(ctx)
+		}()
+
+		// Ensure Run blocks (does not return immediately).
+		select {
+		case err := <-errCh:
+			t.Fatalf("expected Run to block, but it returned: %v", err)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		cancel()
+
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("expected Run to return after context cancellation")
+		}
+	})
+
+	t.Run("other errors should be returned", func(t *testing.T) {
+		i := New[compapi.Component](Options{
+			Cache: &fakeCache{
+				getInformerErr: errors.New("some other error"),
+			},
+		})
+
+		err := i.Run(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to get setup Component informer")
+		assert.Contains(t, err.Error(), "some other error")
 	})
 }
 


### PR DESCRIPTION
When a CRD (e.g. `MCPServer`) is not yet installed on the cluster, the operator informer now logs a warning and runs as a no-op instead of fatally crashing. This fixes version-skew integration tests where a newer control plane operator runs against an older cluster that does not have all CRDs registered.