### PR TITLE
Scheduler: fix sidecar streaming reconnection on scheduler pod restart

### DIFF
--- a/docs/release_notes/v1.16.13.md
+++ b/docs/release_notes/v1.16.13.md
@@ -1,0 +1,28 @@
+# Dapr 1.16.13
+
+This update includes bug fixes:
+
+- [Scheduled jobs stop firing after a scheduler pod restart](#scheduled-jobs-stop-firing-after-a-scheduler-pod-restart)
+
+## Scheduled jobs stop firing after a scheduler pod restart
+
+### Problem
+
+When a scheduler pod in a multi-node cluster restarted, all scheduled jobs could stop firing for an extended or indefinite period.
+The sidecar's metadata endpoint continued to report connected scheduler addresses, but no job triggers were delivered to the application.
+
+### Impact
+
+Any deployment running the scheduler service with multiple replicas was affected.
+During routine operations that cause a scheduler pod to restart, applications stopped receiving scheduled job triggers until an unrelated cluster event happened to re-establish the connections.
+
+### Root Cause
+
+The sidecar maintains a streaming connection to each scheduler pod for receiving job triggers.
+These connections were managed by a shared runner. When any single connection encountered an error (such as the replaced scheduler pod briefly accepting then closing the connection during startup), the runner cancelled all connections, including healthy ones to the other scheduler pods.
+No reconnection was attempted because the host-watching mechanism had no reason to emit a new event when cluster membership had not changed.
+
+### Solution
+
+Each per-scheduler streaming connector now retries independently on failure with a half-second backoff.
+A transient failure on one scheduler connection no longer affects healthy connections to other scheduler pods.

--- a/pkg/runtime/scheduler/internal/cluster/connector.go
+++ b/pkg/runtime/scheduler/internal/cluster/connector.go
@@ -31,47 +31,77 @@ type connector struct {
 	wfengine wfengine.Interface
 }
 
-// run starts the scheduler connector.
+// run starts the scheduler connector, retrying on failures so that a single
+// scheduler connection error does not tear down the other healthy connections
+// managed by the same RunnerManager.
 func (c *connector) run(ctx context.Context) error {
-	stream, err := c.client.WatchJobs(ctx)
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	if err != nil {
-		log.Errorf("Failed to watch scheduler jobs, retrying: %s", err)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Second):
-		}
-		return err
-	}
-
-	if err = stream.Send(c.req); err != nil {
+	var failCount int
+	for {
+		stream, err := c.client.WatchJobs(ctx)
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
-		log.Errorf("scheduler stream error, re-connecting: %s", err)
-		return err
+		if err != nil {
+			failCount++
+			if failCount == 1 {
+				log.Errorf("Failed to watch scheduler jobs, retrying: %s", err)
+			} else {
+				log.Debugf("Failed to watch scheduler jobs (attempt %d), retrying: %s", failCount, err)
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second / 2):
+				continue
+			}
+		}
+
+		if err = stream.Send(c.req); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			failCount++
+			if failCount == 1 {
+				log.Errorf("Scheduler stream error, re-connecting: %s", err)
+			} else {
+				log.Debugf("Scheduler stream error (attempt %d), re-connecting: %s", failCount, err)
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second / 2):
+				continue
+			}
+		}
+
+		failCount = 0
+		log.Infof("Scheduler stream connected for %s", c.req.GetInitial().GetAcceptJobTypes())
+
+		err = (&streamer{
+			stream:   stream,
+			resultCh: make(chan *schedulerv1pb.WatchJobsRequest),
+			channels: c.channels,
+			actors:   c.actors,
+			wfengine: c.wfengine,
+		}).run(ctx)
+		if err == nil {
+			log.Infof("Scheduler stream disconnected")
+		} else {
+			log.Errorf("Scheduler stream disconnected: %v", err)
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second / 2):
+		}
 	}
-
-	log.Infof("Scheduler stream connected for %s", c.req.GetInitial().GetAcceptJobTypes())
-
-	err = (&streamer{
-		stream:   stream,
-		resultCh: make(chan *schedulerv1pb.WatchJobsRequest),
-		channels: c.channels,
-		actors:   c.actors,
-		wfengine: c.wfengine,
-	}).run(ctx)
-
-	if err == nil {
-		log.Infof("Scheduler stream disconnected")
-	} else {
-		log.Errorf("Scheduler stream disconnected: %v", err)
-	}
-
-	return err
 }

--- a/tests/integration/suite/daprd/jobs/streaming/reconnect4.go
+++ b/tests/integration/suite/daprd/jobs/streaming/reconnect4.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(reconnect4))
+}
+
+type reconnect4 struct {
+	daprd      *daprd.Daprd
+	scheduler1 *scheduler.Scheduler
+	scheduler2 *scheduler.Scheduler
+	scheduler3 *scheduler.Scheduler
+	scheduler4 *scheduler.Scheduler
+
+	jobCalledMap map[string]struct{}
+	lock         sync.Mutex
+}
+
+func (r *reconnect4) Setup(t *testing.T) []framework.Option {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skip due to Windows specific error on loss of connection")
+	}
+
+	r.jobCalledMap = make(map[string]struct{})
+	srv := app.New(t,
+		app.WithOnJobEventFn(func(ctx context.Context, in *runtimev1pb.JobEventRequest) (*runtimev1pb.JobEventResponse, error) {
+			r.lock.Lock()
+			r.jobCalledMap[in.GetName()] = struct{}{}
+			r.lock.Unlock()
+			return new(runtimev1pb.JobEventResponse), nil
+		}),
+	)
+
+	fp := ports.Reserve(t, 6)
+	port1, port2, port3 := fp.Port(t), fp.Port(t), fp.Port(t)
+	port4, port5, port6 := fp.Port(t), fp.Port(t), fp.Port(t)
+
+	opts := []scheduler.Option{
+		scheduler.WithInitialCluster(fmt.Sprintf(
+			"scheduler-0=http://127.0.0.1:%d,scheduler-1=http://127.0.0.1:%d,scheduler-2=http://127.0.0.1:%d",
+			port1, port2, port3),
+		),
+	}
+
+	r.scheduler1 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-0"), scheduler.WithEtcdClientPort(port4))...)
+	r.scheduler2 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-1"), scheduler.WithEtcdClientPort(port5))...)
+	r.scheduler3 = scheduler.New(t, append(opts, scheduler.WithID("scheduler-2"), scheduler.WithEtcdClientPort(port6))...)
+
+	r.scheduler4 = scheduler.New(t,
+		scheduler.WithID(r.scheduler2.ID()),
+		scheduler.WithEtcdClientPort(port5),
+		scheduler.WithInitialCluster(r.scheduler2.InitialCluster()),
+		scheduler.WithDataDir(r.scheduler2.DataDir()),
+		scheduler.WithPort(r.scheduler2.Port()),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithSchedulerAddresses(r.scheduler1.Address()),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppPort(srv.Port(t)),
+	)
+
+	fp.Free(t)
+	return []framework.Option{
+		framework.WithProcesses(srv, r.scheduler1, r.scheduler2, r.scheduler3, r.daprd),
+	}
+}
+
+func (r *reconnect4) Run(t *testing.T, ctx context.Context) {
+	r.scheduler1.WaitUntilRunning(t, ctx)
+	r.scheduler2.WaitUntilRunning(t, ctx)
+	r.scheduler3.WaitUntilRunning(t, ctx)
+
+	r.daprd.WaitUntilRunning(t, ctx)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, r.daprd.GetMetaScheduler(c, ctx).GetConnectedAddresses(), 3)
+	}, time.Second*10, time.Millisecond*10)
+
+	for i := range 5 {
+		_, err := r.daprd.GRPCClient(t, ctx).ScheduleJobAlpha1(ctx, &runtimev1pb.ScheduleJobRequest{
+			Job: &runtimev1pb.Job{
+				Name:     strconv.Itoa(i),
+				Schedule: ptr.Of("@every 1s"),
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		r.lock.Lock()
+		assert.Len(c, r.jobCalledMap, 5)
+		r.lock.Unlock()
+	}, time.Second*10, time.Millisecond*10)
+
+	r.scheduler2.Kill(t)
+
+	time.Sleep(time.Second * 5)
+
+	r.lock.Lock()
+	r.jobCalledMap = make(map[string]struct{})
+	r.lock.Unlock()
+
+	r.scheduler4.Run(t, ctx)
+	r.scheduler4.WaitUntilRunning(t, ctx)
+	r.scheduler4.WaitUntilLeadership(t, ctx, 3)
+	t.Cleanup(func() { r.scheduler4.Kill(t) })
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, r.daprd.GetMetaScheduler(c, ctx).GetConnectedAddresses(), 3)
+	}, time.Second*40, time.Millisecond*10)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		r.lock.Lock()
+		assert.Len(c, r.jobCalledMap, 5)
+		r.lock.Unlock()
+	}, time.Second*40, time.Millisecond*10)
+}


### PR DESCRIPTION
A single per-scheduler streaming connector error tore down all sibling
connections via the RunnerManager. No reconnection was attempted because
the host-watching mechanism had no reason to emit a new event when
cluster membership hadn't changed. Each connector now retries
independently with a half-second backoff.