### PR TITLE
refactor: simplify workflow concurrency config getters

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -238,14 +238,14 @@ func (w *WorkflowSpec) GetMaxConcurrentWorkflowInvocations() *int32 {
 	if w == nil || w.MaxConcurrentWorkflowInvocations <= 0 {
 		return nil
 	}
-	return new(w.MaxConcurrentWorkflowInvocations)
+	return &w.MaxConcurrentWorkflowInvocations
 }
 
 func (w *WorkflowSpec) GetMaxConcurrentActivityInvocations() *int32 {
 	if w == nil || w.MaxConcurrentActivityInvocations <= 0 {
 		return nil
 	}
-	return new(w.MaxConcurrentActivityInvocations)
+	return &w.MaxConcurrentActivityInvocations
 }
 
 func (w *WorkflowSpec) GetGlobalMaxConcurrentWorkflowInvocations() *int32 {


### PR DESCRIPTION
## Summary

Simplifies `GetMaxConcurrentWorkflowInvocations()` and `GetMaxConcurrentActivityInvocations()` to return the address of the field directly, avoiding construction of a pointer to a copied value.

## Context

These getters use the pointer return type to encode "configured vs unset"; positive values are consumed immediately by the workflow engine when constructing worker options. Returning the address of the stored field avoids creating a separate pointer to a copied value, while preserving the existing nil-for-unset behavior.

Current:
```go
return new(w.MaxConcurrentWorkflowInvocations)
```

Changed to:
```go
return &w.MaxConcurrentWorkflowInvocations
```

Same change for `GetMaxConcurrentActivityInvocations()`.

## Impact

- No intended behavior change; current call sites only check for nil and immediately dereference the returned value when building workflow worker options
- Avoids constructing a pointer to a copied value on each getter call
- Keeps the getter shape consistent with the other workflow concurrency getters, while preserving the existing <=0 means unset behavior

---

_Discovered while investigating #9772 (workflow concurrency bug). This PR does not fix that issue — it's a separate cleanup._