### PR TITLE
test: add WaitUntilActorsReady to fix workflow flakes

### DIFF
--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -236,6 +236,52 @@ func (d *Daprd) WaitUntilRunning(t *testing.T, ctx context.Context) {
 	}, 30*time.Second, 10*time.Millisecond)
 }
 
+// WaitUntilActorsReady blocks until the actor runtime reports hostReady=true
+// via the metadata endpoint. This indicates actor type registration with
+// placement has completed and the runtime can accept actor API calls
+// (including workflow operations that use actor reminders).
+//
+// Use this after Restart() when tests immediately invoke workflow or actor
+// APIs, to avoid "operations on actor reminders are only possible on hosted
+// actor types" errors during the post-restart registration window.
+//
+// Only call this when the daprd is expected to have actor placement enabled.
+// If actors are disabled or placement is not configured, this will timeout.
+func (d *Daprd) WaitUntilActorsReady(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	client := client.HTTP(t)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(cctx, http.MethodGet, fmt.Sprintf("http://%s/v1.0/metadata", d.HTTPAddress()), nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		if !assert.NoError(c, err) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equal(c, http.StatusOK, resp.StatusCode) {
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoError(c, err) {
+			return
+		}
+		var meta Metadata
+		if !assert.NoError(c, json.Unmarshal(body, &meta)) {
+			return
+		}
+		if meta.ActorRuntime == nil {
+			assert.Fail(c, "actorRuntime is nil (actors may be disabled)")
+			return
+		}
+		assert.True(c, meta.ActorRuntime.HostReady,
+			"actorRuntime.hostReady is false (status=%s, placement=%s)",
+			meta.ActorRuntime.RuntimeStatus, meta.ActorRuntime.Placement)
+	}, 30*time.Second, 10*time.Millisecond)
+}
+
 func (d *Daprd) WaitUntilAppHealth(t *testing.T, ctx context.Context) {
 	switch d.appProtocol {
 	case "http":

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -255,7 +255,9 @@ func (d *Daprd) WaitUntilActorsReady(t *testing.T, ctx context.Context) {
 		cctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		req, err := http.NewRequestWithContext(cctx, http.MethodGet, fmt.Sprintf("http://%s/v1.0/metadata", d.HTTPAddress()), nil)
-		require.NoError(t, err)
+		if !assert.NoError(c, err) {
+			return
+		}
 		resp, err := client.Do(req)
 		if !assert.NoError(c, err) {
 			return

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -134,6 +134,7 @@ func (s *signatureStripped) assertLoadFails(t *testing.T, ctx context.Context, i
 	t.Helper()
 	s.daprd.Restart(t, ctx)
 	s.daprd.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilActorsReady(t, ctx)
 
 	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
 	require.NoError(t, client.StartWorker(ctx, dworkflow.NewRegistry()))


### PR DESCRIPTION
## Summary

- Add `WaitUntilActorsReady` helper to the integration test framework that polls the metadata endpoint until `actorRuntime.hostReady` is true
- Apply it in the `signatureStripped` workflow signing test after `Restart()` to close a race between `WaitUntilRunning` completing and actor placement registration finishing
- Use `assert.NoError` instead of `require.NoError` inside `EventuallyWithT` callbacks so the retry loop works correctly

Without this fix, the signing test intermittently fails with "operations on actor reminders are only possible on hosted actor types" because `WaitUntilRunning` returns before the actor runtime has re-registered with placement.

## Test plan

- [ ] `make test-integration ARGS="-run Test_Integration/daprd/workflow/signing/signatureStripped"` passes without flakes