### PR TITLE
Fix daprd sidecar placement dissemination timeout handling

### DIFF
--- a/docs/release_notes/v1.17.4.md
+++ b/docs/release_notes/v1.17.4.md
@@ -5,6 +5,7 @@ This update contains bug fixes:
 - [Cross-app workflow stuck in PENDING when the first action is a remote activity or child workflow call to an offline app](#cross-app-workflow-stuck-in-pending-when-the-first-action-is-a-remote-activity-or-child-workflow-call-to-an-offline-app)
 - [Dapr forwards hop-by-hop HTTP headers when proxying service invocation requests](#dapr-forwards-hop-by-hop-http-headers-when-proxying-service-invocation-requests)
 - [Workflow events lost during ContinueAsNew under high event volume](#workflow-events-lost-during-continueasnew-under-high-event-volume)
+- [Workflow and actor operations freeze when a slow sidecar delays placement dissemination](#workflow-and-actor-operations-freeze-when-a-slow-sidecar-delays-placement-dissemination)
 
 ## Pulsar pub/sub ignores processMode from component metadata and lacks async backpressure
 
@@ -133,3 +134,43 @@ Two related issues cause event loss and duplicate processing when the workflow e
 1. **State snapshot and restore on failure**: Before executing the workflow, the orchestrator saves a snapshot of the runtime state. The engine still mutates the in-memory workflow state during execution, but if execution fails for any reason, the orchestrator restores the snapshot so the actor's cached state remains consistent with what was last persisted to the state store.
 
 2. **Inbox replacement with carryover events**: When partial `ContinueAsNew` progress is saved, unprocessed carryover events (buffered `EventRaised` events from the engine's `ContinueAsNew` state) are moved from history to the inbox, and the stale original inbox is discarded. On retry, only the unprocessed carryover events are delivered as new events, preventing duplicate processing.
+
+## Workflow and actor operations freeze when a slow sidecar delays placement dissemination
+
+### Problem
+
+When one daprd sidecar in a namespace is slow to respond during placement table dissemination (for example, due to GC pressure, high actor load, or network latency), all other sidecars in the same namespace experience frozen workflow and actor operations. Scheduling new workflows, invoking actors, and running `dapr workflow terminate` or `dapr workflow purge` all hang indefinitely. After restarting the app, workflows may appear as RUNNING but no activities execute, and `get_workflow_state` returns nothing.
+
+### Impact
+
+Any deployment with multiple replicas using actors or workflows is affected. A single slow sidecar can freeze all actor and workflow operations across every other sidecar in the namespace for as long as the placement server takes to time out the slow peer (8 seconds by default), plus the sidecar's own 5-second timeout. In practice, this created a 10-15 second window where:
+
+- All actor method invocations hang
+- All workflow scheduling, termination, and purge operations hang
+- Actor reminders stop firing
+- Applications stop responding to health probes and are declared unhealthy by Kubernetes
+- With a workflow SDK client connected, the daprd process enters a zombie state where it can neither serve requests nor exit
+
+The issue is particularly severe during rolling updates, where pod cycling causes repeated dissemination rounds that can trigger the timeout multiple times in succession.
+
+### Root Cause
+
+When the daprd sidecar receives a LOCK order from the placement server during actor table dissemination, it blocks all in-flight actor operations (the "inflight lock") until it receives the corresponding UNLOCK. The placement server only sends UNLOCK after every sidecar in the namespace has responded to each phase (LOCK, UPDATE, UNLOCK). If one sidecar is slow, no other sidecar receives UPDATE or UNLOCK.
+
+The daprd sidecar has a 5-second timeout for this wait. When the timeout fired, it killed the entire placement subsystem by sending a fatal error through the internal error channel, which terminated the placement connection permanently. The sidecar never reconnected. Actor operations that were queued during the LOCK phase were silently abandoned, and any new actor operations hung indefinitely because the placement client was dead.
+
+### Solution
+
+The dissemination timeout now closes the placement stream and triggers an automatic reconnection, instead of killing the placement subsystem. After the timeout:
+
+1. The sidecar closes its stream to the placement server
+2. All actors are halted and the routing table is cleared
+3. The sidecar reconnects to placement and re-registers
+4. A new dissemination round completes and actor operations resume
+
+This matches the existing recovery behavior for network disconnections (EOF, connection reset), which already reconnected successfully. The timeout was the only error path that did not reconnect.
+
+Additionally, this release fixes two related issues in the dissemination subsystem:
+
+- The placement readiness flag was set immediately after reconnecting, before the new dissemination round completed. This caused the daprd to report healthy to metadata queries while actor operations were still blocked. The readiness flag is now only set after the first successful UNLOCK.
+- Recycled disseminator objects from the internal pool could carry a stale timeout version counter from their previous use, potentially causing a valid timeout to be incorrectly ignored. The counter is now reset on reuse.

--- a/pkg/actors/internal/placement/loops/disseminator/disseminator.go
+++ b/pkg/actors/internal/placement/loops/disseminator/disseminator.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dapr/dapr/pkg/actors/internal/placement/loops"
@@ -49,7 +50,7 @@ type Options struct {
 	HTarget       healthz.Target
 
 	DisseminationTimeout time.Duration
-	Cancel               context.CancelCauseFunc
+	Ready                *atomic.Bool
 
 	Inflight  *inflight.Inflight
 	Namespace string
@@ -65,10 +66,10 @@ type disseminator struct {
 	actorTable   table.Interface
 	scheduler    schedclient.Reloader
 	healthTarget healthz.Target
+	ready        *atomic.Bool
 
 	timeout        time.Duration
 	timeoutQ       *timeout.Timeout
-	cancel         context.CancelCauseFunc
 	timeoutVersion uint64
 
 	streamLoop loop.Interface[loops.EventStream]
@@ -89,7 +90,9 @@ func New(ctx context.Context, opts Options) loop.Interface[loops.EventDiss] {
 
 	diss.currentOperation = v1pb.HostOperation_LOCK
 	diss.currentVersion = 0
+	diss.timeoutVersion = 0
 	diss.healthTarget = opts.HTarget
+	diss.ready = opts.Ready
 
 	diss.loop = LoopFactoryCache.NewLoop(diss)
 	diss.inflight = opts.Inflight
@@ -99,8 +102,6 @@ func New(ctx context.Context, opts Options) loop.Interface[loops.EventDiss] {
 		Loop:    diss.loop,
 		Timeout: opts.DisseminationTimeout,
 	})
-	diss.cancel = opts.Cancel
-
 	diss.streamLoop = stream.New(ctx, stream.Options{
 		Channel:       opts.Channel,
 		PlacementLoop: opts.PlacementLoop,
@@ -155,10 +156,17 @@ func (d *disseminator) handleTimeout(ctx context.Context, timeout *loops.Dissemi
 		return
 	}
 
-	log.Warnf("Dissemination timeout for version %d, shutting down", timeout.Version)
+	log.Warnf("Dissemination timeout for version %d, closing stream to reconnect", timeout.Version)
 
-	d.cancel(fmt.Errorf("dissemination timeout after %s for version %d",
-		d.timeout,
-		timeout.Version,
-	))
+	// Close the stream rather than killing the placement subsystem. The recv
+	// goroutine will exit and enqueue ConnCloseStream to the placement loop,
+	// which will shut down this disseminator, halt actors, and reconnect to
+	// placement. This ensures actor operations are unblocked promptly instead
+	// of hanging until the server-side timeout resolves the slow peer.
+	d.streamLoop.Close(&loops.Shutdown{
+		Error: fmt.Errorf("dissemination timeout after %s for version %d",
+			d.timeout,
+			timeout.Version,
+		),
+	})
 }

--- a/pkg/actors/internal/placement/loops/disseminator/order.go
+++ b/pkg/actors/internal/placement/loops/disseminator/order.go
@@ -77,10 +77,12 @@ func (d *disseminator) handleOrder(ctx context.Context, order *loops.StreamOrder
 
 	case operationUpdate:
 		if d.currentVersion > version {
-			d.cancel(fmt.Errorf("version mismatch: expected %d, got %d",
-				d.currentVersion,
-				version,
-			))
+			d.streamLoop.Close(&loops.Shutdown{
+				Error: fmt.Errorf("version mismatch: expected %d, got %d",
+					d.currentVersion,
+					version,
+				),
+			})
 			return nil
 		}
 
@@ -136,9 +138,12 @@ func (d *disseminator) handleOrder(ctx context.Context, order *loops.StreamOrder
 		})
 
 		d.healthTarget.Ready()
+		d.ready.Store(true)
 
 	default:
-		d.cancel(fmt.Errorf("unknown operation: %s", order.Order.GetOperation()))
+		d.streamLoop.Close(&loops.Shutdown{
+			Error: fmt.Errorf("unknown operation: %s", order.Order.GetOperation()),
+		})
 		return nil
 	}
 

--- a/pkg/actors/internal/placement/loops/disseminator/order_test.go
+++ b/pkg/actors/internal/placement/loops/disseminator/order_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package disseminator
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func newTestDisseminator(t *testing.T) (*disseminator, *healthzfake.Fake, *sched
 		currentOperation: v1pb.HostOperation_LOCK,
 		currentVersion:   0,
 		timeout:          time.Second * 30,
-		cancel:           func(error) {},
+		ready:            new(atomic.Bool),
 	}
 
 	diss.loop = dissLoop

--- a/pkg/actors/internal/placement/loops/disseminator/order_test.go
+++ b/pkg/actors/internal/placement/loops/disseminator/order_test.go
@@ -71,6 +71,113 @@ func newTestDisseminator(t *testing.T) (*disseminator, *healthzfake.Fake, *sched
 	return diss, ht, sched
 }
 
+func TestHandleTimeout(t *testing.T) {
+	t.Run("matching version closes stream", func(t *testing.T) {
+		diss, _, _ := newTestDisseminator(t)
+
+		var streamClosed bool
+		diss.streamLoop = loopfake.New[loops.EventStream]().
+			WithClose(func(loops.EventStream) {
+				streamClosed = true
+			})
+
+		diss.timeoutVersion = 3
+		diss.handleTimeout(t.Context(), &loops.DisseminationTimeout{Version: 3})
+		assert.True(t, streamClosed, "stream should be closed on matching timeout version")
+	})
+
+	t.Run("old version is ignored", func(t *testing.T) {
+		diss, _, _ := newTestDisseminator(t)
+
+		var streamClosed bool
+		diss.streamLoop = loopfake.New[loops.EventStream]().
+			WithClose(func(loops.EventStream) {
+				streamClosed = true
+			})
+
+		diss.timeoutVersion = 5
+		diss.handleTimeout(t.Context(), &loops.DisseminationTimeout{Version: 3})
+		assert.False(t, streamClosed, "stream should not be closed for stale timeout version")
+	})
+}
+
+func TestHandleOrder_UpdateVersionMismatch(t *testing.T) {
+	t.Run("update with lower version closes stream", func(t *testing.T) {
+		diss, _, _ := newTestDisseminator(t)
+
+		var streamClosed bool
+		diss.streamLoop = loopfake.New[loops.EventStream]().
+			WithClose(func(loops.EventStream) {
+				streamClosed = true
+			})
+
+		diss.currentVersion = 10
+		err := diss.handleOrder(t.Context(), &loops.StreamOrder{
+			Order: &v1pb.PlacementOrder{
+				Operation: operationUpdate,
+				Version:   5,
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, streamClosed, "stream should be closed on version mismatch")
+	})
+}
+
+func TestHandleOrder_UnknownOperation(t *testing.T) {
+	t.Run("unknown operation closes stream", func(t *testing.T) {
+		diss, _, _ := newTestDisseminator(t)
+
+		var streamClosed bool
+		diss.streamLoop = loopfake.New[loops.EventStream]().
+			WithClose(func(loops.EventStream) {
+				streamClosed = true
+			})
+
+		err := diss.handleOrder(t.Context(), &loops.StreamOrder{
+			Order: &v1pb.PlacementOrder{
+				Operation: "invalid",
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, streamClosed, "stream should be closed on unknown operation")
+	})
+}
+
+func TestHandleTimeout_UpdateDequeuesTimeout(t *testing.T) {
+	t.Run("UPDATE arriving before timeout dequeues the timeout", func(t *testing.T) {
+		diss, _, _ := newTestDisseminator(t)
+
+		var streamClosed bool
+		diss.streamLoop = loopfake.New[loops.EventStream]().
+			WithClose(func(loops.EventStream) {
+				streamClosed = true
+			})
+
+		err := diss.handleOrder(t.Context(), &loops.StreamOrder{
+			Order: &v1pb.PlacementOrder{
+				Operation: operationLock,
+				Version:   5,
+			},
+		})
+		require.NoError(t, err)
+
+		err = diss.handleOrder(t.Context(), &loops.StreamOrder{
+			Order: &v1pb.PlacementOrder{
+				Operation: operationUpdate,
+				Version:   5,
+				Tables:    &v1pb.PlacementTables{},
+			},
+		})
+		require.NoError(t, err)
+
+		savedVersion := diss.timeoutVersion - 1
+		diss.handleTimeout(t.Context(), &loops.DisseminationTimeout{
+			Version: savedVersion,
+		})
+		assert.False(t, streamClosed, "timeout should be ignored after UPDATE dequeued it")
+	})
+}
+
 func TestHandleOrder_UnlockVersionMismatch(t *testing.T) {
 	t.Run("unlock with lower version is ignored and currentVersion is preserved", func(t *testing.T) {
 		diss, ht, _ := newTestDisseminator(t)

--- a/pkg/actors/internal/placement/loops/placement/placement.go
+++ b/pkg/actors/internal/placement/loops/placement/placement.go
@@ -52,7 +52,6 @@ type Options struct {
 	Scheduler  schedclient.Reloader
 
 	DisseminationTimeout time.Duration
-	Cancel               context.CancelCauseFunc
 }
 
 type placement struct {
@@ -77,7 +76,6 @@ type placement struct {
 	host     *v1pb.Host
 
 	dissTimeout time.Duration
-	cancel      context.CancelCauseFunc
 
 	wg sync.WaitGroup
 }
@@ -97,7 +95,6 @@ func New(opts Options) loop.Interface[loops.EventPlace] {
 		actorTable:  opts.ActorTable,
 		scheduler:   opts.Scheduler,
 		dissTimeout: opts.DisseminationTimeout,
-		cancel:      opts.Cancel,
 	}
 	place.loop = loop.New[loops.EventPlace](8).NewLoop(place)
 	return place.loop
@@ -196,7 +193,7 @@ func (p *placement) handleReconnect(ctx context.Context, recon *loops.PlacementR
 		Scheduler:            p.scheduler,
 		HTarget:              p.htarget,
 		DisseminationTimeout: p.dissTimeout,
-		Cancel:               p.cancel,
+		Ready:                p.ready,
 	})
 
 	p.wg.Go(func() {
@@ -219,8 +216,6 @@ func (p *placement) handleReconnect(ctx context.Context, recon *loops.PlacementR
 		p.dissLoop.Enqueue(l.(loops.EventDiss))
 	}
 	p.lookups = nil
-
-	p.ready.Store(true)
 
 	return nil
 }

--- a/pkg/actors/internal/placement/loops/placement/placement_test.go
+++ b/pkg/actors/internal/placement/loops/placement/placement_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/pkg/actors/internal/placement/loops"
+	"github.com/dapr/dapr/pkg/actors/internal/placement/loops/disseminator/inflight"
 	tablefake "github.com/dapr/dapr/pkg/actors/table/fake"
 	healthzfake "github.com/dapr/dapr/pkg/healthz/fake"
 	loopfake "github.com/dapr/kit/events/loop/fake"
@@ -52,6 +53,7 @@ func TestHandleCloseStream_NotReady(t *testing.T) {
 			htarget:    ht,
 			dissLoop:   dissLoop,
 			actorTable: tablefake.New(),
+			inflight:   inflight.New(inflight.Options{Hostname: "localhost", Port: "3500"}),
 			idx:        1,
 		}
 

--- a/pkg/actors/internal/placement/placement.go
+++ b/pkg/actors/internal/placement/placement.go
@@ -72,7 +72,6 @@ type placement struct {
 	port     string
 	table    table.Interface
 	ready    *atomic.Bool
-	errCh    chan error
 
 	loop loop.Interface[loops.EventPlace]
 }
@@ -125,8 +124,6 @@ func New(opts Options) (Interface, error) {
 
 	var ready atomic.Bool
 
-	errCh := make(chan error, 1)
-
 	return &placement{
 		ready:    &ready,
 		hostname: opts.Hostname,
@@ -149,9 +146,6 @@ func New(opts Options) (Interface, error) {
 				Namespace: opts.Namespace,
 			},
 			DisseminationTimeout: time.Second * 5,
-			Cancel: func(cause error) {
-				errCh <- cause
-			},
 		}),
 	}, nil
 }
@@ -168,14 +162,6 @@ func (p *placement) Run(ctx context.Context) error {
 
 	return concurrency.NewRunnerManager(
 		p.loop.Run,
-		func(ctx context.Context) error {
-			select {
-			case err := <-p.errCh:
-				return err
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		},
 		func(ctx context.Context) error {
 			p.loop.Enqueue(&loops.PlacementReconnect{
 				ActorTypes: new(atypes),

--- a/pkg/scheduler/server/internal/pool/loops/stream/stream_test.go
+++ b/pkg/scheduler/server/internal/pool/loops/stream/stream_test.go
@@ -240,7 +240,7 @@ func Test_Stream(t *testing.T) {
 			ptr1 := called1.Load()
 			ptr2 := called2.Load()
 			ptr3 := called3.Load()
-			if !assert.NotNil(c, ptr1) && !assert.NotNil(c, ptr2) && !assert.NotNil(c, ptr2) {
+			if !assert.NotNil(c, ptr1) || !assert.NotNil(c, ptr2) || !assert.NotNil(c, ptr3) {
 				return
 			}
 			assert.Equal(c, api.TriggerResponseResult_SUCCESS, *ptr1)

--- a/tests/integration/suite/daprd/placement/disstimeout/crossreplica.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/crossreplica.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(crossreplica))
+}
+
+// crossreplica tests that cross-replica actor invocations work after two
+// dissemination timeout+reconnect cycles. An actor invocation from replica A
+// that routes to replica B requires both replicas to have functional placement
+// clients and correct routing tables.
+type crossreplica struct {
+	actors []*dactors.Actors
+	place  *placement.Placement
+
+	called1 atomic.Int64
+	called2 atomic.Int64
+}
+
+func (cr *crossreplica) Setup(t *testing.T) []framework.Option {
+	cr.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	actor1 := dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(cr.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			cr.called1.Add(1)
+			w.Write([]byte(`OK`))
+		}),
+	)
+	actor2 := dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPeerActor(actor1),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			cr.called2.Add(1)
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	cr.actors = []*dactors.Actors{actor1, actor2}
+
+	return []framework.Option{
+		framework.WithProcesses(actor1, actor2),
+	}
+}
+
+func (cr *crossreplica) Run(t *testing.T, ctx context.Context) {
+	cr.actors[0].WaitUntilRunning(t, ctx)
+	cr.actors[1].WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := cr.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 2)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+
+	var id atomic.Int64
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactor/%d/method/foo",
+			cr.actors[0].Daprd().HTTPPort(), id.Add(1))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+		assert.NoError(c, err)
+		resp, err := httpClient.Do(req)
+		assert.NoError(c, err)
+		if resp != nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+		assert.Positive(c, cr.called1.Load())
+		assert.Positive(c, cr.called2.Load())
+	}, time.Second*10, time.Millisecond*10)
+
+	connectBlocker := func(t *testing.T, bid string) {
+		t.Helper()
+		client := cr.place.Client(t, ctx)
+		blocker, err := client.ReportDaprStatus(ctx)
+		require.NoError(t, err)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: bid, Port: 9999,
+			Entities: []string{"myactor"}, Id: bid, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, err := blocker.Recv(); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+	}
+
+	cr.called1.Store(0)
+	cr.called2.Store(0)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactor/%d/method/foo",
+			cr.actors[0].Daprd().HTTPPort(), id.Add(1))
+		req, err := http.NewRequestWithContext(rctx, http.MethodPost, reqURL, nil)
+		assert.NoError(c, err)
+		resp, err := httpClient.Do(req)
+		if !assert.NoError(c, err, "cross-replica actor invocation should not hang after timeout recovery") {
+			return
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		assert.Positive(c, cr.called1.Load())
+		assert.Positive(c, cr.called2.Load())
+	}, time.Second*10, time.Millisecond*100)
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/disstimeout.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/disstimeout.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(disstimeout))
+}
+
+type disstimeout struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+}
+
+func (d *disstimeout) Setup(t *testing.T) []framework.Option {
+	d.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	d.actors = dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(d.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(d.actors),
+	}
+}
+
+func (d *disstimeout) Run(t *testing.T, ctx context.Context) {
+	d.actors.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := d.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactor/test1/method/foo", d.actors.Daprd().HTTPPort())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := d.place.Client(t, ctx)
+		blocker, berr := client.ReportDaprStatus(ctx)
+		require.NoError(t, berr)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"myactor"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, recvErr := blocker.Recv(); recvErr != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+
+		rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		req, err = http.NewRequestWithContext(rctx, http.MethodPost, reqURL, nil)
+		require.NoError(t, err)
+		resp, err = httpClient.Do(req)
+		cancel()
+		require.NoError(t, err, "actor invocation should not hang after dissemination timeout cycle %d", i)
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/healthready.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/healthready.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(healthready))
+}
+
+// healthready tests that daprd's health endpoint returns healthy after two
+// dissemination timeout+reconnect cycles. During the timeout, handleCloseStream
+// sets placement ready=false and healthTarget is only set Ready() after UNLOCK.
+// After recovery, the daprd must report healthy again.
+type healthready struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+}
+
+func (h *healthready) Setup(t *testing.T) []framework.Option {
+	h.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	h.actors = dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(h.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(h.actors),
+	}
+}
+
+func (h *healthready) Run(t *testing.T, ctx context.Context) {
+	h.actors.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := h.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	healthURL := fmt.Sprintf("http://localhost:%d/v1.0/healthz", h.actors.Daprd().HTTPPort())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := h.place.Client(t, ctx)
+		blocker, berr := client.ReportDaprStatus(ctx)
+		require.NoError(t, berr)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"myactor"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, recvErr := blocker.Recv(); recvErr != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+	}
+
+	rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err = http.NewRequestWithContext(rctx, http.MethodGet, healthURL, nil)
+	require.NoError(t, err)
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err, "health endpoint should respond after timeout recovery")
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode, "daprd should report healthy after timeout recovery")
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/inflight.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/inflight.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(inflight))
+}
+
+// inflight tests that actor invocations started DURING the LOCK phase (when
+// the inflight lock is nil) are unblocked after timeout recovery, not abandoned
+// forever. Callers wait on a response channel with a select on ctx.Done(). If
+// HaltAll doesn't cancel their context (e.g. the actor was never created), the
+// caller hangs until the caller's own context deadline fires.
+type inflight struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+}
+
+func (inf *inflight) Setup(t *testing.T) []framework.Option {
+	inf.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	inf.actors = dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(inf.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(inf.actors),
+	}
+}
+
+func (inf *inflight) Run(t *testing.T, ctx context.Context) {
+	inf.actors.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := inf.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	daprdURL := fmt.Sprintf("http://localhost:%d", inf.actors.Daprd().HTTPPort())
+
+	client := inf.place.Client(t, ctx)
+	blocker, err := client.ReportDaprStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, blocker.Send(&v1pb.Host{
+		Name: "blocker", Port: 9999,
+		Entities: []string{"myactor"}, Id: "blocker", Namespace: "default",
+	}))
+	go func() {
+		for {
+			if _, err := blocker.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+
+	time.Sleep(time.Second)
+
+	inflightDone := make(chan int, 1)
+	go func() {
+		rctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+		defer cancel()
+		reqURL := daprdURL + "/v1.0/actors/myactor/newactor/method/foo"
+		req, err := http.NewRequestWithContext(rctx, http.MethodPost, reqURL, nil)
+		if err != nil {
+			inflightDone <- 0
+			return
+		}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			inflightDone <- 0
+			return
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		inflightDone <- resp.StatusCode
+	}()
+
+	select {
+	case code := <-inflightDone:
+		assert.Equal(t, http.StatusOK, code,
+			"actor invocation queued during LOCK phase should complete after recovery")
+	case <-time.After(12 * time.Second):
+		require.Fail(t, "actor invocation queued during LOCK phase hung indefinitely")
+	}
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/multiplereplicas.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/multiplereplicas.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(multiplereplicas))
+}
+
+type multiplereplicas struct {
+	actors []*dactors.Actors
+	place  *placement.Placement
+}
+
+func (m *multiplereplicas) Setup(t *testing.T) []framework.Option {
+	m.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	actor1 := dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(m.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+	actor2 := dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPeerActor(actor1),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	m.actors = []*dactors.Actors{actor1, actor2}
+
+	return []framework.Option{
+		framework.WithProcesses(actor1, actor2),
+	}
+}
+
+func (m *multiplereplicas) Run(t *testing.T, ctx context.Context) {
+	m.actors[0].WaitUntilRunning(t, ctx)
+	m.actors[1].WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := m.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 2)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	for _, a := range m.actors {
+		reqURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactor/test1/method/foo", a.Daprd().HTTPPort())
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := m.place.Client(t, ctx)
+		blocker, err := client.ReportDaprStatus(ctx)
+		require.NoError(t, err)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"myactor"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, err := blocker.Recv(); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+
+		for j, a := range m.actors {
+			reqURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactor/replica%d_%d/method/foo", a.Daprd().HTTPPort(), i, j)
+			rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			req, err := http.NewRequestWithContext(rctx, http.MethodPost, reqURL, nil)
+			require.NoError(t, err)
+			resp, err := httpClient.Do(req)
+			cancel()
+			require.NoError(t, err, "actor invocation on replica %d should not hang after dissemination timeout cycle %d", j, i)
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		}
+	}
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/reminders.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/reminders.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(reminders))
+}
+
+// reminders tests that actor reminders registered before a dissemination
+// timeout continue to fire after two timeout+reconnect cycles. During the
+// timeout window, the scheduler still holds the reminder but the inflight lock
+// is nil, so reminder delivery is blocked. After recovery, reminders must
+// resume.
+type reminders struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+
+	reminderCalled atomic.Int64
+}
+
+func (rm *reminders) Setup(t *testing.T) []framework.Option {
+	rm.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	rm.actors = dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(rm.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/method/remind/") {
+				rm.reminderCalled.Add(1)
+			}
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(rm.actors),
+	}
+}
+
+func (rm *reminders) Run(t *testing.T, ctx context.Context) {
+	rm.actors.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := rm.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	daprdURL := fmt.Sprintf("http://localhost:%d", rm.actors.Daprd().HTTPPort())
+
+	reqURL := daprdURL + "/v1.0/actors/myactor/reminder1/method/foo"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := rm.place.Client(t, ctx)
+		blocker, berr := client.ReportDaprStatus(ctx)
+		require.NoError(t, berr)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"myactor"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, recvErr := blocker.Recv(); recvErr != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+	}
+
+	rm.reminderCalled.Store(0)
+	reminderURL := daprdURL + "/v1.0/actors/myactor/reminder1/reminders/myreminder"
+	reminderBody := `{"dueTime":"0ms","period":"1s"}`
+	rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err = http.NewRequestWithContext(rctx, http.MethodPost, reminderURL, strings.NewReader(reminderBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err, "reminder registration should not hang after timeout recovery")
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Positive(c, rm.reminderCalled.Load())
+	}, time.Second*5, time.Millisecond*100)
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/repeated.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/repeated.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(repeated))
+}
+
+// repeated tests that a daprd sidecar survives two consecutive dissemination
+// timeout cycles. After the first blocker is resolved and the sidecar
+// reconnects, a second blocker triggers the same scenario. The sidecar must
+// recover both times.
+type repeated struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+}
+
+func (r *repeated) Setup(t *testing.T) []framework.Option {
+	r.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	r.actors = dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(r.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.actors),
+	}
+}
+
+func (r *repeated) Run(t *testing.T, ctx context.Context) {
+	r.actors.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := r.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactor/test1/method/foo", r.actors.Daprd().HTTPPort())
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := r.place.Client(t, ctx)
+		blocker, err := client.ReportDaprStatus(ctx)
+		require.NoError(t, err)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name:      id,
+			Port:      9999,
+			Entities:  []string{"myactor"},
+			Id:        id,
+			Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, err := blocker.Recv(); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	assertActorWorks := func(t *testing.T) {
+		t.Helper()
+		rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(rctx, http.MethodPost, reqURL, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err, "actor invocation should not hang")
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	connectBlocker(t, "blocker-1")
+	time.Sleep(9 * time.Second)
+	assertActorWorks(t)
+
+	connectBlocker(t, "blocker-2")
+	time.Sleep(9 * time.Second)
+	assertActorWorks(t)
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/state.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/state.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(state))
+}
+
+// state tests that actor state persisted before a dissemination timeout is
+// still accessible after two timeout+reconnect cycles. This exercises the
+// HaltAll → actor deactivation → state persistence → re-activation path.
+type state struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+}
+
+func (s *state) Setup(t *testing.T) []framework.Option {
+	s.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	s.actors = dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(s.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.actors),
+	}
+}
+
+func (s *state) Run(t *testing.T, ctx context.Context) {
+	s.actors.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := s.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	daprdURL := fmt.Sprintf("http://localhost:%d", s.actors.Daprd().HTTPPort())
+
+	reqURL := daprdURL + "/v1.0/actors/myactor/stateful1/method/foo"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	stateURL := daprdURL + "/v1.0/actors/myactor/stateful1/state"
+	stateBody := `[{"operation":"upsert","request":{"key":"color","value":"blue"}}]`
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, stateURL, strings.NewReader(stateBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := s.place.Client(t, ctx)
+		blocker, berr := client.ReportDaprStatus(ctx)
+		require.NoError(t, berr)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"myactor"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, recvErr := blocker.Recv(); recvErr != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+	}
+
+	rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err = http.NewRequestWithContext(rctx, http.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err, "actor re-activation should not hang after timeout recovery")
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	getURL := daprdURL + "/v1.0/actors/myactor/stateful1/state/color"
+	req, err = http.NewRequestWithContext(rctx, http.MethodGet, getURL, nil)
+	require.NoError(t, err)
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err)
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `"blue"`, string(b))
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/tablecorrect.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/tablecorrect.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(tablecorrect))
+}
+
+// tablecorrect tests that the placement table is correct after two
+// timeout+reconnect cycles. After recovery, the daprd must appear in the
+// server's placement table with the correct actor types, name, and namespace.
+// The blocker must NOT appear (it was disconnected by the server timeout).
+type tablecorrect struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+}
+
+func (tc *tablecorrect) Setup(t *testing.T) []framework.Option {
+	tc.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	tc.actors = dactors.New(t,
+		dactors.WithActorTypes("typeA", "typeB"),
+		dactors.WithPlacement(tc.place),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(tc.actors),
+	}
+}
+
+func (tc *tablecorrect) Run(t *testing.T, ctx context.Context) {
+	tc.actors.WaitUntilRunning(t, ctx)
+
+	expHost := placement.Host{
+		Entities:  []string{"typeA", "typeB"},
+		Name:      tc.actors.Daprd().InternalGRPCAddress(),
+		ID:        tc.actors.Daprd().AppID(),
+		APIVLevel: 20,
+		Namespace: "default",
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := tc.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Equal(c, []placement.Host{expHost}, table.Tables["default"].Hosts)
+	}, time.Second*15, time.Millisecond*100)
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := tc.place.Client(t, ctx)
+		blocker, err := client.ReportDaprStatus(ctx)
+		require.NoError(t, err)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"typeA"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, err := blocker.Recv(); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, "blocker-tc-"+string(rune('a'+i)))
+		time.Sleep(9 * time.Second)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := tc.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Equal(c, []placement.Host{expHost}, table.Tables["default"].Hosts)
+	}, time.Second*10, time.Millisecond*500)
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/workflow.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/workflow.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(workflow))
+}
+
+type workflow struct {
+	actors *dactors.Actors
+	place  *placement.Placement
+}
+
+func (w *workflow) Setup(t *testing.T) []framework.Option {
+	w.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+
+	w.actors = dactors.New(t,
+		dactors.WithActorTypes("myactor"),
+		dactors.WithPlacement(w.place),
+		dactors.WithActorTypeHandler("myactor", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`OK`))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(w.actors),
+	}
+}
+
+func (w *workflow) Run(t *testing.T, ctx context.Context) {
+	w.actors.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := w.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	wfClient := dworkflow.NewClient(w.actors.Daprd().GRPCConn(t, ctx))
+	wfCtx, wfCancel := context.WithCancel(ctx)
+	t.Cleanup(wfCancel)
+	require.NoError(t, wfClient.StartWorker(wfCtx, dworkflow.NewRegistry()))
+
+	appID := w.actors.Daprd().AppID()
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := w.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		if !assert.Len(c, table.Tables["default"].Hosts, 1) {
+			return
+		}
+		assert.ElementsMatch(c, []string{
+			"dapr.internal.default." + appID + ".activity",
+			"dapr.internal.default." + appID + ".retentioner",
+			"dapr.internal.default." + appID + ".workflow",
+			"myactor",
+		}, table.Tables["default"].Hosts[0].Entities)
+	}, time.Second*15, time.Millisecond*100)
+
+	httpClient := fclient.HTTP(t)
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/actors/myactor/test1/method/foo", w.actors.Daprd().HTTPPort())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := w.place.Client(t, ctx)
+		blocker, berr := client.ReportDaprStatus(ctx)
+		require.NoError(t, berr)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"myactor"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, recvErr := blocker.Recv(); recvErr != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+
+		rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		req, err = http.NewRequestWithContext(rctx, http.MethodPost, reqURL, nil)
+		require.NoError(t, err)
+		resp, err = httpClient.Do(req)
+		cancel()
+		require.NoError(t, err, "actor invocation should not hang after dissemination timeout cycle %d", i)
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+}

--- a/tests/integration/suite/daprd/placement/disstimeout/workflowexec.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/workflowexec.go
@@ -100,7 +100,7 @@ func (w *workflowexec) Run(t *testing.T, ctx context.Context) {
 	backendClient := dtclient.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
 
 	r := task.NewTaskRegistry()
-	r.AddWorkflowN("TimeoutWorkflow", func(ctx *task.OrchestrationContext) (any, error) {
+	r.AddWorkflowN("TimeoutWorkflow", func(ctx *task.WorkflowContext) (any, error) {
 		var input string
 		if ierr := ctx.GetInput(&input); ierr != nil {
 			return nil, ierr

--- a/tests/integration/suite/daprd/placement/disstimeout/workflowexec.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/workflowexec.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disstimeout
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	dtclient "github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(workflowexec))
+}
+
+// workflowexec tests that a workflow started BEFORE a dissemination timeout
+// can complete its activity execution AFTER recovery. This reproduces the
+// production scenario where workflows were stuck in RUNNING with no activities
+// executing.
+type workflowexec struct {
+	daprd      *daprd.Daprd
+	place      *placement.Placement
+	httpClient *http.Client
+}
+
+func (w *workflowexec) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(""))
+	})
+	handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"entities": []}`))
+	})
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	sched := scheduler.New(t)
+	w.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*7),
+	)
+	w.daprd = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithPlacementAddresses(w.place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithScheduler(sched),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(w.place, sched, srv, w.daprd),
+	}
+}
+
+func (w *workflowexec) Run(t *testing.T, ctx context.Context) {
+	w.place.WaitUntilRunning(t, ctx)
+	w.daprd.WaitUntilRunning(t, ctx)
+
+	w.httpClient = fclient.HTTP(t)
+
+	conn, err := grpc.DialContext(ctx, //nolint:staticcheck
+		w.daprd.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(), //nolint:staticcheck
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	backendClient := dtclient.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+
+	r := task.NewTaskRegistry()
+	r.AddWorkflowN("TimeoutWorkflow", func(ctx *task.OrchestrationContext) (any, error) {
+		var input string
+		if ierr := ctx.GetInput(&input); ierr != nil {
+			return nil, ierr
+		}
+		var output string
+		aerr := ctx.CallActivity("SayHello", task.WithActivityInput(input)).Await(&output)
+		return output, aerr
+	})
+	r.AddActivityN("SayHello", func(ctx task.ActivityContext) (any, error) {
+		var name string
+		if ierr := ctx.GetInput(&name); ierr != nil {
+			return nil, ierr
+		}
+		return fmt.Sprintf("Hello, %s!", name), nil
+	})
+
+	taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
+	t.Cleanup(cancelTaskhub)
+	require.NoError(t, backendClient.StartWorkItemListener(taskhubCtx, r))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		table := w.place.PlacementTables(t, ctx)
+		if !assert.NotNil(c, table.Tables["default"]) {
+			return
+		}
+		if !assert.NotNil(c, table.Tables["default"].Hosts) {
+			return
+		}
+		assert.Len(c, table.Tables["default"].Hosts, 1)
+	}, time.Second*15, time.Millisecond*100)
+
+	connectBlocker := func(t *testing.T, id string) {
+		t.Helper()
+		client := w.place.Client(t, ctx)
+		blocker, berr := client.ReportDaprStatus(ctx)
+		require.NoError(t, berr)
+		require.NoError(t, blocker.Send(&v1pb.Host{
+			Name: id, Port: 9999,
+			Entities: []string{"myactor"}, Id: id, Namespace: "default",
+		}))
+		go func() {
+			for {
+				if _, recvErr := blocker.Recv(); recvErr != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	for i := range 2 {
+		connectBlocker(t, fmt.Sprintf("blocker-%d", i))
+		time.Sleep(9 * time.Second)
+	}
+
+	instanceID := w.startWorkflow(ctx, t, "TimeoutWorkflow", "World")
+
+	metadata, err := backendClient.WaitForWorkflowCompletion(ctx, api.InstanceID(instanceID), api.WithFetchPayloads(true))
+	require.NoError(t, err, "workflow should complete after timeout recovery")
+	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
+	assert.Equal(t, `"Hello, World!"`, metadata.GetOutput().GetValue())
+}
+
+func (w *workflowexec) startWorkflow(ctx context.Context, t *testing.T, name, input string) string {
+	t.Helper()
+
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0-beta1/workflows/dapr/%s/start", w.daprd.HTTPPort(), name)
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(rctx, http.MethodPost, reqURL, strings.NewReader(string(data)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := w.httpClient.Do(req)
+	require.NoError(t, err, "workflow start should not hang after timeout recovery")
+	defer resp.Body.Close()
+	if !assert.Equal(t, http.StatusAccepted, resp.StatusCode) {
+		b, _ := io.ReadAll(resp.Body)
+		require.Fail(t, string(b))
+	}
+	var response struct {
+		InstanceID string `json:"instanceID"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&response))
+	return response.InstanceID
+}

--- a/tests/integration/suite/daprd/placement/placement.go
+++ b/tests/integration/suite/daprd/placement/placement.go
@@ -15,6 +15,7 @@ package placement
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/cluster"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/disstimeout"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/multiple"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/notypes"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/placement/reconnect"


### PR DESCRIPTION
When a slow sidecar delays placement table dissemination, the daprd sidecar's 5-second timeout fired and sent a fatal error through the internal error channel, killing the entire placement subsystem. The sidecar never reconnected. All actor and workflow operations hung because the inflight lock was abandoned in a nil state.

The dissemination timeout now closes the placement stream, triggering the existing handleCloseStream -> handleReconnect path. This matches the recovery behavior for network disconnections (EOF, connection reset), which already reconnected successfully. The timeout was the only error path that did not reconnect.

The same fix is applied to the version mismatch and unknown operation error paths in handleOrder, which had the same fatal-error-instead-of- reconnect behavior.

---

Workflow and actor operations freeze when a slow sidecar delays placement dissemination

Problem

When one daprd sidecar in a namespace is slow to respond during placement table dissemination (for example, due to GC pressure, high actor load, or network latency), all other sidecars in the same namespace experience frozen workflow and actor operations. Scheduling new workflows, invoking actors, and running `dapr workflow terminate` or `dapr workflow purge` all hang indefinitely. After restarting the app, workflows may appear as RUNNING but no activities execute, and `get_workflow_state` returns nothing.

Impact

Any deployment with multiple replicas using actors or workflows is affected. A single slow sidecar can freeze all actor and workflow operations across every other sidecar in the namespace for as long as the placement server takes to time out the slow peer (8 seconds by default), plus the sidecar's own 5-second timeout. In practice, this created a 10-15 second window where:

- All actor method invocations hang
- All workflow scheduling, termination, and purge operations hang
- Actor reminders stop firing
- Applications stop responding to health probes and are declared unhealthy by Kubernetes
- With a workflow SDK client connected, the daprd process enters a zombie state where it can neither serve requests nor exit

The issue is particularly severe during rolling updates, where pod cycling causes repeated dissemination rounds that can trigger the timeout multiple times in succession.

Root Cause

When the daprd sidecar receives a LOCK order from the placement server during actor table dissemination, it blocks all in-flight actor operations (the "inflight lock") until it receives the corresponding UNLOCK. The placement server only sends UNLOCK after every sidecar in the namespace has responded to each phase (LOCK, UPDATE, UNLOCK). If one sidecar is slow, no other sidecar receives UPDATE or UNLOCK.

The daprd sidecar has a 5-second timeout for this wait. When the timeout fired, it killed the entire placement subsystem by sending a fatal error through the internal error channel, which terminated the placement connection permanently. The sidecar never reconnected. Actor operations that were queued during the LOCK phase were silently abandoned, and any new actor operations hung indefinitely because the placement client was dead.

Solution

The dissemination timeout now closes the placement stream and triggers an automatic reconnection, instead of killing the placement subsystem. After the timeout:

1. The sidecar closes its stream to the placement server
2. All actors are halted and the routing table is cleared
3. The sidecar reconnects to placement and re-registers
4. A new dissemination round completes and actor operations resume

This matches the existing recovery behavior for network disconnections (EOF, connection reset), which already reconnected successfully. The timeout was the only error path that did not reconnect.

Additionally, this release fixes two related issues in the dissemination subsystem:

- The placement readiness flag was set immediately after reconnecting, before the new dissemination round completed. This caused the daprd to report healthy to metadata queries while actor operations were still blocked. The readiness flag is now only set after the first successful UNLOCK.
- Recycled disseminator objects from the internal pool could carry a stale timeout version counter from their previous use, potentially causing a valid timeout to be incorrectly ignored. The counter is now reset on reuse.