### PR TITLE
Workflow: dedup duplicate completion events at the actor inbox

### DIFF
--- a/docs/release_notes/v1.17.7.md
+++ b/docs/release_notes/v1.17.7.md
@@ -3,6 +3,7 @@
 This update contains the following bug fixes:
 - [Workflow GetWorkItems gRPC stream torn down when the history payload exceeds the max body size](#workflow-getworkitems-grpc-stream-torn-down-when-the-history-payload-exceeds-the-max-body-size)
 - [Workflows orphaned or not purged after scheduler pod restart under load](#workflows-orphaned-or-not-purged-after-scheduler-pod-restart-under-load)
+- [Workflow inbox accumulates duplicate completion events under pod migration, driving an SDK spin loop](#workflow-inbox-accumulates-duplicate-completion-events-under-pod-migration-driving-an-sdk-spin-loop)
 
 ## Workflow GetWorkItems gRPC stream torn down when the history payload exceeds the max body size
 
@@ -81,3 +82,52 @@ Three changes close the loss windows:
    This recovers workflows whose completion was persisted in a prior run but whose retention reminder Create was lost.
 
 The retention reminder's due time is now anchored to the workflow's actual completion time rather than the moment of the Create call, so retries converge on a single reminder at a stable due time instead of pushing retention back on every retry.
+
+## Workflow inbox accumulates duplicate completion events under pod migration, driving an SDK spin loop
+
+### Problem
+
+When the workflow actor on one pod was cancelled mid-flight (typically during a rolling deployment) after dispatching an activity but before its state save committed, the activity actor still completed normally and posted its `TaskCompleted` event back to the workflow actor's inbox.
+On the next workflow activation, the orchestrator re-yielded the same `ScheduleTask` because its replay state did not yet reflect the dispatch, so the activity actor ran a second time and posted a second `TaskCompleted` for the same `taskScheduledId`.
+The same shape applied to `TaskFailed`, `TimerFired`, and child-workflow completions delivered through the inbox.
+
+The language SDK's `process_event` handlers for these event kinds silently `return` when no matching pending task is found, producing zero new actions, so dapr re-fired the wake-up reminder against the same un-cleared inbox and the cycle repeated.
+
+### Impact
+
+Any deployment running workflows whose hosting pods are restarted during load is affected.
+This is most visible during routine operations such as Kubernetes rolling updates or node drains.
+
+Visible symptoms include:
+
+- A workflow appears stuck in `RUNNING` while its persisted history grows steadily with full activity payloads.
+- Sidecar logs show repeated `dropping duplicate event: executionStarted` warnings on the dapr side, paired with thousands of `Ignoring unexpected taskCompleted event with ID = N` warnings on the SDK side for the same instance.
+- An activity executes more times than the workflow function calls it, because the activity actor re-runs each time the orchestrator re-yields the schedule.
+
+### Root Cause
+
+Two layers were missing safeguards.
+
+First, the workflow actor's `addWorkflowEvent` (the inbox-write boundary called by the activity actor and by sub-workflow completion delivery) did not deduplicate task-resolution events.
+A redelivered completion was appended to the inbox, persisted, and a new wake-up reminder was created, even when the same resolution was already committed to history or queued in the inbox from an earlier delivery.
+
+Second, the orchestrator's `callActivities` did not check whether the activity it was about to dispatch had already resolved.
+When the orchestrator re-yielded a `ScheduleTask` because its replay state was missing the corresponding `TaskScheduled` (e.g. after a partial save was lost on cancellation), the activity actor was invoked again, ran the activity body again, and posted yet another `TaskCompleted` to the inbox.
+The two layers compounded: the inbox grew because the dispatch produced new completions, the orchestrator re-ran because the inbox grew, and the SDK silently spun on the unmatched events.
+
+### Solution
+
+Two complementary checks were added in the workflow actor, both backed by a shared dedup helper:
+
+1. **Inbox-write dedup in `addWorkflowEvent`**.
+   A `TaskCompleted` / `TaskFailed` / `TimerFired` / `ChildWorkflowInstance{Completed,Failed}` whose correlator (`taskScheduledId` or `timerId`) already appears in either `state.History` or `state.Inbox` is dropped before it reaches `state.AddToInbox`, the transactional save, and the new-event reminder.
+   `EventRaised` and `ExecutionTerminated` are intentionally excluded: `EventRaised` is a user signal that may legitimately repeat, and `ExecutionTerminated` is idempotent.
+
+2. **Dispatch-skip in `callActivities`**.
+   Before invoking the activity actor for a `TaskScheduled`, the workflow actor checks whether a matching `TaskCompleted` or `TaskFailed` for the same `taskScheduledId` is already in `state.History` or `state.Inbox`.
+   If it is, the dispatch is suppressed; the orchestrator's stale re-yield no longer triggers a second activity run.
+
+The underlying engine in `durabletask-go` was hardened in lockstep: `runtimestate.AddEvent` now also rejects a resolution event whose correlator is already present, providing defence in depth for any caller that bypasses the actor's inbox-write path.
+The `Stalled`-clear logic runs only on a successful add, so a duplicate-rejection error preserves a prior stalled state.
+
+After upgrading, persisted histories from older daprd versions that already accumulated duplicates are silently truncated on next workflow load (the duplicate entries are not re-added to the in-memory `OldEvents`), so the upgrade is one-way for that state.

--- a/go.mod
+++ b/go.mod
@@ -529,7 +529,6 @@ replace (
 // replace github.com/dapr/components-contrib => ../components-contrib
 // replace github.com/dapr/kit => ../kit
 // replace github.com/dapr/durabletask-go => ../durabletask-go
-
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.mod
+++ b/go.mod
@@ -529,6 +529,9 @@ replace (
 // replace github.com/dapr/components-contrib => ../components-contrib
 // replace github.com/dapr/kit => ../kit
 // replace github.com/dapr/durabletask-go => ../durabletask-go
+
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
+
+replace github.com/dapr/durabletask-go => github.com/joshvanl/durabletask-go v0.0.0-20260504234400-183b404d6512

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.17.3
-	github.com/dapr/durabletask-go v0.11.4-0.20260501180811-87617bcc7be2
+	github.com/dapr/durabletask-go v0.11.4-0.20260506025704-7dbf65e58c0d
 	github.com/dapr/kit v0.17.1-0.20260505124817-5579fd105e21
 	github.com/diagridio/go-etcd-cron v0.12.5-0.20260430160035-0e8ef88f5628
 	github.com/evanphx/json-patch/v5 v5.9.0
@@ -533,5 +533,3 @@ replace (
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
-
-replace github.com/dapr/durabletask-go => github.com/joshvanl/durabletask-go v0.0.0-20260504234400-183b404d6512

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,6 @@ github.com/dapr/components-contrib v1.17.3 h1:lhSvLZ1nGGkmlRKCpzgNEsnNXqOWjFlhAt
 github.com/dapr/components-contrib v1.17.3/go.mod h1:lVPRj9ywzkUWoKXxRTAJbvS+Vg8A882av/nynGstNE4=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.11.4-0.20260501180811-87617bcc7be2 h1:Rf1cpQZqTnUpv63zybZB8thGi16HOo9CVhPlYrNb760=
-github.com/dapr/durabletask-go v0.11.4-0.20260501180811-87617bcc7be2/go.mod h1:/qqf208i7YnZgQ6Yxuee42yk+DLnZYe7horTwo0fVYI=
 github.com/dapr/kit v0.17.1-0.20260505124817-5579fd105e21 h1:eQaTMLBT+Z5X4imJ5C9iE83n7LOW/L1KHXcttHD9y/Q=
 github.com/dapr/kit v0.17.1-0.20260505124817-5579fd105e21/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1102,6 +1100,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/durabletask-go v0.0.0-20260504234400-183b404d6512 h1:ya/4l28QInTWr9GmbZNQucrLc9UN5pVNUSayS61k9Gw=
+github.com/joshvanl/durabletask-go v0.0.0-20260504234400-183b404d6512/go.mod h1:/qqf208i7YnZgQ6Yxuee42yk+DLnZYe7horTwo0fVYI=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/dapr/components-contrib v1.17.3 h1:lhSvLZ1nGGkmlRKCpzgNEsnNXqOWjFlhAt
 github.com/dapr/components-contrib v1.17.3/go.mod h1:lVPRj9ywzkUWoKXxRTAJbvS+Vg8A882av/nynGstNE4=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
+github.com/dapr/durabletask-go v0.11.4-0.20260506025704-7dbf65e58c0d h1:PnntTmmRdTylj0aon8bVkEKIOpOvw5YRwSKhTKzqLGk=
+github.com/dapr/durabletask-go v0.11.4-0.20260506025704-7dbf65e58c0d/go.mod h1:/qqf208i7YnZgQ6Yxuee42yk+DLnZYe7horTwo0fVYI=
 github.com/dapr/kit v0.17.1-0.20260505124817-5579fd105e21 h1:eQaTMLBT+Z5X4imJ5C9iE83n7LOW/L1KHXcttHD9y/Q=
 github.com/dapr/kit v0.17.1-0.20260505124817-5579fd105e21/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1100,8 +1102,6 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/joshvanl/durabletask-go v0.0.0-20260504234400-183b404d6512 h1:ya/4l28QInTWr9GmbZNQucrLc9UN5pVNUSayS61k9Gw=
-github.com/joshvanl/durabletask-go v0.0.0-20260504234400-183b404d6512/go.mod h1:/qqf208i7YnZgQ6Yxuee42yk+DLnZYe7horTwo0fVYI=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/dedup"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/events"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
@@ -43,6 +44,14 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 
 	var result dispatchResult
 	for _, e := range es {
+		// Don't redispatch activities whose resolution is already in history
+		// or the inbox; the activity actor would just produce another
+		// completion and grow the inbox.
+		if dedup.IsTaskAlreadyResolved(e, state.History, state.Inbox) {
+			log.Debugf("Workflow actor '%s': skipping dispatch of '%s::%d' - resolution already present", o.actorID, e.GetTaskScheduled().GetName(), e.GetEventId())
+			continue
+		}
+
 		err := o.callActivity(ctx, e, dueTime, state.Generation, outgoingHistory[e.GetEventId()])
 		if err != nil {
 			if errors.Is(err, todo.ErrDuplicateInvocation) {

--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -34,7 +34,7 @@ import (
 	"github.com/dapr/durabletask-go/backend"
 )
 
-func (o *orchestrator) callActivities(ctx context.Context, es []*backend.HistoryEvent, state *wfenginestate.State, outgoingHistory map[int32]*protos.PropagatedHistory) dispatchResult {
+func (o *orchestrator) callActivities(ctx context.Context, es []*backend.HistoryEvent, state *wfenginestate.State, rs *backend.WorkflowRuntimeState, outgoingHistory map[int32]*protos.PropagatedHistory) dispatchResult {
 	var dueTime time.Time
 	if len(state.History) > 0 {
 		dueTime = state.History[0].GetTimestamp().AsTime()
@@ -44,10 +44,14 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 
 	var result dispatchResult
 	for _, e := range es {
-		// Don't redispatch activities whose resolution is already in history
-		// or the inbox; the activity actor would just produce another
-		// completion and grow the inbox.
-		if dedup.IsTaskAlreadyResolved(e, state.History, state.Inbox) {
+		// Don't redispatch activities whose resolution is already known to the
+		// current generation's runtime state. We check rs.OldEvents/NewEvents
+		// rather than state.History/state.Inbox because the persisted state has
+		// not been updated yet for this work item; in particular after a
+		// ContinueAsNew the persisted history still reflects the previous
+		// generation, while rs has been reset by the engine and only contains
+		// the current generation's events.
+		if dedup.IsTaskAlreadyResolved(e, rs.GetOldEvents(), rs.GetNewEvents()) {
 			log.Debugf("Workflow actor '%s': skipping dispatch of '%s::%d' - resolution already present", o.actorID, e.GetTaskScheduled().GetName(), e.GetEventId())
 			continue
 		}

--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -16,6 +16,7 @@ package orchestrator
 import (
 	"context"
 
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/dedup"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/backend"
@@ -56,6 +57,15 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 	// Only reject user events when the workflow is stalled.
 	if o.rstate.Stalled != nil && e.GetEventRaised() != nil {
 		return api.ErrStalled
+	}
+
+	// Drop completion events whose resolution is already in history or the
+	// inbox; otherwise an inbox redelivery (e.g. an activity actor reminder
+	// firing twice during pod migration) would pin the workflow in a
+	// replay/spin loop.
+	if dedup.IsDuplicateCompletion(e, state.History, state.Inbox) {
+		log.Debugf("Workflow actor '%s': dropping duplicate completion event already present in history/inbox", o.actorID)
+		return nil
 	}
 
 	if e.GetTaskCompleted() != nil || e.GetTaskFailed() != nil {

--- a/pkg/actors/targets/workflow/orchestrator/dedup/dedup.go
+++ b/pkg/actors/targets/workflow/orchestrator/dedup/dedup.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"github.com/dapr/durabletask-go/backend"
+	dtdedup "github.com/dapr/durabletask-go/backend/runtimestate/dedup"
+)
+
+// IsDuplicateCompletion reports whether e is a TaskCompleted / TaskFailed /
+// TimerFired / ChildWorkflowInstance{Completed,Failed} that already has a
+// matching resolution recorded in either history or inbox. Returns false for
+// events without resolution semantics (e.g. EventRaised, ExecutionTerminated):
+// those are user/control-plane events that may legitimately repeat.
+func IsDuplicateCompletion(e *backend.HistoryEvent, history, inbox []*backend.HistoryEvent) bool {
+	kind, id, ok := dtdedup.Of(e)
+	if !ok {
+		return false
+	}
+	return dtdedup.IsPresent(history, kind, id) || dtdedup.IsPresent(inbox, kind, id)
+}
+
+// IsTaskAlreadyResolved reports whether a TaskScheduled event has a matching
+// TaskCompleted or TaskFailed resolution already in history or queued in the
+// inbox.
+func IsTaskAlreadyResolved(taskScheduled *backend.HistoryEvent, history, inbox []*backend.HistoryEvent) bool {
+	if taskScheduled.GetTaskScheduled() == nil {
+		return false
+	}
+	id := taskScheduled.GetEventId()
+	return dtdedup.IsPresent(history, dtdedup.KindTask, id) ||
+		dtdedup.IsPresent(inbox, dtdedup.KindTask, id)
+}

--- a/pkg/actors/targets/workflow/orchestrator/dedup/dedup_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/dedup/dedup_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/dedup"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+func taskCompleted(id int32) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: id},
+		},
+	}
+}
+
+func taskFailed(id int32) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{TaskScheduledId: id},
+		},
+	}
+}
+
+func timerFired(id int32) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TimerFired{
+			TimerFired: &protos.TimerFiredEvent{TimerId: id},
+		},
+	}
+}
+
+func childCompleted(id int32) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId: id,
+			},
+		},
+	}
+}
+
+func eventRaised(name string) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_EventRaised{
+			EventRaised: &protos.EventRaisedEvent{Name: name},
+		},
+	}
+}
+
+func taskScheduled(eventID int32, name string) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   eventID,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskScheduled{
+			TaskScheduled: &protos.TaskScheduledEvent{Name: name},
+		},
+	}
+}
+
+func TestIsDuplicateCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		event   *backend.HistoryEvent
+		history []*backend.HistoryEvent
+		inbox   []*backend.HistoryEvent
+		want    bool
+	}{
+		{name: "no history or inbox", event: taskCompleted(1), want: false},
+		{name: "match in history", event: taskCompleted(1), history: []*backend.HistoryEvent{taskCompleted(1)}, want: true},
+		{name: "match in inbox", event: taskCompleted(2), inbox: []*backend.HistoryEvent{taskCompleted(2)}, want: true},
+		{name: "TaskFailed for same id as TaskCompleted in history", event: taskFailed(3), history: []*backend.HistoryEvent{taskCompleted(3)}, want: true},
+		{name: "different id", event: taskCompleted(2), history: []*backend.HistoryEvent{taskCompleted(1)}, want: false},
+		{name: "TimerFired matched", event: timerFired(7), history: []*backend.HistoryEvent{timerFired(7)}, want: true},
+		{name: "Timer id same as Task id is not a match", event: timerFired(1), history: []*backend.HistoryEvent{taskCompleted(1)}, want: false},
+		{name: "ChildWorkflowInstanceCompleted matched", event: childCompleted(4), history: []*backend.HistoryEvent{childCompleted(4)}, want: true},
+		{name: "EventRaised never deduped here", event: eventRaised("approval"), history: []*backend.HistoryEvent{eventRaised("approval")}, want: false},
+		{name: "inbox match wins over history mismatch", event: taskCompleted(5), history: []*backend.HistoryEvent{taskCompleted(99)}, inbox: []*backend.HistoryEvent{taskCompleted(5)}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, dedup.IsDuplicateCompletion(tt.event, tt.history, tt.inbox))
+		})
+	}
+}
+
+func TestIsTaskAlreadyResolved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		scheduled *backend.HistoryEvent
+		history   []*backend.HistoryEvent
+		inbox     []*backend.HistoryEvent
+		want      bool
+	}{
+		{name: "nothing recorded", scheduled: taskScheduled(1, "fetch_demographics"), want: false},
+		{name: "TaskCompleted in history", scheduled: taskScheduled(1, "fetch_demographics"), history: []*backend.HistoryEvent{taskCompleted(1)}, want: true},
+		{name: "TaskFailed in history is also a resolution", scheduled: taskScheduled(2, "get_bill"), history: []*backend.HistoryEvent{taskFailed(2)}, want: true},
+		{name: "resolution in inbox still counts", scheduled: taskScheduled(3, "check_unit_charges"), inbox: []*backend.HistoryEvent{taskCompleted(3)}, want: true},
+		{name: "resolution exists for a different id", scheduled: taskScheduled(4, "publish_agent_completed"), history: []*backend.HistoryEvent{taskCompleted(99)}, want: false},
+		{name: "non-TaskScheduled input returns false", scheduled: taskCompleted(1), history: []*backend.HistoryEvent{taskCompleted(1)}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, dedup.IsTaskAlreadyResolved(tt.scheduled, tt.history, tt.inbox))
+		})
+	}
+}

--- a/pkg/actors/targets/workflow/orchestrator/rerun.go
+++ b/pkg/actors/targets/workflow/orchestrator/rerun.go
@@ -176,9 +176,11 @@ func (o *orchestrator) rerunWorkflowInstanceRequest(ctx context.Context, request
 	outgoingActPropHist := buildRerunOutgoingHistory(activities, newState, o.actorID, o.appID, taskScheduledScope)
 	outgoingChildPropHist := buildRerunOutgoingHistory(childWFs, newState, o.actorID, o.appID, childWorkflowCreatedScope)
 
+	rerunRS := runtimestate.NewWorkflowRuntimeState(o.actorID, newState.CustomStatus, newState.History)
+
 	if err = errors.Join(
 		o.callChildWorkflows(ctx, startedEvent.GetName(), childWFs, outgoingChildPropHist),
-		o.callActivities(ctx, activities, newState, outgoingActPropHist).err,
+		o.callActivities(ctx, activities, newState, rerunRS, outgoingActPropHist).err,
 		o.createTimers(ctx, timers, newState.Generation),
 	); err != nil {
 		return err

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -321,7 +321,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	}
 
 	// Dispatch activities and messages, collecting failures.
-	activityResult := o.callActivities(ctx, pendingTasks, state, wi.OutgoingHistory)
+	activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
 	addResult := o.callAddEventStateMessage(ctx, addWorkflows)
 	createResult := o.callCreateWorkflowStateMessage(ctx, createWorkflows)
 

--- a/tests/integration/framework/workflow/dedup.go
+++ b/tests/integration/framework/workflow/dedup.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+)
+
+// InjectInboxEvent appends evt to the workflow actor's persisted inbox in the
+// SQLite state store and increments the metadata's InboxLength by one. The
+// caller is responsible for invalidating the actor's in-memory cache (e.g. via
+// daprd.Restart) before relying on the injection to take effect.
+func InjectInboxEvent(t *testing.T, ctx context.Context, db *sqlite.SQLite, daprd *daprd.Daprd, instanceID string, evt *protos.HistoryEvent) {
+	t.Helper()
+
+	keyPrefix := workflowActorKeyPrefix(daprd, instanceID)
+
+	raw, err := proto.Marshal(evt)
+	require.NoError(t, err)
+
+	idx := db.CountStateKeys(t, ctx, instanceID+"||inbox")
+	db.WriteStateValue(t, ctx, fmt.Sprintf("%sinbox-%06d", keyPrefix, idx), raw)
+
+	key, metaRaw := db.ReadStateValue(t, ctx, instanceID, "metadata")
+	var metadata backend.BackendWorkflowStateMetadata
+	require.NoError(t, proto.Unmarshal(metaRaw, &metadata))
+	metadata.InboxLength++
+	updated, err := proto.Marshal(&metadata)
+	require.NoError(t, err)
+	db.WriteStateValue(t, ctx, key, updated)
+}
+
+// RemoveHistoryEvent deletes the first history event matching pred and
+// renumbers any subsequent history-* keys to keep the sequence contiguous.
+// The metadata's HistoryLength is decremented by one.
+func RemoveHistoryEvent(t *testing.T, ctx context.Context, db *sqlite.SQLite, daprd *daprd.Daprd, instanceID string, pred func(*protos.HistoryEvent) bool) {
+	t.Helper()
+
+	keyPrefix := workflowActorKeyPrefix(daprd, instanceID)
+
+	values := db.ReadStateValues(t, ctx, instanceID, "history")
+	target := -1
+	for i, raw := range values {
+		var ev protos.HistoryEvent
+		require.NoError(t, proto.Unmarshal(raw, &ev))
+		if pred(&ev) {
+			target = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, target, 0, "no history event matched the predicate")
+
+	conn := db.GetConnection(t)
+	tableName := db.TableName()
+
+	deleteKey := fmt.Sprintf("%shistory-%06d", keyPrefix, target)
+	//nolint:gosec
+	_, err := conn.ExecContext(ctx, "DELETE FROM "+tableName+" WHERE key = ?", deleteKey)
+	require.NoError(t, err)
+
+	for i := target + 1; i < len(values); i++ {
+		oldKey := fmt.Sprintf("%shistory-%06d", keyPrefix, i)
+		newKey := fmt.Sprintf("%shistory-%06d", keyPrefix, i-1)
+		//nolint:gosec
+		_, err = conn.ExecContext(ctx, "UPDATE "+tableName+" SET key = ? WHERE key = ?", newKey, oldKey)
+		require.NoError(t, err)
+	}
+
+	key, metaRaw := db.ReadStateValue(t, ctx, instanceID, "metadata")
+	var metadata backend.BackendWorkflowStateMetadata
+	require.NoError(t, proto.Unmarshal(metaRaw, &metadata))
+	require.Positive(t, metadata.HistoryLength)
+	metadata.HistoryLength--
+	updatedMeta, err := proto.Marshal(&metadata)
+	require.NoError(t, err)
+	db.WriteStateValue(t, ctx, key, updatedMeta)
+}
+
+// CountHistoryEventsMatching returns the number of events in the workflow's
+// history (as exposed via GetInstanceHistory) that satisfy pred.
+func CountHistoryEventsMatching(t *testing.T, ctx context.Context, cl *client.TaskHubGrpcClient, id api.InstanceID, pred func(*protos.HistoryEvent) bool) int {
+	t.Helper()
+	hist, err := cl.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+	count := 0
+	for _, e := range hist.GetEvents() {
+		if pred(e) {
+			count++
+		}
+	}
+	return count
+}
+
+// IsTaskCompletedFor returns a predicate that matches a TaskCompleted event
+// for the given TaskScheduledId.
+func IsTaskCompletedFor(taskScheduledID int32) func(*protos.HistoryEvent) bool {
+	return func(e *protos.HistoryEvent) bool {
+		c := e.GetTaskCompleted()
+		return c != nil && c.GetTaskScheduledId() == taskScheduledID
+	}
+}
+
+func IsTaskFailedFor(taskScheduledID int32) func(*protos.HistoryEvent) bool {
+	return func(e *protos.HistoryEvent) bool {
+		c := e.GetTaskFailed()
+		return c != nil && c.GetTaskScheduledId() == taskScheduledID
+	}
+}
+
+func IsTimerFiredFor(timerID int32) func(*protos.HistoryEvent) bool {
+	return func(e *protos.HistoryEvent) bool {
+		c := e.GetTimerFired()
+		return c != nil && c.GetTimerId() == timerID
+	}
+}
+
+func IsChildCompletedFor(taskScheduledID int32) func(*protos.HistoryEvent) bool {
+	return func(e *protos.HistoryEvent) bool {
+		c := e.GetChildWorkflowInstanceCompleted()
+		return c != nil && c.GetTaskScheduledId() == taskScheduledID
+	}
+}
+
+func IsChildFailedFor(taskScheduledID int32) func(*protos.HistoryEvent) bool {
+	return func(e *protos.HistoryEvent) bool {
+		c := e.GetChildWorkflowInstanceFailed()
+		return c != nil && c.GetTaskScheduledId() == taskScheduledID
+	}
+}
+
+func IsTaskScheduledFor(eventID int32) func(*protos.HistoryEvent) bool {
+	return func(e *protos.HistoryEvent) bool {
+		return e.GetTaskScheduled() != nil && e.GetEventId() == eventID
+	}
+}
+
+func workflowActorKeyPrefix(daprd *daprd.Daprd, instanceID string) string {
+	appID := daprd.AppID()
+	return appID + "||dapr.internal.default." + appID + ".workflow||" + instanceID + "||"
+}

--- a/tests/integration/suite/daprd/workflow/dedup/childcompleted.go
+++ b/tests/integration/suite/daprd/workflow/dedup/childcompleted.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childcompleted))
+}
+
+type childcompleted struct {
+	workflow *workflow.Workflow
+}
+
+func (cc *childcompleted) Setup(t *testing.T) []framework.Option {
+	cc.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(cc.workflow),
+	}
+}
+
+func (cc *childcompleted) Run(t *testing.T, ctx context.Context) {
+	cc.workflow.WaitUntilRunning(t, ctx)
+
+	var childCalls atomic.Int32
+
+	cc.workflow.Registry().AddWorkflowN("dedup-childparent", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallChildWorkflow("dedup-child").Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, ctx.WaitForSingleEvent("done", time.Minute).Await(nil)
+	})
+	cc.workflow.Registry().AddWorkflowN("dedup-child", func(ctx *task.WorkflowContext) (any, error) {
+		childCalls.Add(1)
+		return "ok", nil
+	})
+
+	cl := cc.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-childparent")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(1), childCalls.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsChildCompletedFor(0)))
+	}, 15*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, cc.workflow.DB(), cc.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId: 0,
+				Result:          wrapperspb.String(`"ok"`),
+			},
+		},
+	})
+
+	cc.workflow.Dapr().Restart(t, ctx)
+	cc.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = cc.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "done"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	assert.Equal(t, int32(1), childCalls.Load(), "child workflow must not re-run")
+	assert.Equal(t, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsChildCompletedFor(0)),
+		"history must contain exactly one ChildWorkflowInstanceCompleted for taskScheduledId=0")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/childfailed.go
+++ b/tests/integration/suite/daprd/workflow/dedup/childfailed.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childfailed))
+}
+
+type childfailed struct {
+	workflow *workflow.Workflow
+}
+
+func (cf *childfailed) Setup(t *testing.T) []framework.Option {
+	cf.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(cf.workflow),
+	}
+}
+
+func (cf *childfailed) Run(t *testing.T, ctx context.Context) {
+	cf.workflow.WaitUntilRunning(t, ctx)
+
+	var childCalls atomic.Int32
+
+	cf.workflow.Registry().AddWorkflowN("dedup-failparent", func(ctx *task.WorkflowContext) (any, error) {
+		err := ctx.CallChildWorkflow("dedup-failchild").Await(nil)
+		if err == nil {
+			return nil, errors.New("child unexpectedly succeeded")
+		}
+		return nil, ctx.WaitForSingleEvent("done", time.Minute).Await(nil)
+	})
+	cf.workflow.Registry().AddWorkflowN("dedup-failchild", func(ctx *task.WorkflowContext) (any, error) {
+		childCalls.Add(1)
+		return nil, errors.New("planned failure")
+	})
+
+	cl := cf.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-failparent")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(1), childCalls.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsChildFailedFor(0)))
+	}, 15*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, cf.workflow.DB(), cf.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceFailed{
+			ChildWorkflowInstanceFailed: &protos.ChildWorkflowInstanceFailedEvent{
+				TaskScheduledId: 0,
+				FailureDetails: &protos.TaskFailureDetails{
+					ErrorType:    "injected",
+					ErrorMessage: "duplicate child failure",
+				},
+			},
+		},
+	})
+
+	cf.workflow.Dapr().Restart(t, ctx)
+	cf.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = cf.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "done"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	assert.Equal(t, int32(1), childCalls.Load(), "child workflow must not re-run")
+	assert.Equal(t, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsChildFailedFor(0)),
+		"history must contain exactly one ChildWorkflowInstanceFailed for taskScheduledId=0")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/dedup/continueasnew.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(continueasnew))
+}
+
+type continueasnew struct {
+	workflow *workflow.Workflow
+}
+
+func (c *continueasnew) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const iterations = 5
+	var activityCalls atomic.Int32
+
+	c.workflow.Registry().AddWorkflowN("dedup-continueasnew", func(ctx *task.WorkflowContext) (any, error) {
+		var iter int
+		require.NoError(t, ctx.GetInput(&iter))
+
+		if err := ctx.CallActivity("ping").Await(nil); err != nil {
+			return nil, err
+		}
+
+		if iter+1 >= iterations {
+			return iter + 1, nil
+		}
+		ctx.ContinueAsNew(iter + 1)
+		return nil, nil
+	})
+	require.NoError(t, c.workflow.Registry().AddActivityN("ping", func(ctx task.ActivityContext) (any, error) {
+		activityCalls.Add(1)
+		return nil, nil
+	}))
+
+	cl := c.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-continueasnew")
+	require.NoError(t, err)
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	time.Sleep(time.Second * 2)
+	assert.Equal(t, int32(iterations), activityCalls.Load(),
+		"activity must run once per ContinueAsNew iteration; same EventId across generations must not be skipped")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/skipresolved.go
+++ b/tests/integration/suite/daprd/workflow/dedup/skipresolved.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(skipresolved))
+}
+
+type skipresolved struct {
+	workflow *workflow.Workflow
+}
+
+func (sr *skipresolved) Setup(t *testing.T) []framework.Option {
+	sr.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(sr.workflow),
+	}
+}
+
+func (sr *skipresolved) Run(t *testing.T, ctx context.Context) {
+	sr.workflow.WaitUntilRunning(t, ctx)
+
+	var activityCalls atomic.Int32
+
+	sr.workflow.Registry().AddWorkflowN("dedup-skipresolved", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("inc").Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, ctx.WaitForSingleEvent("done", time.Minute).Await(nil)
+	})
+	require.NoError(t, sr.workflow.Registry().AddActivityN("inc", func(ctx task.ActivityContext) (any, error) {
+		activityCalls.Add(1)
+		return nil, nil
+	}))
+
+	cl := sr.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-skipresolved")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(1), activityCalls.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskCompletedFor(0)))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	fworkflow.RemoveHistoryEvent(t, ctx, sr.workflow.DB(), sr.workflow.Dapr(), string(id), fworkflow.IsTaskScheduledFor(0))
+
+	sr.workflow.Dapr().Restart(t, ctx)
+	sr.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = sr.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "done"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	assert.Equal(t, int32(1), activityCalls.Load(),
+		"activity must not be re-dispatched once its resolution is in history")
+	assert.Equal(t, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskCompletedFor(0)),
+		"history must contain exactly one TaskCompleted for taskScheduledId=0")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/taskcompleted.go
+++ b/tests/integration/suite/daprd/workflow/dedup/taskcompleted.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(taskcompleted))
+}
+
+type taskcompleted struct {
+	workflow *workflow.Workflow
+}
+
+func (tc *taskcompleted) Setup(t *testing.T) []framework.Option {
+	tc.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(tc.workflow),
+	}
+}
+
+func (tc *taskcompleted) Run(t *testing.T, ctx context.Context) {
+	tc.workflow.WaitUntilRunning(t, ctx)
+
+	var activityCalls atomic.Int32
+
+	tc.workflow.Registry().AddWorkflowN("dedup-taskcompleted", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("inc").Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, ctx.WaitForSingleEvent("done", time.Minute).Await(nil)
+	})
+	require.NoError(t, tc.workflow.Registry().AddActivityN("inc", func(ctx task.ActivityContext) (any, error) {
+		activityCalls.Add(1)
+		return nil, nil
+	}))
+
+	cl := tc.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-taskcompleted")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(1), activityCalls.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskCompletedFor(0)))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, tc.workflow.DB(), tc.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 0,
+				Result:          wrapperspb.String(`null`),
+			},
+		},
+	})
+
+	tc.workflow.Dapr().Restart(t, ctx)
+	tc.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = tc.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "done"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	assert.Equal(t, int32(1), activityCalls.Load(), "activity must not re-run")
+	assert.Equal(t, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskCompletedFor(0)),
+		"history must contain exactly one TaskCompleted for taskScheduledId=0")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/taskfailed.go
+++ b/tests/integration/suite/daprd/workflow/dedup/taskfailed.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(taskfailed))
+}
+
+type taskfailed struct {
+	workflow *workflow.Workflow
+}
+
+func (tf *taskfailed) Setup(t *testing.T) []framework.Option {
+	tf.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(tf.workflow),
+	}
+}
+
+func (tf *taskfailed) Run(t *testing.T, ctx context.Context) {
+	tf.workflow.WaitUntilRunning(t, ctx)
+
+	var activityCalls atomic.Int32
+
+	tf.workflow.Registry().AddWorkflowN("dedup-taskfailed", func(ctx *task.WorkflowContext) (any, error) {
+		err := ctx.CallActivity("boom").Await(nil)
+		if err == nil {
+			return nil, errors.New("activity unexpectedly succeeded")
+		}
+		return nil, ctx.WaitForSingleEvent("done", time.Minute).Await(nil)
+	})
+	require.NoError(t, tf.workflow.Registry().AddActivityN("boom", func(ctx task.ActivityContext) (any, error) {
+		activityCalls.Add(1)
+		return nil, errors.New("planned failure")
+	}))
+
+	cl := tf.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-taskfailed")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int32(1), activityCalls.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskFailedFor(0)))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, tf.workflow.DB(), tf.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{
+				TaskScheduledId: 0,
+				FailureDetails: &protos.TaskFailureDetails{
+					ErrorType:    "injected",
+					ErrorMessage: "duplicate failure",
+				},
+			},
+		},
+	})
+
+	tf.workflow.Dapr().Restart(t, ctx)
+	tf.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = tf.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "done"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	assert.Equal(t, int32(1), activityCalls.Load(), "activity must not re-run")
+	assert.Equal(t, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskFailedFor(0)),
+		"history must contain exactly one TaskFailed for taskScheduledId=0")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/timerfired.go
+++ b/tests/integration/suite/daprd/workflow/dedup/timerfired.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(timerfired))
+}
+
+type timerfired struct {
+	workflow *workflow.Workflow
+}
+
+func (tf *timerfired) Setup(t *testing.T) []framework.Option {
+	tf.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(tf.workflow),
+	}
+}
+
+func (tf *timerfired) Run(t *testing.T, ctx context.Context) {
+	tf.workflow.WaitUntilRunning(t, ctx)
+
+	tf.workflow.Registry().AddWorkflowN("dedup-timerfired", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CreateTimer(100 * time.Millisecond).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, ctx.WaitForSingleEvent("done", time.Minute).Await(nil)
+	})
+
+	cl := tf.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-timerfired")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTimerFiredFor(0)))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, tf.workflow.DB(), tf.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TimerFired{
+			TimerFired: &protos.TimerFiredEvent{
+				TimerId: 0,
+				FireAt:  timestamppb.Now(),
+			},
+		},
+	})
+
+	tf.workflow.Dapr().Restart(t, ctx)
+	tf.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = tf.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "done"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	assert.Equal(t, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTimerFiredFor(0)),
+		"history must contain exactly one TimerFired for timerId=0")
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/basic"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/continueasnew"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/crossapp"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/dedup"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/disk"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/externalevent"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/get"


### PR DESCRIPTION
A workflow actor's inbox could accumulate duplicate TaskCompleted/TaskFailed/TimerFired/ChildWorkflowInstance{Completed, Failed} events when the upstream emitter (typically an activity actor whose run-activity reminder fires twice during pod migration) re-sent a completion that the parent had already committed to history. The language SDKs do not deduplicate these on the read side: they walk pending_tasks, find no matching entry, log "Ignoring unexpected <event> with ID = N" and silently return without producing actions. The next reminder fire reads the same inbox, runs the orchestrator again, and the cycle repeats.

This change adds two complementary checks in the workflow actor, both backed by a shared dedup helper that mirrors the engine-side dedup in durabletask-go's runtimestate/dedup subpackage:

- addWorkflowEvent (the inbox-write boundary) drops a completion whose resolution is already present in either state.History or state.Inbox. EventRaised and ExecutionTerminated are intentionally excluded: EventRaised is a user-raised signal that may legitimately repeat and ExecutionTerminated is idempotent. A dropped event short-circuits before the inbox AddToInbox, the signAndSaveState round-trip, and the new-event reminder, so a misbehaving emitter no longer drives redundant workflow runs.

- callActivities (the dispatch boundary) skips invoking the activity actor for any TaskScheduled whose resolution (TaskCompleted/TaskFailed) is already in state.History or state.Inbox.

Uses branch: https://github.com/dapr/durabletask-go/pull/96