### PR TITLE
Add workflow history signing for tamper detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.17.3
 	github.com/dapr/durabletask-go v0.11.4-0.20260413145313-c4b7279b6a8e
-	github.com/dapr/kit v0.17.1-0.20260402173438-be272d92042b
+	github.com/dapr/kit v0.17.1-0.20260409110905-18c6fce40d5d
 	github.com/diagridio/go-etcd-cron v0.12.4
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0c
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
 github.com/dapr/durabletask-go v0.11.4-0.20260413145313-c4b7279b6a8e h1:SSBxGb1/dOmzyWZhKNHVliw/VemiYgLKlv8oOTIsGG0=
 github.com/dapr/durabletask-go v0.11.4-0.20260413145313-c4b7279b6a8e/go.mod h1:nElJPTX9FmveqErAmvTXZrAmt2nnyTQ7Glj0ahPphSY=
-github.com/dapr/kit v0.17.1-0.20260402173438-be272d92042b h1:hXbRlNKvmMGbiMSRy3MX04kH5OiMgH82PRuLN7adtwE=
-github.com/dapr/kit v0.17.1-0.20260402173438-be272d92042b/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
+github.com/dapr/kit v0.17.1-0.20260409110905-18c6fce40d5d h1:3QXEaZEBsKmOo1hMqcSL+LFZmigzMPMJietg2s5X11Y=
+github.com/dapr/kit v0.17.1-0.20260409110905-18c6fce40d5d/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -56,7 +56,7 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, historyEventBytes [
 	log.Debugf("Workflow actor '%s': adding event to the workflow inbox", o.actorID)
 	state.AddToInbox(&e)
 
-	if err := o.saveInternalState(ctx, state); err != nil {
+	if err := o.signAndSaveState(ctx, state); err != nil {
 		return err
 	}
 

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -110,7 +110,7 @@ func (o *orchestrator) scheduleWorkflowStart(ctx context.Context, startEvent *ba
 		return err
 	}
 	state.AddToInbox(startEvent)
-	if err := o.saveInternalState(ctx, state); err != nil {
+	if err := o.signAndSaveState(ctx, state); err != nil {
 		return err
 	}
 

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/kit/concurrency/slice"
+	"github.com/dapr/kit/crypto/spiffe/signer"
 )
 
 var orchestratorCache = sync.Pool{
@@ -53,6 +54,10 @@ type Options struct {
 	EventSink        EventSink
 	ActorTypeBuilder *common.ActorTypeBuilder
 	RetentionPolicy  *config.WorkflowStateRetentionPolicy
+
+	// Signer provides cryptographic signing and verification. If nil, history
+	// signing is disabled.
+	Signer *signer.Signer
 }
 
 type factory struct {
@@ -69,6 +74,7 @@ type factory struct {
 	eventSink        EventSink
 	actorTypeBuilder *common.ActorTypeBuilder
 	retentionPolicy  *config.WorkflowStateRetentionPolicy
+	signer           *signer.Signer
 
 	scheduler todo.WorkflowScheduler
 
@@ -119,6 +125,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 		actorTypeBuilder:   opts.ActorTypeBuilder,
 		placement:          placement,
 		retentionPolicy:    opts.RetentionPolicy,
+		signer:             opts.Signer,
 		scheduler:          opts.Scheduler,
 		deactivateCh:       deactivateCh,
 	}, nil

--- a/pkg/actors/targets/workflow/orchestrator/rerun.go
+++ b/pkg/actors/targets/workflow/orchestrator/rerun.go
@@ -160,7 +160,7 @@ func (o *orchestrator) rerunWorkflowInstanceRequest(ctx context.Context, request
 
 	newState.FromWorkflowState(&workflowState)
 
-	if err = o.saveInternalState(ctx, newState); err != nil {
+	if err = o.signAndSaveState(ctx, newState); err != nil {
 		return fmt.Errorf("failed to save workflow state: %w", err)
 	}
 

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -441,41 +441,43 @@ func filterValidInboxEvents(state *wfenginestate.State) []*backend.HistoryEvent 
 
 	valid := make([]*backend.HistoryEvent, 0, len(state.Inbox))
 	for _, e := range state.Inbox {
-		switch {
-		case e.GetTaskCompleted() != nil:
-			taskID := e.GetTaskCompleted().GetTaskScheduledId()
+		// exhaustive linter will error here on missing types not implemented on
+		// the switch.
+		switch et := e.GetEventType().(type) {
+		case *protos.HistoryEvent_TaskCompleted:
+			taskID := et.TaskCompleted.GetTaskScheduledId()
 			if _, ok := scheduledTaskIDs[taskID]; !ok {
 				log.Warnf("Dropping injected inbox event: task result for task %d not scheduled in signed history", taskID)
 				continue
 			}
-		case e.GetTaskFailed() != nil:
-			taskID := e.GetTaskFailed().GetTaskScheduledId()
+		case *protos.HistoryEvent_TaskFailed:
+			taskID := et.TaskFailed.GetTaskScheduledId()
 			if _, ok := scheduledTaskIDs[taskID]; !ok {
 				log.Warnf("Dropping injected inbox event: task failure for task %d not scheduled in signed history", taskID)
 				continue
 			}
-		case e.GetChildWorkflowInstanceCompleted() != nil:
-			taskID := e.GetChildWorkflowInstanceCompleted().GetTaskScheduledId()
+		case *protos.HistoryEvent_ChildWorkflowInstanceCompleted:
+			taskID := et.ChildWorkflowInstanceCompleted.GetTaskScheduledId()
 			if _, ok := createdChildIDs[taskID]; !ok {
 				log.Warnf("Dropping injected inbox event: child workflow result for task %d not created in signed history", taskID)
 				continue
 			}
-		case e.GetChildWorkflowInstanceFailed() != nil:
-			taskID := e.GetChildWorkflowInstanceFailed().GetTaskScheduledId()
+		case *protos.HistoryEvent_ChildWorkflowInstanceFailed:
+			taskID := et.ChildWorkflowInstanceFailed.GetTaskScheduledId()
 			if _, ok := createdChildIDs[taskID]; !ok {
 				log.Warnf("Dropping injected inbox event: child workflow failure for task %d not created in signed history", taskID)
 				continue
 			}
-		case e.GetEventRaised() != nil,
-			e.GetTimerFired() != nil,
-			e.GetExecutionStarted() != nil,
-			e.GetExecutionTerminated() != nil,
-			e.GetExecutionResumed() != nil,
-			e.GetExecutionSuspended() != nil:
+		case *protos.HistoryEvent_EventRaised,
+			*protos.HistoryEvent_TimerFired,
+			*protos.HistoryEvent_ExecutionStarted,
+			*protos.HistoryEvent_ExecutionTerminated,
+			*protos.HistoryEvent_ExecutionResumed,
+			*protos.HistoryEvent_ExecutionSuspended:
 			// Legitimate inbox event types that do not correspond to a previously
 			// scheduled operation.
 		default:
-			log.Warnf("Dropping injected inbox event: unknown event type")
+			log.Warnf("Dropping injected inbox event: unknown event type %T", et)
 			continue
 		}
 		valid = append(valid, e)

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -60,6 +60,11 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		}
 
 		timerEvent := durableTimer.GetTimerEvent()
+		// Validate the timer event is actually a TimerFired event. A crafted
+		// reminder could contain arbitrary event types to inject into the inbox.
+		if timerEvent.GetTimerFired() == nil {
+			return todo.RunCompletedTrue, fmt.Errorf("workflow actor '%s': timer reminder contains non-TimerFired event type %T", o.actorID, timerEvent.GetEventType())
+		}
 		// timer fired event is precreated at the moment of creating the timer
 		// set the timestamp to now so it is accurately recorded in the history
 		timerEvent.Timestamp = timestamppb.Now()
@@ -71,6 +76,29 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		// for some of those already processed events.
 		log.Debugf("Workflow actor '%s': ignoring run request for reminder '%s' because the workflow inbox is empty", o.actorID, reminder.Name)
 		return todo.RunCompletedTrue, nil
+	}
+
+	// Validate inbox events: result events (TaskCompleted/TaskFailed,
+	// ChildWorkflowInstanceCompleted/Failed) must match operations that
+	// were scheduled in signed history. Invalid events are purged from
+	// the inbox and the state is saved to prevent the same invalid events
+	// from blocking execution on retry.
+	if o.signer != nil {
+		filtered := filterValidInboxEvents(state)
+		if len(filtered) != len(state.Inbox) {
+			log.Warnf("Workflow actor '%s': purged %d injected inbox events that did not match signed history",
+				o.actorID, len(state.Inbox)-len(filtered))
+			// Clear and re-add valid events so state change tracking
+			// generates the correct delete operations for the state store.
+			state.ClearInbox()
+			for _, e := range filtered {
+				state.AddToInbox(e)
+			}
+			if err = o.signAndSaveState(ctx, state); err != nil {
+				return todo.RunCompletedFalse, fmt.Errorf("failed to save state after purging injected events: %w", err)
+			}
+			return todo.RunCompletedFalse, fmt.Errorf("workflow actor '%s': inbox contained injected events that were purged; retrying", o.actorID)
+		}
 	}
 
 	var esHistoryEvent *backend.HistoryEvent
@@ -197,7 +225,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 
 				state.Generation++
 
-				if err = o.saveInternalState(ctx, state); err != nil {
+				if err = o.signAndSaveState(ctx, state); err != nil {
 					o.rstate = rstateSnapshot
 					return todo.RunCompletedFalse, err
 				}
@@ -299,7 +327,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			rs.NewEvents = filtered
 			state.ApplyRuntimeStateChanges(rs)
 			rs.NewEvents = origNewEvents
-			if saveErr := o.saveInternalState(ctx, state); saveErr != nil {
+			if saveErr := o.signAndSaveState(ctx, state); saveErr != nil {
 				return todo.RunCompletedFalse, saveErr
 			}
 			executionStatus = diag.StatusRecoverable
@@ -313,7 +341,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	state.ApplyRuntimeStateChanges(rs)
 	state.ClearInbox()
 
-	err = o.saveInternalState(ctx, state)
+	err = o.signAndSaveState(ctx, state)
 	if err != nil {
 		return todo.RunCompletedFalse, err
 	}
@@ -415,4 +443,55 @@ func (o *orchestrator) handleRetention(ctx context.Context, status protos.Orches
 	}
 
 	return nil
+}
+
+// filterValidInboxEvents returns inbox events that pass validation. Result
+// events (TaskCompleted/TaskFailed, ChildWorkflowInstanceCompleted/Failed)
+// must match operations that were scheduled in signed history. Invalid events
+// are dropped and logged.
+func filterValidInboxEvents(state *wfenginestate.State) []*backend.HistoryEvent {
+	// Build sets of scheduled operation event IDs from history.
+	scheduledTaskIDs := make(map[int32]struct{})
+	createdChildIDs := make(map[int32]struct{})
+	for _, e := range state.History {
+		switch {
+		case e.GetTaskScheduled() != nil:
+			scheduledTaskIDs[e.GetEventId()] = struct{}{}
+		case e.GetChildWorkflowInstanceCreated() != nil:
+			createdChildIDs[e.GetEventId()] = struct{}{}
+		}
+	}
+
+	valid := make([]*backend.HistoryEvent, 0, len(state.Inbox))
+	for _, e := range state.Inbox {
+		switch {
+		case e.GetTaskCompleted() != nil:
+			taskID := e.GetTaskCompleted().GetTaskScheduledId()
+			if _, ok := scheduledTaskIDs[taskID]; !ok {
+				log.Warnf("Dropping injected inbox event: task result for task %d not scheduled in signed history", taskID)
+				continue
+			}
+		case e.GetTaskFailed() != nil:
+			taskID := e.GetTaskFailed().GetTaskScheduledId()
+			if _, ok := scheduledTaskIDs[taskID]; !ok {
+				log.Warnf("Dropping injected inbox event: task failure for task %d not scheduled in signed history", taskID)
+				continue
+			}
+		case e.GetChildWorkflowInstanceCompleted() != nil:
+			taskID := e.GetChildWorkflowInstanceCompleted().GetTaskScheduledId()
+			if _, ok := createdChildIDs[taskID]; !ok {
+				log.Warnf("Dropping injected inbox event: child workflow result for task %d not created in signed history", taskID)
+				continue
+			}
+		case e.GetChildWorkflowInstanceFailed() != nil:
+			taskID := e.GetChildWorkflowInstanceFailed().GetTaskScheduledId()
+			if _, ok := createdChildIDs[taskID]; !ok {
+				log.Warnf("Dropping injected inbox event: child workflow failure for task %d not created in signed history", taskID)
+				continue
+			}
+		}
+		valid = append(valid, e)
+	}
+
+	return valid
 }

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -78,29 +78,6 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		return todo.RunCompletedTrue, nil
 	}
 
-	// Validate inbox events: result events (TaskCompleted/TaskFailed,
-	// ChildWorkflowInstanceCompleted/Failed) must match operations that
-	// were scheduled in signed history. Invalid events are purged from
-	// the inbox and the state is saved to prevent the same invalid events
-	// from blocking execution on retry.
-	if o.signer != nil {
-		filtered := filterValidInboxEvents(state)
-		if len(filtered) != len(state.Inbox) {
-			log.Warnf("Workflow actor '%s': purged %d injected inbox events that did not match signed history",
-				o.actorID, len(state.Inbox)-len(filtered))
-			// Clear and re-add valid events so state change tracking
-			// generates the correct delete operations for the state store.
-			state.ClearInbox()
-			for _, e := range filtered {
-				state.AddToInbox(e)
-			}
-			if err = o.signAndSaveState(ctx, state); err != nil {
-				return todo.RunCompletedFalse, fmt.Errorf("failed to save state after purging injected events: %w", err)
-			}
-			return todo.RunCompletedFalse, fmt.Errorf("workflow actor '%s': inbox contained injected events that were purged; retrying", o.actorID)
-		}
-	}
-
 	var esHistoryEvent *backend.HistoryEvent
 	for _, e := range state.Inbox {
 		if es := e.GetExecutionStarted(); es != nil {
@@ -489,6 +466,17 @@ func filterValidInboxEvents(state *wfenginestate.State) []*backend.HistoryEvent 
 				log.Warnf("Dropping injected inbox event: child workflow failure for task %d not created in signed history", taskID)
 				continue
 			}
+		case e.GetEventRaised() != nil,
+			e.GetTimerFired() != nil,
+			e.GetExecutionStarted() != nil,
+			e.GetExecutionTerminated() != nil,
+			e.GetExecutionResumed() != nil,
+			e.GetExecutionSuspended() != nil:
+			// Legitimate inbox event types that do not correspond to a previously
+			// scheduled operation.
+		default:
+			log.Warnf("Dropping injected inbox event: unknown event type")
+			continue
 		}
 		valid = append(valid, e)
 	}

--- a/pkg/actors/targets/workflow/orchestrator/run_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/run_test.go
@@ -311,3 +311,129 @@ func Test_runWorkflow_canSaveMovesCarryoverToInbox(t *testing.T) {
 
 	assert.Equal(t, `3`, o.rstate.GetStartEvent().GetInput().GetValue())
 }
+
+func TestFilterValidInboxEvents_EmptyInbox(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	result := filterValidInboxEvents(state)
+	assert.Empty(t, result)
+}
+
+func TestFilterValidInboxEvents_TaskCompletedValid(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 1, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "activity1"}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_TaskCompleted{TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 1, Result: wrapperspb.String("ok")}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Len(t, result, 1)
+}
+
+func TestFilterValidInboxEvents_TaskCompletedNoMatch(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 1, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "activity1"}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_TaskCompleted{TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 999, Result: wrapperspb.String("ok")}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Empty(t, result)
+}
+
+func TestFilterValidInboxEvents_TaskFailedValid(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 2, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "activity2"}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_TaskFailed{TaskFailed: &protos.TaskFailedEvent{TaskScheduledId: 2}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Len(t, result, 1)
+}
+
+func TestFilterValidInboxEvents_TaskFailedNoMatch(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 2, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "activity2"}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_TaskFailed{TaskFailed: &protos.TaskFailedEvent{TaskScheduledId: 777}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Empty(t, result)
+}
+
+func TestFilterValidInboxEvents_ChildWorkflowCompletedValid(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 5, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{TaskScheduledId: 5}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Len(t, result, 1)
+}
+
+func TestFilterValidInboxEvents_ChildWorkflowCompletedNoMatch(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 5, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{TaskScheduledId: 99}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Empty(t, result)
+}
+
+func TestFilterValidInboxEvents_ChildWorkflowFailedNoMatch(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 5, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_ChildWorkflowInstanceFailed{ChildWorkflowInstanceFailed: &protos.ChildWorkflowInstanceFailedEvent{TaskScheduledId: 42}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Empty(t, result)
+}
+
+func TestFilterValidInboxEvents_EventRaisedPassesThrough(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_EventRaised{EventRaised: &protos.EventRaisedEvent{Name: "myevent"}}},
+	}
+	result := filterValidInboxEvents(state)
+	assert.Len(t, result, 1)
+}
+
+func TestFilterValidInboxEvents_MixedValidAndInvalid(t *testing.T) {
+	t.Parallel()
+	state := wfenginestate.NewState(wfenginestate.Options{})
+	state.History = []*backend.HistoryEvent{
+		{EventId: 1, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "activity1"}}},
+		{EventId: 5, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{}}},
+	}
+	state.Inbox = []*backend.HistoryEvent{
+		{EventId: -1, EventType: &protos.HistoryEvent_TaskCompleted{TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 1, Result: wrapperspb.String("ok")}}},
+		{EventId: -1, EventType: &protos.HistoryEvent_TaskCompleted{TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 999, Result: wrapperspb.String("injected")}}},
+		{EventId: -1, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{TaskScheduledId: 5}}},
+		{EventId: -1, EventType: &protos.HistoryEvent_EventRaised{EventRaised: &protos.EventRaisedEvent{Name: "myevent"}}},
+	}
+	result := filterValidInboxEvents(state)
+	// task 1 valid, task 999 dropped, child 5 valid, event raised kept
+	assert.Len(t, result, 3)
+}

--- a/pkg/actors/targets/workflow/orchestrator/signing.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing.go
@@ -38,6 +38,15 @@ func (o *orchestrator) signNewEvents(state *wfenginestate.State) error {
 		return nil
 	}
 
+	// Defensive: the added count cannot exceed the history length. Without
+	// this guard, the int subtraction below would underflow and the uint64
+	// cast would produce a massive startIndex, panicking in the marshal loop
+	// with a misleading out-of-bounds error instead of a clear message here.
+	if newEventCount > len(state.History) {
+		return fmt.Errorf("signNewEvents called with newEventCount=%d but history has only %d events",
+			newEventCount, len(state.History))
+	}
+
 	//nolint:gosec
 	startIndex := uint64(len(state.History) - newEventCount)
 

--- a/pkg/actors/targets/workflow/orchestrator/signing.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+
+	actorsapi "github.com/dapr/dapr/pkg/actors/api"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/durabletask-go/backend/historysigning"
+)
+
+// signNewEvents deterministically marshals the newly added history events,
+// creates a HistorySignature covering them, and appends it (along with any
+// new signing certificate) to the state.
+// The marshaled bytes are stored on the state so that GetSaveRequest can
+// persist the exact bytes that were signed.
+// If signer is nil (mTLS disabled or feature flag off), this is a no-op.
+func (o *orchestrator) signNewEvents(state *wfenginestate.State, newEventCount int) error {
+	if o.signer == nil {
+		return nil
+	}
+
+	if newEventCount == 0 {
+		return nil
+	}
+
+	//nolint:gosec
+	startIndex := uint64(len(state.History) - newEventCount)
+
+	// Marshal new events deterministically. These exact bytes will be both
+	// signed and persisted to the state store.
+	rawNewEvents := make([][]byte, newEventCount)
+	for i := range newEventCount {
+		data, err := historysigning.MarshalEvent(state.History[startIndex+uint64(i)])
+		if err != nil {
+			return fmt.Errorf("failed to marshal history event %d: %w", startIndex+uint64(i), err)
+		}
+		rawNewEvents[i] = data
+	}
+
+	state.SetMarshaledNewHistory(rawNewEvents)
+
+	var prevSigRaw []byte
+	if len(state.RawSignatures) > 0 {
+		prevSigRaw = state.RawSignatures[len(state.RawSignatures)-1]
+	}
+
+	result, err := historysigning.Sign(o.signer, historysigning.SignOptions{
+		RawEvents:            rawNewEvents,
+		StartEventIndex:      startIndex,
+		PreviousSignatureRaw: prevSigRaw,
+		ExistingCerts:        state.SigningCertificates,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to sign history events: %w", err)
+	}
+
+	if result.NewCert != nil {
+		state.AddSigningCertificate(result.NewCert)
+	}
+
+	state.AddSignature(result.Signature, result.RawSignature)
+
+	return nil
+}
+
+// failSignatureVerification deletes all reminders for this workflow to prevent
+// endless retries. The workflow state is left untouched.
+func (o *orchestrator) failSignatureVerification(ctx context.Context) {
+	log.Warnf("Workflow actor '%s': signature verification failed, deleting reminders to stop retries", o.actorID)
+
+	if err := o.reminders.DeleteByActorID(ctx, &actorsapi.DeleteRemindersByActorIDRequest{
+		ActorType: o.actorType,
+		ActorID:   o.actorID,
+	}); err != nil {
+		log.Errorf("Workflow actor '%s': failed to delete workflow reminders: %s", o.actorID, err)
+	}
+
+	if err := o.reminders.DeleteByActorID(ctx, &actorsapi.DeleteRemindersByActorIDRequest{
+		ActorType:       o.activityActorType,
+		ActorID:         o.actorID + "::",
+		MatchIDAsPrefix: true,
+	}); err != nil {
+		log.Errorf("Workflow actor '%s': failed to delete activity reminders: %s", o.actorID, err)
+	}
+}

--- a/pkg/actors/targets/workflow/orchestrator/signing.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing.go
@@ -28,17 +28,28 @@ import (
 // The marshaled bytes are stored on the state so that GetSaveRequest can
 // persist the exact bytes that were signed.
 // If signer is nil (mTLS disabled or feature flag off), this is a no-op.
-func (o *orchestrator) signNewEvents(state *wfenginestate.State, newEventCount int) error {
+func (o *orchestrator) signNewEvents(state *wfenginestate.State) error {
 	if o.signer == nil {
 		return nil
 	}
 
+	newEventCount := state.HistoryAddedCount()
 	if newEventCount == 0 {
 		return nil
 	}
 
 	//nolint:gosec
 	startIndex := uint64(len(state.History) - newEventCount)
+
+	// Defensive: when there is no previous signature, this must be the very
+	// first signature for the workflow, which requires the batch to cover the
+	// entire history. Otherwise we'd produce a chain-less signature over a
+	// suffix of the history which the verifier would reject, but the defect
+	// would only surface on reload. Fail fast instead.
+	if len(state.RawSignatures) == 0 && startIndex != 0 {
+		return fmt.Errorf("cannot sign partial history (%d events, starting at index %d) without a previous signature",
+			newEventCount, startIndex)
+	}
 
 	// Marshal new events deterministically. These exact bytes will be both
 	// signed and persisted to the state store.

--- a/pkg/actors/targets/workflow/orchestrator/signing_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/dapr/pkg/actors/api"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/backend/historysigning"
+	"github.com/dapr/kit/crypto/spiffe/signer"
+	"github.com/dapr/kit/crypto/spiffe/trustanchors/fake"
+)
+
+func generateTestCert(t *testing.T) ([]byte, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:     time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+		URIs:         []*url.URL{{Scheme: "spiffe", Host: "example.org", Path: "/ns/default/app-a"}},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	require.NoError(t, err)
+	return certDER, priv
+}
+
+func testSigner(t *testing.T, certDER []byte, key ed25519.PrivateKey) *signer.Signer {
+	t.Helper()
+	return testSignerWithTrust(t, certDER, key, false)
+}
+
+func testSignerWithTrust(t *testing.T, certDER []byte, key ed25519.PrivateKey, withTrustAnchors bool) *signer.Signer {
+	t.Helper()
+	certs, err := x509.ParseCertificates(certDER)
+	require.NoError(t, err)
+	id, err := x509svid.IDFromCert(certs[0])
+	require.NoError(t, err)
+	source := &staticSVIDSource{svid: &x509svid.SVID{
+		ID:           id,
+		Certificates: certs,
+		PrivateKey:   key,
+	}}
+	if withTrustAnchors {
+		return signer.New(source, fake.New(certs...))
+	}
+	return signer.New(source, nil)
+}
+
+type staticSVIDSource struct {
+	svid *x509svid.SVID
+}
+
+func (s *staticSVIDSource) GetX509SVID() (*x509svid.SVID, error) {
+	return s.svid, nil
+}
+
+func testState(events ...*backend.HistoryEvent) *wfenginestate.State {
+	s := wfenginestate.NewState(wfenginestate.Options{
+		AppID:             "test-app",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+	})
+	for _, e := range events {
+		s.AddToHistory(e)
+	}
+	return s
+}
+
+func testHistoryEvent(id int32) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.New(time.Date(2026, 3, 18, 12, 0, int(id), 0, time.UTC)),
+		EventType: &protos.HistoryEvent_WorkflowStarted{
+			WorkflowStarted: &protos.WorkflowStartedEvent{},
+		},
+	}
+}
+
+func TestSignNewEvents_NilCrypto(t *testing.T) {
+	t.Parallel()
+
+	o := &orchestrator{factory: &factory{signer: nil}}
+	s := testState(testHistoryEvent(0))
+
+	err := o.signNewEvents(s, 1)
+	require.NoError(t, err)
+
+	assert.Empty(t, s.Signatures)
+	assert.Empty(t, s.SigningCertificates)
+}
+
+func TestSignNewEvents_ZeroEvents(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	o := &orchestrator{factory: &factory{signer: testSigner(t, certDER, priv)}}
+	s := testState(testHistoryEvent(0))
+
+	err := o.signNewEvents(s, 0)
+	require.NoError(t, err)
+
+	assert.Empty(t, s.Signatures)
+	assert.Empty(t, s.SigningCertificates)
+}
+
+func TestSignNewEvents_SignsAndAppends(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	o := &orchestrator{factory: &factory{signer: testSigner(t, certDER, priv)}}
+
+	events := []*backend.HistoryEvent{
+		testHistoryEvent(0),
+		testHistoryEvent(1),
+		testHistoryEvent(2),
+	}
+	s := testState(events...)
+
+	err := o.signNewEvents(s, 3)
+	require.NoError(t, err)
+
+	assert.Len(t, s.Signatures, 1)
+	assert.Len(t, s.SigningCertificates, 1)
+
+	sig := s.Signatures[0]
+	assert.Equal(t, uint64(0), sig.GetStartEventIndex())
+	assert.Equal(t, uint64(3), sig.GetEventCount())
+	assert.Nil(t, sig.GetPreviousSignatureDigest())
+}
+
+func TestSignNewEvents_ChainsToExistingSignature(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	o := &orchestrator{factory: &factory{signer: testSigner(t, certDER, priv)}}
+
+	// First batch: sign 2 events.
+	events := []*backend.HistoryEvent{
+		testHistoryEvent(0),
+		testHistoryEvent(1),
+	}
+	s := testState(events...)
+
+	err := o.signNewEvents(s, 2)
+	require.NoError(t, err)
+	require.Len(t, s.Signatures, 1)
+	require.Len(t, s.SigningCertificates, 1)
+
+	// Second batch: add and sign 1 more event.
+	s.AddToHistory(testHistoryEvent(2))
+
+	err = o.signNewEvents(s, 1)
+	require.NoError(t, err)
+
+	require.Len(t, s.Signatures, 2)
+	// Certificate should be reused.
+	assert.Len(t, s.SigningCertificates, 1)
+
+	sig2 := s.Signatures[1]
+	assert.Equal(t, uint64(2), sig2.GetStartEventIndex())
+	assert.Equal(t, uint64(1), sig2.GetEventCount())
+	assert.NotNil(t, sig2.GetPreviousSignatureDigest())
+}
+
+func TestSignNewEvents_SetsMarshaledNewHistory(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	o := &orchestrator{factory: &factory{signer: testSigner(t, certDER, priv)}}
+
+	events := []*backend.HistoryEvent{
+		testHistoryEvent(0),
+		testHistoryEvent(1),
+	}
+	s := testState(events...)
+
+	err := o.signNewEvents(s, 2)
+	require.NoError(t, err)
+
+	// Verify the marshaled bytes were set by checking GetSaveRequest produces
+	// upserts for history keys with the correct deterministic bytes.
+	req, err := s.GetSaveRequest("test")
+	require.NoError(t, err)
+
+	for i, e := range events {
+		expected, merr := historysigning.MarshalEvent(e)
+		require.NoError(t, merr)
+
+		key := fmt.Sprintf("history-%06d", i)
+		found := false
+		for _, op := range req.Operations {
+			if op.Operation == api.Upsert {
+				if u, ok := op.Request.(api.TransactionalUpsert); ok {
+					if u.Key == key {
+						assert.Equal(t, expected, u.Value, "history event %d bytes should match deterministic marshal", i)
+						found = true
+						break
+					}
+				}
+			}
+		}
+		assert.True(t, found, "expected upsert for %s", key)
+	}
+}
+
+func TestSignNewEvents_VerifiesWithHistorySigning(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sig := testSigner(t, certDER, priv)
+	o := &orchestrator{factory: &factory{signer: sig}}
+
+	events := []*backend.HistoryEvent{
+		testHistoryEvent(0),
+		testHistoryEvent(1),
+		testHistoryEvent(2),
+	}
+	st := testState(events...)
+
+	err := o.signNewEvents(st, 3)
+	require.NoError(t, err)
+
+	// Independently verify the signature using historysigning.VerifySignature.
+	rawEvents := make([][]byte, len(events))
+	for i, e := range events {
+		rawEvents[i], err = historysigning.MarshalEvent(e)
+		require.NoError(t, err)
+	}
+
+	err = historysigning.VerifySignature(sig, st.Signatures[0], st.SigningCertificates, rawEvents)
+	require.NoError(t, err)
+}
+
+// TestSignNewEvents_RoundTripDeterminism verifies that signatures survive a
+// full sign → save → load → verify cycle. The saved raw bytes must be
+// preserved exactly so that chain linking digests remain valid.
+func TestSignNewEvents_RoundTripDeterminism(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+	o := &orchestrator{factory: &factory{signer: sgn}}
+
+	// Sign two batches to test chain linking across a save cycle.
+	events := []*backend.HistoryEvent{
+		testHistoryEvent(0),
+		testHistoryEvent(1),
+	}
+	st := testState(events...)
+
+	err := o.signNewEvents(st, 2)
+	require.NoError(t, err)
+	require.Len(t, st.Signatures, 1)
+	require.Len(t, st.RawSignatures, 1)
+
+	// Build save request — this is what goes to the state store.
+	req, err := st.GetSaveRequest("test-actor")
+	require.NoError(t, err)
+
+	// Extract the persisted bytes for signatures, certs, and history.
+	savedBytes := make(map[string][]byte)
+	for _, op := range req.Operations {
+		if op.Operation == api.Upsert {
+			if u, ok := op.Request.(api.TransactionalUpsert); ok {
+				if v, ok := u.Value.([]byte); ok {
+					savedBytes[u.Key] = v
+				}
+			}
+		}
+	}
+
+	// Verify signature bytes were saved.
+	sigBytes, ok := savedBytes["signature-000000"]
+	require.True(t, ok, "signature-000000 should be in save request")
+	assert.Equal(t, st.RawSignatures[0], sigBytes,
+		"saved bytes must match RawSignatures exactly")
+
+	// Simulate a load: unmarshal signature from saved bytes and verify chain.
+	var loadedSig backend.HistorySignature
+	require.NoError(t, proto.Unmarshal(sigBytes, &loadedSig))
+
+	// Reconstruct raw events from saved history bytes.
+	var rawEvents [][]byte
+	for i := 0; ; i++ {
+		key := fmt.Sprintf("history-%06d", i)
+		b, exists := savedBytes[key]
+		if !exists {
+			break
+		}
+		rawEvents = append(rawEvents, b)
+	}
+	require.Len(t, rawEvents, 2)
+
+	// Verify chain using loaded raw bytes (same as LoadWorkflowState would).
+	err = historysigning.VerifyChain(historysigning.VerifyChainOptions{
+		RawSignatures: [][]byte{sigBytes},
+		Certs:         st.SigningCertificates,
+		AllRawEvents:  rawEvents,
+		Signer:        sgn,
+	})
+	require.NoError(t, err, "signatures must verify after round-trip")
+
+	// Now add a second batch and verify chain linking works with the
+	// raw bytes from the first batch. Simulate what LoadWorkflowState
+	// does: preserve RawSignatures across the save cycle.
+	savedRawSigs := make([][]byte, len(st.RawSignatures))
+	copy(savedRawSigs, st.RawSignatures)
+	st.ResetChangeTracking()
+	// Simulate reload: restore raw signatures as LoadWorkflowState would.
+	st.RawSignatures = savedRawSigs
+	st.AddToHistory(testHistoryEvent(2))
+
+	err = o.signNewEvents(st, 1)
+	require.NoError(t, err)
+	require.Len(t, st.Signatures, 2)
+	require.Len(t, st.RawSignatures, 2)
+
+	// Rebuild raw events including the new one.
+	newRaw, err := historysigning.MarshalEvent(testHistoryEvent(2))
+	require.NoError(t, err)
+	rawEvents = append(rawEvents, newRaw)
+
+	// Verify full chain with both signatures.
+	err = historysigning.VerifyChain(historysigning.VerifyChainOptions{
+		RawSignatures: st.RawSignatures,
+		Certs:         st.SigningCertificates,
+		AllRawEvents:  rawEvents,
+		Signer:        sgn,
+	})
+	require.NoError(t, err, "chained signatures must verify after round-trip")
+}

--- a/pkg/actors/targets/workflow/orchestrator/signing_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing_test.go
@@ -115,7 +115,7 @@ func TestSignNewEvents_NilCrypto(t *testing.T) {
 	o := &orchestrator{factory: &factory{signer: nil}}
 	s := testState(testHistoryEvent(0))
 
-	err := o.signNewEvents(s, 1)
+	err := o.signNewEvents(s)
 	require.NoError(t, err)
 
 	assert.Empty(t, s.Signatures)
@@ -127,9 +127,12 @@ func TestSignNewEvents_ZeroEvents(t *testing.T) {
 
 	certDER, priv := generateTestCert(t)
 	o := &orchestrator{factory: &factory{signer: testSigner(t, certDER, priv)}}
+	// Start with history already persisted (no pending additions) by
+	// clearing change tracking, mirroring a freshly-loaded state.
 	s := testState(testHistoryEvent(0))
+	s.ResetChangeTracking()
 
-	err := o.signNewEvents(s, 0)
+	err := o.signNewEvents(s)
 	require.NoError(t, err)
 
 	assert.Empty(t, s.Signatures)
@@ -149,7 +152,7 @@ func TestSignNewEvents_SignsAndAppends(t *testing.T) {
 	}
 	s := testState(events...)
 
-	err := o.signNewEvents(s, 3)
+	err := o.signNewEvents(s)
 	require.NoError(t, err)
 
 	assert.Len(t, s.Signatures, 1)
@@ -174,15 +177,17 @@ func TestSignNewEvents_ChainsToExistingSignature(t *testing.T) {
 	}
 	s := testState(events...)
 
-	err := o.signNewEvents(s, 2)
+	err := o.signNewEvents(s)
 	require.NoError(t, err)
 	require.Len(t, s.Signatures, 1)
 	require.Len(t, s.SigningCertificates, 1)
 
-	// Second batch: add and sign 1 more event.
+	// Simulate the post-save reset that the orchestrator performs in the
+	// real flow, then append a new event so only it counts as pending.
+	s.ResetChangeTracking()
 	s.AddToHistory(testHistoryEvent(2))
 
-	err = o.signNewEvents(s, 1)
+	err = o.signNewEvents(s)
 	require.NoError(t, err)
 
 	require.Len(t, s.Signatures, 2)
@@ -207,7 +212,7 @@ func TestSignNewEvents_SetsMarshaledNewHistory(t *testing.T) {
 	}
 	s := testState(events...)
 
-	err := o.signNewEvents(s, 2)
+	err := o.signNewEvents(s)
 	require.NoError(t, err)
 
 	// Verify the marshaled bytes were set by checking GetSaveRequest produces
@@ -250,7 +255,7 @@ func TestSignNewEvents_VerifiesWithHistorySigning(t *testing.T) {
 	}
 	st := testState(events...)
 
-	err := o.signNewEvents(st, 3)
+	err := o.signNewEvents(st)
 	require.NoError(t, err)
 
 	// Independently verify the signature using historysigning.VerifySignature.
@@ -281,7 +286,7 @@ func TestSignNewEvents_RoundTripDeterminism(t *testing.T) {
 	}
 	st := testState(events...)
 
-	err := o.signNewEvents(st, 2)
+	err := o.signNewEvents(st)
 	require.NoError(t, err)
 	require.Len(t, st.Signatures, 1)
 	require.Len(t, st.RawSignatures, 1)
@@ -343,7 +348,7 @@ func TestSignNewEvents_RoundTripDeterminism(t *testing.T) {
 	st.RawSignatures = savedRawSigs
 	st.AddToHistory(testHistoryEvent(2))
 
-	err = o.signNewEvents(st, 1)
+	err = o.signNewEvents(st)
 	require.NoError(t, err)
 	require.Len(t, st.Signatures, 2)
 	require.Len(t, st.RawSignatures, 2)

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -15,6 +15,8 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"google.golang.org/protobuf/types/known/anypb"
@@ -24,6 +26,7 @@ import (
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -43,20 +46,36 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 		AppID:             o.appID,
 		WorkflowActorType: o.actorType,
 		ActivityActorType: o.activityActorType,
+		Signer:            o.signer,
 	})
 	if err != nil {
+		var verifyErr *wferrors.VerificationError
+		if errors.As(err, &verifyErr) {
+			o.failSignatureVerification(ctx)
+		}
 		return nil, nil, err
 	}
 	if state == nil {
 		// No such state exists in the state store
 		return nil, nil, nil
 	}
+
 	// Update cached state
 	o.state = state
 	o.rstate = runtimestate.NewWorkflowRuntimeState(o.actorID, state.CustomStatus, state.History)
 	o.ometa = o.ometaFromState(o.rstate, o.getExecutionStartedEvent(state))
 
 	return state, o.ometa, nil
+}
+
+// signAndSaveState signs any newly added history events and then persists
+// the state. This is the single entry point for all state persistence —
+// callers must never call saveInternalState directly.
+func (o *orchestrator) signAndSaveState(ctx context.Context, state *wfenginestate.State) error {
+	if err := o.signNewEvents(state, state.HistoryAddedCount()); err != nil {
+		return fmt.Errorf("failed to sign new history events: %w", err)
+	}
+	return o.saveInternalState(ctx, state)
 }
 
 func (o *orchestrator) saveInternalState(ctx context.Context, state *wfenginestate.State) error {

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -86,7 +86,7 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 // the state. This is the single entry point for all state persistence —
 // callers must never call saveInternalState directly.
 func (o *orchestrator) signAndSaveState(ctx context.Context, state *wfenginestate.State) error {
-	if err := o.signNewEvents(state, state.HistoryAddedCount()); err != nil {
+	if err := o.signNewEvents(state); err != nil {
 		return fmt.Errorf("failed to sign new history events: %w", err)
 	}
 	return o.saveInternalState(ctx, state)

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -61,10 +61,11 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 	}
 
 	// When signing is enabled, any inbox event that does not match signed
-	// history can only have been written via state store tampering. Treat
-	// the state as unrecoverable: fail the workflow terminally so no
-	// further progress is made on forged input.
-	if o.signer != nil {
+	// history can only have been written via state store tampering. Treat the
+	// state as unrecoverable: fail the workflow terminally so no further
+	// progress is made on forged input. Skip the scan on an empty inbox as
+	// nothing to validate and the history-index build is pure waste.
+	if o.signer != nil && len(state.Inbox) > 0 {
 		if filtered := filterValidInboxEvents(state); len(filtered) != len(state.Inbox) {
 			o.failSignatureVerification(ctx)
 			return nil, nil, wferrors.NewVerificationError(

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -60,6 +60,20 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 		return nil, nil, nil
 	}
 
+	// When signing is enabled, any inbox event that does not match signed
+	// history can only have been written via state store tampering. Treat
+	// the state as unrecoverable: fail the workflow terminally so no
+	// further progress is made on forged input.
+	if o.signer != nil {
+		if filtered := filterValidInboxEvents(state); len(filtered) != len(state.Inbox) {
+			o.failSignatureVerification(ctx)
+			return nil, nil, wferrors.NewVerificationError(
+				fmt.Errorf("workflow actor '%s': inbox contained %d events that did not match signed history (state store tampering)",
+					o.actorID, len(state.Inbox)-len(filtered)),
+			)
+		}
+	}
+
 	// Update cached state
 	o.state = state
 	o.rstate = runtimestate.NewWorkflowRuntimeState(o.actorID, state.CustomStatus, state.History)

--- a/pkg/actors/targets/workflow/orchestrator/versioning.go
+++ b/pkg/actors/targets/workflow/orchestrator/versioning.go
@@ -84,7 +84,7 @@ func (o *orchestrator) stallWorkflow(ctx context.Context, state *wfenginestate.S
 	}
 	if hasFilteredNewEvents || hasStalledEvent {
 		state.ApplyRuntimeStateChanges(rs)
-		err := o.saveInternalState(ctx, state)
+		err := o.signAndSaveState(ctx, state)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -68,6 +68,12 @@ const (
 	// When enabled, daprd loads MCPServer manifests at startup,
 	// and makes them available for tool execution via workflow orchestrations.
 	MCPServerResource Feature = "MCPServerResource"
+
+	// WorkflowSignState enables cryptographic signing of workflow history
+	// state. When enabled and mTLS is active, each workflow execution's
+	// history events are signed using the app's X.509 SVID identity,
+	// creating a verifiable chain of signatures. Enabled by default.
+	WorkflowSignState Feature = "WorkflowSignState"
 )
 
 // end feature flags section

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -69,11 +69,11 @@ const (
 	// and makes them available for tool execution via workflow orchestrations.
 	MCPServerResource Feature = "MCPServerResource"
 
-	// WorkflowSignState enables cryptographic signing of workflow history
-	// state. When enabled and mTLS is active, each workflow execution's
+	// WorkflowHistorySigning enables cryptographic signing of workflow
+	// history. When enabled and mTLS is active, each workflow execution's
 	// history events are signed using the app's X.509 SVID identity,
 	// creating a verifiable chain of signatures. Disabled by default.
-	WorkflowSignState Feature = "WorkflowSignState"
+	WorkflowHistorySigning Feature = "WorkflowHistorySigning"
 )
 
 // end feature flags section

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -72,7 +72,7 @@ const (
 	// WorkflowSignState enables cryptographic signing of workflow history
 	// state. When enabled and mTLS is active, each workflow execution's
 	// history events are signed using the app's X.509 SVID identity,
-	// creating a verifiable chain of signatures. Disabled by default.
+	// creating a verifiable chain of signatures. Enabled by default.
 	WorkflowSignState Feature = "WorkflowSignState"
 )
 

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -72,7 +72,7 @@ const (
 	// WorkflowSignState enables cryptographic signing of workflow history
 	// state. When enabled and mTLS is active, each workflow execution's
 	// history events are signed using the app's X.509 SVID identity,
-	// creating a verifiable chain of signatures. Enabled by default.
+	// creating a verifiable chain of signatures. Disabled by default.
 	WorkflowSignState Feature = "WorkflowSignState"
 )
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -312,7 +312,7 @@ func newDaprRuntime(ctx context.Context,
 		return nil, fmt.Errorf("invalid mode: %s", runtimeConfig.mode)
 	}
 
-	wfe := wfengine.New(wfengine.Options{
+	wfe, err := wfengine.New(wfengine.Options{
 		AppID:                           runtimeConfig.id,
 		Namespace:                       namespace,
 		Actors:                          actors,
@@ -326,6 +326,9 @@ func newDaprRuntime(ctx context.Context,
 		ComponentStore:                  compStore,
 		Signer:                          sec.Signer(),
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	jobsManager, err := scheduler.New(scheduler.Options{
 		Namespace:        namespace,

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -89,6 +89,7 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/wfengine"
 	"github.com/dapr/dapr/pkg/security"
 	"github.com/dapr/dapr/utils"
+	"github.com/dapr/kit/crypto/spiffe/signer"
 )
 
 var log = logger.NewLogger("dapr.runtime")
@@ -312,6 +313,11 @@ func newDaprRuntime(ctx context.Context,
 		return nil, fmt.Errorf("invalid mode: %s", runtimeConfig.mode)
 	}
 
+	var signer *signer.Signer
+	if sec != nil {
+		signer = sec.Signer()
+	}
+
 	wfe, err := wfengine.New(wfengine.Options{
 		AppID:                           runtimeConfig.id,
 		Namespace:                       namespace,
@@ -324,7 +330,7 @@ func newDaprRuntime(ctx context.Context,
 		WorkflowsRemoteActivityReminder: globalConfig.IsFeatureEnabled(config.WorkflowsRemoteActivityReminder),
 		WorkflowSignState:               globalConfig.IsFeatureEnabled(config.WorkflowSignState),
 		ComponentStore:                  compStore,
-		Signer:                          sec.Signer(),
+		Signer:                          signer,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -313,9 +313,9 @@ func newDaprRuntime(ctx context.Context,
 		return nil, fmt.Errorf("invalid mode: %s", runtimeConfig.mode)
 	}
 
-	var signer *signer.Signer
+	var wfSigner *signer.Signer
 	if sec != nil {
-		signer = sec.Signer()
+		wfSigner = sec.Signer()
 	}
 
 	wfe, err := wfengine.New(wfengine.Options{
@@ -330,7 +330,7 @@ func newDaprRuntime(ctx context.Context,
 		WorkflowsRemoteActivityReminder: globalConfig.IsFeatureEnabled(config.WorkflowsRemoteActivityReminder),
 		WorkflowSignState:               globalConfig.IsFeatureEnabled(config.WorkflowSignState),
 		ComponentStore:                  compStore,
-		Signer:                          signer,
+		Signer:                          wfSigner,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -322,7 +322,9 @@ func newDaprRuntime(ctx context.Context,
 		EventSink:                       runtimeConfig.workflowEventSink,
 		EnableClusteredDeployment:       globalConfig.IsFeatureEnabled(config.WorkflowsClusteredDeployment),
 		WorkflowsRemoteActivityReminder: globalConfig.IsFeatureEnabled(config.WorkflowsRemoteActivityReminder),
+		WorkflowSignState:               globalConfig.IsFeatureEnabled(config.WorkflowSignState),
 		ComponentStore:                  compStore,
+		Signer:                          sec.Signer(),
 	})
 
 	jobsManager, err := scheduler.New(scheduler.Options{

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -328,7 +328,7 @@ func newDaprRuntime(ctx context.Context,
 		EventSink:                       runtimeConfig.workflowEventSink,
 		EnableClusteredDeployment:       globalConfig.IsFeatureEnabled(config.WorkflowsClusteredDeployment),
 		WorkflowsRemoteActivityReminder: globalConfig.IsFeatureEnabled(config.WorkflowsRemoteActivityReminder),
-		WorkflowSignState:               globalConfig.IsFeatureEnabled(config.WorkflowSignState),
+		WorkflowHistorySigning:          globalConfig.IsFeatureEnabled(config.WorkflowHistorySigning),
 		ComponentStore:                  compStore,
 		Signer:                          wfSigner,
 	})

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -56,6 +56,7 @@ import (
 	"github.com/dapr/durabletask-go/backend/local"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
 	"github.com/dapr/kit/concurrency"
+	"github.com/dapr/kit/crypto/spiffe/signer"
 	"github.com/dapr/kit/logger"
 )
 
@@ -92,6 +93,7 @@ type Options struct {
 	WorkflowsRemoteActivityReminder bool
 
 	RetentionPolicy *config.WorkflowStateRetentionPolicy
+	Signer          *signer.Signer
 }
 
 type Actors struct {
@@ -108,6 +110,7 @@ type Actors struct {
 	eventSink           orchestrator.EventSink
 	compStore           *compstore.ComponentStore
 	retentionPolicy     *config.WorkflowStateRetentionPolicy
+	signer              *signer.Signer
 
 	enableClusteredDeployment       bool
 	workflowsRemoteActivityReminder bool
@@ -144,6 +147,7 @@ func New(opts Options) *Actors {
 		activityWorkItemChan:      make(chan *backend.ActivityWorkItem, 1),
 		eventSink:                 opts.EventSink,
 		retentionPolicy:           opts.RetentionPolicy,
+		signer:                    opts.Signer,
 
 		enableClusteredDeployment:       opts.EnableClusteredDeployment,
 		workflowsRemoteActivityReminder: opts.WorkflowsRemoteActivityReminder,
@@ -165,6 +169,7 @@ func (abe *Actors) RegisterActors(ctx context.Context) error {
 		Actors:             abe.actors,
 		RetentionActorType: abe.retentionerActorType,
 		RetentionPolicy:    abe.retentionPolicy,
+		Signer:             abe.signer,
 		Scheduler: func(ctx context.Context, wi *backend.WorkflowWorkItem) error {
 			log.Debugf("%s: scheduling workflow execution with durabletask engine", wi.InstanceID)
 
@@ -577,6 +582,7 @@ func (abe *Actors) loadInternalState(ctx context.Context, id api.InstanceID) (*s
 		AppID:             abe.appID,
 		WorkflowActorType: abe.workflowActorType,
 		ActivityActorType: abe.activityActorType,
+		Signer:            abe.signer,
 	})
 	if err != nil {
 		return nil, err
@@ -720,6 +726,7 @@ func (abe *Actors) GetInstanceHistory(ctx context.Context, req *protos.GetInstan
 		AppID:             abe.appID,
 		WorkflowActorType: abe.workflowActorType,
 		ActivityActorType: abe.activityActorType,
+		Signer:            abe.signer,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/runtime/wfengine/state/errors/errors.go
+++ b/pkg/runtime/wfengine/state/errors/errors.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+// VerificationError is returned by LoadWorkflowState when signature
+// verification fails. The State is still returned alongside this error so
+// callers can build failure metadata from it.
+type VerificationError struct {
+	err error
+}
+
+func NewVerificationError(err error) *VerificationError {
+	return &VerificationError{err}
+}
+
+func (e *VerificationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *VerificationError) Unwrap() error {
+	return e.err
+}

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -719,8 +719,9 @@ func verifySignatureChain(s *State, sgn *signer.Signer) error {
 }
 
 // verifyCertAppIdentity checks that a DER-encoded signing certificate chain
-// contains a SPIFFE ID whose final path segment matches the expected app ID.
-// SPIFFE IDs follow the pattern: spiffe://<trust-domain>/ns/<namespace>/<app-id>
+// contains a SPIFFE ID matching the expected app ID. SPIFFE IDs follow the
+// pattern: spiffe://<trust-domain>/ns/<namespace>/<app-id>
+// The function validates the full path structure, not just the last segment.
 func verifyCertAppIdentity(certChainDER []byte, expectedAppID string) error {
 	if len(certChainDER) == 0 {
 		return errors.New("certificate chain is empty")
@@ -740,13 +741,13 @@ func verifyCertAppIdentity(certChainDER []byte, expectedAppID string) error {
 		return fmt.Errorf("failed to extract SPIFFE ID: %w", err)
 	}
 
-	// The SPIFFE ID path is "/ns/<namespace>/<app-id>". Extract the last
-	// segment as the app ID.
+	// Validate the full SPIFFE path structure: /ns/<namespace>/<app-id>
+	// Split produces: ["", "ns", "<namespace>", "<app-id>"]
 	segments := strings.Split(spiffeID.Path(), "/")
-	if len(segments) < 2 {
-		return fmt.Errorf("SPIFFE ID %q has too few path segments", spiffeID)
+	if len(segments) != 4 || segments[0] != "" || segments[1] != "ns" || segments[2] == "" || segments[3] == "" {
+		return fmt.Errorf("SPIFFE ID %q does not match expected path format /ns/<namespace>/<app-id>", spiffeID)
 	}
-	certAppID := segments[len(segments)-1]
+	certAppID := segments[3]
 
 	if certAppID != expectedAppID {
 		return fmt.Errorf("certificate SPIFFE ID app %q does not match expected app %q", certAppID, expectedAppID)

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -597,8 +597,9 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetSigningCertificateLength() {
 		key = getMultiEntryKeyName(sigcertKeyPrefix, i)
 		if bulkRes[key] == nil {
-			wfLogger.Warnf("Failed to load signing cert state key '%s': not found", key)
-			continue
+			return nil, wferrors.NewVerificationError(
+				fmt.Errorf("signing certificate state key '%s' declared in metadata but not found in state store — possible tampering", key),
+			)
 		}
 
 		var cert backend.SigningCertificate
@@ -613,8 +614,9 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetSignatureLength() {
 		key = getMultiEntryKeyName(signatureKeyPrefix, i)
 		if bulkRes[key] == nil {
-			wfLogger.Warnf("Failed to load signature state key '%s': not found", key)
-			continue
+			return nil, wferrors.NewVerificationError(
+				fmt.Errorf("signature state key '%s' declared in metadata but not found in state store — possible tampering", key),
+			)
 		}
 
 		var sig backend.HistorySignature
@@ -650,10 +652,10 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 
 	// Signing enforcement. Once signing is enabled for a cluster, it is a
 	// one-way commitment: workflows created with signing must always run on
-	// signing-enabled hosts, and workflows created without signing cannot
-	// be migrated to signing-enabled hosts. Workflows that violate these
-	// rules are terminated. Operators must ensure all unsigned workflows
-	// complete or are purged before enabling signing cluster-wide.
+	// signing-enabled hosts, and workflows created without signing cannot be
+	// migrated to signing-enabled hosts. Workflows that violate these rules are
+	// terminated. Operators must ensure all unsigned workflows complete or are
+	// purged before enabling signing cluster-wide.
 	if len(wState.Signatures) > 0 {
 		if opts.Signer == nil {
 			return wState, wferrors.NewVerificationError(
@@ -685,10 +687,10 @@ func verifySignatureChain(s *State, sgn *signer.Signer) error {
 		last := s.Signatures[len(s.Signatures)-1]
 		coveredEvents := last.GetStartEventIndex() + last.GetEventCount()
 		if coveredEvents < uint64(len(rawEvents)) {
-			// Signatures don't cover all history events. This means the
-			// workflow ran on a non-signing host mid-flight, creating
-			// an unsigned gap. These events have no integrity proof and
-			// could have been tampered with. The workflow must be purged.
+			// Signatures don't cover all history events. This means the workflow ran
+			// on a non-signing host mid-flight, creating an unsigned gap. These
+			// events have no integrity proof and could have been tampered with. The
+			// workflow must be purged.
 			return fmt.Errorf("signatures cover events [0, %d) but %d history events exist; %d events have no integrity proof — this workflow ran on a non-signing host and cannot be recovered",
 				coveredEvents, len(rawEvents), uint64(len(rawEvents))-coveredEvents)
 		}
@@ -702,15 +704,14 @@ func verifySignatureChain(s *State, sgn *signer.Signer) error {
 		return err
 	}
 
-	// Verify that all signing certificates belong to the expected app.
-	// This prevents cross-app signature forgery where App B signs events
-	// for App A's workflow using a valid certificate from the same trust
-	// domain.
-	if s.appID != "" {
-		for i, cert := range s.SigningCertificates {
-			if err := verifyCertAppIdentity(cert.GetCertificate(), s.appID); err != nil {
-				return fmt.Errorf("signing certificate %d: %w", i, err)
-			}
+	// Verify that all signing certificates belong to the expected app. This
+	// prevents cross-app signature forgery where App B signs events for App A's
+	// workflow using a valid certificate from the same trust domain. The appID
+	// is guaranteed non-empty here because LoadWorkflowState rejects signed
+	// workflows with an empty AppID.
+	for i, cert := range s.SigningCertificates {
+		if err := verifyCertAppIdentity(cert.GetCertificate(), s.appID); err != nil {
+			return fmt.Errorf("signing certificate %d: %w", i, err)
 		}
 	}
 

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -15,26 +15,40 @@ package state
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/state"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/backend/historysigning"
+	"github.com/dapr/kit/crypto/spiffe/signer"
 	"github.com/dapr/kit/logger"
 )
 
 const (
-	inboxKeyPrefix   = "inbox"
-	historyKeyPrefix = "history"
-	customStatusKey  = "customStatus"
-	metadataKey      = "metadata"
+	inboxKeyPrefix     = "inbox"
+	historyKeyPrefix   = "history"
+	sigcertKeyPrefix   = "sigcert"
+	signatureKeyPrefix = "signature"
+	customStatusKey    = "customStatus"
+	metadataKey        = "metadata"
+
+	// maxStateEntries is the upper bound for any metadata count field
+	// (inbox, history, signatures, certificates). This prevents OOM from
+	// an attacker inflating metadata values in the state store.
+	maxStateEntries = 1_000_000
 )
 
 var wfLogger = logger.NewLogger("dapr.runtime.actor.target.workflow.state")
@@ -43,6 +57,7 @@ type Options struct {
 	AppID             string
 	WorkflowActorType string
 	ActivityActorType string
+	Signer            *signer.Signer
 }
 
 type State struct {
@@ -50,16 +65,38 @@ type State struct {
 	workflowActorType string
 	activityActorType string
 
-	Inbox        []*backend.HistoryEvent
-	History      []*backend.HistoryEvent
-	CustomStatus *wrapperspb.StringValue
-	Generation   uint64
+	Inbox               []*backend.HistoryEvent
+	History             []*backend.HistoryEvent
+	SigningCertificates []*backend.SigningCertificate
+	Signatures          []*backend.HistorySignature
+	CustomStatus        *wrapperspb.StringValue
+	Generation          uint64
+
+	// RawHistory holds the raw bytes of history events as loaded from the
+	// state store. These are used for signature verification to verify
+	// against the actual persisted bytes.
+	RawHistory [][]byte
+
+	// RawSignatures holds the raw serialized bytes of each HistorySignature
+	// as loaded from the state store or returned by SignResult.RawSignature.
+	// These are the single source of truth for digest computation in chain
+	// linking and must be preserved exactly as stored.
+	RawSignatures [][]byte
+
+	// marshaledNewHistory holds deterministically marshaled bytes for newly
+	// added history events, set by SetMarshaledNewHistory. When set, these
+	// exact bytes are persisted to the state store (matching what was signed).
+	marshaledNewHistory [][]byte
 
 	// change tracking
-	inboxAddedCount     int
-	inboxRemovedCount   int
-	historyAddedCount   int
-	historyRemovedCount int
+	inboxAddedCount                 int
+	inboxRemovedCount               int
+	historyAddedCount               int
+	historyRemovedCount             int
+	signingCertificatesAddedCount   int
+	signingCertificatesRemovedCount int
+	signaturesAddedCount            int
+	signaturesRemovedCount          int
 }
 
 // TODO: @joshvanl: remove in v1.16
@@ -85,6 +122,14 @@ func (s *State) Reset() {
 	s.historyAddedCount = 0
 	s.historyRemovedCount += len(s.History)
 	s.History = nil
+	s.RawHistory = nil
+	s.signingCertificatesAddedCount = 0
+	s.signingCertificatesRemovedCount += len(s.SigningCertificates)
+	s.SigningCertificates = nil
+	s.signaturesAddedCount = 0
+	s.signaturesRemovedCount += len(s.Signatures)
+	s.Signatures = nil
+	s.RawSignatures = nil
 	s.CustomStatus = nil
 	s.Generation++
 }
@@ -95,6 +140,12 @@ func (s *State) ResetChangeTracking() {
 	s.inboxRemovedCount = 0
 	s.historyAddedCount = 0
 	s.historyRemovedCount = 0
+	s.signingCertificatesAddedCount = 0
+	s.signingCertificatesRemovedCount = 0
+	s.signaturesAddedCount = 0
+	s.signaturesRemovedCount = 0
+	s.marshaledNewHistory = nil
+	s.RawHistory = nil
 }
 
 func (s *State) ApplyRuntimeStateChanges(rs *backend.WorkflowRuntimeState) {
@@ -102,6 +153,13 @@ func (s *State) ApplyRuntimeStateChanges(rs *backend.WorkflowRuntimeState) {
 		s.historyRemovedCount += len(s.History)
 		s.historyAddedCount = 0
 		s.History = nil
+		s.signingCertificatesRemovedCount += len(s.SigningCertificates)
+		s.signingCertificatesAddedCount = 0
+		s.SigningCertificates = nil
+		s.signaturesRemovedCount += len(s.Signatures)
+		s.signaturesAddedCount = 0
+		s.Signatures = nil
+		s.RawSignatures = nil
 	}
 
 	newHistoryEvents := rs.GetNewEvents()
@@ -121,6 +179,31 @@ func (s *State) AddToHistory(e *backend.HistoryEvent) {
 	s.historyAddedCount++
 }
 
+func (s *State) AddSigningCertificate(cert *backend.SigningCertificate) {
+	s.SigningCertificates = append(s.SigningCertificates, cert)
+	s.signingCertificatesAddedCount++
+}
+
+func (s *State) AddSignature(sig *backend.HistorySignature, raw []byte) {
+	s.Signatures = append(s.Signatures, sig)
+	s.RawSignatures = append(s.RawSignatures, raw)
+	s.signaturesAddedCount++
+}
+
+// HistoryAddedCount returns the number of history events added since the
+// last save or reset. Used by the orchestrator to know how many events
+// need signing.
+func (s *State) HistoryAddedCount() int {
+	return s.historyAddedCount
+}
+
+// SetMarshaledNewHistory stores pre-marshaled bytes for newly added history
+// events. These bytes will be used by GetSaveRequest instead of re-marshaling,
+// ensuring the persisted bytes match exactly what was signed.
+func (s *State) SetMarshaledNewHistory(raw [][]byte) {
+	s.marshaledNewHistory = raw
+}
+
 func (s *State) ClearInbox() {
 	for _, e := range s.Inbox {
 		if e.GetTimerFired() != nil {
@@ -137,16 +220,30 @@ func (s *State) ClearInbox() {
 
 func (s *State) GetSaveRequest(actorID string) (*api.TransactionalRequest, error) {
 	// TODO: Batching up the save requests into smaller chunks to avoid batch size limits in Dapr state stores.
+	opsCapacity := s.inboxAddedCount + s.inboxRemovedCount +
+		s.historyAddedCount + s.historyRemovedCount +
+		s.signingCertificatesAddedCount + s.signingCertificatesRemovedCount +
+		s.signaturesAddedCount + s.signaturesRemovedCount +
+		2 // customStatus + metadata
 	req := &api.TransactionalRequest{
-		ActorType: s.workflowActorType,
-		ActorID:   actorID,
+		ActorType:  s.workflowActorType,
+		ActorID:    actorID,
+		Operations: make([]api.TransactionalOperation, 0, opsCapacity),
 	}
 
 	if err := addStateOperations(req, inboxKeyPrefix, s.Inbox, s.inboxAddedCount, s.inboxRemovedCount); err != nil {
 		return nil, err
 	}
 
-	if err := addStateOperations(req, historyKeyPrefix, s.History, s.historyAddedCount, s.historyRemovedCount); err != nil {
+	if err := s.addHistoryOperations(req); err != nil {
+		return nil, err
+	}
+
+	if err := addProtoStateOperations(req, sigcertKeyPrefix, s.SigningCertificates, s.signingCertificatesAddedCount, s.signingCertificatesRemovedCount); err != nil {
+		return nil, err
+	}
+
+	if err := addRawBytesStateOperations(req, signatureKeyPrefix, s.RawSignatures, s.signaturesAddedCount, s.signaturesRemovedCount); err != nil {
 		return nil, err
 	}
 
@@ -171,9 +268,11 @@ func (s *State) GetSaveRequest(actorID string) (*api.TransactionalRequest, error
 	}
 
 	metaProto, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
-		InboxLength:   uint64(len(s.Inbox)),
-		HistoryLength: uint64(len(s.History)),
-		Generation:    s.Generation,
+		InboxLength:              uint64(len(s.Inbox)),
+		HistoryLength:            uint64(len(s.History)),
+		Generation:               s.Generation,
+		SignatureLength:          uint64(len(s.Signatures)),
+		SigningCertificateLength: uint64(len(s.SigningCertificates)),
 	})
 	if err != nil {
 		return nil, err
@@ -222,6 +321,42 @@ func (s *State) String() string {
 	)
 }
 
+// addHistoryOperations adds upsert/delete operations for history events. If
+// marshaledNewHistory was set (by the signing flow), those pre-marshaled bytes
+// are used directly so the persisted bytes match what was signed. Otherwise
+// events are marshaled with proto.Marshal.
+func (s *State) addHistoryOperations(req *api.TransactionalRequest) error {
+	start := len(s.History) - s.historyAddedCount
+	for i := start; i < len(s.History); i++ {
+		var data []byte
+		var err error
+		localIdx := i - start
+		if localIdx < len(s.marshaledNewHistory) {
+			data = s.marshaledNewHistory[localIdx]
+		} else {
+			data, err = proto.Marshal(s.History[i])
+			if err != nil {
+				return err
+			}
+		}
+
+		req.Operations = append(req.Operations, api.TransactionalOperation{
+			Operation: api.Upsert,
+			//nolint:gosec
+			Request: api.TransactionalUpsert{Key: getMultiEntryKeyName(historyKeyPrefix, uint64(i)), Value: data},
+		})
+	}
+
+	for i := len(s.History); i < s.historyRemovedCount; i++ {
+		req.Operations = append(req.Operations, api.TransactionalOperation{
+			Operation: api.Delete,
+			Request:   api.TransactionalDelete{Key: getMultiEntryKeyName(historyKeyPrefix, uint64(i))},
+		})
+	}
+
+	return nil
+}
+
 func addStateOperations(req *api.TransactionalRequest, keyPrefix string, events []*backend.HistoryEvent, addedCount int, removedCount int) error {
 	// TODO: Investigate whether Dapr state stores put limits on batch sizes. It seems some storage
 	//       providers have limits and we need to know if that impacts this algorithm:
@@ -250,19 +385,60 @@ func addStateOperations(req *api.TransactionalRequest, keyPrefix string, events 
 	return nil
 }
 
-func addPurgeStateOperations(req *api.TransactionalRequest, keyPrefix string, events []*backend.HistoryEvent) error {
-	// TODO: Investigate whether Dapr state stores put limits on batch sizes. It seems some storage
-	//       providers have limits and we need to know if that impacts this algorithm:
-	//       https://learn.microsoft.com/azure/cosmos-db/nosql/transactional-batch#limitations
-	for i := range events {
+// addProtoStateOperations persists newly added proto messages and deletes removed ones.
+func addProtoStateOperations[T proto.Message](req *api.TransactionalRequest, keyPrefix string, items []T, addedCount int, removedCount int) error {
+	for i := len(items) - addedCount; i < len(items); i++ {
+		data, err := proto.Marshal(items[i])
+		if err != nil {
+			return err
+		}
+
+		req.Operations = append(req.Operations, api.TransactionalOperation{
+			Operation: api.Upsert,
+			//nolint:gosec
+			Request: api.TransactionalUpsert{Key: getMultiEntryKeyName(keyPrefix, uint64(i)), Value: data},
+		})
+	}
+
+	for i := len(items); i < removedCount; i++ {
 		req.Operations = append(req.Operations, api.TransactionalOperation{
 			Operation: api.Delete,
-
-			Request: api.TransactionalDelete{Key: getMultiEntryKeyName(keyPrefix, uint64(i))},
+			Request:   api.TransactionalDelete{Key: getMultiEntryKeyName(keyPrefix, uint64(i))},
 		})
 	}
 
 	return nil
+}
+
+// addRawBytesStateOperations persists pre-serialized raw bytes directly,
+// without re-marshaling. This preserves byte-exact determinism required for
+// signature chain linking.
+func addRawBytesStateOperations(req *api.TransactionalRequest, keyPrefix string, rawItems [][]byte, addedCount int, removedCount int) error {
+	for i := len(rawItems) - addedCount; i < len(rawItems); i++ {
+		req.Operations = append(req.Operations, api.TransactionalOperation{
+			Operation: api.Upsert,
+			//nolint:gosec
+			Request: api.TransactionalUpsert{Key: getMultiEntryKeyName(keyPrefix, uint64(i)), Value: rawItems[i]},
+		})
+	}
+
+	for i := len(rawItems); i < removedCount; i++ {
+		req.Operations = append(req.Operations, api.TransactionalOperation{
+			Operation: api.Delete,
+			Request:   api.TransactionalDelete{Key: getMultiEntryKeyName(keyPrefix, uint64(i))},
+		})
+	}
+
+	return nil
+}
+
+func addPurgeStateOperations(req *api.TransactionalRequest, keyPrefix string, count int) {
+	for i := range count {
+		req.Operations = append(req.Operations, api.TransactionalOperation{
+			Operation: api.Delete,
+			Request:   api.TransactionalDelete{Key: getMultiEntryKeyName(keyPrefix, uint64(i))},
+		})
+	}
 }
 
 func LoadWorkflowState(ctx context.Context, state state.Interface, actorID string, opts Options) (*State, error) {
@@ -301,17 +477,36 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		metadata.HistoryLength = metadataJSON.HistoryLength
 	}
 
-	// Load inbox, history, and custom status using a bulk request
+	// Validate metadata bounds to prevent OOM from inflated state store values.
+	for _, entry := range []struct {
+		name  string
+		value uint64
+	}{
+		{"inbox", metadata.GetInboxLength()},
+		{"history", metadata.GetHistoryLength()},
+		{"signatures", metadata.GetSignatureLength()},
+		{"signing certificates", metadata.GetSigningCertificateLength()},
+	} {
+		if entry.value > maxStateEntries {
+			return nil, fmt.Errorf("workflow '%s' metadata %s length %d exceeds maximum %d", actorID, entry.name, entry.value, maxStateEntries)
+		}
+	}
+
+	// Load inbox, history, signing certs, signatures, and custom status using a bulk request
 	wState := NewState(opts)
 	wState.Generation = metadata.GetGeneration()
 	wState.Inbox = make([]*backend.HistoryEvent, 0, metadata.GetInboxLength())
 	wState.History = make([]*backend.HistoryEvent, 0, metadata.GetHistoryLength())
+	wState.RawHistory = make([][]byte, 0, metadata.GetHistoryLength())
+	wState.SigningCertificates = make([]*backend.SigningCertificate, 0, metadata.GetSigningCertificateLength())
+	wState.Signatures = make([]*backend.HistorySignature, 0, metadata.GetSignatureLength())
 
+	totalKeys := metadata.GetInboxLength() + metadata.GetHistoryLength() +
+		metadata.GetSigningCertificateLength() + metadata.GetSignatureLength() + 1
 	bulkReq := &api.GetBulkStateRequest{
 		ActorType: opts.WorkflowActorType,
 		ActorID:   actorID,
-		// Initializing with size for all the inbox, history, and custom status
-		Keys: make([]string, metadata.GetInboxLength()+metadata.GetHistoryLength()+1),
+		Keys:      make([]string, totalKeys),
 	}
 
 	var n int
@@ -326,6 +521,16 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 
 	for i := range metadata.GetHistoryLength() {
 		bulkReq.Keys[n] = getMultiEntryKeyName(historyKeyPrefix, i)
+		n++
+	}
+
+	for i := range metadata.GetSigningCertificateLength() {
+		bulkReq.Keys[n] = getMultiEntryKeyName(sigcertKeyPrefix, i)
+		n++
+	}
+
+	for i := range metadata.GetSignatureLength() {
+		bulkReq.Keys[n] = getMultiEntryKeyName(signatureKeyPrefix, i)
 		n++
 	}
 
@@ -375,6 +580,42 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		}
 
 		wState.History = append(wState.History, &hist)
+		wState.RawHistory = append(wState.RawHistory, bulkRes[key])
+	}
+
+	for i := range metadata.GetSigningCertificateLength() {
+		key = getMultiEntryKeyName(sigcertKeyPrefix, i)
+		if bulkRes[key] == nil {
+			wfLogger.Warnf("Failed to load signing cert state key '%s': not found", key)
+			continue
+		}
+
+		var cert backend.SigningCertificate
+		err = proto.Unmarshal(bulkRes[key], &cert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal signing certificate from state key '%s': %w", key, err)
+		}
+
+		wState.SigningCertificates = append(wState.SigningCertificates, &cert)
+	}
+
+	for i := range metadata.GetSignatureLength() {
+		key = getMultiEntryKeyName(signatureKeyPrefix, i)
+		if bulkRes[key] == nil {
+			wfLogger.Warnf("Failed to load signature state key '%s': not found", key)
+			continue
+		}
+
+		var sig backend.HistorySignature
+		err = proto.Unmarshal(bulkRes[key], &sig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal history signature from state key '%s': %w", key, err)
+		}
+
+		wState.Signatures = append(wState.Signatures, &sig)
+		raw := make([]byte, len(bulkRes[key]))
+		copy(raw, bulkRes[key])
+		wState.RawSignatures = append(wState.RawSignatures, raw)
 	}
 
 	if len(bulkRes[customStatusKey]) > 0 {
@@ -396,28 +637,124 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 
 	wfLogger.Debugf("%s: loaded %d state records in %v", actorID, 1+len(bulkRes), time.Since(loadStartTime))
 
+	// Signing enforcement. Once signing is enabled for a cluster, it is a
+	// one-way commitment: workflows created with signing must always run on
+	// signing-enabled hosts, and workflows created without signing cannot
+	// be migrated to signing-enabled hosts. Workflows that violate these
+	// rules are terminated. Operators must ensure all unsigned workflows
+	// complete or are purged before enabling signing cluster-wide.
+	if len(wState.Signatures) > 0 {
+		if opts.Signer == nil {
+			return wState, wferrors.NewVerificationError(
+				fmt.Errorf("workflow '%s' has signed history but no signer is configured; cannot verify signatures — signing cannot be disabled for workflows that were created with signing enabled", actorID),
+			)
+		}
+		if opts.AppID == "" {
+			return wState, wferrors.NewVerificationError(
+				fmt.Errorf("workflow '%s' has signed history but app ID is not configured; cannot verify signer identity", actorID),
+			)
+		}
+		if err := verifySignatureChain(wState, opts.Signer); err != nil {
+			return wState, wferrors.NewVerificationError(
+				fmt.Errorf("workflow history signature verification failed for '%s': %w", actorID, err),
+			)
+		}
+	} else if opts.Signer != nil && len(wState.History) > 0 {
+		return wState, wferrors.NewVerificationError(
+			fmt.Errorf("workflow '%s' has %d unsigned history events but signing is enabled — signing cannot be enabled for workflows that were created without signing; ensure all unsigned workflows complete or are purged before enabling signing", actorID, len(wState.History)),
+		)
+	}
+
 	return wState, nil
+}
+
+func verifySignatureChain(s *State, sgn *signer.Signer) error {
+	rawEvents := s.RawHistory
+	if len(s.Signatures) > 0 {
+		last := s.Signatures[len(s.Signatures)-1]
+		coveredEvents := last.GetStartEventIndex() + last.GetEventCount()
+		if coveredEvents < uint64(len(rawEvents)) {
+			// Signatures don't cover all history events. This means the
+			// workflow ran on a non-signing host mid-flight, creating
+			// an unsigned gap. These events have no integrity proof and
+			// could have been tampered with. The workflow must be purged.
+			return fmt.Errorf("signatures cover events [0, %d) but %d history events exist; %d events have no integrity proof — this workflow ran on a non-signing host and cannot be recovered",
+				coveredEvents, len(rawEvents), uint64(len(rawEvents))-coveredEvents)
+		}
+	}
+	if err := historysigning.VerifyChain(historysigning.VerifyChainOptions{
+		RawSignatures: s.RawSignatures,
+		Certs:         s.SigningCertificates,
+		AllRawEvents:  rawEvents,
+		Signer:        sgn,
+	}); err != nil {
+		return err
+	}
+
+	// Verify that all signing certificates belong to the expected app.
+	// This prevents cross-app signature forgery where App B signs events
+	// for App A's workflow using a valid certificate from the same trust
+	// domain.
+	if s.appID != "" {
+		for i, cert := range s.SigningCertificates {
+			if err := verifyCertAppIdentity(cert.GetCertificate(), s.appID); err != nil {
+				return fmt.Errorf("signing certificate %d: %w", i, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// verifyCertAppIdentity checks that a DER-encoded signing certificate chain
+// contains a SPIFFE ID whose final path segment matches the expected app ID.
+// SPIFFE IDs follow the pattern: spiffe://<trust-domain>/ns/<namespace>/<app-id>
+func verifyCertAppIdentity(certChainDER []byte, expectedAppID string) error {
+	if len(certChainDER) == 0 {
+		return errors.New("certificate chain is empty")
+	}
+
+	certs, err := x509.ParseCertificates(certChainDER)
+	if err != nil {
+		return fmt.Errorf("failed to parse certificate chain: %w", err)
+	}
+	if len(certs) == 0 {
+		return errors.New("no certificates in chain")
+	}
+
+	leaf := certs[0]
+	spiffeID, err := x509svid.IDFromCert(leaf)
+	if err != nil {
+		return fmt.Errorf("failed to extract SPIFFE ID: %w", err)
+	}
+
+	// The SPIFFE ID path is "/ns/<namespace>/<app-id>". Extract the last
+	// segment as the app ID.
+	segments := strings.Split(spiffeID.Path(), "/")
+	if len(segments) < 2 {
+		return fmt.Errorf("SPIFFE ID %q has too few path segments", spiffeID)
+	}
+	certAppID := segments[len(segments)-1]
+
+	if certAppID != expectedAppID {
+		return fmt.Errorf("certificate SPIFFE ID app %q does not match expected app %q", certAppID, expectedAppID)
+	}
+
+	return nil
 }
 
 func (s *State) GetPurgeRequest(actorID string) (*api.TransactionalRequest, error) {
 	req := &api.TransactionalRequest{
 		ActorType: s.workflowActorType,
 		ActorID:   actorID,
-		// Initial capacity should be enough to contain the entire inbox, history, and custom status + metadata
-		Operations: make([]api.TransactionalOperation, 0, len(s.Inbox)+len(s.History)+2),
+		// Initial capacity should be enough to contain the entire inbox, history, signing data, and custom status + metadata
+		Operations: make([]api.TransactionalOperation, 0, len(s.Inbox)+len(s.History)+len(s.SigningCertificates)+len(s.Signatures)+2),
 	}
 
-	// Inbox Purging
-	err := addPurgeStateOperations(req, inboxKeyPrefix, s.Inbox)
-	if err != nil {
-		return nil, err
-	}
-
-	// History Purging
-	err = addPurgeStateOperations(req, historyKeyPrefix, s.History)
-	if err != nil {
-		return nil, err
-	}
+	addPurgeStateOperations(req, inboxKeyPrefix, len(s.Inbox))
+	addPurgeStateOperations(req, historyKeyPrefix, len(s.History))
+	addPurgeStateOperations(req, sigcertKeyPrefix, len(s.SigningCertificates))
+	addPurgeStateOperations(req, signatureKeyPrefix, len(s.Signatures))
 
 	req.Operations = append(req.Operations,
 		api.TransactionalOperation{
@@ -458,5 +795,15 @@ func (s *State) FromWorkflowState(state *protos.BackendWorkflowState) {
 }
 
 func getMultiEntryKeyName(prefix string, i uint64) string {
-	return fmt.Sprintf("%s-%06d", prefix, i)
+	s := strconv.FormatUint(i, 10)
+	const padLen = 6
+	var b strings.Builder
+	b.Grow(len(prefix) + 1 + padLen)
+	b.WriteString(prefix)
+	b.WriteByte('-')
+	for j := len(s); j < padLen; j++ {
+		b.WriteByte('0')
+	}
+	b.WriteString(s)
+	return b.String()
 }

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -488,21 +488,32 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		{"signing certificates", metadata.GetSigningCertificateLength()},
 	} {
 		if entry.value > maxStateEntries {
-			return nil, fmt.Errorf("workflow '%s' metadata %s length %d exceeds maximum %d", actorID, entry.name, entry.value, maxStateEntries)
+			return nil, wferrors.NewVerificationError(
+				fmt.Errorf("workflow '%s' metadata %s length %d exceeds maximum %d", actorID, entry.name, entry.value, maxStateEntries),
+			)
 		}
 	}
+
+	// Safe to convert after maxStateEntries bounds check above.
+	//nolint:gosec
+	inboxLen := int(metadata.GetInboxLength())
+	//nolint:gosec
+	historyLen := int(metadata.GetHistoryLength())
+	//nolint:gosec
+	signingCertLen := int(metadata.GetSigningCertificateLength())
+	//nolint:gosec
+	signatureLen := int(metadata.GetSignatureLength())
 
 	// Load inbox, history, signing certs, signatures, and custom status using a bulk request
 	wState := NewState(opts)
 	wState.Generation = metadata.GetGeneration()
-	wState.Inbox = make([]*backend.HistoryEvent, 0, metadata.GetInboxLength())
-	wState.History = make([]*backend.HistoryEvent, 0, metadata.GetHistoryLength())
-	wState.RawHistory = make([][]byte, 0, metadata.GetHistoryLength())
-	wState.SigningCertificates = make([]*backend.SigningCertificate, 0, metadata.GetSigningCertificateLength())
-	wState.Signatures = make([]*backend.HistorySignature, 0, metadata.GetSignatureLength())
+	wState.Inbox = make([]*backend.HistoryEvent, 0, inboxLen)
+	wState.History = make([]*backend.HistoryEvent, 0, historyLen)
+	wState.RawHistory = make([][]byte, 0, historyLen)
+	wState.SigningCertificates = make([]*backend.SigningCertificate, 0, signingCertLen)
+	wState.Signatures = make([]*backend.HistorySignature, 0, signatureLen)
 
-	totalKeys := metadata.GetInboxLength() + metadata.GetHistoryLength() +
-		metadata.GetSigningCertificateLength() + metadata.GetSignatureLength() + 1
+	totalKeys := inboxLen + historyLen + signingCertLen + signatureLen + 1
 	bulkReq := &api.GetBulkStateRequest{
 		ActorType: opts.WorkflowActorType,
 		ActorID:   actorID,

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -686,13 +686,14 @@ func verifySignatureChain(s *State, sgn *signer.Signer) error {
 	if len(s.Signatures) > 0 {
 		last := s.Signatures[len(s.Signatures)-1]
 		coveredEvents := last.GetStartEventIndex() + last.GetEventCount()
-		if coveredEvents < uint64(len(rawEvents)) {
-			// Signatures don't cover all history events. This means the workflow ran
-			// on a non-signing host mid-flight, creating an unsigned gap. These
-			// events have no integrity proof and could have been tampered with. The
-			// workflow must be purged.
-			return fmt.Errorf("signatures cover events [0, %d) but %d history events exist; %d events have no integrity proof — this workflow ran on a non-signing host and cannot be recovered",
-				coveredEvents, len(rawEvents), uint64(len(rawEvents))-coveredEvents)
+		if coveredEvents != uint64(len(rawEvents)) {
+			// Signature coverage does not match history length. Either an unsigned
+			// gap exists (coveredEvents < len) because the workflow ran on a
+			// non-signing host, or events were removed from history while
+			// signatures remain (coveredEvents > len). In both cases, the state
+			// has no valid integrity proof and the workflow cannot be recovered.
+			return fmt.Errorf("signatures cover events [0, %d) but %d history events exist — signature coverage mismatch, state cannot be verified",
+				coveredEvents, len(rawEvents))
 		}
 	}
 	if err := historysigning.VerifyChain(historysigning.VerifyChainOptions{

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -1,0 +1,481 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+func addSig(t *testing.T, s *State, sig *backend.HistorySignature) {
+	t.Helper()
+	raw, err := proto.MarshalOptions{Deterministic: true}.Marshal(sig)
+	require.NoError(t, err)
+	s.AddSignature(sig, raw)
+}
+
+func testOpts() Options {
+	return Options{
+		AppID:             "test-app",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+	}
+}
+
+func testEvent(id int32) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_WorkflowStarted{
+			WorkflowStarted: &protos.WorkflowStartedEvent{},
+		},
+	}
+}
+
+func TestGetMultiEntryKeyName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		prefix string
+		index  uint64
+		want   string
+	}{
+		{"history", 0, "history-000000"},
+		{"history", 1, "history-000001"},
+		{"history", 42, "history-000042"},
+		{"history", 999999, "history-999999"},
+		{"history", 1000000, "history-1000000"},
+		{"inbox", 5, "inbox-000005"},
+		{"sigcert", 0, "sigcert-000000"},
+		{"signature", 123, "signature-000123"},
+	}
+
+	for _, tc := range tests {
+		got := getMultiEntryKeyName(tc.prefix, tc.index)
+		assert.Equal(t, tc.want, got, "prefix=%s index=%d", tc.prefix, tc.index)
+	}
+}
+
+func TestNewState(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	assert.Equal(t, uint64(1), s.Generation)
+	assert.Empty(t, s.Inbox)
+	assert.Empty(t, s.History)
+	assert.Empty(t, s.SigningCertificates)
+	assert.Empty(t, s.Signatures)
+}
+
+func TestAddToHistory(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	e1 := testEvent(0)
+	e2 := testEvent(1)
+	s.AddToHistory(e1)
+	s.AddToHistory(e2)
+
+	assert.Len(t, s.History, 2)
+	assert.Equal(t, 2, s.historyAddedCount)
+}
+
+func TestAddSigningCertificateAndSignature(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	cert := &backend.SigningCertificate{Certificate: []byte("cert-data")}
+	sig := &backend.HistorySignature{
+		StartEventIndex: 0,
+		EventCount:      1,
+		Signature:       []byte("sig-data"),
+	}
+
+	s.AddSigningCertificate(cert)
+	addSig(t, s, sig)
+
+	assert.Len(t, s.SigningCertificates, 1)
+	assert.Equal(t, 1, s.signingCertificatesAddedCount)
+	assert.Len(t, s.Signatures, 1)
+	assert.Equal(t, 1, s.signaturesAddedCount)
+}
+
+func TestReset(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	s.AddToInbox(testEvent(0))
+	s.AddToHistory(testEvent(0))
+	s.AddToHistory(testEvent(1))
+	s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig")})
+	s.CustomStatus = wrapperspb.String("running")
+
+	s.Reset()
+
+	assert.Nil(t, s.Inbox)
+	assert.Nil(t, s.History)
+	assert.Nil(t, s.SigningCertificates)
+	assert.Nil(t, s.Signatures)
+	assert.Nil(t, s.CustomStatus)
+	assert.Equal(t, uint64(2), s.Generation)
+
+	// Removed counts should reflect the items that were cleared.
+	assert.Equal(t, 1, s.inboxRemovedCount)
+	assert.Equal(t, 2, s.historyRemovedCount)
+	assert.Equal(t, 1, s.signingCertificatesRemovedCount)
+	assert.Equal(t, 1, s.signaturesRemovedCount)
+
+	// Added counts should be zeroed.
+	assert.Equal(t, 0, s.inboxAddedCount)
+	assert.Equal(t, 0, s.historyAddedCount)
+	assert.Equal(t, 0, s.signingCertificatesAddedCount)
+	assert.Equal(t, 0, s.signaturesAddedCount)
+}
+
+func TestResetChangeTracking(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	s.AddToHistory(testEvent(0))
+	s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig")})
+	s.SetMarshaledNewHistory([][]byte{{1, 2, 3}})
+
+	s.ResetChangeTracking()
+
+	assert.Equal(t, 0, s.historyAddedCount)
+	assert.Equal(t, 0, s.historyRemovedCount)
+	assert.Equal(t, 0, s.signingCertificatesAddedCount)
+	assert.Equal(t, 0, s.signingCertificatesRemovedCount)
+	assert.Equal(t, 0, s.signaturesAddedCount)
+	assert.Equal(t, 0, s.signaturesRemovedCount)
+	assert.Nil(t, s.marshaledNewHistory)
+}
+
+func TestApplyRuntimeStateChanges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without continue-as-new", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+		addSig(t, s, &backend.HistorySignature{Signature: []byte("sig")})
+
+		// Reset tracking so we can see what ApplyRuntimeStateChanges does.
+		s.ResetChangeTracking()
+
+		rs := &backend.WorkflowRuntimeState{
+			NewEvents: []*backend.HistoryEvent{testEvent(1), testEvent(2)},
+		}
+
+		s.ApplyRuntimeStateChanges(rs)
+
+		// History should grow, signing data stays.
+		assert.Len(t, s.History, 3)
+		assert.Equal(t, 2, s.historyAddedCount)
+		assert.Len(t, s.SigningCertificates, 1)
+		assert.Len(t, s.Signatures, 1)
+	})
+
+	t.Run("with continue-as-new", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		s.AddToHistory(testEvent(1))
+		s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+		addSig(t, s, &backend.HistorySignature{Signature: []byte("sig")})
+
+		// Reset tracking so we can see what ApplyRuntimeStateChanges does.
+		s.ResetChangeTracking()
+
+		rs := &backend.WorkflowRuntimeState{
+			ContinuedAsNew: true,
+			NewEvents:      []*backend.HistoryEvent{testEvent(0)},
+		}
+
+		s.ApplyRuntimeStateChanges(rs)
+
+		// Old history and signing data should be cleared.
+		assert.Len(t, s.History, 1)
+		assert.Equal(t, 1, s.historyAddedCount)
+		assert.Equal(t, 2, s.historyRemovedCount)
+		assert.Empty(t, s.SigningCertificates)
+		assert.Equal(t, 1, s.signingCertificatesRemovedCount)
+		assert.Empty(t, s.Signatures)
+		assert.Equal(t, 1, s.signaturesRemovedCount)
+	})
+}
+
+func TestSetMarshaledNewHistory(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+	raw := [][]byte{{1, 2, 3}, {4, 5, 6}}
+
+	s.SetMarshaledNewHistory(raw)
+	assert.Equal(t, raw, s.marshaledNewHistory)
+}
+
+func TestGetSaveRequest_HistoryWithMarshaledBytes(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	e := testEvent(0)
+	s.AddToHistory(e)
+
+	// Pre-marshal with deterministic marshaling.
+	marshaledBytes, err := proto.MarshalOptions{Deterministic: true}.Marshal(e)
+	require.NoError(t, err)
+	s.SetMarshaledNewHistory([][]byte{marshaledBytes})
+
+	req, err := s.GetSaveRequest("actor1")
+	require.NoError(t, err)
+
+	// Find the history upsert operation.
+	var historyOp *api.TransactionalUpsert
+	for _, op := range req.Operations {
+		if op.Operation == api.Upsert {
+			if u, ok := op.Request.(api.TransactionalUpsert); ok {
+				if u.Key == "history-000000" {
+					historyOp = &u
+					break
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, historyOp, "expected history-000000 upsert")
+	assert.Equal(t, marshaledBytes, historyOp.Value, "persisted bytes should match pre-marshaled bytes")
+}
+
+func TestGetSaveRequest_HistoryWithoutMarshaledBytes(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	e := testEvent(0)
+	s.AddToHistory(e)
+
+	// No SetMarshaledNewHistory call — should use proto.Marshal fallback.
+	req, err := s.GetSaveRequest("actor1")
+	require.NoError(t, err)
+
+	expected, err := proto.Marshal(e)
+	require.NoError(t, err)
+
+	var historyOp *api.TransactionalUpsert
+	for _, op := range req.Operations {
+		if op.Operation == api.Upsert {
+			if u, ok := op.Request.(api.TransactionalUpsert); ok {
+				if u.Key == "history-000000" {
+					historyOp = &u
+					break
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, historyOp, "expected history-000000 upsert")
+	assert.Equal(t, expected, historyOp.Value)
+}
+
+func TestGetSaveRequest_SigningDataOperations(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	s.AddToHistory(testEvent(0))
+	s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert-data")})
+	addSig(t, s, &backend.HistorySignature{
+		StartEventIndex: 0,
+		EventCount:      1,
+		Signature:       []byte("sig-data"),
+	})
+
+	req, err := s.GetSaveRequest("actor1")
+	require.NoError(t, err)
+
+	// Collect operation keys by type.
+	upsertKeys := make(map[string]bool)
+	for _, op := range req.Operations {
+		if op.Operation == api.Upsert {
+			if u, ok := op.Request.(api.TransactionalUpsert); ok {
+				upsertKeys[u.Key] = true
+			}
+		}
+	}
+
+	assert.True(t, upsertKeys["sigcert-000000"], "expected sigcert upsert")
+	assert.True(t, upsertKeys["signature-000000"], "expected signature upsert")
+	assert.True(t, upsertKeys["metadata"], "expected metadata upsert")
+}
+
+func TestGetSaveRequest_DeletesOnReset(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	// Add history and signing data, then reset to simulate continue-as-new.
+	s.AddToHistory(testEvent(0))
+	s.AddToHistory(testEvent(1))
+	s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig1")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig2")})
+
+	s.Reset()
+
+	// Add one new history event after reset.
+	s.AddToHistory(testEvent(0))
+
+	req, err := s.GetSaveRequest("actor1")
+	require.NoError(t, err)
+
+	deleteKeys := make(map[string]bool)
+	upsertKeys := make(map[string]bool)
+	for _, op := range req.Operations {
+		switch op.Operation {
+		case api.Delete:
+			if d, ok := op.Request.(api.TransactionalDelete); ok {
+				deleteKeys[d.Key] = true
+			}
+		case api.Upsert:
+			if u, ok := op.Request.(api.TransactionalUpsert); ok {
+				upsertKeys[u.Key] = true
+			}
+		}
+	}
+
+	// New event at index 0 should be upserted.
+	assert.True(t, upsertKeys["history-000000"], "expected history-000000 upsert")
+
+	// Old event at index 1 should be deleted.
+	assert.True(t, deleteKeys["history-000001"], "expected history-000001 delete")
+
+	// Old signing data should be deleted.
+	assert.True(t, deleteKeys["sigcert-000000"], "expected sigcert-000000 delete")
+	assert.True(t, deleteKeys["signature-000000"], "expected signature-000000 delete")
+	assert.True(t, deleteKeys["signature-000001"], "expected signature-000001 delete")
+}
+
+func TestGetSaveRequest_PreAllocatesOperations(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	// Add several items so we can verify pre-allocation.
+	for i := range 5 {
+		s.AddToHistory(testEvent(int32(i)))
+	}
+	s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig")})
+
+	req, err := s.GetSaveRequest("actor1")
+	require.NoError(t, err)
+
+	// The slice should have been pre-allocated to exactly fit without
+	// triggering append growth beyond the initial capacity.
+	// We expect: 5 history + 1 sigcert + 1 signature + 1 customStatus + 1 metadata = 9
+	assert.Len(t, req.Operations, 9)
+}
+
+func TestGetPurgeRequest(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	s.AddToInbox(testEvent(0))
+	s.AddToHistory(testEvent(0))
+	s.AddToHistory(testEvent(1))
+	s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig1")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig2")})
+
+	req, err := s.GetPurgeRequest("actor1")
+	require.NoError(t, err)
+
+	deleteKeys := make(map[string]bool)
+	for _, op := range req.Operations {
+		if op.Operation == api.Delete {
+			if d, ok := op.Request.(api.TransactionalDelete); ok {
+				deleteKeys[d.Key] = true
+			}
+		}
+	}
+
+	assert.True(t, deleteKeys["inbox-000000"])
+	assert.True(t, deleteKeys["history-000000"])
+	assert.True(t, deleteKeys["history-000001"])
+	assert.True(t, deleteKeys["sigcert-000000"])
+	assert.True(t, deleteKeys["signature-000000"])
+	assert.True(t, deleteKeys["signature-000001"])
+	assert.True(t, deleteKeys["customStatus"])
+	assert.True(t, deleteKeys["metadata"])
+
+	// Total: 1 inbox + 2 history + 1 sigcert + 2 sig + customStatus + metadata = 8
+	assert.Len(t, req.Operations, 8)
+}
+
+func TestGetSaveRequest_MetadataIncludesSigningLengths(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	s.AddToHistory(testEvent(0))
+	s.AddSigningCertificate(&backend.SigningCertificate{Certificate: []byte("cert")})
+	addSig(t, s, &backend.HistorySignature{Signature: []byte("sig")})
+
+	req, err := s.GetSaveRequest("actor1")
+	require.NoError(t, err)
+
+	// Find and unmarshal the metadata operation.
+	var metadataBytes []byte
+	for _, op := range req.Operations {
+		if op.Operation == api.Upsert {
+			if u, ok := op.Request.(api.TransactionalUpsert); ok {
+				if u.Key == "metadata" {
+					metadataBytes, _ = u.Value.([]byte)
+					break
+				}
+			}
+		}
+	}
+
+	require.NotEmpty(t, metadataBytes)
+
+	var meta backend.BackendWorkflowStateMetadata
+	require.NoError(t, proto.Unmarshal(metadataBytes, &meta))
+
+	assert.Equal(t, uint64(1), meta.GetHistoryLength())
+	assert.Equal(t, uint64(1), meta.GetSigningCertificateLength())
+	assert.Equal(t, uint64(1), meta.GetSignatureLength())
+}

--- a/pkg/runtime/wfengine/state/state_verify_test.go
+++ b/pkg/runtime/wfengine/state/state_verify_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestCert(t *testing.T, spiffeID string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	uri, err := url.Parse(spiffeID)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		URIs:         []*url.URL{uri},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return certDER
+}
+
+func generateTestCertNoURI(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return certDER
+}
+
+func TestVerifyCertAppIdentity_ValidMatch(t *testing.T) {
+	t.Parallel()
+
+	certDER := generateTestCert(t, "spiffe://example.com/ns/default/myapp")
+	err := verifyCertAppIdentity(certDER, "myapp")
+	assert.NoError(t, err)
+}
+
+func TestVerifyCertAppIdentity_WrongAppID(t *testing.T) {
+	t.Parallel()
+
+	certDER := generateTestCert(t, "spiffe://example.com/ns/default/app-a")
+	err := verifyCertAppIdentity(certDER, "app-b")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
+func TestVerifyCertAppIdentity_EmptyCertChain(t *testing.T) {
+	t.Parallel()
+
+	err := verifyCertAppIdentity([]byte{}, "myapp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestVerifyCertAppIdentity_InvalidDER(t *testing.T) {
+	t.Parallel()
+
+	err := verifyCertAppIdentity([]byte{0xDE, 0xAD, 0xBE, 0xEF}, "myapp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse")
+}
+
+func TestVerifyCertAppIdentity_NoURISAN(t *testing.T) {
+	t.Parallel()
+
+	certDER := generateTestCertNoURI(t)
+	err := verifyCertAppIdentity(certDER, "myapp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SPIFFE ID")
+}
+
+func TestVerifyCertAppIdentity_DeepPath(t *testing.T) {
+	t.Parallel()
+
+	certDER := generateTestCert(t, "spiffe://example.com/ns/prod/region/us-east/myapp")
+	err := verifyCertAppIdentity(certDER, "myapp")
+	assert.NoError(t, err)
+}

--- a/pkg/runtime/wfengine/state/state_verify_test.go
+++ b/pkg/runtime/wfengine/state/state_verify_test.go
@@ -108,10 +108,21 @@ func TestVerifyCertAppIdentity_NoURISAN(t *testing.T) {
 	assert.Contains(t, err.Error(), "SPIFFE ID")
 }
 
-func TestVerifyCertAppIdentity_DeepPath(t *testing.T) {
+func TestVerifyCertAppIdentity_DeepPathRejected(t *testing.T) {
 	t.Parallel()
 
+	// A SPIFFE ID with extra path segments beyond /ns/<namespace>/<app>
+	// should be rejected — only the exact 3-segment format is accepted.
 	certDER := generateTestCert(t, "spiffe://example.com/ns/prod/region/us-east/myapp")
+	err := verifyCertAppIdentity(certDER, "myapp")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match expected path format")
+}
+
+func TestVerifyCertAppIdentity_CorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	certDER := generateTestCert(t, "spiffe://example.com/ns/production/myapp")
 	err := verifyCertAppIdentity(certDER, "myapp")
 	assert.NoError(t, err)
 }

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -85,17 +85,22 @@ type engine struct {
 	registerGrpcServerFn func(grpcServer grpc.ServiceRegistrar)
 }
 
-func New(opts Options) Interface {
+func New(opts Options) (Interface, error) {
 	var retPolicy *config.WorkflowStateRetentionPolicy
 	if opts.Spec != nil {
 		retPolicy = opts.Spec.StateRetentionPolicy
 	}
 
 	// Disable history signing if the WorkflowSignState feature flag is not
-	// enabled (it is enabled by default).
+	// enabled.
 	s := opts.Signer
 	if !opts.WorkflowSignState {
 		s = nil
+	} else if s == nil {
+		// The feature flag is explicitly enabled but mTLS is not available.
+		// This is a misconfiguration — signing requires mTLS for the SPIFFE
+		// identity used as the signing key.
+		return nil, fmt.Errorf("WorkflowSignState feature flag is enabled but mTLS is not configured; workflow history signing requires mTLS to be active")
 	}
 
 	// If no backend was initialized by the manager, create a backend backed by actors
@@ -190,7 +195,7 @@ func New(opts Options) Interface {
 			logger: wfBackendLogger,
 			client: backend.NewTaskHubClient(abackend),
 		},
-	}
+	}, nil
 }
 
 func (wfe *engine) RegisterGrpcServer(server *grpc.Server) {

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/processor"
 	backendactors "github.com/dapr/dapr/pkg/runtime/wfengine/backends/actors"
 	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/kit/crypto/spiffe/signer"
 	"github.com/dapr/kit/logger"
 )
 
@@ -64,6 +65,11 @@ type Options struct {
 
 	EnableClusteredDeployment       bool
 	WorkflowsRemoteActivityReminder bool
+	WorkflowSignState               bool
+
+	// Signer provides cryptographic signing and verification. If nil, history
+	// signing is disabled.
+	Signer *signer.Signer
 }
 
 type engine struct {
@@ -85,6 +91,13 @@ func New(opts Options) Interface {
 		retPolicy = opts.Spec.StateRetentionPolicy
 	}
 
+	// Disable history signing if the WorkflowSignState feature flag is not
+	// enabled (it is enabled by default).
+	s := opts.Signer
+	if !opts.WorkflowSignState {
+		s = nil
+	}
+
 	// If no backend was initialized by the manager, create a backend backed by actors
 	abackend := backendactors.New(backendactors.Options{
 		AppID:           opts.AppID,
@@ -94,6 +107,7 @@ func New(opts Options) Interface {
 		EventSink:       opts.EventSink,
 		ComponentStore:  opts.ComponentStore,
 		RetentionPolicy: retPolicy,
+		Signer:          s,
 
 		EnableClusteredDeployment:       opts.EnableClusteredDeployment,
 		WorkflowsRemoteActivityReminder: opts.WorkflowsRemoteActivityReminder,

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -66,7 +66,7 @@ type Options struct {
 
 	EnableClusteredDeployment       bool
 	WorkflowsRemoteActivityReminder bool
-	WorkflowSignState               bool
+	WorkflowHistorySigning          bool
 
 	// Signer provides cryptographic signing and verification. If nil, history
 	// signing is disabled.
@@ -92,16 +92,16 @@ func New(opts Options) (Interface, error) {
 		retPolicy = opts.Spec.StateRetentionPolicy
 	}
 
-	// Disable history signing if the WorkflowSignState feature flag is not
+	// Disable history signing if the WorkflowHistorySigning feature flag is not
 	// enabled.
 	s := opts.Signer
-	if !opts.WorkflowSignState {
+	if !opts.WorkflowHistorySigning {
 		s = nil
 	} else if s == nil {
 		// The feature flag is explicitly enabled but mTLS is not available. This
 		// is a misconfiguration. Signing requires mTLS for the SPIFFE identity
 		// used as the signing key.
-		return nil, errors.New("WorkflowSignState feature flag is enabled but mTLS is not configured; workflow history signing requires mTLS to be active")
+		return nil, errors.New("WorkflowHistorySigning feature flag is enabled but mTLS is not configured; workflow history signing requires mTLS to be active")
 	}
 
 	// If no backend was initialized by the manager, create a backend backed by actors

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -17,6 +17,7 @@ package wfengine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -97,10 +98,10 @@ func New(opts Options) (Interface, error) {
 	if !opts.WorkflowSignState {
 		s = nil
 	} else if s == nil {
-		// The feature flag is explicitly enabled but mTLS is not available.
-		// This is a misconfiguration — signing requires mTLS for the SPIFFE
-		// identity used as the signing key.
-		return nil, fmt.Errorf("WorkflowSignState feature flag is enabled but mTLS is not configured; workflow history signing requires mTLS to be active")
+		// The feature flag is explicitly enabled but mTLS is not available. This
+		// is a misconfiguration. Signing requires mTLS for the SPIFFE identity
+		// used as the signing key.
+		return nil, errors.New("WorkflowSignState feature flag is enabled but mTLS is not configured; workflow history signing requires mTLS to be active")
 	}
 
 	// If no backend was initialized by the manager, create a backend backed by actors

--- a/pkg/security/fake/fake.go
+++ b/pkg/security/fake/fake.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/dapr/pkg/security"
+	"github.com/dapr/kit/crypto/spiffe/signer"
 )
 
 type Fake struct {
@@ -246,6 +247,10 @@ func (f *Fake) Run(ctx context.Context) error {
 
 func (f *Fake) Handler(context.Context) (security.Handler, error) {
 	return f, nil
+}
+
+func (f *Fake) Signer() *signer.Signer {
+	return nil
 }
 
 func (f *Fake) ID() spiffeid.ID {

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/crypto/spiffe"
 	spiffecontext "github.com/dapr/kit/crypto/spiffe/context"
+	"github.com/dapr/kit/crypto/spiffe/signer"
 	"github.com/dapr/kit/crypto/spiffe/trustanchors"
 	"github.com/dapr/kit/crypto/spiffe/trustanchors/file"
 	"github.com/dapr/kit/crypto/spiffe/trustanchors/static"
@@ -67,6 +68,10 @@ type Handler interface {
 	ID() spiffeid.ID
 	WatchTrustAnchors(context.Context, chan<- []byte)
 	IdentityDir() *string
+
+	// Signer returns a Signer for signing and verifying using the workload's
+	// identity and trust anchors. Returns nil if mTLS is not enabled.
+	Signer() *signer.Signer
 }
 
 // Provider is the security provider.
@@ -488,6 +493,13 @@ func (s *security) WithSVIDContext(ctx context.Context) context.Context {
 
 func (s *security) IdentityDir() *string {
 	return s.identityDir
+}
+
+func (s *security) Signer() *signer.Signer {
+	if s.spiffe == nil {
+		return nil
+	}
+	return signer.New(s.spiffe.X509SVIDSource(), s.trustAnchors)
 }
 
 func (s *security) ID() spiffeid.ID {

--- a/tests/integration/framework/process/sqlite/sqlite.go
+++ b/tests/integration/framework/process/sqlite/sqlite.go
@@ -18,11 +18,13 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	// Blank import for the sqlite driver
 	_ "modernc.org/sqlite"
@@ -195,6 +197,72 @@ func (s *SQLite) CountStateKeys(t *testing.T, ctx context.Context, keyPrefix str
 		"%||"+keyPrefix+"-%",
 	).Scan(&count))
 	return count
+}
+
+// DeleteStateKeys deletes all rows whose key matches the given SQL LIKE
+// pattern. Use `%` as the wildcard (e.g. `%||signature-%`).
+func (s *SQLite) DeleteStateKeys(t *testing.T, ctx context.Context, likePattern string) {
+	t.Helper()
+
+	_, err := s.GetConnection(t).ExecContext(ctx,
+		"DELETE FROM "+s.tableName+" WHERE key LIKE ?", likePattern)
+	require.NoError(t, err)
+}
+
+// ReadStateValue loads and base64-decodes the single value for the given
+// workflow instance and exact key suffix (e.g. "metadata"). Fails the test
+// if no such row exists.
+func (s *SQLite) ReadStateValue(t *testing.T, ctx context.Context, instanceID, keySuffix string) (string, []byte) {
+	t.Helper()
+
+	var key, encoded string
+	err := s.GetConnection(t).QueryRowContext(ctx,
+		"SELECT key, value FROM "+s.tableName+" WHERE key LIKE ? AND key LIKE ? LIMIT 1",
+		"%||"+instanceID+"||%", "%||"+keySuffix,
+	).Scan(&key, &encoded)
+	if errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("no %s row for instance %s", keySuffix, instanceID)
+	}
+	require.NoError(t, err)
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	return key, raw
+}
+
+// FirstStateValue returns the (key, base64-decoded value) of the first row
+// matching the given instance ID and key prefix (e.g. "history"). Fails the
+// test if no such row exists.
+func (s *SQLite) FirstStateValue(t *testing.T, ctx context.Context, instanceID, keyPrefix string) (string, []byte) {
+	t.Helper()
+
+	var key, encoded string
+	err := s.GetConnection(t).QueryRowContext(ctx,
+		"SELECT key, value FROM "+s.tableName+" WHERE key LIKE ? ORDER BY key LIMIT 1",
+		"%||"+instanceID+"||"+keyPrefix+"-%",
+	).Scan(&key, &encoded)
+	if errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("no %s-* row for instance %s", keyPrefix, instanceID)
+	}
+	require.NoError(t, err)
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	return key, raw
+}
+
+// WriteStateValue base64-encodes and writes the given raw bytes to the state
+// store under the exact key provided. Uses INSERT OR REPLACE so it works for
+// both new rows and overwrites.
+func (s *SQLite) WriteStateValue(t *testing.T, ctx context.Context, key string, raw []byte) {
+	t.Helper()
+
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	_, err := s.GetConnection(t).ExecContext(ctx,
+		"INSERT OR REPLACE INTO "+s.tableName+" (key, value, is_binary, etag) VALUES (?, ?, 1, ?)",
+		key, encoded, strconv.FormatInt(time.Now().UnixNano(), 10),
+	)
+	require.NoError(t, err)
 }
 
 func toDynamicValue(t *testing.T, val string) commonapi.DynamicValue {

--- a/tests/integration/framework/process/sqlite/sqlite.go
+++ b/tests/integration/framework/process/sqlite/sqlite.go
@@ -16,6 +16,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"path/filepath"
 	"runtime"
@@ -159,6 +160,41 @@ func (s *SQLite) GetComponent(t *testing.T) string {
 
 func (s *SQLite) TableName() string {
 	return s.tableName
+}
+
+// ReadStateValues reads base64-encoded state values from the SQLite database
+// matching the given instance ID and key prefix.
+func (s *SQLite) ReadStateValues(t *testing.T, ctx context.Context, instanceID, keyPrefix string) [][]byte {
+	t.Helper()
+
+	pattern := "%||" + instanceID + "||" + keyPrefix + "-%"
+	rows, err := s.GetConnection(t).QueryContext(ctx,
+		"SELECT value FROM "+s.tableName+" WHERE key LIKE ? ORDER BY key", pattern)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var values [][]byte
+	for rows.Next() {
+		var encoded string
+		require.NoError(t, rows.Scan(&encoded))
+		raw, err := base64.StdEncoding.DecodeString(encoded)
+		require.NoError(t, err)
+		values = append(values, raw)
+	}
+	require.NoError(t, rows.Err())
+	return values
+}
+
+// CountStateKeys returns the number of state keys matching the given prefix.
+func (s *SQLite) CountStateKeys(t *testing.T, ctx context.Context, keyPrefix string) int {
+	t.Helper()
+
+	var count int
+	require.NoError(t, s.GetConnection(t).QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM "+s.tableName+" WHERE key LIKE ?",
+		"%||"+keyPrefix+"-%",
+	).Scan(&count))
+	return count
 }
 
 func toDynamicValue(t *testing.T, val string) commonapi.DynamicValue {

--- a/tests/integration/framework/workflow/signing.go
+++ b/tests/integration/framework/workflow/signing.go
@@ -31,19 +31,31 @@ import (
 	"github.com/dapr/kit/crypto/spiffe/trustanchors/fake"
 )
 
+// SigningData holds signatures, certificates, and raw history events for a
+// workflow instance, loaded from the state store for verification.
+type SigningData struct {
+	// RawSignatures are the raw serialized bytes of each HistorySignature
+	// as stored. Required for digest computation in chain verification.
+	RawSignatures [][]byte
+	// Signatures are the parsed HistorySignature protos.
+	Signatures []*protos.HistorySignature
+	// Certs are the signing certificates.
+	Certs []*protos.SigningCertificate
+	// RawEvents are the raw serialized bytes of each history event as stored.
+	RawEvents [][]byte
+}
+
 // UnmarshalSigningData reads and unmarshals signatures, certificates, and raw
 // history events from the SQLite state store for the given workflow instance.
-// Returns raw signature bytes alongside parsed protos, as raw bytes are needed
-// for digest computation in chain verification.
-func UnmarshalSigningData(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string) (rawSigs [][]byte, sigs []*protos.HistorySignature, certs []*protos.SigningCertificate, rawEvents [][]byte) {
+func UnmarshalSigningData(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string) SigningData {
 	t.Helper()
 
 	sigValues := db.ReadStateValues(t, ctx, instanceID, "signature")
 	certValues := db.ReadStateValues(t, ctx, instanceID, "sigcert")
-	rawEvents = db.ReadStateValues(t, ctx, instanceID, "history")
+	rawEvents := db.ReadStateValues(t, ctx, instanceID, "history")
 
-	rawSigs = make([][]byte, len(sigValues))
-	sigs = make([]*protos.HistorySignature, len(sigValues))
+	rawSigs := make([][]byte, len(sigValues))
+	sigs := make([]*protos.HistorySignature, len(sigValues))
 	for i, v := range sigValues {
 		sigs[i] = new(protos.HistorySignature)
 		require.NoError(t, proto.Unmarshal(v, sigs[i]))
@@ -51,13 +63,34 @@ func UnmarshalSigningData(t *testing.T, ctx context.Context, db *sqlite.SQLite, 
 		copy(rawSigs[i], v)
 	}
 
-	certs = make([]*protos.SigningCertificate, len(certValues))
+	certs := make([]*protos.SigningCertificate, len(certValues))
 	for i, v := range certValues {
 		certs[i] = new(protos.SigningCertificate)
 		require.NoError(t, proto.Unmarshal(v, certs[i]))
 	}
 
-	return rawSigs, sigs, certs, rawEvents
+	return SigningData{
+		RawSignatures: rawSigs,
+		Signatures:    sigs,
+		Certs:         certs,
+		RawEvents:     rawEvents,
+	}
+}
+
+// SignatureCount returns the number of signature entries stored for the
+// given workflow instance. Use this in tests to verify signing happened
+// or did not happen, instead of calling CountStateKeys directly with a
+// raw key prefix string (which is error-prone).
+func SignatureCount(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string) int {
+	t.Helper()
+	return len(db.ReadStateValues(t, ctx, instanceID, "signature"))
+}
+
+// CertificateCount returns the number of signing certificate entries stored
+// for the given workflow instance.
+func CertificateCount(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string) int {
+	t.Helper()
+	return len(db.ReadStateValues(t, ctx, instanceID, "sigcert"))
 }
 
 // VerifySignatureChain verifies the full history signature chain for a
@@ -66,19 +99,19 @@ func UnmarshalSigningData(t *testing.T, ctx context.Context, db *sqlite.SQLite, 
 func VerifySignatureChain(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string, trustAnchors []byte) {
 	t.Helper()
 
-	rawSigs, _, certs, rawEvents := UnmarshalSigningData(t, ctx, db, instanceID)
+	data := UnmarshalSigningData(t, ctx, db, instanceID)
 
-	require.NotEmpty(t, rawSigs, "expected signature records")
-	require.NotEmpty(t, certs, "expected certificate records")
-	require.NotEmpty(t, rawEvents, "expected history records")
+	require.NotEmpty(t, data.RawSignatures, "expected signature records")
+	require.NotEmpty(t, data.Certs, "expected certificate records")
+	require.NotEmpty(t, data.RawEvents, "expected history records")
 
 	authorities := parsePEMCertificates(t, trustAnchors)
 	s := signer.New(nil, fake.New(authorities...))
 
 	require.NoError(t, historysigning.VerifyChain(historysigning.VerifyChainOptions{
-		RawSignatures: rawSigs,
-		Certs:         certs,
-		AllRawEvents:  rawEvents,
+		RawSignatures: data.RawSignatures,
+		Certs:         data.Certs,
+		AllRawEvents:  data.RawEvents,
 		Signer:        s,
 	}))
 }

--- a/tests/integration/framework/workflow/signing.go
+++ b/tests/integration/framework/workflow/signing.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/historysigning"
+	"github.com/dapr/kit/crypto/spiffe/signer"
+	"github.com/dapr/kit/crypto/spiffe/trustanchors/fake"
+)
+
+// UnmarshalSigningData reads and unmarshals signatures, certificates, and raw
+// history events from the SQLite state store for the given workflow instance.
+// Returns raw signature bytes alongside parsed protos, as raw bytes are needed
+// for digest computation in chain verification.
+func UnmarshalSigningData(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string) (rawSigs [][]byte, sigs []*protos.HistorySignature, certs []*protos.SigningCertificate, rawEvents [][]byte) {
+	t.Helper()
+
+	sigValues := db.ReadStateValues(t, ctx, instanceID, "signature")
+	certValues := db.ReadStateValues(t, ctx, instanceID, "sigcert")
+	rawEvents = db.ReadStateValues(t, ctx, instanceID, "history")
+
+	rawSigs = make([][]byte, len(sigValues))
+	sigs = make([]*protos.HistorySignature, len(sigValues))
+	for i, v := range sigValues {
+		sigs[i] = new(protos.HistorySignature)
+		require.NoError(t, proto.Unmarshal(v, sigs[i]))
+		rawSigs[i] = make([]byte, len(v))
+		copy(rawSigs[i], v)
+	}
+
+	certs = make([]*protos.SigningCertificate, len(certValues))
+	for i, v := range certValues {
+		certs[i] = new(protos.SigningCertificate)
+		require.NoError(t, proto.Unmarshal(v, certs[i]))
+	}
+
+	return rawSigs, sigs, certs, rawEvents
+}
+
+// VerifySignatureChain verifies the full history signature chain for a
+// workflow instance, including cryptographic signatures and certificate
+// chain-of-trust against the given trust anchors.
+func VerifySignatureChain(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string, trustAnchors []byte) {
+	t.Helper()
+
+	rawSigs, _, certs, rawEvents := UnmarshalSigningData(t, ctx, db, instanceID)
+
+	require.NotEmpty(t, rawSigs, "expected signature records")
+	require.NotEmpty(t, certs, "expected certificate records")
+	require.NotEmpty(t, rawEvents, "expected history records")
+
+	authorities := parsePEMCertificates(t, trustAnchors)
+	s := signer.New(nil, fake.New(authorities...))
+
+	require.NoError(t, historysigning.VerifyChain(historysigning.VerifyChainOptions{
+		RawSignatures: rawSigs,
+		Certs:         certs,
+		AllRawEvents:  rawEvents,
+		Signer:        s,
+	}))
+}
+
+// parsePEMCertificates parses a PEM-encoded certificate bundle into x509
+// certificates.
+func parsePEMCertificates(t *testing.T, pemData []byte) []*x509.Certificate {
+	t.Helper()
+	var certs []*x509.Certificate
+	for {
+		var block *pem.Block
+		block, pemData = pem.Decode(pemData)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		certs = append(certs, cert)
+	}
+	require.NotEmpty(t, certs, "no certificates found in PEM data")
+	return certs
+}
+
+// VerifyCertAppID checks that all signing certificates for a workflow instance
+// contain a SPIFFE ID matching the expected app ID in the "default" namespace,
+// and that each certificate has a 2-deep chain (leaf + issuer intermediate).
+func VerifyCertAppID(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID, expectedAppID string) {
+	t.Helper()
+
+	certValues := db.ReadStateValues(t, ctx, instanceID, "sigcert")
+	require.NotEmpty(t, certValues, "expected certificate records")
+
+	expectedID := spiffeid.RequireFromSegments(
+		spiffeid.RequireTrustDomainFromString("public"),
+		"ns", "default", expectedAppID,
+	)
+
+	for i, raw := range certValues {
+		var sc protos.SigningCertificate
+		require.NoError(t, proto.Unmarshal(raw, &sc))
+
+		certs, err := x509.ParseCertificates(sc.GetCertificate())
+		require.NoError(t, err, "failed to parse signing certificate %d", i)
+		require.Len(t, certs, 2, "signing certificate %d should have leaf + issuer intermediate", i)
+		leaf := certs[0]
+
+		// Verify the leaf was issued by the intermediate.
+		assert.Equal(t, certs[1].Subject, leaf.Issuer, "signing certificate %d leaf issuer mismatch", i)
+		assert.False(t, leaf.IsCA, "signing certificate %d leaf should not be a CA", i)
+		assert.True(t, certs[1].IsCA, "signing certificate %d intermediate should be a CA", i)
+
+		require.NotEmpty(t, leaf.URIs, "signing certificate %d has no URI SANs", i)
+		id, err := spiffeid.FromURI(leaf.URIs[0])
+		require.NoError(t, err, "signing certificate %d has invalid SPIFFE ID", i)
+
+		assert.Equal(t, expectedID, id, "signing certificate %d SPIFFE ID mismatch", i)
+	}
+}

--- a/tests/integration/framework/workflow/signing.go
+++ b/tests/integration/framework/workflow/signing.go
@@ -93,6 +93,13 @@ func CertificateCount(t *testing.T, ctx context.Context, db *sqlite.SQLite, inst
 	return len(db.ReadStateValues(t, ctx, instanceID, "sigcert"))
 }
 
+// HistoryCount returns the number of history entries stored for the given
+// workflow instance.
+func HistoryCount(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string) int {
+	t.Helper()
+	return len(db.ReadStateValues(t, ctx, instanceID, "history"))
+}
+
 // VerifySignatureChain verifies the full history signature chain for a
 // workflow instance, including cryptographic signatures and certificate
 // chain-of-trust against the given trust anchors.

--- a/tests/integration/framework/workflow/signing.go
+++ b/tests/integration/framework/workflow/signing.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/historysigning"
 	"github.com/dapr/kit/crypto/spiffe/signer"
 	"github.com/dapr/kit/crypto/spiffe/trustanchors/fake"
@@ -98,6 +99,24 @@ func CertificateCount(t *testing.T, ctx context.Context, db *sqlite.SQLite, inst
 func HistoryCount(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string) int {
 	t.Helper()
 	return len(db.ReadStateValues(t, ctx, instanceID, "history"))
+}
+
+// MutateMetadata loads the persisted BackendWorkflowStateMetadata for the
+// given workflow instance, applies the mutation, and writes it back. Used
+// by negative tests that simulate state store tampering.
+func MutateMetadata(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string, mutate func(*backend.BackendWorkflowStateMetadata)) {
+	t.Helper()
+
+	key, raw := db.ReadStateValue(t, ctx, instanceID, "metadata")
+
+	var metadata backend.BackendWorkflowStateMetadata
+	require.NoError(t, proto.Unmarshal(raw, &metadata))
+
+	mutate(&metadata)
+
+	updated, err := proto.Marshal(&metadata)
+	require.NoError(t, err)
+	db.WriteStateValue(t, ctx, key, updated)
 }
 
 // VerifySignatureChain verifies the full history signature chain for a

--- a/tests/integration/suite/daprd/workflow/continueasnew/raisebatchnodup.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/raisebatchnodup.go
@@ -15,21 +15,23 @@ package continueasnew
 
 import (
 	"context"
+	"encoding/base64"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/task"
-
-	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 )
 
 func init() {
@@ -99,10 +101,33 @@ func (r *raisebatchnodup) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(2 * time.Second)
-
+	// Wait for the deactivation reminder to be processed. Poll the state
+	// store until the workflow metadata generation has advanced (CAN
+	// increments generation).
 	db := r.workflow.DB().GetConnection(t)
 	tableName := r.workflow.DB().TableName()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var gen int64
+		metaKey := appID + "||" + actorType + "||" + actorID + "||metadata"
+		//nolint:gosec
+		row := db.QueryRowContext(ctx, "SELECT value FROM '"+tableName+"' WHERE key = ?", metaKey)
+		var val string
+		if !assert.NoError(c, row.Scan(&val)) {
+			return
+		}
+		raw, derr := base64.StdEncoding.DecodeString(val)
+		if !assert.NoError(c, derr) {
+			return
+		}
+		var meta backend.BackendWorkflowStateMetadata
+		if !assert.NoError(c, proto.Unmarshal(raw, &meta)) {
+			return
+		}
+		//nolint:gosec
+		gen = int64(meta.GetGeneration())
+		assert.Greater(c, gen, int64(1), "generation should advance from CAN")
+	}, 10*time.Second, 10*time.Millisecond)
+
 	writeInboxToDB(t, ctx, db, tableName, appID, actorType, actorID, totalEvents, wrapperspb.String(`true`))
 
 	_, err = gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{

--- a/tests/integration/suite/daprd/workflow/signing/activity.go
+++ b/tests/integration/suite/daprd/workflow/signing/activity.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(activity))
+}
+
+// activity verifies that a workflow calling a single activity produces a valid
+// signature chain and correct SPIFFE identity in signing certificates.
+type activity struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (a *activity) Setup(t *testing.T) []framework.Option {
+	a.sentry = sentry.New(t)
+	a.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	a.place = placement.New(t, placement.WithSentry(t, a.sentry))
+	a.sched = scheduler.New(t, scheduler.WithSentry(a.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	a.daprd = daprd.New(t,
+		daprd.WithSentry(t, a.sentry),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithScheduler(a.sched),
+		daprd.WithResourceFiles(a.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.sentry, a.db, a.place, a.sched, a.daprd),
+	}
+}
+
+func (a *activity) Run(t *testing.T, ctx context.Context) {
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-activity", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("noop").Await(nil); err != nil {
+			return nil, err
+		}
+		return "", nil
+	})
+	reg.AddActivityN("noop", func(ctx dworkflow.ActivityContext) (any, error) {
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(a.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-activity")
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	fworkflow.VerifySignatureChain(t, ctx, a.db, id, a.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, a.db, id, a.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/activity.go
+++ b/tests/integration/suite/daprd/workflow/signing/activity.go
@@ -64,7 +64,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/basic.go
+++ b/tests/integration/suite/daprd/workflow/signing/basic.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+// basic verifies that a simple workflow with no operations produces a valid
+// signature chain and correct SPIFFE identity in signing certificates.
+type basic struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	b.sentry = sentry.New(t)
+	b.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	b.place = placement.New(t, placement.WithSentry(t, b.sentry))
+	b.sched = scheduler.New(t, scheduler.WithSentry(b.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	b.daprd = daprd.New(t,
+		daprd.WithSentry(t, b.sentry),
+		daprd.WithPlacementAddresses(b.place.Address()),
+		daprd.WithScheduler(b.sched),
+		daprd.WithResourceFiles(b.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(b.sentry, b.db, b.place, b.sched, b.daprd),
+	}
+}
+
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-basic", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(b.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-basic")
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	fworkflow.VerifySignatureChain(t, ctx, b.db, id, b.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, b.db, id, b.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/basic.go
+++ b/tests/integration/suite/daprd/workflow/signing/basic.go
@@ -64,7 +64,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/certexpiry.go
+++ b/tests/integration/suite/daprd/workflow/signing/certexpiry.go
@@ -144,7 +144,7 @@ func (c *certexpiry) Run(t *testing.T, ctx context.Context) {
 
 	// The SVID rotated multiple times during the workflow. Each rotation
 	// produces a new signing certificate entry.
-	certCount := c.db.CountStateKeys(t, ctx, "sigcert")
+	certCount := fworkflow.CertificateCount(t, ctx, c.db, id)
 	assert.GreaterOrEqual(t, certCount, 2,
 		"expected at least 2 certificates from natural SVID rotation, got %d", certCount)
 

--- a/tests/integration/suite/daprd/workflow/signing/certexpiry.go
+++ b/tests/integration/suite/daprd/workflow/signing/certexpiry.go
@@ -84,7 +84,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/certexpiry.go
+++ b/tests/integration/suite/daprd/workflow/signing/certexpiry.go
@@ -15,7 +15,6 @@ package signing
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -50,9 +49,9 @@ type certexpiry struct {
 }
 
 func (c *certexpiry) Setup(t *testing.T) []framework.Option {
-	// Configure sentry with a very short workload cert TTL (10s).
-	// The SPIFFE library renews at 50% of the validity period, so
-	// renewal happens every ~5 seconds.
+	// Configure sentry with a very short workload cert TTL (10s). The SPIFFE
+	// library renews at 50% of the validity period, so renewal happens every ~5
+	// seconds.
 	c.sentry = sentry.New(t,
 		sentry.WithConfiguration(`
 apiVersion: dapr.io/v1alpha1
@@ -97,16 +96,16 @@ spec:
 func (c *certexpiry) Run(t *testing.T, ctx context.Context) {
 	c.daprd.WaitUntilRunning(t, ctx)
 
-	// The workflow waits for multiple external events spaced apart in
-	// time, giving the SVID time to rotate between events.
-	const numEvents = 5
-
+	// The workflow waits for two external events with a gap in between so the
+	// SVID rotates at least once. Any more events just add wall-clock time
+	// without exercising new code paths.
 	reg := dworkflow.NewRegistry()
 	reg.AddWorkflowN("sign-certexpiry", func(ctx *dworkflow.WorkflowContext) (any, error) {
-		for i := range numEvents {
-			if err := ctx.WaitForExternalEvent(fmt.Sprintf("event-%d", i), time.Second*60).Await(nil); err != nil {
-				return nil, err
-			}
+		if err := ctx.WaitForExternalEvent("event-0", time.Second*60).Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.WaitForExternalEvent("event-1", time.Second*60).Await(nil); err != nil {
+			return nil, err
 		}
 		return nil, nil
 	})
@@ -121,34 +120,23 @@ func (c *certexpiry) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	assert.Equal(t, dworkflow.StatusRunning, meta.RuntimeStatus)
 
-	// Send events spaced 6 seconds apart. With a 10s TTL and renewal at 50%
-	// (5s), the SVID should rotate at least once between events.
-	for i := range numEvents {
-		if i > 0 {
-			time.Sleep(6 * time.Second)
-		}
-		require.NoError(t, client.RaiseEvent(ctx, id, fmt.Sprintf("event-%d", i)))
+	require.NoError(t, client.RaiseEvent(ctx, id, "event-0"))
+	require.EventuallyWithT(t, func(col *assert.CollectT) {
+		assert.GreaterOrEqual(col, fworkflow.CertificateCount(t, ctx, c.db, id), 1)
+	}, 10*time.Second, 10*time.Millisecond)
 
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			m, ferr := client.FetchWorkflowMetadata(ctx, id)
-			if !assert.NoError(c, ferr) {
-				return
-			}
-			assert.NotEqual(c, dworkflow.StatusFailed, m.RuntimeStatus)
-		}, 10*time.Second, 100*time.Millisecond)
-	}
+	time.Sleep(7 * time.Second)
+
+	require.NoError(t, client.RaiseEvent(ctx, id, "event-1"))
 
 	meta, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 	assert.Equal(t, dworkflow.StatusCompleted, meta.RuntimeStatus)
 
-	// The SVID rotated multiple times during the workflow. Each rotation
-	// produces a new signing certificate entry.
 	certCount := fworkflow.CertificateCount(t, ctx, c.db, id)
 	assert.GreaterOrEqual(t, certCount, 2,
 		"expected at least 2 certificates from natural SVID rotation, got %d", certCount)
 
-	// The full signature chain must be valid across all certificate rotations.
 	fworkflow.VerifySignatureChain(t, ctx, c.db, id, c.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, c.db, id, c.daprd.AppID())
 }

--- a/tests/integration/suite/daprd/workflow/signing/certexpiry.go
+++ b/tests/integration/suite/daprd/workflow/signing/certexpiry.go
@@ -145,7 +145,7 @@ func (c *certexpiry) Run(t *testing.T, ctx context.Context) {
 	// The SVID rotated multiple times during the workflow. Each rotation
 	// produces a new signing certificate entry.
 	certCount := c.db.CountStateKeys(t, ctx, "sigcert")
-	assert.Equal(t, 5, certCount,
+	assert.GreaterOrEqual(t, certCount, 2,
 		"expected at least 2 certificates from natural SVID rotation, got %d", certCount)
 
 	// The full signature chain must be valid across all certificate rotations.

--- a/tests/integration/suite/daprd/workflow/signing/certexpiry.go
+++ b/tests/integration/suite/daprd/workflow/signing/certexpiry.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(certexpiry))
+}
+
+// certexpiry verifies that when the workload certificate TTL is very short (10
+// seconds), the sidecar's SVID naturally rotates during a long-running
+// workflow. Each rotation produces a new signing certificate in the state
+// store, and the full signature chain must remain valid across rotations.
+type certexpiry struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (c *certexpiry) Setup(t *testing.T) []framework.Option {
+	// Configure sentry with a very short workload cert TTL (10s).
+	// The SPIFFE library renews at 50% of the validity period, so
+	// renewal happens every ~5 seconds.
+	c.sentry = sentry.New(t,
+		sentry.WithConfiguration(`
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sentryconfig
+spec:
+  mtls:
+    workloadCertTTL: "10s"
+    allowedClockSkew: "5s"
+`),
+	)
+
+	c.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	c.place = placement.New(t, placement.WithSentry(t, c.sentry))
+	c.sched = scheduler.New(t, scheduler.WithSentry(c.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	c.daprd = daprd.New(t,
+		daprd.WithSentry(t, c.sentry),
+		daprd.WithPlacement(c.place),
+		daprd.WithScheduler(c.sched),
+		daprd.WithResourceFiles(c.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.sentry, c.db, c.place, c.sched, c.daprd),
+	}
+}
+
+func (c *certexpiry) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	// The workflow waits for multiple external events spaced apart in
+	// time, giving the SVID time to rotate between events.
+	const numEvents = 5
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-certexpiry", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		for i := range numEvents {
+			if err := ctx.WaitForExternalEvent(fmt.Sprintf("event-%d", i), time.Second*60).Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-certexpiry")
+	require.NoError(t, err)
+
+	meta, err := client.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusRunning, meta.RuntimeStatus)
+
+	// Send events spaced 6 seconds apart. With a 10s TTL and renewal at 50%
+	// (5s), the SVID should rotate at least once between events.
+	for i := range numEvents {
+		if i > 0 {
+			time.Sleep(6 * time.Second)
+		}
+		require.NoError(t, client.RaiseEvent(ctx, id, fmt.Sprintf("event-%d", i)))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			m, ferr := client.FetchWorkflowMetadata(ctx, id)
+			if !assert.NoError(c, ferr) {
+				return
+			}
+			assert.NotEqual(c, dworkflow.StatusFailed, m.RuntimeStatus)
+		}, 10*time.Second, 100*time.Millisecond)
+	}
+
+	meta, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusCompleted, meta.RuntimeStatus)
+
+	// The SVID rotated multiple times during the workflow. Each rotation
+	// produces a new signing certificate entry.
+	certCount := c.db.CountStateKeys(t, ctx, "sigcert")
+	assert.Equal(t, 5, certCount,
+		"expected at least 2 certificates from natural SVID rotation, got %d", certCount)
+
+	// The full signature chain must be valid across all certificate rotations.
+	fworkflow.VerifySignatureChain(t, ctx, c.db, id, c.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, c.db, id, c.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/certrotation.go
+++ b/tests/integration/suite/daprd/workflow/signing/certrotation.go
@@ -98,7 +98,7 @@ func (c *certrotation) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	assert.Equal(t, dworkflow.StatusRunning, meta.RuntimeStatus)
 
-	assert.Positive(t, c.db.CountStateKeys(t, ctx, "sigcert"))
+	assert.Positive(t, fworkflow.CertificateCount(t, ctx, c.db, id))
 
 	// Restart daprd to force sentry to issue a new SVID certificate.
 	c.daprd.Restart(t, ctx)
@@ -113,7 +113,7 @@ func (c *certrotation) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 
 	// After restart sentry issues a new cert, so we expect at least 2 sigcerts.
-	assert.GreaterOrEqual(t, c.db.CountStateKeys(t, ctx, "sigcert"), 2)
+	assert.GreaterOrEqual(t, fworkflow.CertificateCount(t, ctx, c.db, id), 2)
 
 	fworkflow.VerifySignatureChain(t, ctx, c.db, id, c.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, c.db, id, c.daprd.AppID())

--- a/tests/integration/suite/daprd/workflow/signing/certrotation.go
+++ b/tests/integration/suite/daprd/workflow/signing/certrotation.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(certrotation))
+}
+
+// certrotation verifies that restarting daprd mid-workflow (which causes
+// sentry to issue a new SVID certificate) results in additional signing
+// certificates being stored and the full signature chain remaining valid.
+type certrotation struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (c *certrotation) Setup(t *testing.T) []framework.Option {
+	c.sentry = sentry.New(t)
+	c.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	c.place = placement.New(t, placement.WithSentry(t, c.sentry))
+	c.sched = scheduler.New(t, scheduler.WithSentry(c.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	c.daprd = daprd.New(t,
+		daprd.WithSentry(t, c.sentry),
+		daprd.WithPlacementAddresses(c.place.Address()),
+		daprd.WithScheduler(c.sched),
+		daprd.WithResourceFiles(c.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.sentry, c.db, c.place, c.sched, c.daprd),
+	}
+}
+
+func (c *certrotation) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-certrot", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.WaitForExternalEvent("continue", time.Second*30).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-certrot")
+	require.NoError(t, err)
+
+	meta, err := client.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusRunning, meta.RuntimeStatus)
+
+	assert.Positive(t, c.db.CountStateKeys(t, ctx, "sigcert"))
+
+	// Restart daprd to force sentry to issue a new SVID certificate.
+	c.daprd.Restart(t, ctx)
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	client = dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	require.NoError(t, client.RaiseEvent(ctx, id, "continue"))
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	// After restart sentry issues a new cert, so we expect at least 2 sigcerts.
+	assert.GreaterOrEqual(t, c.db.CountStateKeys(t, ctx, "sigcert"), 2)
+
+	fworkflow.VerifySignatureChain(t, ctx, c.db, id, c.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, c.db, id, c.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/certrotation.go
+++ b/tests/integration/suite/daprd/workflow/signing/certrotation.go
@@ -67,7 +67,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -75,7 +75,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -123,10 +123,10 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 
 	assert.Positive(tt, i.db.CountStateKeys(tt, ctx, "signature"))
 
-	// Send the "continue" event so the parent can complete. Also send a
-	// fake child workflow completion via the addWorkflowEvent actor method.
-	// The fake event should be filtered out by inbox validation since there
-	// is no matching ChildWorkflowInstanceCreated with TaskScheduledId 9999.
+	// Send the "continue" event so the parent can complete. The inbox
+	// filtering validates that only legitimate child workflow results
+	// (matching ChildWorkflowInstanceCreated in signed history) are
+	// accepted — fake results would be purged by filterValidInboxEvents.
 	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
 
 	meta, err = client.WaitForWorkflowCompletion(ctx, id)

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(childInjection))
+}
+
+// childInjection verifies that injecting a fake ChildWorkflowInstanceCompleted
+// event into the inbox is rejected when signing is enabled. A
+// ChildWorkflowInstanceCompleted referencing a TaskScheduledId that was never
+// scheduled in the signed history is detected by validateInboxEvents and causes
+// the orchestrator run to fail, leaving the workflow in RUNNING state without
+// processing the injected event.
+type childInjection struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (i *childInjection) Setup(tt *testing.T) []framework.Option {
+	i.sentry = sentry.New(tt)
+	i.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	i.place = placement.New(tt, placement.WithSentry(tt, i.sentry))
+	i.sched = scheduler.New(tt, scheduler.WithSentry(i.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	i.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, i.sentry),
+		daprd.WithPlacement(i.place),
+		daprd.WithScheduler(i.sched),
+		daprd.WithResourceFiles(i.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(i.sentry, i.db, i.place, i.sched, i.daprd),
+	}
+}
+
+func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
+	i.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-child-inject-parent", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		// Schedule a real child workflow.
+		if err := ctx.CallChildWorkflow("sign-child-inject-child").Await(nil); err != nil {
+			return nil, err
+		}
+		// Wait for an external event so the parent stays RUNNING after the
+		// child completes.
+		var payload string
+		if err := ctx.WaitForExternalEvent("continue", time.Second*30).Await(&payload); err != nil {
+			return nil, err
+		}
+		return payload, nil
+	})
+	reg.AddWorkflowN("sign-child-inject-child", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "child-done", nil
+	})
+
+	client := dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-child-inject-parent")
+	require.NoError(tt, err)
+
+	// Wait for the workflow to be running and give the child time to complete.
+	meta, err := client.WaitForWorkflowStart(ctx, id)
+	require.NoError(tt, err)
+	assert.Equal(tt, dworkflow.StatusRunning, meta.RuntimeStatus)
+
+	// Wait until the parent is waiting for the external event (child has
+	// completed and the parent has progressed past CallChildWorkflow).
+	require.EventuallyWithT(tt, func(c *assert.CollectT) {
+		meta, err = client.FetchWorkflowMetadata(ctx, id)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, dworkflow.StatusRunning, meta.RuntimeStatus)
+	}, time.Second*10, time.Millisecond*100)
+
+	assert.Positive(tt, i.db.CountStateKeys(tt, ctx, "signature"))
+
+	// Send the "continue" event so the parent can complete. Also send a
+	// fake child workflow completion via the addWorkflowEvent actor method.
+	// The fake event should be filtered out by inbox validation since there
+	// is no matching ChildWorkflowInstanceCreated with TaskScheduledId 9999.
+	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
+
+	meta, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+	assert.Equal(tt, dworkflow.StatusCompleted, meta.RuntimeStatus)
+
+	// Verify signatures exist for the completed workflow.
+	assert.Positive(tt, i.db.CountStateKeys(tt, ctx, "signature"))
+}

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -178,33 +178,18 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	require.NoError(tt, err)
 
 	// Restart daprd to clear the in-memory cache and force re-loading state
-	// from the store. This triggers the orchestrator to process the inbox.
+	// from the store.
 	i.daprd.Restart(tt, ctx)
 	i.daprd.WaitUntilRunning(tt, ctx)
 
 	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
-	// The workflow should remain RUNNING because the injected
-	// ChildWorkflowInstanceCompleted was rejected by inbox validation
-	// (no matching ChildWorkflowInstanceCreated for TaskScheduledId 9999).
-	require.EventuallyWithT(tt, func(c *assert.CollectT) {
-		meta, err = client.FetchWorkflowMetadata(ctx, id)
-		if !assert.NoError(c, err) {
-			return
-		}
-		assert.Equal(c, dworkflow.StatusRunning, meta.RuntimeStatus)
-	}, time.Second*10, time.Millisecond*100)
-
-	assert.Positive(tt, i.db.CountStateKeys(tt, ctx, "signature"))
-
-	// Send the "continue" event so the parent can complete. The inbox
-	// filtering validates that only legitimate child workflow results
-	// (matching ChildWorkflowInstanceCreated in signed history) are
-	// accepted- fake results would be purged by filterValidInboxEvents.
-	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
-
-	meta, err = client.WaitForWorkflowCompletion(ctx, id)
-	require.NoError(tt, err)
-	assert.Equal(tt, dworkflow.StatusCompleted, meta.RuntimeStatus)
+	// Inbox injection is treated as state store tampering: any operation that
+	// loads the actor state detects the forged inbox entry and rejects the
+	// call. RaiseEvent goes through the orchestrator actor, so it surfaces
+	// the tampering error directly.
+	err = client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event"))
+	require.Error(tt, err)
+	assert.Contains(tt, err.Error(), "state store tampering")
 }

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -126,7 +126,7 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	// Send the "continue" event so the parent can complete. The inbox
 	// filtering validates that only legitimate child workflow results
 	// (matching ChildWorkflowInstanceCreated in signed history) are
-	// accepted — fake results would be purged by filterValidInboxEvents.
+	// accepted- fake results would be purged by filterValidInboxEvents.
 	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
 
 	meta, err = client.WaitForWorkflowCompletion(ctx, id)

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -15,9 +15,7 @@ package signing
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -126,10 +124,7 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	// referencing a TaskScheduledId (9999) that was never scheduled in the
 	// workflow's signed history.
 	appID := i.daprd.AppID()
-	actorType := "dapr.internal.default." + appID + ".workflow"
-	db := i.db.GetConnection(tt)
-	tableName := i.db.TableName()
-	keyPrefix := appID + "||" + actorType + "||" + id + "||"
+	keyPrefix := appID + "||dapr.internal.default." + appID + ".workflow||" + id + "||"
 
 	fakeEvt := &protos.HistoryEvent{
 		EventId:   int32(-1),
@@ -144,38 +139,12 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	raw, err := proto.Marshal(fakeEvt)
 	require.NoError(tt, err)
 
-	encoded := base64.StdEncoding.EncodeToString(raw)
-	inboxKey := fmt.Sprintf("%sinbox-%06d", keyPrefix, 0)
-
-	_, err = db.ExecContext(ctx,
-		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
-		inboxKey, encoded, strconv.FormatInt(time.Now().UnixNano(), 10),
-	)
-	require.NoError(tt, err)
+	i.db.WriteStateValue(tt, ctx, fmt.Sprintf("%sinbox-%06d", keyPrefix, 0), raw)
 
 	// Update the workflow metadata to reflect the injected inbox event.
-	metaKey := keyPrefix + "metadata"
-	var existingVal string
-	require.NoError(tt, db.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT value FROM '%s' WHERE key = ?", tableName),
-		metaKey,
-	).Scan(&existingVal))
-
-	var wfMeta backend.BackendWorkflowStateMetadata
-	metaRaw, err := base64.StdEncoding.DecodeString(existingVal)
-	require.NoError(tt, err)
-	require.NoError(tt, proto.Unmarshal(metaRaw, &wfMeta))
-
-	wfMeta.InboxLength = uint64(1)
-	metaRaw, err = proto.Marshal(&wfMeta)
-	require.NoError(tt, err)
-
-	metaEncoded := base64.StdEncoding.EncodeToString(metaRaw)
-	_, err = db.ExecContext(ctx,
-		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
-		metaKey, metaEncoded, strconv.FormatInt(time.Now().UnixNano(), 10),
-	)
-	require.NoError(tt, err)
+	fworkflow.MutateMetadata(tt, ctx, i.db, id, func(m *backend.BackendWorkflowStateMetadata) {
+		m.InboxLength = 1
+	})
 
 	// Restart daprd to clear the in-memory cache and force re-loading state
 	// from the store.

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -15,11 +15,17 @@ package signing
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
@@ -27,7 +33,10 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
 
@@ -38,9 +47,8 @@ func init() {
 // childInjection verifies that injecting a fake ChildWorkflowInstanceCompleted
 // event into the inbox is rejected when signing is enabled. A
 // ChildWorkflowInstanceCompleted referencing a TaskScheduledId that was never
-// scheduled in the signed history is detected by validateInboxEvents and causes
-// the orchestrator run to fail, leaving the workflow in RUNNING state without
-// processing the injected event.
+// scheduled in the signed history is detected by filterValidInboxEvents and
+// purged before being processed, leaving the workflow in RUNNING state.
 type childInjection struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement
@@ -84,12 +92,9 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 
 	reg := dworkflow.NewRegistry()
 	reg.AddWorkflowN("sign-child-inject-parent", func(ctx *dworkflow.WorkflowContext) (any, error) {
-		// Schedule a real child workflow.
 		if err := ctx.CallChildWorkflow("sign-child-inject-child").Await(nil); err != nil {
 			return nil, err
 		}
-		// Wait for an external event so the parent stays RUNNING after the
-		// child completes.
 		var payload string
 		if err := ctx.WaitForExternalEvent("continue", time.Second*30).Await(&payload); err != nil {
 			return nil, err
@@ -106,13 +111,83 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	id, err := client.ScheduleWorkflow(ctx, "sign-child-inject-parent")
 	require.NoError(tt, err)
 
-	// Wait for the workflow to be running and give the child time to complete.
 	meta, err := client.WaitForWorkflowStart(ctx, id)
 	require.NoError(tt, err)
 	assert.Equal(tt, dworkflow.StatusRunning, meta.RuntimeStatus)
 
-	// Wait until the parent is waiting for the external event (child has
-	// completed and the parent has progressed past CallChildWorkflow).
+	// Wait until the child workflow's completion has been signed into the
+	// parent's history (parent has progressed past CallChildWorkflow and is
+	// now waiting for the external event).
+	require.EventuallyWithT(tt, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, fworkflow.SignatureCount(tt, ctx, i.db, id), 2)
+	}, time.Second*10, time.Millisecond*100)
+
+	// Inject a fake ChildWorkflowInstanceCompleted event into the inbox
+	// referencing a TaskScheduledId (9999) that was never scheduled in the
+	// workflow's signed history.
+	appID := i.daprd.AppID()
+	actorType := "dapr.internal.default." + appID + ".workflow"
+	db := i.db.GetConnection(tt)
+	tableName := i.db.TableName()
+	keyPrefix := appID + "||" + actorType + "||" + id + "||"
+
+	fakeEvt := &protos.HistoryEvent{
+		EventId:   int32(-1),
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId: int32(9999),
+				Result:          wrapperspb.String(`"injected-child-result"`),
+			},
+		},
+	}
+	raw, err := proto.Marshal(fakeEvt)
+	require.NoError(tt, err)
+
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	inboxKey := fmt.Sprintf("%sinbox-%06d", keyPrefix, 0)
+
+	_, err = db.ExecContext(ctx,
+		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
+		inboxKey, encoded, strconv.FormatInt(time.Now().UnixNano(), 10),
+	)
+	require.NoError(tt, err)
+
+	// Update the workflow metadata to reflect the injected inbox event.
+	metaKey := keyPrefix + "metadata"
+	var existingVal string
+	require.NoError(tt, db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT value FROM '%s' WHERE key = ?", tableName),
+		metaKey,
+	).Scan(&existingVal))
+
+	var wfMeta backend.BackendWorkflowStateMetadata
+	metaRaw, err := base64.StdEncoding.DecodeString(existingVal)
+	require.NoError(tt, err)
+	require.NoError(tt, proto.Unmarshal(metaRaw, &wfMeta))
+
+	wfMeta.InboxLength = uint64(1)
+	metaRaw, err = proto.Marshal(&wfMeta)
+	require.NoError(tt, err)
+
+	metaEncoded := base64.StdEncoding.EncodeToString(metaRaw)
+	_, err = db.ExecContext(ctx,
+		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
+		metaKey, metaEncoded, strconv.FormatInt(time.Now().UnixNano(), 10),
+	)
+	require.NoError(tt, err)
+
+	// Restart daprd to clear the in-memory cache and force re-loading state
+	// from the store. This triggers the orchestrator to process the inbox.
+	i.daprd.Restart(tt, ctx)
+	i.daprd.WaitUntilRunning(tt, ctx)
+
+	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	// The workflow should remain RUNNING because the injected
+	// ChildWorkflowInstanceCompleted was rejected by inbox validation
+	// (no matching ChildWorkflowInstanceCreated for TaskScheduledId 9999).
 	require.EventuallyWithT(tt, func(c *assert.CollectT) {
 		meta, err = client.FetchWorkflowMetadata(ctx, id)
 		if !assert.NoError(c, err) {
@@ -132,7 +207,4 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	meta, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(tt, err)
 	assert.Equal(tt, dworkflow.StatusCompleted, meta.RuntimeStatus)
-
-	// Verify signatures exist for the completed workflow.
-	assert.Positive(tt, i.db.CountStateKeys(tt, ctx, "signature"))
 }

--- a/tests/integration/suite/daprd/workflow/signing/childworkflow.go
+++ b/tests/integration/suite/daprd/workflow/signing/childworkflow.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(childworkflow))
+}
+
+// childworkflow verifies that a parent workflow invoking a child workflow
+// produces a valid signature chain and correct SPIFFE identity in signing
+// certificates for the parent instance.
+type childworkflow struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (c *childworkflow) Setup(t *testing.T) []framework.Option {
+	c.sentry = sentry.New(t)
+	c.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	c.place = placement.New(t, placement.WithSentry(t, c.sentry))
+	c.sched = scheduler.New(t, scheduler.WithSentry(c.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	c.daprd = daprd.New(t,
+		daprd.WithSentry(t, c.sentry),
+		daprd.WithPlacementAddresses(c.place.Address()),
+		daprd.WithScheduler(c.sched),
+		daprd.WithResourceFiles(c.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.sentry, c.db, c.place, c.sched, c.daprd),
+	}
+}
+
+func (c *childworkflow) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-parent", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CallChildWorkflow("sign-child").Await(nil); err != nil {
+			return nil, err
+		}
+		return "parent-done", nil
+	})
+	reg.AddWorkflowN("sign-child", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("noop").Await(nil); err != nil {
+			return nil, err
+		}
+		return "", nil
+	})
+	reg.AddActivityN("noop", func(ctx dworkflow.ActivityContext) (any, error) {
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-parent")
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	fworkflow.VerifySignatureChain(t, ctx, c.db, id, c.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, c.db, id, c.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/childworkflow.go
+++ b/tests/integration/suite/daprd/workflow/signing/childworkflow.go
@@ -65,7 +65,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/signing/continueasnew.go
@@ -66,7 +66,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/signing/continueasnew.go
@@ -104,8 +104,8 @@ func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
 	fworkflow.VerifySignatureChain(t, ctx, c.db, id, c.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, c.db, id, c.daprd.AppID())
 
-	// ContinueAsNew resets history, so the history record count should be small.
-	//nolint:dogsled
-	_, _, _, rawEvents := fworkflow.UnmarshalSigningData(t, ctx, c.db, id)
-	assert.Less(t, len(rawEvents), 10, "ContinueAsNew should reset history, keeping it small")
+	// After ContinueAsNew, history is reset and the final iteration has
+	// exactly 3 events: WorkflowStarted, ExecutionStarted, and ExecutionCompleted.
+	data := fworkflow.UnmarshalSigningData(t, ctx, c.db, id)
+	assert.Len(t, data.RawEvents, 3, "ContinueAsNew final iteration should have exactly 3 events")
 }

--- a/tests/integration/suite/daprd/workflow/signing/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/signing/continueasnew.go
@@ -108,4 +108,11 @@ func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
 	// exactly 3 events: WorkflowStarted, ExecutionStarted, and ExecutionCompleted.
 	data := fworkflow.UnmarshalSigningData(t, ctx, c.db, id)
 	assert.Len(t, data.RawEvents, 3, "ContinueAsNew final iteration should have exactly 3 events")
+
+	// The signature chain is also reset on ContinueAsNew, so the first
+	// signature of the final iteration must not chain back to any prior
+	// signature (PreviousSignatureDigest must be empty).
+	require.NotEmpty(t, data.Signatures)
+	assert.Empty(t, data.Signatures[0].GetPreviousSignatureDigest(),
+		"first signature after ContinueAsNew should have no previous digest (chain reset)")
 }

--- a/tests/integration/suite/daprd/workflow/signing/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/signing/continueasnew.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(continueasnew))
+}
+
+// continueasnew verifies that a workflow using ContinueAsNew produces a valid
+// signature chain and correct SPIFFE identity in signing certificates, and that
+// history is reset (kept small) after ContinueAsNew iterations.
+type continueasnew struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (c *continueasnew) Setup(t *testing.T) []framework.Option {
+	c.sentry = sentry.New(t)
+	c.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	c.place = placement.New(t, placement.WithSentry(t, c.sentry))
+	c.sched = scheduler.New(t, scheduler.WithSentry(c.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	c.daprd = daprd.New(t,
+		daprd.WithSentry(t, c.sentry),
+		daprd.WithPlacementAddresses(c.place.Address()),
+		daprd.WithScheduler(c.sched),
+		daprd.WithResourceFiles(c.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.sentry, c.db, c.place, c.sched, c.daprd),
+	}
+}
+
+func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-can", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		var iteration int
+		if err := ctx.GetInput(&iteration); err != nil {
+			return nil, err
+		}
+		if iteration < 3 {
+			ctx.ContinueAsNew(iteration + 1)
+			return nil, nil
+		}
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-can", dworkflow.WithInput(1))
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	fworkflow.VerifySignatureChain(t, ctx, c.db, id, c.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, c.db, id, c.daprd.AppID())
+
+	// ContinueAsNew resets history, so the history record count should be small.
+	//nolint:dogsled
+	_, _, _, rawEvents := fworkflow.UnmarshalSigningData(t, ctx, c.db, id)
+	assert.Less(t, len(rawEvents), 10, "ContinueAsNew should reset history, keeping it small")
+}

--- a/tests/integration/suite/daprd/workflow/signing/disabled.go
+++ b/tests/integration/suite/daprd/workflow/signing/disabled.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(disabled))
+}
+
+// disabled verifies that when the WorkflowSignState feature flag is disabled,
+// no signatures or signing certificates are produced for a completed workflow.
+type disabled struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (d *disabled) Setup(tt *testing.T) []framework.Option {
+	d.sentry = sentry.New(tt)
+	d.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	d.place = placement.New(tt, placement.WithSentry(tt, d.sentry))
+	d.sched = scheduler.New(tt, scheduler.WithSentry(d.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	d.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, d.sentry),
+		daprd.WithPlacementAddresses(d.place.Address()),
+		daprd.WithScheduler(d.sched),
+		daprd.WithResourceFiles(d.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: signoff
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: false
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(d.sentry, d.db, d.place, d.sched, d.daprd),
+	}
+}
+
+func (d *disabled) Run(tt *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-disabled", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(d.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-disabled")
+	require.NoError(tt, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+
+	assert.Equal(tt, 0, d.db.CountStateKeys(tt, ctx, "signature"))
+	assert.Equal(tt, 0, d.db.CountStateKeys(tt, ctx, "sigcert"))
+
+	// Verify that history events were still produced.
+	assert.Positive(tt, d.db.CountStateKeys(tt, ctx, "history"))
+
+	// Verify workflow completed successfully.
+	meta, err := client.FetchWorkflowMetadata(ctx, id)
+	require.NoError(tt, err)
+	assert.Equal(tt, dworkflow.StatusCompleted, meta.RuntimeStatus)
+}

--- a/tests/integration/suite/daprd/workflow/signing/disabled.go
+++ b/tests/integration/suite/daprd/workflow/signing/disabled.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -91,8 +92,8 @@ func (d *disabled) Run(tt *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(tt, err)
 
-	assert.Equal(tt, 0, d.db.CountStateKeys(tt, ctx, "signature"))
-	assert.Equal(tt, 0, d.db.CountStateKeys(tt, ctx, "sigcert"))
+	assert.Equal(tt, 0, fworkflow.SignatureCount(tt, ctx, d.db, id))
+	assert.Equal(tt, 0, fworkflow.CertificateCount(tt, ctx, d.db, id))
 
 	// Verify that history events were still produced.
 	assert.Positive(tt, d.db.CountStateKeys(tt, ctx, "history"))

--- a/tests/integration/suite/daprd/workflow/signing/disabled.go
+++ b/tests/integration/suite/daprd/workflow/signing/disabled.go
@@ -35,7 +35,7 @@ func init() {
 	suite.Register(new(disabled))
 }
 
-// disabled verifies that when the WorkflowSignState feature flag is disabled,
+// disabled verifies that when the WorkflowHistorySigning feature flag is disabled,
 // no signatures or signing certificates are produced for a completed workflow.
 type disabled struct {
 	sentry *sentry.Sentry
@@ -65,7 +65,7 @@ metadata:
   name: signoff
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: false
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/disabled.go
+++ b/tests/integration/suite/daprd/workflow/signing/disabled.go
@@ -96,7 +96,7 @@ func (d *disabled) Run(tt *testing.T, ctx context.Context) {
 	assert.Equal(tt, 0, fworkflow.CertificateCount(tt, ctx, d.db, id))
 
 	// Verify that history events were still produced.
-	assert.Positive(tt, d.db.CountStateKeys(tt, ctx, "history"))
+	assert.Positive(tt, fworkflow.HistoryCount(tt, ctx, d.db, id))
 
 	// Verify workflow completed successfully.
 	meta, err := client.FetchWorkflowMetadata(ctx, id)

--- a/tests/integration/suite/daprd/workflow/signing/enablesigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/enablesigning.go
@@ -67,7 +67,7 @@ metadata:
   name: signoff
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: false
 `),
 	)
@@ -109,7 +109,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/enablesigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/enablesigning.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -92,7 +93,7 @@ func (e *enablesigning) Run(t *testing.T, ctx context.Context) {
 
 	_, err = client1.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
-	assert.Equal(t, 0, e.db.CountStateKeys(t, ctx, "signature"))
+	assert.Equal(t, 0, fworkflow.SignatureCount(t, ctx, e.db, id))
 
 	e.daprd1.Kill(t)
 

--- a/tests/integration/suite/daprd/workflow/signing/enablesigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/enablesigning.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(enablesigning))
+}
+
+// enablesigning verifies that when a workflow starts on a non-signing host
+// then moves to a signing host, the workflow is rejected because the unsigned
+// history has no integrity proof. Catch-up signing is not performed because
+// the unsigned events could have been tampered with.
+type enablesigning struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	db     *sqlite.SQLite
+	daprd1 *daprd.Daprd
+}
+
+func (e *enablesigning) Setup(t *testing.T) []framework.Option {
+	e.sentry = sentry.New(t)
+	e.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	e.place = placement.New(t, placement.WithSentry(t, e.sentry))
+	e.sched = scheduler.New(t, scheduler.WithSentry(e.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	e.daprd1 = daprd.New(t,
+		daprd.WithSentry(t, e.sentry),
+		daprd.WithPlacementAddresses(e.place.Address()),
+		daprd.WithScheduler(e.sched),
+		daprd.WithResourceFiles(e.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: signoff
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: false
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(e.sentry, e.db, e.place, e.sched, e.daprd1),
+	}
+}
+
+func (e *enablesigning) Run(t *testing.T, ctx context.Context) {
+	e.daprd1.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-enable", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	client1 := dworkflow.NewClient(e.daprd1.GRPCConn(t, ctx))
+	require.NoError(t, client1.StartWorker(ctx, reg))
+
+	id, err := client1.ScheduleWorkflow(ctx, "sign-enable")
+	require.NoError(t, err)
+
+	_, err = client1.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, 0, e.db.CountStateKeys(t, ctx, "signature"))
+
+	e.daprd1.Kill(t)
+
+	daprd2 := daprd.New(t,
+		daprd.WithSentry(t, e.sentry),
+		daprd.WithAppID(e.daprd1.AppID()),
+		daprd.WithPlacementAddresses(e.place.Address()),
+		daprd.WithScheduler(e.sched),
+		daprd.WithResourceFiles(e.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+	daprd2.Run(t, ctx)
+	t.Cleanup(func() { daprd2.Cleanup(t) })
+	daprd2.WaitUntilRunning(t, ctx)
+
+	client2 := dworkflow.NewClient(daprd2.GRPCConn(t, ctx))
+	require.NoError(t, client2.StartWorker(ctx, reg))
+
+	// The workflow should fail to load because the unsigned history
+	// from the non-signing host has no integrity proof.
+	_, err = client2.FetchWorkflowMetadata(ctx, id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsigned history events")
+}

--- a/tests/integration/suite/daprd/workflow/signing/externalevent.go
+++ b/tests/integration/suite/daprd/workflow/signing/externalevent.go
@@ -65,7 +65,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/externalevent.go
+++ b/tests/integration/suite/daprd/workflow/signing/externalevent.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(externalevent))
+}
+
+// externalevent verifies that a workflow waiting for an external event produces
+// a valid signature chain and correct SPIFFE identity in signing certificates.
+type externalevent struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (e *externalevent) Setup(t *testing.T) []framework.Option {
+	e.sentry = sentry.New(t)
+	e.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	e.place = placement.New(t, placement.WithSentry(t, e.sentry))
+	e.sched = scheduler.New(t, scheduler.WithSentry(e.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	e.daprd = daprd.New(t,
+		daprd.WithSentry(t, e.sentry),
+		daprd.WithPlacementAddresses(e.place.Address()),
+		daprd.WithScheduler(e.sched),
+		daprd.WithResourceFiles(e.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(e.sentry, e.db, e.place, e.sched, e.daprd),
+	}
+}
+
+func (e *externalevent) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-event", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.WaitForExternalEvent("continue", time.Second*10).Await(nil); err != nil {
+			return nil, err
+		}
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(e.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-event")
+	require.NoError(t, err)
+
+	require.NoError(t, client.RaiseEvent(ctx, id, "continue"))
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	fworkflow.VerifySignatureChain(t, ctx, e.db, id, e.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, e.db, id, e.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
@@ -44,10 +45,11 @@ func init() {
 }
 
 // inboxInjection verifies that injecting a fake TaskCompleted event into the
-// inbox is rejected when signing is enabled. A TaskCompleted referencing a
-// TaskScheduledId that was never scheduled in the signed history is detected
-// by validateInboxEvents and causes the orchestrator run to fail, leaving
-// the workflow in RUNNING state without processing the injected event.
+// inbox is rejected when signing is enabled. The workflow schedules a real
+// activity and then waits for an external event. A TaskCompleted referencing
+// a TaskScheduledId that was never scheduled in the signed history is purged
+// by filterValidInboxEvents, leaving the workflow in RUNNING state without
+// processing the injected event.
 type inboxInjection struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement
@@ -91,11 +93,17 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 
 	reg := dworkflow.NewRegistry()
 	reg.AddWorkflowN("sign-inbox-inject", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("noop").Await(nil); err != nil {
+			return nil, err
+		}
 		var payload string
 		if err := ctx.WaitForExternalEvent("continue", time.Second*30).Await(&payload); err != nil {
 			return nil, err
 		}
 		return payload, nil
+	})
+	reg.AddActivityN("noop", func(ctx dworkflow.ActivityContext) (any, error) {
+		return nil, nil
 	})
 
 	client := dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
@@ -107,7 +115,13 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 	meta, err := client.WaitForWorkflowStart(ctx, id)
 	require.NoError(tt, err)
 	assert.Equal(tt, dworkflow.StatusRunning, meta.RuntimeStatus)
-	assert.Positive(tt, i.db.CountStateKeys(tt, ctx, "signature"))
+
+	// Wait until the activity has completed and been signed into history
+	// (parent has scheduled and awaited the task, and is now waiting for
+	// the external event).
+	require.EventuallyWithT(tt, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, fworkflow.SignatureCount(tt, ctx, i.db, id), 2)
+	}, time.Second*10, time.Millisecond*100)
 
 	// Inject a fake TaskCompleted event into the inbox referencing a
 	// TaskScheduledId (9999) that was never scheduled in the workflow history.

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -15,9 +15,7 @@ package signing
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -126,10 +124,7 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 	// Inject a fake TaskCompleted event into the inbox referencing a
 	// TaskScheduledId (9999) that was never scheduled in the workflow history.
 	appID := i.daprd.AppID()
-	actorType := "dapr.internal.default." + appID + ".workflow"
-	db := i.db.GetConnection(tt)
-	tableName := i.db.TableName()
-	keyPrefix := appID + "||" + actorType + "||" + id + "||"
+	keyPrefix := appID + "||dapr.internal.default." + appID + ".workflow||" + id + "||"
 
 	fakeEvt := &protos.HistoryEvent{
 		EventId:   int32(-1),
@@ -144,40 +139,12 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 	raw, err := proto.Marshal(fakeEvt)
 	require.NoError(tt, err)
 
-	encoded := base64.StdEncoding.EncodeToString(raw)
-	inboxKey := fmt.Sprintf("%sinbox-%06d", keyPrefix, 0)
-
-	_, err = db.ExecContext(ctx,
-		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
-		inboxKey, encoded, strconv.FormatInt(time.Now().UnixNano(), 10),
-	)
-	require.NoError(tt, err)
+	i.db.WriteStateValue(tt, ctx, fmt.Sprintf("%sinbox-%06d", keyPrefix, 0), raw)
 
 	// Update the workflow metadata to reflect the injected inbox event.
-	metaKey := keyPrefix + "metadata"
-	var existingVal string
-	var isBin bool
-	require.NoError(tt, db.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT value, is_binary FROM '%s' WHERE key = ?", tableName),
-		metaKey,
-	).Scan(&existingVal, &isBin))
-	require.True(tt, isBin)
-
-	var wfMeta backend.BackendWorkflowStateMetadata
-	metaRaw, err := base64.StdEncoding.DecodeString(existingVal)
-	require.NoError(tt, err)
-	require.NoError(tt, proto.Unmarshal(metaRaw, &wfMeta))
-
-	wfMeta.InboxLength = uint64(1)
-	metaRaw, err = proto.Marshal(&wfMeta)
-	require.NoError(tt, err)
-
-	metaEncoded := base64.StdEncoding.EncodeToString(metaRaw)
-	_, err = db.ExecContext(ctx,
-		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
-		metaKey, metaEncoded, strconv.FormatInt(time.Now().UnixNano(), 10),
-	)
-	require.NoError(tt, err)
+	fworkflow.MutateMetadata(tt, ctx, i.db, id, func(m *backend.BackendWorkflowStateMetadata) {
+		m.InboxLength = 1
+	})
 
 	// Restart daprd to clear the in-memory cache and force re-loading state
 	// from the store.

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -180,28 +180,18 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 	require.NoError(tt, err)
 
 	// Restart daprd to clear the in-memory cache and force re-loading state
-	// from the store. This triggers the orchestrator to process the inbox.
+	// from the store.
 	i.daprd.Restart(tt, ctx)
 	i.daprd.WaitUntilRunning(tt, ctx)
 
 	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
-	// The workflow should remain RUNNING because the injected TaskCompleted
-	// was rejected by inbox validation (no matching TaskScheduled in history).
-	require.EventuallyWithT(tt, func(c *assert.CollectT) {
-		meta, err = client.FetchWorkflowMetadata(ctx, id)
-		if !assert.NoError(c, err) {
-			return
-		}
-		assert.Equal(c, dworkflow.StatusRunning, meta.RuntimeStatus)
-	}, time.Second*10, time.Millisecond*100)
-
-	// Send a real external event to confirm the workflow is still healthy
-	// and can complete normally after the injected event was rejected.
-	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
-
-	meta, err = client.WaitForWorkflowCompletion(ctx, id)
-	require.NoError(tt, err)
-	assert.Equal(tt, dworkflow.StatusCompleted, meta.RuntimeStatus)
+	// Inbox injection is treated as state store tampering: any operation that
+	// loads the actor state detects the forged inbox entry and rejects the
+	// call. RaiseEvent goes through the orchestrator actor, so it surfaces
+	// the tampering error directly.
+	err = client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event"))
+	require.Error(tt, err)
+	assert.Contains(tt, err.Error(), "state store tampering")
 }

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -76,7 +76,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(inboxInjection))
+}
+
+// inboxInjection verifies that injecting a fake TaskCompleted event into the
+// inbox is rejected when signing is enabled. A TaskCompleted referencing a
+// TaskScheduledId that was never scheduled in the signed history is detected
+// by validateInboxEvents and causes the orchestrator run to fail, leaving
+// the workflow in RUNNING state without processing the injected event.
+type inboxInjection struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (i *inboxInjection) Setup(tt *testing.T) []framework.Option {
+	i.sentry = sentry.New(tt)
+	i.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	i.place = placement.New(tt, placement.WithSentry(tt, i.sentry))
+	i.sched = scheduler.New(tt, scheduler.WithSentry(i.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	i.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, i.sentry),
+		daprd.WithPlacementAddresses(i.place.Address()),
+		daprd.WithScheduler(i.sched),
+		daprd.WithResourceFiles(i.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(i.sentry, i.db, i.place, i.sched, i.daprd),
+	}
+}
+
+func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
+	i.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-inbox-inject", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		var payload string
+		if err := ctx.WaitForExternalEvent("continue", time.Second*30).Await(&payload); err != nil {
+			return nil, err
+		}
+		return payload, nil
+	})
+
+	client := dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-inbox-inject")
+	require.NoError(tt, err)
+
+	meta, err := client.WaitForWorkflowStart(ctx, id)
+	require.NoError(tt, err)
+	assert.Equal(tt, dworkflow.StatusRunning, meta.RuntimeStatus)
+	assert.Positive(tt, i.db.CountStateKeys(tt, ctx, "signature"))
+
+	// Inject a fake TaskCompleted event into the inbox referencing a
+	// TaskScheduledId (9999) that was never scheduled in the workflow history.
+	appID := i.daprd.AppID()
+	actorType := "dapr.internal.default." + appID + ".workflow"
+	db := i.db.GetConnection(tt)
+	tableName := i.db.TableName()
+	keyPrefix := appID + "||" + actorType + "||" + id + "||"
+
+	fakeEvt := &protos.HistoryEvent{
+		EventId:   int32(-1),
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: int32(9999),
+				Result:          wrapperspb.String(`"injected"`),
+			},
+		},
+	}
+	raw, err := proto.Marshal(fakeEvt)
+	require.NoError(tt, err)
+
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	inboxKey := fmt.Sprintf("%sinbox-%06d", keyPrefix, 0)
+
+	_, err = db.ExecContext(ctx,
+		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
+		inboxKey, encoded, strconv.FormatInt(time.Now().UnixNano(), 10),
+	)
+	require.NoError(tt, err)
+
+	// Update the workflow metadata to reflect the injected inbox event.
+	metaKey := keyPrefix + "metadata"
+	var existingVal string
+	var isBin bool
+	require.NoError(tt, db.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT value, is_binary FROM '%s' WHERE key = ?", tableName),
+		metaKey,
+	).Scan(&existingVal, &isBin))
+	require.True(tt, isBin)
+
+	var wfMeta backend.BackendWorkflowStateMetadata
+	metaRaw, err := base64.StdEncoding.DecodeString(existingVal)
+	require.NoError(tt, err)
+	require.NoError(tt, proto.Unmarshal(metaRaw, &wfMeta))
+
+	wfMeta.InboxLength = uint64(1)
+	metaRaw, err = proto.Marshal(&wfMeta)
+	require.NoError(tt, err)
+
+	metaEncoded := base64.StdEncoding.EncodeToString(metaRaw)
+	_, err = db.ExecContext(ctx,
+		fmt.Sprintf("INSERT OR REPLACE INTO '%s' (key, value, is_binary, etag) VALUES (?, ?, 1, ?)", tableName),
+		metaKey, metaEncoded, strconv.FormatInt(time.Now().UnixNano(), 10),
+	)
+	require.NoError(tt, err)
+
+	// Restart daprd to clear the in-memory cache and force re-loading state
+	// from the store. This triggers the orchestrator to process the inbox.
+	i.daprd.Restart(tt, ctx)
+	i.daprd.WaitUntilRunning(tt, ctx)
+
+	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	// The workflow should remain RUNNING because the injected TaskCompleted
+	// was rejected by inbox validation (no matching TaskScheduled in history).
+	require.EventuallyWithT(tt, func(c *assert.CollectT) {
+		meta, err = client.FetchWorkflowMetadata(ctx, id)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Equal(c, dworkflow.StatusRunning, meta.RuntimeStatus)
+	}, time.Second*10, time.Millisecond*100)
+
+	// Send a real external event to confirm the workflow is still healthy
+	// and can complete normally after the injected event was rejected.
+	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
+
+	meta, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+	assert.Equal(tt, dworkflow.StatusCompleted, meta.RuntimeStatus)
+}

--- a/tests/integration/suite/daprd/workflow/signing/largepayload.go
+++ b/tests/integration/suite/daprd/workflow/signing/largepayload.go
@@ -66,7 +66,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/largepayload.go
+++ b/tests/integration/suite/daprd/workflow/signing/largepayload.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(largepayload))
+}
+
+// largepayload verifies that a workflow with a large activity result (100,000
+// characters) passes through the signing pipeline and produces a valid
+// signature chain.
+type largepayload struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (l *largepayload) Setup(tt *testing.T) []framework.Option {
+	l.sentry = sentry.New(tt)
+	l.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	l.place = placement.New(tt, placement.WithSentry(tt, l.sentry))
+	l.sched = scheduler.New(tt, scheduler.WithSentry(l.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	l.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, l.sentry),
+		daprd.WithPlacementAddresses(l.place.Address()),
+		daprd.WithScheduler(l.sched),
+		daprd.WithResourceFiles(l.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(l.sentry, l.db, l.place, l.sched, l.daprd),
+	}
+}
+
+func (l *largepayload) Run(tt *testing.T, ctx context.Context) {
+	l.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-large", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		var result string
+		if err := ctx.CallActivity("big-result").Await(&result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	})
+	reg.AddActivityN("big-result", func(ctx dworkflow.ActivityContext) (any, error) {
+		return strings.Repeat("x", 100000), nil
+	})
+
+	client := dworkflow.NewClient(l.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-large")
+	require.NoError(tt, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+
+	fworkflow.VerifySignatureChain(tt, ctx, l.db, id, l.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(tt, ctx, l.db, id, l.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/multiactivity.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiactivity.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(multiactivity))
+}
+
+// multiactivity verifies that a workflow calling multiple sequential activities
+// produces at least one signature per activity execution and that the full
+// signature chain remains valid.
+type multiactivity struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (m *multiactivity) Setup(t *testing.T) []framework.Option {
+	m.sentry = sentry.New(t)
+	m.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	m.place = placement.New(t, placement.WithSentry(t, m.sentry))
+	m.sched = scheduler.New(t, scheduler.WithSentry(m.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	m.daprd = daprd.New(t,
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacementAddresses(m.place.Address()),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.sentry, m.db, m.place, m.sched, m.daprd),
+	}
+}
+
+func (m *multiactivity) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	var counter atomic.Int32
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-multi", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		for range 5 {
+			if err := ctx.CallActivity("counter").Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+	reg.AddActivityN("counter", func(ctx dworkflow.ActivityContext) (any, error) {
+		counter.Add(1)
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(m.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-multi")
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, m.db.CountStateKeys(t, ctx, "signature"), 5)
+
+	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, m.db, id, m.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/multiactivity.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiactivity.go
@@ -105,7 +105,11 @@ func (m *multiactivity) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
-	assert.GreaterOrEqual(t, fworkflow.SignatureCount(t, ctx, m.db, id), 5)
+	// Each of the 5 activities produces a separate orchestrator run (because
+	// the workflow awaits between calls), and the initial + final runs each
+	// produce one signature as well. 5 activity-result runs + 1 initial run =
+	// 6 signatures.
+	assert.Equal(t, 6, fworkflow.SignatureCount(t, ctx, m.db, id))
 
 	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, m.db, id, m.daprd.AppID())

--- a/tests/integration/suite/daprd/workflow/signing/multiactivity.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiactivity.go
@@ -105,7 +105,7 @@ func (m *multiactivity) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
-	assert.GreaterOrEqual(t, m.db.CountStateKeys(t, ctx, "signature"), 5)
+	assert.GreaterOrEqual(t, fworkflow.SignatureCount(t, ctx, m.db, id), 5)
 
 	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, m.db, id, m.daprd.AppID())

--- a/tests/integration/suite/daprd/workflow/signing/multiactivity.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiactivity.go
@@ -67,7 +67,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/multiapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiapp.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(multiapp))
+}
+
+// multiapp verifies that when two daprd instances share the same state store
+// and the orchestrator runs on one instance, the signatures are attributed to
+// the orchestrator's app ID.
+type multiapp struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (m *multiapp) Setup(t *testing.T) []framework.Option {
+	m.sentry = sentry.New(t)
+	m.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	m.place = placement.New(t, placement.WithSentry(t, m.sentry))
+	m.sched = scheduler.New(t, scheduler.WithSentry(m.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	m.daprd1 = daprd.New(t,
+		daprd.WithAppID("sign-xapp-orch"),
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacementAddresses(m.place.Address()),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	m.daprd2 = daprd.New(t,
+		daprd.WithAppID("sign-xapp-act"),
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacementAddresses(m.place.Address()),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.sentry, m.db, m.place, m.sched, m.daprd1, m.daprd2),
+	}
+}
+
+func (m *multiapp) Run(t *testing.T, ctx context.Context) {
+	m.daprd1.WaitUntilRunning(t, ctx)
+	m.daprd2.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-xapp", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("remote-noop").Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	reg.AddActivityN("remote-noop", func(ctx dworkflow.ActivityContext) (any, error) {
+		return nil, nil
+	})
+
+	// Both instances register the same workflow and activity.
+	client1 := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
+	require.NoError(t, client1.StartWorker(ctx, reg))
+
+	client2 := dworkflow.NewClient(m.daprd2.GRPCConn(t, ctx))
+	require.NoError(t, client2.StartWorker(ctx, reg))
+
+	// Schedule on the orchestrator instance.
+	id, err := client1.ScheduleWorkflow(ctx, "sign-xapp")
+	require.NoError(t, err)
+
+	_, err = client1.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, m.db, id, m.daprd1.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/signing/multiapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiapp.go
@@ -15,9 +15,13 @@ package signing
 
 import (
 	"context"
+	"crypto/x509"
 	"testing"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
@@ -27,6 +31,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
 
@@ -125,4 +130,23 @@ func (m *multiapp) Run(t *testing.T, ctx context.Context) {
 
 	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, m.db, id, m.daprd1.AppID())
+
+	// Negative check: no certificate should be attributed to daprd2's app ID
+	// (activity-only app). Signing is always tied to the orchestrator identity.
+	certValues := m.db.ReadStateValues(t, ctx, id, "sigcert")
+	require.NotEmpty(t, certValues)
+	unexpected := spiffeid.RequireFromSegments(
+		spiffeid.RequireTrustDomainFromString("public"),
+		"ns", "default", m.daprd2.AppID(),
+	)
+	for i, raw := range certValues {
+		var sc protos.SigningCertificate
+		require.NoError(t, proto.Unmarshal(raw, &sc))
+		certs, err := x509.ParseCertificates(sc.GetCertificate())
+		require.NoError(t, err)
+		require.NotEmpty(t, certs[0].URIs)
+		id, err := spiffeid.FromURI(certs[0].URIs[0])
+		require.NoError(t, err)
+		assert.NotEqual(t, unexpected, id, "certificate %d unexpectedly attributed to daprd2", i)
+	}
 }

--- a/tests/integration/suite/daprd/workflow/signing/multiapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiapp.go
@@ -72,7 +72,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)
@@ -89,7 +89,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/multiappchild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiappchild.go
@@ -127,7 +127,7 @@ func (m *multiappchild) Run(t *testing.T, ctx context.Context) {
 	_, err = client1.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
-	assert.Positive(t, m.db.CountStateKeys(t, ctx, "sigcert"))
+	assert.Positive(t, fworkflow.CertificateCount(t, ctx, m.db, id))
 
 	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, m.db, id, "sign-parent-app")

--- a/tests/integration/suite/daprd/workflow/signing/multiappchild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiappchild.go
@@ -100,25 +100,29 @@ func (m *multiappchild) Run(t *testing.T, ctx context.Context) {
 	m.daprd1.WaitUntilRunning(t, ctx)
 	m.daprd2.WaitUntilRunning(t, ctx)
 
-	reg := dworkflow.NewRegistry()
-	reg.AddWorkflowN("sign-xapp-parent", func(ctx *dworkflow.WorkflowContext) (any, error) {
+	regParent := dworkflow.NewRegistry()
+	regParent.AddWorkflowN("sign-xapp-parent", func(ctx *dworkflow.WorkflowContext) (any, error) {
 		var result string
-		if err := ctx.CallActivity("remote-act").Await(&result); err != nil {
+		if err := ctx.CallActivity("remote-act",
+			dworkflow.WithActivityAppID(m.daprd2.AppID()),
+		).Await(&result); err != nil {
 			return nil, err
 		}
 		return "parent-done:" + result, nil
 	})
-	reg.AddActivityN("remote-act", func(ctx dworkflow.ActivityContext) (any, error) {
+
+	regChild := dworkflow.NewRegistry()
+	regChild.AddActivityN("remote-act", func(ctx dworkflow.ActivityContext) (any, error) {
 		return "from-child-app", nil
 	})
 
-	// Both instances register the same workflow and activity so that
-	// placement can route the activity to either instance.
+	// daprd1 runs the orchestrator; daprd2 hosts the activity. The parent
+	// explicitly routes the activity call to daprd2 via WithActivityAppID.
 	client1 := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
-	require.NoError(t, client1.StartWorker(ctx, reg))
+	require.NoError(t, client1.StartWorker(ctx, regParent))
 
 	client2 := dworkflow.NewClient(m.daprd2.GRPCConn(t, ctx))
-	require.NoError(t, client2.StartWorker(ctx, reg))
+	require.NoError(t, client2.StartWorker(ctx, regChild))
 
 	// Schedule on the parent (orchestrator) instance.
 	id, err := client1.ScheduleWorkflow(ctx, "sign-xapp-parent")

--- a/tests/integration/suite/daprd/workflow/signing/multiappchild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiappchild.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(multiappchild))
+}
+
+// multiappchild verifies that when two daprd instances with different app IDs
+// share the same state store and the orchestrator on one instance calls an
+// activity registered on the other, signatures are produced and the chain
+// remains valid with certificates attributed to the orchestrator's app ID.
+type multiappchild struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (m *multiappchild) Setup(t *testing.T) []framework.Option {
+	m.sentry = sentry.New(t)
+	m.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	m.place = placement.New(t, placement.WithSentry(t, m.sentry))
+	m.sched = scheduler.New(t, scheduler.WithSentry(m.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	m.daprd1 = daprd.New(t,
+		daprd.WithAppID("sign-parent-app"),
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacementAddresses(m.place.Address()),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	m.daprd2 = daprd.New(t,
+		daprd.WithAppID("sign-child-app"),
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacementAddresses(m.place.Address()),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.sentry, m.db, m.place, m.sched, m.daprd1, m.daprd2),
+	}
+}
+
+func (m *multiappchild) Run(t *testing.T, ctx context.Context) {
+	m.daprd1.WaitUntilRunning(t, ctx)
+	m.daprd2.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-xapp-parent", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		var result string
+		if err := ctx.CallActivity("remote-act").Await(&result); err != nil {
+			return nil, err
+		}
+		return "parent-done:" + result, nil
+	})
+	reg.AddActivityN("remote-act", func(ctx dworkflow.ActivityContext) (any, error) {
+		return "from-child-app", nil
+	})
+
+	// Both instances register the same workflow and activity so that
+	// placement can route the activity to either instance.
+	client1 := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
+	require.NoError(t, client1.StartWorker(ctx, reg))
+
+	client2 := dworkflow.NewClient(m.daprd2.GRPCConn(t, ctx))
+	require.NoError(t, client2.StartWorker(ctx, reg))
+
+	// Schedule on the parent (orchestrator) instance.
+	id, err := client1.ScheduleWorkflow(ctx, "sign-xapp-parent")
+	require.NoError(t, err)
+
+	_, err = client1.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	assert.Positive(t, m.db.CountStateKeys(t, ctx, "sigcert"))
+
+	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, m.db, id, "sign-parent-app")
+}

--- a/tests/integration/suite/daprd/workflow/signing/multiappchild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiappchild.go
@@ -69,7 +69,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)
@@ -86,7 +86,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/multireplica.go
+++ b/tests/integration/suite/daprd/workflow/signing/multireplica.go
@@ -130,7 +130,7 @@ func (m *multireplica) Run(t *testing.T, ctx context.Context) {
 	// Send the first event from replica 1 and wait for it to be processed.
 	require.NoError(t, client.RaiseEvent(ctx, id, "event-0"))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Positive(c, m.db.CountStateKeys(t, ctx, "signature"))
+		assert.Positive(c, fworkflow.SignatureCount(t, ctx, m.db, id))
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Cycle through replicas. Each iteration: kill current, create new
@@ -138,7 +138,7 @@ func (m *multireplica) Run(t *testing.T, ctx context.Context) {
 	// processed (signature count increases).
 	currentDaprd := m.daprd1
 	for i := 1; i < totalReplicas; i++ {
-		prevSigCount := m.db.CountStateKeys(t, ctx, "signature")
+		prevSigCount := fworkflow.SignatureCount(t, ctx, m.db, id)
 		currentDaprd.Kill(t)
 
 		newDaprd := m.newDaprd(t)
@@ -153,7 +153,7 @@ func (m *multireplica) Run(t *testing.T, ctx context.Context) {
 
 		// Wait for the new replica to process the event and sign it.
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			assert.Greater(c, m.db.CountStateKeys(t, ctx, "signature"), prevSigCount)
+			assert.Greater(c, fworkflow.SignatureCount(t, ctx, m.db, id), prevSigCount)
 		}, 10*time.Second, 100*time.Millisecond)
 
 		currentDaprd = newDaprd
@@ -169,7 +169,7 @@ func (m *multireplica) Run(t *testing.T, ctx context.Context) {
 	// orchestrator moved between all 3 replicas (via kill/recreate), each
 	// replica signed history events with its unique cert. All 3 must be in the
 	// certificate table.
-	certCount := m.db.CountStateKeys(t, ctx, "sigcert")
+	certCount := fworkflow.CertificateCount(t, ctx, m.db, id)
 	assert.GreaterOrEqual(t, certCount, totalReplicas,
 		"expected at least %d certificates (one per replica), got %d", totalReplicas, certCount)
 

--- a/tests/integration/suite/daprd/workflow/signing/multireplica.go
+++ b/tests/integration/suite/daprd/workflow/signing/multireplica.go
@@ -72,7 +72,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)
@@ -95,7 +95,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/multireplica.go
+++ b/tests/integration/suite/daprd/workflow/signing/multireplica.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(multireplica))
+}
+
+// multireplica verifies that a workflow can migrate across 3 replicas of the
+// same app ID. Each replica has its own SVID certificate. The workflow waits
+// for external events; between events, the current replica is killed and a
+// new one created, forcing placement to reassign the orchestrator actor.
+// After 3 migrations, all 3 replica certificates must be stored in the
+// state store and the full signature chain must be valid.
+type multireplica struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	db     *sqlite.SQLite
+	daprd1 *daprd.Daprd
+}
+
+func (m *multireplica) Setup(t *testing.T) []framework.Option {
+	m.sentry = sentry.New(t)
+	m.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	m.place = placement.New(t, placement.WithSentry(t, m.sentry))
+	m.sched = scheduler.New(t, scheduler.WithSentry(m.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	m.daprd1 = daprd.New(t,
+		daprd.WithAppID("sign-replica-app"),
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacement(m.place),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.sentry, m.db, m.place, m.sched, m.daprd1),
+	}
+}
+
+func (m *multireplica) newDaprd(t *testing.T) *daprd.Daprd {
+	return daprd.New(t,
+		daprd.WithAppID("sign-replica-app"),
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacement(m.place),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+}
+
+func (m *multireplica) Run(t *testing.T, ctx context.Context) {
+	m.daprd1.WaitUntilRunning(t, ctx)
+
+	const totalReplicas = 3
+
+	// The workflow waits for totalReplicas external events.
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-replica", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		for i := range totalReplicas {
+			if err := ctx.WaitForExternalEvent(fmt.Sprintf("event-%d", i), time.Second*30).Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-replica")
+	require.NoError(t, err)
+
+	meta, err := client.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusRunning, meta.RuntimeStatus)
+
+	// Send the first event from replica 1 and wait for it to be processed.
+	require.NoError(t, client.RaiseEvent(ctx, id, "event-0"))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Positive(c, m.db.CountStateKeys(t, ctx, "signature"))
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Cycle through replicas. Each iteration: kill current, create new
+	// (same app ID, new SVID cert), send event, wait for it to be
+	// processed (signature count increases).
+	currentDaprd := m.daprd1
+	for i := 1; i < totalReplicas; i++ {
+		prevSigCount := m.db.CountStateKeys(t, ctx, "signature")
+		currentDaprd.Kill(t)
+
+		newDaprd := m.newDaprd(t)
+		newDaprd.Run(t, ctx)
+		t.Cleanup(func() { newDaprd.Cleanup(t) })
+		newDaprd.WaitUntilRunning(t, ctx)
+
+		newClient := dworkflow.NewClient(newDaprd.GRPCConn(t, ctx))
+		require.NoError(t, newClient.StartWorker(ctx, reg))
+
+		require.NoError(t, newClient.RaiseEvent(ctx, id, fmt.Sprintf("event-%d", i)))
+
+		// Wait for the new replica to process the event and sign it.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Greater(c, m.db.CountStateKeys(t, ctx, "signature"), prevSigCount)
+		}, 10*time.Second, 100*time.Millisecond)
+
+		currentDaprd = newDaprd
+	}
+
+	// Wait for completion.
+	lastClient := dworkflow.NewClient(currentDaprd.GRPCConn(t, ctx))
+	meta, err = lastClient.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusCompleted, meta.RuntimeStatus)
+
+	// Each replica had its own private key and SVID certificate. Since the
+	// orchestrator moved between all 3 replicas (via kill/recreate), each
+	// replica signed history events with its unique cert. All 3 must be in the
+	// certificate table.
+	certCount := m.db.CountStateKeys(t, ctx, "sigcert")
+	assert.GreaterOrEqual(t, certCount, totalReplicas,
+		"expected at least %d certificates (one per replica), got %d", totalReplicas, certCount)
+
+	// The full signature chain must be valid across all replicas' signatures.
+	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
+
+	// Every certificate must belong to the same app ID despite coming from
+	// different replicas.
+	fworkflow.VerifyCertAppID(t, ctx, m.db, id, "sign-replica-app")
+}

--- a/tests/integration/suite/daprd/workflow/signing/multireplicachild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multireplicachild.go
@@ -75,7 +75,7 @@ metadata:
   name: sign-on-%d
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `, i)),
 		)

--- a/tests/integration/suite/daprd/workflow/signing/multireplicachild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multireplicachild.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(multireplicachild))
+}
+
+// multireplicachild runs 3 replicas of the same app and schedules a parent
+// workflow that spawns 100 child workflows. Each child gets a unique instance
+// ID, so placement distributes them across all 3 replicas. Each replica signs
+// its child workflow history with its own SVID certificate. After completion,
+// the test verifies that all 3 certificates appear in the state store and that
+// each child workflow's signature chain is valid.
+type multireplicachild struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	db     *sqlite.SQLite
+	daprds [3]*daprd.Daprd
+}
+
+func (m *multireplicachild) Setup(t *testing.T) []framework.Option {
+	m.sentry = sentry.New(t)
+	m.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	m.place = placement.New(t, placement.WithSentry(t, m.sentry))
+	m.sched = scheduler.New(t, scheduler.WithSentry(m.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	//nolint:prealloc
+	procs := []process.Interface{m.sentry, m.db, m.place, m.sched}
+	for i := range 3 {
+		m.daprds[i] = daprd.New(t,
+			daprd.WithAppID("sign-repchild-app"),
+			daprd.WithSentry(t, m.sentry),
+			daprd.WithPlacement(m.place),
+			daprd.WithScheduler(m.sched),
+			daprd.WithResourceFiles(m.db.GetComponent(t)),
+			daprd.WithConfigManifests(t, fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on-%d
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`, i)),
+		)
+		procs = append(procs, m.daprds[i])
+	}
+
+	return []framework.Option{
+		framework.WithProcesses(procs...),
+	}
+}
+
+func (m *multireplicachild) Run(t *testing.T, ctx context.Context) {
+	for i := range 3 {
+		m.daprds[i].WaitUntilRunning(t, ctx)
+	}
+
+	const numChildren = 100
+
+	reg := dworkflow.NewRegistry()
+
+	// Parent workflow spawns numChildren child workflows sequentially.
+	reg.AddWorkflowN("sign-repchild-parent", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		for i := range numChildren {
+			if err := ctx.CallChildWorkflow(
+				"sign-repchild-child",
+				dworkflow.WithChildWorkflowInput(i),
+				dworkflow.WithChildWorkflowInstanceID(fmt.Sprintf("child-%03d", i)),
+			).Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+
+	// Child workflow returns immediately.
+	reg.AddWorkflowN("sign-repchild-child", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "child-done", nil
+	})
+
+	// Start workers on ALL replicas.
+	for i := range 3 {
+		client := dworkflow.NewClient(m.daprds[i].GRPCConn(t, ctx))
+		require.NoError(t, client.StartWorker(ctx, reg))
+	}
+
+	// Schedule from replica 0.
+	client := dworkflow.NewClient(m.daprds[0].GRPCConn(t, ctx))
+	id, err := client.ScheduleWorkflow(ctx, "sign-repchild-parent")
+	require.NoError(t, err)
+
+	meta, err := client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusCompleted, meta.RuntimeStatus)
+
+	// Each child workflow instance stores its own sigcert entry, so there
+	// are ~101 sigcert keys globally (1 parent + 100 children). What we
+	// care about is that 3 UNIQUE certificates exist (one per replica).
+	// Collect all sigcert DER bytes and deduplicate.
+	rows, err := m.db.GetConnection(t).QueryContext(ctx,
+		"SELECT value FROM '"+m.db.TableName()+"' WHERE key LIKE '%||sigcert-%'")
+	require.NoError(t, err)
+	defer rows.Close()
+	uniqueCerts := make(map[string]struct{})
+	for rows.Next() {
+		var val string
+		require.NoError(t, rows.Scan(&val))
+		uniqueCerts[val] = struct{}{}
+	}
+	require.NoError(t, rows.Err())
+	assert.Len(t, uniqueCerts, 3,
+		"expected 3 unique certificates (one per replica), got %d", len(uniqueCerts))
+
+	// Verify the parent workflow's signature chain.
+	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, m.db, id, "sign-repchild-app")
+}

--- a/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
+++ b/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
@@ -78,5 +78,9 @@ func (n *nomtlserror) Run(t *testing.T, ctx context.Context) {
 	n.sched.WaitUntilRunning(t, ctx)
 	n.place.WaitUntilRunning(t, ctx)
 
+	// The log line confirms daprd detected the misconfiguration. The
+	// daprd.WithExit1() option asserts at process cleanup that daprd
+	// actually exited with code 1, so both the error message and the
+	// fatal-exit are verified by the end of the test.
 	n.logline.EventuallyFoundAll(t)
 }

--- a/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
+++ b/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
@@ -34,6 +34,8 @@ func init() {
 // explicitly enabled but mTLS is not configured (no sentry), daprd fails
 // to start with a clear error message.
 type nomtlserror struct {
+	sched   *scheduler.Scheduler
+	place   *placement.Placement
 	logline *logline.LogLine
 }
 
@@ -42,8 +44,8 @@ func (n *nomtlserror) Setup(t *testing.T) []framework.Option {
 		sqlite.WithActorStateStore(true),
 		sqlite.WithCreateStateTables(),
 	)
-	place := placement.New(t)
-	sched := scheduler.New(t)
+	n.place = placement.New(t)
+	n.sched = scheduler.New(t)
 
 	n.logline = logline.New(t,
 		logline.WithStdoutLineContains("WorkflowSignState feature flag is enabled but mTLS is not configured"),
@@ -51,8 +53,8 @@ func (n *nomtlserror) Setup(t *testing.T) []framework.Option {
 
 	daprd := daprd.New(t,
 		// No WithSentry — mTLS is NOT configured.
-		daprd.WithPlacement(place),
-		daprd.WithScheduler(sched),
+		daprd.WithPlacement(n.place),
+		daprd.WithScheduler(n.sched),
 		daprd.WithResourceFiles(db.GetComponent(t)),
 		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
 kind: Configuration
@@ -68,10 +70,13 @@ spec:
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(n.logline, db, place, sched, daprd),
+		framework.WithProcesses(n.logline, db, n.place, n.sched, daprd),
 	}
 }
 
-func (n *nomtlserror) Run(t *testing.T, _ context.Context) {
+func (n *nomtlserror) Run(t *testing.T, ctx context.Context) {
+	n.sched.WaitUntilRunning(t, ctx)
+	n.place.WaitUntilRunning(t, ctx)
+
 	n.logline.EventuallyFoundAll(t)
 }

--- a/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
+++ b/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(nomtlserror))
+}
+
+// nomtlserror verifies that when the WorkflowSignState feature flag is
+// explicitly enabled but mTLS is not configured (no sentry), daprd fails
+// to start with a clear error message.
+type nomtlserror struct {
+	logline *logline.LogLine
+}
+
+func (n *nomtlserror) Setup(t *testing.T) []framework.Option {
+	db := sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	place := placement.New(t)
+	sched := scheduler.New(t)
+
+	n.logline = logline.New(t,
+		logline.WithStdoutLineContains("WorkflowSignState feature flag is enabled but mTLS is not configured"),
+	)
+
+	daprd := daprd.New(t,
+		// No WithSentry — mTLS is NOT configured.
+		daprd.WithPlacement(place),
+		daprd.WithScheduler(sched),
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+		daprd.WithExit1(),
+		daprd.WithLogLineStdout(n.logline),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(n.logline, db, place, sched, daprd),
+	}
+}
+
+func (n *nomtlserror) Run(t *testing.T, _ context.Context) {
+	n.logline.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
+++ b/tests/integration/suite/daprd/workflow/signing/nomtlserror.go
@@ -30,7 +30,7 @@ func init() {
 	suite.Register(new(nomtlserror))
 }
 
-// nomtlserror verifies that when the WorkflowSignState feature flag is
+// nomtlserror verifies that when the WorkflowHistorySigning feature flag is
 // explicitly enabled but mTLS is not configured (no sentry), daprd fails
 // to start with a clear error message.
 type nomtlserror struct {
@@ -48,7 +48,7 @@ func (n *nomtlserror) Setup(t *testing.T) []framework.Option {
 	n.sched = scheduler.New(t)
 
 	n.logline = logline.New(t,
-		logline.WithStdoutLineContains("WorkflowSignState feature flag is enabled but mTLS is not configured"),
+		logline.WithStdoutLineContains("WorkflowHistorySigning feature flag is enabled but mTLS is not configured"),
 	)
 
 	daprd := daprd.New(t,
@@ -62,7 +62,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 		daprd.WithExit1(),

--- a/tests/integration/suite/daprd/workflow/signing/nosigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/nosigning.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(nosigning))
+}
+
+// nosigning verifies that a workflow without mTLS and without signing enabled
+// produces history entries but no signatures or signing certificates.
+type nosigning struct {
+	daprd *daprd.Daprd
+	db    *sqlite.SQLite
+}
+
+func (n *nosigning) Setup(t *testing.T) []framework.Option {
+	n.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	place := placement.New(t)
+	sched := scheduler.New(t)
+
+	n.daprd = daprd.New(t,
+		daprd.WithPlacement(place),
+		daprd.WithScheduler(sched),
+		daprd.WithResourceFiles(n.db.GetComponent(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(n.db, place, sched, n.daprd),
+	}
+}
+
+func (n *nosigning) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-no-mtls", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(n.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-no-mtls")
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, n.db.CountStateKeys(t, ctx, "signature"))
+	assert.Equal(t, 0, n.db.CountStateKeys(t, ctx, "sigcert"))
+	assert.Positive(t, n.db.CountStateKeys(t, ctx, "history"))
+}

--- a/tests/integration/suite/daprd/workflow/signing/nosigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/nosigning.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -76,7 +77,7 @@ func (n *nosigning) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, n.db.CountStateKeys(t, ctx, "signature"))
-	assert.Equal(t, 0, n.db.CountStateKeys(t, ctx, "sigcert"))
+	assert.Equal(t, 0, fworkflow.SignatureCount(t, ctx, n.db, id))
+	assert.Equal(t, 0, fworkflow.CertificateCount(t, ctx, n.db, id))
 	assert.Positive(t, n.db.CountStateKeys(t, ctx, "history"))
 }

--- a/tests/integration/suite/daprd/workflow/signing/nosigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/nosigning.go
@@ -79,5 +79,5 @@ func (n *nosigning) Run(t *testing.T, ctx context.Context) {
 
 	assert.Equal(t, 0, fworkflow.SignatureCount(t, ctx, n.db, id))
 	assert.Equal(t, 0, fworkflow.CertificateCount(t, ctx, n.db, id))
-	assert.Positive(t, n.db.CountStateKeys(t, ctx, "history"))
+	assert.Positive(t, fworkflow.HistoryCount(t, ctx, n.db, id))
 }

--- a/tests/integration/suite/daprd/workflow/signing/purge.go
+++ b/tests/integration/suite/daprd/workflow/signing/purge.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -92,13 +93,13 @@ func (p *purge) Run(tt *testing.T, ctx context.Context) {
 	require.NoError(tt, err)
 
 	// Verify signatures and certificates exist before purge.
-	assert.Positive(tt, p.db.CountStateKeys(tt, ctx, "signature"))
-	assert.Positive(tt, p.db.CountStateKeys(tt, ctx, "sigcert"))
+	assert.Positive(tt, fworkflow.SignatureCount(tt, ctx, p.db, id))
+	assert.Positive(tt, fworkflow.CertificateCount(tt, ctx, p.db, id))
 
 	// Purge the workflow.
 	require.NoError(tt, client.PurgeWorkflowState(ctx, id))
 
 	// Verify all signing data has been removed.
-	assert.Equal(tt, 0, p.db.CountStateKeys(tt, ctx, "signature"))
-	assert.Equal(tt, 0, p.db.CountStateKeys(tt, ctx, "sigcert"))
+	assert.Equal(tt, 0, fworkflow.SignatureCount(tt, ctx, p.db, id))
+	assert.Equal(tt, 0, fworkflow.CertificateCount(tt, ctx, p.db, id))
 }

--- a/tests/integration/suite/daprd/workflow/signing/purge.go
+++ b/tests/integration/suite/daprd/workflow/signing/purge.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(purge))
+}
+
+// purge verifies that purging a completed workflow removes all signing data
+// (signatures and signing certificates) from the state store.
+type purge struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (p *purge) Setup(tt *testing.T) []framework.Option {
+	p.sentry = sentry.New(tt)
+	p.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	p.place = placement.New(tt, placement.WithSentry(tt, p.sentry))
+	p.sched = scheduler.New(tt, scheduler.WithSentry(p.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	p.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, p.sentry),
+		daprd.WithPlacementAddresses(p.place.Address()),
+		daprd.WithScheduler(p.sched),
+		daprd.WithResourceFiles(p.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(p.sentry, p.db, p.place, p.sched, p.daprd),
+	}
+}
+
+func (p *purge) Run(tt *testing.T, ctx context.Context) {
+	p.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-purge", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(p.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-purge")
+	require.NoError(tt, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+
+	// Verify signatures and certificates exist before purge.
+	assert.Positive(tt, p.db.CountStateKeys(tt, ctx, "signature"))
+	assert.Positive(tt, p.db.CountStateKeys(tt, ctx, "sigcert"))
+
+	// Purge the workflow.
+	require.NoError(tt, client.PurgeWorkflowState(ctx, id))
+
+	// Verify all signing data has been removed.
+	assert.Equal(tt, 0, p.db.CountStateKeys(tt, ctx, "signature"))
+	assert.Equal(tt, 0, p.db.CountStateKeys(tt, ctx, "sigcert"))
+}

--- a/tests/integration/suite/daprd/workflow/signing/purge.go
+++ b/tests/integration/suite/daprd/workflow/signing/purge.go
@@ -65,7 +65,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/restart.go
+++ b/tests/integration/suite/daprd/workflow/signing/restart.go
@@ -65,7 +65,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/restart.go
+++ b/tests/integration/suite/daprd/workflow/signing/restart.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(restart))
+}
+
+// restart verifies that signatures survive a daprd restart and the signature
+// chain remains valid after reloading state from the store.
+type restart struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (r *restart) Setup(tt *testing.T) []framework.Option {
+	r.sentry = sentry.New(tt)
+	r.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	r.place = placement.New(tt, placement.WithSentry(tt, r.sentry))
+	r.sched = scheduler.New(tt, scheduler.WithSentry(r.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	r.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, r.sentry),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithScheduler(r.sched),
+		daprd.WithResourceFiles(r.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.sentry, r.db, r.place, r.sched, r.daprd),
+	}
+}
+
+func (r *restart) Run(tt *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-restart", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(r.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-restart")
+	require.NoError(tt, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+
+	fworkflow.VerifySignatureChain(tt, ctx, r.db, id, r.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(tt, ctx, r.db, id, r.daprd.AppID())
+
+	// Restart daprd to clear any cached state and force reloading from store.
+	r.daprd.Restart(tt, ctx)
+	r.daprd.WaitUntilRunning(tt, ctx)
+
+	client = dworkflow.NewClient(r.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	// Verify the signature chain is still valid after restart.
+	fworkflow.VerifySignatureChain(tt, ctx, r.db, id, r.sentry.CABundle().X509.TrustAnchors)
+
+	meta, err := client.FetchWorkflowMetadata(ctx, id)
+	require.NoError(tt, err)
+	assert.Equal(tt, dworkflow.StatusCompleted, meta.RuntimeStatus)
+}

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -139,4 +139,3 @@ func (s *signatureStripped) assertLoadFails(t *testing.T, ctx context.Context, i
 	_, err := client.FetchWorkflowMetadata(ctx, id)
 	require.Error(t, err)
 }
-

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/backend"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(signatureStripped))
+}
+
+// signatureStripped verifies that when all signature-* and sigcert-* keys are
+// stripped from the state store (but history remains), the workflow is marked as
+// FAILED with a signature verification error indicating unsigned history events.
+type signatureStripped struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (s *signatureStripped) Setup(tt *testing.T) []framework.Option {
+	s.sentry = sentry.New(tt)
+	s.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	s.place = placement.New(tt, placement.WithSentry(tt, s.sentry))
+	s.sched = scheduler.New(tt, scheduler.WithSentry(s.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	s.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, s.sentry),
+		daprd.WithPlacementAddresses(s.place.Address()),
+		daprd.WithScheduler(s.sched),
+		daprd.WithResourceFiles(s.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.sentry, s.db, s.place, s.sched, s.daprd),
+	}
+}
+
+func (s *signatureStripped) Run(tt *testing.T, ctx context.Context) {
+	s.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-stripped", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(s.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-stripped")
+	require.NoError(tt, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+
+	assert.Positive(tt, s.db.CountStateKeys(tt, ctx, "signature"))
+	assert.Positive(tt, s.db.CountStateKeys(tt, ctx, "sigcert"))
+
+	db := s.db.GetConnection(tt)
+	tableName := s.db.TableName()
+
+	// Delete all signature-* and sigcert-* keys from the state store.
+	//nolint:gosec
+	_, err = db.ExecContext(ctx,
+		"DELETE FROM "+tableName+" WHERE key LIKE '%||signature-%' OR key LIKE '%||sigcert-%'",
+	)
+	require.NoError(tt, err)
+
+	// Update the metadata key to set SignatureLength and SigningCertificateLength to 0.
+	var metaKey, metaValue string
+	require.NoError(tt, db.QueryRowContext(ctx,
+		"SELECT key, value FROM "+tableName+" WHERE key LIKE '%||metadata' LIMIT 1",
+	).Scan(&metaKey, &metaValue))
+
+	raw, err := base64.StdEncoding.DecodeString(metaValue)
+	require.NoError(tt, err)
+
+	var metadata backend.BackendWorkflowStateMetadata
+	require.NoError(tt, proto.Unmarshal(raw, &metadata))
+
+	metadata.SignatureLength = 0
+	metadata.SigningCertificateLength = 0
+
+	updated, err := proto.Marshal(&metadata)
+	require.NoError(tt, err)
+	encoded := base64.StdEncoding.EncodeToString(updated)
+
+	//nolint:gosec
+	_, err = db.ExecContext(ctx,
+		"UPDATE "+tableName+" SET value = ? WHERE key = ?",
+		encoded, metaKey,
+	)
+	require.NoError(tt, err)
+
+	// Restart daprd to clear any cached state.
+	s.daprd.Restart(tt, ctx)
+	s.daprd.WaitUntilRunning(tt, ctx)
+
+	client = dworkflow.NewClient(s.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	_, err = client.FetchWorkflowMetadata(ctx, id)
+	require.Error(tt, err)
+	assert.Contains(tt, err.Error(), "unsigned history events")
+}

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -68,7 +68,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -15,7 +15,9 @@ package signing
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,9 +40,10 @@ func init() {
 	suite.Register(new(signatureStripped))
 }
 
-// signatureStripped verifies that when all signature-* and sigcert-* keys are
-// stripped from the state store (but history remains), the workflow is marked as
-// FAILED with a signature verification error indicating unsigned history events.
+// signatureStripped verifies that stripping any of the four signing-related
+// state fields (signature keys, sigcert keys, SignatureLength metadata,
+// SigningCertificateLength metadata) results in a verification error on
+// reload. Each scenario runs as a subtest with its own workflow instance.
 type signatureStripped struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement
@@ -82,67 +85,105 @@ spec:
 func (s *signatureStripped) Run(tt *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(tt, ctx)
 
+	tt.Run("signature_keys_deleted", func(t *testing.T) {
+		id := s.scheduleAndComplete(t, ctx)
+		deleteKeys(t, ctx, s.db, "%||signature-%")
+		s.assertLoadFails(t, ctx, id)
+	})
+
+	tt.Run("sigcert_keys_deleted", func(t *testing.T) {
+		id := s.scheduleAndComplete(t, ctx)
+		deleteKeys(t, ctx, s.db, "%||sigcert-%")
+		s.assertLoadFails(t, ctx, id)
+	})
+
+	tt.Run("metadata_signature_length_zeroed", func(t *testing.T) {
+		id := s.scheduleAndComplete(t, ctx)
+		mutateMetadata(t, ctx, s.db, id, func(m *backend.BackendWorkflowStateMetadata) {
+			m.SignatureLength = 0
+		})
+		s.assertLoadFails(t, ctx, id)
+	})
+
+	tt.Run("metadata_signing_certificate_length_zeroed", func(t *testing.T) {
+		id := s.scheduleAndComplete(t, ctx)
+		mutateMetadata(t, ctx, s.db, id, func(m *backend.BackendWorkflowStateMetadata) {
+			m.SigningCertificateLength = 0
+		})
+		s.assertLoadFails(t, ctx, id)
+	})
+}
+
+func (s *signatureStripped) scheduleAndComplete(t *testing.T, ctx context.Context) string {
+	t.Helper()
 	reg := dworkflow.NewRegistry()
 	reg.AddWorkflowN("sign-stripped", func(ctx *dworkflow.WorkflowContext) (any, error) {
 		return "", nil
 	})
-
-	client := dworkflow.NewClient(s.daprd.GRPCConn(tt, ctx))
-	require.NoError(tt, client.StartWorker(ctx, reg))
+	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-stripped")
-	require.NoError(tt, err)
-
+	require.NoError(t, err)
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
-	require.NoError(tt, err)
+	require.NoError(t, err)
+	assert.Positive(t, fworkflow.SignatureCount(t, ctx, s.db, id))
+	assert.Positive(t, fworkflow.CertificateCount(t, ctx, s.db, id))
+	return id
+}
 
-	assert.Positive(tt, fworkflow.SignatureCount(tt, ctx, s.db, id))
-	assert.Positive(tt, fworkflow.CertificateCount(tt, ctx, s.db, id))
+func (s *signatureStripped) assertLoadFails(t *testing.T, ctx context.Context, id string) {
+	t.Helper()
+	s.daprd.Restart(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
 
-	db := s.db.GetConnection(tt)
-	tableName := s.db.TableName()
+	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, dworkflow.NewRegistry()))
 
-	// Delete all signature-* and sigcert-* keys from the state store.
-	//nolint:gosec
-	_, err = db.ExecContext(ctx,
-		"DELETE FROM "+tableName+" WHERE key LIKE '%||signature-%' OR key LIKE '%||sigcert-%'",
+	_, err := client.FetchWorkflowMetadata(ctx, id)
+	require.Error(t, err)
+}
+
+func deleteKeys(t *testing.T, ctx context.Context, db *sqlite.SQLite, likePattern string) {
+	t.Helper()
+	_, err := db.GetConnection(t).ExecContext(ctx,
+		"DELETE FROM "+db.TableName()+" WHERE key LIKE ?",
+		likePattern,
 	)
-	require.NoError(tt, err)
+	require.NoError(t, err)
+}
 
-	// Update the metadata key to set SignatureLength and SigningCertificateLength to 0.
+func mutateMetadata(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string, mutate func(*backend.BackendWorkflowStateMetadata)) {
+	t.Helper()
+	conn := db.GetConnection(t)
+	tableName := db.TableName()
+
 	var metaKey, metaValue string
-	require.NoError(tt, db.QueryRowContext(ctx,
-		"SELECT key, value FROM "+tableName+" WHERE key LIKE '%||metadata' LIMIT 1",
-	).Scan(&metaKey, &metaValue))
+	err := conn.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT key, value FROM '%s' WHERE key LIKE ? AND key LIKE '%%||metadata' LIMIT 1", tableName),
+		"%"+instanceID+"%",
+	).Scan(&metaKey, &metaValue)
+	if err == sql.ErrNoRows {
+		t.Fatalf("no metadata row for instance %s", instanceID)
+	}
+	require.NoError(t, err)
 
 	raw, err := base64.StdEncoding.DecodeString(metaValue)
-	require.NoError(tt, err)
+	require.NoError(t, err)
 
 	var metadata backend.BackendWorkflowStateMetadata
-	require.NoError(tt, proto.Unmarshal(raw, &metadata))
+	require.NoError(t, proto.Unmarshal(raw, &metadata))
 
-	metadata.SignatureLength = 0
-	metadata.SigningCertificateLength = 0
+	mutate(&metadata)
 
 	updated, err := proto.Marshal(&metadata)
-	require.NoError(tt, err)
+	require.NoError(t, err)
 	encoded := base64.StdEncoding.EncodeToString(updated)
 
 	//nolint:gosec
-	_, err = db.ExecContext(ctx,
+	_, err = conn.ExecContext(ctx,
 		"UPDATE "+tableName+" SET value = ? WHERE key = ?",
 		encoded, metaKey,
 	)
-	require.NoError(tt, err)
-
-	// Restart daprd to clear any cached state.
-	s.daprd.Restart(tt, ctx)
-	s.daprd.WaitUntilRunning(tt, ctx)
-
-	client = dworkflow.NewClient(s.daprd.GRPCConn(tt, ctx))
-	require.NoError(tt, client.StartWorker(ctx, reg))
-
-	_, err = client.FetchWorkflowMetadata(ctx, id)
-	require.Error(tt, err)
-	assert.Contains(tt, err.Error(), "unsigned history events")
+	require.NoError(t, err)
 }

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/backend"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
@@ -95,8 +96,8 @@ func (s *signatureStripped) Run(tt *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(tt, err)
 
-	assert.Positive(tt, s.db.CountStateKeys(tt, ctx, "signature"))
-	assert.Positive(tt, s.db.CountStateKeys(tt, ctx, "sigcert"))
+	assert.Positive(tt, fworkflow.SignatureCount(tt, ctx, s.db, id))
+	assert.Positive(tt, fworkflow.CertificateCount(tt, ctx, s.db, id))
 
 	db := s.db.GetConnection(tt)
 	tableName := s.db.TableName()

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -15,14 +15,10 @@ package signing
 
 import (
 	"context"
-	"database/sql"
-	"encoding/base64"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
@@ -87,19 +83,19 @@ func (s *signatureStripped) Run(tt *testing.T, ctx context.Context) {
 
 	tt.Run("signature_keys_deleted", func(t *testing.T) {
 		id := s.scheduleAndComplete(t, ctx)
-		deleteKeys(t, ctx, s.db, "%||signature-%")
+		s.db.DeleteStateKeys(t, ctx, "%||signature-%")
 		s.assertLoadFails(t, ctx, id)
 	})
 
 	tt.Run("sigcert_keys_deleted", func(t *testing.T) {
 		id := s.scheduleAndComplete(t, ctx)
-		deleteKeys(t, ctx, s.db, "%||sigcert-%")
+		s.db.DeleteStateKeys(t, ctx, "%||sigcert-%")
 		s.assertLoadFails(t, ctx, id)
 	})
 
 	tt.Run("metadata_signature_length_zeroed", func(t *testing.T) {
 		id := s.scheduleAndComplete(t, ctx)
-		mutateMetadata(t, ctx, s.db, id, func(m *backend.BackendWorkflowStateMetadata) {
+		fworkflow.MutateMetadata(t, ctx, s.db, id, func(m *backend.BackendWorkflowStateMetadata) {
 			m.SignatureLength = 0
 		})
 		s.assertLoadFails(t, ctx, id)
@@ -107,7 +103,7 @@ func (s *signatureStripped) Run(tt *testing.T, ctx context.Context) {
 
 	tt.Run("metadata_signing_certificate_length_zeroed", func(t *testing.T) {
 		id := s.scheduleAndComplete(t, ctx)
-		mutateMetadata(t, ctx, s.db, id, func(m *backend.BackendWorkflowStateMetadata) {
+		fworkflow.MutateMetadata(t, ctx, s.db, id, func(m *backend.BackendWorkflowStateMetadata) {
 			m.SigningCertificateLength = 0
 		})
 		s.assertLoadFails(t, ctx, id)
@@ -144,46 +140,3 @@ func (s *signatureStripped) assertLoadFails(t *testing.T, ctx context.Context, i
 	require.Error(t, err)
 }
 
-func deleteKeys(t *testing.T, ctx context.Context, db *sqlite.SQLite, likePattern string) {
-	t.Helper()
-	_, err := db.GetConnection(t).ExecContext(ctx,
-		"DELETE FROM "+db.TableName()+" WHERE key LIKE ?",
-		likePattern,
-	)
-	require.NoError(t, err)
-}
-
-func mutateMetadata(t *testing.T, ctx context.Context, db *sqlite.SQLite, instanceID string, mutate func(*backend.BackendWorkflowStateMetadata)) {
-	t.Helper()
-	conn := db.GetConnection(t)
-	tableName := db.TableName()
-
-	var metaKey, metaValue string
-	err := conn.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT key, value FROM '%s' WHERE key LIKE ? AND key LIKE '%%||metadata' LIMIT 1", tableName),
-		"%"+instanceID+"%",
-	).Scan(&metaKey, &metaValue)
-	if err == sql.ErrNoRows {
-		t.Fatalf("no metadata row for instance %s", instanceID)
-	}
-	require.NoError(t, err)
-
-	raw, err := base64.StdEncoding.DecodeString(metaValue)
-	require.NoError(t, err)
-
-	var metadata backend.BackendWorkflowStateMetadata
-	require.NoError(t, proto.Unmarshal(raw, &metadata))
-
-	mutate(&metadata)
-
-	updated, err := proto.Marshal(&metadata)
-	require.NoError(t, err)
-	encoded := base64.StdEncoding.EncodeToString(updated)
-
-	//nolint:gosec
-	_, err = conn.ExecContext(ctx,
-		"UPDATE "+tableName+" SET value = ? WHERE key = ?",
-		encoded, metaKey,
-	)
-	require.NoError(t, err)
-}

--- a/tests/integration/suite/daprd/workflow/signing/signinggap.go
+++ b/tests/integration/suite/daprd/workflow/signing/signinggap.go
@@ -67,7 +67,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)
@@ -125,7 +125,7 @@ metadata:
   name: signoff
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: false
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/signinggap.go
+++ b/tests/integration/suite/daprd/workflow/signing/signinggap.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(signinggap))
+}
+
+// signinggap verifies that a signed workflow cannot be operated on after
+// signing is disabled. Signing is a one-way commitment: once enabled for a
+// workflow, it cannot be disabled.
+type signinggap struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	db     *sqlite.SQLite
+	daprd1 *daprd.Daprd
+}
+
+func (s *signinggap) Setup(t *testing.T) []framework.Option {
+	s.sentry = sentry.New(t)
+	s.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	s.place = placement.New(t, placement.WithSentry(t, s.sentry))
+	s.sched = scheduler.New(t, scheduler.WithSentry(s.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	s.daprd1 = daprd.New(t,
+		daprd.WithSentry(t, s.sentry),
+		daprd.WithPlacementAddresses(s.place.Address()),
+		daprd.WithScheduler(s.sched),
+		daprd.WithResourceFiles(s.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.sentry, s.db, s.place, s.sched, s.daprd1),
+	}
+}
+
+func (s *signinggap) Run(t *testing.T, ctx context.Context) {
+	s.daprd1.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-gap", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.WaitForExternalEvent("event1", time.Second*30).Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.WaitForExternalEvent("event2", time.Second*30).Await(nil); err != nil {
+			return nil, err
+		}
+		return "", nil
+	})
+
+	appID := s.daprd1.AppID()
+
+	client1 := dworkflow.NewClient(s.daprd1.GRPCConn(t, ctx))
+	require.NoError(t, client1.StartWorker(ctx, reg))
+
+	id, err := client1.ScheduleWorkflow(ctx, "sign-gap")
+	require.NoError(t, err)
+
+	meta, err := client1.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusRunning, meta.RuntimeStatus)
+
+	require.NoError(t, client1.RaiseEvent(ctx, id, "event1"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Positive(c, s.db.CountStateKeys(t, ctx, "signature"))
+	}, time.Second*10, time.Millisecond*100)
+
+	s.daprd1.Kill(t)
+
+	// Phase 2: attempt to use a signing-disabled host with the signed
+	// workflow. This must fail because signing is a one-way commitment.
+	daprd2 := daprd.New(t,
+		daprd.WithSentry(t, s.sentry),
+		daprd.WithAppID(appID),
+		daprd.WithPlacementAddresses(s.place.Address()),
+		daprd.WithScheduler(s.sched),
+		daprd.WithResourceFiles(s.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: signoff
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: false
+`),
+	)
+	daprd2.Run(t, ctx)
+	t.Cleanup(func() { daprd2.Cleanup(t) })
+	daprd2.WaitUntilRunning(t, ctx)
+
+	client2 := dworkflow.NewClient(daprd2.GRPCConn(t, ctx))
+	require.NoError(t, client2.StartWorker(ctx, reg))
+
+	// Raising an event on a signed workflow from a non-signing host should fail.
+	err = client2.RaiseEvent(ctx, id, "event2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signing cannot be disabled")
+}

--- a/tests/integration/suite/daprd/workflow/signing/signinggap.go
+++ b/tests/integration/suite/daprd/workflow/signing/signinggap.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -105,7 +106,7 @@ func (s *signinggap) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, client1.RaiseEvent(ctx, id, "event1"))
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Positive(c, s.db.CountStateKeys(t, ctx, "signature"))
+		assert.Positive(c, fworkflow.SignatureCount(t, ctx, s.db, id))
 	}, time.Second*10, time.Millisecond*100)
 
 	s.daprd1.Kill(t)

--- a/tests/integration/suite/daprd/workflow/signing/tampered.go
+++ b/tests/integration/suite/daprd/workflow/signing/tampered.go
@@ -15,7 +15,6 @@ package signing
 
 import (
 	"context"
-	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,16 +98,7 @@ func (tp *tampered) Run(tt *testing.T, ctx context.Context) {
 	assert.Positive(tt, fworkflow.SignatureCount(tt, ctx, tp.db, id))
 
 	// Tamper with a history event by modifying its EventId.
-	db := tp.db.GetConnection(tt)
-	tableName := tp.db.TableName()
-
-	var histKey, histValue string
-	require.NoError(tt, db.QueryRowContext(ctx,
-		"SELECT key, value FROM "+tableName+" WHERE key LIKE '%||history-%' LIMIT 1",
-	).Scan(&histKey, &histValue))
-
-	raw, err := base64.StdEncoding.DecodeString(histValue)
-	require.NoError(tt, err)
+	histKey, raw := tp.db.FirstStateValue(tt, ctx, id, "history")
 
 	var evt protos.HistoryEvent
 	require.NoError(tt, proto.Unmarshal(raw, &evt))
@@ -117,14 +107,8 @@ func (tp *tampered) Run(tt *testing.T, ctx context.Context) {
 
 	updated, err := proto.Marshal(&evt)
 	require.NoError(tt, err)
-	encoded := base64.StdEncoding.EncodeToString(updated)
 
-	//nolint:gosec
-	_, err = db.ExecContext(ctx,
-		"UPDATE "+tableName+" SET value = ? WHERE key = ?",
-		encoded, histKey,
-	)
-	require.NoError(tt, err)
+	tp.db.WriteStateValue(tt, ctx, histKey, updated)
 
 	// Restart daprd to clear any cached state.
 	tp.daprd.Restart(tt, ctx)

--- a/tests/integration/suite/daprd/workflow/signing/tampered.go
+++ b/tests/integration/suite/daprd/workflow/signing/tampered.go
@@ -68,7 +68,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/tampered.go
+++ b/tests/integration/suite/daprd/workflow/signing/tampered.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api/protos"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
@@ -95,7 +96,7 @@ func (tp *tampered) Run(tt *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(tt, err)
 
-	assert.Positive(tt, tp.db.CountStateKeys(tt, ctx, "signature"))
+	assert.Positive(tt, fworkflow.SignatureCount(tt, ctx, tp.db, id))
 
 	// Tamper with a history event by modifying its EventId.
 	db := tp.db.GetConnection(tt)

--- a/tests/integration/suite/daprd/workflow/signing/tampered.go
+++ b/tests/integration/suite/daprd/workflow/signing/tampered.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(tampered))
+}
+
+// tampered verifies that a completed workflow with a tampered history event
+// is detected as invalid after a daprd restart, resulting in a FAILED status
+// with a signature verification error.
+type tampered struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (t *tampered) Setup(tt *testing.T) []framework.Option {
+	t.sentry = sentry.New(tt)
+	t.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	t.place = placement.New(tt, placement.WithSentry(tt, t.sentry))
+	t.sched = scheduler.New(tt, scheduler.WithSentry(t.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	t.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, t.sentry),
+		daprd.WithPlacementAddresses(t.place.Address()),
+		daprd.WithScheduler(t.sched),
+		daprd.WithResourceFiles(t.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(t.sentry, t.db, t.place, t.sched, t.daprd),
+	}
+}
+
+func (tp *tampered) Run(tt *testing.T, ctx context.Context) {
+	tp.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-tamper", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(tp.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-tamper")
+	require.NoError(tt, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(tt, err)
+
+	assert.Positive(tt, tp.db.CountStateKeys(tt, ctx, "signature"))
+
+	// Tamper with a history event by modifying its EventId.
+	db := tp.db.GetConnection(tt)
+	tableName := tp.db.TableName()
+
+	var histKey, histValue string
+	require.NoError(tt, db.QueryRowContext(ctx,
+		"SELECT key, value FROM "+tableName+" WHERE key LIKE '%||history-%' LIMIT 1",
+	).Scan(&histKey, &histValue))
+
+	raw, err := base64.StdEncoding.DecodeString(histValue)
+	require.NoError(tt, err)
+
+	var evt protos.HistoryEvent
+	require.NoError(tt, proto.Unmarshal(raw, &evt))
+
+	evt.EventId += 9999
+
+	updated, err := proto.Marshal(&evt)
+	require.NoError(tt, err)
+	encoded := base64.StdEncoding.EncodeToString(updated)
+
+	//nolint:gosec
+	_, err = db.ExecContext(ctx,
+		"UPDATE "+tableName+" SET value = ? WHERE key = ?",
+		encoded, histKey,
+	)
+	require.NoError(tt, err)
+
+	// Restart daprd to clear any cached state.
+	tp.daprd.Restart(tt, ctx)
+	tp.daprd.WaitUntilRunning(tt, ctx)
+
+	client = dworkflow.NewClient(tp.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	_, err = client.FetchWorkflowMetadata(ctx, id)
+	require.Error(tt, err)
+	assert.Contains(tt, err.Error(), "signature verification failed")
+}

--- a/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
+++ b/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
@@ -68,7 +68,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
+++ b/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(tamperedrunning))
+}
+
+// tamperedrunning verifies that a running workflow with a tampered history
+// event is detected as invalid after a daprd restart, resulting in a FAILED
+// status with a signature verification error.
+type tamperedrunning struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (t *tamperedrunning) Setup(tt *testing.T) []framework.Option {
+	t.sentry = sentry.New(tt)
+	t.db = sqlite.New(tt,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	t.place = placement.New(tt, placement.WithSentry(tt, t.sentry))
+	t.sched = scheduler.New(tt, scheduler.WithSentry(t.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	t.daprd = daprd.New(tt,
+		daprd.WithSentry(tt, t.sentry),
+		daprd.WithPlacementAddresses(t.place.Address()),
+		daprd.WithScheduler(t.sched),
+		daprd.WithResourceFiles(t.db.GetComponent(tt)),
+		daprd.WithConfigManifests(tt, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(t.sentry, t.db, t.place, t.sched, t.daprd),
+	}
+}
+
+func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
+	tr.daprd.WaitUntilRunning(tt, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-tamper-running", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		var payload string
+		if err := ctx.WaitForExternalEvent("continue", time.Second*30).Await(&payload); err != nil {
+			return nil, err
+		}
+		return payload, nil
+	})
+
+	client := dworkflow.NewClient(tr.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-tamper-running")
+	require.NoError(tt, err)
+
+	meta, err := client.WaitForWorkflowStart(ctx, id)
+	require.NoError(tt, err)
+	assert.Equal(tt, dworkflow.StatusRunning, meta.RuntimeStatus)
+
+	// Tamper with a history event by modifying its EventId.
+	db := tr.db.GetConnection(tt)
+	tableName := tr.db.TableName()
+
+	var histKey, histValue string
+	require.NoError(tt, db.QueryRowContext(ctx,
+		"SELECT key, value FROM "+tableName+" WHERE key LIKE '%||history-%' LIMIT 1",
+	).Scan(&histKey, &histValue))
+
+	raw, err := base64.StdEncoding.DecodeString(histValue)
+	require.NoError(tt, err)
+
+	var evt protos.HistoryEvent
+	require.NoError(tt, proto.Unmarshal(raw, &evt))
+
+	evt.EventId += 9999
+
+	updated, err := proto.Marshal(&evt)
+	require.NoError(tt, err)
+	encoded := base64.StdEncoding.EncodeToString(updated)
+
+	//nolint:gosec
+	_, err = db.ExecContext(ctx,
+		"UPDATE "+tableName+" SET value = ? WHERE key = ?",
+		encoded, histKey,
+	)
+	require.NoError(tt, err)
+
+	// Restart daprd to clear any cached state.
+	tr.daprd.Restart(tt, ctx)
+	tr.daprd.WaitUntilRunning(tt, ctx)
+
+	client = dworkflow.NewClient(tr.daprd.GRPCConn(tt, ctx))
+	require.NoError(tt, client.StartWorker(ctx, reg))
+
+	_, err = client.FetchWorkflowMetadata(ctx, id)
+	require.Error(tt, err)
+	assert.Contains(tt, err.Error(), "signature verification failed")
+}

--- a/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
+++ b/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
@@ -15,7 +15,6 @@ package signing
 
 import (
 	"context"
-	"encoding/base64"
 	"testing"
 	"time"
 
@@ -102,16 +101,7 @@ func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
 	assert.Equal(tt, dworkflow.StatusRunning, meta.RuntimeStatus)
 
 	// Tamper with a history event by modifying its EventId.
-	db := tr.db.GetConnection(tt)
-	tableName := tr.db.TableName()
-
-	var histKey, histValue string
-	require.NoError(tt, db.QueryRowContext(ctx,
-		"SELECT key, value FROM "+tableName+" WHERE key LIKE '%||history-%' LIMIT 1",
-	).Scan(&histKey, &histValue))
-
-	raw, err := base64.StdEncoding.DecodeString(histValue)
-	require.NoError(tt, err)
+	histKey, raw := tr.db.FirstStateValue(tt, ctx, id, "history")
 
 	var evt protos.HistoryEvent
 	require.NoError(tt, proto.Unmarshal(raw, &evt))
@@ -120,14 +110,8 @@ func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
 
 	updated, err := proto.Marshal(&evt)
 	require.NoError(tt, err)
-	encoded := base64.StdEncoding.EncodeToString(updated)
 
-	//nolint:gosec
-	_, err = db.ExecContext(ctx,
-		"UPDATE "+tableName+" SET value = ? WHERE key = ?",
-		encoded, histKey,
-	)
-	require.NoError(tt, err)
+	tr.db.WriteStateValue(tt, ctx, histKey, updated)
 
 	// Restart daprd to clear any cached state.
 	tr.daprd.Restart(tt, ctx)

--- a/tests/integration/suite/daprd/workflow/signing/terminate.go
+++ b/tests/integration/suite/daprd/workflow/signing/terminate.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(terminate))
+}
+
+// terminate verifies that a workflow which is terminated mid-execution still
+// has valid signatures recorded in the state store for the events that were
+// processed before termination.
+type terminate struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (tr *terminate) Setup(t *testing.T) []framework.Option {
+	tr.sentry = sentry.New(t)
+	tr.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	tr.place = placement.New(t, placement.WithSentry(t, tr.sentry))
+	tr.sched = scheduler.New(t, scheduler.WithSentry(tr.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	tr.daprd = daprd.New(t,
+		daprd.WithSentry(t, tr.sentry),
+		daprd.WithPlacementAddresses(tr.place.Address()),
+		daprd.WithScheduler(tr.sched),
+		daprd.WithResourceFiles(tr.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(tr.sentry, tr.db, tr.place, tr.sched, tr.daprd),
+	}
+}
+
+func (tr *terminate) Run(t *testing.T, ctx context.Context) {
+	tr.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-term", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.WaitForExternalEvent("never-coming", time.Second*60).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(tr.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-term")
+	require.NoError(t, err)
+
+	meta, err := client.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusRunning, meta.RuntimeStatus)
+
+	require.NoError(t, client.TerminateWorkflow(ctx, id))
+
+	meta, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusTerminated, meta.RuntimeStatus)
+
+	assert.Positive(t, tr.db.CountStateKeys(t, ctx, "signature"))
+}

--- a/tests/integration/suite/daprd/workflow/signing/terminate.go
+++ b/tests/integration/suite/daprd/workflow/signing/terminate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
 )
@@ -103,5 +104,5 @@ func (tr *terminate) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	assert.Equal(t, dworkflow.StatusTerminated, meta.RuntimeStatus)
 
-	assert.Positive(t, tr.db.CountStateKeys(t, ctx, "signature"))
+	assert.Positive(t, fworkflow.SignatureCount(t, ctx, tr.db, id))
 }

--- a/tests/integration/suite/daprd/workflow/signing/terminate.go
+++ b/tests/integration/suite/daprd/workflow/signing/terminate.go
@@ -67,7 +67,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/threeapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/threeapp.go
@@ -69,7 +69,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)
@@ -86,7 +86,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)
@@ -103,7 +103,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/threeapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/threeapp.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(threeapp))
+}
+
+// threeapp verifies that a workflow spanning three daprd instances (app A
+// orchestrates, calling activities that may be routed to app B or app C)
+// produces valid signatures with certificates attributed to the orchestrator.
+type threeapp struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd1 *daprd.Daprd
+	daprd2 *daprd.Daprd
+	daprd3 *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (a *threeapp) Setup(t *testing.T) []framework.Option {
+	a.sentry = sentry.New(t)
+	a.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	a.place = placement.New(t, placement.WithSentry(t, a.sentry))
+	a.sched = scheduler.New(t, scheduler.WithSentry(a.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	a.daprd1 = daprd.New(t,
+		daprd.WithAppID("sign-three-a"),
+		daprd.WithSentry(t, a.sentry),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithScheduler(a.sched),
+		daprd.WithResourceFiles(a.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	a.daprd2 = daprd.New(t,
+		daprd.WithAppID("sign-three-b"),
+		daprd.WithSentry(t, a.sentry),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithScheduler(a.sched),
+		daprd.WithResourceFiles(a.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	a.daprd3 = daprd.New(t,
+		daprd.WithAppID("sign-three-c"),
+		daprd.WithSentry(t, a.sentry),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithScheduler(a.sched),
+		daprd.WithResourceFiles(a.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.sentry, a.db, a.place, a.sched, a.daprd1, a.daprd2, a.daprd3),
+	}
+}
+
+func (a *threeapp) Run(t *testing.T, ctx context.Context) {
+	a.daprd1.WaitUntilRunning(t, ctx)
+	a.daprd2.WaitUntilRunning(t, ctx)
+	a.daprd3.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-chain", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		var b, c string
+		if err := ctx.CallActivity("step-b").Await(&b); err != nil {
+			return nil, err
+		}
+		if err := ctx.CallActivity("step-c").Await(&c); err != nil {
+			return nil, err
+		}
+		return b + "+" + c, nil
+	})
+	reg.AddActivityN("step-b", func(ctx dworkflow.ActivityContext) (any, error) {
+		return "from-b", nil
+	})
+	reg.AddActivityN("step-c", func(ctx dworkflow.ActivityContext) (any, error) {
+		return "from-c", nil
+	})
+
+	// All three instances register the same workflow and activities so that
+	// placement can route activities across the cluster.
+	client1 := dworkflow.NewClient(a.daprd1.GRPCConn(t, ctx))
+	require.NoError(t, client1.StartWorker(ctx, reg))
+
+	client2 := dworkflow.NewClient(a.daprd2.GRPCConn(t, ctx))
+	require.NoError(t, client2.StartWorker(ctx, reg))
+
+	client3 := dworkflow.NewClient(a.daprd3.GRPCConn(t, ctx))
+	require.NoError(t, client3.StartWorker(ctx, reg))
+
+	// Schedule on the orchestrator instance (app A).
+	id, err := client1.ScheduleWorkflow(ctx, "sign-chain")
+	require.NoError(t, err)
+
+	meta, err := client1.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dworkflow.StatusCompleted, meta.RuntimeStatus)
+
+	assert.Positive(t, a.db.CountStateKeys(t, ctx, "signature"))
+	assert.GreaterOrEqual(t, a.db.CountStateKeys(t, ctx, "sigcert"), 1)
+
+	fworkflow.VerifySignatureChain(t, ctx, a.db, id, a.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, a.db, id, "sign-three-a")
+}

--- a/tests/integration/suite/daprd/workflow/signing/threeapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/threeapp.go
@@ -155,8 +155,8 @@ func (a *threeapp) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	assert.Equal(t, dworkflow.StatusCompleted, meta.RuntimeStatus)
 
-	assert.Positive(t, a.db.CountStateKeys(t, ctx, "signature"))
-	assert.GreaterOrEqual(t, a.db.CountStateKeys(t, ctx, "sigcert"), 1)
+	assert.Positive(t, fworkflow.SignatureCount(t, ctx, a.db, id))
+	assert.GreaterOrEqual(t, fworkflow.CertificateCount(t, ctx, a.db, id), 1)
 
 	fworkflow.VerifySignatureChain(t, ctx, a.db, id, a.sentry.CABundle().X509.TrustAnchors)
 	fworkflow.VerifyCertAppID(t, ctx, a.db, id, "sign-three-a")

--- a/tests/integration/suite/daprd/workflow/signing/timer.go
+++ b/tests/integration/suite/daprd/workflow/signing/timer.go
@@ -65,7 +65,7 @@ metadata:
   name: sign-on
 spec:
   features:
-  - name: WorkflowSignState
+  - name: WorkflowHistorySigning
     enabled: true
 `),
 	)

--- a/tests/integration/suite/daprd/workflow/signing/timer.go
+++ b/tests/integration/suite/daprd/workflow/signing/timer.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(timer))
+}
+
+// timer verifies that a workflow with a durable timer produces a valid
+// signature chain and correct SPIFFE identity in signing certificates.
+type timer struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	daprd  *daprd.Daprd
+	db     *sqlite.SQLite
+}
+
+func (m *timer) Setup(t *testing.T) []framework.Option {
+	m.sentry = sentry.New(t)
+	m.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithCreateStateTables(),
+	)
+	m.place = placement.New(t, placement.WithSentry(t, m.sentry))
+	m.sched = scheduler.New(t, scheduler.WithSentry(m.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+
+	m.daprd = daprd.New(t,
+		daprd.WithSentry(t, m.sentry),
+		daprd.WithPlacementAddresses(m.place.Address()),
+		daprd.WithScheduler(m.sched),
+		daprd.WithResourceFiles(m.db.GetComponent(t)),
+		daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowSignState
+    enabled: true
+`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.sentry, m.db, m.place, m.sched, m.daprd),
+	}
+}
+
+func (m *timer) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("sign-timer", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CreateTimer(time.Millisecond * 10).Await(nil); err != nil {
+			return nil, err
+		}
+		return "", nil
+	})
+
+	client := dworkflow.NewClient(m.daprd.GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-timer")
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	fworkflow.VerifySignatureChain(t, ctx, m.db, id, m.sentry.CABundle().X509.TrustAnchors)
+	fworkflow.VerifyCertAppID(t, ctx, m.db, id, m.daprd.AppID())
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/retries"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/security"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/signing"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/starttime"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/taskexecutionid"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/terminate"


### PR DESCRIPTION
Adds cryptographic signing and verification of workflow history events using the sidecar's mTLS X.509 SVID identity, creating an auditable chain of signatures that is verified each time workflow state is loaded.

How it works

Each workflow execution step produces a batch of history events that are signed and chained to the previous signature:

```
  ┌─────────────────────────────────────────────────────────────┐
  │                    Workflow History                         │
  │  Event 0 ─ Event 1 ─ Event 2 ─ Event 3 ─ Event 4 ─ Event 5  │
  └─────┬──────────┬─────────┬──────────┬─────────┬──────────┬──┘
        │          │         │          │         │          │
        ▼          ▼         ▼          ▼         ▼          ▼
  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
  │    Signature 0   │  │    Signature 1   │  │    Signature 2   │
  │  Events [0,2)    │  │  Events [2,4)    │  │  Events [4,6)    │
  │  prevDigest: nil ├─►│ prevDigest: d0   ├─►│  prevDigest: d1  │
  │  cert: 0         │  │  cert: 0         │  │  cert: 1         │
  └────────┬─────────┘  └──────────────────┘  └───────┬──────────┘
           │                                          │
           ▼                                          ▼
  ┌───────────────────┐                    ┌───────────────────┐
  │ Cert 0 (Boot 1)   │                    │ Cert 1 (Boot 2)   │
  │ SVID: /ns/default │                    │ SVID: /ns/default │
  │       /myapp      │                    │       /myapp      │
  └───────────────────┘                    └───────────────────┘
```

On every load, the full chain is verified: linkage, contiguity, digests, cryptographic signatures, cert validity, CA trust, and SPIFFE app identity.

Signing

- Each batch of new history events is deterministically marshaled, digested (SHA-256), and signed with the sidecar's SPIFFE private key.
- Signatures chain to the previous via previousSignatureDigest, forming a hash chain from genesis.
- Raw signature bytes are preserved exactly as stored for deterministic chain linking — signatures are never re-marshaled.
- A single signAndSaveState entry point ensures every state persistence path signs before saving; no code path can bypass signing.

Verification and enforcement

- On every state load, the full signature chain is verified: chain linkage, event contiguity, digest recomputation, cryptographic signature, certificate validity at event time, and CA chain-of-trust.
- Signing is a one-way commitment: enabling signing for a workflow is permanent. Disabling signing on a signed workflow, or enabling signing on an unsigned workflow, is a hard verification error. There is no catch-up signing — unsigned history has no integrity proof and is rejected.
- SPIFFE app identity binding: each signing certificate's SPIFFE ID is validated against the workflow's owning app ID, preventing cross-app signature forgery within the same trust domain.
- Inbox event validation: TaskCompleted, TaskFailed, ChildWorkflowInstanceCompleted, and ChildWorkflowInstanceFailed events are validated against scheduled operations in signed history. Injected events referencing non-existent operations are purged from the inbox.
- Timer event type validation: timer reminders must contain TimerFired events; other event types are rejected.
- Metadata bounds checking: all metadata count fields are capped at 1M entries to prevent OOM from inflated state store values.

Configuration

- Controlled by WorkflowSignState feature flag (disabled by default).
- Requires mTLS (Sentry) to be active; without mTLS, the signer is nil and signing does not occur.
