### PR TITLE
fix(wf acl): allow system internal history events through AddWorkflowEvent

### DIFF
--- a/pkg/acl/workflow/extract.go
+++ b/pkg/acl/workflow/extract.go
@@ -120,6 +120,7 @@ func WorkflowNameFromCreateRequest(data []byte) (string, error) {
 
 func operationFromHistoryEvent(ev *backend.HistoryEvent) (wfaclapi.WorkflowOperation, error) {
 	switch {
+	// User-initiated operations subject to access control.
 	case ev.GetExecutionTerminated() != nil:
 		return wfaclapi.WorkflowOperationTerminate, nil
 	case ev.GetEventRaised() != nil:
@@ -128,6 +129,18 @@ func operationFromHistoryEvent(ev *backend.HistoryEvent) (wfaclapi.WorkflowOpera
 		return wfaclapi.WorkflowOperationPause, nil
 	case ev.GetExecutionResumed() != nil:
 		return wfaclapi.WorkflowOperationResume, nil
+
+	// System-internal continuations also flow through AddWorkflowEvent but are not user operations.
+	// An activity result publishes a TaskCompleted or TaskFailed.
+	// A finishing child workflow publishes a ChildWorkflowInstanceCompleted or
+	// ChildWorkflowInstanceFailed back to the parent.
+	// These are not subject to access control.
+	case ev.GetTaskCompleted() != nil,
+		ev.GetTaskFailed() != nil,
+		ev.GetChildWorkflowInstanceCompleted() != nil,
+		ev.GetChildWorkflowInstanceFailed() != nil:
+		return "", nil
+
 	default:
 		return "", fmt.Errorf("AddWorkflowEvent HistoryEvent has unsupported event type %T", ev.GetEventType())
 	}


### PR DESCRIPTION
# Description

Fixes a hang in workflows that combine **child workflows** with the **workflow access policy** feature. When a child workflow completes, the runtime publishes a `ChildWorkflowInstanceCompleted` history event to the parent via `AddWorkflowEvent`. The access policy was rejecting this as a malformed request, the parent's reminder retried every second, and the workflow never reached a terminal state.

This PR explicitly whitelist the system-internal events. They return an empty operation, which the access-policy caller already treats as "not subject to access control".

This is impacting my MCPServer integration tests with:
```
level=warning msg="Workflow actor '...': workflow access policy denied call 'AddWorkflowEvent': could not derive operation from request: AddWorkflowEvent HistoryEvent has unsupported event type *protos.HistoryEvent_ChildWorkflowInstanceCompleted"

level=error msg="failed to invoke scheduled actor reminder named: start-jSFwMuvm due to: ... access denied by workflow access policy: malformed request for method 'AddWorkflowEvent'"
```
https://github.com/dapr/dapr/pull/9731

Integration tests that catch this bug are in my MCPServer PR linked above...

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
