### PR TITLE
fix(runtime): stop subscriptions and bindings after block-shutdown window

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -497,15 +497,18 @@ func (a *DaprRuntime) Run(parentCtx context.Context) error {
 
 			log.Infof("Blocking graceful shutdown for %s or until app reports unhealthy...", *a.runtimeConfig.blockShutdownDuration)
 
-			a.processor.Subscriber().StopAllSubscriptionsForever()
-			a.processor.Binding().StopReadingFromBindings(true)
-
 			select {
 			case <-a.clock.After(*a.runtimeConfig.blockShutdownDuration):
 				log.Info("Block shutdown period expired, entering shutdown...")
 			case <-a.isAppHealthy:
 				log.Info("App reported unhealthy, entering shutdown...")
 			}
+
+			// Stop subscriptions and input bindings AFTER the block-shutdown
+			// window expires. During the window they remain active so the app
+			// can drain in-flight pub/sub messages and binding events. See #9604.
+			a.processor.Subscriber().StopAllSubscriptionsForever()
+			a.processor.Binding().StopReadingFromBindings(true)
 
 			return nil
 		})

--- a/tests/integration/suite/daprd/shutdown/block/app/binding/inflight.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/binding/inflight.go
@@ -125,13 +125,17 @@ func (i *inflight) Run(t *testing.T, ctx context.Context) {
 		assert.Fail(t, "timeout")
 	}
 
+	// During block-shutdown the input binding remains active so the app can drain
+	// in-flight events. A binding event sent now should be delivered to the app
+	// successfully. closeInvoke is already closed, so the handler returns
+	// immediately. See dapr/dapr#9604.
 	ch = i.binding.SendMessage(new(compv1.ReadResponse))
 	select {
 	case req := <-ch:
-		assert.Empty(t, req.GetResponseData())
-		assert.Equal(t, &compv1.AckResponseError{Message: "input binding is closed"}, req.GetResponseError())
+		assert.Equal(t, "hello world", string(req.GetResponseData()))
+		assert.Nil(t, req.GetResponseError(), "binding events delivered during block-shutdown should succeed")
 	case <-time.After(time.Second * 10):
-		assert.Fail(t, "timeout")
+		assert.Fail(t, "timeout waiting for in-window binding event")
 	}
 
 	client := i.daprd.GRPCClient(t, ctx)

--- a/tests/integration/suite/daprd/shutdown/block/app/healthy.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/healthy.go
@@ -150,6 +150,9 @@ func (h *healthy) Run(t *testing.T, ctx context.Context) {
 		return h.healthzCalled.Load() > healthzCalled
 	}, time.Second*5, time.Millisecond*10)
 
+	// During block-shutdown the subscription remains active so the app can drain
+	// in-flight pub/sub messages. A publish made now should still reach the
+	// subscriber. See dapr/dapr#9604.
 	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
 		PubsubName: "foo",
 		Topic:      "topic",
@@ -158,8 +161,8 @@ func (h *healthy) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	select {
 	case <-h.routeCh:
-		assert.Fail(t, "pubsub should not have sent message to subscriber")
-	case <-time.After(time.Second):
+	case <-time.After(time.Second * 5):
+		assert.Fail(t, "pubsub message should have been delivered during block-shutdown window")
 	}
 	_, err = client.SaveState(ctx, &rtv1.SaveStateRequest{
 		StoreName: "mystore",

--- a/tests/integration/suite/daprd/shutdown/block/app/pubsub/bulk.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/pubsub/bulk.go
@@ -149,21 +149,21 @@ func (b *bulk) Run(t *testing.T, ctx context.Context) {
 		close(daprdStopped)
 	}()
 
-LOOP:
-	for {
-		_, err := client.BulkPublishEvent(ctx, &rtv1.BulkPublishRequest{
-			PubsubName: "foo",
-			Topic:      "def",
-			Entries: []*rtv1.BulkPublishRequestEntry{
-				{EntryId: "1", Event: []byte(`{"status":"completed"}`), ContentType: "application/json"},
-			},
-		})
-		require.NoError(t, err)
-		select {
-		case <-b.recvRoute2:
-		case <-time.After(time.Second / 2):
-			break LOOP
-		}
+	// During block-shutdown the subscription remains active so the app can drain
+	// in-flight pub/sub messages. A bulk publish made now should still reach
+	// route2 — see dapr/dapr#9604.
+	_, err = client.BulkPublishEvent(ctx, &rtv1.BulkPublishRequest{
+		PubsubName: "foo",
+		Topic:      "def",
+		Entries: []*rtv1.BulkPublishRequestEntry{
+			{EntryId: "1", Event: []byte(`{"status":"completed"}`), ContentType: "application/json"},
+		},
+	})
+	require.NoError(t, err)
+	select {
+	case <-b.recvRoute2:
+	case <-time.After(time.Second * 5):
+		assert.Fail(t, "expected route2 to be delivered during block-shutdown window")
 	}
 
 	close(b.returnPublish)

--- a/tests/integration/suite/daprd/shutdown/block/app/pubsub/inflight.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/pubsub/inflight.go
@@ -125,16 +125,17 @@ func (i *inflight) Run(t *testing.T, ctx context.Context) {
 		assert.Fail(t, "timeout")
 	}
 
-	// Publish another message after in-flight has completed. Since the
-	// subscription is now closed (but the subscription context is not yet
-	// cancelled), the handler should block rather than returning an error that
-	// would cause the broker to NACK the message. The message should never be
-	// ack'd or nack'd— the broker connection will be torn down instead.
+	// During block-shutdown the subscription remains active so the app can drain
+	// in-flight messages. A message published now should be delivered to the
+	// handler and ack'd successfully. closeInvoke is already closed, so the
+	// handler returns immediately. See dapr/dapr#9604.
 	ch = i.broker.PublishHelloWorld("a")
 	select {
-	case <-ch:
-		assert.Fail(t, "expected no ack/nack for message published after subscription closed")
-	case <-time.After(time.Second * 3):
+	case req := <-ch:
+		assert.Nil(t, req.GetAckError(), "messages published during block-shutdown should be delivered successfully")
+		assert.Equal(t, "foo", req.GetAckMessageId())
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "timeout waiting for in-window message ack")
 	}
 
 	client := i.daprd.GRPCClient(t, ctx)

--- a/tests/integration/suite/daprd/shutdown/block/app/pubsub/single.go
+++ b/tests/integration/suite/daprd/shutdown/block/app/pubsub/single.go
@@ -143,19 +143,19 @@ func (s *single) Run(t *testing.T, ctx context.Context) {
 		}
 	})
 
-LOOP:
-	for {
-		_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
-			PubsubName: "foo",
-			Topic:      "def",
-			Data:       []byte(`{"status":"completed"}`),
-		})
-		require.NoError(t, err)
-		select {
-		case <-s.recvRoute2:
-		case <-time.After(time.Second / 2):
-			break LOOP
-		}
+	// During block-shutdown the subscription remains active so the app can drain
+	// in-flight pub/sub messages and binding events. A publish made now should
+	// still reach route2 — see dapr/dapr#9604.
+	_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+		PubsubName: "foo",
+		Topic:      "def",
+		Data:       []byte(`{"status":"completed"}`),
+	})
+	require.NoError(t, err)
+	select {
+	case <-s.recvRoute2:
+	case <-time.After(time.Second * 5):
+		assert.Fail(t, "expected route2 to be delivered during block-shutdown window")
 	}
 
 	close(s.returnPublish)

--- a/tests/integration/suite/daprd/shutdown/block/timeout.go
+++ b/tests/integration/suite/daprd/shutdown/block/timeout.go
@@ -184,14 +184,16 @@ func (i *timeout) Run(t *testing.T, ctx context.Context) {
 		close(daprdStopped)
 	}()
 
-	t.Run("daprd APIs should still be available during blocked shutdown, except input bindings and subscriptions", func(t *testing.T) {
+	t.Run("daprd APIs, input bindings, and subscriptions should all be available during blocked shutdown", func(t *testing.T) {
+		// During block-shutdown, subscriptions and input bindings remain active
+		// so the app can drain in-flight events. See dapr/dapr#9604.
 		time.Sleep(time.Second / 2)
 
 		i.listening.Store(true)
 		select {
 		case <-i.bindingChan:
-			assert.Fail(t, "binding event should not have been sent to subscriber")
-		case <-time.After(time.Second / 2):
+		case <-time.After(time.Second):
+			assert.Fail(t, "binding event should have been delivered during block-shutdown window")
 		}
 
 		_, err = client.PublishEvent(ctx, &rtv1.PublishEventRequest{
@@ -203,8 +205,8 @@ func (i *timeout) Run(t *testing.T, ctx context.Context) {
 
 		select {
 		case <-i.routeCh:
-			assert.Fail(t, "pubsub message should not have been sent to subscriber")
-		case <-time.After(time.Second / 2):
+		case <-time.After(time.Second):
+			assert.Fail(t, "pubsub message should have been delivered during block-shutdown window")
 		}
 
 		_, err = client.SaveState(ctx, &rtv1.SaveStateRequest{


### PR DESCRIPTION
# Description

PR #9619 (and its 1.17 backport #9836) was filed to fix issue #9604 — pub/sub messages were being NACK'd to the dead-letter queue during graceful shutdown. The release note promised:

> **FIX** Pub/sub subscriptions are now stopped after `block-shutdown-duration` expires instead of immediately on SIGTERM, preventing queued messages from being incorrectly NACKed to the dead-letter queue during graceful shutdown.

But the runtime ordering change was never written. #9619 only added a block-on-`<-ctx.Done()` path in the subscription handler — which fixes the NACK→DLQ disposition for pluggable brokers, but does **not** keep subscriptions alive during the block window. Buffered messages (e.g. in Kafka's `claim.Messages()` queue) still hit `s.closed=true` and never reach the app.

## Behavior matrix

| Event arrives... | Before this PR | After this PR |
|---|---|---|
| Before SIGTERM | Delivered to app | Delivered to app (unchanged) |
| During block-shutdown window | Blocked in handler / NACK'd | **Delivered to app** |
| After block-shutdown window expires | (n/a — already shut down) | Blocked in handler (#9619 path) |
| After app reports unhealthy | Blocked in handler / NACK'd | Blocked in handler (#9619 path) |

The original NACK→DLQ protection from #9619 still applies — once the block window ends, late-arriving messages are still held by the block-on-`<-ctx.Done()` path rather than NACK'd.

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
