### PR TITLE
[1.17] fix service invocation path traversal ACL bypass

### DIFF
--- a/docs/release_notes/v1.17.5.md
+++ b/docs/release_notes/v1.17.5.md
@@ -1,0 +1,42 @@
+# Dapr 1.17.5
+
+This update contains a critical security fix:
+- [Security: Service invocation path traversal bypasses access control policies](#security-service-invocation-path-traversal-bypasses-access-control-policies)
+
+## Security: Service invocation path traversal bypasses access control policies
+
+### Problem
+
+Reserved URL characters and path traversal sequences in service invocation method paths could bypass access control policies.
+An attacker with access to the Dapr HTTP or gRPC API could invoke operations on a target application that the ACL was configured to deny.
+
+### Impact
+
+Any deployment using access control policies for service invocation is affected. An attacker who can reach the Dapr API (HTTP or gRPC) could:
+
+- Use encoded path traversal (`admin%2F..%2Fpublic`) to reach an allowed path (`/public`) while the method started from a denied prefix (`/admin`).
+- Use encoded fragment (`%23`) or query (`%3F`) characters to cause the ACL to evaluate a different path than what was delivered to the target application.
+- Use a bare `%` to crash the ACL normalization, potentially bypassing the policy entirely.
+
+The gRPC API was the more dangerous vector because gRPC passes the method as a raw string with no client-side URL sanitization — `#`, `?`, `%`, `../`, and control characters were all delivered literally.
+
+### Root Cause
+
+The method path was normalized independently in two places:
+
+1. The ACL used `purell.NormalizeURLString` which treated the method as a URL — decoding `%XX`, resolving `../`, and stripping `#` as a fragment delimiter and `?` as a query delimiter.
+2. The dispatch layer (`constructRequest` for HTTP, gRPC passthrough) used the raw method string.
+
+This created a mismatch: the ACL authorized one path while the target application received a different one. For example, `admin%2F..%2Fpublic` was normalized by the ACL to `public` (allowed), but the target application received the raw `admin/../public`.
+
+### Solution
+
+The method path is now normalized at the service invocation edge — in `directMessaging.Invoke` for HTTP and gRPC public API calls, in `callLocalValidateACL` for gRPC internal calls, and in the gRPC proxy handler for proxied calls. The normalized form is used for both the ACL check and the outbound dispatch, eliminating the mismatch. The ACL is a pure policy evaluation layer and performs no normalization of its own.
+
+For HTTP, Go's `net/http` server decodes percent-encoding in `r.URL.Path` before the method is extracted. For gRPC, method strings are raw (no percent-decoding) and are treated as opaque — percent-encoded sequences like `%2F` are literal characters, not path separators.
+
+Normalization uses `path.Clean` to resolve `../` and duplicate slashes, and rejects method paths containing `#`, `?`, null bytes, or control characters. The `purell` dependency has been removed from the ACL path.
+
+As defense-in-depth, `constructRequest` in the HTTP channel applies `path.Clean` to the method before building the outbound URL.
+
+Users are strongly encouraged to upgrade to this release.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	connectrpc.com/connect v1.19.1
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/PaesslerAG/jsonpath v0.1.1
-	github.com/PuerkitoBio/purell v1.2.1
 	github.com/aavaz-ai/pii-scrubber v0.0.0-20220812094047-3fa450ab6973
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,6 @@ github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
-github.com/PuerkitoBio/purell v1.2.1 h1:QsZ4TjvwiMpat6gBCBxEQI0rcS9ehtkKtSpiUnd9N28=
-github.com/PuerkitoBio/purell v1.2.1/go.mod h1:ZwHcC/82TOaovDi//J/804umJFFmbOHPngi8iYYv/Eo=
 github.com/RoaringBitmap/roaring v1.1.0 h1:b10lZrZXaY6Q6EKIRrmOF519FIyQQ5anPgGr3niw2yY=
 github.com/RoaringBitmap/roaring v1.1.0/go.mod h1:icnadbWcNyfEHlYdr+tDlOTih1Bf/h+rzPpv4sbomAA=
 github.com/RoaringBitmap/roaring/v2 v2.8.0 h1:y1rdtixfXvaITKzkfiKvScI0hlBJHe9sfzJp8cgeM7w=

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/PuerkitoBio/purell"
-
 	"github.com/dapr/kit/logger"
 
 	"github.com/dapr/dapr/pkg/config"
@@ -141,14 +139,6 @@ func ParseAccessControlSpec(accessControlSpec *config.AccessControlSpec, isHTTP 
 	return &accessControlList, nil
 }
 
-func normalizeOperation(operation string) (string, error) {
-	s, err := purell.NormalizeURLString(operation, purell.FlagsUsuallySafeGreedy|purell.FlagRemoveDuplicateSlashes)
-	if err != nil {
-		return "", err
-	}
-	return s, nil
-}
-
 func ApplyAccessControlPolicies(ctx context.Context, operation string, httpVerb commonv1pb.HTTPExtension_Verb, isHTTP bool, acl *config.AccessControlList) (bool, string) {
 	// Apply access control list filter
 	spiffeID, ok, err := spiffe.FromGRPCContext(ctx)
@@ -162,18 +152,13 @@ func ApplyAccessControlPolicies(ctx context.Context, operation string, httpVerb 
 		log.Debugf("Error while reading spiffe id from client cert. applying default global policy action")
 	}
 
-	operation, err = normalizeOperation(operation)
-	var errMessage string
-
-	if err != nil {
-		errMessage = fmt.Sprintf("error in method normalization: %v", err)
-		log.Debugf(errMessage)
-		return false, errMessage
-	}
-
+	// The operation is expected to be already normalized by the caller
+	// (NormalizeMethod at the service invocation entry point). The ACL is a pure
+	// policy evaluation layer- it does not mutate its input.
 	action, actionPolicy := isOperationAllowedByAccessControlPolicy(spiffeID, operation, httpVerb, isHTTP, acl)
 	emitACLMetrics(spiffeID, actionPolicy, action)
 
+	var errMessage string
 	if !action {
 		errMessage = fmt.Sprintf("access control policy has denied access to id: %s operation: %s verb: %s", spiffeID.URL(), operation, httpVerb)
 		log.Debug(errMessage)

--- a/pkg/acl/acl_test.go
+++ b/pkg/acl/acl_test.go
@@ -624,60 +624,7 @@ func Test_isOperationAllowedByAccessControlPolicy(t *testing.T) {
 	})
 }
 
-func TestNormalizeOperation(t *testing.T) {
-	t.Run("normal path no slash", func(t *testing.T) {
-		p := "path"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "path", p)
-	})
-
-	t.Run("normal path caps", func(t *testing.T) {
-		p := "Path"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "Path", p)
-	})
-
-	t.Run("single slash", func(t *testing.T) {
-		p := "/path"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "/path", p)
-	})
-
-	t.Run("multiple slashes", func(t *testing.T) {
-		p := "///path"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "/path", p)
-	})
-
-	t.Run("prefix", func(t *testing.T) {
-		p := "../path"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "path", p)
-	})
-
-	t.Run("encoded", func(t *testing.T) {
-		p := "path%72"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "pathr", p)
-	})
-
-	t.Run("normal multiple paths", func(t *testing.T) {
-		p := "path1/path2/path3"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "path1/path2/path3", p)
-	})
-
-	t.Run("normal multiple paths leading slash", func(t *testing.T) {
-		p := "/path1/path2/path3"
-		p, _ = normalizeOperation(p)
-
-		assert.Equal(t, "/path1/path2/path3", p)
-	})
-}
+// normalizeOperation was removed — the ACL no longer normalizes at
+// runtime. Normalization is the responsibility of the service invocation
+// entry points (NormalizeMethod). The behavior previously tested here is
+// covered by pkg/method.TestNormalizeMethod.

--- a/pkg/actors/targets/app/app.go
+++ b/pkg/actors/targets/app/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors/internal/key"
 	"github.com/dapr/dapr/pkg/actors/targets/app/lock"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/dapr/pkg/messaging/method"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
@@ -152,7 +153,10 @@ func (a *app) doInvokeMethod(ctx context.Context, req *internalv1pb.InternalInvo
 }
 
 func (a *app) InvokeReminder(ctx context.Context, reminder *api.Reminder) error {
-	invokeMethod := "remind/" + reminder.Name
+	invokeMethod, err := method.NormalizeMethod("remind/" + reminder.Name)
+	if err != nil {
+		return fmt.Errorf("invalid reminder name: %w", err)
+	}
 	data, err := json.Marshal(&api.ReminderResponse{
 		DueTime: reminder.DueTime,
 		Period:  reminder.Period.String(),
@@ -181,7 +185,10 @@ func (a *app) InvokeReminder(ctx context.Context, reminder *api.Reminder) error 
 }
 
 func (a *app) InvokeTimer(ctx context.Context, reminder *api.Reminder) error {
-	invokeMethod := "timer/" + reminder.Name
+	invokeMethod, err := method.NormalizeMethod("timer/" + reminder.Name)
+	if err != nil {
+		return fmt.Errorf("invalid timer name: %w", err)
+	}
 	data, err := json.Marshal(&api.TimerResponse{
 		Callback: reminder.Callback,
 		Data:     reminder.Data,

--- a/pkg/api/grpc/daprinternal.go
+++ b/pkg/api/grpc/daprinternal.go
@@ -33,6 +33,7 @@ import (
 	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 	"github.com/dapr/dapr/pkg/messages"
 	"github.com/dapr/dapr/pkg/messaging"
+	"github.com/dapr/dapr/pkg/messaging/method"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
@@ -372,11 +373,24 @@ func (a *api) CallActorStream(req *internalv1pb.InternalInvokeRequest, stream in
 	return nil
 }
 
-// Used by CallLocal and CallLocalStream to check the request against the access control list
+// Used by CallLocal and CallLocalStream to check the request against the access control list.
+// The method is normalized (forbidden characters rejected, path traversal resolved) as
+// defense-in-depth before ACL evaluation. The normalized form is written back to the
+// request so dispatch uses the same canonical string.
 func (a *api) callLocalValidateACL(ctx context.Context, req *invokev1.InvokeMethodRequest) error {
+	// Normalize method as defense-in-depth (caller should have already normalized).
+	operation := req.Message().GetMethod()
+	normalized, err := method.NormalizeMethod(operation)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid method: %v", err)
+	}
+	if normalized != operation {
+		req.Message().Method = normalized
+		operation = normalized
+	}
+
 	if a.accessControlList != nil {
 		// An access control policy has been specified for the app. Apply the policies.
-		operation := req.Message().GetMethod()
 		var httpVerb commonv1pb.HTTPExtension_Verb //nolint:nosnakecase
 		// Get the HTTP verb in case the application protocol is "http"
 		appProtocolIsHTTP := a.Universal.AppConnectionConfig().Protocol.IsHTTP()

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -55,6 +55,7 @@ import (
 	"github.com/dapr/dapr/pkg/encryption"
 	"github.com/dapr/dapr/pkg/messages"
 	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	"github.com/dapr/dapr/pkg/messaging/method"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/outbox"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
@@ -1182,6 +1183,22 @@ func (a *api) InvokeActor(ctx context.Context, in *runtimev1pb.InvokeActorReques
 		in.Metadata = make(map[string]string)
 	}
 	in.Metadata["Dapr-API-Call"] = "true"
+
+	for _, param := range []struct{ name, val string }{
+		{"actorType", in.GetActorType()}, {"actorId", in.GetActorId()},
+	} {
+		if vErr := method.ValidateName(param.val); vErr != nil {
+			apiServerLogger.Debug(vErr)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %v", param.name, vErr)
+		}
+	}
+
+	normalized, err := method.NormalizeMethod(in.GetMethod())
+	if err != nil {
+		apiServerLogger.Debug(err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid actor method: %v", err)
+	}
+	in.Method = normalized
 
 	req := in.ToInternalInvokeRequest()
 

--- a/pkg/api/http/actors.go
+++ b/pkg/api/http/actors.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -34,6 +35,7 @@ import (
 	"github.com/dapr/dapr/pkg/api/http/endpoints"
 	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 	"github.com/dapr/dapr/pkg/messages"
+	methodutil "github.com/dapr/dapr/pkg/messaging/method"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
@@ -184,7 +186,14 @@ func (a *api) onCreateActorReminder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req.Name = chi.URLParamFromCtx(ctx, nameParam)
+	name := chi.URLParamFromCtx(ctx, nameParam)
+	if vErr := methodutil.ValidateName(name); vErr != nil {
+		msg := messages.ErrBadRequest.WithFormat(vErr)
+		respondWithError(w, msg)
+		log.Debug(msg)
+		return
+	}
+	req.Name = name
 	req.ActorType = chi.URLParamFromCtx(ctx, actorTypeParam)
 	req.ActorID = chi.URLParamFromCtx(ctx, actorIDParam)
 
@@ -232,7 +241,14 @@ func (a *api) onCreateActorTimer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req.Name = chi.URLParamFromCtx(ctx, nameParam)
+	name := chi.URLParamFromCtx(ctx, nameParam)
+	if vErr := methodutil.ValidateName(name); vErr != nil {
+		msg := messages.ErrBadRequest.WithFormat(vErr)
+		respondWithError(w, msg)
+		log.Debug(msg)
+		return
+	}
+	req.Name = name
 	req.ActorType = chi.URLParamFromCtx(ctx, actorTypeParam)
 	req.ActorID = chi.URLParamFromCtx(ctx, actorIDParam)
 
@@ -389,8 +405,24 @@ func (a *api) onDirectActorMessage(w http.ResponseWriter, r *http.Request) {
 
 	actorType := chi.URLParamFromCtx(ctx, actorTypeParam)
 	actorID := chi.URLParamFromCtx(ctx, actorIDParam)
+	for _, param := range []struct{ name, val string }{
+		{"actorType", actorType}, {"actorId", actorID},
+	} {
+		if vErr := methodutil.ValidateName(param.val); vErr != nil {
+			msg := messages.ErrBadRequest.WithFormat(fmt.Sprintf("invalid %s: %v", param.name, vErr))
+			respondWithError(w, msg)
+			log.Debug(msg)
+			return
+		}
+	}
 	verb := strings.ToUpper(r.Method)
-	method := chi.URLParamFromCtx(ctx, methodParam)
+	method, err := methodutil.NormalizeMethod(chi.URLParamFromCtx(ctx, methodParam))
+	if err != nil {
+		msg := messages.ErrBadRequest.WithFormat(err)
+		respondWithError(w, msg)
+		log.Debug(msg)
+		return
+	}
 
 	// Actor invocation doesn't support streaming, so we need to read the entire reqBody
 	reqBody, err := io.ReadAll(r.Body)

--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -95,13 +95,10 @@ func (a *api) constructDirectMessagingEndpoints() []endpoints.Endpoint {
 }
 
 func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
-	// RawPath could be empty
-	reqPath := r.URL.RawPath
-	if reqPath == "" {
-		reqPath = r.URL.Path
-	}
-
-	targetID, invokeMethodName := findTargetIDAndMethod(reqPath, r.Header)
+	// Use Path (decoded) rather than RawPath so that percent-encoded characters
+	// are resolved before method extraction. This ensures the method string
+	// used for ACL evaluation and dispatch is the decoded canonical form.
+	targetID, invokeMethodName := findTargetIDAndMethod(r.URL.Path, r.Header)
 	if targetID == "" {
 		respondWithError(w, messages.ErrDirectInvokeNoAppID)
 		return
@@ -396,7 +393,10 @@ func findTargetIDAndMethod(reqPath string, headers http.Header) (targetID string
 		// - `http%3A%2F%2Fexample.com/method/mymethod`
 		if idx = strings.Index(reqPath, "/method/"); idx > 0 {
 			targetID := reqPath[:idx]
-			method := reqPath[(idx + len("/method/")):]
+			method := path.Clean(reqPath[(idx + len("/method/")):])
+			if method == "." {
+				method = ""
+			}
 			if t, _ := url.QueryUnescape(targetID); t != "" {
 				targetID = t
 			}

--- a/pkg/api/universal/actors.go
+++ b/pkg/api/universal/actors.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/reminders"
 	"github.com/dapr/dapr/pkg/messages"
+	"github.com/dapr/dapr/pkg/messaging/method"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/kit/ptr"
 )
@@ -53,6 +54,12 @@ func (a *Universal) RegisterActorTimer(ctx context.Context, in *runtimev1pb.Regi
 			a.logger.Debug(err)
 			return nil, err
 		}
+	}
+
+	if vErr := method.ValidateName(in.GetName()); vErr != nil {
+		vErr = messages.ErrBadRequest.WithFormat(vErr)
+		a.logger.Debug(vErr)
+		return nil, vErr
 	}
 
 	req := &api.CreateTimerRequest{
@@ -112,6 +119,12 @@ func (a *Universal) RegisterActorReminder(ctx context.Context, in *runtimev1pb.R
 			a.logger.Debug(err)
 			return nil, err
 		}
+	}
+
+	if vErr := method.ValidateName(in.GetName()); vErr != nil {
+		vErr = messages.ErrBadRequest.WithFormat(vErr)
+		a.logger.Debug(vErr)
+		return nil, vErr
 	}
 
 	//nolint:protogetter

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -560,7 +561,13 @@ func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMeth
 	// Construct app channel URI: VERB http://localhost:3000/method?query1=value1
 	msg := req.Message()
 	verb := msg.GetHttpExtension().GetVerb().String()
-	method := msg.GetMethod()
+	// Defense-in-depth: resolve path traversal before building the outbound
+	// URL. The caller should have already normalized via NormalizeMethod, but
+	// we apply path.Clean here to guarantee no ../ reaches the target app.
+	method := path.Clean(msg.GetMethod())
+	if method == "." {
+		method = ""
+	}
 	var headers []commonapi.NameValuePair
 
 	uri := strings.Builder{}

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dapr/dapr/pkg/channel"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
+	"github.com/dapr/dapr/pkg/messaging/method"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
@@ -151,6 +152,17 @@ func (d *directMessaging) Close() error {
 
 // Invoke takes a message requests and invokes an app, either local or remote.
 func (d *directMessaging) Invoke(ctx context.Context, targetAppID string, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
+	// Normalize the method at the service invocation edge: reject forbidden
+	// characters and resolve path traversal. The normalized form is used for
+	// both ACL evaluation and dispatch to the target app.
+	if msg := req.Message(); msg != nil {
+		normalized, normErr := method.NormalizeMethod(msg.GetMethod())
+		if normErr != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid method: %v", normErr)
+		}
+		msg.Method = normalized
+	}
+
 	app, err := d.getRemoteApp(ctx, targetAppID)
 	if err != nil {
 		return nil, err

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dapr/dapr/pkg/api/grpc/proxy/codec"
 	"github.com/dapr/dapr/pkg/config"
 	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
+	"github.com/dapr/dapr/pkg/messaging/method"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/proto/common/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
@@ -121,6 +122,13 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 	}
 
 	if isLocal {
+		// Normalize the method before ACL evaluation and dispatch.
+		normalizedName, normErr := method.NormalizeMethod(fullName)
+		if normErr != nil {
+			return ctx, nil, nil, nopTeardown, status.Errorf(codes.InvalidArgument, "invalid method: %v", normErr)
+		}
+		fullName = normalizedName
+
 		// proxy locally to the app
 		if p.acl != nil {
 			ok, authError := acl.ApplyAccessControlPolicies(ctx, fullName, common.HTTPExtension_NONE, false, p.acl) //nolint:nosnakecase

--- a/pkg/messaging/method/normalize.go
+++ b/pkg/messaging/method/normalize.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package method
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// ValidateName checks that a name (e.g. reminder or timer name) does not
+// contain characters that could cause path traversal or injection when the
+// name is embedded in a URL path. Unlike NormalizeMethod, this rejects any
+// name containing '/' or '\' since names are identifiers, not paths.
+func ValidateName(name string) error {
+	if strings.ContainsAny(name, "#?\x00/\\") {
+		return fmt.Errorf("name contains forbidden character: %q", name)
+	}
+	for i := range name {
+		b := name[i]
+		if b < 0x20 || b == 0x7f {
+			return fmt.Errorf("name contains control character at position %d: %q", i, name)
+		}
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("name is a path traversal sequence: %q", name)
+	}
+	return nil
+}
+
+// NormalizeMethod validates and cleans a service invocation method name.
+// It rejects methods containing '#', '?', null bytes, or control characters
+// (bytes 0x01-0x1f and 0x7f), then resolves path traversal via path.Clean.
+// The caller is responsible for percent-decoding (for HTTP) before calling.
+func NormalizeMethod(method string) (string, error) {
+	if strings.ContainsAny(method, "#?\x00") {
+		return "", fmt.Errorf("method contains forbidden character: %q", method)
+	}
+
+	// Reject control characters (0x01-0x1f and 0x7f DEL).
+	for i := range method {
+		b := method[i]
+		if b < 0x20 || b == 0x7f {
+			return "", fmt.Errorf("method contains control character at position %d: %q", i, method)
+		}
+	}
+
+	// Resolve path traversal sequences.
+	cleaned := path.Clean(method)
+
+	// path.Clean on rootless paths can leave leading "../" — strip them.
+	for strings.HasPrefix(cleaned, "../") {
+		cleaned = cleaned[3:]
+	}
+	if cleaned == ".." {
+		cleaned = ""
+	}
+	// path.Clean converts empty to "."
+	if cleaned == "." {
+		cleaned = ""
+	}
+
+	return cleaned, nil
+}

--- a/pkg/messaging/method/normalize_test.go
+++ b/pkg/messaging/method/normalize_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package method
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeMethod(t *testing.T) {
+	t.Run("rejects hash", func(t *testing.T) {
+		_, err := NormalizeMethod("test#stream")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects question mark", func(t *testing.T) {
+		_, err := NormalizeMethod("test?stream")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects null byte", func(t *testing.T) {
+		_, err := NormalizeMethod("test\x00stream")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects control characters", func(t *testing.T) {
+		_, err := NormalizeMethod("test\x01stream")
+		require.Error(t, err)
+		_, err = NormalizeMethod("test\tstream")
+		require.Error(t, err)
+		_, err = NormalizeMethod("test\nstream")
+		require.Error(t, err)
+		_, err = NormalizeMethod("test\rstream")
+		require.Error(t, err)
+	})
+
+	t.Run("allows percent", func(t *testing.T) {
+		got, err := NormalizeMethod("test%stream")
+		require.NoError(t, err)
+		assert.Equal(t, "test%stream", got)
+	})
+
+	t.Run("allows percent-encoded sequences as raw", func(t *testing.T) {
+		got, err := NormalizeMethod("test%25stream")
+		require.NoError(t, err)
+		assert.Equal(t, "test%25stream", got)
+	})
+
+	t.Run("allows double quote", func(t *testing.T) {
+		got, err := NormalizeMethod(`test"stream`)
+		require.NoError(t, err)
+		assert.Equal(t, `test"stream`, got)
+	})
+
+	t.Run("allows asterisk", func(t *testing.T) {
+		got, err := NormalizeMethod("test*stream")
+		require.NoError(t, err)
+		assert.Equal(t, "test*stream", got)
+	})
+
+	t.Run("allows backslash", func(t *testing.T) {
+		got, err := NormalizeMethod(`test\stream`)
+		require.NoError(t, err)
+		assert.Equal(t, `test\stream`, got)
+	})
+
+	t.Run("resolves traversal", func(t *testing.T) {
+		got, err := NormalizeMethod("admin/../public")
+		require.NoError(t, err)
+		assert.Equal(t, "public", got)
+	})
+
+	t.Run("resolves leading traversal", func(t *testing.T) {
+		got, err := NormalizeMethod("../../etc/passwd")
+		require.NoError(t, err)
+		assert.Equal(t, "etc/passwd", got)
+	})
+
+	t.Run("simple method unchanged", func(t *testing.T) {
+		got, err := NormalizeMethod("mymethod")
+		require.NoError(t, err)
+		assert.Equal(t, "mymethod", got)
+	})
+
+	t.Run("method with slashes", func(t *testing.T) {
+		got, err := NormalizeMethod("api/v1/users")
+		require.NoError(t, err)
+		assert.Equal(t, "api/v1/users", got)
+	})
+}
+
+func TestValidateName(t *testing.T) {
+	t.Run("rejects forward slash", func(t *testing.T) {
+		require.Error(t, ValidateName("../../method/evil"))
+	})
+
+	t.Run("rejects backslash", func(t *testing.T) {
+		require.Error(t, ValidateName(`test\evil`))
+	})
+
+	t.Run("rejects hash", func(t *testing.T) {
+		require.Error(t, ValidateName("test#stream"))
+	})
+
+	t.Run("rejects question mark", func(t *testing.T) {
+		require.Error(t, ValidateName("test?redirect=evil"))
+	})
+
+	t.Run("rejects null byte", func(t *testing.T) {
+		require.Error(t, ValidateName("test\x00evil"))
+	})
+
+	t.Run("rejects carriage return", func(t *testing.T) {
+		require.Error(t, ValidateName("test\revil"))
+	})
+
+	t.Run("rejects double-dot", func(t *testing.T) {
+		require.Error(t, ValidateName(".."))
+	})
+
+	t.Run("rejects single dot", func(t *testing.T) {
+		require.Error(t, ValidateName("."))
+	})
+
+	t.Run("allows simple name", func(t *testing.T) {
+		require.NoError(t, ValidateName("myreminder"))
+	})
+
+	t.Run("allows name with hyphens", func(t *testing.T) {
+		require.NoError(t, ValidateName("my-reminder-1"))
+	})
+
+	t.Run("allows name with dots", func(t *testing.T) {
+		require.NoError(t, ValidateName("my.reminder"))
+	})
+
+	t.Run("allows percent", func(t *testing.T) {
+		require.NoError(t, ValidateName("test%25stream"))
+	})
+}

--- a/tests/integration/suite/actors/call/acl.go
+++ b/tests/integration/suite/actors/call/acl.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package call
+
+import (
+	"context"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(actorACL))
+}
+
+// actorACL verifies that path traversal in actor method names cannot escape
+// the /actors/{type}/{id}/method/ prefix to reach non-actor endpoints on
+// the app.
+type actorACL struct {
+	app *actors.Actors
+
+	secretHits atomic.Int64
+	rootHits   atomic.Int64
+}
+
+func (a *actorACL) Setup(t *testing.T) []framework.Option {
+	a.app = actors.New(t,
+		actors.WithActorTypes("mytype"),
+		actors.WithActorTypeHandler("mytype", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			w.Write([]byte("actor:" + r.URL.Path))
+		}),
+		actors.WithHandler("/secret", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			a.secretHits.Add(1)
+			w.Write([]byte("secret"))
+		}),
+		actors.WithHandler("/", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			if r.URL.Path == "/secret" {
+				a.secretHits.Add(1)
+			}
+			a.rootHits.Add(1)
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.app),
+	}
+}
+
+func (a *actorACL) Run(t *testing.T, ctx context.Context) {
+	a.app.WaitUntilRunning(t, ctx)
+	a.app.Placement().WaitUntilRunning(t, ctx)
+
+	grpcClient := a.app.GRPCClient(t, ctx)
+	httpClient := client.HTTP(t)
+
+	a.secretHits.Store(0)
+	a.rootHits.Store(0)
+
+	grpcInvoke := func(t *testing.T, method string) error {
+		t.Helper()
+		_, err := grpcClient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Method:    method,
+		})
+		return err
+	}
+
+	httpInvoke := func(t *testing.T, methodSuffix string) int {
+		t.Helper()
+		url := fmt.Sprintf(
+			"http://%s/v1.0/actors/mytype/1/method/%s",
+			a.app.Daprd().HTTPAddress(),
+			methodSuffix,
+		)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		io.ReadAll(resp.Body)
+		return resp.StatusCode
+	}
+
+	// gRPC: path traversal that would escape actor prefix.
+	// Without NormalizeMethod, "../../../../secret" would build:
+	// actors/mytype/1/method/../../../../secret → path.Clean → /secret
+	// With NormalizeMethod, it resolves to "secret" before path construction:
+	// actors/mytype/1/method/secret → stays within actor prefix.
+
+	t.Run("grpc: deep traversal to /secret", func(t *testing.T) {
+		// NormalizeMethod resolves ../../../../secret → secret.
+		// The app receives /actors/mytype/1/method/secret, not /secret.
+		err := grpcInvoke(t, "../../../../secret")
+		require.NoError(t, err)
+	})
+
+	t.Run("grpc: traversal with method prefix escape", func(t *testing.T) {
+		err := grpcInvoke(t, "../../../secret")
+		require.NoError(t, err)
+	})
+
+	t.Run("grpc: relative traversal to secret", func(t *testing.T) {
+		err := grpcInvoke(t, "foo/../../../secret")
+		require.NoError(t, err)
+	})
+
+	// HTTP: encoded traversal attempts.
+	t.Run("http: deep traversal to /secret", func(t *testing.T) {
+		status := httpInvoke(t, "..%2F..%2F..%2F..%2Fsecret")
+		assert.Equal(t, nethttp.StatusOK, status)
+	})
+
+	t.Run("http: traversal with method prefix escape", func(t *testing.T) {
+		status := httpInvoke(t, "..%2F..%2F..%2Fsecret")
+		assert.Equal(t, nethttp.StatusOK, status)
+	})
+
+	// Core invariant: the /secret handler must NEVER have been reached
+	// by any of the traversal attacks above.
+	t.Run("/secret handler was never reached", func(t *testing.T) {
+		assert.Equalf(t, int64(0), a.secretHits.Load(),
+			"/secret handler was hit %d times — actor method traversal escaped actor prefix!",
+			a.secretHits.Load())
+	})
+}

--- a/tests/integration/suite/actors/call/methodinjection.go
+++ b/tests/integration/suite/actors/call/methodinjection.go
@@ -1,0 +1,441 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package call
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(methodinjection))
+}
+
+type methodinjection struct {
+	app *actors.Actors
+
+	mu      sync.Mutex
+	lastURL string
+}
+
+func (m *methodinjection) Setup(t *testing.T) []framework.Option {
+	m.app = actors.New(t,
+		actors.WithActorTypes("mytype"),
+		actors.WithActorTypeHandler("mytype", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			m.mu.Lock()
+			m.lastURL = r.URL.Path + "|" + r.URL.RawQuery
+			m.mu.Unlock()
+			w.Write([]byte(r.URL.Path + "|" + r.URL.RawQuery))
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(m.app),
+	}
+}
+
+func (m *methodinjection) Run(t *testing.T, ctx context.Context) {
+	m.app.WaitUntilRunning(t, ctx)
+
+	grpcClient := m.app.GRPCClient(t, ctx)
+	httpClient := client.HTTP(t)
+
+	// Wait for actor placement to be ready.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := grpcClient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "mytype",
+			ActorId:   "warmup",
+			Method:    "ping",
+		})
+		assert.NoError(c, err)
+	}, time.Second*10, time.Millisecond*100)
+
+	httpInvoke := func(t *testing.T, methodSuffix string) (int, string) {
+		t.Helper()
+		url := fmt.Sprintf(
+			"http://%s/v1.0/actors/mytype/1/method/%s",
+			m.app.Daprd().HTTPAddress(),
+			methodSuffix,
+		)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return resp.StatusCode, string(body)
+	}
+
+	grpcInvoke := func(t *testing.T, method string) error {
+		t.Helper()
+		_, err := grpcClient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Method:    method,
+		})
+		return err
+	}
+
+	// gRPC: methods with forbidden characters are rejected by NormalizeMethod.
+	// gRPC passes the method as a raw string — no URL encoding.
+
+	t.Run("grpc: question mark rejected", func(t *testing.T) {
+		err := grpcInvoke(t, "legit?redirect=attacker.com")
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: hash rejected", func(t *testing.T) {
+		err := grpcInvoke(t, "legit#fragment")
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: null byte rejected", func(t *testing.T) {
+		err := grpcInvoke(t, "legit\x00evil")
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: carriage return rejected", func(t *testing.T) {
+		err := grpcInvoke(t, "legit\revil")
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: newline rejected", func(t *testing.T) {
+		err := grpcInvoke(t, "legit\nevil")
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: tab rejected", func(t *testing.T) {
+		err := grpcInvoke(t, "legit\tevil")
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: path traversal resolved", func(t *testing.T) {
+		err := grpcInvoke(t, "admin/../legit")
+		require.NoError(t, err)
+		m.mu.Lock()
+		got := m.lastURL
+		m.mu.Unlock()
+		// path.Clean resolves admin/../legit → legit. The actor framework
+		// prepends /actors/mytype/1/method/.
+		assert.Contains(t, got, "/method/legit|")
+		assert.NotContains(t, got, "..")
+	})
+
+	t.Run("grpc: safe method works", func(t *testing.T) {
+		err := grpcInvoke(t, "mymethod")
+		require.NoError(t, err)
+		m.mu.Lock()
+		got := m.lastURL
+		m.mu.Unlock()
+		assert.Contains(t, got, "/method/mymethod|")
+	})
+
+	// HTTP: Go's HTTP client percent-decodes the URL before sending.
+	// Characters like %3F decode to '?' which NormalizeMethod rejects.
+
+	t.Run("http: encoded question mark rejected", func(t *testing.T) {
+		// %3F decodes to '?' → NormalizeMethod rejects
+		status, _ := httpInvoke(t, "legit%3Fredirect=attacker.com")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: encoded hash rejected", func(t *testing.T) {
+		// %23 decodes to '#' → NormalizeMethod rejects
+		status, _ := httpInvoke(t, "legit%23fragment")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: encoded null byte rejected", func(t *testing.T) {
+		status, _ := httpInvoke(t, "legit%00evil")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: encoded carriage return rejected", func(t *testing.T) {
+		status, _ := httpInvoke(t, "legit%0Devil")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: traversal resolved", func(t *testing.T) {
+		status, body := httpInvoke(t, "admin%2F..%2Flegit")
+		assert.Equal(t, nethttp.StatusOK, status)
+		assert.Contains(t, body, "/method/legit|")
+		assert.NotContains(t, body, "..")
+	})
+
+	t.Run("http: safe method works", func(t *testing.T) {
+		status, body := httpInvoke(t, "mymethod")
+		assert.Equal(t, nethttp.StatusOK, status)
+		assert.Contains(t, body, "/method/mymethod|")
+	})
+
+	// Literal '?' in the HTTP URL is a query delimiter — the HTTP framework
+	// splits it before it reaches Dapr. The method is "legit" and query
+	// params are forwarded to the callee (standard HTTP behavior).
+	// The real attack vector is via gRPC where '?' is part of the method
+	// string — that case is blocked by NormalizeMethod above.
+	t.Run("http: literal question mark is query delimiter", func(t *testing.T) {
+		status, body := httpInvoke(t, "legit?redirect=attacker.com")
+		assert.Equal(t, nethttp.StatusOK, status)
+		// The method received by the app must be "legit", not
+		// "legit?redirect=attacker.com".
+		assert.Contains(t, body, "/method/legit|")
+	})
+
+	// Reminder and timer name injection tests.
+	// Reminder/timer names are concatenated into the actor method path as
+	// "remind/{name}" or "timer/{name}". A crafted name like
+	// "../../method/evil" would traverse to an arbitrary actor method.
+
+	httpCreateReminder := func(t *testing.T, name string) int {
+		t.Helper()
+		url := fmt.Sprintf(
+			"http://%s/v1.0/actors/mytype/1/reminders/%s",
+			m.app.Daprd().HTTPAddress(),
+			name,
+		)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url,
+			bytes.NewReader([]byte(`{"dueTime":"1000s","period":"1000s"}`)))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		io.ReadAll(resp.Body)
+		return resp.StatusCode
+	}
+
+	httpCreateTimer := func(t *testing.T, name string) int {
+		t.Helper()
+		url := fmt.Sprintf(
+			"http://%s/v1.0/actors/mytype/1/timers/%s",
+			m.app.Daprd().HTTPAddress(),
+			name,
+		)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url,
+			bytes.NewReader([]byte(`{"dueTime":"1000s","period":"1000s"}`)))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		io.ReadAll(resp.Body)
+		return resp.StatusCode
+	}
+
+	// Reminder name injection via gRPC.
+	t.Run("grpc: reminder traversal name rejected", func(t *testing.T) {
+		_, err := grpcClient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Name:      "../../method/evil",
+			DueTime:   "1000s",
+			Period:    "1000s",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: reminder question mark rejected", func(t *testing.T) {
+		_, err := grpcClient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Name:      "legit?redirect=evil",
+			DueTime:   "1000s",
+			Period:    "1000s",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: reminder carriage return rejected", func(t *testing.T) {
+		_, err := grpcClient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Name:      "legit\revil",
+			DueTime:   "1000s",
+			Period:    "1000s",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: reminder safe name works", func(t *testing.T) {
+		_, err := grpcClient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Name:      "myreminder",
+			DueTime:   "1000s",
+			Period:    "1000s",
+		})
+		require.NoError(t, err)
+	})
+
+	// Timer name injection via gRPC.
+	t.Run("grpc: timer traversal name rejected", func(t *testing.T) {
+		_, err := grpcClient.RegisterActorTimer(ctx, &rtv1.RegisterActorTimerRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Name:      "../../method/evil",
+			DueTime:   "1000s",
+			Period:    "1000s",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: timer question mark rejected", func(t *testing.T) {
+		_, err := grpcClient.RegisterActorTimer(ctx, &rtv1.RegisterActorTimerRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Name:      "legit?redirect=evil",
+			DueTime:   "1000s",
+			Period:    "1000s",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: timer safe name works", func(t *testing.T) {
+		_, err := grpcClient.RegisterActorTimer(ctx, &rtv1.RegisterActorTimerRequest{
+			ActorType: "mytype",
+			ActorId:   "1",
+			Name:      "mytimer",
+			DueTime:   "1000s",
+			Period:    "1000s",
+		})
+		require.NoError(t, err)
+	})
+
+	// Reminder name injection via HTTP.
+	t.Run("http: reminder traversal name rejected", func(t *testing.T) {
+		// %2F decodes to '/' — chi extracts "..%2F..%2Fmethod%2Fevil" which
+		// decodes to "../../method/evil" → NormalizeMethod rejects traversal.
+		status := httpCreateReminder(t, "..%2F..%2Fmethod%2Fevil")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: reminder question mark rejected", func(t *testing.T) {
+		status := httpCreateReminder(t, "legit%3Fredirect=evil")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: reminder carriage return rejected", func(t *testing.T) {
+		status := httpCreateReminder(t, "legit%0Devil")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: reminder safe name works", func(t *testing.T) {
+		status := httpCreateReminder(t, "myreminder-http")
+		assert.Equal(t, nethttp.StatusNoContent, status)
+	})
+
+	// Timer name injection via HTTP.
+	t.Run("http: timer traversal name rejected", func(t *testing.T) {
+		status := httpCreateTimer(t, "..%2F..%2Fmethod%2Fevil")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: timer question mark rejected", func(t *testing.T) {
+		status := httpCreateTimer(t, "legit%3Fredirect=evil")
+		assert.Equal(t, nethttp.StatusBadRequest, status)
+	})
+
+	t.Run("http: timer safe name works", func(t *testing.T) {
+		status := httpCreateTimer(t, "mytimer-http")
+		assert.Equal(t, nethttp.StatusNoContent, status)
+	})
+
+	// Actor ID injection tests.
+	// Actor IDs are concatenated into the path: actors/{type}/{id}/method/{method}
+	// A crafted ID could traverse out of the expected path structure.
+
+	t.Run("grpc: actor ID with traversal rejected", func(t *testing.T) {
+		err := grpcInvoke(t, "ping")
+		// Warm call to make sure placement is ready before switching IDs.
+		_ = err
+
+		_, err = grpcClient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "mytype",
+			ActorId:   "../../evil",
+			Method:    "ping",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: actor ID with slash rejected", func(t *testing.T) {
+		_, err := grpcClient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "mytype",
+			ActorId:   "id/traversal",
+			Method:    "ping",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: actor ID with question mark rejected", func(t *testing.T) {
+		_, err := grpcClient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "mytype",
+			ActorId:   "id?inject=true",
+			Method:    "ping",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("grpc: actor type with traversal rejected", func(t *testing.T) {
+		_, err := grpcClient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "../evil",
+			ActorId:   "1",
+			Method:    "ping",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("http: actor ID with traversal rejected", func(t *testing.T) {
+		url := fmt.Sprintf(
+			"http://%s/v1.0/actors/mytype/..%%2F..%%2Fevil/method/ping",
+			m.app.Daprd().HTTPAddress(),
+		)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		io.ReadAll(resp.Body)
+		assert.Equal(t, nethttp.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("http: actor ID with question mark rejected", func(t *testing.T) {
+		url := fmt.Sprintf(
+			"http://%s/v1.0/actors/mytype/id%%3Finject=true/method/ping",
+			m.app.Daprd().HTTPAddress(),
+		)
+		req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, url, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		io.ReadAll(resp.Body)
+		assert.Equal(t, nethttp.StatusBadRequest, resp.StatusCode)
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/fuzz.go
@@ -62,14 +62,24 @@ func (f *fuzzgrpc) Setup(t *testing.T) []framework.Option {
 	f.daprd1 = procdaprd.New(t, procdaprd.WithAppProtocol("grpc"), procdaprd.WithAppPort(srv.Port(t)))
 	f.daprd2 = procdaprd.New(t)
 
-	f.methods = make([]string, numTests)
 	f.bodies = make([][]byte, numTests)
 	f.queries = make([]map[string]string, numTests)
 	for i := range numTests {
 		fz := fuzz.New()
-		fz.NumElements(0, 100).Fuzz(&f.methods[i])
 		fz.NumElements(0, 100).Fuzz(&f.bodies[i])
 		fz.NumElements(0, 100).Fuzz(&f.queries[i])
+	}
+	// Generate method names that don't contain characters forbidden by
+	// NormalizeMethod (#, ?, %, \x00). Fuzzed strings frequently contain
+	// these, causing the test to fail on method validation rather than
+	// testing the actual invocation path.
+	f.methods = make([]string, 0, numTests)
+	for len(f.methods) < numTests {
+		var m string
+		fuzz.New().NumElements(0, 100).Fuzz(&m)
+		if !strings.ContainsAny(m, "#?%\x00") {
+			f.methods = append(f.methods, m)
+		}
 	}
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/grpc.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/grpc.go
@@ -16,4 +16,5 @@ package grpc
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/grpc/appapitoken"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/grpc/daprapitoken"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/grpc/reservedchars"
 )

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/reservedchars/acl.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/reservedchars/acl.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedchars
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	grpcapp "github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(acl))
+}
+
+type acl struct {
+	caller *procdaprd.Daprd
+	callee *procdaprd.Daprd
+}
+
+func (r *acl) Setup(t *testing.T) []framework.Option {
+	onInvoke := func(ctx context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
+		return &commonv1.InvokeResponse{
+			Data: &anypb.Any{Value: []byte(in.GetMethod())},
+		}, nil
+	}
+
+	srv := grpcapp.New(t, grpcapp.WithOnInvokeFn(onInvoke))
+
+	sen := sentry.New(t)
+	bundle := sen.CABundle()
+	taFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(taFile, bundle.X509.TrustAnchors, 0o600))
+
+	pl := placement.New(t,
+		placement.WithEnableTLS(true),
+		placement.WithTrustAnchorsFile(taFile),
+		placement.WithSentryAddress(sen.Address()),
+	)
+	sch := scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+
+	r.caller = procdaprd.New(t)
+	callerAppID := r.caller.AppID()
+
+	cnf := configapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Configuration"},
+		ObjectMeta: metav1.ObjectMeta{Name: "acl-config", Namespace: "default"},
+		Spec: configapi.ConfigurationSpec{
+			NameResolutionSpec: &configapi.NameResolutionSpec{Component: "mdns"},
+			MTLSSpec: &configapi.MTLSSpec{
+				ControlPlaneTrustDomain: "localhost",
+				SentryAddress:           sen.Address(),
+			},
+			AccessControlSpec: &configapi.AccessControlSpec{
+				DefaultAction: "deny",
+				TrustDomain:   "public",
+				AppPolicies: []configapi.AppPolicySpec{
+					{
+						AppName:       callerAppID,
+						DefaultAction: "deny",
+						TrustDomain:   "public",
+						Namespace:     "default",
+						AppOperationActions: []configapi.AppOperationAction{
+							{Operation: "/public", Action: "allow"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeapi := kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("localhost"),
+			"default",
+			sen.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationList(t, &configapi.ConfigurationList{
+			TypeMeta: metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "ConfigurationList"},
+			Items:    []configapi.Configuration{cnf},
+		}),
+	)
+
+	op := operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sen.TrustAnchorsFile(t)),
+	)
+
+	daprdOpts := func(extra ...procdaprd.Option) []procdaprd.Option {
+		opts := []procdaprd.Option{
+			procdaprd.WithConfigs("acl-config"),
+			procdaprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(bundle.X509.TrustAnchors))),
+			procdaprd.WithSentryAddress(sen.Address()),
+			procdaprd.WithEnableMTLS(true),
+			procdaprd.WithMode("kubernetes"),
+			procdaprd.WithPlacementAddresses(pl.Address()),
+			procdaprd.WithSchedulerAddresses(sch.Address()),
+			procdaprd.WithControlPlaneAddress(op.Address()),
+			procdaprd.WithDisableK8sSecretStore(true),
+			procdaprd.WithNamespace("default"),
+		}
+		return append(opts, extra...)
+	}
+
+	r.callee = procdaprd.New(t, daprdOpts(
+		procdaprd.WithAppProtocol("grpc"),
+		procdaprd.WithAppPort(srv.Port(t)),
+	)...)
+	r.caller = procdaprd.New(t, daprdOpts(
+		procdaprd.WithAppID(callerAppID),
+	)...)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, sen, kubeapi, pl, sch, op, r.callee, r.caller),
+	}
+}
+
+func (r *acl) Run(t *testing.T, ctx context.Context) {
+	r.caller.WaitUntilRunning(t, ctx)
+	r.callee.WaitUntilRunning(t, ctx)
+
+	//nolint:staticcheck
+	conn, err := grpc.DialContext(ctx, r.caller.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := rtv1.NewDaprClient(conn)
+
+	invoke := func(t *testing.T, method string) (sent string, body string, code codes.Code) {
+		t.Helper()
+		resp, err := client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
+			Id: r.callee.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method:        method,
+				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+			},
+		})
+		if err != nil {
+			return method, status.Convert(err).Message(), status.Convert(err).Code()
+		}
+		return method, string(resp.GetData().GetValue()), codes.OK
+	}
+
+	t.Run("allowed path succeeds", func(t *testing.T) {
+		sent, body, code := invoke(t, "public")
+		assert.Equalf(t, codes.OK, code, "caller sent %q, callee received: %s", sent, body)
+		assert.Equal(t, "public", body)
+	})
+
+	t.Run("denied path is rejected", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin")
+		assert.Equalf(t, codes.Internal.String(), code.String(), "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// gRPC passes the method as a raw string — no URL encoding, no fragment
+	// stripping, no query splitting. All characters reach Dapr literally.
+
+	// Methods containing #, ?, or \x00 are rejected by NormalizeMethod before
+	// ACL evaluation. The error is wrapped by ErrDirectInvoke as codes.Internal.
+
+	t.Run("hash in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin#stream")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("question mark in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin?stream")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// NormalizeMethod no longer decodes percent-encoding, so raw % is not
+	// forbidden. The method passes through to ACL as "admin%stream" which
+	// doesn't match /public → denied by ACL (Internal).
+	t.Run("percent in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin%stream")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// Plain path traversal is resolved before dispatch and ACL check.
+	// admin/../public resolves to "public" which is allowed by ACL.
+	t.Run("path traversal to allowed path", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin/../public")
+		assert.Equalf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+		assert.Equal(t, "public", body)
+	})
+
+	// admin/../../public resolves to "public" (extra ../ is clamped).
+	t.Run("double traversal to allowed path", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin/../../public")
+		assert.Equalf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+		assert.Equal(t, "public", body)
+	})
+
+	// public/../unauthorized resolves to "unauthorized" which is denied by ACL.
+	t.Run("traversal to arbitrary path", func(t *testing.T) {
+		sent, body, code := invoke(t, "public/../unauthorized")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// Methods with # are rejected by NormalizeMethod before ACL.
+	t.Run("hash hides traversal after allowed prefix", func(t *testing.T) {
+		sent, body, code := invoke(t, "public#/../admin")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// Methods with ? are rejected by NormalizeMethod before ACL.
+	t.Run("question mark hides traversal after allowed prefix", func(t *testing.T) {
+		sent, body, code := invoke(t, "public?/../admin")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// NormalizeMethod no longer decodes %, so raw % passes through.
+	// path.Clean("public%/../admin") → "admin". ACL denies → Internal.
+	t.Run("percent hides traversal after allowed prefix", func(t *testing.T) {
+		sent, body, code := invoke(t, "public%/../admin")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("null byte in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin\x00public")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// NormalizeMethod no longer decodes percent-encoding, so
+	// admin%2F..%2Fpublic stays as-is. path.Clean has no / to resolve.
+	// ACL sees /admin%2F..%2Fpublic → doesn't match /public → denied.
+	t.Run("encoded slash traversal", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin%2F..%2Fpublic")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("backslash traversal", func(t *testing.T) {
+		sent, body, code := invoke(t, `admin\..\public`)
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("multiple reserved characters", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin#?%bypass")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// Edge cases: characters/patterns that NormalizeMethod might miss.
+
+	t.Run("backslash traversal to allowed path", func(t *testing.T) {
+		// Go's path.Clean doesn't treat \ as separator but Windows backends do.
+		sent, body, code := invoke(t, `/admin\..\public`)
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("semicolon path parameter on allowed path", func(t *testing.T) {
+		// Spring/Java strip ;params before routing. If ACL matches /public
+		// literally, /public;evil wouldn't match → denied. But Java would
+		// route to /public.
+		sent, body, code := invoke(t, "/public;../../admin")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("tab in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "/admin\t/../public")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("newline in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "/admin\n/../public")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("carriage return in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "/admin\r/../public")
+		assert.NotEqualf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("unicode fullwidth solidus traversal", func(t *testing.T) {
+		// U+FF0F (／) looks like / but isn't. Some frameworks normalize it.
+		sent, body, code := invoke(t, "/admin\uff0f..\uff0fpublic")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("overlong utf8 slash", func(t *testing.T) {
+		// %C0%AF is overlong UTF-8 for /. Go doesn't decode it as / but some
+		// C-based backends do.
+		sent, body, code := invoke(t, "/admin\xc0\xaf..\xc0\xafpublic")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// NormalizeMethod no longer decodes percent-encoding, so %09/%0A/%0D
+	// are treated as literal printable characters. path.Clean resolves ../
+	// and the result reaches ACL as /public → allowed.
+	t.Run("encoded tab in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "/admin%09/../public")
+		assert.Equalf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body, "callee must receive clean path, not raw traversal")
+	})
+
+	t.Run("encoded newline in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "/admin%0A/../public")
+		assert.Equalf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body, "callee must receive clean path, not raw traversal")
+	})
+
+	t.Run("encoded carriage return in method", func(t *testing.T) {
+		sent, body, code := invoke(t, "/admin%0D/../public")
+		assert.Equalf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body, "callee must receive clean path, not raw traversal")
+	})
+
+	// Percent-encoded slashes (%2F) are literal characters in gRPC methods.
+	// NormalizeMethod does not decode percent-encoding, so path.Clean sees
+	// no '/' separators and cannot resolve traversal. The ACL must also
+	// treat them as literals (not decode them).
+
+	t.Run("encoded slash without traversal", func(t *testing.T) {
+		// admin%2Fpublic is a single opaque segment — no path separator.
+		// ACL sees /admin%2Fpublic → doesn't match /public → denied.
+		sent, body, code := invoke(t, "admin%2Fpublic")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("double encoded slash traversal", func(t *testing.T) {
+		// admin%2F..%2F..%2Fpublic is opaque — no real slashes for traversal.
+		sent, body, code := invoke(t, "admin%2F..%2F..%2Fpublic")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	t.Run("encoded slash from nested denied path", func(t *testing.T) {
+		// admin%2Fsecret%2F..%2F..%2Fpublic is opaque.
+		sent, body, code := invoke(t, "admin%2Fsecret%2F..%2F..%2Fpublic")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// Mixed literal and encoded slashes: the literal / is the only path
+	// separator. path.Clean resolves ../ relative to real segments.
+
+	t.Run("mixed literal and encoded slash traversal", func(t *testing.T) {
+		// admin%2Fsecret/../public → path.Clean sees one real '/' between
+		// "admin%2Fsecret" and ".." → resolves to "public" → ACL allows.
+		sent, body, code := invoke(t, "admin%2Fsecret/../public")
+		assert.Equalf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+		assert.Equal(t, "public", body)
+	})
+
+	t.Run("traversal with encoded slash to denied path", func(t *testing.T) {
+		// public/../admin%2Fsecret → resolves to "admin%2Fsecret" → denied.
+		sent, body, code := invoke(t, "public/../admin%2Fsecret")
+		assert.Equalf(t, codes.Internal, code, "caller sent method %q, callee received: %s", sent, body)
+	})
+
+	// Verify callee receives the normalized method, not the raw input.
+	t.Run("callee receives normalized method from traversal", func(t *testing.T) {
+		sent, body, code := invoke(t, "admin/../public")
+		assert.Equalf(t, codes.OK, code, "caller sent method %q, callee received: %s", sent, body)
+		// Callee should receive "public", not "admin/../public"
+		assert.Equal(t, "public", body)
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/reservedchars/aclbypass.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/reservedchars/aclbypass.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedchars
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(aclbypass))
+}
+
+type aclbypass struct {
+	caller           *procdaprd.Daprd
+	callee           *procdaprd.Daprd
+	unauthorizedHits *atomic.Int64
+}
+
+func (r *aclbypass) Setup(t *testing.T) []framework.Option {
+	var unauthorizedHits atomic.Int64
+	r.unauthorizedHits = &unauthorizedHits
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("path:" + req.URL.Path))
+	})
+	handler.HandleFunc("/unauthorized", func(w http.ResponseWriter, req *http.Request) {
+		unauthorizedHits.Add(1)
+		w.Write([]byte("unauthorized"))
+	})
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+
+	sen := sentry.New(t)
+	bundle := sen.CABundle()
+	taFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(taFile, bundle.X509.TrustAnchors, 0o600))
+
+	pl := placement.New(t,
+		placement.WithEnableTLS(true),
+		placement.WithTrustAnchorsFile(taFile),
+		placement.WithSentryAddress(sen.Address()),
+	)
+	sch := scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+
+	r.caller = procdaprd.New(t)
+	callerAppID := r.caller.AppID()
+
+	cnf := configapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Configuration"},
+		ObjectMeta: metav1.ObjectMeta{Name: "acl-config", Namespace: "default"},
+		Spec: configapi.ConfigurationSpec{
+			NameResolutionSpec: &configapi.NameResolutionSpec{Component: "mdns"},
+			MTLSSpec: &configapi.MTLSSpec{
+				ControlPlaneTrustDomain: "localhost",
+				SentryAddress:           sen.Address(),
+			},
+			AccessControlSpec: &configapi.AccessControlSpec{
+				DefaultAction: "deny",
+				TrustDomain:   "public",
+				AppPolicies: []configapi.AppPolicySpec{
+					{
+						AppName:       callerAppID,
+						DefaultAction: "deny",
+						TrustDomain:   "public",
+						Namespace:     "default",
+						AppOperationActions: []configapi.AppOperationAction{
+							{Operation: "/public", HTTPVerb: []string{"*"}, Action: "allow"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeapi := kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("localhost"),
+			"default",
+			sen.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationList(t, &configapi.ConfigurationList{
+			TypeMeta: metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "ConfigurationList"},
+			Items:    []configapi.Configuration{cnf},
+		}),
+	)
+
+	op := operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sen.TrustAnchorsFile(t)),
+	)
+
+	daprdOpts := func(extra ...procdaprd.Option) []procdaprd.Option {
+		opts := []procdaprd.Option{
+			procdaprd.WithConfigs("acl-config"),
+			procdaprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(bundle.X509.TrustAnchors))),
+			procdaprd.WithSentryAddress(sen.Address()),
+			procdaprd.WithEnableMTLS(true),
+			procdaprd.WithMode("kubernetes"),
+			procdaprd.WithPlacementAddresses(pl.Address()),
+			procdaprd.WithSchedulerAddresses(sch.Address()),
+			procdaprd.WithControlPlaneAddress(op.Address()),
+			procdaprd.WithDisableK8sSecretStore(true),
+			procdaprd.WithNamespace("default"),
+		}
+		return append(opts, extra...)
+	}
+
+	// Callee is an HTTP app — the method goes through constructRequest/URL parsing
+	r.callee = procdaprd.New(t, daprdOpts(procdaprd.WithAppPort(srv.Port()))...)
+	r.caller = procdaprd.New(t, daprdOpts(procdaprd.WithAppID(callerAppID))...)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, sen, kubeapi, pl, sch, op, r.callee, r.caller),
+	}
+}
+
+func (r *aclbypass) Run(t *testing.T, ctx context.Context) {
+	r.caller.WaitUntilRunning(t, ctx)
+	r.callee.WaitUntilRunning(t, ctx)
+
+	//nolint:staticcheck
+	conn, err := grpc.DialContext(ctx, r.caller.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := rtv1.NewDaprClient(conn)
+
+	invoke := func(t *testing.T, method string) (string, codes.Code) {
+		t.Helper()
+		resp, err := client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
+			Id: r.callee.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method:        method,
+				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+			},
+		})
+		if err != nil {
+			return status.Convert(err).Message(), status.Convert(err).Code()
+		}
+		return string(resp.GetData().GetValue()), codes.OK
+	}
+
+	t.Run("sanity: allowed path works", func(t *testing.T) {
+		body, code := invoke(t, "/public")
+		assert.Equal(t, codes.OK, code)
+		assert.Contains(t, body, "public")
+	})
+
+	t.Run("sanity: denied path rejected", func(t *testing.T) {
+		_, code := invoke(t, "/unauthorized")
+		assert.Equal(t, codes.Internal, code)
+	})
+
+	// NormalizeMethod no longer decodes percent-encoding. Via gRPC, %23 and
+	// %3F are literal characters (not # or ?). They pass NormalizeMethod.
+	// path.Clean resolves ../ and the result reaches ACL evaluation.
+
+	t.Run("encoded hash with traversal reaches unauthorized", func(t *testing.T) {
+		// /public%23/../unauthorized → path.Clean → /unauthorized → ACL denies
+		body, code := invoke(t, "/public%23/../unauthorized")
+		assert.Equalf(t, codes.Internal, code,
+			"should resolve to /unauthorized and be denied by ACL: callee received: %s", body)
+	})
+
+	t.Run("encoded question mark with traversal", func(t *testing.T) {
+		// /public%3F/../unauthorized → path.Clean → /unauthorized → ACL denies
+		body, code := invoke(t, "/public%3F/../unauthorized")
+		assert.Equalf(t, codes.Internal, code,
+			"should resolve to /unauthorized and be denied by ACL: callee received: %s", body)
+	})
+
+	t.Run("double dot with encoded hash", func(t *testing.T) {
+		// /public%23/../../unauthorized → path.Clean → /unauthorized → ACL denies
+		body, code := invoke(t, "/public%23/../../unauthorized")
+		assert.Equalf(t, codes.Internal, code,
+			"should resolve to /unauthorized and be denied by ACL: callee received: %s", body)
+	})
+
+	t.Run("nested path with encoded hash traversal", func(t *testing.T) {
+		// /public/sub%23/../../unauthorized → path.Clean → /unauthorized → ACL denies
+		body, code := invoke(t, "/public/sub%23/../../unauthorized")
+		assert.Equalf(t, codes.Internal, code,
+			"should resolve to /unauthorized and be denied by ACL: callee received: %s", body)
+	})
+
+	t.Run("carriage return with traversal", func(t *testing.T) {
+		// /public\r/../unauthorized → NormalizeMethod rejects \r (control char)
+		body, code := invoke(t, "/public\r/../unauthorized")
+		assert.NotEqualf(t, codes.OK, code,
+			"should be rejected — \\r is a control character: callee received: %s", body)
+	})
+
+	// Plain traversal (no forbidden chars) is resolved by path.Clean.
+	// /public/../unauthorized resolves to /unauthorized which is denied by ACL.
+	t.Run("plain traversal to unauthorized is denied by ACL", func(t *testing.T) {
+		body, code := invoke(t, "/public/../unauthorized")
+		assert.Equalf(t, codes.Internal, code,
+			"should resolve to /unauthorized and be denied by ACL: callee received: %s", body)
+	})
+
+	// Percent-encoded slash traversal via gRPC — the key attack vector.
+	// NormalizeMethod does NOT decode %2F for gRPC methods, so the ACL
+	// must also NOT decode them. Both sides must see the same literal string.
+
+	t.Run("encoded slash traversal to allowed path is denied", func(t *testing.T) {
+		// admin%2F..%2Fpublic is an opaque string with no real slashes.
+		// ACL must NOT decode %2F and treat it as traversal to /public.
+		body, code := invoke(t, "admin%2F..%2Fpublic")
+		assert.Equalf(t, codes.Internal, code,
+			"should NOT be allowed — %%2F must not be decoded by ACL: callee received: %s", body)
+	})
+
+	t.Run("double encoded slash traversal is denied", func(t *testing.T) {
+		body, code := invoke(t, "admin%2F..%2F..%2Fpublic")
+		assert.Equalf(t, codes.Internal, code,
+			"should NOT be allowed — %%2F must not be decoded by ACL: callee received: %s", body)
+	})
+
+	t.Run("encoded slash from nested path is denied", func(t *testing.T) {
+		body, code := invoke(t, "admin%2Fsecret%2F..%2F..%2Fpublic")
+		assert.Equalf(t, codes.Internal, code,
+			"should NOT be allowed — %%2F must not be decoded by ACL: callee received: %s", body)
+	})
+
+	// Prove the callee's /unauthorized handler was NEVER reached by any
+	// of the traversal attacks above. This is the core CVE invariant:
+	// if the ACL denies the request, the callee must not be invoked.
+	t.Run("callee /unauthorized handler was never reached", func(t *testing.T) {
+		assert.Equalf(t, int64(0), r.unauthorizedHits.Load(),
+			"the /unauthorized handler was hit %d times — ACL bypass detected!", r.unauthorizedHits.Load())
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/reservedchars/pathcorrectness.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/reservedchars/pathcorrectness.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedchars
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(pathcorrectness))
+}
+
+type pathcorrectness struct {
+	caller *procdaprd.Daprd
+	callee *procdaprd.Daprd
+}
+
+func (r *pathcorrectness) Setup(t *testing.T) []framework.Option {
+	onInvoke := func(ctx context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
+		return &commonv1.InvokeResponse{
+			Data: &anypb.Any{Value: []byte(in.GetMethod())},
+		}, nil
+	}
+
+	srv := app.New(t, app.WithOnInvokeFn(onInvoke))
+	r.callee = procdaprd.New(t,
+		procdaprd.WithAppProtocol("grpc"),
+		procdaprd.WithAppPort(srv.Port(t)),
+	)
+	r.caller = procdaprd.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, r.callee, r.caller),
+	}
+}
+
+func (r *pathcorrectness) Run(t *testing.T, ctx context.Context) {
+	r.caller.WaitUntilRunning(t, ctx)
+	r.callee.WaitUntilRunning(t, ctx)
+
+	//nolint:staticcheck
+	conn, err := grpc.DialContext(ctx, r.caller.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := rtv1.NewDaprClient(conn)
+
+	invoke := func(t *testing.T, method string) (string, codes.Code) {
+		t.Helper()
+		resp, err := client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
+			Id: r.callee.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method:        method,
+				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+			},
+		})
+		if err != nil {
+			return status.Convert(err).Message(), status.Convert(err).Code()
+		}
+		return string(resp.GetData().GetValue()), codes.OK
+	}
+
+	// Methods containing #, ?, or \x00 are rejected by NormalizeMethod.
+	// (% is no longer forbidden since NormalizeMethod no longer decodes.)
+	rejectedTests := []struct {
+		name   string
+		method string
+	}{
+		{name: "hash in method", method: "test#stream"},
+		{name: "question mark in method", method: "test?stream"},
+		{name: "null byte in method", method: "test\x00stream"},
+		{name: "carriage return in method", method: "test\rstream"},
+		{name: "multiple reserved characters", method: "a#b?c%d"},
+	}
+
+	for _, tt := range rejectedTests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, code := invoke(t, tt.method)
+			assert.NotEqualf(t, codes.OK, code,
+				"method %q should be rejected", tt.method)
+		})
+	}
+
+	// Safe characters pass through normally. NormalizeMethod no longer
+	// decodes percent-encoding, so % and percent-encoded sequences pass
+	// through as raw strings.
+	safeTests := []struct {
+		name           string
+		method         string
+		expectedMethod string
+	}{
+		{
+			name:           "double quote in method",
+			method:         `test"stream`,
+			expectedMethod: `test"stream`,
+		},
+		{
+			name:           "asterisk in method",
+			method:         "test*stream",
+			expectedMethod: "test*stream",
+		},
+		{
+			name:           "backslash in method",
+			method:         `test\stream`,
+			expectedMethod: `test\stream`,
+		},
+		{
+			name:           "percent in method",
+			method:         "test%stream",
+			expectedMethod: "test%stream",
+		},
+		{
+			name:           "encoded percent in method",
+			method:         "test%25stream",
+			expectedMethod: "test%25stream",
+		},
+	}
+
+	for _, tt := range safeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, code := invoke(t, tt.method)
+			assert.Equalf(t, codes.OK, code, "method %q should pass through normally", tt.method)
+			assert.Equalf(t, tt.expectedMethod, got,
+				"callee should receive the exact method string sent by caller via gRPC")
+		})
+	}
+
+	// Path traversal is resolved before dispatch; callee gets the clean path.
+	t.Run("path traversal", func(t *testing.T) {
+		got, code := invoke(t, "admin/../public")
+		assert.Equalf(t, codes.OK, code, "path traversal should be resolved, not rejected")
+		assert.Equalf(t, "public", got,
+			"callee should receive the resolved path, not the raw traversal")
+	})
+
+	// Percent-encoded slashes (%2F) are literal characters in gRPC.
+	// They are NOT decoded — callee receives them as-is.
+	t.Run("encoded slash preserved in method", func(t *testing.T) {
+		got, code := invoke(t, "test%2Fstream")
+		assert.Equalf(t, codes.OK, code, "method %q should pass through normally", "test%2Fstream")
+		assert.Equalf(t, "test%2Fstream", got,
+			"callee should receive literal %%2F, not a decoded slash")
+	})
+
+	t.Run("encoded slash traversal preserved literally", func(t *testing.T) {
+		// admin%2F..%2Fpublic has no real '/' — callee receives it as-is.
+		got, code := invoke(t, "admin%2F..%2Fpublic")
+		assert.Equalf(t, codes.OK, code, "method %q should pass through normally", "admin%2F..%2Fpublic")
+		assert.Equalf(t, "admin%2F..%2Fpublic", got,
+			"callee should receive literal percent-encoded slashes, not decoded")
+	})
+
+	t.Run("double traversal resolved", func(t *testing.T) {
+		got, code := invoke(t, "admin/../../public")
+		assert.Equalf(t, codes.OK, code, "double traversal should be resolved")
+		assert.Equalf(t, "public", got,
+			"extra ../ should be clamped, callee receives clean path")
+	})
+
+	t.Run("trailing slash cleaned", func(t *testing.T) {
+		got, code := invoke(t, "public/")
+		assert.Equalf(t, codes.OK, code, "trailing slash should be cleaned")
+		assert.Equalf(t, "public", got,
+			"trailing slash should be removed by path.Clean")
+	})
+
+	t.Run("duplicate slashes cleaned", func(t *testing.T) {
+		got, code := invoke(t, "api///v1///users")
+		assert.Equalf(t, codes.OK, code, "duplicate slashes should be cleaned")
+		assert.Equalf(t, "api/v1/users", got,
+			"duplicate slashes should be collapsed by path.Clean")
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/fuzz.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/fuzz.go
@@ -74,7 +74,7 @@ func (f *fuzzhttp) Setup(t *testing.T) []framework.Option {
 
 	var (
 		alphaNumeric     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-		pathChars        = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/#[]@!$'()+,=")
+		pathChars        = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/[]@!$'()+,=")
 		headerNameChars  = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
 		headerValueChars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789a_ :;.,\\/\"'?!(){}[]@<>=-+*#$&`|~^%")
 		queryChars       = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/#[]@!$&'()*+,=")

--- a/tests/integration/suite/daprd/serviceinvocation/http/http.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/http.go
@@ -15,5 +15,6 @@ package http
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/http/appapitoken"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/http/reservedchars"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/serviceinvocation/http/streaming"
 )

--- a/tests/integration/suite/daprd/serviceinvocation/http/reservedchars/acl.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/reservedchars/acl.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedchars
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(acl))
+}
+
+type acl struct {
+	caller *procdaprd.Daprd
+	callee *procdaprd.Daprd
+}
+
+func (r *acl) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(req.URL.Path))
+	})
+	handler.HandleFunc("/unauthorized", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("unauthorized"))
+	})
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+
+	sen := sentry.New(t)
+	bundle := sen.CABundle()
+	taFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(taFile, bundle.X509.TrustAnchors, 0o600))
+
+	pl := placement.New(t,
+		placement.WithEnableTLS(true),
+		placement.WithTrustAnchorsFile(taFile),
+		placement.WithSentryAddress(sen.Address()),
+	)
+	sch := scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+
+	// Create caller first so we know its appID for the ACL policy.
+	r.caller = procdaprd.New(t)
+	callerAppID := r.caller.AppID()
+
+	cnf := configapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Configuration"},
+		ObjectMeta: metav1.ObjectMeta{Name: "acl-config", Namespace: "default"},
+		Spec: configapi.ConfigurationSpec{
+			NameResolutionSpec: &configapi.NameResolutionSpec{Component: "mdns"},
+			MTLSSpec: &configapi.MTLSSpec{
+				ControlPlaneTrustDomain: "localhost",
+				SentryAddress:           sen.Address(),
+			},
+			AccessControlSpec: &configapi.AccessControlSpec{
+				DefaultAction: "deny",
+				TrustDomain:   "public",
+				AppPolicies: []configapi.AppPolicySpec{
+					{
+						AppName:       callerAppID,
+						DefaultAction: "deny",
+						TrustDomain:   "public",
+						Namespace:     "default",
+						AppOperationActions: []configapi.AppOperationAction{
+							{Operation: "/public", HTTPVerb: []string{"*"}, Action: "allow"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeapi := kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("localhost"),
+			"default",
+			sen.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationList(t, &configapi.ConfigurationList{
+			TypeMeta: metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "ConfigurationList"},
+			Items:    []configapi.Configuration{cnf},
+		}),
+	)
+
+	op := operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sen.TrustAnchorsFile(t)),
+	)
+
+	daprdOpts := func(appPort ...int) []procdaprd.Option {
+		opts := []procdaprd.Option{
+			procdaprd.WithConfigs("acl-config"),
+			procdaprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(bundle.X509.TrustAnchors))),
+			procdaprd.WithSentryAddress(sen.Address()),
+			procdaprd.WithEnableMTLS(true),
+			procdaprd.WithMode("kubernetes"),
+			procdaprd.WithPlacementAddresses(pl.Address()),
+			procdaprd.WithSchedulerAddresses(sch.Address()),
+			procdaprd.WithControlPlaneAddress(op.Address()),
+			procdaprd.WithDisableK8sSecretStore(true),
+			procdaprd.WithNamespace("default"),
+		}
+		if len(appPort) > 0 {
+			opts = append(opts, procdaprd.WithAppPort(appPort[0]))
+		}
+		return opts
+	}
+
+	r.callee = procdaprd.New(t, daprdOpts(srv.Port())...)
+	r.caller = procdaprd.New(t, append(daprdOpts(), procdaprd.WithAppID(callerAppID))...)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, sen, kubeapi, pl, sch, op, r.callee, r.caller),
+	}
+}
+
+func (r *acl) Run(t *testing.T, ctx context.Context) {
+	r.caller.WaitUntilRunning(t, ctx)
+	r.callee.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	invoke := func(t *testing.T, methodSuffix string) (int, string, string) {
+		t.Helper()
+		reqURL := fmt.Sprintf(
+			"http://localhost:%d/v1.0/invoke/%s/method/%s",
+			r.caller.HTTPPort(),
+			r.callee.AppID(),
+			methodSuffix,
+		)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return resp.StatusCode, string(body), reqURL
+	}
+
+	t.Run("allowed path succeeds", func(t *testing.T) {
+		status, body, sent := invoke(t, "public")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	t.Run("denied path is rejected", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	// NormalizeMethod rejects methods containing decoded #, ?, or % with
+	// HTTP 500 before ACL evaluation.
+
+	t.Run("hash cannot truncate path to bypass ACL", func(t *testing.T) {
+		// Go's HTTP client decodes %23 → '#' and resolves '../..' in the
+		// URL path before the request reaches the handler. The handler
+		// sees the resolved path ('admin'), not the raw attack payload.
+		// ACL correctly denies 'admin'.
+		status, body, sent := invoke(t, "public%23../../admin")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("question mark cannot inject query to bypass ACL", func(t *testing.T) {
+		// Decoded method contains '?' → rejected by NormalizeMethod.
+		status, body, sent := invoke(t, "admin%3Fignored")
+		assert.Equalf(t, http.StatusInternalServerError, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("percent in path does not bypass ACL", func(t *testing.T) {
+		// %25 decodes to literal '%' which is allowed per RFC 3986.
+		// The decoded path admin%stream is denied by ACL.
+		status, body, sent := invoke(t, "admin%25stream")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("quote in path does not bypass ACL", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin%22stream")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("asterisk in path does not match as wildcard", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin%2Astream")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("backslash in path does not bypass ACL", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin%5Cstream")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	// Path traversal is resolved before ACL check. Encoded slashes decode
+	// to real slashes, then ../ segments are resolved, and ACL sees the
+	// clean path. admin/../public resolves to /public which is allowed.
+
+	t.Run("encoded slash traversal resolves to allowed path", func(t *testing.T) {
+		// admin%2F..%2Fpublic decodes to admin/../public → resolves to /public → allowed.
+		status, body, sent := invoke(t, "admin%2F..%2Fpublic")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	t.Run("double encoded traversal resolves to allowed path", func(t *testing.T) {
+		// admin%2F..%2F..%2Fpublic decodes to admin/../../public → resolves to /public → allowed.
+		status, body, sent := invoke(t, "admin%2F..%2F..%2Fpublic")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	t.Run("encoded traversal from nested denied path resolves to allowed", func(t *testing.T) {
+		// admin%2Fsecret%2F..%2F..%2Fpublic decodes to admin/secret/../../public → resolves to /public → allowed.
+		status, body, sent := invoke(t, "admin%2Fsecret%2F..%2F..%2Fpublic")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	t.Run("encoded backslash traversal", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin%5C..%5Cpublic")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("mixed slash and backslash traversal", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin%2F..%5C..%2Fpublic")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("dot segment only traversal", func(t *testing.T) {
+		// ..%2Fpublic decodes to ../public → resolves to /public → allowed.
+		status, body, sent := invoke(t, "..%2Fpublic")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	t.Run("encoded null byte in path", func(t *testing.T) {
+		// %00 decodes to \x00 → rejected by NormalizeMethod.
+		status, body, sent := invoke(t, "admin%00public")
+		assert.Equalf(t, http.StatusInternalServerError, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("multiple reserved characters combined", func(t *testing.T) {
+		// %23%3F%25 decodes to #?% → rejected by NormalizeMethod.
+		status, body, sent := invoke(t, "admin%23%3F%25bypass")
+		assert.Equalf(t, http.StatusInternalServerError, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	// Go's HTTP stack decodes %23 → '#' and %3F → '?' which have URL
+	// semantics (fragment delimiter and query separator). Combined with
+	// '../' path traversal, the HTTP framework resolves the path before
+	// the handler. The handler sees the resolved path, and the ACL
+	// correctly denies it. The attack is blocked at 403, not 500.
+
+	t.Run("hash hides traversal after allowed prefix", func(t *testing.T) {
+		// HTTP client resolves decoded '#' and '../' → handler sees 'admin' → ACL denies.
+		status, body, sent := invoke(t, "public%23%2F..%2Fadmin")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("question mark hides traversal after allowed prefix", func(t *testing.T) {
+		// HTTP framework resolves decoded '?' and '../' → handler sees
+		// resolved path → ACL denies.
+		status, body, sent := invoke(t, "public%3F%2F..%2Fadmin")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("hash hides deep traversal to reach denied path", func(t *testing.T) {
+		// HTTP framework resolves '../' → handler sees denied path → ACL denies.
+		status, body, sent := invoke(t, "public%23%2F..%2F..%2Fsecret%2Fadmin")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("allowed prefix with hash then null byte and traversal", func(t *testing.T) {
+		// HTTP framework resolves traversal → handler sees resolved path → ACL denies.
+		status, body, sent := invoke(t, "public%23%00%2F..%2Fadmin")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("percent with traversal after allowed prefix", func(t *testing.T) {
+		// %25 decodes to literal '%' (allowed per RFC 3986).
+		// Full path: public%/../admin → path.Clean resolves to admin → denied.
+		status, body, sent := invoke(t, "public%25%2F..%2Fadmin")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	// Traversal with only encoded slashes (no #/?/%/\x00): resolves before
+	// ACL. public/../unauthorized resolves to /unauthorized which is denied by ACL.
+	t.Run("traversal reaches unrelated handler behind ACL", func(t *testing.T) {
+		status, body, sent := invoke(t, "public%2F..%2Funauthorized")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	// Literal (unencoded) characters — these test what a standard HTTP
+	// client sends when the raw character appears in the URL. The HTTP
+	// client interprets '#' as fragment (stripped) and '?' as query
+	// (splits path). These are the realistic attack vectors.
+
+	t.Run("literal hash strips path to allowed prefix", func(t *testing.T) {
+		// HTTP client strips '#../../admin' as fragment, sends just /public.
+		// The ACL correctly sees /public and allows it — this is NOT a
+		// bypass because the attack payload was never sent.
+		status, body, sent := invoke(t, "public#../../admin")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	t.Run("literal question mark on denied path", func(t *testing.T) {
+		// HTTP client sends /admin with query 'bypass' — ACL evaluates /admin.
+		status, body, sent := invoke(t, "admin?bypass")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("literal quote on denied path", func(t *testing.T) {
+		status, body, sent := invoke(t, `admin"stream`)
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("literal asterisk on denied path", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin*stream")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("literal backslash on denied path", func(t *testing.T) {
+		status, body, sent := invoke(t, `admin\stream`)
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	// Verify callee receives the normalized method, not the raw traversal.
+	t.Run("callee receives clean path from encoded traversal", func(t *testing.T) {
+		status, body, sent := invoke(t, "admin%2F..%2Fpublic")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	// Duplicate slashes are collapsed by path.Clean. /public/extra
+	// matches the /public prefix in the ACL trie, so it is allowed.
+	t.Run("duplicate slashes collapsed", func(t *testing.T) {
+		status, body, sent := invoke(t, "public///extra")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public/extra", body)
+	})
+
+	// Traversal that exits and re-enters the allowed path prefix.
+	t.Run("traversal exit and reenter allowed path", func(t *testing.T) {
+		// public/../public → resolves to /public → allowed.
+		status, body, sent := invoke(t, "public%2F..%2Fpublic")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+
+	// Double traversal from deeply nested path.
+	t.Run("deep nested traversal to allowed", func(t *testing.T) {
+		status, body, sent := invoke(t, "a%2Fb%2Fc%2F..%2F..%2F..%2Fpublic")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Equal(t, "/public", body)
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/reservedchars/aclbypass.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/reservedchars/aclbypass.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedchars
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	grpcapp "github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(aclbypass))
+}
+
+type aclbypass struct {
+	caller           *procdaprd.Daprd
+	callee           *procdaprd.Daprd
+	unauthorizedHits *atomic.Int64
+}
+
+func (r *aclbypass) Setup(t *testing.T) []framework.Option {
+	var unauthorizedHits atomic.Int64
+	r.unauthorizedHits = &unauthorizedHits
+
+	onInvoke := func(ctx context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
+		if strings.Contains(in.GetMethod(), "unauthorized") {
+			unauthorizedHits.Add(1)
+		}
+		return &commonv1.InvokeResponse{
+			Data: &anypb.Any{Value: []byte(in.GetMethod())},
+		}, nil
+	}
+	srv := grpcapp.New(t, grpcapp.WithOnInvokeFn(onInvoke))
+
+	sen := sentry.New(t)
+	bundle := sen.CABundle()
+	taFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(taFile, bundle.X509.TrustAnchors, 0o600))
+
+	pl := placement.New(t,
+		placement.WithEnableTLS(true),
+		placement.WithTrustAnchorsFile(taFile),
+		placement.WithSentryAddress(sen.Address()),
+	)
+	sch := scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+
+	r.caller = procdaprd.New(t)
+	callerAppID := r.caller.AppID()
+
+	cnf := configapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Configuration"},
+		ObjectMeta: metav1.ObjectMeta{Name: "acl-config", Namespace: "default"},
+		Spec: configapi.ConfigurationSpec{
+			NameResolutionSpec: &configapi.NameResolutionSpec{Component: "mdns"},
+			MTLSSpec: &configapi.MTLSSpec{
+				ControlPlaneTrustDomain: "localhost",
+				SentryAddress:           sen.Address(),
+			},
+			AccessControlSpec: &configapi.AccessControlSpec{
+				DefaultAction: "deny",
+				TrustDomain:   "public",
+				AppPolicies: []configapi.AppPolicySpec{
+					{
+						AppName:       callerAppID,
+						DefaultAction: "deny",
+						TrustDomain:   "public",
+						Namespace:     "default",
+						AppOperationActions: []configapi.AppOperationAction{
+							{Operation: "/public", HTTPVerb: []string{"*"}, Action: "allow"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	kubeapi := kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("localhost"),
+			"default",
+			sen.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationList(t, &configapi.ConfigurationList{
+			TypeMeta: metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "ConfigurationList"},
+			Items:    []configapi.Configuration{cnf},
+		}),
+	)
+
+	op := operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(sen.TrustAnchorsFile(t)),
+	)
+
+	daprdOpts := func(extra ...procdaprd.Option) []procdaprd.Option {
+		opts := []procdaprd.Option{
+			procdaprd.WithConfigs("acl-config"),
+			procdaprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(bundle.X509.TrustAnchors))),
+			procdaprd.WithSentryAddress(sen.Address()),
+			procdaprd.WithEnableMTLS(true),
+			procdaprd.WithMode("kubernetes"),
+			procdaprd.WithPlacementAddresses(pl.Address()),
+			procdaprd.WithSchedulerAddresses(sch.Address()),
+			procdaprd.WithControlPlaneAddress(op.Address()),
+			procdaprd.WithDisableK8sSecretStore(true),
+			procdaprd.WithNamespace("default"),
+		}
+		return append(opts, extra...)
+	}
+
+	r.callee = procdaprd.New(t, daprdOpts(
+		procdaprd.WithAppProtocol("grpc"),
+		procdaprd.WithAppPort(srv.Port(t)),
+	)...)
+	r.caller = procdaprd.New(t, daprdOpts(procdaprd.WithAppID(callerAppID))...)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, sen, kubeapi, pl, sch, op, r.callee, r.caller),
+	}
+}
+
+func (r *aclbypass) Run(t *testing.T, ctx context.Context) {
+	r.caller.WaitUntilRunning(t, ctx)
+	r.callee.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	invoke := func(t *testing.T, methodSuffix string) (sent string, body string, status int) {
+		t.Helper()
+		sent = fmt.Sprintf(
+			"http://localhost:%d/v1.0/invoke/%s/method/%s",
+			r.caller.HTTPPort(),
+			r.callee.AppID(),
+			methodSuffix,
+		)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, sent, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return sent, string(b), resp.StatusCode
+	}
+
+	t.Run("sanity: allowed path works", func(t *testing.T) {
+		sent, body, status := invoke(t, "public")
+		assert.Equalf(t, http.StatusOK, status, "caller sent: %s, callee received: %s", sent, body)
+		assert.Contains(t, body, "public")
+	})
+
+	t.Run("sanity: denied path rejected", func(t *testing.T) {
+		sent, body, status := invoke(t, "unauthorized")
+		assert.Equalf(t, http.StatusForbidden, status, "caller sent: %s, callee received: %s", sent, body)
+	})
+
+	// Go's HTTP stack decodes %23 → '#' and %3F → '?' which have URL
+	// semantics. Combined with '../' path traversal, the HTTP framework
+	// resolves the path before the handler sees it. The handler receives
+	// the resolved path and the ACL correctly denies it (403).
+
+	t.Run("encoded hash with traversal", func(t *testing.T) {
+		sent, body, status := invoke(t, "public%23/../unauthorized")
+		assert.Equalf(t, http.StatusForbidden, status,
+			"caller sent: %s, callee received: %s — HTTP framework resolves traversal, ACL denies", sent, body)
+	})
+
+	t.Run("encoded question mark with traversal", func(t *testing.T) {
+		sent, body, status := invoke(t, "public%3F/../unauthorized")
+		assert.Equalf(t, http.StatusForbidden, status,
+			"caller sent: %s, callee received: %s — HTTP framework resolves traversal, ACL denies", sent, body)
+	})
+
+	t.Run("double dot with encoded hash", func(t *testing.T) {
+		sent, body, status := invoke(t, "public%23/../../unauthorized")
+		assert.Equalf(t, http.StatusForbidden, status,
+			"caller sent: %s, callee received: %s — HTTP framework resolves traversal, ACL denies", sent, body)
+	})
+
+	t.Run("nested path with encoded hash traversal", func(t *testing.T) {
+		sent, body, status := invoke(t, "public/sub%23/../../unauthorized")
+		assert.Equalf(t, http.StatusForbidden, status,
+			"caller sent: %s, callee received: %s — HTTP framework resolves traversal, ACL denies", sent, body)
+	})
+
+	t.Run("encoded slash traversal to unauthorized", func(t *testing.T) {
+		sent, body, status := invoke(t, "public%2F..%2Funauthorized")
+		assert.Equalf(t, http.StatusForbidden, status,
+			"caller sent: %s, callee received: %s", sent, body)
+	})
+
+	t.Run("encoded carriage return with traversal", func(t *testing.T) {
+		// HTTP client decodes %0D → \r and resolves /../ traversal before
+		// the request reaches Dapr. The handler sees the resolved path
+		// ("unauthorized") and the ACL correctly denies it (403).
+		sent, body, status := invoke(t, "public%0D/../unauthorized")
+		assert.Equalf(t, http.StatusForbidden, status,
+			"caller sent: %s, callee received: %s — HTTP framework resolves traversal, ACL denies", sent, body)
+	})
+
+	// HTTP decodes %25 → %, NormalizeMethod allows % (not forbidden).
+	// path.Clean("public%/../unauthorized") → "unauthorized" → ACL denies → Forbidden.
+	t.Run("percent hides traversal", func(t *testing.T) {
+		sent, body, status := invoke(t, "public%25/../unauthorized")
+		assert.Equalf(t, http.StatusForbidden, status,
+			"caller sent: %s, callee received: %s — should resolve to /unauthorized and be denied by ACL", sent, body)
+	})
+
+	// Prove the callee was NEVER invoked with an "unauthorized" method
+	// by any of the traversal attacks above. This is the core CVE
+	// invariant: if the ACL denies the request, the callee must not
+	// be invoked with the denied path.
+	t.Run("callee never received unauthorized method", func(t *testing.T) {
+		assert.Equalf(t, int64(0), r.unauthorizedHits.Load(),
+			"callee received 'unauthorized' method %d times — ACL bypass detected!", r.unauthorizedHits.Load())
+	})
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/reservedchars/pathcorrectness.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/reservedchars/pathcorrectness.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedchars
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(pathcorrectness))
+}
+
+type pathcorrectness struct {
+	caller *procdaprd.Daprd
+	callee *procdaprd.Daprd
+}
+
+func (r *pathcorrectness) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(req.URL.Path + "|" + req.URL.RawQuery))
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	r.callee = procdaprd.New(t, procdaprd.WithAppPort(srv.Port()))
+	r.caller = procdaprd.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, r.callee, r.caller),
+	}
+}
+
+func (r *pathcorrectness) Run(t *testing.T, ctx context.Context) {
+	r.caller.WaitUntilRunning(t, ctx)
+	r.callee.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	invoke := func(t *testing.T, methodSuffix string) (int, string) {
+		t.Helper()
+		reqURL := fmt.Sprintf(
+			"http://localhost:%d/v1.0/invoke/%s/method/%s",
+			r.caller.HTTPPort(),
+			r.callee.AppID(),
+			methodSuffix,
+		)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return resp.StatusCode, string(body)
+	}
+
+	// Forbidden characters: encoded #, ?, % are rejected after decoding.
+	t.Run("encoded hash is rejected", func(t *testing.T) {
+		status, _ := invoke(t, "test%23stream")
+		assert.Equal(t, http.StatusInternalServerError, status)
+	})
+
+	t.Run("encoded question mark is rejected", func(t *testing.T) {
+		status, _ := invoke(t, "test%3Fstream")
+		assert.Equal(t, http.StatusInternalServerError, status)
+	})
+
+	t.Run("encoded percent is allowed", func(t *testing.T) {
+		// HTTP decodes %25 → %, NormalizeMethod allows it, but
+		// constructRequest fails building the outbound URL because
+		// Go's url.Parse rejects bare % followed by non-hex chars.
+		status, _ := invoke(t, "test%25stream")
+		assert.Equal(t, http.StatusInternalServerError, status)
+	})
+
+	t.Run("encoded null byte is rejected", func(t *testing.T) {
+		status, _ := invoke(t, "test%00stream")
+		assert.Equal(t, http.StatusInternalServerError, status)
+	})
+
+	t.Run("encoded carriage return is rejected", func(t *testing.T) {
+		status, _ := invoke(t, "test%0Dstream")
+		assert.Equal(t, http.StatusInternalServerError, status)
+	})
+
+	t.Run("multiple forbidden characters rejected", func(t *testing.T) {
+		status, _ := invoke(t, "a%23b%3Fc%25d")
+		assert.Equal(t, http.StatusInternalServerError, status)
+	})
+
+	// Safe characters: decoded and passed through to callee.
+	t.Run("double quote in path", func(t *testing.T) {
+		status, body := invoke(t, "test%22stream")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `/test"stream|`, body)
+	})
+
+	t.Run("asterisk in path", func(t *testing.T) {
+		status, body := invoke(t, "test%2Astream")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/test*stream|", body)
+	})
+
+	t.Run("backslash in path", func(t *testing.T) {
+		status, body := invoke(t, "test%5Cstream")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `/test\stream|`, body)
+	})
+
+	// Traversal: resolved by path.Clean, callee gets the clean path.
+	t.Run("encoded traversal is resolved", func(t *testing.T) {
+		status, body := invoke(t, "admin%2F..%2Fpublic")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/public|", body)
+	})
+
+	// Literal characters: HTTP client handles these before they reach Dapr.
+	t.Run("literal hash truncated by HTTP client", func(t *testing.T) {
+		status, body := invoke(t, "test#stream")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/test|", body)
+	})
+
+	t.Run("literal question mark split by HTTP client", func(t *testing.T) {
+		status, body := invoke(t, "test?stream")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/test|stream", body)
+	})
+
+	t.Run("literal quote in path", func(t *testing.T) {
+		status, body := invoke(t, `test"stream`)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `/test"stream|`, body)
+	})
+
+	t.Run("literal asterisk in path", func(t *testing.T) {
+		status, body := invoke(t, "test*stream")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/test*stream|", body)
+	})
+
+	t.Run("literal backslash in path", func(t *testing.T) {
+		status, body := invoke(t, `test\stream`)
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, `/test\stream|`, body)
+	})
+
+	// dapr-app-id header path: the method is the entire URL path.
+	// Tests the other branch in findTargetIDAndMethod.
+	invokeViaHeader := func(t *testing.T, path string) (int, string) {
+		t.Helper()
+		reqURL := fmt.Sprintf("http://localhost:%d%s", r.caller.HTTPPort(), path)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("dapr-app-id", r.callee.AppID())
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return resp.StatusCode, string(body)
+	}
+
+	t.Run("header: normal path", func(t *testing.T) {
+		status, body := invokeViaHeader(t, "/mymethod")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/mymethod|", body)
+	})
+
+	t.Run("header: traversal resolved", func(t *testing.T) {
+		status, body := invokeViaHeader(t, "/admin/../public")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/public|", body)
+	})
+
+	t.Run("header: encoded hash rejected", func(t *testing.T) {
+		status, _ := invokeViaHeader(t, "/test%23stream")
+		assert.Equal(t, http.StatusInternalServerError, status)
+	})
+
+	t.Run("header: encoded traversal resolved", func(t *testing.T) {
+		status, body := invokeViaHeader(t, "/admin%2F..%2Fpublic")
+		assert.Equal(t, http.StatusOK, status)
+		assert.Equal(t, "/public|", body)
+	})
+}


### PR DESCRIPTION
Reserved URL characters and path traversal sequences in service invocation method paths could bypass access control policies. The ACL normalized the method independently from the dispatch layer. The ACL saw one path while the target application received a different one.

For example, `admin%2F..%2Fpublic` was normalized by the ACL to "public" (allowed), but the target received the raw `admin/../public`. The gRPC API was the more dangerous vector since it passes methods as raw strings with no client-side URL sanitization.

The method path is now normalized at the service invocation edge — `directMessaging.Invoke` for HTTP and gRPC public API calls, `callLocalValidateACL` for gRPC internal calls, and the gRPC proxy handler for proxied calls. The normalized form is used for both ACL evaluation and outbound dispatch. The ACL is a pure policy evaluation layer and performs no normalization of its own.

For HTTP, Go's net/http server decodes percent-encoding in r.URL.Path before the method is extracted. For gRPC, method strings are raw — no percent-decoding is applied. Percent-encoded sequences like %2F are literal characters, not path separators.

Normalization (`pkg/messaging/method.NormalizeMethod`) rejects methods containing #, ?, null bytes, or control characters, then resolves path traversal via path.Clean. The purell dependency has been removed from the ACL path. constructRequest applies path.Clean as defense-in-depth. findTargetIDAndMethod applies path.Clean for consistency across all three extraction branches.

---

Security: Service invocation path traversal bypasses access control policies

Problem

Reserved URL characters and path traversal sequences in service invocation method paths could bypass access control policies. An attacker with access to the Dapr HTTP or gRPC API could invoke operations on a target application that the ACL was configured to deny.

Impact

Any deployment using access control policies for service invocation is affected. An attacker who can reach the Dapr API (HTTP or gRPC) could:

- Use encoded path traversal (`admin%2F..%2Fpublic`) to reach an allowed path (`/public`) while the method started from a denied prefix (`/admin`).
- Use encoded fragment (`%23`) or query (`%3F`) characters to cause the ACL to evaluate a different path than what was delivered to the target application.

The gRPC API was the more dangerous vector because gRPC passes the method as a raw string with no client-side URL sanitization — `#`, `?`, `%`, `../`, and control characters were all delivered literally.

Root Cause

The method path was normalized independently in two places:

1. The ACL used `purell.NormalizeURLString` which treated the method as a URL — decoding `%XX`, resolving `../`, and stripping `#` as a fragment delimiter and `?` as a query delimiter.
2. The dispatch layer (`constructRequest` for HTTP, gRPC passthrough) used the raw method string.

This created a mismatch: the ACL authorized one path while the target application received a different one. For example, `admin%2F..%2Fpublic` was normalized by the ACL to `public` (allowed), but the target application received the raw `admin/../public`.

Solution

The method path is now normalized at the service invocation edge — in `directMessaging.Invoke` for HTTP and gRPC public API calls, in `callLocalValidateACL` for gRPC internal calls, and in the gRPC proxy handler for proxied calls. The normalized form is used for both the ACL check and the outbound dispatch, eliminating the mismatch. The ACL is a pure policy evaluation layer and performs no normalization of its own.

For HTTP, Go's `net/http` server decodes percent-encoding in `r.URL.Path` before the method is extracted. For gRPC, method strings are raw (no percent-decoding) and are treated as opaque — percent-encoded sequences like `%2F` are literal characters, not path separators.

Normalization uses `path.Clean` to resolve `../` and duplicate slashes, and rejects method paths containing `#`, `?`, null bytes, or control characters. The `purell` dependency has been removed from the ACL path.

As defense-in-depth, `constructRequest` in the HTTP channel applies `path.Clean` to the method before building the outbound URL.

Users are strongly encouraged to upgrade to this release.