### PR TITLE
Fix flaky memory check in `dapr-standalone-validation`

### DIFF
--- a/.github/scripts/validate_sidecar_resources.py
+++ b/.github/scripts/validate_sidecar_resources.py
@@ -14,16 +14,23 @@
 
 # This script validates resource utilization of a Dapr sidecar.
 
-import re
+import os
 import subprocess
 import time
-import os
+
 import numpy as np
-import psutil
 import requests
 
 from pathlib import Path
 from scipy.stats import ttest_ind
+
+# Scrape Go heap-in-use instead of process RSS: RSS reflects OS reclaim
+# timing (MADV_FREE keeps freed pages resident until memory pressure), so
+# it's noisy across runs. go_memstats_heap_inuse_bytes reports what Go
+# actually holds and is stable across runs of the same binary.
+METRICS_PORT = 9090
+METRICS_URL = f"http://127.0.0.1:{METRICS_PORT}/metrics"
+METRIC_NAME = "go_memstats_heap_inuse_bytes"
 
 def get_binary_size(binary_path):
     try:
@@ -39,38 +46,63 @@ def run_process_background(args):
 
 def kill_process(process):
     process.terminate()
-
-def get_memory_info(process):
     try:
-        process_info = psutil.Process(process.pid)
-        resident_memory = process_info.memory_info().rss / (1024 * 1024)  # in megabytes
-        return resident_memory
-    except psutil.NoSuchProcess:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+def scrape_heap_inuse_mb():
+    try:
+        resp = requests.get(METRICS_URL, timeout=2)
+        resp.raise_for_status()
+    except requests.exceptions.RequestException:
         return None
+    for line in resp.text.splitlines():
+        if line.startswith("#"):
+            continue
+        if line.startswith(METRIC_NAME + " ") or line.startswith(METRIC_NAME + "{"):
+            try:
+                return float(line.split()[-1]) / (1024 * 1024)
+            except (ValueError, IndexError):
+                return None
+    return None
+
+def wait_for_metrics(timeout_s=30):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if scrape_heap_inuse_mb() is not None:
+            return True
+        time.sleep(0.5)
+    return False
 
 def run_sidecar(executable, app_id):
     print(f"Running {executable} ...")
-    expanded_executable=Path(executable).expanduser()
-    args = [expanded_executable, "--app-id", f"{app_id}"]
+    expanded_executable = Path(executable).expanduser()
+    args = [
+        str(expanded_executable),
+        "--app-id", app_id,
+        "--metrics-port", str(METRICS_PORT),
+    ]
 
-    # Run the process in the background
     background_process = run_process_background(args)
 
-    memory_data = []
+    try:
+        if not wait_for_metrics(timeout_s=30):
+            raise Exception(f"Metrics endpoint at {METRICS_URL} did not become ready for {executable}")
 
-    # Initial wait to remove any noise from initialization.
-    time.sleep(10)
+        # Initial wait to remove any noise from initialization.
+        time.sleep(10)
 
-    # Collect resident memory every second for X seconds
-    cycles = int(getenv("SECONDS_FOR_PROCESS_TO_RUN", 5))
-    for _ in range(cycles):
-        time.sleep(1)
-        memory = get_memory_info(background_process)
-        if memory is not None:
-            memory_data.append(memory)
-
-    # Kill the process
-    kill_process(background_process)
+        memory_data = []
+        cycles = int(getenv("SECONDS_FOR_PROCESS_TO_RUN", 5))
+        for _ in range(cycles):
+            time.sleep(1)
+            memory = scrape_heap_inuse_mb()
+            if memory is not None:
+                memory_data.append(memory)
+    finally:
+        kill_process(background_process)
 
     if len(memory_data) == 0:
         raise Exception(f"Could not collect data for {executable}: {( memory_data )}")
@@ -146,7 +178,7 @@ if __name__ == "__main__":
     memory_data_new = run_sidecar(new_binary, "treatment")
     memory_data_old = run_sidecar(old_binary, "control")
 
-    memory_diff = test_diff(memory_data_old, memory_data_new, "memory utilization (in MB)", "tp75_plus_10percent")
+    memory_diff = test_diff(memory_data_old, memory_data_new, "Go heap in-use (in MB)", "tp75_plus_10percent")
 
     if binary_size_diff or memory_diff:
         raise Exception("Found significant differences.")

--- a/.github/workflows/dapr-standalone-validation.yml
+++ b/.github/workflows/dapr-standalone-validation.yml
@@ -51,7 +51,7 @@ jobs:
           python3 -m pip install --upgrade pip
       - name: Install required Python packages
         run: |
-          python3 -m pip install numpy scipy psutil requests
+          python3 -m pip install numpy scipy requests
       - name: Install latest Dapr CLI
         uses: dapr/.github/.github/actions/setup-dapr-cli@main
         with:


### PR DESCRIPTION
## Summary

`.github/scripts/validate_sidecar_resources.py` samples sidecar memory via `psutil` RSS over a 5–30 second window. The check produces wildly inconsistent results across runs of the same code, sometimes claiming a ~40 MB regression, sometimes a ~90 MB *improvement* with no actual change in the binary. We should stop using OS-reported RSS and scrape `go_memstats_heap_inuse_bytes` from daprd's `/metrics` endpoint instead.

## Example of the instability

Two runs from the same PR:

**[Run A](https://github.com/dapr/dapr/actions/runs/24566466458/job/71827826735)** flags a regression:
```
Mean for memory utilization (new): 162.37 MB
Mean for memory utilization (old): 120.35 MB
Warning! Found significant increase in memory utilization.
```

**[Run B](https://github.com/dapr/dapr/actions/runs/24566466458/job/72097333108)** looks like an improvement:
```
Mean for memory utilization (new): 122.35 MB
Mean for memory utilization (old): 208.45 MB
```

## Why RSS is unreliable here

1. **`MADV_FREE` keeps freed pages resident.** Since Go 1.12 on Linux, the runtime returns unused pages to the OS with `MADV_FREE`, which lets the kernel reclaim them *lazily* under memory pressure. Until pressure appears, those pages still count toward RSS. Two runs of the same binary on runners with different memory pressure will report very different RSS for identical working sets.
2. **Go's GC is non-deterministic in timing.** The GC schedule depends on `GOGC`, `GOMEMLIMIT`, and how much headroom the runtime sees. Sampling at a fixed wall-clock moment captures whatever phase of the GC cycle we happen to land in.
3. **Runner noise.** GitHub-hosted runners have variable co-tenant load, affecting both OS reclaim behavior and scheduling.
4. **Sample size is tiny.** 5 one-second samples after 10s warmup is not enough for anything to settle; the percentile math is effectively measuring a single flatlined number.

Any of these on their own would inject noise; together they make the check useless as a regression gate.

## Why `go_memstats_heap_inuse_bytes` is more stable

daprd already exposes a Prometheus `/metrics` endpoint on port 9090 (on by default). The Go runtime collector publishes `go_memstats_heap_inuse_bytes`, which is:

- **Measured inside the Go runtime**, not inferred from OS page accounting — so `MADV_FREE` timing and kernel reclaim mood don't affect it.
- **A direct readout of bytes in in-use heap spans** — it reflects what Go is actively holding, which is the thing we actually care about when asking "did this PR use more memory?".
- **Unaffected by runner-level memory pressure variance.**

Combined with a proper wait for the endpoint to come up (so we sample *after* startup settles, not during it), this removes the dominant noise sources observed above.

## Proposed fix

- Replace `psutil` RSS sampling in `validate_sidecar_resources.py` with an HTTP scrape of `go_memstats_heap_inuse_bytes` from `http://127.0.0.1:9090/metrics`.
- Wait for the metrics endpoint to respond before beginning the warmup period, so the samples are taken against a live sidecar rather than a starting one.
- Drop `psutil` from the workflow's pip install.