### PR TITLE
worfklows: single-RTT cold load, chunked saves, native purge fast path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -527,6 +527,8 @@ replace (
 // replace github.com/dapr/components-contrib => ../components-contrib
 // replace github.com/dapr/kit => ../kit
 // replace github.com/dapr/durabletask-go => ../durabletask-go
-//
+
+replace github.com/dapr/components-contrib => github.com/joshvanl/components-contrib v0.0.0-20260423204741-2008a135be42
+
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,6 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.17.3 h1:lhSvLZ1nGGkmlRKCpzgNEsnNXqOWjFlhAtp1Rjxp8HU=
-github.com/dapr/components-contrib v1.17.3/go.mod h1:lVPRj9ywzkUWoKXxRTAJbvS+Vg8A882av/nynGstNE4=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
 github.com/dapr/durabletask-go v0.11.4-0.20260413145313-c4b7279b6a8e h1:SSBxGb1/dOmzyWZhKNHVliw/VemiYgLKlv8oOTIsGG0=
@@ -1101,6 +1099,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/components-contrib v0.0.0-20260423204741-2008a135be42 h1:VkmOqmiU32FJb+UeW0WT/N7Qpe2BXn9ZY/iqxLhRTLM=
+github.com/joshvanl/components-contrib v0.0.0-20260423204741-2008a135be42/go.mod h1:nfeWBCYOBFRgYZ+q3A8fHVJkP5n8N3QyB+6O9S5D5uE=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/actors/state/fake/fake.go
+++ b/pkg/actors/state/fake/fake.go
@@ -23,6 +23,8 @@ type Fake struct {
 	getFn                         func(ctx context.Context, req *api.GetStateRequest, lock bool) (*api.StateResponse, error)
 	getBulkFn                     func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error)
 	transactionalStateOperationFn func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error
+	multiMaxSizeFn                func() int
+	deleteActorStateFn            func(ctx context.Context, actorType, actorID string) (bool, error)
 }
 
 func New() *Fake {
@@ -35,6 +37,12 @@ func New() *Fake {
 		},
 		transactionalStateOperationFn: func(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error {
 			return nil
+		},
+		multiMaxSizeFn: func() int {
+			return 0
+		},
+		deleteActorStateFn: func(ctx context.Context, actorType, actorID string) (bool, error) {
+			return false, nil
 		},
 	}
 }
@@ -54,6 +62,16 @@ func (f *Fake) WithTransactionalStateOperationFn(fn func(ctx context.Context, ig
 	return f
 }
 
+func (f *Fake) WithMultiMaxSizeFn(fn func() int) *Fake {
+	f.multiMaxSizeFn = fn
+	return f
+}
+
+func (f *Fake) WithDeleteActorStateFn(fn func(ctx context.Context, actorType, actorID string) (bool, error)) *Fake {
+	f.deleteActorStateFn = fn
+	return f
+}
+
 func (f *Fake) Get(ctx context.Context, req *api.GetStateRequest, lock bool) (*api.StateResponse, error) {
 	return f.getFn(ctx, req, lock)
 }
@@ -64,4 +82,12 @@ func (f *Fake) GetBulk(ctx context.Context, req *api.GetBulkStateRequest, lock b
 
 func (f *Fake) TransactionalStateOperation(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error {
 	return f.transactionalStateOperationFn(ctx, ignoreHosted, req, lock)
+}
+
+func (f *Fake) MultiMaxSize() int {
+	return f.multiMaxSizeFn()
+}
+
+func (f *Fake) DeleteActorState(ctx context.Context, actorType, actorID string) (bool, error) {
+	return f.deleteActorStateFn(ctx, actorType, actorID)
 }

--- a/pkg/actors/state/state.go
+++ b/pkg/actors/state/state.go
@@ -47,6 +47,18 @@ type Interface interface {
 
 	// TransactionalStateOperation performs a transactional state operation with the actor state store.
 	TransactionalStateOperation(ctx context.Context, ignoreHosted bool, req *api.TransactionalRequest, lock bool) error
+
+	// MultiMaxSize reports the maximum number of operations the configured
+	// state store will accept in a single transactional request. Returns 0
+	// when the store does not expose a limit.
+	MultiMaxSize() int
+
+	// DeleteActorState removes all state keys belonging to the given actor
+	// instance. When the configured store supports contribstate.DeleteWithPrefix
+	// this is a single server-side operation; otherwise the caller is
+	// responsible for falling back to a transactional delete. Returns
+	// (ok=false, nil) when the store does not implement DeleteWithPrefix.
+	DeleteActorState(ctx context.Context, actorType, actorID string) (ok bool, err error)
 }
 
 type Backend interface {
@@ -248,6 +260,42 @@ func (s *state) executeStateStoreTransaction(ctx context.Context, operations []c
 		return struct{}{}, store.Multi(ctx, stateReq)
 	})
 	return err
+}
+
+func (s *state) DeleteActorState(ctx context.Context, actorType, actorID string) (bool, error) {
+	storeName, store, err := s.stateStore()
+	if err != nil {
+		return false, err
+	}
+	pfx, ok := store.(contribstate.DeleteWithPrefix)
+	if !ok || !contribstate.FeatureDeleteWithPrefix.IsPresent(store.Features()) {
+		return false, nil
+	}
+	// Keys for an actor are stored as appID||actorType||actorID||<inner-key>
+	// — matching construction in TransactionalStateOperation above.
+	prefix := key.ConstructComposite(s.appID, actorType, actorID) + api.DaprSeparator
+	policyRunner := resiliency.NewRunner[struct{}](ctx,
+		s.resiliency.ComponentOutboundPolicy(storeName, resiliency.Statestore),
+	)
+	_, err = policyRunner(func(ctx context.Context) (struct{}, error) {
+		_, perr := pfx.DeleteWithPrefix(ctx, contribstate.DeleteWithPrefixRequest{Prefix: prefix})
+		return struct{}{}, perr
+	})
+	if err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func (s *state) MultiMaxSize() int {
+	_, store, err := s.stateStore()
+	if err != nil {
+		return 0
+	}
+	if maxMulti, ok := store.(contribstate.TransactionalStoreMultiMaxSize); ok {
+		return maxMulti.MultiMaxSize()
+	}
+	return 0
 }
 
 func (s *state) stateStore() (string, Backend, error) {

--- a/pkg/actors/state/state_test.go
+++ b/pkg/actors/state/state_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	contribmd "github.com/dapr/components-contrib/metadata"
+	contribstate "github.com/dapr/components-contrib/state"
+	placementfake "github.com/dapr/dapr/pkg/actors/internal/placement/fake"
+	tablefake "github.com/dapr/dapr/pkg/actors/table/fake"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+)
+
+type recordingStore struct {
+	features []contribstate.Feature
+
+	// multiMaxSize is the value the optional TransactionalStoreMultiMaxSize
+	// method should return. 0 means the interface is not implemented.
+	multiMaxSize int
+
+	// deleteWithPrefixErr, when non-nil, is returned from DeleteWithPrefix.
+	deleteWithPrefixErr error
+
+	// deleteWithPrefixCount is returned from DeleteWithPrefix.Count.
+	deleteWithPrefixCount int64
+
+	// observedPrefix captures the prefix passed to DeleteWithPrefix on the
+	// most recent call. Empty if never called.
+	observedPrefix string
+
+	// deleteWithPrefixCalls counts DeleteWithPrefix invocations.
+	deleteWithPrefixCalls int
+}
+
+func (r *recordingStore) Init(context.Context, contribstate.Metadata) error { return nil }
+func (r *recordingStore) Features() []contribstate.Feature                  { return r.features }
+func (r *recordingStore) Close() error                                      { return nil }
+
+func (r *recordingStore) Get(context.Context, *contribstate.GetRequest) (*contribstate.GetResponse, error) {
+	return &contribstate.GetResponse{}, nil
+}
+
+func (r *recordingStore) Set(context.Context, *contribstate.SetRequest) error { return nil }
+func (r *recordingStore) Delete(context.Context, *contribstate.DeleteRequest) error {
+	return nil
+}
+
+func (r *recordingStore) BulkGet(context.Context, []contribstate.GetRequest, contribstate.BulkGetOpts) ([]contribstate.BulkGetResponse, error) {
+	return nil, nil
+}
+
+func (r *recordingStore) BulkSet(context.Context, []contribstate.SetRequest, contribstate.BulkStoreOpts) error {
+	return nil
+}
+
+func (r *recordingStore) BulkDelete(context.Context, []contribstate.DeleteRequest, contribstate.BulkStoreOpts) error {
+	return nil
+}
+
+func (r *recordingStore) Multi(context.Context, *contribstate.TransactionalStateRequest) error {
+	return nil
+}
+
+func (r *recordingStore) GetComponentMetadata() contribmd.MetadataMap { return contribmd.MetadataMap{} }
+
+// DeleteWithPrefix records the call and returns the preconfigured result.
+// Satisfies contribstate.DeleteWithPrefix.
+func (r *recordingStore) DeleteWithPrefix(_ context.Context, req contribstate.DeleteWithPrefixRequest) (contribstate.DeleteWithPrefixResponse, error) {
+	r.deleteWithPrefixCalls++
+	r.observedPrefix = req.Prefix
+	return contribstate.DeleteWithPrefixResponse{Count: r.deleteWithPrefixCount}, r.deleteWithPrefixErr
+}
+
+// withMultiMax wraps recordingStore and optionally implements
+// TransactionalStoreMultiMaxSize. Kept separate so the base recordingStore
+// stays a clean contribstate.Store — we attach the optional interface
+// conditionally to mirror real contrib components.
+type withMultiMax struct {
+	*recordingStore
+}
+
+func (w withMultiMax) MultiMaxSize() int { return w.multiMaxSize }
+
+// Assert interface satisfaction at compile time.
+var (
+	_ contribstate.Store                          = (*recordingStore)(nil)
+	_ contribstate.TransactionalStore             = (*recordingStore)(nil)
+	_ contribstate.DeleteWithPrefix               = (*recordingStore)(nil)
+	_ contribstate.TransactionalStoreMultiMaxSize = withMultiMax{}
+)
+
+func newTestState(t *testing.T, store contribstate.Store) (*state, *recordingStore) {
+	t.Helper()
+
+	rec, ok := store.(*recordingStore)
+	if !ok {
+		if w, ok2 := store.(withMultiMax); ok2 {
+			rec = w.recordingStore
+		}
+	}
+
+	cs := compstore.New()
+	cs.AddStateStore("test-store", store)
+	require.NoError(t, cs.AddStateStoreActor("test-store", store))
+
+	s := New(Options{
+		AppID:      "test-app",
+		StoreName:  "test-store",
+		CompStore:  cs,
+		Resiliency: resiliency.New(nil),
+		Table:      tablefake.New(),
+		Placement:  placementfake.New(),
+	}).(*state)
+
+	return s, rec
+}
+
+func TestDeleteActorState_UsesContribFastPathWhenFeaturePresent(t *testing.T) {
+	store := &recordingStore{
+		features: []contribstate.Feature{
+			contribstate.FeatureETag,
+			contribstate.FeatureTransactional,
+			contribstate.FeatureDeleteWithPrefix,
+		},
+		deleteWithPrefixCount: 5,
+	}
+	s, rec := newTestState(t, store)
+
+	ok, err := s.DeleteActorState(t.Context(), "wf", "inst-1")
+	require.NoError(t, err)
+	assert.True(t, ok, "DeleteActorState must return true when the store advertises FeatureDeleteWithPrefix")
+	assert.Equal(t, 1, rec.deleteWithPrefixCalls, "contrib DeleteWithPrefix must be called exactly once")
+
+	// The composite prefix is appID||actorType||actorID||, built the same
+	// way as in the transactional path so state keys line up.
+	assert.Equal(t, "test-app||wf||inst-1||", rec.observedPrefix,
+		"DeleteActorState must pass the actor-key prefix with trailing DaprSeparator")
+}
+
+func TestDeleteActorState_ReturnsFalseWhenFeatureMissing(t *testing.T) {
+	// No FeatureDeleteWithPrefix in Features(). The caller must fall back
+	// to the transactional-delete path (see purgeWorkflowForce).
+	store := &recordingStore{
+		features: []contribstate.Feature{
+			contribstate.FeatureETag,
+			contribstate.FeatureTransactional,
+		},
+	}
+	s, rec := newTestState(t, store)
+
+	ok, err := s.DeleteActorState(t.Context(), "wf", "inst-2")
+	require.NoError(t, err)
+	assert.False(t, ok, "DeleteActorState must return (false, nil) when the feature is not advertised")
+	assert.Zero(t, rec.deleteWithPrefixCalls, "contrib DeleteWithPrefix must not be called when the feature is absent")
+}
+
+func TestDeleteActorState_PropagatesContribError(t *testing.T) {
+	boom := errors.New("boom")
+	store := &recordingStore{
+		features: []contribstate.Feature{
+			contribstate.FeatureETag,
+			contribstate.FeatureTransactional,
+			contribstate.FeatureDeleteWithPrefix,
+		},
+		deleteWithPrefixErr: boom,
+	}
+	s, _ := newTestState(t, store)
+
+	ok, err := s.DeleteActorState(t.Context(), "wf", "inst-3")
+	assert.True(t, ok, "ok must be true so the caller knows the fast path was taken (and failed)")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+}
+
+func TestMultiMaxSize_ReportsStoreLimit(t *testing.T) {
+	base := &recordingStore{
+		features: []contribstate.Feature{
+			contribstate.FeatureETag,
+			contribstate.FeatureTransactional,
+		},
+		multiMaxSize: 100,
+	}
+	store := withMultiMax{recordingStore: base}
+	s, _ := newTestState(t, store)
+
+	assert.Equal(t, 100, s.MultiMaxSize(),
+		"MultiMaxSize must surface the contrib store's TransactionalStoreMultiMaxSize limit "+
+			"(used by GetChunkedSaveRequest to split large workflow saves)")
+}
+
+func TestMultiMaxSize_ReturnsZeroWhenUnlimited(t *testing.T) {
+	// Store does not implement TransactionalStoreMultiMaxSize → unlimited.
+	store := &recordingStore{
+		features: []contribstate.Feature{
+			contribstate.FeatureETag,
+			contribstate.FeatureTransactional,
+		},
+	}
+	s, _ := newTestState(t, store)
+
+	assert.Zero(t, s.MultiMaxSize(),
+		"MultiMaxSize must return 0 when the store does not expose a limit")
+}

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -95,15 +95,21 @@ func (o *orchestrator) signAndSaveState(ctx context.Context, state *wfenginestat
 
 func (o *orchestrator) saveInternalState(ctx context.Context, state *wfenginestate.State) error {
 	// generate and run a state store operation that saves all changes
-	req, err := state.GetSaveRequest(o.actorID)
+	chunks, err := state.GetChunkedSaveRequest(o.actorID, o.actorState.MultiMaxSize())
 	if err != nil {
 		return err
 	}
 
-	log.Debugf("Workflow actor '%s': saving %d keys to actor state store", o.actorID, len(req.Operations))
+	if len(chunks) == 1 {
+		log.Debugf("Workflow actor '%s': saving %d keys to actor state store", o.actorID, len(chunks[0].Operations))
+	} else {
+		log.Debugf("Workflow actor '%s': saving across %d chunks (state store MultiMaxSize=%d)", o.actorID, len(chunks), o.actorState.MultiMaxSize())
+	}
 
-	if err = o.actorState.TransactionalStateOperation(ctx, true, req, false); err != nil {
-		return err
+	for i, req := range chunks {
+		if err = o.actorState.TransactionalStateOperation(ctx, true, req, false); err != nil {
+			return fmt.Errorf("workflow actor '%s': save chunk %d/%d failed: %w", o.actorID, i+1, len(chunks), err)
+		}
 	}
 
 	// ResetChangeTracking should always be called after a save operation succeeds

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -765,20 +765,6 @@ func (abe *Actors) purgeWorkflowForce(ctx context.Context, id api.InstanceID) er
 		return err
 	}
 
-	s, err := state.LoadWorkflowState(ctx, astate, id.String(), state.Options{
-		AppID:             abe.appID,
-		WorkflowActorType: abe.workflowActorType,
-		ActivityActorType: abe.activityActorType,
-	})
-	if err != nil {
-		return err
-	}
-
-	req, err := s.GetPurgeRequest(id.String())
-	if err != nil {
-		return err
-	}
-
 	reminders, err := abe.actors.Reminders(ctx)
 	if err != nil {
 		return err
@@ -789,10 +775,37 @@ func (abe *Actors) purgeWorkflowForce(ctx context.Context, id api.InstanceID) er
 		return err
 	}
 
+	// Prefer native DeleteWithPrefix when the state store supports it: one
+	// round trip vs. loading state + building a transactional delete with
+	// N operations. Falls back to the load+transaction path otherwise.
+	stateDeleteFn := func(ctx context.Context) error {
+		ok, derr := astate.DeleteActorState(ctx, abe.workflowActorType, id.String())
+		if derr != nil {
+			return derr
+		}
+		if ok {
+			return nil
+		}
+		s, lerr := state.LoadWorkflowState(ctx, astate, id.String(), state.Options{
+			AppID:             abe.appID,
+			WorkflowActorType: abe.workflowActorType,
+			ActivityActorType: abe.activityActorType,
+		})
+		if lerr != nil {
+			return lerr
+		}
+		if s == nil {
+			return nil
+		}
+		req, perr := s.GetPurgeRequest(id.String())
+		if perr != nil {
+			return perr
+		}
+		return astate.TransactionalStateOperation(ctx, true, req, false)
+	}
+
 	return concurrency.Join(ctx,
-		func(ctx context.Context) error {
-			return astate.TransactionalStateOperation(ctx, true, req, false)
-		},
+		stateDeleteFn,
 		func(ctx context.Context) error {
 			return sched.DeleteByActorID(ctx, &actorsapi.DeleteRemindersByActorIDRequest{
 				ActorType:       abe.workflowActorType,

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -49,6 +49,14 @@ const (
 	// (inbox, history, signatures, certificates). This prevents OOM from
 	// an attacker inflating metadata values in the state store.
 	maxStateEntries = 1_000_000
+
+	// speculativeReadHint is the number of per-slice (inbox/history/sigcert/
+	// signature) keys the cold-load path speculatively fetches in the same
+	// bulk request as the metadata key. For workflows whose actual lengths
+	// all fit within this bound the load completes in a single round trip;
+	// longer workflows pay a second round trip to fetch the tail (matching
+	// the pre-speculation cost). See LoadWorkflowState.
+	speculativeReadHint = 32
 )
 
 var wfLogger = logger.NewLogger("dapr.runtime.actor.target.workflow.state")
@@ -218,8 +226,70 @@ func (s *State) ClearInbox() {
 	s.inboxAddedCount = 0
 }
 
+// GetChunkedSaveRequest returns one or more transactional requests whose
+// operations respect maxChunkSize. maxChunkSize <= 0 disables chunking (the
+// result is a single-element slice equivalent to GetSaveRequest).
+//
+// Crash-recovery invariant: the metadata key is the length-of-truth counter.
+// If we commit chunks progressively and crash between them, a subsequent load
+// sees the OLD metadata and ignores any keys we already wrote at indices
+// beyond the old length. To preserve this, metadata is always the last
+// operation in the last chunk, and all deletions are kept in the same chunk as
+// metadata (a pre-committed delete at an index < oldLength would leave a
+// "hole" that a subsequent load would treat as a warning). This is safe for
+// appending saves; the purge / ContinueAsNew path with many deletions should
+// use DeleteWithPrefix (see state.FeatureDeleteWithPrefix).
+func (s *State) GetChunkedSaveRequest(actorID string, maxChunkSize int) ([]*api.TransactionalRequest, error) {
+	full, err := s.GetSaveRequest(actorID)
+	if err != nil {
+		return nil, err
+	}
+
+	if maxChunkSize <= 0 || len(full.Operations) <= maxChunkSize {
+		return []*api.TransactionalRequest{full}, nil
+	}
+
+	var upserts, finals []api.TransactionalOperation
+	for _, op := range full.Operations {
+		switch r := op.Request.(type) {
+		case api.TransactionalUpsert:
+			if r.Key == metadataKey || r.Key == customStatusKey {
+				finals = append(finals, op)
+			} else {
+				upserts = append(upserts, op)
+			}
+		case api.TransactionalDelete:
+			finals = append(finals, op)
+		default:
+			return nil, fmt.Errorf("workflow save: unexpected operation type %T", op.Request)
+		}
+	}
+
+	if len(finals) > maxChunkSize {
+		return nil, fmt.Errorf("workflow save: final commit chunk has %d ops (deletes + customStatus + metadata) which exceeds state store MultiMaxSize %d; use DeleteWithPrefix for purge", len(finals), maxChunkSize)
+	}
+
+	chunks := make([]*api.TransactionalRequest, 0, (len(upserts)+maxChunkSize-1)/maxChunkSize+1)
+	for i := 0; i < len(upserts); i += maxChunkSize {
+		end := i + maxChunkSize
+		if end > len(upserts) {
+			end = len(upserts)
+		}
+		chunks = append(chunks, &api.TransactionalRequest{
+			ActorType:  s.workflowActorType,
+			ActorID:    actorID,
+			Operations: upserts[i:end],
+		})
+	}
+	chunks = append(chunks, &api.TransactionalRequest{
+		ActorType:  s.workflowActorType,
+		ActorID:    actorID,
+		Operations: finals,
+	})
+	return chunks, nil
+}
+
 func (s *State) GetSaveRequest(actorID string) (*api.TransactionalRequest, error) {
-	// TODO: Batching up the save requests into smaller chunks to avoid batch size limits in Dapr state stores.
 	opsCapacity := s.inboxAddedCount + s.inboxRemovedCount +
 		s.historyAddedCount + s.historyRemovedCount +
 		s.signingCertificatesAddedCount + s.signingCertificatesRemovedCount +
@@ -444,33 +514,46 @@ func addPurgeStateOperations(req *api.TransactionalRequest, keyPrefix string, co
 func LoadWorkflowState(ctx context.Context, state state.Interface, actorID string, opts Options) (*State, error) {
 	loadStartTime := time.Now()
 
-	// Load metadata
-	req := api.GetStateRequest{
+	// Speculative bulk: request metadata + customStatus + the first
+	// speculativeReadHint keys of each slice in one round trip. Metadata is
+	// the length-of-truth; keys beyond the actual lengths come back missing
+	// and are simply ignored.
+	bulkReq := &api.GetBulkStateRequest{
 		ActorType: opts.WorkflowActorType,
 		ActorID:   actorID,
-		Key:       metadataKey,
+		Keys:      make([]string, 0, 2+4*speculativeReadHint),
+	}
+	bulkReq.Keys = append(bulkReq.Keys, metadataKey, customStatusKey)
+	for i := uint64(0); i < speculativeReadHint; i++ {
+		bulkReq.Keys = append(bulkReq.Keys,
+			getMultiEntryKeyName(inboxKeyPrefix, i),
+			getMultiEntryKeyName(historyKeyPrefix, i),
+			getMultiEntryKeyName(sigcertKeyPrefix, i),
+			getMultiEntryKeyName(signatureKeyPrefix, i),
+		)
 	}
 
-	res, err := state.Get(ctx, &req, false)
+	bulkRes, err := state.GetBulk(ctx, bulkReq, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load workflow metadata: %w", err)
+		return nil, fmt.Errorf("failed to load workflow state: %w", err)
 	}
 
-	if len(res.Data) == 0 {
+	metaBytes := bulkRes[metadataKey]
+	if len(metaBytes) == 0 {
 		// no state found
 		return nil, nil
 	}
 
 	var metadata backend.BackendWorkflowStateMetadata
-	if err = proto.Unmarshal(res.Data, &metadata); err != nil {
+	if err = proto.Unmarshal(metaBytes, &metadata); err != nil {
 		// TODO: @joshvanl: remove in v1.16
 		var metadataJSON legacyWorkflowStateMetadata
-		jerr := json.Unmarshal(res.Data, &metadataJSON)
+		jerr := json.Unmarshal(metaBytes, &metadataJSON)
 		if jerr != nil {
 			return nil, fmt.Errorf("failed to unmarshal workflow metadata: %w", err)
 		}
 
-		wfLogger.Debugf("Loaded legacy workflow state metadata: %s", res.Data)
+		wfLogger.Debugf("Loaded legacy workflow state metadata: %s", metaBytes)
 
 		metadata.Generation = metadataJSON.Generation
 		metadata.InboxLength = metadataJSON.InboxLength
@@ -504,7 +587,33 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	//nolint:gosec
 	signatureLen := int(metadata.GetSignatureLength())
 
-	// Load inbox, history, signing certs, signatures, and custom status using a bulk request
+	// If any slice exceeds the speculative hint, fetch the tail keys in a second
+	// bulk request and merge.
+	var tailKeys []string
+	appendTail := func(prefix string, length uint64) {
+		for i := uint64(speculativeReadHint); i < length; i++ {
+			tailKeys = append(tailKeys, getMultiEntryKeyName(prefix, i))
+		}
+	}
+	appendTail(inboxKeyPrefix, metadata.GetInboxLength())
+	appendTail(historyKeyPrefix, metadata.GetHistoryLength())
+	appendTail(sigcertKeyPrefix, metadata.GetSigningCertificateLength())
+	appendTail(signatureKeyPrefix, metadata.GetSignatureLength())
+
+	if len(tailKeys) > 0 {
+		tailRes, terr := state.GetBulk(ctx, &api.GetBulkStateRequest{
+			ActorType: opts.WorkflowActorType,
+			ActorID:   actorID,
+			Keys:      tailKeys,
+		}, false)
+		if terr != nil {
+			return nil, fmt.Errorf("failed to load workflow state tail: %w", terr)
+		}
+		for k, v := range tailRes {
+			bulkRes[k] = v
+		}
+	}
+
 	wState := NewState(opts)
 	wState.Generation = metadata.GetGeneration()
 	wState.Inbox = make([]*backend.HistoryEvent, 0, inboxLen)
@@ -512,44 +621,6 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	wState.RawHistory = make([][]byte, 0, historyLen)
 	wState.SigningCertificates = make([]*backend.SigningCertificate, 0, signingCertLen)
 	wState.Signatures = make([]*backend.HistorySignature, 0, signatureLen)
-
-	totalKeys := inboxLen + historyLen + signingCertLen + signatureLen + 1
-	bulkReq := &api.GetBulkStateRequest{
-		ActorType: opts.WorkflowActorType,
-		ActorID:   actorID,
-		Keys:      make([]string, totalKeys),
-	}
-
-	var n int
-
-	bulkReq.Keys[n] = customStatusKey
-
-	n++
-	for i := range metadata.GetInboxLength() {
-		bulkReq.Keys[n] = getMultiEntryKeyName(inboxKeyPrefix, i)
-		n++
-	}
-
-	for i := range metadata.GetHistoryLength() {
-		bulkReq.Keys[n] = getMultiEntryKeyName(historyKeyPrefix, i)
-		n++
-	}
-
-	for i := range metadata.GetSigningCertificateLength() {
-		bulkReq.Keys[n] = getMultiEntryKeyName(sigcertKeyPrefix, i)
-		n++
-	}
-
-	for i := range metadata.GetSignatureLength() {
-		bulkReq.Keys[n] = getMultiEntryKeyName(signatureKeyPrefix, i)
-		n++
-	}
-
-	// Perform the request
-	bulkRes, err := state.GetBulk(ctx, bulkReq, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load workflow state: %w", err)
-	}
 
 	defer func() {
 		// TODO: @joshvanl: remove in v1.16 where we will no longer have legacy

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -14,6 +14,9 @@ limitations under the License.
 package state
 
 import (
+	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/pkg/actors/api"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 )
@@ -478,4 +482,185 @@ func TestGetSaveRequest_MetadataIncludesSigningLengths(t *testing.T) {
 	assert.Equal(t, uint64(1), meta.GetHistoryLength())
 	assert.Equal(t, uint64(1), meta.GetSigningCertificateLength())
 	assert.Equal(t, uint64(1), meta.GetSignatureLength())
+}
+
+func TestGetChunkedSaveRequest_NoChunkingWhenUnderLimit(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+	s.AddToHistory(testEvent(1))
+	s.AddToHistory(testEvent(2))
+
+	chunks, err := s.GetChunkedSaveRequest("actor1", 0)
+	require.NoError(t, err)
+	assert.Len(t, chunks, 1, "maxChunkSize <= 0 should never chunk")
+
+	chunks, err = s.GetChunkedSaveRequest("actor1", 1_000)
+	require.NoError(t, err)
+	assert.Len(t, chunks, 1, "ops under limit should fit in one chunk")
+}
+
+func TestGetChunkedSaveRequest_MetadataAlwaysLast(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+	for i := int32(0); i < 25; i++ {
+		s.AddToHistory(testEvent(i))
+	}
+
+	chunks, err := s.GetChunkedSaveRequest("actor1", 10)
+	require.NoError(t, err)
+	require.Greater(t, len(chunks), 1, "25 history adds + metadata should require chunking with limit=10")
+
+	// metadata must live in the final chunk, as its last operation.
+	last := chunks[len(chunks)-1]
+	require.NotEmpty(t, last.Operations)
+	tail := last.Operations[len(last.Operations)-1]
+	up, ok := tail.Request.(api.TransactionalUpsert)
+	require.True(t, ok, "final op should be an Upsert")
+	assert.Equal(t, metadataKey, up.Key, "final op must be the metadata write")
+
+	// No earlier chunk may contain metadata or customStatus.
+	for i, c := range chunks[:len(chunks)-1] {
+		for _, op := range c.Operations {
+			if u, ok := op.Request.(api.TransactionalUpsert); ok {
+				assert.NotEqual(t, metadataKey, u.Key, "chunk %d must not contain metadata", i)
+				assert.NotEqual(t, customStatusKey, u.Key, "chunk %d must not contain customStatus", i)
+			}
+		}
+	}
+
+	// Every chunk must respect the size limit.
+	for i, c := range chunks {
+		assert.LessOrEqual(t, len(c.Operations), 10, "chunk %d exceeds limit", i)
+	}
+}
+
+func TestGetChunkedSaveRequest_FinalChunkTooLarge(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+	// Simulate a ContinueAsNew / purge: many history entries, no adds. This
+	// produces a pile of deletes that must all fit with metadata in the
+	// final chunk.
+	for i := int32(0); i < 20; i++ {
+		s.AddToHistory(testEvent(i))
+	}
+	req1, err := s.GetSaveRequest("a")
+	require.NoError(t, err)
+	_ = req1
+	s.Reset() // pushes 20 deletes into the next save
+
+	_, err = s.GetChunkedSaveRequest("a", 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DeleteWithPrefix", "error should point user to DeleteWithPrefix for purge")
+}
+
+// storeFromBytes builds a GetBulk response from a keyed byte map. Missing keys
+// are returned absent from the map, matching real state-store semantics.
+func storeFromBytes(entries map[string][]byte) func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error) {
+	return func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error) {
+		resp := api.BulkStateResponse{}
+		for _, k := range req.Keys {
+			if v, ok := entries[k]; ok {
+				resp[k] = v
+			}
+		}
+		return resp, nil
+	}
+}
+
+func TestLoadWorkflowState_EmptyStateIsOneRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	fake := statefake.New().WithGetBulkFn(func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error) {
+		calls.Add(1)
+		// Metadata key absent ⇒ no workflow state.
+		return api.BulkStateResponse{}, nil
+	})
+
+	ws, err := LoadWorkflowState(t.Context(), fake, "no-such-id", testOpts())
+	require.NoError(t, err)
+	assert.Nil(t, ws)
+	assert.Equal(t, int32(1), calls.Load(), "empty state should cost one GetBulk round trip")
+}
+
+func TestLoadWorkflowState_SmallHistoryIsOneRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// 5 history events, 3 inbox, no signing — all comfortably under
+	// speculativeReadHint.
+	metaBytes, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
+		Generation:    1,
+		InboxLength:   3,
+		HistoryLength: 5,
+	})
+	require.NoError(t, err)
+
+	entries := map[string][]byte{metadataKey: metaBytes}
+	for i := uint64(0); i < 5; i++ {
+		b, err := proto.Marshal(testEvent(int32(i)))
+		require.NoError(t, err)
+		entries[getMultiEntryKeyName(historyKeyPrefix, i)] = b
+	}
+	for i := uint64(0); i < 3; i++ {
+		b, err := proto.Marshal(testEvent(int32(100 + i)))
+		require.NoError(t, err)
+		entries[getMultiEntryKeyName(inboxKeyPrefix, i)] = b
+	}
+
+	var calls atomic.Int32
+	fake := statefake.New().WithGetBulkFn(func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error) {
+		calls.Add(1)
+		return storeFromBytes(entries)(ctx, req, lock)
+	})
+
+	ws, err := LoadWorkflowState(t.Context(), fake, "wf-1", testOpts())
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	assert.Len(t, ws.History, 5)
+	assert.Len(t, ws.Inbox, 3)
+	assert.Equal(t, int32(1), calls.Load(), "history fitting under speculativeReadHint should cost one GetBulk")
+}
+
+func TestLoadWorkflowState_LongHistoryTriggersTailFetch(t *testing.T) {
+	t.Parallel()
+
+	const longHistory = speculativeReadHint + 10 // 42 events
+	metaBytes, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
+		Generation:    1,
+		HistoryLength: longHistory,
+	})
+	require.NoError(t, err)
+
+	entries := map[string][]byte{metadataKey: metaBytes}
+	for i := uint64(0); i < longHistory; i++ {
+		b, err := proto.Marshal(testEvent(int32(i)))
+		require.NoError(t, err)
+		entries[getMultiEntryKeyName(historyKeyPrefix, i)] = b
+	}
+
+	var calls atomic.Int32
+	var secondCallKeys []string
+	fake := statefake.New().WithGetBulkFn(func(ctx context.Context, req *api.GetBulkStateRequest, lock bool) (api.BulkStateResponse, error) {
+		n := calls.Add(1)
+		if n == 2 {
+			secondCallKeys = append([]string(nil), req.Keys...)
+		}
+		return storeFromBytes(entries)(ctx, req, lock)
+	})
+
+	ws, err := LoadWorkflowState(t.Context(), fake, "wf-long", testOpts())
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	assert.Len(t, ws.History, int(longHistory))
+	assert.Equal(t, int32(2), calls.Load(), "history exceeding speculativeReadHint should cost a tail GetBulk")
+	// Tail request must only fetch the 10 missing indices, not refetch the
+	// speculated ones — otherwise we haven't saved any work.
+	assert.Len(t, secondCallKeys, 10)
+	for i, k := range secondCallKeys {
+		want := getMultiEntryKeyName(historyKeyPrefix, uint64(speculativeReadHint+i))
+		assert.Equal(t, want, k, fmt.Sprintf("tail key %d", i))
+	}
 }

--- a/tests/integration/suite/daprd/hotreload/operator/informer/components.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/components.go
@@ -178,7 +178,7 @@ func (c *components) Run(t *testing.T, ctx context.Context) {
 			exp := []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 			}
 			assert.ElementsMatch(ct, exp, c.daprd1.GetMetaRegisteredComponents(ct, ctx))

--- a/tests/integration/suite/daprd/hotreload/operator/state.go
+++ b/tests/integration/suite/daprd/hotreload/operator/state.go
@@ -214,7 +214,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 				},
 				{
 					Name: "abc", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
@@ -283,7 +283,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "abc", Type: "state.in-memory", Version: "v1",
@@ -345,7 +345,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 			assert.ElementsMatch(c, []*rtv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
@@ -400,7 +400,7 @@ func (s *state) Run(t *testing.T, ctx context.Context) {
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",

--- a/tests/integration/suite/daprd/hotreload/selfhosted/state.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/state.go
@@ -188,7 +188,7 @@ spec:
 				},
 				{
 					Name: "abc", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",
@@ -246,7 +246,7 @@ spec:
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "abc", Type: "state.in-memory", Version: "v1",
@@ -291,7 +291,7 @@ spec:
 			assert.ElementsMatch(c, []*rtpbv1.RegisteredComponents{
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "bar", Type: "state.in-memory", Version: "v1",
@@ -342,7 +342,7 @@ spec:
 				{Name: "bar", Type: "secretstores.local.file", Version: "v1"},
 				{
 					Name: "123", Type: "state.sqlite", Version: "v1",
-					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "ACTOR"},
+					Capabilities: []string{"ETAG", "TRANSACTIONAL", "TTL", "KEYS_LIKE", "DELETE_WITH_PREFIX", "ACTOR"},
 				},
 				{
 					Name: "xyz", Type: "state.in-memory", Version: "v1",


### PR DESCRIPTION
Cuts avoidable state-store round trips in the workflow engine hot paths and lets the purge path use the native DeleteWithPrefix contrib API.

- Cold load (GET_BULK): 2 RTT -> 1 RTT for the common case

LoadWorkflowState used to Get(metadata) first to learn the inbox / history / signature / sigcert lengths, then GetBulk() those keys. Replaces this with a single speculative GetBulk over `metadata + customStatus + the first speculativeReadHint (32) keys of each slice`. If the metadata lengths all fit within the hint, we're done in one RTT. If any slice overflows, we issue a second GetBulk only for the missing tail, matching the pre-speculation 2-RTT cost. Every workflow with <=32 events in each slice (the overwhelming majority of production workloads) now completes cold load in a single RTT.

- Save (MULTI): auto-chunking for stores with MultiMaxSize

Adds GetChunkedSaveRequest(actorID, maxChunkSize) on *State. When maxChunkSize > 0 (for stores that advertise
TransactionalStoreMultiMaxSize — Cosmos DB caps at 100 ops), the flat operation list is split into chunks with a hard invariant: the `metadata` key is ALWAYS the last operation in the last chunk, and deletes are co-located with it. This preserves crash recovery: if we crash between chunks, a later load sees the OLD metadata lengths and ignores any keys already written at indices beyond the old length; pre-committed deletes at indices < oldLength are exactly the case metadata-last protects against.

The orchestrator save loop iterates chunks, erroring out on any individual TransactionalStateOperation failure with enough context to identify which chunk (of how many) tripped.

- Purge: native DeleteWithPrefix fast path

Extends the actor-state Interface with:
  * MultiMaxSize() int — surfaces the contrib store's TransactionalStoreMultiMaxSize (used by GetChunkedSaveRequest above).
  * DeleteActorState(ctx, actorType, actorID) (ok bool, err error) — delegates to the contrib state.DeleteWithPrefix when the store advertises FeatureDeleteWithPrefix, passing the composite prefix `appID||actorType||actorID||`. Returns (false, nil) when the feature is absent so callers can fall back.

purgeWorkflowForce now prefers this fast path: one server-side DELETE WHERE key LIKE 'prefix%' AND NOT LIKE 'prefix%||%' (or equivalent per backend) instead of loading the workflow state and building an N-op transactional delete. Falls back to the load + GetPurgeRequest + TransactionalStateOperation path when the store doesn't advertise the feature.