### PR TITLE
feat: Error Standardization: Health API

### DIFF
--- a/pkg/api/errors/health.go
+++ b/pkg/api/errors/health.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	"github.com/dapr/kit/errors"
+)
+
+type HealthError struct{}
+
+func Health() *HealthError {
+	return &HealthError{}
+}
+
+func (h *HealthError) NotReady(targets []string) error {
+	return errors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		fmt.Sprintf("dapr is not ready: [%s]", strings.Join(targets, " ")),
+		errorcodes.HealthNotReady.Code,
+		string(errorcodes.HealthNotReady.Category),
+	).
+		WithErrorInfo(errorcodes.HealthNotReady.GrpcCode, nil).
+		Build()
+}
+
+func (h *HealthError) AppIDNotMatch() error {
+	return errors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		"dapr app-id does not match",
+		errorcodes.HealthAppidNotMatch.Code,
+		string(errorcodes.HealthAppidNotMatch.Category),
+	).
+		WithErrorInfo(errorcodes.HealthAppidNotMatch.GrpcCode, nil).
+		Build()
+}
+
+func (h *HealthError) OutboundNotReady() error {
+	return errors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		"dapr outbound is not ready",
+		errorcodes.HealthOutboundNotReady.Code,
+		string(errorcodes.HealthOutboundNotReady.Category),
+	).
+		WithErrorInfo(errorcodes.HealthOutboundNotReady.GrpcCode, nil).
+		Build()
+}

--- a/pkg/api/http/healthz.go
+++ b/pkg/api/http/healthz.go
@@ -16,8 +16,8 @@ package http
 import (
 	"net/http"
 
+	apierrors "github.com/dapr/dapr/pkg/api/errors"
 	"github.com/dapr/dapr/pkg/api/http/endpoints"
-	"github.com/dapr/dapr/pkg/messages"
 )
 
 var endpointGroupHealthzV1 = &endpoints.EndpointGroup{
@@ -57,9 +57,9 @@ func (a *api) constructHealthzEndpoints() []endpoints.Endpoint {
 
 func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.healthz.IsReady() {
-		msg := messages.ErrHealthNotReady.WithFormat(a.healthz.GetUnhealthyTargets())
-		respondWithError(w, msg)
-		log.Debug(msg)
+		err := apierrors.Health().NotReady(a.healthz.GetUnhealthyTargets())
+		respondWithError(w, err)
+		log.Debug(err)
 		return
 	}
 
@@ -67,9 +67,9 @@ func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 	// This is used by some components (e.g. Consul nameresolver) to check if the app was replaced with a different one
 	qs := r.URL.Query()
 	if qs.Has("appid") && qs.Get("appid") != a.universal.AppID() {
-		msg := messages.ErrHealthAppIDNotMatch
-		respondWithError(w, msg)
-		log.Debug(msg)
+		err := apierrors.Health().AppIDNotMatch()
+		respondWithError(w, err)
+		log.Debug(err)
 		return
 	}
 
@@ -78,9 +78,9 @@ func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 
 func (a *api) onGetOutboundHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.outboundHealthz.IsReady() {
-		msg := messages.ErrOutboundHealthNotReady
-		respondWithError(w, msg)
-		log.Debug(msg)
+		err := apierrors.Health().OutboundNotReady()
+		respondWithError(w, err)
+		log.Debug(err)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Standardizes Health API errors using the rich error type pattern established in the State, PubSub, Configuration, and Workflow API standardizations.

- Adds `HealthError` struct in `pkg/api/errors/health.go` with `NotReady`, `AppIDNotMatch`, and `OutboundNotReady` methods
- Updates `pkg/api/http/healthz.go` to use the new domain-specific error type, replacing `messages.APIError` usage

The new errors use `kiterrors.ErrorBuilder` with `WithErrorInfo()` to produce structured gRPC/HTTP error responses.

Fixes #7488

## Test plan

- [ ] `go test ./pkg/api/http/ -run TestV1HealthzEndpoint` passes
- [ ] `go test ./pkg/api/errors/...` passes