### PR TITLE
fix: use ECDSA certs for Kube webhook-facing services (operator, injector)

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -277,6 +278,13 @@ func (o *operator) Start(ctx context.Context) error {
 				return rErr
 			}
 
+			// Prefer ECDSA trust anchors for webhook caBundle if available.
+			// Managed Kube API servers (e.g. AKS) may not support Ed25519
+			// for TLS verification of conversion webhooks.
+			if ecCA := o.ecTrustAnchorsFromConfigMap(ctx); ecCA != nil {
+				caBundle = ecCA
+			}
+
 			for {
 				rErr = o.patchConversionWebhooksInCRDs(ctx, caBundle, o.mgr.GetConfig(), "subscriptions.dapr.io")
 				if rErr != nil {
@@ -402,4 +410,22 @@ func buildScheme(opts Options) (*runtime.Scheme, error) {
 	}
 
 	return scheme, errors.Join(errs...)
+}
+
+// ecTrustAnchorsFromConfigMap reads the ECDSA webhook trust anchors from the
+// dapr-trust-bundle configmap. Returns nil if not present.
+func (o *operator) ecTrustAnchorsFromConfigMap(ctx context.Context) []byte {
+	cfg := o.mgr.GetConfig()
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil
+	}
+	cm, err := client.CoreV1().ConfigMaps(security.CurrentNamespace()).Get(ctx, "dapr-trust-bundle", v1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	if ecCA, ok := cm.Data["ec-ca.crt"]; ok && ecCA != "" {
+		return []byte(ecCA)
+	}
+	return nil
 }

--- a/pkg/sentry/server/ca/bundle/bundle.go
+++ b/pkg/sentry/server/ca/bundle/bundle.go
@@ -66,11 +66,19 @@ type X509 struct {
 	IssChain []*x509.Certificate
 	// IssKey is the issuer private key.
 	IssKey any
-	// ECIssChain is a secondary ECDSA issuer certificate chain used for
-	// Kubernetes webhook-facing services (operator, injector) whose certs
-	// must be verifiable by the Kube API server which may not support Ed25519.
+
+	// ECTrustAnchors is PEM encoded ECDSA trust anchors for Kube webhook
+	// caBundle injection. This is a self-signed ECDSA root CA, separate from
+	// the Ed25519 trust anchors, so the full chain is verifiable by API
+	// servers that do not support Ed25519.
+	ECTrustAnchors []byte
+	// ECIssChainPEM is the PEM encoded ECDSA issuer certificate chain.
+	ECIssChainPEM []byte
+	// ECIssKeyPEM is the PEM encoded ECDSA issuer private key.
+	ECIssKeyPEM []byte
+	// ECIssChain is the ECDSA issuer certificate chain.
 	ECIssChain []*x509.Certificate
-	// ECIssKey is the ECDSA private key for the secondary issuer.
+	// ECIssKey is the ECDSA private key for the webhook issuer.
 	ECIssKey crypto.Signer
 }
 
@@ -124,37 +132,82 @@ func GenerateX509(opts OptionsX509) (*X509, error) {
 		return nil, err
 	}
 
-	// Generate a secondary ECDSA issuer for Kubernetes webhook-facing
-	// services. The Kube API server may not support Ed25519 for TLS
-	// verification of conversion/admission webhooks.
+	ecBundle, err := GenerateECX509(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA webhook CA: %w", err)
+	}
+
+	return &X509{
+		TrustAnchors:   trustAnchors,
+		IssChainPEM:    issCertPEM,
+		IssKeyPEM:      issKeyPEM,
+		IssChain:       []*x509.Certificate{issCert},
+		IssKey:         issKey,
+		ECTrustAnchors: ecBundle.TrustAnchors,
+		ECIssChainPEM:  ecBundle.IssChainPEM,
+		ECIssKeyPEM:    ecBundle.IssKeyPEM,
+		ECIssChain:     ecBundle.IssChain,
+		ECIssKey:       ecBundle.IssKey.(crypto.Signer),
+	}, nil
+}
+
+// GenerateECX509 generates a self-signed ECDSA P-256 CA bundle for Kubernetes
+// webhook-facing services. The Kube API server on managed platforms (e.g. AKS)
+// may not support Ed25519 for TLS verification of conversion/admission
+// webhooks. This CA is completely independent so the entire cert chain is
+// verifiable using only ECDSA.
+func GenerateECX509(opts OptionsX509) (*X509, error) {
+	log.Debug("Generating ECDSA webhook CA bundle")
+
+	ecRootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA root key: %w", err)
+	}
+
+	ecRootCert, err := generateRootCert(opts.TrustDomain, opts.AllowedClockSkew, opts.OverrideCATTL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA root cert: %w", err)
+	}
+	ecRootCertDER, err := x509.CreateCertificate(rand.Reader, ecRootCert, ecRootCert, &ecRootKey.PublicKey, ecRootKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign ECDSA root cert: %w", err)
+	}
+	trustAnchors := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ecRootCertDER})
+	ecRootCert, err = x509.ParseCertificate(ecRootCertDER)
+	if err != nil {
+		return nil, err
+	}
+
 	ecIssKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate ECDSA key for webhook issuer: %w", err)
+		return nil, fmt.Errorf("failed to generate ECDSA issuer key: %w", err)
 	}
+	ecIssKeyDer, err := x509.MarshalPKCS8PrivateKey(ecIssKey)
+	if err != nil {
+		return nil, err
+	}
+	issKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: ecIssKeyDer})
 
 	ecIssCert, err := generateIssuerCert(opts.TrustDomain, opts.AllowedClockSkew, opts.OverrideCATTL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ECDSA issuer cert: %w", err)
 	}
-	ecIssCert.SignatureAlgorithm = x509.ECDSAWithSHA256
-
-	ecIssCertDER, err := x509.CreateCertificate(rand.Reader, ecIssCert, rootCert, &ecIssKey.PublicKey, opts.X509RootKey)
+	ecIssCertDER, err := x509.CreateCertificate(rand.Reader, ecIssCert, ecRootCert, &ecIssKey.PublicKey, ecRootKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign ECDSA issuer cert: %w", err)
 	}
-	ecIssCertParsed, err := x509.ParseCertificate(ecIssCertDER)
+	issChainPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ecIssCertDER})
+	ecIssCert, err = x509.ParseCertificate(ecIssCertDER)
 	if err != nil {
 		return nil, err
 	}
 
 	return &X509{
 		TrustAnchors: trustAnchors,
-		IssChainPEM:  issCertPEM,
+		IssChainPEM:  issChainPEM,
 		IssKeyPEM:    issKeyPEM,
-		IssChain:     []*x509.Certificate{issCert},
-		IssKey:       issKey,
-		ECIssChain:   []*x509.Certificate{ecIssCertParsed},
-		ECIssKey:     ecIssKey,
+		IssChain:     []*x509.Certificate{ecIssCert},
+		IssKey:       ecIssKey,
 	}, nil
 }
 

--- a/pkg/sentry/server/ca/bundle/bundle.go
+++ b/pkg/sentry/server/ca/bundle/bundle.go
@@ -15,7 +15,9 @@ package bundle
 
 import (
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
@@ -64,6 +66,12 @@ type X509 struct {
 	IssChain []*x509.Certificate
 	// IssKey is the issuer private key.
 	IssKey any
+	// ECIssChain is a secondary ECDSA issuer certificate chain used for
+	// Kubernetes webhook-facing services (operator, injector) whose certs
+	// must be verifiable by the Kube API server which may not support Ed25519.
+	ECIssChain []*x509.Certificate
+	// ECIssKey is the ECDSA private key for the secondary issuer.
+	ECIssKey crypto.Signer
 }
 
 type JWT struct {
@@ -116,12 +124,37 @@ func GenerateX509(opts OptionsX509) (*X509, error) {
 		return nil, err
 	}
 
+	// Generate a secondary ECDSA issuer for Kubernetes webhook-facing
+	// services. The Kube API server may not support Ed25519 for TLS
+	// verification of conversion/admission webhooks.
+	ecIssKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA key for webhook issuer: %w", err)
+	}
+
+	ecIssCert, err := generateIssuerCert(opts.TrustDomain, opts.AllowedClockSkew, opts.OverrideCATTL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA issuer cert: %w", err)
+	}
+	ecIssCert.SignatureAlgorithm = x509.ECDSAWithSHA256
+
+	ecIssCertDER, err := x509.CreateCertificate(rand.Reader, ecIssCert, rootCert, &ecIssKey.PublicKey, opts.X509RootKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign ECDSA issuer cert: %w", err)
+	}
+	ecIssCertParsed, err := x509.ParseCertificate(ecIssCertDER)
+	if err != nil {
+		return nil, err
+	}
+
 	return &X509{
 		TrustAnchors: trustAnchors,
 		IssChainPEM:  issCertPEM,
 		IssKeyPEM:    issKeyPEM,
 		IssChain:     []*x509.Certificate{issCert},
 		IssKey:       issKey,
+		ECIssChain:   []*x509.Certificate{ecIssCertParsed},
+		ECIssKey:     ecIssKey,
 	}, nil
 }
 

--- a/pkg/sentry/server/ca/bundle/bundle_test.go
+++ b/pkg/sentry/server/ca/bundle/bundle_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package bundle
 
 import (
+	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
@@ -21,10 +22,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,6 +82,100 @@ func TestGenerateX509Bundle(t *testing.T) {
 		expectedDefaultTTL := time.Hour * 24 * 365
 		require.WithinDuration(t, time.Now().Add(expectedDefaultTTL), rootCert.NotAfter, time.Hour*24)
 	})
+}
+
+func TestGenerateX509Bundle_ECFields(t *testing.T) {
+	_, x509RootKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	bundle, err := GenerateX509(OptionsX509{
+		X509RootKey:      x509RootKey,
+		TrustDomain:      "test.example.com",
+		AllowedClockSkew: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// EC fields should be populated
+	require.NotEmpty(t, bundle.ECTrustAnchors, "ECTrustAnchors should be populated")
+	require.NotEmpty(t, bundle.ECIssChainPEM, "ECIssChainPEM should be populated")
+	require.NotEmpty(t, bundle.ECIssKeyPEM, "ECIssKeyPEM should be populated")
+	require.NotNil(t, bundle.ECIssChain, "ECIssChain should be populated")
+	require.Len(t, bundle.ECIssChain, 1)
+	require.NotNil(t, bundle.ECIssKey, "ECIssKey should be populated")
+
+	// EC trust anchors should be different from main trust anchors
+	assert.NotEqual(t, bundle.TrustAnchors, bundle.ECTrustAnchors,
+		"ECDSA trust anchors should be independent from Ed25519 trust anchors")
+
+	// EC root should be self-signed ECDSA
+	ecRoot, _ := decodePEM(t, bundle.ECTrustAnchors)
+	require.NotNil(t, ecRoot)
+	assert.IsType(t, &ecdsa.PublicKey{}, ecRoot.PublicKey, "EC root should use ECDSA key")
+	require.NoError(t, ecRoot.CheckSignatureFrom(ecRoot), "EC root should be self-signed")
+
+	// EC issuer should be signed by EC root (not Ed25519 root)
+	require.NoError(t, bundle.ECIssChain[0].CheckSignatureFrom(ecRoot),
+		"EC issuer should be signed by EC root")
+	assert.IsType(t, &ecdsa.PublicKey{}, bundle.ECIssChain[0].PublicKey,
+		"EC issuer should use ECDSA key")
+
+	// Main issuer should still be Ed25519
+	mainRoot, _ := decodePEM(t, bundle.TrustAnchors)
+	assert.IsType(t, ed25519.PublicKey{}, mainRoot.PublicKey,
+		"Main root should remain Ed25519")
+}
+
+func TestGenerateECX509(t *testing.T) {
+	bundle, err := GenerateECX509(OptionsX509{
+		TrustDomain:      "test.example.com",
+		AllowedClockSkew: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, bundle.TrustAnchors)
+	require.NotEmpty(t, bundle.IssChainPEM)
+	require.NotEmpty(t, bundle.IssKeyPEM)
+	require.NotNil(t, bundle.IssChain)
+	require.Len(t, bundle.IssChain, 1)
+	require.NotNil(t, bundle.IssKey)
+
+	// Root should be self-signed ECDSA
+	root, _ := decodePEM(t, bundle.TrustAnchors)
+	require.NotNil(t, root)
+	assert.IsType(t, &ecdsa.PublicKey{}, root.PublicKey)
+	assert.True(t, root.IsCA)
+	require.NoError(t, root.CheckSignatureFrom(root))
+
+	// Issuer should be signed by ECDSA root
+	require.NoError(t, bundle.IssChain[0].CheckSignatureFrom(root))
+	assert.IsType(t, &ecdsa.PublicKey{}, bundle.IssChain[0].PublicKey)
+	assert.True(t, bundle.IssChain[0].IsCA)
+
+	// Full chain verification: sign a leaf cert and verify chain
+	leafKey, err := ecdsa.GenerateKey(bundle.IssChain[0].PublicKey.(*ecdsa.PublicKey).Curve, rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(99),
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, bundle.IssChain[0], &leafKey.PublicKey, bundle.IssKey)
+	require.NoError(t, err)
+	leaf, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	// Verify leaf → issuer → root chain
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(root)
+	intPool := x509.NewCertPool()
+	intPool.AddCert(bundle.IssChain[0])
+	_, err = leaf.Verify(x509.VerifyOptions{
+		Roots:         rootPool,
+		Intermediates: intPool,
+	})
+	require.NoError(t, err, "Full ECDSA chain should verify without Ed25519")
 }
 
 func TestGenerateJWTBundle(t *testing.T) {

--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -58,6 +58,12 @@ type SignRequest struct {
 
 	// Optional DNS names to add to the certificate.
 	DNS []string
+
+	// IsKubeWebhook indicates that this cert will be presented to the Kube
+	// API server (e.g. conversion/admission webhooks). When true, the cert
+	// is signed with an ECDSA issuer for compatibility with API servers that
+	// do not support Ed25519.
+	IsKubeWebhook bool
 }
 
 // Signer is the interface for the CA.
@@ -271,7 +277,16 @@ func (c *ca) SignIdentity(ctx context.Context, req *SignRequest) ([]*x509.Certif
 	}
 	tmpl.DNSNames = append(tmpl.DNSNames, req.DNS...)
 
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, c.bundle.X509.IssChain[0], req.PublicKey, c.bundle.X509.IssKey)
+	// Use the ECDSA issuer for Kube webhook-facing services so the cert
+	// chain is verifiable by API servers that don't support Ed25519.
+	issChain := c.bundle.X509.IssChain
+	issKey := c.bundle.X509.IssKey
+	if req.IsKubeWebhook && c.bundle.X509.ECIssChain != nil {
+		issChain = c.bundle.X509.ECIssChain
+		issKey = c.bundle.X509.ECIssKey
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, issChain[0], req.PublicKey, issKey)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +296,7 @@ func (c *ca) SignIdentity(ctx context.Context, req *SignRequest) ([]*x509.Certif
 		return nil, err
 	}
 
-	return append([]*x509.Certificate{cert}, c.bundle.X509.IssChain...), nil
+	return append([]*x509.Certificate{cert}, issChain...), nil
 }
 
 // TODO: Remove this method in v1.12 since it is not used any more.

--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -152,7 +152,7 @@ func New(ctx context.Context, conf config.Config) (Signer, error) {
 	// pre-ECDSA-webhook version). This is a self-signed ECDSA CA used only
 	// for operator/injector webhook certs so the Kube API server can verify
 	// the chain without Ed25519 support.
-	if bndle.X509 != nil && bndle.X509.ECIssChain == nil {
+	if bndle.X509 != nil && bndle.X509.ECIssChain == nil && conf.TrustDomain != "" {
 		needsWrite = true
 		log.Info("ECDSA webhook CA not found: generating")
 		ecBundle, ecErr := bundle.GenerateECX509(bundle.OptionsX509{

--- a/pkg/sentry/server/ca/ca.go
+++ b/pkg/sentry/server/ca/ca.go
@@ -148,6 +148,27 @@ func New(ctx context.Context, conf config.Config) (Signer, error) {
 		log.Info("Generating self-signed CA certs and persisting to store")
 	}
 
+	// Generate ECDSA webhook CA if not present (new install or upgrade from
+	// pre-ECDSA-webhook version). This is a self-signed ECDSA CA used only
+	// for operator/injector webhook certs so the Kube API server can verify
+	// the chain without Ed25519 support.
+	if bndle.X509 != nil && bndle.X509.ECIssChain == nil {
+		needsWrite = true
+		log.Info("ECDSA webhook CA not found: generating")
+		ecBundle, ecErr := bundle.GenerateECX509(bundle.OptionsX509{
+			TrustDomain:      conf.TrustDomain,
+			AllowedClockSkew: conf.AllowedClockSkew,
+		})
+		if ecErr != nil {
+			return nil, fmt.Errorf("failed to generate ECDSA webhook CA: %w", ecErr)
+		}
+		bndle.X509.ECTrustAnchors = ecBundle.TrustAnchors
+		bndle.X509.ECIssChainPEM = ecBundle.IssChainPEM
+		bndle.X509.ECIssKeyPEM = ecBundle.IssKeyPEM
+		bndle.X509.ECIssChain = ecBundle.IssChain
+		bndle.X509.ECIssKey = ecBundle.IssKey.(crypto.Signer)
+	}
+
 	if bndle.JWT == nil && conf.JWT.Enabled {
 		needsWrite = true
 

--- a/pkg/sentry/server/ca/ca_test.go
+++ b/pkg/sentry/server/ca/ca_test.go
@@ -369,3 +369,83 @@ func TestSignIdentity(t *testing.T) {
 		require.NoError(t, clientCert[0].CheckSignatureFrom(int2Crt))
 	})
 }
+
+func TestSignIdentity_IsKubeWebhook(t *testing.T) {
+	dir := t.TempDir()
+	rootCertPath := filepath.Join(dir, "ca.crt")
+	issuerCertPath := filepath.Join(dir, "issuer.crt")
+	issuerKeyPath := filepath.Join(dir, "issuer.key")
+	jwtSigningKeyPath := filepath.Join(dir, "jwt.key")
+	jwksPath := filepath.Join(dir, "jwks.json")
+
+	config := config.Config{
+		TrustDomain:      "example.test.dapr.io",
+		WorkloadCertTTL:  time.Hour,
+		AllowedClockSkew: time.Minute,
+		RootCertPath:     rootCertPath,
+		IssuerCertPath:   issuerCertPath,
+		IssuerKeyPath:    issuerKeyPath,
+		JWT: config.ConfigJWT{
+			Enabled:        false,
+			SigningKeyPath: jwtSigningKeyPath,
+			JWKSPath:       jwksPath,
+		},
+	}
+
+	// Let sentry auto-generate everything (including ECDSA CA)
+	ca, err := New(t.Context(), config)
+	require.NoError(t, err)
+
+	clientPK, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	t.Run("regular workload uses Ed25519 issuer", func(t *testing.T) {
+		chain, err := ca.SignIdentity(t.Context(), &SignRequest{
+			PublicKey:     clientPK.Public(),
+			TrustDomain:  "example.test.dapr.io",
+			Namespace:    "default",
+			AppID:        "my-app",
+			IsKubeWebhook: false,
+		})
+		require.NoError(t, err)
+		require.True(t, len(chain) >= 2)
+
+		// Issuer cert (chain[1]) should use Ed25519
+		assert.Equal(t, x509.PureEd25519, chain[1].SignatureAlgorithm,
+			"Regular workload issuer should use Ed25519")
+	})
+
+	t.Run("webhook workload uses ECDSA issuer", func(t *testing.T) {
+		chain, err := ca.SignIdentity(t.Context(), &SignRequest{
+			PublicKey:     clientPK.Public(),
+			TrustDomain:  "example.test.dapr.io",
+			Namespace:    "default",
+			AppID:        "dapr-operator",
+			IsKubeWebhook: true,
+		})
+		require.NoError(t, err)
+		require.True(t, len(chain) >= 2)
+
+		// Issuer cert (chain[1]) should use ECDSA
+		assert.Equal(t, x509.ECDSAWithSHA256, chain[1].SignatureAlgorithm,
+			"Webhook issuer should use ECDSA")
+		assert.IsType(t, &ecdsa.PublicKey{}, chain[1].PublicKey,
+			"Webhook issuer key should be ECDSA")
+	})
+
+	t.Run("webhook cert verifiable with ECDSA-only chain", func(t *testing.T) {
+		chain, err := ca.SignIdentity(t.Context(), &SignRequest{
+			PublicKey:     clientPK.Public(),
+			TrustDomain:  "example.test.dapr.io",
+			Namespace:    "default",
+			AppID:        "dapr-operator",
+			IsKubeWebhook: true,
+		})
+		require.NoError(t, err)
+		require.True(t, len(chain) >= 2)
+
+		// Leaf should be verifiable from ECDSA issuer
+		require.NoError(t, chain[0].CheckSignatureFrom(chain[1]),
+			"Leaf cert should be verifiable from ECDSA issuer")
+	})
+}

--- a/pkg/sentry/server/ca/kube.go
+++ b/pkg/sentry/server/ca/kube.go
@@ -15,6 +15,7 @@ package ca
 
 import (
 	"context"
+	"crypto"
 	"fmt"
 	"path/filepath"
 
@@ -72,6 +73,24 @@ func (k *kube) get(ctx context.Context) (bundle.Bundle, error) {
 		if err != nil {
 			return bundle.Bundle{}, fmt.Errorf("failed to verify CA bundle: %w", err)
 		}
+
+		// Load persisted ECDSA webhook CA if present
+		if ecTrustAnchors, ok := secret.Data["ec-ca.crt"]; ok {
+			if ecIssChainPEM, ok := secret.Data["ec-tls.crt"]; ok {
+				if ecIssKeyPEM, ok := secret.Data["ec-tls.key"]; ok {
+					ecBundle, ecErr := verifyX509Bundle(ecTrustAnchors, ecIssChainPEM, ecIssKeyPEM)
+					if ecErr != nil {
+						log.Warnf("Failed to verify persisted ECDSA webhook CA, will regenerate: %v", ecErr)
+					} else {
+						bndle.X509.ECTrustAnchors = ecBundle.TrustAnchors
+						bndle.X509.ECIssChainPEM = ecBundle.IssChainPEM
+						bndle.X509.ECIssKeyPEM = ecBundle.IssKeyPEM
+						bndle.X509.ECIssChain = ecBundle.IssChain
+						bndle.X509.ECIssKey = ecBundle.IssKey.(crypto.Signer)
+					}
+				}
+			}
+		}
 	}
 
 	// Check for JWT signing key and JWKS
@@ -119,6 +138,13 @@ func (k *kube) store(ctx context.Context, bundle bundle.Bundle) error {
 	secret.Data[filepath.Base(k.config.IssuerCertPath)] = bundle.X509.IssChainPEM
 	secret.Data[filepath.Base(k.config.IssuerKeyPath)] = bundle.X509.IssKeyPEM
 
+	// Persist ECDSA webhook CA if present
+	if bundle.X509.ECTrustAnchors != nil {
+		secret.Data["ec-ca.crt"] = bundle.X509.ECTrustAnchors
+		secret.Data["ec-tls.crt"] = bundle.X509.ECIssChainPEM
+		secret.Data["ec-tls.key"] = bundle.X509.ECIssKeyPEM
+	}
+
 	// Add JWT related data if available
 	if bundle.JWT != nil {
 		if bundle.JWT.SigningKeyPEM != nil {
@@ -145,6 +171,11 @@ func (k *kube) store(ctx context.Context, bundle bundle.Bundle) error {
 	}
 
 	configMap.Data[filepath.Base(k.config.RootCertPath)] = string(bundle.X509.TrustAnchors)
+
+	// Add ECDSA trust anchors for webhook caBundle injection
+	if bundle.X509.ECTrustAnchors != nil {
+		configMap.Data["ec-ca.crt"] = string(bundle.X509.ECTrustAnchors)
+	}
 
 	// If the OIDC server is enabled, clients could use that to access the JWKS
 	// to verify JWTs. However, the OIDC server is not required and so it is

--- a/pkg/sentry/server/ca/selfhosted.go
+++ b/pkg/sentry/server/ca/selfhosted.go
@@ -36,6 +36,13 @@ func (s *selfhosted) store(_ context.Context, bundle bundle.Bundle) error {
 	files[s.config.IssuerCertPath] = bundle.X509.IssChainPEM
 	files[s.config.IssuerKeyPath] = bundle.X509.IssKeyPEM
 
+	// Persist ECDSA webhook CA alongside the main CA
+	if bundle.X509.ECTrustAnchors != nil {
+		files[s.config.RootCertPath+".ec-ca"] = bundle.X509.ECTrustAnchors
+		files[s.config.IssuerCertPath+".ec"] = bundle.X509.ECIssChainPEM
+		files[s.config.IssuerKeyPath+".ec"] = bundle.X509.ECIssKeyPEM
+	}
+
 	if s.config.JWT.Enabled {
 		files[s.config.JWT.SigningKeyPath] = bundle.JWT.SigningKeyPEM
 		files[s.config.JWT.JWKSPath] = bundle.JWT.JWKSJson

--- a/pkg/sentry/server/server.go
+++ b/pkg/sentry/server/server.go
@@ -213,7 +213,8 @@ func (s *Server) signCertificate(ctx context.Context, req *sentryv1pb.SignCertif
 	// calls for CRD conversion and sidecar injection. Their certs must use
 	// ECDSA because some managed Kube API servers (e.g. AKS) do not
 	// support Ed25519 for TLS verification.
-	isKubeWebhook := req.GetId() == "dapr-operator" || req.GetId() == "dapr-injector"
+	isKubeWebhook := req.GetNamespace() == security.CurrentNamespace() &&
+		(req.GetId() == "dapr-operator" || req.GetId() == "dapr-injector")
 
 	chain, err := s.ca.SignIdentity(ctx, &ca.SignRequest{
 		PublicKey:     csr.PublicKey,

--- a/pkg/sentry/server/server.go
+++ b/pkg/sentry/server/server.go
@@ -209,12 +209,19 @@ func (s *Server) signCertificate(ctx context.Context, req *sentryv1pb.SignCertif
 		}
 	}
 
+	// The operator and injector serve webhooks that the Kube API server
+	// calls for CRD conversion and sidecar injection. Their certs must use
+	// ECDSA because some managed Kube API servers (e.g. AKS) do not
+	// support Ed25519 for TLS verification.
+	isKubeWebhook := req.GetId() == "dapr-operator" || req.GetId() == "dapr-injector"
+
 	chain, err := s.ca.SignIdentity(ctx, &ca.SignRequest{
-		PublicKey:   csr.PublicKey,
-		TrustDomain: res.TrustDomain.String(),
-		Namespace:   namespace,
-		AppID:       req.GetId(),
-		DNS:         dns,
+		PublicKey:     csr.PublicKey,
+		TrustDomain:  res.TrustDomain.String(),
+		Namespace:    namespace,
+		AppID:        req.GetId(),
+		DNS:          dns,
+		IsKubeWebhook: isKubeWebhook,
 	})
 	if err != nil {
 		log.Errorf("Error signing identity: %v", err)


### PR DESCRIPTION
## Summary

Since #9598 switched all X.509 certs to Ed25519, the Kube API server on managed platforms (AKS) fails TLS handshakes with the Dapr conversion/admission webhooks:

```
conversion webhook for dapr.io/v1alpha1, Kind=Subscription failed:
Post "https://dapr-webhook.dapr-tests.svc:443/convert?timeout=30s":
remote error: tls: handshake failure
```

**Root cause**: Azure's managed AKS API server does not support Ed25519 for TLS verification of webhooks.

**Fix**: Adds a fully independent self-signed ECDSA P-256 CA to the sentry CA bundle. The operator uses this ECDSA CA's trust anchor as the `caBundle` for conversion webhooks, so the entire cert chain is verifiable without Ed25519. All other workload certs remain Ed25519 for history signing payload efficiency.

### Architecture

```
Ed25519 CA (unchanged)                ECDSA CA (new)
├── Ed25519 root                      ├── ECDSA P-256 root
├── Ed25519 issuer                    ├── ECDSA P-256 issuer
└── signs: all workload certs         └── signs: operator + injector certs only
    (daprd, scheduler, placement)         (webhook-facing, verified by API server)
```

### Changes
- `pkg/sentry/server/ca/bundle/bundle.go` — new `GenerateECX509()` for self-signed ECDSA CA; `X509` struct gains EC fields
- `pkg/sentry/server/ca/ca.go` — `SignRequest.IsKubeWebhook` flag; auto-generate ECDSA CA on upgrade if not present
- `pkg/sentry/server/ca/kube.go` — persist/load `ec-ca.crt`, `ec-tls.crt`, `ec-tls.key` in trust bundle secret; write `ec-ca.crt` to configmap
- `pkg/sentry/server/ca/selfhosted.go` — persist ECDSA CA to filesystem
- `pkg/sentry/server/server.go` — set `IsKubeWebhook` for operator/injector with namespace guard
- `pkg/operator/operator.go` — read `ec-ca.crt` from configmap for webhook `caBundle`

### Backward compatibility
- On upgrade, sentry auto-generates the ECDSA CA if not found in the stored bundle
- If `ec-ca.crt` is not in the configmap (pre-upgrade), operator falls back to main trust anchors

Failing run: https://github.com/dapr/dapr/actions/runs/25104241881/job/73562072366

## Test plan
- [ ] Sentry unit/integration tests pass
- [ ] Operator unit tests pass
- [ ] Perf tests pass on AKS (webhook conversion succeeds)
- [ ] `kubectl apply` a Subscription CRD — conversion webhook works
- [ ] Verify Ed25519 still used for workload mTLS (non-webhook services)

Generated with [Claude Code](https://claude.com/claude-code)