### PR TITLE
feat: add initContainers and extraContainers support to control plane Helm charts

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml
@@ -38,7 +38,14 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.global.initContainers.operator }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
+    {{- with .Values.global.extraContainers.operator }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
       - name: dapr-operator
         livenessProbe:
           httpGet:

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml
@@ -45,7 +45,14 @@ spec:
     spec:
       securityContext:
         fsGroup: {{ .Values.fsGroup }}
+    {{- with .Values.global.initContainers.placement }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
+    {{- with .Values.global.extraContainers.placement }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
       - name: dapr-placement-server
         livenessProbe:
           httpGet:

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml
@@ -54,7 +54,14 @@ spec:
     spec:
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
+    {{- with .Values.global.initContainers.scheduler }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
+    {{- with .Values.global.extraContainers.scheduler }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
       - name: dapr-scheduler-server
         livenessProbe:
           httpGet:

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -70,7 +70,14 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.global.initContainers.sentry }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
+    {{- with .Values.global.extraContainers.sentry }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
       - name: dapr-sentry
         livenessProbe:
           httpGet:

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml
@@ -43,7 +43,14 @@ spec:
       hostNetwork: true
       {{- end }}
       serviceAccountName: dapr-injector
+    {{- with .Values.global.initContainers.injector }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
+    {{- with .Values.global.extraContainers.injector }}
+        {{- toYaml . | nindent 6 }}
+    {{- end }}
       - name: dapr-sidecar-injector
         livenessProbe:
           httpGet:

--- a/charts/dapr/values.yaml
+++ b/charts/dapr/values.yaml
@@ -64,6 +64,22 @@ global:
   #  operator:
   #  injector:
   #  scheduler:
+  # extraContainers are used to add additional sidecar containers to the Dapr
+  # control plane pods. Useful for compliance, logging, and telemetry agents.
+  extraContainers: {}
+  #  sentry:
+  #  placement:
+  #  operator:
+  #  injector:
+  #  scheduler:
+  # initContainers are used to add custom init containers to the Dapr control
+  # plane pods. Useful for pre-flight setup tasks.
+  initContainers: {}
+  #  sentry:
+  #  placement:
+  #  operator:
+  #  injector:
+  #  scheduler:
 
   actors:
     # Enables actor functionality in the cluster

--- a/tests/integration/framework/process/helm/helm.go
+++ b/tests/integration/framework/process/helm/helm.go
@@ -46,9 +46,12 @@ func New(t *testing.T, fopts ...OptionFunc) *Helm {
 	}
 
 	// helm options (not all are available)
-	args := make([]string, 0, 2*(len(opts.setValues)+len(opts.showOnly)))
+	args := make([]string, 0, 2*(len(opts.setValues)+len(opts.setJSONValues)+len(opts.showOnly)))
 	for _, v := range opts.setValues {
 		args = append(args, "--set", v)
+	}
+	for _, v := range opts.setJSONValues {
+		args = append(args, "--set-json", v)
 	}
 	for _, v := range opts.showOnly {
 		args = append(args, "--show-only", v)

--- a/tests/integration/framework/process/helm/options.go
+++ b/tests/integration/framework/process/helm/options.go
@@ -30,7 +30,8 @@ type OptionFunc func(*options)
 
 // options contains the options for running helm in integration tests.
 type options struct {
-	setValues []string
+	setValues     []string
+	setJSONValues []string
 
 	// list of resources to show only
 	showOnly []string
@@ -103,6 +104,12 @@ func WithShowOnly(chart, tplYamlFileName string) OptionFunc {
 			tplYamlFileName += ".yaml"
 		}
 		o.showOnly = append(o.showOnly, fmt.Sprintf("%s/templates/%s", chart, tplYamlFileName))
+	}
+}
+
+func WithSetJSON(values ...string) OptionFunc {
+	return func(o *options) {
+		o.setJSONValues = append(o.setJSONValues, values...)
 	}
 }
 

--- a/tests/integration/suite/helm/containers/containers.go
+++ b/tests/integration/suite/helm/containers/containers.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/helm"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(containers))
+}
+
+// containers tests that initContainers and extraContainers are correctly
+// rendered in control plane Helm chart templates.
+type containers struct {
+	defaultOperator   *helm.Helm
+	defaultPlacement  *helm.Helm
+	defaultScheduler  *helm.Helm
+	defaultSentry     *helm.Helm
+	defaultInjector   *helm.Helm
+	withInitOperator  *helm.Helm
+	withInitPlacement *helm.Helm
+	withInitScheduler *helm.Helm
+	withInitSentry    *helm.Helm
+	withInitInjector  *helm.Helm
+	withExtraOperator *helm.Helm
+	withExtraInjector *helm.Helm
+	withBothSentry    *helm.Helm
+}
+
+func (c *containers) Setup(t *testing.T) []framework.Option {
+	// Default configs (no initContainers or extraContainers)
+	c.defaultOperator = helm.New(t,
+		helm.WithShowOnly("charts/dapr_operator", "dapr_operator_deployment"),
+	)
+	c.defaultPlacement = helm.New(t,
+		helm.WithShowOnly("charts/dapr_placement", "dapr_placement_statefulset"),
+	)
+	c.defaultScheduler = helm.New(t,
+		helm.WithShowOnly("charts/dapr_scheduler", "dapr_scheduler_statefulset"),
+	)
+	c.defaultSentry = helm.New(t,
+		helm.WithShowOnly("charts/dapr_sentry", "dapr_sentry_deployment"),
+	)
+	c.defaultInjector = helm.New(t,
+		helm.WithShowOnly("charts/dapr_sidecar_injector", "dapr_sidecar_injector_deployment"),
+	)
+
+	// With initContainers
+	c.withInitOperator = helm.New(t,
+		helm.WithShowOnly("charts/dapr_operator", "dapr_operator_deployment"),
+		helm.WithSetJSON(
+			`global.initContainers.operator=[{"name":"init-certs","image":"busybox:1.36","command":["sh","-c","echo init"]}]`,
+		),
+	)
+	c.withInitPlacement = helm.New(t,
+		helm.WithShowOnly("charts/dapr_placement", "dapr_placement_statefulset"),
+		helm.WithSetJSON(
+			`global.initContainers.placement=[{"name":"init-data","image":"alpine:3.19","command":["sh","-c","echo ready"]}]`,
+		),
+	)
+	c.withInitScheduler = helm.New(t,
+		helm.WithShowOnly("charts/dapr_scheduler", "dapr_scheduler_statefulset"),
+		helm.WithSetJSON(
+			`global.initContainers.scheduler=[{"name":"init-config","image":"busybox:1.36","command":["sh","-c","echo config"]}]`,
+		),
+	)
+	c.withInitSentry = helm.New(t,
+		helm.WithShowOnly("charts/dapr_sentry", "dapr_sentry_deployment"),
+		helm.WithSetJSON(
+			`global.initContainers.sentry=[{"name":"init-pki","image":"busybox:1.36","command":["sh","-c","echo pki"]}]`,
+		),
+	)
+	c.withInitInjector = helm.New(t,
+		helm.WithShowOnly("charts/dapr_sidecar_injector", "dapr_sidecar_injector_deployment"),
+		helm.WithSetJSON(
+			`global.initContainers.injector=[{"name":"init-webhook","image":"busybox:1.36","command":["sh","-c","echo webhook"]}]`,
+		),
+	)
+
+	// With extraContainers
+	c.withExtraOperator = helm.New(t,
+		helm.WithShowOnly("charts/dapr_operator", "dapr_operator_deployment"),
+		helm.WithSetJSON(
+			`global.extraContainers.operator=[{"name":"log-collector","image":"fluent/fluentd:v1.16","ports":[{"containerPort":24224}]}]`,
+		),
+	)
+	c.withExtraInjector = helm.New(t,
+		helm.WithShowOnly("charts/dapr_sidecar_injector", "dapr_sidecar_injector_deployment"),
+		helm.WithSetJSON(
+			`global.extraContainers.injector=[{"name":"metrics-proxy","image":"prom/pushgateway:v1.7","ports":[{"containerPort":9091}]}]`,
+		),
+	)
+
+	// With both initContainers and extraContainers
+	c.withBothSentry = helm.New(t,
+		helm.WithShowOnly("charts/dapr_sentry", "dapr_sentry_deployment"),
+		helm.WithSetJSON(
+			`global.initContainers.sentry=[{"name":"init-pki","image":"busybox:1.36","command":["sh","-c","echo pki"]}]`,
+			`global.extraContainers.sentry=[{"name":"audit-logger","image":"fluent/fluentd:v1.16"}]`,
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(
+			c.defaultOperator,
+			c.defaultPlacement,
+			c.defaultScheduler,
+			c.defaultSentry,
+			c.defaultInjector,
+			c.withInitOperator,
+			c.withInitPlacement,
+			c.withInitScheduler,
+			c.withInitSentry,
+			c.withInitInjector,
+			c.withExtraOperator,
+			c.withExtraInjector,
+			c.withBothSentry,
+		),
+	}
+}
+
+func (c *containers) Run(t *testing.T, ctx context.Context) {
+	t.Run("default has no initContainers", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultOperator)
+		require.Len(t, deployments, 1)
+		assert.Empty(t, deployments[0].Spec.Template.Spec.InitContainers,
+			"operator should have no initContainers by default")
+
+		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultSentry)
+		require.Len(t, deployments, 1)
+		assert.Empty(t, deployments[0].Spec.Template.Spec.InitContainers,
+			"sentry should have no initContainers by default")
+
+		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultInjector)
+		require.Len(t, deployments, 1)
+		assert.Empty(t, deployments[0].Spec.Template.Spec.InitContainers,
+			"injector should have no initContainers by default")
+
+		stss := helm.UnmarshalStdout[appsv1.StatefulSet](t, c.defaultPlacement)
+		require.Len(t, stss, 1)
+		assert.Empty(t, stss[0].Spec.Template.Spec.InitContainers,
+			"placement should have no initContainers by default")
+
+		stss = helm.UnmarshalStdout[appsv1.StatefulSet](t, c.defaultScheduler)
+		require.Len(t, stss, 1)
+		assert.Empty(t, stss[0].Spec.Template.Spec.InitContainers,
+			"scheduler should have no initContainers by default")
+	})
+
+	t.Run("default has only one container per component", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultOperator)
+		require.Len(t, deployments, 1)
+		assert.Len(t, deployments[0].Spec.Template.Spec.Containers, 1,
+			"operator should have exactly one container by default")
+
+		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultSentry)
+		require.Len(t, deployments, 1)
+		assert.Len(t, deployments[0].Spec.Template.Spec.Containers, 1,
+			"sentry should have exactly one container by default")
+
+		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultInjector)
+		require.Len(t, deployments, 1)
+		assert.Len(t, deployments[0].Spec.Template.Spec.Containers, 1,
+			"injector should have exactly one container by default")
+
+		stss := helm.UnmarshalStdout[appsv1.StatefulSet](t, c.defaultPlacement)
+		require.Len(t, stss, 1)
+		assert.Len(t, stss[0].Spec.Template.Spec.Containers, 1,
+			"placement should have exactly one container by default")
+
+		stss = helm.UnmarshalStdout[appsv1.StatefulSet](t, c.defaultScheduler)
+		require.Len(t, stss, 1)
+		assert.Len(t, stss[0].Spec.Template.Spec.Containers, 1,
+			"scheduler should have exactly one container by default")
+	})
+
+	t.Run("initContainers on operator deployment", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withInitOperator)
+		require.Len(t, deployments, 1)
+		initContainers := deployments[0].Spec.Template.Spec.InitContainers
+		require.Len(t, initContainers, 1)
+		assert.Equal(t, "init-certs", initContainers[0].Name)
+		assert.Equal(t, "busybox:1.36", initContainers[0].Image)
+		assert.Equal(t, []string{"sh", "-c", "echo init"}, initContainers[0].Command)
+	})
+
+	t.Run("initContainers on placement statefulset", func(t *testing.T) {
+		stss := helm.UnmarshalStdout[appsv1.StatefulSet](t, c.withInitPlacement)
+		require.Len(t, stss, 1)
+		initContainers := stss[0].Spec.Template.Spec.InitContainers
+		require.Len(t, initContainers, 1)
+		assert.Equal(t, "init-data", initContainers[0].Name)
+		assert.Equal(t, "alpine:3.19", initContainers[0].Image)
+	})
+
+	t.Run("initContainers on scheduler statefulset", func(t *testing.T) {
+		stss := helm.UnmarshalStdout[appsv1.StatefulSet](t, c.withInitScheduler)
+		require.Len(t, stss, 1)
+		initContainers := stss[0].Spec.Template.Spec.InitContainers
+		require.Len(t, initContainers, 1)
+		assert.Equal(t, "init-config", initContainers[0].Name)
+		assert.Equal(t, "busybox:1.36", initContainers[0].Image)
+	})
+
+	t.Run("initContainers on sentry deployment", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withInitSentry)
+		require.Len(t, deployments, 1)
+		initContainers := deployments[0].Spec.Template.Spec.InitContainers
+		require.Len(t, initContainers, 1)
+		assert.Equal(t, "init-pki", initContainers[0].Name)
+		assert.Equal(t, "busybox:1.36", initContainers[0].Image)
+	})
+
+	t.Run("initContainers on injector deployment", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withInitInjector)
+		require.Len(t, deployments, 1)
+		initContainers := deployments[0].Spec.Template.Spec.InitContainers
+		require.Len(t, initContainers, 1)
+		assert.Equal(t, "init-webhook", initContainers[0].Name)
+		assert.Equal(t, "busybox:1.36", initContainers[0].Image)
+	})
+
+	t.Run("extraContainers on operator deployment", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withExtraOperator)
+		require.Len(t, deployments, 1)
+		allContainers := deployments[0].Spec.Template.Spec.Containers
+		require.Len(t, allContainers, 2, "should have main container plus extra container")
+
+		// Find the extra container (not the main dapr-operator one)
+		var extraContainer *int
+		for i := range allContainers {
+			if allContainers[i].Name == "log-collector" {
+				extraContainer = &i
+				break
+			}
+		}
+		require.NotNil(t, extraContainer, "log-collector extra container should exist")
+		assert.Equal(t, "fluent/fluentd:v1.16", allContainers[*extraContainer].Image)
+		require.Len(t, allContainers[*extraContainer].Ports, 1)
+		assert.Equal(t, int32(24224), allContainers[*extraContainer].Ports[0].ContainerPort)
+	})
+
+	t.Run("extraContainers on injector deployment", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withExtraInjector)
+		require.Len(t, deployments, 1)
+		allContainers := deployments[0].Spec.Template.Spec.Containers
+		require.Len(t, allContainers, 2, "should have main container plus extra container")
+
+		var found bool
+		for _, c := range allContainers {
+			if c.Name == "metrics-proxy" {
+				found = true
+				assert.Equal(t, "prom/pushgateway:v1.7", c.Image)
+				require.Len(t, c.Ports, 1)
+				assert.Equal(t, int32(9091), c.Ports[0].ContainerPort)
+			}
+		}
+		assert.True(t, found, "metrics-proxy extra container should exist")
+	})
+
+	t.Run("both initContainers and extraContainers on sentry", func(t *testing.T) {
+		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withBothSentry)
+		require.Len(t, deployments, 1)
+
+		// Verify initContainers
+		initContainers := deployments[0].Spec.Template.Spec.InitContainers
+		require.Len(t, initContainers, 1)
+		assert.Equal(t, "init-pki", initContainers[0].Name)
+		assert.Equal(t, "busybox:1.36", initContainers[0].Image)
+
+		// Verify extraContainers alongside main container
+		allContainers := deployments[0].Spec.Template.Spec.Containers
+		require.Len(t, allContainers, 2, "should have main container plus extra container")
+
+		var found bool
+		for _, c := range allContainers {
+			if c.Name == "audit-logger" {
+				found = true
+				assert.Equal(t, "fluent/fluentd:v1.16", c.Image)
+			}
+		}
+		assert.True(t, found, "audit-logger extra container should exist")
+	})
+}

--- a/tests/integration/suite/helm/containers/containers.go
+++ b/tests/integration/suite/helm/containers/containers.go
@@ -140,21 +140,34 @@ func (c *containers) Setup(t *testing.T) []framework.Option {
 	}
 }
 
+// findDeployment returns the first Deployment from the helm template output.
+// Some templates (e.g. sentry) emit multiple YAML documents (Secret,
+// ConfigMap, Deployment), so we filter by Kind rather than assuming a single
+// document.
+func findDeployment(t *testing.T, h *helm.Helm) appsv1.Deployment {
+	t.Helper()
+	all := helm.UnmarshalStdout[appsv1.Deployment](t, h)
+	for _, d := range all {
+		if d.Kind == "Deployment" {
+			return d
+		}
+	}
+	t.Fatal("no Deployment found in helm template output")
+	return appsv1.Deployment{}
+}
+
 func (c *containers) Run(t *testing.T, ctx context.Context) {
 	t.Run("default has no initContainers", func(t *testing.T) {
-		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultOperator)
-		require.Len(t, deployments, 1)
-		assert.Empty(t, deployments[0].Spec.Template.Spec.InitContainers,
+		dep := findDeployment(t, c.defaultOperator)
+		assert.Empty(t, dep.Spec.Template.Spec.InitContainers,
 			"operator should have no initContainers by default")
 
-		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultSentry)
-		require.Len(t, deployments, 1)
-		assert.Empty(t, deployments[0].Spec.Template.Spec.InitContainers,
+		dep = findDeployment(t, c.defaultSentry)
+		assert.Empty(t, dep.Spec.Template.Spec.InitContainers,
 			"sentry should have no initContainers by default")
 
-		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultInjector)
-		require.Len(t, deployments, 1)
-		assert.Empty(t, deployments[0].Spec.Template.Spec.InitContainers,
+		dep = findDeployment(t, c.defaultInjector)
+		assert.Empty(t, dep.Spec.Template.Spec.InitContainers,
 			"injector should have no initContainers by default")
 
 		stss := helm.UnmarshalStdout[appsv1.StatefulSet](t, c.defaultPlacement)
@@ -169,19 +182,16 @@ func (c *containers) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("default has only one container per component", func(t *testing.T) {
-		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultOperator)
-		require.Len(t, deployments, 1)
-		assert.Len(t, deployments[0].Spec.Template.Spec.Containers, 1,
+		dep := findDeployment(t, c.defaultOperator)
+		assert.Len(t, dep.Spec.Template.Spec.Containers, 1,
 			"operator should have exactly one container by default")
 
-		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultSentry)
-		require.Len(t, deployments, 1)
-		assert.Len(t, deployments[0].Spec.Template.Spec.Containers, 1,
+		dep = findDeployment(t, c.defaultSentry)
+		assert.Len(t, dep.Spec.Template.Spec.Containers, 1,
 			"sentry should have exactly one container by default")
 
-		deployments = helm.UnmarshalStdout[appsv1.Deployment](t, c.defaultInjector)
-		require.Len(t, deployments, 1)
-		assert.Len(t, deployments[0].Spec.Template.Spec.Containers, 1,
+		dep = findDeployment(t, c.defaultInjector)
+		assert.Len(t, dep.Spec.Template.Spec.Containers, 1,
 			"injector should have exactly one container by default")
 
 		stss := helm.UnmarshalStdout[appsv1.StatefulSet](t, c.defaultPlacement)
@@ -224,9 +234,8 @@ func (c *containers) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("initContainers on sentry deployment", func(t *testing.T) {
-		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withInitSentry)
-		require.Len(t, deployments, 1)
-		initContainers := deployments[0].Spec.Template.Spec.InitContainers
+		dep := findDeployment(t, c.withInitSentry)
+		initContainers := dep.Spec.Template.Spec.InitContainers
 		require.Len(t, initContainers, 1)
 		assert.Equal(t, "init-pki", initContainers[0].Name)
 		assert.Equal(t, "busybox:1.36", initContainers[0].Image)
@@ -280,17 +289,16 @@ func (c *containers) Run(t *testing.T, ctx context.Context) {
 	})
 
 	t.Run("both initContainers and extraContainers on sentry", func(t *testing.T) {
-		deployments := helm.UnmarshalStdout[appsv1.Deployment](t, c.withBothSentry)
-		require.Len(t, deployments, 1)
+		dep := findDeployment(t, c.withBothSentry)
 
 		// Verify initContainers
-		initContainers := deployments[0].Spec.Template.Spec.InitContainers
+		initContainers := dep.Spec.Template.Spec.InitContainers
 		require.Len(t, initContainers, 1)
 		assert.Equal(t, "init-pki", initContainers[0].Name)
 		assert.Equal(t, "busybox:1.36", initContainers[0].Image)
 
 		// Verify extraContainers alongside main container
-		allContainers := deployments[0].Spec.Template.Spec.Containers
+		allContainers := dep.Spec.Template.Spec.Containers
 		require.Len(t, allContainers, 2, "should have main container plus extra container")
 
 		var found bool

--- a/tests/integration/suite/helm/helm.go
+++ b/tests/integration/suite/helm/helm.go
@@ -14,5 +14,6 @@ limitations under the License.
 package helm
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/helm/containers"
 	_ "github.com/dapr/dapr/tests/integration/suite/helm/service"
 )


### PR DESCRIPTION
## Summary
- Adds `global.initContainers` and `global.extraContainers` configuration blocks to `values.yaml` for all five control plane components (Operator, Sentry, Placement, Injector, Scheduler)
- Updates all five Helm chart templates to consume these values, allowing users to inject custom init containers and sidecar containers
- Follows the existing pattern established by `global.extraVolumes` and `global.extraVolumeMounts`, with per-component keys under the global configuration
- Adds Helm integration tests covering default/init-only/extra-only/both scenarios across all five components

## Motivation
Some users need to inject custom containers into control plane pods for compliance, logging, and telemetry requirements (e.g. log shippers, telemetry agents, secret pre-flight init containers). Today this requires forking the chart.

This PR mirrors the existing `extraVolumes`/`extraVolumeMounts` pattern to provide `initContainers` and `extraContainers` support.

Resolves #9494. Supersedes the previous closed PR #9549 — this one adds the Helm integration tests that were requested for review.

## Usage example
```yaml
global:
  initContainers:
    operator:
      - name: init-setup
        image: busybox:1.36
        command: ["sh", "-c", "echo init"]
  extraContainers:
    sentry:
      - name: log-collector
        image: fluent/fluentd:v1.16
```

## Changes
| File | Change |
|------|--------|
| `charts/dapr/values.yaml` | Added `global.extraContainers` and `global.initContainers` configuration blocks |
| `charts/dapr/charts/dapr_operator/templates/dapr_operator_deployment.yaml` | Added initContainers + extraContainers template blocks |
| `charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml` | Added initContainers + extraContainers template blocks |
| `charts/dapr/charts/dapr_placement/templates/dapr_placement_statefulset.yaml` | Added initContainers + extraContainers template blocks |
| `charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_deployment.yaml` | Added initContainers + extraContainers template blocks |
| `charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_statefulset.yaml` | Added initContainers + extraContainers template blocks |
| `tests/integration/suite/helm/containers/containers.go` | New helm integration tests for init/extra containers |
| `tests/integration/framework/process/helm/{helm,options}.go` | Add `--set-json` option support to helm test framework |
| `tests/integration/suite/helm/helm.go` | Register new containers suite |

## Tests
New integration suite under `tests/integration/suite/helm/containers/` exercises:
- default render produces no `initContainers` or extra containers on any of the five components
- default render produces exactly one container per control plane component
- `global.initContainers.<component>` renders correctly for each of operator, sentry, placement, injector, scheduler
- `global.extraContainers.<component>` renders correctly for operator and injector
- both `initContainers` and `extraContainers` set together on sentry render correctly

Run locally:
```
make test-integration ARGS='-focus containers'
```

Result: all 10 subtests pass.

## Release note
```
**ADD** Support for custom sidecars/init containers in Dapr Control Plane Helm charts.
```