### PR TITLE
fix: add IPv6 and dual-stack support to GetHostAddress()

### DIFF
--- a/docs/release_notes/v1.17.7.md
+++ b/docs/release_notes/v1.17.7.md
@@ -7,6 +7,7 @@ This update contains the following bug fixes:
 - [Kafka in-flight pub/sub messages abandoned during graceful shutdown](#kafka-in-flight-pubsub-messages-abandoned-during-graceful-shutdown)
 - [Long actor drainOngoingCallTimeout blocks placement dissemination and resets the placement stream](#long-actor-drainongoingcalltimeout-blocks-placement-dissemination-and-resets-the-placement-stream)
 - [Workflow activity body executes multiple times in parallel during scheduler or daprd reconnect](#workflow-activity-body-executes-multiple-times-in-parallel-during-scheduler-or-daprd-reconnect)
+- [daprd and scheduler crash with "could not determine host IP address" on IPv6-only clusters](#daprd-and-scheduler-crash-with-could-not-determine-host-ip-address-on-ipv6-only-clusters)
 
 ## Workflow GetWorkItems gRPC stream torn down when the history payload exceeds the max body size
 
@@ -235,3 +236,23 @@ Concurrent reminder retries become followers: they observe the owner's outcome v
 
 The cache key includes the durabletask `TaskExecutionId` so that retries of the same scheduling share the entry while a new workflow run that reuses the same instance ID (for example after a `Purge` followed by a fresh `ScheduleNewWorkflow`) gets a fresh entry.
 Cached outcomes are released after a 60 second TTL.
+
+## daprd and scheduler crash with "could not determine host IP address" on IPv6-only clusters
+
+### Problem
+
+`GetHostAddress()` only worked on IPv4 networks: it dialed `8.8.8.8` (IPv4 only) and the fallback only accepted addresses where `To4() != nil`. On IPv6-only clusters, daprd and the scheduler crashed at startup with "could not determine host IP address".
+
+### Impact
+
+Any deployment running on an IPv6-only network was unable to start daprd or the scheduler.
+
+### Root Cause
+
+The UDP dial target was hardcoded to `8.8.8.8:80`, which requires IPv4 connectivity. The fallback interface enumeration filtered for `To4() != nil`, excluding all IPv6 addresses. Several downstream call sites also built `host:port` strings with plain concatenation (`host + ":" + port`), which produces invalid addresses for IPv6 literals (missing brackets).
+
+### Solution
+
+Replaced the hardcoded `8.8.8.8` probe with UDP dials to RFC documentation addresses (`192.0.2.1` for IPv4 and `2001:db8::1` for IPv6). The interface fallback now considers both IPv4 and IPv6 addresses with priority ordering: public IPv4, IPv6 GUA, private IPv4/CGNAT, IPv6 ULA, and link-local as last resort.
+
+Call sites that consume the address were updated to use `net.JoinHostPort` (actor placement, `IsActorLocal`) and RFC 7239 IPv6 quoting in the `Forwarded` header (direct messaging).

--- a/pkg/actors/internal/placement/loops/loops.go
+++ b/pkg/actors/internal/placement/loops/loops.go
@@ -15,7 +15,7 @@ package loops
 
 import (
 	"context"
-	"strings"
+	"net"
 	"time"
 
 	"github.com/dapr/dapr/pkg/actors/api"
@@ -136,13 +136,16 @@ type SetEntityDrainOngoingCallTimeouts struct {
 }
 
 func IsActorLocal(targetActorAddress, hostAddress string, port string) bool {
-	if targetActorAddress == hostAddress+":"+port {
+	if targetActorAddress == net.JoinHostPort(hostAddress, port) {
 		// Easy case when there is a perfect match
 		return true
 	}
 
-	if utils.IsLocalhost(hostAddress) && strings.HasSuffix(targetActorAddress, ":"+port) {
-		return utils.IsLocalhost(targetActorAddress[0 : len(targetActorAddress)-len(port)-1])
+	if utils.IsLocalhost(hostAddress) {
+		tHost, tPort, err := net.SplitHostPort(targetActorAddress)
+		if err == nil && tPort == port {
+			return utils.IsLocalhost(tHost)
+		}
 	}
 
 	return false

--- a/pkg/actors/internal/placement/loops/loops_test.go
+++ b/pkg/actors/internal/placement/loops/loops_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loops
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsActorLocal(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		host   string
+		port   string
+		want   bool
+	}{
+		// IPv4 exact match
+		{"IPv4 match", "10.0.0.1:5000", "10.0.0.1", "5000", true},
+		{"IPv4 no match different host", "10.0.0.2:5000", "10.0.0.1", "5000", false},
+		{"IPv4 no match different port", "10.0.0.1:6000", "10.0.0.1", "5000", false},
+
+		// IPv6 exact match
+		{"IPv6 match", "[2001:db8::1]:5000", "2001:db8::1", "5000", true},
+		{"IPv6 no match", "[2001:db8::2]:5000", "2001:db8::1", "5000", false},
+
+		// Localhost equivalences
+		{"localhost to 127.0.0.1", "127.0.0.1:5000", "localhost", "5000", true},
+		{"127.0.0.1 to localhost", "localhost:5000", "127.0.0.1", "5000", true},
+		{"localhost to ::1", "[::1]:5000", "localhost", "5000", true},
+		{"::1 to localhost", "localhost:5000", "::1", "5000", true},
+
+		// Non-localhost host with localhost target — should not match
+		{"non-localhost host", "localhost:5000", "10.0.0.1", "5000", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsActorLocal(tt.target, tt.host, tt.port))
+		})
+	}
+}

--- a/pkg/actors/internal/placement/placement.go
+++ b/pkg/actors/internal/placement/placement.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -146,7 +147,7 @@ func New(opts Options) (Interface, error) {
 			Healthz:    opts.Healthz,
 			Connector:  conn,
 			InitialHost: &v1pb.Host{
-				Name:      opts.Hostname + ":" + strconv.Itoa(opts.Port),
+				Name:      net.JoinHostPort(opts.Hostname, strconv.Itoa(opts.Port)),
 				Id:        opts.AppID,
 				ApiLevel:  20,
 				Namespace: opts.Namespace,

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -67,6 +68,7 @@ type directMessaging struct {
 	resolver            nr.Resolver
 	resolverMulti       nr.ResolverMulti
 	hostAddress         string
+	hostFwdAddr         string
 	hostName            string
 	maxRequestBodySize  int
 	proxy               Proxy
@@ -106,6 +108,12 @@ func NewDirectMessaging(opts NewDirectMessagingOpts) invokev1.DirectMessaging {
 	hAddr, _ := utils.GetHostAddress()
 	hName, _ := os.Hostname()
 
+	// RFC 7239: IPv6 addresses must be quoted and bracketed in the Forwarded header.
+	hFwdAddr := hAddr
+	if ip := net.ParseIP(hAddr); ip != nil && ip.To4() == nil {
+		hFwdAddr = `"[` + hAddr + `]"`
+	}
+
 	dm := &directMessaging{
 		appID:               opts.AppID,
 		namespace:           opts.Namespace,
@@ -119,6 +127,7 @@ func NewDirectMessaging(opts NewDirectMessagingOpts) invokev1.DirectMessaging {
 		readBufferSize:      opts.ReadBufferSize,
 		resiliency:          opts.Resiliency,
 		hostAddress:         hAddr,
+		hostFwdAddr:         hFwdAddr,
 		hostName:            hName,
 		compStore:           opts.CompStore,
 	}
@@ -578,13 +587,16 @@ func (d *directMessaging) addForwardedHeadersToMetadata(req *invokev1.InvokeMeth
 		// Add X-Forwarded-For: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 		addOrCreate("X-Forwarded-For", d.hostAddress)
 
-		forwardedHeaderValue += "for=" + d.hostAddress + ";by=" + d.hostAddress + ";"
+		forwardedHeaderValue += "for=" + d.hostFwdAddr + ";by=" + d.hostFwdAddr
 	}
 
 	if d.hostName != "" {
 		// Add X-Forwarded-Host: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
 		addOrCreate("X-Forwarded-Host", d.hostName)
 
+		if forwardedHeaderValue != "" {
+			forwardedHeaderValue += ";"
+		}
 		forwardedHeaderValue += "host=" + d.hostName
 	}
 

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -80,6 +80,7 @@ func TestForwardedHeaders(t *testing.T) {
 
 		dm := &directMessaging{}
 		dm.hostAddress = "1"
+		dm.hostFwdAddr = "1"
 		dm.hostName = "2"
 
 		dm.addForwardedHeadersToMetadata(req)
@@ -94,6 +95,40 @@ func TestForwardedHeaders(t *testing.T) {
 		assert.Equal(t, "for=1;by=1;host=2", md.GetValues()[0])
 	})
 
+	t.Run("forwarded headers without host name", func(t *testing.T) {
+		req := invokev1.NewInvokeMethodRequest("GET").
+			WithMetadata(map[string][]string{})
+		defer req.Close()
+
+		dm := &directMessaging{}
+		dm.hostAddress = "10.0.0.1"
+		dm.hostFwdAddr = "10.0.0.1"
+
+		dm.addForwardedHeadersToMetadata(req)
+
+		md := req.Metadata()["Forwarded"]
+		assert.Equal(t, "for=10.0.0.1;by=10.0.0.1", md.GetValues()[0])
+	})
+
+	t.Run("forwarded headers with IPv6 address", func(t *testing.T) {
+		req := invokev1.NewInvokeMethodRequest("GET").
+			WithMetadata(map[string][]string{})
+		defer req.Close()
+
+		dm := &directMessaging{}
+		dm.hostAddress = "2001:db8::1"
+		dm.hostFwdAddr = `"[2001:db8::1]"`
+		dm.hostName = "host1"
+
+		dm.addForwardedHeadersToMetadata(req)
+
+		md := req.Metadata()["X-Forwarded-For"]
+		assert.Equal(t, "2001:db8::1", md.GetValues()[0])
+
+		md = req.Metadata()["Forwarded"]
+		assert.Equal(t, `for="[2001:db8::1]";by="[2001:db8::1]";host=host1`, md.GetValues()[0])
+	})
+
 	t.Run("forwarded headers get appended", func(t *testing.T) {
 		req := invokev1.NewInvokeMethodRequest("GET").
 			WithMetadata(map[string][]string{
@@ -105,6 +140,7 @@ func TestForwardedHeaders(t *testing.T) {
 
 		dm := &directMessaging{}
 		dm.hostAddress = "1"
+		dm.hostFwdAddr = "1"
 		dm.hostName = "2"
 
 		dm.addForwardedHeadersToMetadata(req)

--- a/utils/host.go
+++ b/utils/host.go
@@ -26,34 +26,114 @@ const (
 )
 
 // GetHostAddress selects a valid outbound IP address for the host.
+// It first tries a UDP dial to documentation addresses to discover the
+// kernel-preferred outbound address, then falls back to enumerating
+// interface addresses ordered by preference:
+//  1. Public IPv4
+//  2. IPv6 GUA (Global Unicast)
+//  3. Private IPv4 (RFC 1918, CGNAT)
+//  4. IPv6 ULA
+//  5. Link-Local Addresses
 func GetHostAddress() (string, error) {
-	if val, ok := os.LookupEnv(HostIPEnvVar); ok && val != "" {
+	return getHostAddress(os.LookupEnv, net.Dial, net.InterfaceAddrs)
+}
+
+func getHostAddress(
+	lookupEnv func(string) (string, bool),
+	dial func(string, string) (net.Conn, error),
+	interfaceAddrs func() ([]net.Addr, error),
+) (string, error) {
+	if val, ok := lookupEnv(HostIPEnvVar); ok && val != "" {
 		return val, nil
 	}
 
-	// Use udp so no handshake is made.
-	// Any IP can be used, since connection is not established, but we used a known DNS IP.
-	conn, err := net.Dial("udp", "8.8.8.8:80")
-	if err != nil {
-		// Could not find one via a  UDP connection, so we fallback to the "old" way: try first non-loopback IPv4:
-		addrs, err := net.InterfaceAddrs()
+	_, clatSubnet, _ := net.ParseCIDR("192.0.0.0/29")
+	ipByDial := func(a string) (string, bool) {
+		conn, err := dial("udp", a)
 		if err != nil {
-			return "", fmt.Errorf("error getting interface IP addresses: %w", err)
+			return "", false
 		}
+		defer conn.Close()
 
-		for _, addr := range addrs {
-			if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-				if ipnet.IP.To4() != nil {
-					return ipnet.IP.String(), nil
-				}
-			}
+		udpAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+		if !ok || udpAddr == nil || udpAddr.IP == nil {
+			return "", false
 		}
-
-		return "", errors.New("could not determine host IP address")
+		if clatSubnet.Contains(udpAddr.IP) {
+			return "", false
+		}
+		return udpAddr.IP.String(), true
 	}
 
-	defer conn.Close()
-	return conn.LocalAddr().(*net.UDPAddr).IP.String(), nil
+	// Try UDP dial to documentation addresses (no packets are sent).
+	// This asks the kernel routing table for the preferred source address.
+	for _, a := range []string{"192.0.2.1:80", "[2001:db8::1]:80"} {
+		if ip, ok := ipByDial(a); ok {
+			return ip, nil
+		}
+	}
+
+	// Fallback: enumerate interface addresses sorted by priority.
+	addrs, err := interfaceAddrs()
+	if err != nil {
+		return "", fmt.Errorf("error getting interface IP addresses: %w", err)
+	}
+
+	var best net.IP
+	bestPrio := 100
+
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() || clatSubnet.Contains(ipnet.IP) {
+			continue
+		}
+
+		ip := ipnet.IP
+		prio := addrPriority(ip)
+		if prio < 0 {
+			continue
+		}
+		if best == nil || prio < bestPrio {
+			best = ip
+			bestPrio = prio
+		}
+	}
+
+	if best != nil {
+		return best.String(), nil
+	}
+
+	return "", errors.New("could not determine host IP address")
+}
+
+// addrPriority returns a sort priority for the given IP address.
+// Lower values are preferred. Returns -1 if the address should be skipped.
+func addrPriority(ip net.IP) int {
+	// Use Link Local as last resort
+	if ip.IsLinkLocalUnicast() {
+		return 99
+	}
+	if ip.To4() != nil {
+		if ip.IsPrivate() || isCGNAT(ip) {
+			return 2 // private IPv4 (RFC 1918) or shared (RFC 6598)
+		}
+		return 0 // public IPv4
+	}
+	// IPv6
+	if ip.IsPrivate() {
+		return 3 // ULA (fc00::/7)
+	}
+	if ip.IsGlobalUnicast() {
+		return 1 // GUA (2000::/3)
+	}
+	return -1 // skip everything else
+}
+
+// isCGNAT reports whether ip is in the RFC 6598 Shared Address Space
+// (100.64.0.0/10). Go's net.IP.IsPrivate() does not cover this range.
+func isCGNAT(ip net.IP) bool {
+	ip4 := ip.To4()
+	return ip4 != nil && ip4[0] == 100 && ip4[1]&0xc0 == 64
 }
 
 func IsLocalhost(addr string) bool {

--- a/utils/host_test.go
+++ b/utils/host_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,4 +37,292 @@ func TestGetHostAdress(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, address)
 	})
+}
+
+// fakeConn implements net.Conn with a configurable LocalAddr.
+type fakeConn struct {
+	net.Conn
+	addr net.Addr
+}
+
+func (c *fakeConn) LocalAddr() net.Addr { return c.addr }
+func (c *fakeConn) Close() error        { return nil }
+
+// fakeIPNet returns a *net.IPNet with the given IP and a full mask.
+func fakeIPNet(ip net.IP) *net.IPNet {
+	bits := 32
+	if ip.To4() == nil {
+		bits = 128
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}
+}
+
+func noEnv(string) (string, bool) { return "", false }
+
+func failDial(string, string) (net.Conn, error) {
+	return nil, errors.New("no route")
+}
+
+func dialReturning(ip net.IP) func(string, string) (net.Conn, error) {
+	return func(string, string) (net.Conn, error) {
+		return &fakeConn{addr: &net.UDPAddr{IP: ip}}, nil
+	}
+}
+
+// dialReturningOn succeeds only when the target matches addr, otherwise fails.
+func dialReturningOn(addr string, ip net.IP) func(string, string) (net.Conn, error) {
+	return func(_, target string) (net.Conn, error) {
+		if target == addr {
+			return &fakeConn{addr: &net.UDPAddr{IP: ip}}, nil
+		}
+		return nil, errors.New("no route")
+	}
+}
+
+func ifaceAddrs(ips ...net.IP) func() ([]net.Addr, error) {
+	return func() ([]net.Addr, error) {
+		addrs := make([]net.Addr, len(ips))
+		for i, ip := range ips {
+			addrs[i] = fakeIPNet(ip)
+		}
+		return addrs, nil
+	}
+}
+
+func noIfaces() ([]net.Addr, error) { return nil, nil }
+
+func TestGetHostAddressDetailed(t *testing.T) {
+	tests := []struct {
+		name       string
+		lookupEnv  func(string) (string, bool)
+		dial       func(string, string) (net.Conn, error)
+		ifaceAddrs func() ([]net.Addr, error)
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "env var override",
+			lookupEnv:  func(key string) (string, bool) { return "1.2.3.4", true },
+			dial:       failDial,
+			ifaceAddrs: noIfaces,
+			want:       "1.2.3.4",
+		},
+		{
+			name:       "env var empty is ignored",
+			lookupEnv:  func(key string) (string, bool) { return "", true },
+			dial:       dialReturning(net.ParseIP("10.0.0.1")),
+			ifaceAddrs: noIfaces,
+			want:       "10.0.0.1",
+		},
+		{
+			name:       "dial returns private IPv4",
+			lookupEnv:  noEnv,
+			dial:       dialReturning(net.ParseIP("10.0.0.5")),
+			ifaceAddrs: noIfaces,
+			want:       "10.0.0.5",
+		},
+		{
+			name:       "dial returns IPv6 GUA",
+			lookupEnv:  noEnv,
+			dial:       dialReturning(net.ParseIP("2600::1")),
+			ifaceAddrs: noIfaces,
+			want:       "2600::1",
+		},
+		{
+			name:       "IPv6-only: IPv4 dial fails, IPv6 dial succeeds",
+			lookupEnv:  noEnv,
+			dial:       dialReturningOn("[2001:db8::1]:80", net.ParseIP("2600::1")),
+			ifaceAddrs: noIfaces,
+			want:       "2600::1",
+		},
+		{
+			name:      "dial returns CLAT address, falls through to interfaces",
+			lookupEnv: noEnv,
+			dial:      dialReturning(net.ParseIP("192.0.0.1")), // inside 192.0.0.0/29
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("10.0.0.1"),
+			),
+			want: "10.0.0.1",
+		},
+		{
+			name:      "dial fails, fallback picks public IPv4 over private",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("10.0.0.1"),    // private → prio 2
+				net.ParseIP("203.0.113.5"), // public → prio 0
+			),
+			want: "203.0.113.5",
+		},
+		{
+			name:      "fallback prefers IPv6 GUA over private IPv4",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("10.0.0.1"), // private IPv4 → prio 2
+				net.ParseIP("2600::1"),  // GUA → prio 1
+			),
+			want: "2600::1",
+		},
+		{
+			name:      "fallback prefers private IPv4 over ULA",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("fd12::1"),     // ULA → prio 3
+				net.ParseIP("192.168.1.1"), // private IPv4 → prio 2
+			),
+			want: "192.168.1.1",
+		},
+		{
+			name:      "fallback prefers CGNAT over ULA",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("fd12::1"),    // ULA → prio 3
+				net.ParseIP("100.64.0.1"), // CGNAT → prio 2
+			),
+			want: "100.64.0.1",
+		},
+		{
+			name:      "fallback uses link-local as last resort",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("fe80::1"),
+			),
+			want: "fe80::1",
+		},
+		{
+			name:      "fallback skips loopback",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("127.0.0.1"),
+				net.ParseIP("10.0.0.1"),
+			),
+			want: "10.0.0.1",
+		},
+		{
+			name:      "fallback skips CLAT addresses",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("192.0.0.1"), // CLAT → skipped
+				net.ParseIP("10.0.0.1"),
+			),
+			want: "10.0.0.1",
+		},
+		{
+			name:       "no addresses available returns error",
+			lookupEnv:  noEnv,
+			dial:       failDial,
+			ifaceAddrs: noIfaces,
+			wantErr:    true,
+		},
+		{
+			name:      "only loopback returns error",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: ifaceAddrs(
+				net.ParseIP("127.0.0.1"),
+				net.ParseIP("::1"),
+			),
+			wantErr: true,
+		},
+		{
+			name:      "InterfaceAddrs error propagates",
+			lookupEnv: noEnv,
+			dial:      failDial,
+			ifaceAddrs: func() ([]net.Addr, error) {
+				return nil, errors.New("network subsystem failure")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getHostAddress(tt.lookupEnv, tt.dial, tt.ifaceAddrs)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAddrPriority(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want int
+	}{
+		// Public IPv4 → 0
+		{"public IPv4", "203.0.113.5", 0},
+		{"public IPv4 8.8.8.8", "8.8.8.8", 0},
+
+		// IPv6 GUA → 1
+		{"IPv6 GUA", "2001:db8::1", 1},
+		{"IPv6 GUA 2600::", "2600::1", 1},
+
+		// Private IPv4 → 2
+		{"private 10.x", "10.0.0.1", 2},
+		{"private 172.16.x", "172.16.0.1", 2},
+		{"private 192.168.x", "192.168.1.1", 2},
+
+		// CGNAT → 2
+		{"CGNAT low", "100.64.0.1", 2},
+		{"CGNAT high", "100.127.255.254", 2},
+
+		// IPv6 ULA → 3
+		{"IPv6 ULA fd", "fd12::1", 3},
+
+		// Link-local → 99
+		{"link-local IPv4", "169.254.1.1", 99},
+		{"link-local IPv6", "fe80::1", 99},
+
+		// Skipped → -1
+		{"multicast IPv6", "ff02::1", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip, "failed to parse IP %q", tt.ip)
+			assert.Equal(t, tt.want, addrPriority(ip))
+		})
+	}
+}
+
+func TestIsCGNAT(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		// Inside 100.64.0.0/10
+		{"100.64.0.0", true},
+		{"100.64.0.1", true},
+		{"100.100.100.100", true},
+		{"100.127.255.255", true},
+
+		// Outside 100.64.0.0/10
+		{"100.63.255.255", false},
+		{"100.128.0.0", false},
+		{"10.0.0.1", false},
+		{"192.168.1.1", false},
+
+		// IPv6 → always false
+		{"2001:db8::1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			require.NotNil(t, ip)
+			assert.Equal(t, tt.want, isCGNAT(ip))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- **GetHostAddress()** now works on IPv4, IPv6, and dual-stack networks by probing RFC documentation addresses instead of hardcoded `8.8.8.8`
- Interface fallback uses priority ordering: public IPv4 > IPv6 GUA > private IPv4/CGNAT > IPv6 ULA > link-local
- CLAT-synthesized source addresses (`192.0.0.0/29`) are filtered out
- Safe type assertion and `defer` for connection cleanup prevent potential panics
- Dependency injection (`getHostAddress(lookupEnv, dial, interfaceAddrs)`) enables deterministic testing

- **Call site fixes** for IPv6 compatibility:
  - `placement.go`: `net.JoinHostPort` for initial host name
  - `loops.go`: `net.JoinHostPort`/`net.SplitHostPort` in `IsActorLocal`
  - `direct_messaging.go`: RFC 7239 IPv6 quoting in `Forwarded` header, cached at construction time, trailing semicolon fix

## Test plan

- [x] `go test ./utils/...` — 15 cases for `getHostAddress`, 12 for `addrPriority`, 9 for `isCGNAT`
- [x] `go test ./pkg/actors/internal/placement/loops/...` — 10 cases for `IsActorLocal` (IPv4, IPv6, localhost)
- [x] `go test ./pkg/messaging/...` — IPv6 forwarded header, no-hostname trailing semicolon
- [ ] Manual: verify daprd starts on IPv6-only cluster without "could not determine host IP address"

Fixes #5971
