### PR TITLE
Widen liveness and tighten readiness probe defaults

### DIFF
--- a/charts/dapr/charts/dapr_operator/values.yaml
+++ b/charts/dapr/charts/dapr_operator/values.yaml
@@ -38,13 +38,13 @@ resources: {}
 extraEnvVars: {}
 
 livenessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
+  initialDelaySeconds: 180
+  periodSeconds: 10
   failureThreshold: 5
 readinessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
-  failureThreshold: 5
+  initialDelaySeconds: 1
+  periodSeconds: 1
+  failureThreshold: 3
 
 debug:
   enabled: false

--- a/charts/dapr/charts/dapr_placement/values.yaml
+++ b/charts/dapr/charts/dapr_placement/values.yaml
@@ -43,13 +43,13 @@ replicationFactor: 100
 metadataEnabled: false
 
 livenessProbe:
-  initialDelaySeconds: 10
-  periodSeconds: 3
+  initialDelaySeconds: 180
+  periodSeconds: 10
   failureThreshold: 5
 readinessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
-  failureThreshold: 5
+  initialDelaySeconds: 1
+  periodSeconds: 1
+  failureThreshold: 3
 
 debug:
   enabled: false

--- a/charts/dapr/charts/dapr_scheduler/values.yaml
+++ b/charts/dapr/charts/dapr_scheduler/values.yaml
@@ -57,13 +57,13 @@ etcdClientPassword: ""
 workers: 2048
 
 livenessProbe:
-  initialDelaySeconds: 10
-  periodSeconds: 3
+  initialDelaySeconds: 180
+  periodSeconds: 10
   failureThreshold: 5
 readinessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
-  failureThreshold: 5
+  initialDelaySeconds: 1
+  periodSeconds: 1
+  failureThreshold: 3
 
 debug:
   enabled: false

--- a/charts/dapr/charts/dapr_sentry/values.yaml
+++ b/charts/dapr/charts/dapr_sentry/values.yaml
@@ -65,13 +65,13 @@ oidc:
     keyFile: ""
 
 livenessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
+  initialDelaySeconds: 180
+  periodSeconds: 10
   failureThreshold: 5
 readinessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
-  failureThreshold: 5
+  initialDelaySeconds: 1
+  periodSeconds: 1
+  failureThreshold: 3
 
 debug:
   enabled: false

--- a/charts/dapr/charts/dapr_sidecar_injector/values.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/values.yaml
@@ -41,13 +41,13 @@ objectSelector: {}
 namespaceSelector: {}
 
 livenessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
+  initialDelaySeconds: 180
+  periodSeconds: 10
   failureThreshold: 5
 readinessProbe:
-  initialDelaySeconds: 3
-  periodSeconds: 3
-  failureThreshold: 5
+  initialDelaySeconds: 1
+  periodSeconds: 1
+  failureThreshold: 3
 
 debug:
   enabled: false

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -85,14 +85,14 @@ type SidecarConfig struct {
 	SidecarMemoryRequest                string  `annotation:"dapr.io/sidecar-memory-request"`
 	SidecarMemoryLimit                  string  `annotation:"dapr.io/sidecar-memory-limit"`
 	SidecarListenAddresses              string  `annotation:"dapr.io/sidecar-listen-addresses" default:"[::1],127.0.0.1"`
-	SidecarLivenessProbeDelaySeconds    int32   `annotation:"dapr.io/sidecar-liveness-probe-delay-seconds"    default:"3"`
+	SidecarLivenessProbeDelaySeconds    int32   `annotation:"dapr.io/sidecar-liveness-probe-delay-seconds"    default:"180"`
 	SidecarLivenessProbeTimeoutSeconds  int32   `annotation:"dapr.io/sidecar-liveness-probe-timeout-seconds"  default:"3"`
-	SidecarLivenessProbePeriodSeconds   int32   `annotation:"dapr.io/sidecar-liveness-probe-period-seconds"   default:"6"`
-	SidecarLivenessProbeThreshold       int32   `annotation:"dapr.io/sidecar-liveness-probe-threshold"        default:"3"`
-	SidecarReadinessProbeDelaySeconds   int32   `annotation:"dapr.io/sidecar-readiness-probe-delay-seconds"   default:"3"`
-	SidecarReadinessProbeTimeoutSeconds int32   `annotation:"dapr.io/sidecar-readiness-probe-timeout-seconds" default:"3"`
-	SidecarReadinessProbePeriodSeconds  int32   `annotation:"dapr.io/sidecar-readiness-probe-period-seconds"  default:"6"`
-	SidecarReadinessProbeThreshold      int32   `annotation:"dapr.io/sidecar-readiness-probe-threshold"       default:"3"`
+	SidecarLivenessProbePeriodSeconds   int32   `annotation:"dapr.io/sidecar-liveness-probe-period-seconds"   default:"10"`
+	SidecarLivenessProbeThreshold       int32   `annotation:"dapr.io/sidecar-liveness-probe-threshold"        default:"5"`
+	SidecarReadinessProbeDelaySeconds   int32   `annotation:"dapr.io/sidecar-readiness-probe-delay-seconds"   default:"1"`
+	SidecarReadinessProbeTimeoutSeconds int32   `annotation:"dapr.io/sidecar-readiness-probe-timeout-seconds" default:"1"`
+	SidecarReadinessProbePeriodSeconds  int32   `annotation:"dapr.io/sidecar-readiness-probe-period-seconds"  default:"1"`
+	SidecarReadinessProbeThreshold      int32   `annotation:"dapr.io/sidecar-readiness-probe-threshold"       default:"5"`
 	SidecarImage                        string  `annotation:"dapr.io/sidecar-image"`
 	SidecarSeccompProfileType           string  `annotation:"dapr.io/sidecar-seccomp-profile-type"`
 	HTTPMaxRequestSize                  *int    `annotation:"dapr.io/http-max-request-size"` // Legacy flag


### PR DESCRIPTION
Liveness probes are only appropriate as a last-resort restart mechanism for software you don't own. For processes Dapr owns, short liveness windows turn transient blips (GC pauses, startup work, brief stalls) into restart loops that mask the underlying bug rather than surface it. Readiness is the correct lever for routing traffic away from an unhealthy replica.

This change pushes liveness well past any plausible real-world stall (~230s before kubelet restart) while making readiness more responsive so broken pods stop receiving traffic quickly.

```
Liveness (control plane + injected sidecar):
  initialDelaySeconds: 180
  periodSeconds:        10
  failureThreshold:      5

Readiness (control plane, few replicas, fast isolation):
  initialDelaySeconds: 1
  periodSeconds:       1
  failureThreshold:    3   (~3s to eject)

Readiness (daprd sidecar, more forgiving for user workloads):
  initialDelaySeconds: 1
  periodSeconds:       1
  timeoutSeconds:      1
  failureThreshold:    5   (~5s to eject, absorbs brief GC / CPU stalls)
```