### PR TITLE
fix: remove availability zone requirement from AKS test clusters

### DIFF
--- a/tests/test-infra/azure-aks.bicep
+++ b/tests/test-infra/azure-aks.bicep
@@ -100,11 +100,6 @@ resource aks 'Microsoft.ContainerService/managedClusters@2023-05-01' = {
           type: 'VirtualMachineScaleSets'
           mode: 'System'
           maxPods: 110
-          availabilityZones: [
-            '1'
-            '2'
-            '3'
-          ]
           enableNodePublicIP: false
           vnetSubnetID: enableWindows ? aksVNet::defaultSubnet.id : null
           tags: {}
@@ -122,11 +117,6 @@ resource aks 'Microsoft.ContainerService/managedClusters@2023-05-01' = {
           type: 'VirtualMachineScaleSets'
           mode: 'User'
           maxPods: 110
-          availabilityZones: [
-            '1'
-            '2'
-            '3'
-          ]
           nodeLabels: {}
           nodeTaints: []
           enableNodePublicIP: false
@@ -144,11 +134,6 @@ resource aks 'Microsoft.ContainerService/managedClusters@2023-05-01' = {
           type: 'VirtualMachineScaleSets'
           mode: 'User'
           maxPods: 110
-          availabilityZones: [
-            '1'
-            '2'
-            '3'
-          ]
           nodeLabels: {}
           nodeTaints: []
           enableNodePublicIP: false


### PR DESCRIPTION
## Summary

Perf and e2e test deployments fail on the new Azure subscription with:
```
AvailabilityZoneNotSupported: The zone(s) '1' for resource 'agentpool' is not supported.
The supported zones for location 'eastus' are ''.
```

Removes hardcoded `availabilityZones: ['1', '2', '3']` from all three AKS agent pool profiles (Linux, Windows, ARM64) in the Bicep template. AZs are not needed for ephemeral CI test clusters.

Failing run: https://github.com/dapr/dapr/actions/runs/25101851913/job/73552871492

## Test plan
- [ ] Re-trigger `dapr-perf.yml` — AKS cluster should deploy successfully

Generated with [Claude Code](https://claude.com/claude-code)