### PR TITLE
Fix 'sucessful' typo in scheduler.proto comment

### DIFF
--- a/dapr/proto/scheduler/v1/scheduler.proto
+++ b/dapr/proto/scheduler/v1/scheduler.proto
@@ -125,7 +125,7 @@ message WatchJobsRequestInitial {
 }
 
 // WatchJobsRequestResultStatus is sent by clients to signal where the job
-// triggering was sucessful or failed, in which case should be handled by the
+// triggering was successful or failed, in which case should be handled by the
 // failure policy of the job.
 enum WatchJobsRequestResultStatus {
   // The job was processed successfully.

--- a/pkg/proto/scheduler/v1/scheduler.pb.go
+++ b/pkg/proto/scheduler/v1/scheduler.pb.go
@@ -72,7 +72,7 @@ func (JobTargetType) EnumDescriptor() ([]byte, []int) {
 }
 
 // WatchJobsRequestResultStatus is sent by clients to signal where the job
-// triggering was sucessful or failed, in which case should be handled by the
+// triggering was successful or failed, in which case should be handled by the
 // failure policy of the job.
 type WatchJobsRequestResultStatus int32
 


### PR DESCRIPTION
Comment-only typo fix: `sucessful` -> `successful` in `dapr/proto/scheduler/v1/scheduler.proto`. Also updated the generated `pkg/proto/scheduler/v1/scheduler.pb.go` to keep them in sync.

No behavior changes.