### PR TITLE
Go: Update to v1.26.2

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -1,6 +1,6 @@
 module build-tools
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/google/go-containerregistry v0.11.1-0.20220802162123-c1f9836a4fa9

--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ MODFILES := $(shell find . -name go.mod)
 define modtidy-target
 .PHONY: modtidy-$(1)
 modtidy-$(1):
-	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.26.1; cd -
+	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.26.2; cd -
 endef
 
 # Generate modtidy target action for each go.mod file

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,6 +1,6 @@
 # current directory must be ./dist
 
-FROM golang:1.26.1
+FROM golang:1.26.2
 
 ARG PKG_FILES
 RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,7 +1,7 @@
 # Based on https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/go/.devcontainer/base.Dockerfile
 
-# [Choice] Go version: 1, 1.26.1, etc
-ARG GOVERSION=1.26.1
+# [Choice] Go version: 1, 1.26.2, etc
+ARG GOVERSION=1.26.2
 FROM golang:${GOVERSION}-bullseye
 
 # [Option] Install zsh

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ This includes dockerfiles to build Dapr release and debug images and development
 
 The Dev Container can be rebuilt with custom options. Relevant args (and their default values) include:
 
-* `GOVERSION` (default: `1.26.1`)
+* `GOVERSION` (default: `1.26.2`)
 * `INSTALL_ZSH` (default: `true`)
 * `KUBECTL_VERSION` (default: `latest`)
 * `HELM_VERSION` (default: `latest`)

--- a/docs/development/setup-dapr-development-env.md
+++ b/docs/development/setup-dapr-development-env.md
@@ -23,7 +23,7 @@ This document helps you get started developing Dapr. If you find any problems wh
 
 ## Go (Golang)
 
-1. Download and install [Go 1.26.1 or later](https://golang.org/doc/install#tarball).
+1. Download and install [Go 1.26.2 or later](https://golang.org/doc/install#tarball).
 
 2. Install [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation) for Go debugging, if desired.
 

--- a/docs/release_notes/v1.17.4.md
+++ b/docs/release_notes/v1.17.4.md
@@ -1,10 +1,11 @@
 # Dapr 1.17.4
 
-This update contains bug fixes:
+This update contains bug fixes and security fixes:
 - [Pulsar pub/sub ignores processMode from component metadata and lacks async backpressure](#pulsar-pubsub-ignores-processmode-from-component-metadata-and-lacks-async-backpressure)
 - [Cross-app workflow stuck in PENDING when the first action is a remote activity or child workflow call to an offline app](#cross-app-workflow-stuck-in-pending-when-the-first-action-is-a-remote-activity-or-child-workflow-call-to-an-offline-app)
 - [Dapr forwards hop-by-hop HTTP headers when proxying service invocation requests](#dapr-forwards-hop-by-hop-http-headers-when-proxying-service-invocation-requests)
 - [Workflow events lost during ContinueAsNew under high event volume](#workflow-events-lost-during-continueasnew-under-high-event-volume)
+- [Security: Update Go to 1.26.2 for security fixes](#security-update-go-to-1262-for-security-fixes)
 
 ## Pulsar pub/sub ignores processMode from component metadata and lacks async backpressure
 
@@ -130,3 +131,32 @@ On retry, the workflow resumes from the corrupted counter value instead of the l
 The workflow runtime state is now cloned before being passed to the engine for execution.
 The engine operates on its own copy, so if execution fails for any reason, the actor's cached state remains consistent with what was last persisted to the state store.
 Retries start from the correct state and all events are processed.
+
+## Security: Update Go to 1.26.2 for security fixes
+
+### Problem
+
+Go 1.26.1 contains known security vulnerabilities that are fixed in Go 1.26.2. The following CVEs are addressed:
+
+- **CVE-2026-32282** (`os`): `Root.Chmod` can follow symlinks out of the root on Linux due to `fchmodat` silently ignoring the `AT_SYMLINK_NOFOLLOW` flag, allowing modification of files outside the intended root directory.
+- **CVE-2026-32283** (`crypto/tls`): Multiple key update handshake messages in a single record can cause a TLS connection to deadlock, leading to denial of service.
+- **CVE-2026-27144** (`cmd/compile`): No-op interface conversions bypass overlap checking, allowing the compiler to incorrectly determine non-overlapping memory moves and permit unsafe move operations.
+- **CVE-2026-27143** (`archive/tar`): `tar.Reader` could allocate unbounded memory when reading a maliciously-crafted archive containing a large number of sparse regions encoded in the old GNU sparse map format.
+- **CVE-2026-32288** (`archive/tar`): `tar.Reader` could allocate unbounded memory when reading malicious archives with sparse map extension blocks and sparse file entries.
+- **CVE-2026-32289** (`html/template`): Context was not properly tracked across template branches for JS template literals, leading to incorrect escaping and potential XSS vulnerabilities.
+- **CVE-2026-27140** (`html/template`): Template actions within JS template literals did not properly track brace depth, leading to incorrect escaping.
+- **CVE-2026-33810** (`crypto/x509`): Excluded DNS constraints were not correctly applied to wildcard DNS SANs using a different case than the constraint.
+- **CVE-2026-32280** (`crypto/x509`): Excessive chain-building work in `Verify` when presented with many candidate parent certificates, leading to denial of service.
+- **CVE-2026-32281** (`crypto/x509`): Quadratic work in policy validation with large `PolicyMappings`, leading to denial of service.
+
+### Impact
+
+Users running Dapr built with Go 1.26.1 may be exposed to the security vulnerabilities listed above. These include potential denial of service via crafted TLS messages, tar archives, or X.509 certificates, XSS via HTML template escaping issues, symlink traversal in filesystem operations, and memory safety issues in the compiler.
+
+### Root Cause
+
+The issues originate in the Go standard library and runtime.
+
+### Solution
+
+This release updates the Go toolchain from 1.26.1 to 1.26.2, which includes security fixes from the Go team. All Dapr binaries, Docker images, and test applications are now built with Go 1.26.2.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr
 
-go 1.26.1
+go 1.26.2
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/tests/apps/actorload/Dockerfile
+++ b/tests/apps/actorload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1
+FROM golang:1.26.2
 WORKDIR /actorload/
 COPY . .
 RUN make build

--- a/tests/apps/actorload/go.mod
+++ b/tests/apps/actorload/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/actorload
 
-go 1.26.1
+go 1.26.2
 
 require (
 	fortio.org/fortio v1.6.8

--- a/tests/apps/crypto/Dockerfile
+++ b/tests/apps/crypto/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.1 as build_env
+FROM golang:1.26.2 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/crypto/go.mod
+++ b/tests/apps/crypto/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/crypto
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr/go-sdk v1.8.0

--- a/tests/apps/perf/actor-activation-locker/Dockerfile
+++ b/tests/apps/perf/actor-activation-locker/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.1 as build_env
+FROM golang:1.26.2 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/actor-activation-locker/go.mod
+++ b/tests/apps/perf/actor-activation-locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/actor-activation-locker
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/bsm/redislock v0.8.2

--- a/tests/apps/perf/actorfeatures/Dockerfile
+++ b/tests/apps/perf/actorfeatures/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.26.1-bookworm as build_env
+FROM golang:1.26.2-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod go.sum ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.26.1-bookworm as fortio_build_env
+FROM golang:1.26.2-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/actorfeatures/go.mod
+++ b/tests/apps/perf/actorfeatures/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr/dapr v1.13.4

--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -1,5 +1,5 @@
 # Build the k6 binary with the extension
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 
 WORKDIR $GOPATH/src/go.k6.io/k6
 

--- a/tests/apps/perf/service_invocation_grpc/Dockerfile
+++ b/tests/apps/perf/service_invocation_grpc/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.1 as build_env
+FROM golang:1.26.2 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_grpc/go.mod
+++ b/tests/apps/perf/service_invocation_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_grpc
 
-go 1.26.1
+go 1.26.2
 
 require github.com/dapr/go-sdk v1.8.0
 

--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.1 as build_env
+FROM golang:1.26.2 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_http/go.mod
+++ b/tests/apps/perf/service_invocation_http/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_http
 
-go 1.26.1
+go 1.26.2

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.26.1-bookworm as build_env
+FROM golang:1.26.2-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.26.1-bookworm as fortio_build_env
+FROM golang:1.26.2-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/tester/go.mod
+++ b/tests/apps/perf/tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.26.1
+go 1.26.2

--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/kafka-bindings
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-pubsub/go.mod
+++ b/tests/apps/pluggable_redis-pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-pubsub
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-statestore/go.mod
+++ b/tests/apps/pluggable_redis-statestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-statestore
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pubsub-publisher-streaming/Dockerfile
+++ b/tests/apps/pubsub-publisher-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.1 AS build_env
+FROM golang:1.26.2 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-publisher-streaming/go.mod
+++ b/tests/apps/pubsub-publisher-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-publisher-streaming
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/pubsub-subscriber-streaming/Dockerfile
+++ b/tests/apps/pubsub-subscriber-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.1 AS build_env
+FROM golang:1.26.2 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-subscriber-streaming/go.mod
+++ b/tests/apps/pubsub-subscriber-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-subscriber-streaming
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/resiliencyapp/go.mod
+++ b/tests/apps/resiliencyapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr/dapr v0.0.0

--- a/tests/apps/resiliencyapp_grpc/go.mod
+++ b/tests/apps/resiliencyapp_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp_grpc
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr/dapr v1.7.4

--- a/tests/apps/service_invocation_grpc_proxy_client/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_client/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_client
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/dapr/dapr v0.0.0-00010101000000-000000000000

--- a/tests/apps/service_invocation_grpc_proxy_server/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_server/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_server
 
-go 1.26.1
+go 1.26.2
 
 require (
 	google.golang.org/grpc v1.54.0

--- a/tests/integration/framework/binary/helpers/helmtemplate/go.mod
+++ b/tests/integration/framework/binary/helpers/helmtemplate/go.mod
@@ -1,6 +1,6 @@
 module helm
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
Updates Go version for security fixes.