### PR TITLE
test(operator): fix flaky TestDaprWatchdog_Start by removing sleep

### DIFF
--- a/pkg/operator/watchdog_test.go
+++ b/pkg/operator/watchdog_test.go
@@ -242,14 +242,7 @@ func Test_patchPodLabel(t *testing.T) {
 }
 
 func TestDaprWatchdog_Start(t *testing.T) {
-	// simple test of start
-	ctx, cancel := context.WithCancel(t.Context())
-	cancelled := false
-	defer func() {
-		if !cancelled {
-			cancel()
-		}
-	}()
+	ctx := t.Context()
 
 	singleIterationDurationThreshold = 100 * time.Millisecond
 	defer func() {
@@ -262,7 +255,7 @@ func TestDaprWatchdog_Start(t *testing.T) {
 		client:            ctlClient,
 		maxRestartsPerMin: 0,
 		canPatchPodLabels: true,
-		interval:          200 * time.Millisecond,
+		interval:          50 * time.Millisecond,
 		podSelector:       getSideCarInjectedNotExistsSelector(),
 	}
 	daprized := 5
@@ -273,17 +266,7 @@ func TestDaprWatchdog_Start(t *testing.T) {
 		require.NoError(t, ctlClient.Create(ctx, pod))
 	}
 
-	startDone := make(chan error)
-	go func() {
-		startDone <- dw.Start(ctx)
-	}()
-
-	// let it run a few cycles
-	time.Sleep(time.Second)
-	cancel()
-	cancelled = true
-
-	require.NoError(t, <-startDone)
+	require.NoError(t, dw.Start(ctx))
 
 	t.Log("daprized pods should be deleted except those running")
 	assertExpectedPodsDeleted(t, pods, ctlClient, ctx, daprized, running, injected)


### PR DESCRIPTION
Related to #5915

## Summary

`TestDaprWatchdog_Start` used timing-based synchronization by starting `dw.Start(ctx)` in a goroutine, sleeping for 1 second, and then cancelling the context. That makes the test dependent on scheduler timing and machine load, which can become flaky under CI and especially under race instrumentation.

This change makes the test deterministic and single-iteration based instead of wall-clock based. It sets `dw.interval` below `singleIterationDurationThreshold`, so `DaprWatchdog.Start` returns after the first successful iteration. With that in place, the test can call `dw.Start(ctx)` directly and remove the extra goroutine, `time.Sleep`, and manual cancellation path.

## Verification

Ran:

```bash
go test -race -count=50 -run TestDaprWatchdog_Start ./pkg/operator
```

Result: passed successfully.
