### PR TITLE
Workflow: terminate tampered in-flight workflows

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -41,17 +41,21 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 		return o.state, o.ometa, nil
 	}
 
-	// state is not cached, so try to load it from the state store
-	state, err := wfenginestate.LoadWorkflowState(ctx, o.actorState, o.actorID, wfenginestate.Options{
+	opts := wfenginestate.Options{
 		AppID:             o.appID,
 		WorkflowActorType: o.actorType,
 		ActivityActorType: o.activityActorType,
 		Signer:            o.signer,
-	})
+	}
+
+	// state is not cached, so try to load it from the state store
+	state, err := wfenginestate.LoadWorkflowState(ctx, o.actorState, o.actorID, opts)
 	if err != nil {
 		var verifyErr *wferrors.VerificationError
 		if errors.As(err, &verifyErr) {
-			o.failSignatureVerification(ctx)
+			if !isTerminal(state) {
+				return o.tombstoneTamperedState(ctx, opts, state, err)
+			}
 		}
 		return nil, nil, err
 	}
@@ -64,14 +68,14 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 	// history can only have been written via state store tampering. Treat the
 	// state as unrecoverable: fail the workflow terminally so no further
 	// progress is made on forged input. Skip the scan on an empty inbox as
-	// nothing to validate and the history-index build is pure waste.
-	if o.signer != nil && len(state.Inbox) > 0 {
+	// nothing to validate and the history-index build is pure waste. Skip
+	// when the workflow is already terminal, so we don't re-detect the same
+	// condition on every load.
+	if o.signer != nil && len(state.Inbox) > 0 && !isTerminal(state) {
 		if filtered := filterValidInboxEvents(state); len(filtered) != len(state.Inbox) {
-			o.failSignatureVerification(ctx)
-			return nil, nil, wferrors.NewVerificationError(
-				fmt.Errorf("workflow actor '%s': inbox contained %d events that did not match signed history (state store tampering)",
-					o.actorID, len(state.Inbox)-len(filtered)),
-			)
+			cause := fmt.Errorf("workflow actor '%s': inbox contained %d events that did not match signed history (state store tampering)",
+				o.actorID, len(state.Inbox)-len(filtered))
+			return o.tombstoneTamperedState(ctx, opts, state, cause)
 		}
 	}
 
@@ -81,6 +85,38 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 	o.ometa = o.ometaFromState(o.rstate, o.getExecutionStartedEvent(state))
 
 	return state, o.ometa, nil
+}
+
+// tombstoneTamperedState appends an unsigned ExecutionCompleted(FAILED)
+// tamper marker to the workflow's history (see [wfenginestate.MarkAsFailed])
+// so it surfaces as terminally FAILED on every subsequent load. The original
+// (untrusted) history, inbox, signatures, and certs are left intact for
+// forensics. The actor's reminders are deleted to stop further activations
+// from firing against the dead workflow.
+func (o *orchestrator) tombstoneTamperedState(ctx context.Context, opts wfenginestate.Options, prior *wfenginestate.State, cause error) (*wfenginestate.State, *backend.WorkflowMetadata, error) {
+	log.Warnf("Workflow actor '%s': tampering detected, marking workflow as FAILED: %s", o.actorID, cause)
+
+	failed, err := wfenginestate.MarkAsFailed(ctx, o.actorState, o.actorID, opts, prior, cause)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to append tamper marker: %w", err)
+	}
+
+	o.failSignatureVerification(ctx)
+
+	o.state = failed
+	o.rstate = runtimestate.NewWorkflowRuntimeState(o.actorID, failed.CustomStatus, failed.History)
+	o.ometa = o.ometaFromState(o.rstate, o.getExecutionStartedEvent(failed))
+
+	return failed, o.ometa, nil
+}
+
+// isTerminal reports whether the loaded workflow's history ends in an
+// ExecutionCompleted event of any kind (the runtime's terminal marker).
+// There is nothing for the orchestrator actor to do on a terminal workflow,
+// so the tamper-marker append is skipped — the reader path is responsible
+// for surfacing the verification error to clients.
+func isTerminal(s *wfenginestate.State) bool {
+	return s != nil && len(s.History) > 0 && s.History[len(s.History)-1].GetExecutionCompleted() != nil
 }
 
 // signAndSaveState signs any newly added history events and then persists

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -53,7 +53,7 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 	if err != nil {
 		var verifyErr *wferrors.VerificationError
 		if errors.As(err, &verifyErr) {
-			if !isTerminal(state) {
+			if !isCompleted(state) {
 				return o.tombstoneTamperedState(ctx, opts, state, err)
 			}
 		}
@@ -71,7 +71,7 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 	// nothing to validate and the history-index build is pure waste. Skip
 	// when the workflow is already terminal, so we don't re-detect the same
 	// condition on every load.
-	if o.signer != nil && len(state.Inbox) > 0 && !isTerminal(state) {
+	if o.signer != nil && len(state.Inbox) > 0 && !isCompleted(state) {
 		if filtered := filterValidInboxEvents(state); len(filtered) != len(state.Inbox) {
 			cause := fmt.Errorf("workflow actor '%s': inbox contained %d events that did not match signed history (state store tampering)",
 				o.actorID, len(state.Inbox)-len(filtered))
@@ -88,7 +88,7 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 }
 
 // tombstoneTamperedState appends an unsigned ExecutionCompleted(FAILED)
-// tamper marker to the workflow's history (see [wfenginestate.MarkAsFailed])
+// tamper marker to the workflow's history (see [wfenginestate.MarkAsTamperFailed])
 // so it surfaces as terminally FAILED on every subsequent load. The original
 // (untrusted) history, inbox, signatures, and certs are left intact for
 // forensics. The actor's reminders are deleted to stop further activations
@@ -96,7 +96,7 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 func (o *orchestrator) tombstoneTamperedState(ctx context.Context, opts wfenginestate.Options, prior *wfenginestate.State, cause error) (*wfenginestate.State, *backend.WorkflowMetadata, error) {
 	log.Warnf("Workflow actor '%s': tampering detected, marking workflow as FAILED: %s", o.actorID, cause)
 
-	failed, err := wfenginestate.MarkAsFailed(ctx, o.actorState, o.actorID, opts, prior, cause)
+	failed, err := wfenginestate.MarkAsTamperFailed(ctx, o.actorState, o.actorID, opts, prior, cause)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to append tamper marker: %w", err)
 	}
@@ -110,12 +110,12 @@ func (o *orchestrator) tombstoneTamperedState(ctx context.Context, opts wfengine
 	return failed, o.ometa, nil
 }
 
-// isTerminal reports whether the loaded workflow's history ends in an
+// isCompleted reports whether the loaded workflow's history ends in an
 // ExecutionCompleted event of any kind (the runtime's terminal marker).
 // There is nothing for the orchestrator actor to do on a terminal workflow,
 // so the tamper-marker append is skipped — the reader path is responsible
 // for surfacing the verification error to clients.
-func isTerminal(s *wfenginestate.State) bool {
+func isCompleted(s *wfenginestate.State) bool {
 	return s != nil && len(s.History) > 0 && s.History[len(s.History)-1].GetExecutionCompleted() != nil
 }
 

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -577,8 +577,11 @@ func (abe *Actors) loadInternalState(ctx context.Context, id api.InstanceID) (*s
 		return nil, err
 	}
 
-	// actor id is workflow instance id
-	state, err := state.LoadWorkflowState(ctx, astate, string(id), state.Options{
+	// actor id is workflow instance id. Tamper recovery (appending the
+	// terminal failed event) is the orchestrator actor's responsibility, not
+	// the read path's — readers surface the verification error to clients
+	// and let them detect it.
+	wstate, err := state.LoadWorkflowState(ctx, astate, string(id), state.Options{
 		AppID:             abe.appID,
 		WorkflowActorType: abe.workflowActorType,
 		ActivityActorType: abe.activityActorType,
@@ -588,12 +591,12 @@ func (abe *Actors) loadInternalState(ctx context.Context, id api.InstanceID) (*s
 		return nil, err
 	}
 
-	if state == nil {
+	if wstate == nil {
 		// No such state exists in the state store
 		return nil, nil
 	}
 
-	return state, nil
+	return wstate, nil
 }
 
 // NextWorkflowWorkItem implements backend.Backend

--- a/pkg/runtime/wfengine/state/errors/errors.go
+++ b/pkg/runtime/wfengine/state/errors/errors.go
@@ -23,7 +23,7 @@ const ErrorTypeHistoryTampered = "DAPR_WORKFLOW_HISTORY_TAMPERED"
 // workflow state has been tampered with: signature chain verification has
 // failed, signing material is missing, metadata bounds are exceeded, or
 // inbox events do not match signed history. The recovery action is to mark
-// the workflow as FAILED via [state.MarkAsFailed].
+// the workflow as FAILED via [state.MarkAsTamperFailed].
 //
 // The State (when available) is returned alongside this error so callers
 // can scope the tombstone-write transaction to the existing keys.

--- a/pkg/runtime/wfengine/state/errors/errors.go
+++ b/pkg/runtime/wfengine/state/errors/errors.go
@@ -13,9 +13,20 @@ limitations under the License.
 
 package errors
 
-// VerificationError is returned by LoadWorkflowState when signature
-// verification fails. The State is still returned alongside this error so
-// callers can build failure metadata from it.
+// ErrorTypeHistoryTampered is the well-known FailureDetails.ErrorType set on
+// workflows that are marked failed because their persisted history or signing
+// state was detected as tampered. Clients can match on this constant to
+// programmatically detect the failure mode.
+const ErrorTypeHistoryTampered = "DAPR_WORKFLOW_HISTORY_TAMPERED"
+
+// VerificationError is returned by LoadWorkflowState when the persisted
+// workflow state has been tampered with: signature chain verification has
+// failed, signing material is missing, metadata bounds are exceeded, or
+// inbox events do not match signed history. The recovery action is to mark
+// the workflow as FAILED via [state.MarkAsFailed].
+//
+// The State (when available) is returned alongside this error so callers
+// can scope the tombstone-write transaction to the existing keys.
 type VerificationError struct {
 	err error
 }
@@ -29,5 +40,27 @@ func (e *VerificationError) Error() string {
 }
 
 func (e *VerificationError) Unwrap() error {
+	return e.err
+}
+
+// ConfigurationError is returned by LoadWorkflowState when the workflow
+// state is intact but cannot be loaded under the host's current
+// configuration. This covers the one-way signing commitment (a signed
+// workflow on a non-signing host, or vice versa) and missing app ID
+// configuration. The workflow data is not tampered, so the tombstone
+// recovery path must not run; the operator is expected to fix the config.
+type ConfigurationError struct {
+	err error
+}
+
+func NewConfigurationError(err error) *ConfigurationError {
+	return &ConfigurationError{err}
+}
+
+func (e *ConfigurationError) Error() string {
+	return e.err.Error()
+}
+
+func (e *ConfigurationError) Unwrap() error {
 	return e.err
 }

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/pkg/actors/api"
@@ -597,7 +598,10 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetSigningCertificateLength() {
 		key = getMultiEntryKeyName(sigcertKeyPrefix, i)
 		if bulkRes[key] == nil {
-			return nil, wferrors.NewVerificationError(
+			if hasTamperMarker(wState) {
+				return wState, nil
+			}
+			return wState, wferrors.NewVerificationError(
 				fmt.Errorf("signing certificate state key '%s' declared in metadata but not found in state store — possible tampering", key),
 			)
 		}
@@ -614,7 +618,10 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetSignatureLength() {
 		key = getMultiEntryKeyName(signatureKeyPrefix, i)
 		if bulkRes[key] == nil {
-			return nil, wferrors.NewVerificationError(
+			if hasTamperMarker(wState) {
+				return wState, nil
+			}
+			return wState, wferrors.NewVerificationError(
 				fmt.Errorf("signature state key '%s' declared in metadata but not found in state store — possible tampering", key),
 			)
 		}
@@ -658,27 +665,111 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	// purged before enabling signing cluster-wide.
 	if len(wState.Signatures) > 0 {
 		if opts.Signer == nil {
-			return wState, wferrors.NewVerificationError(
+			return wState, wferrors.NewConfigurationError(
 				fmt.Errorf("workflow '%s' has signed history but no signer is configured; cannot verify signatures — signing cannot be disabled for workflows that were created with signing enabled", actorID),
 			)
 		}
 		if opts.AppID == "" {
-			return wState, wferrors.NewVerificationError(
+			return wState, wferrors.NewConfigurationError(
 				fmt.Errorf("workflow '%s' has signed history but app ID is not configured; cannot verify signer identity", actorID),
 			)
 		}
 		if err := verifySignatureChain(wState, opts.Signer); err != nil {
+			// A workflow that was previously detected as tampered carries an
+			// unsigned ExecutionCompleted(FAILED) marker as its last history
+			// event (see [MarkAsFailed]). The marker is intentionally not
+			// covered by a signature, so the chain check will always fail —
+			// short-circuit here so the workflow continues to surface as
+			// terminally FAILED on every load instead of being unloadable.
+			if hasTamperMarker(wState) {
+				return wState, nil
+			}
 			return wState, wferrors.NewVerificationError(
 				fmt.Errorf("workflow history signature verification failed for '%s': %w", actorID, err),
 			)
 		}
 	} else if opts.Signer != nil && len(wState.History) > 0 {
-		return wState, wferrors.NewVerificationError(
+		return wState, wferrors.NewConfigurationError(
 			fmt.Errorf("workflow '%s' has %d unsigned history events but signing is enabled — signing cannot be enabled for workflows that were created without signing; ensure all unsigned workflows complete or are purged before enabling signing", actorID, len(wState.History)),
 		)
 	}
 
 	return wState, nil
+}
+
+// IsTamperMarker reports whether e is the well-known terminal event written
+// by [MarkAsFailed] to record that the workflow's persisted state was
+// detected as tampered. It is identified by an ExecutionCompleted with
+// status FAILED and FailureDetails.ErrorType set to
+// [wferrors.ErrorTypeHistoryTampered]. Loaders use this check to bypass
+// signature verification on workflows that have already been terminally
+// failed by tamper detection — without the bypass, the broken signature
+// chain would block every subsequent load.
+func IsTamperMarker(e *backend.HistoryEvent) bool {
+	ec := e.GetExecutionCompleted()
+	if ec == nil {
+		return false
+	}
+	if ec.GetWorkflowStatus() != protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED {
+		return false
+	}
+	fd := ec.GetFailureDetails()
+	return fd != nil && fd.GetErrorType() == wferrors.ErrorTypeHistoryTampered
+}
+
+// hasTamperMarker reports whether the loaded state's history ends in the
+// terminal tamper marker event written by [MarkAsFailed]. Used by
+// LoadWorkflowState to short-circuit verification failures on workflows
+// that are already terminally failed.
+func hasTamperMarker(s *State) bool {
+	return s != nil && len(s.History) > 0 && IsTamperMarker(s.History[len(s.History)-1])
+}
+
+// MarkAsFailed appends a single terminal ExecutionCompleted(FAILED) event to
+// the workflow's history to record that its persisted state was detected as
+// tampered. The original (untrusted) history, inbox, signatures, and certs
+// are left intact for forensics — only the marker event is added, and it is
+// not signed. Subsequent loads detect the marker via [IsTamperMarker] and
+// bypass signature verification, so the workflow surfaces as terminally
+// FAILED with [wferrors.ErrorTypeHistoryTampered] in its FailureDetails.
+//
+// MarkAsFailed is idempotent: if prior already ends in a tamper marker the
+// state is returned unchanged with no store write.
+func MarkAsFailed(ctx context.Context, astate state.Interface, actorID string, opts Options, prior *State, cause error) (*State, error) {
+	s := prior
+	if s == nil {
+		s = NewState(opts)
+	}
+
+	if len(s.History) > 0 && IsTamperMarker(s.History[len(s.History)-1]) {
+		return s, nil
+	}
+
+	s.AddToHistory(&backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionCompleted{
+			ExecutionCompleted: &protos.ExecutionCompletedEvent{
+				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+				FailureDetails: &protos.TaskFailureDetails{
+					ErrorType:    wferrors.ErrorTypeHistoryTampered,
+					ErrorMessage: cause.Error(),
+				},
+			},
+		},
+	})
+
+	req, err := s.GetSaveRequest(actorID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := astate.TransactionalStateOperation(ctx, true, req, false); err != nil {
+		return nil, err
+	}
+
+	s.ResetChangeTracking()
+	return s, nil
 }
 
 func verifySignatureChain(s *State, sgn *signer.Signer) error {

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -659,7 +659,7 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 
 	// A workflow that was previously detected as tampered carries an unsigned
 	// ExecutionCompleted(FAILED) marker as its last history event (see
-	// [MarkAsFailed]). It must always remain loadable so callers can observe the
+	// [MarkAsTamperFailed]). It must always remain loadable so callers can observe the
 	// FAILED status. Short-circuit every signing-enforcement check
 	// (configuration mismatch, signature chain failure) when the marker is
 	// present.
@@ -699,7 +699,7 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 }
 
 // IsTamperMarker reports whether e is the well-known terminal event written
-// by [MarkAsFailed] to record that the workflow's persisted state was
+// by [MarkAsTamperFailed] to record that the workflow's persisted state was
 // detected as tampered. It is identified by an ExecutionCompleted with
 // status FAILED and FailureDetails.ErrorType set to
 // [wferrors.ErrorTypeHistoryTampered]. Loaders use this check to bypass
@@ -719,14 +719,14 @@ func IsTamperMarker(e *backend.HistoryEvent) bool {
 }
 
 // hasTamperMarker reports whether the loaded state's history ends in the
-// terminal tamper marker event written by [MarkAsFailed]. Used by
+// terminal tamper marker event written by [MarkAsTamperFailed]. Used by
 // LoadWorkflowState to short-circuit verification failures on workflows
 // that are already terminally failed.
 func hasTamperMarker(s *State) bool {
 	return s != nil && len(s.History) > 0 && IsTamperMarker(s.History[len(s.History)-1])
 }
 
-// MarkAsFailed appends a single terminal ExecutionCompleted(FAILED) event to
+// MarkAsTamperFailed appends a single terminal ExecutionCompleted(FAILED) event to
 // the workflow's history to record that its persisted state was detected as
 // tampered. The original (untrusted) history, inbox, signatures, and certs
 // are left intact for forensics — only the marker event is added, and it is
@@ -734,9 +734,9 @@ func hasTamperMarker(s *State) bool {
 // bypass signature verification, so the workflow surfaces as terminally
 // FAILED with [wferrors.ErrorTypeHistoryTampered] in its FailureDetails.
 //
-// MarkAsFailed is idempotent: if prior already ends in a tamper marker the
+// MarkAsTamperFailed is idempotent: if prior already ends in a tamper marker the
 // state is returned unchanged with no store write.
-func MarkAsFailed(ctx context.Context, astate state.Interface, actorID string, opts Options, prior *State, cause error) (*State, error) {
+func MarkAsTamperFailed(ctx context.Context, astate state.Interface, actorID string, opts Options, prior *State, cause error) (*State, error) {
 	s := prior
 	if s == nil {
 		s = NewState(opts)

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -707,6 +707,9 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 // failed by tamper detection — without the bypass, the broken signature
 // chain would block every subsequent load.
 func IsTamperMarker(e *backend.HistoryEvent) bool {
+	if e == nil {
+		return false
+	}
 	ec := e.GetExecutionCompleted()
 	if ec == nil {
 		return false

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -657,6 +657,16 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 
 	wfLogger.Debugf("%s: loaded %d state records in %v", actorID, 1+len(bulkRes), time.Since(loadStartTime))
 
+	// A workflow that was previously detected as tampered carries an unsigned
+	// ExecutionCompleted(FAILED) marker as its last history event (see
+	// [MarkAsFailed]). It must always remain loadable so callers can observe the
+	// FAILED status. Short-circuit every signing-enforcement check
+	// (configuration mismatch, signature chain failure) when the marker is
+	// present.
+	if hasTamperMarker(wState) {
+		return wState, nil
+	}
+
 	// Signing enforcement. Once signing is enabled for a cluster, it is a
 	// one-way commitment: workflows created with signing must always run on
 	// signing-enabled hosts, and workflows created without signing cannot be
@@ -675,15 +685,6 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 			)
 		}
 		if err := verifySignatureChain(wState, opts.Signer); err != nil {
-			// A workflow that was previously detected as tampered carries an
-			// unsigned ExecutionCompleted(FAILED) marker as its last history
-			// event (see [MarkAsFailed]). The marker is intentionally not
-			// covered by a signature, so the chain check will always fail —
-			// short-circuit here so the workflow continues to surface as
-			// terminally FAILED on every load instead of being unloadable.
-			if hasTamperMarker(wState) {
-				return wState, nil
-			}
 			return wState, wferrors.NewVerificationError(
 				fmt.Errorf("workflow history signature verification failed for '%s': %w", actorID, err),
 			)

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -539,7 +539,7 @@ func TestIsTamperMarker(t *testing.T) {
 	})
 }
 
-func TestMarkAsFailed_AppendsMarkerAndPersists(t *testing.T) {
+func TestMarkAsTamperFailed_AppendsMarkerAndPersists(t *testing.T) {
 	t.Parallel()
 
 	prior := NewState(testOpts())
@@ -555,7 +555,7 @@ func TestMarkAsFailed_AppendsMarkerAndPersists(t *testing.T) {
 		},
 	)
 
-	got, err := MarkAsFailed(t.Context(), store, "wf-1", testOpts(), prior, errors.New("chain broken"))
+	got, err := MarkAsTamperFailed(t.Context(), store, "wf-1", testOpts(), prior, errors.New("chain broken"))
 	require.NoError(t, err)
 	require.NotNil(t, got)
 
@@ -590,7 +590,7 @@ func TestMarkAsFailed_AppendsMarkerAndPersists(t *testing.T) {
 	assert.True(t, foundMarkerUpsert, "expected upsert for the appended marker history key")
 }
 
-func TestMarkAsFailed_Idempotent(t *testing.T) {
+func TestMarkAsTamperFailed_Idempotent(t *testing.T) {
 	t.Parallel()
 
 	prior := NewState(testOpts())
@@ -606,19 +606,19 @@ func TestMarkAsFailed_Idempotent(t *testing.T) {
 		},
 	)
 
-	got, err := MarkAsFailed(t.Context(), store, "wf-1", testOpts(), prior, errors.New("ignored"))
+	got, err := MarkAsTamperFailed(t.Context(), store, "wf-1", testOpts(), prior, errors.New("ignored"))
 	require.NoError(t, err)
 	assert.Same(t, prior, got)
 	assert.Len(t, got.History, 2, "history must not grow when marker already present")
 	assert.Equal(t, 0, writes, "no store write should happen when already marked")
 }
 
-func TestMarkAsFailed_NilPriorCreatesFreshState(t *testing.T) {
+func TestMarkAsTamperFailed_NilPriorCreatesFreshState(t *testing.T) {
 	t.Parallel()
 
 	store := statefake.New()
 
-	got, err := MarkAsFailed(t.Context(), store, "wf-1", testOpts(), nil, errors.New("no prior"))
+	got, err := MarkAsTamperFailed(t.Context(), store, "wf-1", testOpts(), nil, errors.New("no prior"))
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Len(t, got.History, 1)

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -624,3 +624,84 @@ func TestMarkAsFailed_NilPriorCreatesFreshState(t *testing.T) {
 	require.Len(t, got.History, 1)
 	assert.True(t, IsTamperMarker(got.History[0]))
 }
+
+// TestLoadWorkflowState_TamperMarkerBypassesConfigurationError exercises
+// the bypass added so previously tamper-marked workflows remain loadable
+// after a host config change (e.g. signing was disabled). The signing
+// enforcement checks must short-circuit when the loaded history ends in
+// a tamper marker so the FAILED status still surfaces.
+func TestLoadWorkflowState_TamperMarkerBypassesConfigurationError(t *testing.T) {
+	t.Parallel()
+
+	const actorID = "wf-tampered"
+
+	// Build a state with a signature plus a tamper marker as the last
+	// history event, then persist it through a fake store.
+	store := statefake.New()
+	bulk := map[string][]byte{}
+	store = store.
+		WithGetFn(func(_ context.Context, req *api.GetStateRequest, _ bool) (*api.StateResponse, error) {
+			if v, ok := bulk[req.Key]; ok {
+				return &api.StateResponse{Data: v}, nil
+			}
+			return &api.StateResponse{}, nil
+		}).
+		WithGetBulkFn(func(_ context.Context, req *api.GetBulkStateRequest, _ bool) (api.BulkStateResponse, error) {
+			out := api.BulkStateResponse{}
+			for _, k := range req.Keys {
+				if v, ok := bulk[k]; ok {
+					out[k] = v
+				}
+			}
+			return out, nil
+		}).
+		WithTransactionalStateOperationFn(func(_ context.Context, _ bool, req *api.TransactionalRequest, _ bool) error {
+			for _, op := range req.Operations {
+				if op.Operation == api.Upsert {
+					u := op.Request.(api.TransactionalUpsert)
+					bulk[u.Key] = u.Value.([]byte)
+				}
+			}
+			return nil
+		})
+
+	histEvt := testEvent(0)
+	histBytes, err := proto.Marshal(histEvt)
+	require.NoError(t, err)
+	bulk["history-000000"] = histBytes
+
+	markerBytes, err := proto.Marshal(tamperMarkerEvent())
+	require.NoError(t, err)
+	bulk["history-000001"] = markerBytes
+
+	sig := &backend.HistorySignature{StartEventIndex: 0, EventCount: 1, Signature: []byte("sig")}
+	sigBytes, err := proto.Marshal(sig)
+	require.NoError(t, err)
+	bulk["signature-000000"] = sigBytes
+
+	cert := &backend.SigningCertificate{Certificate: []byte("cert")}
+	certBytes, err := proto.Marshal(cert)
+	require.NoError(t, err)
+	bulk["sigcert-000000"] = certBytes
+
+	metaBytes, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
+		HistoryLength:            2,
+		SignatureLength:          1,
+		SigningCertificateLength: 1,
+		Generation:               1,
+	})
+	require.NoError(t, err)
+	bulk["metadata"] = metaBytes
+
+	// Load with no signer / no app ID — the configuration that would
+	// normally yield a ConfigurationError. The tamper marker must
+	// short-circuit the check so the load succeeds.
+	got, err := LoadWorkflowState(t.Context(), store, actorID, Options{
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.History, 2)
+	assert.True(t, IsTamperMarker(got.History[1]))
+}

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package state
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +25,8 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/pkg/actors/api"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 )
@@ -478,4 +482,145 @@ func TestGetSaveRequest_MetadataIncludesSigningLengths(t *testing.T) {
 	assert.Equal(t, uint64(1), meta.GetHistoryLength())
 	assert.Equal(t, uint64(1), meta.GetSigningCertificateLength())
 	assert.Equal(t, uint64(1), meta.GetSignatureLength())
+}
+
+func tamperMarkerEvent() *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionCompleted{
+			ExecutionCompleted: &protos.ExecutionCompletedEvent{
+				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+				FailureDetails: &protos.TaskFailureDetails{
+					ErrorType:    wferrors.ErrorTypeHistoryTampered,
+					ErrorMessage: "boom",
+				},
+			},
+		},
+	}
+}
+
+func TestIsTamperMarker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tamper marker", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, IsTamperMarker(tamperMarkerEvent()))
+	})
+
+	t.Run("non-tamper failed completion", func(t *testing.T) {
+		t.Parallel()
+		e := &backend.HistoryEvent{
+			EventType: &protos.HistoryEvent_ExecutionCompleted{
+				ExecutionCompleted: &protos.ExecutionCompletedEvent{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+					FailureDetails: &protos.TaskFailureDetails{ErrorType: "user-failure"},
+				},
+			},
+		}
+		assert.False(t, IsTamperMarker(e))
+	})
+
+	t.Run("completed without failure details", func(t *testing.T) {
+		t.Parallel()
+		e := &backend.HistoryEvent{
+			EventType: &protos.HistoryEvent_ExecutionCompleted{
+				ExecutionCompleted: &protos.ExecutionCompletedEvent{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+				},
+			},
+		}
+		assert.False(t, IsTamperMarker(e))
+	})
+
+	t.Run("non-completion event", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, IsTamperMarker(testEvent(0)))
+	})
+}
+
+func TestMarkAsFailed_AppendsMarkerAndPersists(t *testing.T) {
+	t.Parallel()
+
+	prior := NewState(testOpts())
+	prior.AddToHistory(testEvent(0))
+	prior.AddToHistory(testEvent(1))
+	prior.ResetChangeTracking()
+
+	var saved *api.TransactionalRequest
+	store := statefake.New().WithTransactionalStateOperationFn(
+		func(_ context.Context, _ bool, req *api.TransactionalRequest, _ bool) error {
+			saved = req
+			return nil
+		},
+	)
+
+	got, err := MarkAsFailed(t.Context(), store, "wf-1", testOpts(), prior, errors.New("chain broken"))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.Len(t, got.History, 3, "marker should be appended to existing history")
+	last := got.History[len(got.History)-1]
+	assert.True(t, IsTamperMarker(last))
+	assert.Equal(t, "chain broken", last.GetExecutionCompleted().GetFailureDetails().GetErrorMessage())
+
+	// First two events must be unchanged.
+	assert.Equal(t, int32(0), got.History[0].GetEventId())
+	assert.Equal(t, int32(1), got.History[1].GetEventId())
+
+	// No new signatures or certs are written — the marker is intentionally unsigned.
+	assert.Empty(t, got.Signatures)
+	assert.Empty(t, got.SigningCertificates)
+
+	// Persistence happened: an upsert at history-000002 must be present.
+	require.NotNil(t, saved)
+	var foundMarkerUpsert bool
+	for _, op := range saved.Operations {
+		if op.Operation != api.Upsert {
+			continue
+		}
+		u, ok := op.Request.(api.TransactionalUpsert)
+		if !ok {
+			continue
+		}
+		if u.Key == "history-000002" {
+			foundMarkerUpsert = true
+		}
+	}
+	assert.True(t, foundMarkerUpsert, "expected upsert for the appended marker history key")
+}
+
+func TestMarkAsFailed_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	prior := NewState(testOpts())
+	prior.AddToHistory(testEvent(0))
+	prior.AddToHistory(tamperMarkerEvent())
+	prior.ResetChangeTracking()
+
+	var writes int
+	store := statefake.New().WithTransactionalStateOperationFn(
+		func(_ context.Context, _ bool, _ *api.TransactionalRequest, _ bool) error {
+			writes++
+			return nil
+		},
+	)
+
+	got, err := MarkAsFailed(t.Context(), store, "wf-1", testOpts(), prior, errors.New("ignored"))
+	require.NoError(t, err)
+	assert.Same(t, prior, got)
+	assert.Len(t, got.History, 2, "history must not grow when marker already present")
+	assert.Equal(t, 0, writes, "no store write should happen when already marked")
+}
+
+func TestMarkAsFailed_NilPriorCreatesFreshState(t *testing.T) {
+	t.Parallel()
+
+	store := statefake.New()
+
+	got, err := MarkAsFailed(t.Context(), store, "wf-1", testOpts(), nil, errors.New("no prior"))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.History, 1)
+	assert.True(t, IsTamperMarker(got.History[0]))
 }

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -43,10 +44,12 @@ func init() {
 }
 
 // childInjection verifies that injecting a fake ChildWorkflowInstanceCompleted
-// event into the inbox is rejected when signing is enabled. A
-// ChildWorkflowInstanceCompleted referencing a TaskScheduledId that was never
-// scheduled in the signed history is detected by filterValidInboxEvents and
-// purged before being processed, leaving the workflow in RUNNING state.
+// event into the inbox marks the workflow as terminally FAILED with the
+// well-known [wferrors.ErrorTypeHistoryTampered] error type. A
+// ChildWorkflowInstanceCompleted referencing a TaskScheduledId that was
+// never scheduled in the signed history is detected by
+// filterValidInboxEvents on the next orchestrator load, which appends a
+// tamper-marker ExecutionCompleted event.
 type childInjection struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement
@@ -154,11 +157,22 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
-	// Inbox injection is treated as state store tampering: any operation that
-	// loads the actor state detects the forged inbox entry and rejects the
-	// call. RaiseEvent goes through the orchestrator actor, so it surfaces
-	// the tampering error directly.
-	err = client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event"))
-	require.Error(tt, err)
-	assert.Contains(tt, err.Error(), "state store tampering")
+	// Inbox injection is treated as state store tampering: the next operation
+	// that activates the orchestrator actor detects the forged inbox entry
+	// and appends a terminal tamper-marker event to the history, leaving the
+	// workflow in a FAILED state. RaiseEvent triggers the activation.
+	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
+
+	require.EventuallyWithT(tt, func(c *assert.CollectT) {
+		meta, err := client.FetchWorkflowMetadata(ctx, id)
+		assert.NoError(c, err)
+		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
+			return
+		}
+		if !assert.NotNil(c, meta.FailureDetails) {
+			return
+		}
+		assert.Equal(c, wferrors.ErrorTypeHistoryTampered, meta.FailureDetails.GetErrorType())
+		assert.Contains(c, meta.FailureDetails.GetErrorMessage(), "state store tampering")
+	}, time.Second*10, time.Millisecond*100)
 }

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -43,11 +44,12 @@ func init() {
 }
 
 // inboxInjection verifies that injecting a fake TaskCompleted event into the
-// inbox is rejected when signing is enabled. The workflow schedules a real
-// activity and then waits for an external event. A TaskCompleted referencing
-// a TaskScheduledId that was never scheduled in the signed history is purged
-// by filterValidInboxEvents, leaving the workflow in RUNNING state without
-// processing the injected event.
+// inbox marks the workflow as terminally FAILED with the well-known
+// [wferrors.ErrorTypeHistoryTampered] error type. The workflow schedules a
+// real activity and then waits for an external event. A TaskCompleted
+// referencing a TaskScheduledId that was never scheduled in the signed
+// history is detected by filterValidInboxEvents on the next orchestrator
+// load, which appends a tamper-marker ExecutionCompleted event.
 type inboxInjection struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement
@@ -154,11 +156,22 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
-	// Inbox injection is treated as state store tampering: any operation that
-	// loads the actor state detects the forged inbox entry and rejects the
-	// call. RaiseEvent goes through the orchestrator actor, so it surfaces
-	// the tampering error directly.
-	err = client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event"))
-	require.Error(tt, err)
-	assert.Contains(tt, err.Error(), "state store tampering")
+	// Inbox injection is treated as state store tampering: the next operation
+	// that activates the orchestrator actor detects the forged inbox entry
+	// and appends a terminal tamper-marker event to the history, leaving the
+	// workflow in a FAILED state. RaiseEvent triggers the activation.
+	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
+
+	require.EventuallyWithT(tt, func(c *assert.CollectT) {
+		meta, err := client.FetchWorkflowMetadata(ctx, id)
+		assert.NoError(c, err)
+		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
+			return
+		}
+		if !assert.NotNil(c, meta.FailureDetails) {
+			return
+		}
+		assert.Equal(c, wferrors.ErrorTypeHistoryTampered, meta.FailureDetails.GetErrorType())
+		assert.Contains(c, meta.FailureDetails.GetErrorMessage(), "state store tampering")
+	}, time.Second*10, time.Millisecond*100)
 }

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -39,7 +39,9 @@ func init() {
 // signatureStripped verifies that stripping any of the four signing-related
 // state fields (signature keys, sigcert keys, SignatureLength metadata,
 // SigningCertificateLength metadata) results in a verification error on
-// reload. Each scenario runs as a subtest with its own workflow instance.
+// reload. The workflows under test have already completed (terminal), so
+// the orchestrator does not append a tamper marker — the reader path
+// surfaces the verification error to the caller.
 type signatureStripped struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement

--- a/tests/integration/suite/daprd/workflow/signing/tampered.go
+++ b/tests/integration/suite/daprd/workflow/signing/tampered.go
@@ -38,8 +38,10 @@ func init() {
 }
 
 // tampered verifies that a completed workflow with a tampered history event
-// is detected as invalid after a daprd restart, resulting in a FAILED status
-// with a signature verification error.
+// is detected as invalid after a daprd restart. Because the workflow had
+// already finished executing, the orchestrator does not append a tamper
+// marker — there is nothing left for the actor to do — so reads of the
+// tampered state surface the verification error to the caller.
 type tampered struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement

--- a/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
+++ b/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -37,9 +38,11 @@ func init() {
 	suite.Register(new(tamperedrunning))
 }
 
-// tamperedrunning verifies that a running workflow with a tampered history
-// event is detected as invalid after a daprd restart, resulting in a FAILED
-// status with a signature verification error.
+// tamperedrunning verifies that a running (non-terminal) workflow with a
+// tampered history event is, on the next orchestrator-actor activation,
+// terminally marked FAILED with the well-known
+// [wferrors.ErrorTypeHistoryTampered] error type — so the executor stops
+// working on the workflow.
 type tamperedrunning struct {
 	sentry *sentry.Sentry
 	place  *placement.Placement
@@ -120,7 +123,21 @@ func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
 	client = dworkflow.NewClient(tr.daprd.GRPCConn(tt, ctx))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
-	_, err = client.FetchWorkflowMetadata(ctx, id)
-	require.Error(tt, err)
-	assert.Contains(tt, err.Error(), "signature verification failed")
+	// Trigger the orchestrator actor by raising the event the workflow is
+	// waiting on. The actor's load detects the tampered history and appends
+	// the terminal tamper marker so the workflow stops being worked on.
+	require.NoError(tt, client.RaiseEvent(ctx, id, "continue", dworkflow.WithEventPayload("real-event")))
+
+	require.EventuallyWithT(tt, func(c *assert.CollectT) {
+		meta, err := client.FetchWorkflowMetadata(ctx, id)
+		assert.NoError(c, err)
+		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
+			return
+		}
+		if !assert.NotNil(c, meta.FailureDetails) {
+			return
+		}
+		assert.Equal(c, wferrors.ErrorTypeHistoryTampered, meta.FailureDetails.GetErrorType())
+		assert.Contains(c, meta.FailureDetails.GetErrorMessage(), "signature verification failed")
+	}, time.Second*10, time.Millisecond*100)
 }


### PR DESCRIPTION
When the orchestrator actor loads a workflow whose persisted history, signatures, or inbox have been tampered with, the actor now appends a terminal ExecutionCompleted event marked with the well-known error type `DAPR_WORKFLOW_HISTORY_TAMPERED`. This stops the executor from acting on forged input and gives clients a stable signal to match on. The original (untrusted) state is left intact for forensics. Only an unsigned terminal event is appended, and LoadWorkflowState bypasses signature verification when it sees the tamper marker so subsequent loads succeed and surface FAILED.

The append is scoped to workflows still in custody of the executor. A workflow that had already finished is left untouched: there is nothing for the actor to do, and the verification error is surfaced to readers who are responsible for detecting the tampering at read time.

Configuration mismatches (signed history loaded by a non-signing host, or vice versa) are split out into a new ConfigurationError type so the tamper-recovery path does not run against intact-but-unloadable workflows.