### PR TITLE
feat(outbox): add outboxInternalTopic metadata to override internal topic name

### DIFF
--- a/pkg/runtime/pubsub/outbox.go
+++ b/pkg/runtime/pubsub/outbox.go
@@ -38,6 +38,7 @@ const (
 	outboxPublishTopicKey            = "outboxPublishTopic"
 	outboxPubsubKey                  = "outboxPubsub"
 	outboxDiscardWhenMissingStateKey = "outboxDiscardWhenMissingState"
+	outboxInternalTopicKey           = "outboxInternalTopic"
 	outboxStatePrefix                = "outbox"
 	defaultStateScanDelay            = time.Second * 1
 )
@@ -49,6 +50,7 @@ type outboxConfig struct {
 	publishTopic                  string
 	outboxPubsub                  string
 	outboxDiscardWhenMissingState bool
+	internalTopic                 string
 }
 
 type outboxImpl struct {
@@ -84,8 +86,8 @@ func NewOutbox(opts OptionsOutbox) outbox.Outbox {
 // AddOrUpdateOutbox examines a statestore for outbox properties and saves it for later usage in outbox operations.
 func (o *outboxImpl) AddOrUpdateOutbox(stateStore v1alpha1.Component) {
 	var (
-		publishPubSub, publishTopicKey, outboxPubsub string
-		outboxDiscardWhenMissingState                bool
+		publishPubSub, publishTopicKey, outboxPubsub, internalTopic string
+		outboxDiscardWhenMissingState                               bool
 	)
 
 	for _, v := range stateStore.Spec.Metadata {
@@ -98,6 +100,8 @@ func (o *outboxImpl) AddOrUpdateOutbox(stateStore v1alpha1.Component) {
 			outboxPubsub = v.Value.String()
 		case outboxDiscardWhenMissingStateKey:
 			outboxDiscardWhenMissingState = kitstrings.IsTruthy(v.Value.String())
+		case outboxInternalTopicKey:
+			internalTopic = v.Value.String()
 		}
 	}
 
@@ -114,6 +118,7 @@ func (o *outboxImpl) AddOrUpdateOutbox(stateStore v1alpha1.Component) {
 			publishTopic:                  publishTopicKey,
 			outboxPubsub:                  outboxPubsub,
 			outboxDiscardWhenMissingState: outboxDiscardWhenMissingState,
+			internalTopic:                 internalTopic,
 		}
 	}
 }
@@ -237,7 +242,7 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 			err = o.publisher.Publish(ctx, &contribPubsub.PublishRequest{
 				PubsubName: c.outboxPubsub,
 				Data:       data,
-				Topic:      outboxTopic(source, c.publishTopic, o.namespace),
+				Topic:      outboxTopic(source, c.publishTopic, o.namespace, c.internalTopic),
 			})
 			if err != nil {
 				return nil, err
@@ -250,7 +255,10 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 	return operations, nil
 }
 
-func outboxTopic(appID, topic, namespace string) string {
+func outboxTopic(appID, topic, namespace, internalTopic string) string {
+	if internalTopic != "" {
+		return internalTopic
+	}
 	return namespace + appID + topic + "outbox"
 }
 
@@ -266,7 +274,7 @@ func (o *outboxImpl) SubscribeToInternalTopics(ctx context.Context, appID string
 		}
 
 		outboxPubsub.Subscribe(ctx, contribPubsub.SubscribeRequest{
-			Topic: outboxTopic(appID, c.publishTopic, o.namespace),
+			Topic: outboxTopic(appID, c.publishTopic, o.namespace, c.internalTopic),
 		}, func(ctx context.Context, msg *contribPubsub.NewMessage) error {
 			var cloudEvent map[string]any
 

--- a/pkg/runtime/pubsub/outbox.go
+++ b/pkg/runtime/pubsub/outbox.go
@@ -38,6 +38,7 @@ const (
 	outboxPublishTopicKey            = "outboxPublishTopic"
 	outboxPubsubKey                  = "outboxPubsub"
 	outboxDiscardWhenMissingStateKey = "outboxDiscardWhenMissingState"
+	outboxInternalTopicKey           = "outboxInternalTopic"
 	outboxStatePrefix                = "outbox"
 	defaultStateScanDelay            = time.Second * 1
 )
@@ -49,6 +50,7 @@ type outboxConfig struct {
 	publishTopic                  string
 	outboxPubsub                  string
 	outboxDiscardWhenMissingState bool
+	internalTopic                 string
 }
 
 type outboxImpl struct {
@@ -101,8 +103,8 @@ func (o *outboxImpl) componentContext(ctx context.Context) context.Context {
 // AddOrUpdateOutbox examines a statestore for outbox properties and saves it for later usage in outbox operations.
 func (o *outboxImpl) AddOrUpdateOutbox(stateStore v1alpha1.Component) {
 	var (
-		publishPubSub, publishTopicKey, outboxPubsub string
-		outboxDiscardWhenMissingState                bool
+		publishPubSub, publishTopicKey, outboxPubsub, internalTopic string
+		outboxDiscardWhenMissingState                               bool
 	)
 
 	for _, v := range stateStore.Spec.Metadata {
@@ -115,6 +117,8 @@ func (o *outboxImpl) AddOrUpdateOutbox(stateStore v1alpha1.Component) {
 			outboxPubsub = v.Value.String()
 		case outboxDiscardWhenMissingStateKey:
 			outboxDiscardWhenMissingState = kitstrings.IsTruthy(v.Value.String())
+		case outboxInternalTopicKey:
+			internalTopic = v.Value.String()
 		}
 	}
 
@@ -131,6 +135,7 @@ func (o *outboxImpl) AddOrUpdateOutbox(stateStore v1alpha1.Component) {
 			publishTopic:                  publishTopicKey,
 			outboxPubsub:                  outboxPubsub,
 			outboxDiscardWhenMissingState: outboxDiscardWhenMissingState,
+			internalTopic:                 internalTopic,
 		}
 	}
 }
@@ -254,7 +259,7 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 			err = o.publisher.Publish(ctx, &contribPubsub.PublishRequest{
 				PubsubName: c.outboxPubsub,
 				Data:       data,
-				Topic:      outboxTopic(source, c.publishTopic, o.namespace),
+				Topic:      outboxTopic(source, c.publishTopic, o.namespace, c.internalTopic),
 			}, TransportModeGRPC)
 			if err != nil {
 				return nil, err
@@ -267,7 +272,10 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 	return operations, nil
 }
 
-func outboxTopic(appID, topic, namespace string) string {
+func outboxTopic(appID, topic, namespace, internalTopic string) string {
+	if internalTopic != "" {
+		return internalTopic
+	}
 	return namespace + appID + topic + "outbox"
 }
 
@@ -283,7 +291,7 @@ func (o *outboxImpl) SubscribeToInternalTopics(ctx context.Context, appID string
 		}
 
 		outboxPubsub.Subscribe(o.componentContext(ctx), contribPubsub.SubscribeRequest{
-			Topic: outboxTopic(appID, c.publishTopic, o.namespace),
+			Topic: outboxTopic(appID, c.publishTopic, o.namespace, c.internalTopic),
 		}, func(ctx context.Context, msg *contribPubsub.NewMessage) error {
 			// The per-message context originates from the pubsub component, so
 			// re-attach the workload's SPIFFE identity for the state operations

--- a/pkg/runtime/pubsub/outbox_test.go
+++ b/pkg/runtime/pubsub/outbox_test.go
@@ -209,6 +209,50 @@ func TestAddOrUpdateOutbox(t *testing.T) {
 		assert.Equal(t, "a", c.outboxPubsub)
 		assert.Equal(t, "a", c.publishPubSub)
 		assert.Equal(t, "1", c.publishTopic)
+		assert.Equal(t, "", c.internalTopic)
+	})
+
+	t.Run("config with internal topic", func(t *testing.T) {
+		o := newTestOutbox(nil).(*outboxImpl)
+		o.AddOrUpdateOutbox(v1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v1alpha1.ComponentSpec{
+				Metadata: []common.NameValuePair{
+					{
+						Name: outboxPublishPubsubKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("a"),
+							},
+						},
+					},
+					{
+						Name: outboxPublishTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("1"),
+							},
+						},
+					},
+					{
+						Name: outboxInternalTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("my-custom-outbox-topic"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		c := o.outboxStores["test"]
+		assert.Equal(t, "a", c.outboxPubsub)
+		assert.Equal(t, "a", c.publishPubSub)
+		assert.Equal(t, "1", c.publishTopic)
+		assert.Equal(t, "my-custom-outbox-topic", c.internalTopic)
 	})
 }
 
@@ -679,6 +723,57 @@ func TestPublishInternal(t *testing.T) {
 
 		require.Error(t, err)
 	})
+
+	t.Run("valid operation with custom internal topic", func(t *testing.T) {
+		o := newTestOutbox(func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
+			assert.Equal(t, "my-custom-outbox-topic", pr.Topic)
+			assert.Equal(t, "a", pr.PubsubName)
+			return nil
+		}).(*outboxImpl)
+
+		o.AddOrUpdateOutbox(v1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v1alpha1.ComponentSpec{
+				Metadata: []common.NameValuePair{
+					{
+						Name: outboxPublishPubsubKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("a"),
+							},
+						},
+					},
+					{
+						Name: outboxPublishTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("1"),
+							},
+						},
+					},
+					{
+						Name: outboxInternalTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("my-custom-outbox-topic"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		_, err := o.PublishInternal(t.Context(), "test", []state.TransactionalStateOperation{
+			state.SetRequest{
+				Key:   "key",
+				Value: "test",
+			},
+		}, "testapp", "", "")
+
+		require.NoError(t, err)
+	})
 }
 
 func TestSubscribeToInternalTopics(t *testing.T) {
@@ -1127,6 +1222,140 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 		// Publishing should not have errored
 		require.NoError(t, <-errCh)
 	})
+
+	t.Run("custom internal topic subscription", func(t *testing.T) {
+		const customInternalTopic = "my-custom-outbox-topic"
+
+		psMock := &outboxPubsubMock{
+			expectedOutboxTopic: customInternalTopic,
+			t:                   t,
+		}
+		stateMock := &outboxStateMock{
+			receivedKey: make(chan string, 1),
+		}
+
+		internalCalledCh := make(chan struct{})
+		externalCalledCh := make(chan struct{})
+		var closed bool
+
+		o := newTestOutbox(func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
+			switch pr.Topic {
+			case customInternalTopic:
+				close(internalCalledCh)
+			case "1":
+				if !closed {
+					close(externalCalledCh)
+					closed = true
+				}
+			}
+
+			return psMock.Publish(ctx, pr)
+		}).(*outboxImpl)
+		o.cloudEventExtractorFn = extractCloudEventProperty
+
+		o.getPubsubFn = func(s string) (contribPubsub.PubSub, bool) {
+			return psMock, true
+		}
+		o.getStateFn = func(s string) (state.Store, bool) {
+			return stateMock, true
+		}
+
+		o.AddOrUpdateOutbox(v1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v1alpha1.ComponentSpec{
+				Metadata: []common.NameValuePair{
+					{
+						Name: outboxPublishPubsubKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("a"),
+							},
+						},
+					},
+					{
+						Name: outboxPublishTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("1"),
+							},
+						},
+					},
+					{
+						Name: outboxInternalTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte(customInternalTopic),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		const appID = "test"
+
+		err := o.SubscribeToInternalTopics(t.Context(), appID)
+		require.NoError(t, err)
+
+		errCh := make(chan error, 1)
+
+		go func() {
+			trs, pErr := o.PublishInternal(t.Context(), "test", []state.TransactionalStateOperation{
+				state.SetRequest{
+					Key:   "1",
+					Value: "hello",
+				},
+			}, appID, "", "")
+
+			trs = append(trs[:0], trs[0+1:]...)
+
+			if pErr != nil {
+				errCh <- pErr
+				return
+			}
+
+			if len(trs) != 1 {
+				errCh <- fmt.Errorf("expected trs to have len(1), but got: %d", len(trs))
+				return
+			}
+
+			errCh <- nil
+
+			stateMock.expectedKey.Store(new(trs[0].GetKey()))
+		}()
+
+		doneCh := make(chan error, 2)
+		timeout := time.After(5 * time.Second)
+
+		go func() {
+			select {
+			case <-internalCalledCh:
+				doneCh <- nil
+			case <-timeout:
+				doneCh <- errors.New("timeout waiting for internalCalledCh")
+			}
+		}()
+		go func() {
+			select {
+			case <-externalCalledCh:
+				doneCh <- nil
+			case <-timeout:
+				doneCh <- errors.New("timeout waiting for externalCalledCh")
+			}
+		}()
+
+		for range 2 {
+			require.NoError(t, <-doneCh)
+		}
+
+		require.NoError(t, <-errCh)
+
+		expected := stateMock.expectedKey.Load()
+		require.NotNil(t, expected)
+		assert.Equal(t, *expected, <-stateMock.receivedKey)
+	})
 }
 
 type outboxPubsubMock struct {
@@ -1215,7 +1444,7 @@ func (o *outboxStateMock) Get(ctx context.Context, req *state.GetRequest) (*stat
 func TestOutboxTopic(t *testing.T) {
 	t.Run("not namespaced", func(t *testing.T) {
 		o := newTestOutbox(nil).(*outboxImpl)
-		topic := outboxTopic("a", "b", o.namespace)
+		topic := outboxTopic("a", "b", o.namespace, "")
 
 		assert.Equal(t, "aboutbox", topic)
 	})
@@ -1224,9 +1453,19 @@ func TestOutboxTopic(t *testing.T) {
 		o := newTestOutbox(nil).(*outboxImpl)
 		o.namespace = "default"
 
-		topic := outboxTopic("a", "b", o.namespace)
+		topic := outboxTopic("a", "b", o.namespace, "")
 
 		assert.Equal(t, "defaultaboutbox", topic)
+	})
+
+	t.Run("custom internal topic", func(t *testing.T) {
+		topic := outboxTopic("a", "b", "default", "my-custom-outbox-topic")
+		assert.Equal(t, "my-custom-outbox-topic", topic)
+	})
+
+	t.Run("empty internal topic falls back to auto-generated", func(t *testing.T) {
+		topic := outboxTopic("app", "topic", "ns", "")
+		assert.Equal(t, "nsapptopicoutbox", topic)
 	})
 }
 

--- a/pkg/runtime/pubsub/outbox_test.go
+++ b/pkg/runtime/pubsub/outbox_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1236,17 +1237,14 @@ func TestSubscribeToInternalTopics(t *testing.T) {
 
 		internalCalledCh := make(chan struct{})
 		externalCalledCh := make(chan struct{})
-		var closed bool
+		var internalOnce, externalOnce sync.Once
 
 		o := newTestOutbox(func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
 			switch pr.Topic {
 			case customInternalTopic:
-				close(internalCalledCh)
+				internalOnce.Do(func() { close(internalCalledCh) })
 			case "1":
-				if !closed {
-					close(externalCalledCh)
-					closed = true
-				}
+				externalOnce.Do(func() { close(externalCalledCh) })
 			}
 
 			return psMock.Publish(ctx, pr)

--- a/tests/integration/suite/daprd/outbox/grpc/internaltopic.go
+++ b/tests/integration/suite/daprd/outbox/grpc/internaltopic.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/dapr/dapr/pkg/proto/common/v1"
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(internalTopic))
+}
+
+type internalTopic struct {
+	eventCalled atomic.Int32
+	daprd       *daprd.Daprd
+	lock        sync.Mutex
+	msg         []byte
+}
+
+func (o *internalTopic) Setup(t *testing.T) []framework.Option {
+	onTopicEvent := func(ctx context.Context, in *runtimev1pb.TopicEventRequest) (*runtimev1pb.TopicEventResponse, error) {
+		o.lock.Lock()
+		defer o.lock.Unlock()
+		o.eventCalled.Add(1)
+		o.msg = in.GetData()
+		return &runtimev1pb.TopicEventResponse{
+			Status: runtimev1pb.TopicEventResponse_SUCCESS,
+		}, nil
+	}
+
+	srv1 := app.New(t, app.WithOnTopicEventFn(onTopicEvent))
+	o.daprd = daprd.New(t, daprd.WithAppID("outboxtest"), daprd.WithAppPort(srv1.Port(t)), daprd.WithAppProtocol("grpc"), daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: outboxPublishPubsub
+    value: "mypubsub"
+  - name: outboxPublishTopic
+    value: "test"
+  - name: outboxInternalTopic
+    value: "custom-outbox-topic"
+`,
+		`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mypubsub'
+spec:
+  type: pubsub.in-memory
+  version: v1
+`,
+		`
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: 'order'
+spec:
+  topic: 'test'
+  routes:
+    default: '/test'
+  pubsubname: 'mypubsub'
+scopes:
+- outboxtest
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(srv1, o.daprd),
+	}
+}
+
+func (o *internalTopic) Run(t *testing.T, ctx context.Context) {
+	o.daprd.WaitUntilRunning(t, ctx)
+
+	conn, err := grpc.DialContext(ctx, o.daprd.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock()) //nolint:staticcheck
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	_, err = runtimev1pb.NewDaprClient(conn).ExecuteStateTransaction(ctx, &runtimev1pb.ExecuteStateTransactionRequest{
+		StoreName: "mystore",
+		Operations: []*runtimev1pb.TransactionalStateOperation{
+			{
+				OperationType: "upsert",
+				Request: &common.StateItem{
+					Key:   "1",
+					Value: []byte("2"),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		o.lock.Lock()
+		defer o.lock.Unlock()
+		return string(o.msg) == "2"
+	}, time.Second*5, time.Millisecond*10, "failed to receive message in time")
+
+	assert.Equal(t, int32(1), o.eventCalled.Load())
+}

--- a/tests/integration/suite/daprd/outbox/http/internaltopic.go
+++ b/tests/integration/suite/daprd/outbox/http/internaltopic.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(internalTopic))
+}
+
+type internalTopic struct {
+	appTestCalled atomic.Int32
+	daprd         *procdaprd.Daprd
+}
+
+func (o *internalTopic) Setup(t *testing.T) []framework.Option {
+	newHTTPServer := func() *prochttp.HTTP {
+		handler := http.NewServeMux()
+		var msg atomic.Value
+
+		handler.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+			o.appTestCalled.Add(1)
+			defer r.Body.Close()
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			msg.Store(b)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("ok"))
+		})
+
+		handler.HandleFunc("/getValue", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			m := msg.Load()
+			if m == nil {
+				return
+			}
+			w.Write(msg.Load().([]byte))
+		})
+
+		return prochttp.New(t, prochttp.WithHandler(handler))
+	}
+	srv1 := newHTTPServer()
+
+	o.daprd = procdaprd.New(t, procdaprd.WithAppID("outboxtest"), procdaprd.WithAppPort(srv1.Port()), procdaprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: outboxPublishPubsub
+    value: "mypubsub"
+  - name: outboxPublishTopic
+    value: "test"
+  - name: outboxInternalTopic
+    value: "custom-outbox-topic"
+`,
+		`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: 'mypubsub'
+spec:
+  type: pubsub.in-memory
+  version: v1
+`,
+		`
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: 'order'
+spec:
+  topic: 'test'
+  routes:
+    default: '/test'
+  pubsubname: 'mypubsub'
+scopes:
+- outboxtest
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(srv1, o.daprd),
+	}
+}
+
+func (o *internalTopic) Run(t *testing.T, ctx context.Context) {
+	o.daprd.WaitUntilRunning(t, ctx)
+
+	postURL := fmt.Sprintf("http://localhost:%d/v1.0/state/mystore/transaction", o.daprd.HTTPPort())
+	stateReq := state.SetRequest{
+		Key:   "1",
+		Value: "2",
+	}
+
+	tr := stateTransactionRequestBody{
+		Operations: []stateTransactionRequestBodyOperation{
+			{
+				Operation: "upsert",
+				Request:   stateReq,
+			},
+		},
+	}
+
+	b, err := json.Marshal(&tr)
+	require.NoError(t, err)
+
+	httpClient := client.HTTP(t)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, postURL, bytes.NewReader(b))
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Empty(t, string(body))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%v/getValue", o.daprd.AppPort(t)), nil)
+		assert.NoError(c, err)
+		resp, err = httpClient.Do(req)
+		assert.NoError(c, err)
+		t.Cleanup(func() {
+			assert.NoError(t, resp.Body.Close())
+		})
+		body, err = io.ReadAll(resp.Body)
+		assert.NoError(c, err)
+
+		var ce map[string]string
+		err = json.Unmarshal(body, &ce)
+		assert.NoError(c, err)
+		assert.Equal(c, "2", ce["data"])
+		assert.Contains(c, ce["id"], "outbox-")
+	}, time.Second*10, time.Millisecond*10)
+
+	assert.Equal(t, int32(1), o.appTestCalled.Load())
+}

--- a/tests/integration/suite/daprd/outbox/http/internaltopic.go
+++ b/tests/integration/suite/daprd/outbox/http/internaltopic.go
@@ -54,7 +54,9 @@ func (o *internalTopic) Setup(t *testing.T) []framework.Option {
 			defer r.Body.Close()
 			b, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
 			}
 
 			msg.Store(b)
@@ -156,11 +158,11 @@ func (o *internalTopic) Run(t *testing.T, ctx context.Context) {
 		req, err = http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%v/getValue", o.daprd.AppPort(t)), nil)
 		assert.NoError(c, err)
 		resp, err = httpClient.Do(req)
-		assert.NoError(c, err)
-		t.Cleanup(func() {
-			assert.NoError(t, resp.Body.Close())
-		})
+		if !assert.NoError(c, err) {
+			return
+		}
 		body, err = io.ReadAll(resp.Body)
+		assert.NoError(c, resp.Body.Close())
 		assert.NoError(c, err)
 
 		var ce map[string]string


### PR DESCRIPTION
## Description

The outbox pattern auto-generates internal topic names using the formula `{namespace}{appID}{topic}outbox`. In environments where the `NAMESPACE` environment variable cannot be configured on the daprd sidecar (e.g., Azure Container Apps), the namespace defaults to `"default"`, producing topic names like `defaultmyappntopicnameoutbox`. Some messaging systems or organizational naming conventions cannot accept topics starting with `"default"` or with this concatenated format.

This PR adds an `outboxInternalTopic` metadata field to outbox-enabled state stores. When set, this value is used as the complete internal topic name with no additional prefix or suffix. When empty or omitted, the existing auto-generated naming is preserved for backward compatibility.

### Usage

```yaml
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: mystore
spec:
  type: state.mysql
  version: v1
  metadata:
  - name: connectionString
    value: "<CONNECTION STRING>"
  - name: outboxPublishPubsub
    value: "mypubsub"
  - name: outboxPublishTopic
    value: "newOrder"
  - name: outboxInternalTopic    # Optional
    value: "myapp-neworder-outbox"
```

## Issue reference

Closes #8933

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [x] Extended the documentation / PR in the https://github.com/dapr/docs repo: dapr/docs#5155
- [x] Specification has been updated / PR in the https://github.com/dapr/docs repo: dapr/docs#5155
- [x] Provided sample for the feature / Created issue in the https://github.com/dapr/docs repo — Not applicable: this is a component metadata field with no new API surface or application code changes. The YAML example in the docs PR suffices.