### PR TITLE
feat: standardize Configuration API errors using rich error types

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Weekly on Saturdays.
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: results.sarif

--- a/pkg/api/errors/configuration.go
+++ b/pkg/api/errors/configuration.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/components-contrib/metadata"
+	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	"github.com/dapr/kit/errors"
+)
+
+type ConfigurationStoreError struct {
+	name             string
+	skipResourceInfo bool
+}
+
+func ConfigurationStore(name string) *ConfigurationStoreError {
+	return &ConfigurationStoreError{name: name}
+}
+
+func (c *ConfigurationStoreError) NotFound(appID string) error {
+	msg := fmt.Sprintf("%s store %s is not found", metadata.ConfigurationStoreType, c.name)
+	c.skipResourceInfo = true
+	var meta map[string]string
+	if len(appID) > 0 {
+		meta = map[string]string{"appID": appID}
+	}
+	return c.build(
+		errors.NewBuilder(
+			codes.InvalidArgument,
+			http.StatusBadRequest,
+			msg,
+			errorcodes.ConfigurationStoreNotFound.Code,
+			string(errorcodes.ConfigurationStoreNotFound.Category),
+		),
+		errorcodes.ConfigurationStoreNotFound.GrpcCode,
+		meta,
+	)
+}
+
+func (c *ConfigurationStoreError) NotConfigured(appID string) error {
+	msg := fmt.Sprintf("%s stores not configured", metadata.ConfigurationStoreType)
+	c.skipResourceInfo = true
+	var meta map[string]string
+	if len(appID) > 0 {
+		meta = map[string]string{"appID": appID}
+	}
+	return c.build(
+		errors.NewBuilder(
+			codes.FailedPrecondition,
+			http.StatusInternalServerError,
+			msg,
+			errorcodes.ConfigurationStoreNotConfigured.Code,
+			string(errorcodes.ConfigurationStoreNotConfigured.Category),
+		),
+		errorcodes.ConfigurationStoreNotConfigured.GrpcCode,
+		meta,
+	)
+}
+
+func (c *ConfigurationStoreError) GetFailed(keys []string, err error) error {
+	return c.build(
+		errors.NewBuilder(
+			codes.Internal,
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to get %s from %s store %s: %v", strings.Join(keys, ","), metadata.ConfigurationStoreType, c.name, err),
+			errorcodes.ConfigurationGet.Code,
+			string(errorcodes.ConfigurationGet.Category),
+		),
+		errorcodes.ConfigurationGet.GrpcCode,
+		nil,
+	)
+}
+
+func (c *ConfigurationStoreError) SubscribeFailed(keys []string, err error) error {
+	return c.build(
+		errors.NewBuilder(
+			codes.InvalidArgument,
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to subscribe %s from %s store %s: %v", strings.Join(keys, ","), metadata.ConfigurationStoreType, c.name, err),
+			errorcodes.ConfigurationSubscribe.Code,
+			string(errorcodes.ConfigurationSubscribe.Category),
+		),
+		errorcodes.ConfigurationSubscribe.GrpcCode,
+		nil,
+	)
+}
+
+func (c *ConfigurationStoreError) UnsubscribeFailed(id string, err error) error {
+	return c.build(
+		errors.NewBuilder(
+			codes.Internal,
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to unsubscribe to configuration request %s: %v", id, err),
+			errorcodes.ConfigurationUnsubscribe.Code,
+			string(errorcodes.ConfigurationUnsubscribe.Category),
+		),
+		errorcodes.ConfigurationUnsubscribe.GrpcCode,
+		nil,
+	)
+}
+
+func (c *ConfigurationStoreError) build(err *errors.ErrorBuilder, errCode string, meta map[string]string) error {
+	if !c.skipResourceInfo {
+		err = err.WithResourceInfo(string(metadata.ConfigurationStoreType), c.name, "", "")
+	}
+	return err.
+		WithErrorInfo(errCode, meta).
+		Build()
+}

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -1235,14 +1235,12 @@ func stringValueOrEmpty(value *string) string {
 
 func (a *api) getConfigurationStore(name string) (configuration.Store, error) {
 	if a.CompStore().ConfigurationsLen() == 0 {
-		err := apierrors.Basic(codes.FailedPrecondition, http.StatusInternalServerError, errorcodes.ConfigurationStoreNotConfigured, messages.ErrConfigurationStoresNotConfigured)
-		return nil, err
+		return nil, apierrors.ConfigurationStore("").NotConfigured(a.AppID())
 	}
 
 	conf, ok := a.CompStore().GetConfiguration(name)
 	if !ok {
-		err := apierrors.Basic(codes.InvalidArgument, http.StatusInternalServerError, errorcodes.ConfigurationStoreNotFound, fmt.Sprintf(messages.ErrConfigurationStoreNotFound, name))
-		return nil, err
+		return nil, apierrors.ConfigurationStore(name).NotFound(a.AppID())
 	}
 	return conf, nil
 }
@@ -1273,7 +1271,7 @@ func (a *api) GetConfiguration(ctx context.Context, in *runtimev1pb.GetConfigura
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(ctx, in.GetStoreName(), diag.Get, err == nil, elapsed)
 
 	if err != nil {
-		richError := apierrors.Basic(codes.Internal, http.StatusInternalServerError, errorcodes.ConfigurationGet, fmt.Sprintf(messages.ErrConfigurationGet, req.Keys, in.GetStoreName(), err.Error()))
+		richError := apierrors.ConfigurationStore(in.GetStoreName()).GetFailed(req.Keys, err)
 		apiServerLogger.Debug(richError)
 		return response, richError
 	}
@@ -1426,7 +1424,7 @@ func (a *api) subscribeConfiguration(ctx context.Context, request *runtimev1pb.S
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), request.GetStoreName(), diag.ConfigurationSubscribe, err == nil, elapsed)
 
 	if err != nil {
-		richError := apierrors.Basic(codes.InvalidArgument, http.StatusInternalServerError, errorcodes.ConfigurationSubscribe, fmt.Sprintf(messages.ErrConfigurationSubscribe, componentReq.Keys, request.GetStoreName(), err))
+		richError := apierrors.ConfigurationStore(request.GetStoreName()).SubscribeFailed(componentReq.Keys, err)
 		apiServerLogger.Debug(richError)
 		return "", richError
 	}

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -1251,14 +1251,12 @@ func stringValueOrEmpty(value *string) string {
 
 func (a *api) getConfigurationStore(name string) (configuration.Store, error) {
 	if a.CompStore().ConfigurationsLen() == 0 {
-		err := apierrors.Basic(codes.FailedPrecondition, http.StatusInternalServerError, errorcodes.ConfigurationStoreNotConfigured, messages.ErrConfigurationStoresNotConfigured)
-		return nil, err
+		return nil, apierrors.ConfigurationStore("").NotConfigured(a.AppID())
 	}
 
 	conf, ok := a.CompStore().GetConfiguration(name)
 	if !ok {
-		err := apierrors.Basic(codes.InvalidArgument, http.StatusInternalServerError, errorcodes.ConfigurationStoreNotFound, fmt.Sprintf(messages.ErrConfigurationStoreNotFound, name))
-		return nil, err
+		return nil, apierrors.ConfigurationStore(name).NotFound(a.AppID())
 	}
 	return conf, nil
 }
@@ -1289,7 +1287,7 @@ func (a *api) GetConfiguration(ctx context.Context, in *runtimev1pb.GetConfigura
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(ctx, in.GetStoreName(), diag.Get, err == nil, elapsed)
 
 	if err != nil {
-		richError := apierrors.Basic(codes.Internal, http.StatusInternalServerError, errorcodes.ConfigurationGet, fmt.Sprintf(messages.ErrConfigurationGet, req.Keys, in.GetStoreName(), err.Error()))
+		richError := apierrors.ConfigurationStore(in.GetStoreName()).GetFailed(req.Keys, err)
 		apiServerLogger.Debug(richError)
 		return response, richError
 	}
@@ -1442,7 +1440,7 @@ func (a *api) subscribeConfiguration(ctx context.Context, request *runtimev1pb.S
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), request.GetStoreName(), diag.ConfigurationSubscribe, err == nil, elapsed)
 
 	if err != nil {
-		richError := apierrors.Basic(codes.InvalidArgument, http.StatusInternalServerError, errorcodes.ConfigurationSubscribe, fmt.Sprintf(messages.ErrConfigurationSubscribe, componentReq.Keys, request.GetStoreName(), err))
+		richError := apierrors.ConfigurationStore(request.GetStoreName()).SubscribeFailed(componentReq.Keys, err)
 		apiServerLogger.Debug(richError)
 		return "", richError
 	}

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -703,20 +703,20 @@ func (a *api) onGetState(w nethttp.ResponseWriter, r *nethttp.Request) {
 
 func (a *api) getConfigurationStoreWithRequestValidation(w nethttp.ResponseWriter, r *nethttp.Request) (configuration.Store, string, error) {
 	if a.universal.CompStore().ConfigurationsLen() == 0 {
-		resp := messages.NewAPIErrorHTTP(messages.ErrConfigurationStoresNotConfigured, errorcodes.ConfigurationStoreNotConfigured, nethttp.StatusInternalServerError)
-		respondWithError(w, resp)
-		log.Debug(resp)
-		return nil, "", errors.New(resp.Message())
+		err := apierrors.ConfigurationStore("").NotConfigured(a.universal.AppID())
+		respondWithError(w, err)
+		log.Debug(err)
+		return nil, "", err
 	}
 
 	storeName := chi.URLParam(r, storeNameParam)
 
 	conf, ok := a.universal.CompStore().GetConfiguration(storeName)
 	if !ok {
-		resp := messages.NewAPIErrorHTTP(fmt.Sprintf(messages.ErrConfigurationStoreNotFound, storeName), errorcodes.ConfigurationStoreNotFound, nethttp.StatusBadRequest)
-		respondWithError(w, resp)
-		log.Debug(resp)
-		return nil, "", errors.New(resp.Message())
+		err := apierrors.ConfigurationStore(storeName).NotFound(a.universal.AppID())
+		respondWithError(w, err)
+		log.Debug(err)
+		return nil, "", err
 	}
 	return conf, storeName, nil
 }
@@ -830,9 +830,9 @@ func (a *api) onSubscribeConfiguration(w nethttp.ResponseWriter, r *nethttp.Requ
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), storeName, diag.ConfigurationSubscribe, err == nil, elapsed)
 
 	if err != nil {
-		resp := messages.NewAPIErrorHTTP(fmt.Sprintf(messages.ErrConfigurationSubscribe, keys, storeName, err.Error()), errorcodes.ConfigurationSubscribe, nethttp.StatusInternalServerError)
-		respondWithError(w, resp)
-		log.Debug(resp)
+		apiErr := apierrors.ConfigurationStore(storeName).SubscribeFailed(keys, err)
+		respondWithError(w, apiErr)
+		log.Debug(apiErr)
 		return
 	}
 
@@ -909,9 +909,9 @@ func (a *api) onGetConfiguration(w nethttp.ResponseWriter, r *nethttp.Request) {
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), storeName, diag.Get, err == nil, elapsed)
 
 	if err != nil {
-		resp := messages.NewAPIErrorHTTP(fmt.Sprintf(messages.ErrConfigurationGet, keys, storeName, err.Error()), errorcodes.ConfigurationGet, nethttp.StatusInternalServerError)
-		respondWithError(w, resp)
-		log.Debug(resp)
+		apiErr := apierrors.ConfigurationStore(storeName).GetFailed(keys, err)
+		respondWithError(w, apiErr)
+		log.Debug(apiErr)
 		return
 	}
 

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -2164,7 +2164,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 500, resp.StatusCode, "Accessing configuration store with bad key should return 500")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_GET", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "failed to get [bad-key] from Configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
+		assert.Equal(t, "failed to get bad-key from configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
 	})
 
 	t.Run("Get Configurations with bad key", func(t *testing.T) {
@@ -2174,7 +2174,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 500, resp.StatusCode, "Accessing configuration store with bad key should return 500")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_GET", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "failed to get [bad-key] from Configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
+		assert.Equal(t, "failed to get bad-key from configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
 	})
 
 	t.Run("Get with none exist configurations store - alpha1", func(t *testing.T) {
@@ -2184,7 +2184,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 400, resp.StatusCode, "Accessing configuration store with none exist configurations store should return 400")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_STORE_NOT_FOUND", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "configuration store nonExistStore not found", resp.ErrorBody["message"])
+		assert.Equal(t, "configuration store nonExistStore is not found", resp.ErrorBody["message"])
 	})
 
 	t.Run("Get with none exist configurations store", func(t *testing.T) {
@@ -2194,7 +2194,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 400, resp.StatusCode, "Accessing configuration store with none exist configurations store should return 400")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_STORE_NOT_FOUND", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "configuration store nonExistStore not found", resp.ErrorBody["message"])
+		assert.Equal(t, "configuration store nonExistStore is not found", resp.ErrorBody["message"])
 	})
 }
 

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -2192,7 +2192,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 500, resp.StatusCode, "Accessing configuration store with bad key should return 500")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_GET", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "failed to get [bad-key] from Configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
+		assert.Equal(t, "failed to get bad-key from configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
 	})
 
 	t.Run("Get Configurations with bad key", func(t *testing.T) {
@@ -2202,7 +2202,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 500, resp.StatusCode, "Accessing configuration store with bad key should return 500")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_GET", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "failed to get [bad-key] from Configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
+		assert.Equal(t, "failed to get bad-key from configuration store store1: get key error: bad-key", resp.ErrorBody["message"])
 	})
 
 	t.Run("Get with none exist configurations store - alpha1", func(t *testing.T) {
@@ -2212,7 +2212,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 400, resp.StatusCode, "Accessing configuration store with none exist configurations store should return 400")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_STORE_NOT_FOUND", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "configuration store nonExistStore not found", resp.ErrorBody["message"])
+		assert.Equal(t, "configuration store nonExistStore is not found", resp.ErrorBody["message"])
 	})
 
 	t.Run("Get with none exist configurations store", func(t *testing.T) {
@@ -2222,7 +2222,7 @@ func TestConfigurationGet(t *testing.T) {
 		assert.Equal(t, 400, resp.StatusCode, "Accessing configuration store with none exist configurations store should return 400")
 		assert.NotNil(t, resp.ErrorBody)
 		assert.Equal(t, "ERR_CONFIGURATION_STORE_NOT_FOUND", resp.ErrorBody["errorCode"])
-		assert.Equal(t, "configuration store nonExistStore not found", resp.ErrorBody["message"])
+		assert.Equal(t, "configuration store nonExistStore is not found", resp.ErrorBody["message"])
 	})
 }
 


### PR DESCRIPTION
## What problem does this PR solve?

Closes #7485 — Error Standardization: Configuration API

The Configuration API used ad-hoc error construction via `apierrors.Basic()` (gRPC) and `messages.NewAPIErrorHTTP()` (HTTP), while other APIs like State and PubSub already use structured, domain-specific error types.

## Changes

- **New**: `pkg/api/errors/configuration.go` — `ConfigurationStoreError` struct with the same pattern as `StateStoreError`
  - `NotFound(appID string) error`
  - `NotConfigured(appID string) error`
  - `GetFailed(keys []string, err error) error`
  - `SubscribeFailed(keys []string, err error) error`
  - `UnsubscribeFailed(id string, err error) error`

- **Updated** `pkg/api/http/http.go` — replaced 3 error sites in `getConfigurationStoreWithRequestValidation`, `onSubscribeConfiguration`, and `onGetConfiguration`

- **Updated** `pkg/api/grpc/grpc.go` — replaced 3 error sites in `getConfigurationStore`, `GetConfiguration`, and `subscribeConfiguration`

- **Updated** `pkg/api/http/http_test.go` — adjusted assertions for the new standardized error messages

## Testing

All existing HTTP API configuration tests pass:
```
go test ./pkg/api/http/... -run "Configuration" -v
--- PASS: TestConfigurationGet
--- PASS: TestV1Alpha1ConfigurationUnsubscribe
```