### PR TITLE
hotreload: enable HotReload by default (GA)

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -29,7 +29,7 @@ import (
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/spf13/cast"
 	"go.opencensus.io/stats/view"
-	yaml "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -90,6 +90,7 @@ const (
 )
 
 var defaultFeatures = map[Feature]bool{
+	HotReload: true,
 	WorkflowsRemoteActivityReminder: true,
 }
 

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -90,7 +90,7 @@ const (
 )
 
 var defaultFeatures = map[Feature]bool{
-	HotReload: true,
+	HotReload:                       true,
 	WorkflowsRemoteActivityReminder: true,
 }
 

--- a/pkg/runtime/hotreload/reconciler/subscriptions.go
+++ b/pkg/runtime/hotreload/reconciler/subscriptions.go
@@ -18,6 +18,7 @@ import (
 
 	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/dapr/pkg/runtime/hotreload/differ"
 	"github.com/dapr/dapr/pkg/runtime/hotreload/loader"
 	"github.com/dapr/dapr/pkg/runtime/processor"
 )
@@ -36,6 +37,11 @@ func (s *subscriptions) update(ctx context.Context, sub subapi.Subscription) {
 	oldSub, exists := s.store.GetDeclarativeSubscription(sub.Name)
 
 	if exists {
+		if differ.AreSame(*oldSub.Comp, sub) {
+			log.Debugf("Subscription update skipped: no changes detected: %s", sub.Name)
+			return
+		}
+
 		log.Infof("Closing existing Subscription to reload: %s", *oldSub.Name)
 
 		err := s.proc.CloseSubscription(ctx, oldSub.Comp)

--- a/tests/config/preview_configurations.yaml
+++ b/tests/config/preview_configurations.yaml
@@ -36,14 +36,3 @@ spec:
       enabled: true
     - name: NotEnabled
       enabled: false
-
----
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-    - name: HotReload
-      enabled: true
-

--- a/tests/e2e/hotreloading/hotreloading_test.go
+++ b/tests/e2e/hotreloading/hotreloading_test.go
@@ -53,7 +53,6 @@ func TestMain(m *testing.M) {
 			Replicas:       1,
 			IngressEnabled: true,
 			MetricsEnabled: true,
-			Config:         "hotreloading",
 		},
 	}
 

--- a/tests/integration/suite/daprd/hotreload/operator/actorstate.go
+++ b/tests/integration/suite/daprd/hotreload/operator/actorstate.go
@@ -68,33 +68,12 @@ func (a *actorstate) Setup(t *testing.T) []framework.Option {
 
 	a.operatorCreate = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 	a.operatorUpdate = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 	a.operatorDelete = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	inmemStore := compapi.Component{

--- a/tests/integration/suite/daprd/hotreload/operator/actorstate.go
+++ b/tests/integration/suite/daprd/hotreload/operator/actorstate.go
@@ -91,7 +91,6 @@ func (a *actorstate) Setup(t *testing.T) []framework.Option {
 
 	a.daprdCreate = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
 			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors)),
 			exec.WithStdout(a.loglineCreate.Stdout()),
@@ -102,7 +101,6 @@ func (a *actorstate) Setup(t *testing.T) []framework.Option {
 	)
 	a.daprdUpdate = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
 			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors)),
 			exec.WithStdout(a.loglineUpdate.Stdout()),
@@ -113,7 +111,6 @@ func (a *actorstate) Setup(t *testing.T) []framework.Option {
 	)
 	a.daprdDelete = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
 			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors)),
 			exec.WithStdout(a.loglineDelete.Stdout()),

--- a/tests/integration/suite/daprd/hotreload/operator/binding/input/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/input/grpc.go
@@ -120,7 +120,6 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 
 	g.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(g.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/binding/input/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/input/grpc.go
@@ -97,13 +97,6 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 
 	g.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	g.operator.AddComponents(compapi.Component{

--- a/tests/integration/suite/daprd/hotreload/operator/binding/input/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/input/http.go
@@ -94,13 +94,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 
 	h.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	h.operator.AddComponents(compapi.Component{

--- a/tests/integration/suite/daprd/hotreload/operator/binding/input/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/input/http.go
@@ -117,7 +117,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 
 	h.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(h.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/binding/output.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/output.go
@@ -81,7 +81,6 @@ func (o *output) Setup(t *testing.T) []framework.Option {
 
 	o.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(o.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/binding/output.go
+++ b/tests/integration/suite/daprd/hotreload/operator/binding/output.go
@@ -65,13 +65,6 @@ func (o *output) Setup(t *testing.T) []framework.Option {
 
 	o.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	o.bindingDir1, o.bindingDir2, o.bindingDir3 = t.TempDir(), t.TempDir(), t.TempDir()

--- a/tests/integration/suite/daprd/hotreload/operator/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/operator/crypto.go
@@ -62,13 +62,6 @@ func (c *crypto) Setup(t *testing.T) []framework.Option {
 
 	c.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	c.cryptoDir1, c.cryptoDir2 = t.TempDir(), t.TempDir()

--- a/tests/integration/suite/daprd/hotreload/operator/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/operator/crypto.go
@@ -75,7 +75,6 @@ func (c *crypto) Setup(t *testing.T) []framework.Option {
 
 	c.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(c.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/ignoreerrors.go
+++ b/tests/integration/suite/daprd/hotreload/operator/ignoreerrors.go
@@ -49,13 +49,6 @@ func (i *ignoreerrors) Setup(t *testing.T) []framework.Option {
 
 	i.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	i.logline = logline.New(t,

--- a/tests/integration/suite/daprd/hotreload/operator/ignoreerrors.go
+++ b/tests/integration/suite/daprd/hotreload/operator/ignoreerrors.go
@@ -61,7 +61,6 @@ func (i *ignoreerrors) Setup(t *testing.T) []framework.Option {
 
 	i.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(i.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/informer/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/components.go
@@ -77,10 +77,7 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 						ControlPlaneTrustDomain: "integration.test.dapr.io",
 						SentryAddress:           sentry.Address(),
 					},
-					Features: []configapi.FeatureSpec{{
-						Name:    "HotReload",
-						Enabled: new(true),
-					}},
+					Features: []configapi.FeatureSpec{},
 				},
 			}},
 		}),

--- a/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/components.go
@@ -72,10 +72,7 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 						ControlPlaneTrustDomain: "integration.test.dapr.io",
 						SentryAddress:           sentry.Address(),
 					},
-					Features: []configapi.FeatureSpec{{
-						Name:    "HotReload",
-						Enabled: new(true),
-					}},
+					Features: []configapi.FeatureSpec{},
 				},
 			}},
 		}),

--- a/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/subscriptions.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/reconnect/subscriptions.go
@@ -78,10 +78,7 @@ func (s *subscriptions) Setup(t *testing.T) []framework.Option {
 						ControlPlaneTrustDomain: "integration.test.dapr.io",
 						SentryAddress:           sentry.Address(),
 					},
-					Features: []configapi.FeatureSpec{{
-						Name:    "HotReload",
-						Enabled: new(true),
-					}},
+					Features: []configapi.FeatureSpec{},
 				},
 			}},
 		}),

--- a/tests/integration/suite/daprd/hotreload/operator/informer/scopes/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/scopes/components.go
@@ -71,10 +71,7 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 						ControlPlaneTrustDomain: "integration.test.dapr.io",
 						SentryAddress:           c.sentry.Address(),
 					},
-					Features: []configapi.FeatureSpec{{
-						Name:    "HotReload",
-						Enabled: new(true),
-					}},
+					Features: []configapi.FeatureSpec{},
 				},
 			}},
 		}),

--- a/tests/integration/suite/daprd/hotreload/operator/informer/subscriptions.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/subscriptions.go
@@ -87,10 +87,7 @@ func (s *subscriptions) Setup(t *testing.T) []framework.Option {
 						ControlPlaneTrustDomain: "integration.test.dapr.io",
 						SentryAddress:           sentry.Address(),
 					},
-					Features: []configapi.FeatureSpec{{
-						Name:    "HotReload",
-						Enabled: new(true),
-					}},
+					Features: []configapi.FeatureSpec{},
 				},
 			}},
 		}),

--- a/tests/integration/suite/daprd/hotreload/operator/mcpserver.go
+++ b/tests/integration/suite/daprd/hotreload/operator/mcpserver.go
@@ -58,7 +58,7 @@ func (m *mcpserver) Setup(t *testing.T) []framework.Option {
 		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
 			return &operatorv1.GetConfigurationResponse{
 				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true},{"name":"MCPServerResource","enabled":true}]}}`,
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"mcpserver"},"spec":{"features":[{"name":"MCPServerResource","enabled":true}]}}`,
 				),
 			}, nil
 		}),
@@ -66,7 +66,7 @@ func (m *mcpserver) Setup(t *testing.T) []framework.Option {
 
 	m.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("mcpserver"),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(m.operator.Address(t)),
 		daprd.WithDisableK8sSecretStore(true),

--- a/tests/integration/suite/daprd/hotreload/operator/middleware/http/app/routeralias.go
+++ b/tests/integration/suite/daprd/hotreload/operator/middleware/http/app/routeralias.go
@@ -59,7 +59,7 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
 			return &operatorv1.GetConfigurationResponse{
 				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"nameResolution": {"component": "mdns"}, "features":[{"name":"HotReload","enabled":true}],
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"middleware"},"spec":{"nameResolution": {"component": "mdns"},
 					"appHttpPipeline":{"handlers":[{"name":"routeralias1","type":"middleware.http.routeralias"},{"name":"routeralias2","type":"middleware.http.routeralias"},{"name":"routeralias3","type":"middleware.http.routeralias"}]}}}`,
 				),
 			}, nil
@@ -104,7 +104,7 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 
 	r.daprd1 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(r.operator.Address(t)),
@@ -114,7 +114,7 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 	)
 	r.daprd2 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(r.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/middleware/http/app/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/operator/middleware/http/app/uppercase.go
@@ -62,7 +62,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
 			return &operatorv1.GetConfigurationResponse{
 				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"nameResolution": {"component": "mdns"}, "features":[{"name":"HotReload","enabled":true}],
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"middleware"},"spec":{"nameResolution": {"component": "mdns"},
 					"appHttpPipeline":{"handlers":[{"name":"uppercase","type":"middleware.http.uppercase"},{"name":"uppercase2","type":"middleware.http.uppercase"}]}}}`,
 				),
 			}, nil
@@ -102,7 +102,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 
 	u.daprd1 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(u.operator.Address(t)),
@@ -112,7 +112,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 	)
 	u.daprd2 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(u.operator.Address(t)),
@@ -122,7 +122,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 	)
 	u.daprd3 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(u.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/middleware/http/server/routeralias.go
+++ b/tests/integration/suite/daprd/hotreload/operator/middleware/http/server/routeralias.go
@@ -59,7 +59,7 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
 			return &operatorv1.GetConfigurationResponse{
 				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"nameResolution": {"component": "mdns"}, "features":[{"name":"HotReload","enabled":true}],
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"middleware"},"spec":{"nameResolution": {"component": "mdns"},
 					"httpPipeline":{"handlers":[{"name":"routeralias1","type":"middleware.http.routeralias"},{"name":"routeralias2","type":"middleware.http.routeralias"},{"name":"routeralias3","type":"middleware.http.routeralias"}]}}}`,
 				),
 			}, nil
@@ -78,7 +78,7 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 
 	r.daprd1 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(r.operator.Address(t)),
@@ -88,7 +88,7 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 	)
 	r.daprd2 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(r.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/middleware/http/server/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/operator/middleware/http/server/uppercase.go
@@ -62,7 +62,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
 			return &operatorv1.GetConfigurationResponse{
 				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"nameResolution": {"component": "mdns"}, "features":[{"name":"HotReload","enabled":true}],
+					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"middleware"},"spec":{"nameResolution": {"component": "mdns"},
 					"httpPipeline":{"handlers":[{"name":"uppercase","type":"middleware.http.uppercase"},{"name":"uppercase2","type":"middleware.http.uppercase"}]}}}`,
 				),
 			}, nil
@@ -102,7 +102,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 
 	u.daprd1 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(u.operator.Address(t)),
@@ -112,7 +112,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 	)
 	u.daprd2 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(u.operator.Address(t)),
@@ -122,7 +122,7 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 	)
 	u.daprd3 = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("middleware"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(u.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/pubsub/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/pubsub/grpc.go
@@ -54,13 +54,6 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 
 	g.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	srv := app.New(t,

--- a/tests/integration/suite/daprd/hotreload/operator/pubsub/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/pubsub/grpc.go
@@ -85,7 +85,6 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 
 	g.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(g.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/pubsub/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/pubsub/http.go
@@ -102,7 +102,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 
 	h.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(h.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/pubsub/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/pubsub/http.go
@@ -87,13 +87,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 
 	h.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	h.operator.AddComponents(compapi.Component{

--- a/tests/integration/suite/daprd/hotreload/operator/secret.go
+++ b/tests/integration/suite/daprd/hotreload/operator/secret.go
@@ -62,13 +62,6 @@ func (s *secret) Setup(t *testing.T) []framework.Option {
 
 	s.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	s.client = client.HTTP(t)

--- a/tests/integration/suite/daprd/hotreload/operator/secret.go
+++ b/tests/integration/suite/daprd/hotreload/operator/secret.go
@@ -68,7 +68,6 @@ func (s *secret) Setup(t *testing.T) []framework.Option {
 
 	s.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(s.operator.Address(t)),
 		daprd.WithDisableK8sSecretStore(true),

--- a/tests/integration/suite/daprd/hotreload/operator/sighup/configuration.go
+++ b/tests/integration/suite/daprd/hotreload/operator/sighup/configuration.go
@@ -70,11 +70,8 @@ func (c *configuration) Setup(t *testing.T) []framework.Option {
 			config := map[string]any{
 				"kind":       "Configuration",
 				"apiVersion": "dapr.io/v1alpha1",
-				"metadata":   map[string]any{"name": "hotreloading"},
+				"metadata":   map[string]any{"name": "tracing"},
 				"spec": map[string]any{
-					"features": []map[string]any{
-						{"name": "HotReload", "enabled": true},
-					},
 					"tracing": map[string]any{
 						"samplingRate": rate,
 					},
@@ -100,7 +97,7 @@ func (c *configuration) Setup(t *testing.T) []framework.Option {
 				b, err := json.Marshal(map[string]any{
 					"kind":       "Configuration",
 					"apiVersion": "dapr.io/v1alpha1",
-					"metadata":   map[string]any{"name": "hotreloading"},
+					"metadata":   map[string]any{"name": "tracing"},
 					"spec": map[string]any{
 						"tracing": map[string]any{
 							"samplingRate": c.samplingCh.Load().(string),
@@ -125,7 +122,7 @@ func (c *configuration) Setup(t *testing.T) []framework.Option {
 
 	c.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("tracing"),
 		daprd.WithExecOptions(
 			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", c.trustAnchor),
 			exec.WithStdout(c.logOut),

--- a/tests/integration/suite/daprd/hotreload/operator/sighup/httpendpoint.go
+++ b/tests/integration/suite/daprd/hotreload/operator/sighup/httpendpoint.go
@@ -67,13 +67,6 @@ func (h *httpendpoint) Setup(t *testing.T) []framework.Option {
 
 	h.operator = operator.New(t,
 		operator.WithSentry(snt),
-		operator.WithGetConfigurationFn(func(_ context.Context, _ *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 		operator.WithListHTTPEndpointsFn(func(_ context.Context, _ *operatorv1.ListHTTPEndpointsRequest) (*operatorv1.ListHTTPEndpointsResponse, error) {
 			if h.hasEndpoint.Load() {
 				return &operatorv1.ListHTTPEndpointsResponse{

--- a/tests/integration/suite/daprd/hotreload/operator/sighup/httpendpoint.go
+++ b/tests/integration/suite/daprd/hotreload/operator/sighup/httpendpoint.go
@@ -100,7 +100,6 @@ func (h *httpendpoint) Setup(t *testing.T) []framework.Option {
 
 	h.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
 			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(snt.CABundle().X509.TrustAnchors)),
 		),

--- a/tests/integration/suite/daprd/hotreload/operator/sighup/nochange.go
+++ b/tests/integration/suite/daprd/hotreload/operator/sighup/nochange.go
@@ -65,11 +65,8 @@ func (n *nochange) Setup(t *testing.T) []framework.Option {
 	initialConfigJSON, err := json.Marshal(map[string]any{
 		"kind":       "Configuration",
 		"apiVersion": "dapr.io/v1alpha1",
-		"metadata":   map[string]any{"name": "hotreloading"},
+		"metadata":   map[string]any{"name": "tracing"},
 		"spec": map[string]any{
-			"features": []map[string]any{
-				{"name": "HotReload", "enabled": true},
-			},
 			"tracing": map[string]any{
 				"samplingRate": "0",
 			},
@@ -181,7 +178,7 @@ func (n *nochange) Setup(t *testing.T) []framework.Option {
 
 	n.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
+		daprd.WithConfigs("tracing"),
 		daprd.WithExecOptions(
 			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(snt.CABundle().X509.TrustAnchors)),
 			exec.WithStdout(n.logOut),
@@ -208,11 +205,8 @@ func (n *nochange) Run(t *testing.T, ctx context.Context) {
 		unchangedConfig, err := json.Marshal(map[string]any{
 			"kind":       "Configuration",
 			"apiVersion": "dapr.io/v1alpha1",
-			"metadata":   map[string]any{"name": "hotreloading"},
+			"metadata":   map[string]any{"name": "tracing"},
 			"spec": map[string]any{
-				"features": []map[string]any{
-					{"name": "HotReload", "enabled": true},
-				},
 				"tracing": map[string]any{
 					"samplingRate": "0",
 				},

--- a/tests/integration/suite/daprd/hotreload/operator/sighup/resiliency.go
+++ b/tests/integration/suite/daprd/hotreload/operator/sighup/resiliency.go
@@ -103,7 +103,6 @@ func (r *resiliency) Setup(t *testing.T) []framework.Option {
 
 	r.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(
 			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", r.trustAnchor),
 			exec.WithStdout(r.logOut),

--- a/tests/integration/suite/daprd/hotreload/operator/sighup/resiliency.go
+++ b/tests/integration/suite/daprd/hotreload/operator/sighup/resiliency.go
@@ -60,13 +60,6 @@ func (r *resiliency) Setup(t *testing.T) []framework.Option {
 
 	r.operator = operator.New(t,
 		operator.WithSentry(snt),
-		operator.WithGetConfigurationFn(func(_ context.Context, _ *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 		operator.WithListResiliencyFn(func(_ context.Context, _ *operatorv1.ListResiliencyRequest) (*operatorv1.ListResiliencyResponse, error) {
 			return new(operatorv1.ListResiliencyResponse), nil
 		}),

--- a/tests/integration/suite/daprd/hotreload/operator/state.go
+++ b/tests/integration/suite/daprd/hotreload/operator/state.go
@@ -63,7 +63,6 @@ func (s *state) Setup(t *testing.T) []framework.Option {
 
 	s.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(s.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/state.go
+++ b/tests/integration/suite/daprd/hotreload/operator/state.go
@@ -59,13 +59,6 @@ func (s *state) Setup(t *testing.T) []framework.Option {
 
 	s.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	s.daprd = daprd.New(t,

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/grpc.go
@@ -53,13 +53,6 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 
 	g.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	g.daprd = daprd.New(t,

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/grpc.go
@@ -59,7 +59,6 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		daprd.WithAppPort(g.sub.Port(t)),
 		daprd.WithAppProtocol("grpc"),
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(g.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/http.go
@@ -61,7 +61,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		daprd.WithAppPort(h.sub.Port()),
 		daprd.WithAppProtocol("http"),
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(h.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/http.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/http.go
@@ -55,13 +55,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 
 	h.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	h.daprd = daprd.New(t,

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/inflight.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/inflight.go
@@ -64,13 +64,6 @@ func (i *inflight) Setup(t *testing.T) []framework.Option {
 	sentry := sentry.New(t)
 	i.operator = operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	i.daprd = daprd.New(t,

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/inflight.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/inflight.go
@@ -69,7 +69,6 @@ func (i *inflight) Setup(t *testing.T) []framework.Option {
 	i.daprd = daprd.New(t,
 		daprd.WithAppPort(i.sub.Port()),
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(i.operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/noapp.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/noapp.go
@@ -47,7 +47,6 @@ func (n *noapp) Setup(t *testing.T) []framework.Option {
 
 	n.daprd = daprd.New(t,
 		daprd.WithMode("kubernetes"),
-		daprd.WithConfigs("hotreloading"),
 		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors))),
 		daprd.WithSentryAddress(sentry.Address()),
 		daprd.WithControlPlaneAddress(operator.Address(t)),

--- a/tests/integration/suite/daprd/hotreload/operator/subscriptions/noapp.go
+++ b/tests/integration/suite/daprd/hotreload/operator/subscriptions/noapp.go
@@ -22,7 +22,6 @@ import (
 
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	subapi "github.com/dapr/dapr/pkg/apis/subscriptions/v2alpha1"
-	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
@@ -44,13 +43,6 @@ func (n *noapp) Setup(t *testing.T) []framework.Option {
 
 	operator := operator.New(t,
 		operator.WithSentry(sentry),
-		operator.WithGetConfigurationFn(func(context.Context, *operatorv1.GetConfigurationRequest) (*operatorv1.GetConfigurationResponse, error) {
-			return &operatorv1.GetConfigurationResponse{
-				Configuration: []byte(
-					`{"kind":"Configuration","apiVersion":"dapr.io/v1alpha1","metadata":{"name":"hotreloading"},"spec":{"features":[{"name":"HotReload","enabled":true}]}}`,
-				),
-			}, nil
-		}),
 	)
 
 	n.daprd = daprd.New(t,

--- a/tests/integration/suite/daprd/hotreload/selfhosted/actorstate.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/actorstate.go
@@ -49,17 +49,6 @@ type actorstate struct {
 }
 
 func (a *actorstate) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	a.loglineCreate = logline.New(t, logline.WithStdoutLineContains(
 		"Aborting to hot-reload a state store component that is used as an actor state store: mystore (state.in-memory/v1)",
 	))
@@ -77,7 +66,6 @@ spec:
 	place := placement.New(t)
 
 	a.daprdCreate = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(a.resDirCreate),
 		daprd.WithPlacementAddresses(place.Address()),
 		daprd.WithExecOptions(
@@ -86,7 +74,6 @@ spec:
 	)
 
 	a.daprdUpdate = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(a.resDirUpdate),
 		daprd.WithPlacementAddresses(place.Address()),
 		daprd.WithExecOptions(
@@ -108,7 +95,6 @@ spec:
 `), 0o600))
 
 	a.daprdDelete = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(a.resDirDelete),
 		daprd.WithPlacementAddresses(place.Address()),
 		daprd.WithExecOptions(

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/closing.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/closing.go
@@ -82,15 +82,6 @@ spec:
 		daprd.WithAppPort(app.Port(t)),
 		daprd.WithAppProtocol("grpc"),
 		daprd.WithResourcesDir(c.dir),
-		daprd.WithConfigManifests(t, `
-apiVersion: dapr.io/v1alpha1
-kind: Configun
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/grpc.go
@@ -51,17 +51,6 @@ func (g *grpc) Setup(t *testing.T) []framework.Option {
 		make(chan string, 1), make(chan string, 1), make(chan string, 1),
 	}
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	g.resDir = t.TempDir()
 
 	g.registered[0].Store(true)
@@ -115,7 +104,6 @@ spec:
 `), 0o600))
 
 	g.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(g.resDir),
 		daprd.WithAppProtocol("grpc"),
 		daprd.WithAppPort(srv.Port(t)),

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/http.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/input/http.go
@@ -51,17 +51,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		make(chan string, 1), make(chan string, 1), make(chan string, 1),
 	}
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	h.resDir = t.TempDir()
 
 	h.registered[0].Store(true)
@@ -112,7 +101,6 @@ spec:
 `), 0o600))
 
 	h.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(h.resDir),
 		daprd.WithAppPort(srv.Port()),
 	)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/binding/output.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/binding/output.go
@@ -47,22 +47,10 @@ type output struct {
 }
 
 func (o *output) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	o.resDir = t.TempDir()
 	o.bindingDir1, o.bindingDir2, o.bindingDir3 = t.TempDir(), t.TempDir(), t.TempDir()
 
 	o.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(o.resDir),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/configuration.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/configuration.go
@@ -54,11 +54,8 @@ func (c *configuration) Setup(t *testing.T) []framework.Option {
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: hotreloading
+  name: tracing
 spec:
-  features:
-  - name: HotReload
-    enabled: true
   tracing:
     samplingRate: "0"`), 0o600))
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/crypto.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/crypto.go
@@ -47,22 +47,10 @@ type crypto struct {
 }
 
 func (c *crypto) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	c.resDir = t.TempDir()
 	c.cryptoDir1, c.cryptoDir2 = t.TempDir(), t.TempDir()
 
 	c.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(c.resDir),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/disabled.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/disabled.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfhosted
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtpbv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(disabled))
+}
+
+// disabled verifies that when the HotReload feature is explicitly disabled
+// via Configuration, components present at startup are still loaded once,
+// but subsequent filesystem changes are NOT picked up.
+type disabled struct {
+	daprd  *daprd.Daprd
+	resDir string
+}
+
+func (d *disabled) Setup(t *testing.T) []framework.Option {
+	d.resDir = t.TempDir()
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: hotreloaddisabled
+spec:
+  features:
+  - name: HotReload
+    enabled: false
+`), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(d.resDir, "initial.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'initial'
+spec:
+  type: state.in-memory
+  version: v1
+  metadata: []
+`), 0o600))
+
+	d.daprd = daprd.New(t,
+		daprd.WithConfigs(configFile),
+		daprd.WithResourcesDir(d.resDir),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(d.daprd),
+	}
+}
+
+func (d *disabled) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	t.Run("initial component from disk is loaded at startup", func(t *testing.T) {
+		resp := d.daprd.GetMetaRegisteredComponents(t, ctx)
+		assert.ElementsMatch(t, []*rtpbv1.RegisteredComponents{
+			{
+				Name: "initial", Type: "state.in-memory", Version: "v1",
+				Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "DELETE_WITH_PREFIX", "KEYS_LIKE", "ACTOR"},
+			},
+		}, resp)
+	})
+
+	t.Run("adding a component file after startup is not picked up", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(d.resDir, "added.yaml"), []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'added'
+spec:
+  type: state.in-memory
+  version: v1
+  metadata: []
+`), 0o600))
+
+		assert.Never(t, func() bool {
+			return len(d.daprd.GetMetaRegisteredComponents(t, ctx)) != 1
+		}, time.Second*3, time.Millisecond*100,
+			"hot reload is disabled so added component must not be loaded")
+	})
+
+	t.Run("deleting a component file after startup does not remove it", func(t *testing.T) {
+		require.NoError(t, os.Remove(filepath.Join(d.resDir, "initial.yaml")))
+
+		assert.Never(t, func() bool {
+			return len(d.daprd.GetMetaRegisteredComponents(t, ctx)) != 1
+		}, time.Second*3, time.Millisecond*100,
+			"hot reload is disabled so deleted component must stay registered")
+	})
+}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/httpendpoint.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/httpendpoint.go
@@ -51,17 +51,6 @@ type httpendpoint struct {
 func (h *httpendpoint) Setup(t *testing.T) []framework.Option {
 	h.resDir = t.TempDir()
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	h.backend = prochttp.New(t,
 		prochttp.WithHandlerFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -75,7 +64,6 @@ spec:
 	)
 
 	h.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(h.resDir),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/ignoreerrors.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/ignoreerrors.go
@@ -48,22 +48,9 @@ func (i *ignoreerrors) Setup(t *testing.T) []framework.Option {
 		),
 	)
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true
-`), 0o600))
-
 	i.resDir = t.TempDir()
 
 	i.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(i.resDir),
 		daprd.WithExit1(),
 		daprd.WithLogLineStdout(i.logline),

--- a/tests/integration/suite/daprd/hotreload/selfhosted/mcpserver.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/mcpserver.go
@@ -49,11 +49,9 @@ func (m *mcpserver) Setup(t *testing.T) []framework.Option {
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: hotreloading
+  name: mcpserver
 spec:
   features:
-  - name: HotReload
-    enabled: true
   - name: MCPServerResource
     enabled: true
 `), 0o600))

--- a/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/app/routeralias.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/app/routeralias.go
@@ -50,11 +50,8 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: hotreloading
+  name: middleware
 spec:
-  features:
-  - name: HotReload
-    enabled: true
   appHttpPipeline:
     handlers:
     - name: routeralias1

--- a/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/app/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/app/uppercase.go
@@ -55,11 +55,8 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: hotreloading
+  name: middleware
 spec:
-  features:
-  - name: HotReload
-    enabled: true
   appHttpPipeline:
     handlers:
     - name: uppercase

--- a/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/server/routeralias.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/server/routeralias.go
@@ -50,11 +50,8 @@ func (r *routeralias) Setup(t *testing.T) []framework.Option {
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: hotreloading
+  name: middleware
 spec:
-  features:
-  - name: HotReload
-    enabled: true
   httpPipeline:
     handlers:
     - name: routeralias1

--- a/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/server/uppercase.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/middleware/http/server/uppercase.go
@@ -55,11 +55,8 @@ func (u *uppercase) Setup(t *testing.T) []framework.Option {
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
-  name: hotreloading
+  name: middleware
 spec:
-  features:
-  - name: HotReload
-    enabled: true
   httpPipeline:
     handlers:
     - name: uppercase

--- a/tests/integration/suite/daprd/hotreload/selfhosted/namespace/set.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/namespace/set.go
@@ -43,17 +43,6 @@ type set struct {
 }
 
 func (s *set) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	s.resDir = t.TempDir()
 
 	s.logline = logline.New(t, logline.WithStdoutLineContains(
@@ -61,7 +50,6 @@ spec:
 	))
 
 	s.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(s.resDir),
 		daprd.WithExit1(),
 		daprd.WithLogLineStdout(s.logline),

--- a/tests/integration/suite/daprd/hotreload/selfhosted/namespace/unset.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/namespace/unset.go
@@ -43,17 +43,6 @@ type unset struct {
 }
 
 func (u *unset) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	u.resDir = t.TempDir()
 
 	u.logline = logline.New(t, logline.WithStdoutLineContains(
@@ -61,7 +50,6 @@ spec:
 	))
 
 	u.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(u.resDir),
 		daprd.WithExit1(),
 		daprd.WithLogLineStdout(u.logline),

--- a/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/grpc.go
@@ -45,17 +45,6 @@ type grpc struct {
 func (g *grpc) Setup(t *testing.T) []framework.Option {
 	g.topicChan = make(chan string, 1)
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-    - name: HotReload
-      enabled: true`), 0o600))
-
 	srv := app.New(t,
 		app.WithOnTopicEventFn(func(_ context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
 			g.topicChan <- in.GetPath()
@@ -85,7 +74,6 @@ spec:
 `), 0o600))
 
 	g.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(g.resDir),
 		daprd.WithAppPort(srv.Port(t)),
 		daprd.WithAppProtocol("grpc"),

--- a/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/http.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/pubsub/http.go
@@ -48,17 +48,6 @@ type http struct {
 func (h *http) Setup(t *testing.T) []framework.Option {
 	h.topicChan = make(chan string, 1)
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-    - name: HotReload
-      enabled: true`), 0o600))
-
 	handler := nethttp.NewServeMux()
 	handler.HandleFunc("/dapr/subscribe", func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		w.WriteHeader(nethttp.StatusOK)
@@ -102,7 +91,6 @@ spec:
 `), 0o600))
 
 	h.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(h.resDir),
 		daprd.WithAppPort(srv.Port()),
 	)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/resiliency.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/resiliency.go
@@ -46,19 +46,7 @@ func (r *resiliency) Setup(t *testing.T) []framework.Option {
 	r.logOut = log.New()
 	r.resDir = t.TempDir()
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	r.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(r.resDir),
 		daprd.WithExecOptions(exec.WithStdout(r.logOut), exec.WithStderr(r.logOut)),
 	)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/scope.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/scope.go
@@ -40,22 +40,9 @@ type scopes struct {
 }
 
 func (s *scopes) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true
-`), 0o600))
-
 	s.resDir = t.TempDir()
 
 	s.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(s.resDir),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/scopes/components.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/scopes/components.go
@@ -41,15 +41,6 @@ func (c *components) Setup(t *testing.T) []framework.Option {
 	c.resDir = t.TempDir()
 
 	c.daprd = daprd.New(t,
-		daprd.WithConfigManifests(t, `
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
- name: hotreloading
-spec:
- features:
- - name: HotReload
-   enabled: true`),
 		daprd.WithResourcesDir(c.resDir),
 		daprd.WithNamespace("default"),
 		daprd.WithAppID("myappid"),

--- a/tests/integration/suite/daprd/hotreload/selfhosted/secret.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/secret.go
@@ -49,22 +49,10 @@ type secret struct {
 }
 
 func (s *secret) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-    - name: HotReload
-      enabled: true`), 0o600))
-
 	s.resDir1, s.resDir2, s.resDir3 = t.TempDir(), t.TempDir(), t.TempDir()
 	s.client = client.HTTP(t)
 
 	s.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(s.resDir1, s.resDir2, s.resDir3),
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"FOO_SEC_1", "bar1",

--- a/tests/integration/suite/daprd/hotreload/selfhosted/state.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/state.go
@@ -48,21 +48,9 @@ type state struct {
 }
 
 func (s *state) Setup(t *testing.T) []framework.Option {
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	s.resDir1, s.resDir2, s.resDir3 = t.TempDir(), t.TempDir(), t.TempDir()
 
 	s.daprd = daprd.New(t,
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(s.resDir1, s.resDir2, s.resDir3),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/closing.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/closing.go
@@ -84,15 +84,6 @@ spec:
 		daprd.WithAppPort(app.Port(t)),
 		daprd.WithAppProtocol("grpc"),
 		daprd.WithResourcesDir(c.dir),
-		daprd.WithConfigManifests(t, `
-apiVersion: dapr.io/v1alpha1
-kind: Configun
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/grpc.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/grpc.go
@@ -46,17 +46,6 @@ type grpc struct {
 func (g *grpc) Setup(t *testing.T) []framework.Option {
 	g.sub = subscriber.New(t)
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	g.resDir1, g.resDir2 = t.TempDir(), t.TempDir()
 
 	for i, dir := range []string{g.resDir1, g.resDir2} {
@@ -74,7 +63,6 @@ spec:
 	g.daprd = daprd.New(t,
 		daprd.WithAppPort(g.sub.Port(t)),
 		daprd.WithAppProtocol("grpc"),
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(g.resDir1, g.resDir2),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/http.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/http.go
@@ -48,17 +48,6 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		subscriber.WithRoutes("/a", "/b", "/c", "/d", "/e", "/f"),
 	)
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	h.resDir1, h.resDir2 = t.TempDir(), t.TempDir()
 
 	for i, dir := range []string{h.resDir1, h.resDir2} {
@@ -76,7 +65,6 @@ spec:
 	h.daprd = daprd.New(t,
 		daprd.WithAppPort(h.sub.Port()),
 		daprd.WithAppProtocol("http"),
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(h.resDir1, h.resDir2),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/inflight.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/inflight.go
@@ -56,17 +56,6 @@ func (i *inflight) Setup(t *testing.T) []framework.Option {
 		}),
 	)
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	i.dir = t.TempDir()
 
 	require.NoError(t, os.WriteFile(filepath.Join(i.dir, "pubsub.yaml"), []byte(`
@@ -81,7 +70,6 @@ spec:
 
 	i.daprd = daprd.New(t,
 		daprd.WithAppPort(i.sub.Port()),
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(i.dir),
 	)
 

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/noapp.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/noapp.go
@@ -62,15 +62,6 @@ spec:
 
 	n.daprd = daprd.New(t,
 		daprd.WithResourcesDir(n.dir),
-		daprd.WithConfigManifests(t, `
-apiVersion: dapr.io/v1alpha1
-kind: Configun
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/stream/persist.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/subscriptions/stream/persist.go
@@ -43,17 +43,6 @@ type persist struct {
 func (p *persist) Setup(t *testing.T) []framework.Option {
 	p.sub = subscriber.New(t)
 
-	configFile := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(configFile, []byte(`
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: hotreloading
-spec:
-  features:
-  - name: HotReload
-    enabled: true`), 0o600))
-
 	p.dir = t.TempDir()
 
 	require.NoError(t, os.WriteFile(filepath.Join(p.dir, "pubsub.yaml"), []byte(`
@@ -69,7 +58,6 @@ spec:
 	p.daprd = daprd.New(t,
 		daprd.WithAppPort(p.sub.Port(t)),
 		daprd.WithAppProtocol("grpc"),
-		daprd.WithConfigs(configFile),
 		daprd.WithResourcesDir(p.dir),
 	)
 


### PR DESCRIPTION
# Description

- Flip the `HotReload` preview feature to on-by-default, graduating hot reload of Components, Subscriptions, MCPServers, Configurations, HTTPEndpoints, and Resiliencies to GA (refs dapr/dapr#9577).
- Harden the Subscription reconciler: skip the close+reopen when an incoming Subscription CRD event is functionally identical to the one already loaded. Prevents a startup race where the boot-time loader and the operator stream both delivered the same Subscription, causing transient subscriber overlap and occasional duplicated/lost messages (observed as flakes in `daprd/subscriptions/declarative/operator/v2alpha1/routes/defaultroute`).
- Clean up the now-redundant `hotreloading` Configurations and `WithConfigs("hotreloading")` wiring across the integration and e2e suites, and add a selfhosted test that pins the opt-out contract via `HotReload: false`.

## Changes

### Runtime
- `pkg/config/configuration.go` — add `HotReload: true` to `defaultFeatures`.
- `pkg/runtime/hotreload/reconciler/subscriptions.go` — guard `update()` with `differ.AreSame` (mirroring the Component reconciler) so duplicate CREATE events do not close+reopen the live subscription.

### Tests
- `tests/config/preview_configurations.yaml`, `tests/e2e/hotreloading/hotreloading_test.go` — drop the removed `hotreloading` Configuration and its e2e reference.
- `tests/integration/suite/daprd/hotreload/...` (operator + selfhosted) — remove explicit `WithConfigs("hotreloading")` from cases that only enabled HotReload, and rename the few mixed Configurations that still carry non-HotReload spec (tracing / mcpserver / middleware) to names descriptive of what remains.
- `tests/integration/suite/daprd/hotreload/selfhosted/disabled.go` — new case asserting that `HotReload: false` disables runtime reloading: initial resources on disk load at startup, and later filesystem add/delete are ignored.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: https://github.com/dapr/dapr/issues/9577

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
