### PR TITLE
fix: preserve trailing slash in service invocation via dapr-app-id header

### DIFF
--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -357,13 +357,24 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// cleanPath normalizes a URL path using path.Clean while preserving a trailing slash
+// if the original path had one. path.Clean strips trailing slashes, which would cause
+// service invocation via the dapr-app-id header to drop intentional trailing slashes.
+func cleanPath(p string) string {
+	cleaned := strings.TrimPrefix(path.Clean(p), "/")
+	if strings.HasSuffix(p, "/") && cleaned != "" {
+		cleaned += "/"
+	}
+	return cleaned
+}
+
 // findTargetIDAndMethod finds ID of the target service and method from the following three places:
 // 1. HTTP header 'dapr-app-id' (path is method)
 // 2. Basic auth header: `http://dapr-app-id:<service-id>@localhost:3500/<method>`
 // 3. URL parameter: `http://localhost:3500/v1.0/invoke/<app-id>/method/<method>`
 func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string, method string) {
 	if appID := headers.Get(consts.DaprAppIDHeader); appID != "" {
-		targetID, method = appID, strings.TrimPrefix(path.Clean(reqPath), "/")
+		targetID, method = appID, cleanPath(reqPath)
 		// Delete the header as it should not be passed forward with the request and is only used by the Dapr API
 		headers.Del(consts.DaprAppIDHeader)
 		return targetID, method
@@ -373,7 +384,7 @@ func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string
 		if s, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic ")); err == nil {
 			pair := strings.Split(string(s), ":")
 			if len(pair) == 2 && strings.EqualFold(pair[0], consts.DaprAppIDHeader) {
-				return pair[1], strings.TrimPrefix(path.Clean(reqPath), "/")
+				return pair[1], cleanPath(reqPath)
 			}
 		}
 	}

--- a/pkg/api/http/directmessaging_test.go
+++ b/pkg/api/http/directmessaging_test.go
@@ -1074,6 +1074,9 @@ func TestFindTargetIDAndMethod(t *testing.T) {
 		{name: "path with https target escaped", path: "/v1.0/invoke/https%3A%2F%2Fexample.com/method/foo", wantTargetID: "https://example.com", wantMethod: "foo"},
 		{name: "path with https target partly escaped", path: "/v1.0/invoke/https%3A/%2Fexample.com/method/foo", wantTargetID: "https://example.com", wantMethod: "foo"},
 		{name: "extra slashes are removed", path: "///foo//bar", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar"},
+		{name: "trailing slash preserved with dapr-app-id header", path: "/foo/bar/", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar/"},
+		{name: "trailing slash preserved with basic auth", path: "/foo/bar/", headers: http.Header{"Authorization": []string{"Basic ZGFwci1hcHAtaWQ6YXV0aA=="}}, wantTargetID: "auth", wantMethod: "foo/bar/"},
+		{name: "trailing slash preserved with extra slashes in path", path: "///foo//bar/", headers: http.Header{"Dapr-App-Id": []string{"myapp"}}, wantTargetID: "myapp", wantMethod: "foo/bar/"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #7686

When invoking a service using the `dapr-app-id` request header or Basic auth, the path was normalized with `path.Clean` which strips trailing slashes as documented Go behavior. This caused endpoints that require a trailing slash to receive 404 responses, while the identical invocation via the `/v1.0/invoke/{appId}/method/{method}` URL path preserved the trailing slash correctly.

### Root cause

`findTargetIDAndMethod` in `pkg/api/http/directmessaging.go` calls `path.Clean(reqPath)` for the header and Basic auth paths, but not for the URL path. `path.Clean` returns `"The returned path ends in a slash only if it is the root "/"."` — so `/foo/bar/` becomes `/foo/bar`.

### Fix

Introduce `cleanPath()` that wraps `path.Clean` but restores the trailing slash if the original path had one. This preserves all existing normalization behavior (deduplication of slashes, `.` and `..` resolution) while keeping intentional trailing slashes.

```
path = "///foo//bar/"  →  cleanPath = "foo/bar/"   (extra slashes deduped, trailing slash preserved)
path = "///foo//bar"   →  cleanPath = "foo/bar"     (unchanged behavior for paths without trailing slash)
```

### Tests

Added 3 test cases to `TestFindTargetIDAndMethod`:
- `trailing slash preserved with dapr-app-id header`
- `trailing slash preserved with basic auth`
- `trailing slash preserved with extra slashes in path`