### PR TITLE
fix: placement dissemination timeout race

### DIFF
--- a/pkg/placement/internal/loops/disseminator/host.go
+++ b/pkg/placement/internal/loops/disseminator/host.go
@@ -89,9 +89,9 @@ func (d *disseminator) doReport(streamIDx uint64, host *v1pb.Host) {
 		return
 	}
 
-	d.timeoutQ.Dequeue(d.currentVersion)
 	d.currentVersion++
 	d.timeoutQ.Enqueue(d.currentVersion)
+	d.timeoutQ.Dequeue(d.currentVersion - 1)
 	d.currentOperation = v1pb.HostOperation_LOCK
 	d.streamsInTargetState = 0
 


### PR DESCRIPTION
Fixes #9885.

When a slow replica connects mid-round and sends REPORT, doReport advances the round version and arms a new timeout. The order of operations creates a race where the timeout can be lost:

**Before (broken):**
1. Dequeue timeout for currentVersion (v1)
2. Increment currentVersion to v2
3. Enqueue timeout for v2

If the v1 timeout fires between steps 1-2, handleTimeout rejects it because timeout.Version (1) != d.currentVersion (2). The new round v2 then has no armed timeout, and the slow stream stays connected forever.

**After (fixed):**
1. Increment currentVersion to v2
2. Enqueue timeout for v2 (arm new timeout first)
3. Dequeue timeout for v1 (then cancel old one)

This ensures the new version's timeout is armed before we could possibly handle a stale timeout event.

The integration test Test_Integration/placement/timeout/slowreplica validates this fix by connecting a slow replica that never responds to LOCK and expecting it to be disconnected after --disseminate-timeout.

Signed-off-by: June Kim <kimjune01@gmail.com>