### PR TITLE
placement: fix dissemination timeout not firing for slow mid-round connections

### DIFF
--- a/pkg/placement/internal/loops/disseminator/host.go
+++ b/pkg/placement/internal/loops/disseminator/host.go
@@ -89,9 +89,9 @@ func (d *disseminator) doReport(streamIDx uint64, host *v1pb.Host) {
 		return
 	}
 
-	d.timeoutQ.Dequeue(d.currentVersion)
 	d.currentVersion++
 	d.timeoutQ.Enqueue(d.currentVersion)
+	d.timeoutQ.Dequeue(d.currentVersion - 1)
 	d.currentOperation = v1pb.HostOperation_LOCK
 	d.streamsInTargetState = 0
 


### PR DESCRIPTION
`doReport` dequeues the old timeout before enqueuing the new one. A stale timer firing in the gap between those two calls gets rejected (wrong version), and now there's nothing armed for the current round. Swap the order so the new timeout is live before the old one is removed.

Fixes #9885