### PR TITLE
fix(runtime): align bulk HTTP pubsub empty status response with single delivery

### DIFF
--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -295,9 +295,11 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 		for _, response := range appBulkResponse.AppResponses {
 			if _, ok := (*bscData.EntryIdIndexMap)[response.EntryId]; ok {
 				switch response.Status {
-				case "":
-					// When statusCode 2xx, Consider empty status field OR not receiving status for an item as retry
-					fallthrough
+				case "", contribpubsub.Success:
+					// When statusCode is 2xx, consider empty status field as success.
+					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Success)]++
+					entryRespReceived[response.EntryId] = true
+					todo.AddBulkResponseEntry(&bsrr.Entries, response.EntryId, nil)
 				case contribpubsub.Retry:
 					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Retry)]++
 					entryRespReceived[response.EntryId] = true
@@ -305,10 +307,6 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 						fmt.Errorf("RETRY required while processing bulk subscribe event for entry id: %v", response.EntryId))
 
 					hasAnyError = true
-				case contribpubsub.Success:
-					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Success)]++
-					entryRespReceived[response.EntryId] = true
-					todo.AddBulkResponseEntry(&bsrr.Entries, response.EntryId, nil)
 				case contribpubsub.Drop:
 					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Drop)]++
 					entryRespReceived[response.EntryId] = true

--- a/pkg/runtime/subscription/postman/http/http_test.go
+++ b/pkg/runtime/subscription/postman/http/http_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/channels"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
+	"github.com/dapr/dapr/pkg/runtime/subscription/postman"
+	"github.com/dapr/dapr/pkg/runtime/subscription/todo"
 	"github.com/dapr/kit/logger"
 )
 
@@ -437,4 +439,67 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		assert.Equal(t, expectedClientError.Error(), err.Error())
 		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 	})
+}
+
+func TestDeliverBulkTreatsEmptyStatusAsSuccess(t *testing.T) {
+	entryID := "entry-1"
+	topic := "topic1"
+
+	mockAppChannel := new(channelt.MockAppChannel)
+	h := New(Options{
+		Channels: new(channels.Channels).WithAppChannel(mockAppChannel),
+	})
+
+	fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
+		WithRawDataString(`{"statuses":[{"entryId":"entry-1","status":""}]}`).
+		WithContentType("application/json")
+	defer fakeResp.Close()
+
+	mockAppChannel.On("InvokeMethod", mock.Anything, mock.Anything).Return(fakeResp, nil)
+
+	entryIDIndexMap := map[string]int{entryID: 0}
+	bulkSubDiag := todo.NewBulkSubIngressDiagnostics()
+	req := &postman.DeliverBulkRequest{
+		BulkSubCallData: &todo.BulkSubscribeCallData{
+			BulkSubDiag:     &bulkSubDiag,
+			EntryIdIndexMap: &entryIDIndexMap,
+			PsName:          "testpubsub",
+			Topic:           topic,
+		},
+		BulkSubMsg: &todo.BulkSubscribedMessage{
+			PubSubMessages: []todo.Message{
+				{
+					CloudEvent: map[string]any{},
+					RawData: &runtimePubsub.BulkSubscribeMessageItem{
+						EntryId:     entryID,
+						Event:       map[string]any{"value": "payload"},
+						Metadata:    map[string]string{"k": "v"},
+						ContentType: "application/json",
+					},
+					Entry: &contribpubsub.BulkMessageEntry{
+						EntryId:     entryID,
+						Event:       []byte(`{"value":"payload"}`),
+						Metadata:    map[string]string{"k": "v"},
+						ContentType: "application/json",
+					},
+				},
+			},
+			Topic:    topic,
+			Metadata: map[string]string{"pubsubName": "testpubsub"},
+			Pubsub:   "testpubsub",
+			Path:     topic,
+		},
+		BulkSubResiliencyRes: &todo.BulkSubscribeResiliencyRes{
+			Entries:  make([]contribpubsub.BulkSubscribeResponseEntry, 0, 1),
+			Envelope: map[string]any{},
+		},
+	}
+
+	require.NoError(t, h.DeliverBulk(t.Context(), req))
+	require.Len(t, req.BulkSubResiliencyRes.Entries, 1)
+	assert.Equal(t, entryID, req.BulkSubResiliencyRes.Entries[0].EntryId)
+	assert.NoError(t, req.BulkSubResiliencyRes.Entries[0].Error)
+	assert.EqualValues(t, 1, bulkSubDiag.StatusWiseDiag[string(contribpubsub.Success)])
+	assert.Zero(t, bulkSubDiag.StatusWiseDiag[string(contribpubsub.Retry)])
+	mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 }


### PR DESCRIPTION
Fixes #8737

Bulk HTTP pubsub delivery currently treats an app response with `status == ""` as RETRY even when the app returned a response entry for that message. Single HTTP delivery and gRPC flows both interpret an empty status as SUCCESS, so the HTTP bulk path is inconsistent and can trigger unnecessary retries.

This change aligns that contract by moving `case ""` onto the SUCCESS branch in `DeliverBulk`. Missing response entries are still handled as RETRY, so the behavior change is limited to explicit empty-status responses from the app.

A regression test covers the empty-status bulk response case, and unit tests passed:

- `go test -tags=unit,allcomponents ./pkg/runtime/subscription/...`
