### PR TITLE
Add support for sub-second precision in reminders

### DIFF
--- a/pkg/actors/api/reminder.go
+++ b/pkg/actors/api/reminder.go
@@ -109,9 +109,11 @@ func (r Reminder) ScheduledTime() time.Time {
 func (r *Reminder) MarshalJSON() ([]byte, error) {
 	type reminderAlias Reminder
 
-	// Custom serializer that encodes times (RegisteredTime and ExpirationTime) in the RFC3339 format.
+	// Custom serializer that encodes times (RegisteredTime and ExpirationTime) in the RFC3339Nano format.
 	// Also adds a custom serializer for Period to omit empty strings.
-	// This is for backwards-compatibility and also because we don't need to store precision with less than seconds
+	// RFC3339Nano preserves sub-second precision for short timers; values without
+	// fractional seconds round-trip as plain RFC3339, so on-disk format is
+	// backwards-compatible with prior whole-second serializations.
 	m := struct {
 		RegisteredTime string          `json:"registeredTime,omitempty"`
 		ExpirationTime string          `json:"expirationTime,omitempty"`
@@ -123,10 +125,10 @@ func (r *Reminder) MarshalJSON() ([]byte, error) {
 	}
 
 	if !r.RegisteredTime.IsZero() {
-		m.RegisteredTime = r.RegisteredTime.Format(time.RFC3339)
+		m.RegisteredTime = r.RegisteredTime.Format(time.RFC3339Nano)
 	}
 	if !r.ExpirationTime.IsZero() {
-		m.ExpirationTime = r.ExpirationTime.Format(time.RFC3339)
+		m.ExpirationTime = r.ExpirationTime.Format(time.RFC3339Nano)
 	}
 
 	m.Period = r.Period.String()
@@ -157,7 +159,9 @@ func (r *Reminder) UnmarshalJSON(data []byte) error {
 		Period: NewEmptyReminderPeriod(),
 	}
 
-	// Parse RegisteredTime and ExpirationTime as dates in the RFC3339 format
+	// Parse RegisteredTime and ExpirationTime as RFC3339Nano dates.
+	// RFC3339Nano accepts both fractional and non-fractional inputs, so it is
+	// backwards-compatible with reminders previously serialized as RFC3339.
 	m := &struct {
 		ExpirationTime string          `json:"expirationTime"`
 		RegisteredTime string          `json:"registeredTime"`
@@ -179,19 +183,17 @@ func (r *Reminder) UnmarshalJSON(data []byte) error {
 	}
 
 	if m.RegisteredTime != "" {
-		r.RegisteredTime, err = time.Parse(time.RFC3339, m.RegisteredTime)
+		r.RegisteredTime, err = time.Parse(time.RFC3339Nano, m.RegisteredTime)
 		if err != nil {
 			return fmt.Errorf("failed to parse RegisteredTime: %w", err)
 		}
-		r.RegisteredTime = r.RegisteredTime.Truncate(time.Second)
 	}
 
 	if m.ExpirationTime != "" {
-		r.ExpirationTime, err = time.Parse(time.RFC3339, m.ExpirationTime)
+		r.ExpirationTime, err = time.Parse(time.RFC3339Nano, m.ExpirationTime)
 		if err != nil {
 			return fmt.Errorf("failed to parse ExpirationTime: %w", err)
 		}
-		r.ExpirationTime = r.ExpirationTime.Truncate(time.Second)
 	}
 
 	return nil
@@ -219,11 +221,11 @@ func (r Reminder) String() string {
 	hasData := r.Data != nil
 	dueTime := "nil"
 	if !r.RegisteredTime.IsZero() {
-		dueTime = "'" + r.RegisteredTime.Format(time.RFC3339) + "'"
+		dueTime = "'" + r.RegisteredTime.Format(time.RFC3339Nano) + "'"
 	}
 	expirationTime := "nil"
 	if !r.ExpirationTime.IsZero() {
-		expirationTime = "'" + r.ExpirationTime.Format(time.RFC3339) + "'"
+		expirationTime = "'" + r.ExpirationTime.Format(time.RFC3339Nano) + "'"
 	}
 	period := r.Period.String()
 	if period == "" {
@@ -253,14 +255,9 @@ func (r *Reminder) RequiresUpdating(new *Reminder) bool {
 		!reflect.DeepEqual(r.Data, new.Data)
 }
 
-// parseTimeTruncateSeconds is a wrapper around timeutils.ParseTime that truncates the time to seconds.
-func parseTimeTruncateSeconds(val string, now *time.Time, truncate bool) (time.Time, error) {
-	t, err := timeutils.ParseTime(val, now)
-	if err != nil {
-		return t, err
-	}
-	if truncate {
-		t = t.Truncate(time.Second)
-	}
-	return t, nil
+// parseReminderTime is a thin wrapper around timeutils.ParseTime preserving
+// sub-second precision so short timers fire at their requested duration rather
+// than at the prior whole-second boundary.
+func parseReminderTime(val string, now *time.Time) (time.Time, error) {
+	return timeutils.ParseTime(val, now)
 }

--- a/pkg/actors/api/reminder_test.go
+++ b/pkg/actors/api/reminder_test.go
@@ -287,3 +287,135 @@ func compactJSON(t *testing.T, data []byte) []byte {
 	require.NoError(t, err)
 	return out.Bytes()
 }
+
+// TestReminderSubSecondPrecision verifies that sub-second precision in
+// RegisteredTime and ExpirationTime survives a JSON round-trip. Earlier
+// versions formatted with time.RFC3339 and explicitly truncated to seconds
+// on unmarshal, causing short timers (e.g. 2s) to fire ahead of schedule
+// because the registered time was rounded down to the prior whole second.
+func TestReminderSubSecondPrecision(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nanos survive JSON round-trip", func(t *testing.T) {
+		t.Parallel()
+		fractional := time.Date(2026, 5, 14, 10, 30, 0, 500_000_000, time.UTC)
+
+		r := Reminder{
+			ActorID:        "id",
+			ActorType:      "type",
+			Name:           "name",
+			RegisteredTime: fractional,
+			ExpirationTime: fractional.Add(time.Minute + 250*time.Millisecond),
+		}
+		var err error
+		r.Period, err = NewReminderPeriod("")
+		require.NoError(t, err)
+
+		encoded, err := json.Marshal(&r)
+		require.NoError(t, err)
+		require.Contains(t, string(encoded), `"registeredTime":"2026-05-14T10:30:00.5Z"`)
+		require.Contains(t, string(encoded), `"expirationTime":"2026-05-14T10:31:00.75Z"`)
+
+		var dec Reminder
+		require.NoError(t, json.Unmarshal(encoded, &dec))
+		require.True(t, dec.RegisteredTime.Equal(r.RegisteredTime),
+			"RegisteredTime nanos not preserved: got %s want %s", dec.RegisteredTime, r.RegisteredTime)
+		require.True(t, dec.ExpirationTime.Equal(r.ExpirationTime),
+			"ExpirationTime nanos not preserved: got %s want %s", dec.ExpirationTime, r.ExpirationTime)
+	})
+
+	t.Run("legacy whole-second RFC3339 still parses", func(t *testing.T) {
+		t.Parallel()
+		const legacy = `{"registeredTime":"2023-03-07T18:29:04Z","expirationTime":"2023-03-07T18:30:00Z","actorID":"id","actorType":"type","name":"name"}`
+
+		var dec Reminder
+		require.NoError(t, json.Unmarshal([]byte(legacy), &dec))
+		require.Equal(t, time.Date(2023, 3, 7, 18, 29, 4, 0, time.UTC), dec.RegisteredTime)
+		require.Equal(t, time.Date(2023, 3, 7, 18, 30, 0, 0, time.UTC), dec.ExpirationTime)
+	})
+}
+
+// TestReminderTrackSubSecondPrecision verifies LastFiredTime preserves
+// sub-second precision through a JSON round-trip and that whole-second
+// RFC3339 values still parse (backwards compatibility).
+func TestReminderTrackSubSecondPrecision(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nanos survive round-trip", func(t *testing.T) {
+		t.Parallel()
+		fractional := time.Date(2026, 5, 14, 10, 30, 0, 750_000_000, time.UTC)
+
+		tr := ReminderTrack{
+			LastFiredTime:  fractional,
+			RepetitionLeft: 3,
+		}
+		encoded, err := json.Marshal(&tr)
+		require.NoError(t, err)
+		require.Contains(t, string(encoded), `"lastFiredTime":"2026-05-14T10:30:00.75Z"`)
+
+		var dec ReminderTrack
+		require.NoError(t, json.Unmarshal(encoded, &dec))
+		require.True(t, dec.LastFiredTime.Equal(tr.LastFiredTime),
+			"LastFiredTime nanos not preserved: got %s want %s", dec.LastFiredTime, tr.LastFiredTime)
+		require.Equal(t, 3, dec.RepetitionLeft)
+	})
+
+	t.Run("legacy whole-second value parses", func(t *testing.T) {
+		t.Parallel()
+		const legacy = `{"lastFiredTime":"2023-03-07T18:29:04Z","RepetitionLeft":1}`
+
+		var dec ReminderTrack
+		require.NoError(t, json.Unmarshal([]byte(legacy), &dec))
+		require.Equal(t, time.Date(2023, 3, 7, 18, 29, 4, 0, time.UTC), dec.LastFiredTime)
+	})
+}
+
+// TestSetReminderTimesSubSecond verifies that parsing duration-style
+// dueTime strings (e.g. "1500ms") preserves sub-second offset from now.
+// Earlier code truncated to whole seconds, causing a 2s timer registered
+// at t=10.8s to fire at t=12.0s instead of t=12.8s.
+func TestSetReminderTimesSubSecond(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 14, 10, 30, 0, 800_000_000, time.UTC)
+
+	t.Run("millisecond dueTime preserves offset", func(t *testing.T) {
+		t.Parallel()
+		req := CreateReminderRequest{
+			ActorID:   "id",
+			ActorType: "type",
+			Name:      "name",
+			DueTime:   "1500ms",
+		}
+		r, err := req.NewReminder(now)
+		require.NoError(t, err)
+		require.Equal(t, now.Add(1500*time.Millisecond), r.RegisteredTime)
+	})
+
+	t.Run("fractional second dueTime preserves offset", func(t *testing.T) {
+		t.Parallel()
+		req := CreateReminderRequest{
+			ActorID:   "id",
+			ActorType: "type",
+			Name:      "name",
+			DueTime:   "2.5s",
+		}
+		r, err := req.NewReminder(now)
+		require.NoError(t, err)
+		require.Equal(t, now.Add(2500*time.Millisecond), r.RegisteredTime)
+	})
+
+	t.Run("two-second timer fires after full two seconds from now", func(t *testing.T) {
+		t.Parallel()
+		req := CreateTimerRequest{
+			ActorID:   "id",
+			ActorType: "type",
+			Name:      "name",
+			DueTime:   "2s",
+		}
+		r, err := req.NewReminder(now)
+		require.NoError(t, err)
+		require.Equal(t, now.Add(2*time.Second), r.RegisteredTime,
+			"timer fire time must be exactly 2s after registration, even when registration time has sub-second nanos")
+	})
+}

--- a/pkg/actors/api/reminders.go
+++ b/pkg/actors/api/reminders.go
@@ -63,7 +63,7 @@ func (req CreateReminderRequest) Key() string {
 }
 
 // NewReminder returns a new Reminder from a CreateReminderRequest object.
-func (req CreateReminderRequest) NewReminder(now time.Time, truncate bool) (reminder *Reminder, err error) {
+func (req CreateReminderRequest) NewReminder(now time.Time) (reminder *Reminder, err error) {
 	reminder = &Reminder{
 		ActorID:   req.ActorID,
 		ActorType: req.ActorType,
@@ -71,7 +71,7 @@ func (req CreateReminderRequest) NewReminder(now time.Time, truncate bool) (remi
 		Data:      req.Data,
 	}
 
-	err = setReminderTimes(reminder, req.DueTime, req.Period, req.TTL, now, "reminder", truncate)
+	err = setReminderTimes(reminder, req.DueTime, req.Period, req.TTL, now, "reminder")
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (req CreateTimerRequest) Key() string {
 }
 
 // NewReminder returns a new Timer from a CreateTimerRequest object.
-func (req CreateTimerRequest) NewReminder(now time.Time, truncate bool) (reminder *Reminder, err error) {
+func (req CreateTimerRequest) NewReminder(now time.Time) (reminder *Reminder, err error) {
 	reminder = &Reminder{
 		ActorID:   req.ActorID,
 		ActorType: req.ActorType,
@@ -143,7 +143,7 @@ func (req CreateTimerRequest) NewReminder(now time.Time, truncate bool) (reminde
 		Data:      req.Data,
 	}
 
-	err = setReminderTimes(reminder, req.DueTime, req.Period, req.TTL, now, "timer", truncate)
+	err = setReminderTimes(reminder, req.DueTime, req.Period, req.TTL, now, "timer")
 	if err != nil {
 		return nil, err
 	}
@@ -178,12 +178,12 @@ func (req *CreateTimerRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func setReminderTimes(reminder *Reminder, dueTime string, period string, ttl string, now time.Time, logMsg string, truncate bool) (err error) {
+func setReminderTimes(reminder *Reminder, dueTime string, period string, ttl string, now time.Time, logMsg string) (err error) {
 	// Due time and registered time
 	reminder.RegisteredTime = now
 	reminder.DueTime = dueTime
 	if dueTime != "" {
-		reminder.RegisteredTime, err = parseTimeTruncateSeconds(dueTime, &now, truncate)
+		reminder.RegisteredTime, err = parseReminderTime(dueTime, &now)
 		if err != nil {
 			return fmt.Errorf("error parsing %s due time: %w", logMsg, err)
 		}
@@ -197,7 +197,7 @@ func setReminderTimes(reminder *Reminder, dueTime string, period string, ttl str
 
 	// Set expiration time if configured
 	if ttl != "" {
-		reminder.ExpirationTime, err = parseTimeTruncateSeconds(ttl, &reminder.RegisteredTime, truncate)
+		reminder.ExpirationTime, err = parseReminderTime(ttl, &reminder.RegisteredTime)
 		if err != nil {
 			return fmt.Errorf("error parsing %s TTL: %w", logMsg, err)
 		}

--- a/pkg/actors/api/track.go
+++ b/pkg/actors/api/track.go
@@ -29,7 +29,10 @@ type ReminderTrack struct {
 func (r *ReminderTrack) MarshalJSON() ([]byte, error) {
 	type reminderTrackAlias ReminderTrack
 
-	// Custom serializer that encodes times (LastFiredTime) in the RFC3339 format, for backwards-compatibility
+	// Custom serializer that encodes times (LastFiredTime) in the RFC3339Nano
+	// format. RFC3339Nano omits the fractional component when nanos are zero,
+	// so the on-disk representation remains backwards-compatible with prior
+	// whole-second RFC3339 serializations.
 	m := &struct {
 		LastFiredTime string `json:"lastFiredTime,omitempty"`
 		*reminderTrackAlias
@@ -38,7 +41,7 @@ func (r *ReminderTrack) MarshalJSON() ([]byte, error) {
 	}
 
 	if !r.LastFiredTime.IsZero() {
-		m.LastFiredTime = r.LastFiredTime.Format(time.RFC3339)
+		m.LastFiredTime = r.LastFiredTime.Format(time.RFC3339Nano)
 	}
 
 	return json.Marshal(m)
@@ -47,7 +50,9 @@ func (r *ReminderTrack) MarshalJSON() ([]byte, error) {
 func (r *ReminderTrack) UnmarshalJSON(data []byte) error {
 	type reminderTrackAlias ReminderTrack
 
-	// Parse RegisteredTime and ExpirationTime as dates in the RFC3339 format
+	// Parse LastFiredTime as RFC3339Nano. RFC3339Nano accepts both fractional
+	// and non-fractional inputs, so it is backwards-compatible with values
+	// previously serialized as RFC3339.
 	m := &struct {
 		LastFiredTime string `json:"lastFiredTime"`
 		*reminderTrackAlias
@@ -60,11 +65,10 @@ func (r *ReminderTrack) UnmarshalJSON(data []byte) error {
 	}
 
 	if m.LastFiredTime != "" {
-		r.LastFiredTime, err = time.Parse(time.RFC3339, m.LastFiredTime)
+		r.LastFiredTime, err = time.Parse(time.RFC3339Nano, m.LastFiredTime)
 		if err != nil {
 			return fmt.Errorf("failed to parse LastFiredTime: %w", err)
 		}
-		r.LastFiredTime = r.LastFiredTime.Truncate(time.Second)
 	}
 
 	return nil

--- a/pkg/actors/internal/scheduler/scheduler.go
+++ b/pkg/actors/internal/scheduler/scheduler.go
@@ -186,7 +186,7 @@ func (s *scheduler) Get(ctx context.Context, req *api.GetReminderRequest) (*api.
 
 	var expirationTime time.Time
 	if job.Job.Ttl != nil {
-		expirationTime, err = time.Parse(time.RFC3339, job.GetJob().GetTtl())
+		expirationTime, err = time.Parse(time.RFC3339Nano, job.GetJob().GetTtl())
 		if err != nil {
 			log.Errorf("Error parsing expiration time for reminder job %s due to: %s", req.Name, err)
 		}

--- a/pkg/actors/targets/workflow/activity/reminder.go
+++ b/pkg/actors/targets/workflow/activity/reminder.go
@@ -45,7 +45,7 @@ func (a *activity) createReminder(ctx context.Context, invocation *protos.Activi
 	return common.CreateReminderWithRetry(ctx, a.reminders, &actorapi.CreateReminderRequest{
 		ActorType: a.actorType,
 		ActorID:   a.actorID,
-		DueTime:   dueTime.Format(time.RFC3339),
+		DueTime:   dueTime.Format(time.RFC3339Nano),
 		Name:      reminderName,
 		// One shot, retry forever, every second.
 		FailurePolicy: &commonv1pb.JobFailurePolicy{

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -42,7 +42,7 @@ func (o *orchestrator) createWorkflowReminder(ctx context.Context, namePrefix st
 // scheduler failure converges on a single retention reminder rather than
 // accumulating duplicates.
 func (o *orchestrator) createRetentionReminder(ctx context.Context, name string, start time.Time) (string, error) {
-	dueTime := start.UTC().Format(time.RFC3339)
+	dueTime := start.UTC().Format(time.RFC3339Nano)
 
 	return name, common.CreateReminderWithRetry(ctx, o.reminders, &actorapi.CreateReminderRequest{
 		ActorType: o.retentionActorType,
@@ -68,7 +68,7 @@ func (o *orchestrator) createReminderWithType(ctx context.Context, namePrefix st
 		return "", fmt.Errorf("failed to generate reminder ID: %w", err)
 	}
 
-	dueTime := start.UTC().Format(time.RFC3339)
+	dueTime := start.UTC().Format(time.RFC3339Nano)
 	reminderName := namePrefix + "-" + base64.RawURLEncoding.EncodeToString(b)
 
 	var adata *anypb.Any

--- a/pkg/actors/targets/workflow/orchestrator/timer.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer.go
@@ -91,7 +91,7 @@ func (o *orchestrator) createTimer(ctx context.Context, e *backend.HistoryEvent,
 
 func (o *orchestrator) createTimerReminder(ctx context.Context, name string, data proto.Message, start time.Time) error {
 	actorType := o.actorTypeBuilder.Workflow(o.appID)
-	dueTime := start.UTC().Format(time.RFC3339)
+	dueTime := start.UTC().Format(time.RFC3339Nano)
 
 	adata, err := anypb.New(data)
 	if err != nil {

--- a/pkg/actors/timers/timers.go
+++ b/pkg/actors/timers/timers.go
@@ -54,7 +54,7 @@ func (t *timers) Create(ctx context.Context, req *api.CreateTimerRequest) error 
 		return fmt.Errorf("can't create timer for actor %s: actor type not registered", req.ActorKey())
 	}
 
-	reminder, err := req.NewReminder(t.clock.Now(), false)
+	reminder, err := req.NewReminder(t.clock.Now())
 	if err != nil {
 		return err
 	}

--- a/pkg/api/universal/actors.go
+++ b/pkg/api/universal/actors.go
@@ -247,7 +247,7 @@ func (a *Universal) GetActorReminder(ctx context.Context, in *runtimev1pb.GetAct
 		period = new(resp.Period.String())
 	}
 	if !resp.ExpirationTime.IsZero() {
-		ttl = new(resp.ExpirationTime.Format(time.RFC3339))
+		ttl = new(resp.ExpirationTime.Format(time.RFC3339Nano))
 	}
 
 	return &runtimev1pb.GetActorReminderResponse{

--- a/tests/integration/suite/actors/reminders/subsecond.go
+++ b/tests/integration/suite/actors/reminders/subsecond.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(subsecond))
+}
+
+// subsecond guards the regression in which actor reminders fired ahead of
+// their requested duration because RegisteredTime was serialized with
+// whole-second precision and truncated to the prior whole second on read.
+type subsecond struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+
+	firedAt atomic.Int64
+}
+
+func (s *subsecond) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"entities": ["myactortype"]}`))
+	})
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler.HandleFunc("/actors/myactortype/myactorid", func(w http.ResponseWriter, r *http.Request) {})
+	handler.HandleFunc("/actors/myactortype/myactorid/method/remind/subsecond", func(w http.ResponseWriter, r *http.Request) {
+		// Record the first fire only; ignore late repeats.
+		s.firedAt.CompareAndSwap(0, time.Now().UnixNano())
+	})
+	handler.HandleFunc("/actors/myactortype/myactorid/method/foo", func(w http.ResponseWriter, r *http.Request) {})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	s.scheduler = procscheduler.New(t)
+	s.place = placement.New(t)
+	s.daprd = daprd.New(t,
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(s.place.Address()),
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithSchedulerAddresses(s.scheduler.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.scheduler, s.place, srv, s.daprd),
+	}
+}
+
+func (s *subsecond) Run(t *testing.T, ctx context.Context) {
+	s.scheduler.WaitUntilRunning(t, ctx)
+	s.place.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	daprdURL := "http://localhost:" + strconv.Itoa(s.daprd.HTTPPort()) + "/v1.0/actors/myactortype/myactorid"
+
+	// Wait until the actor host is ready to receive invocations.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, daprdURL+"/method/foo", nil)
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, rErr := httpClient.Do(req)
+		if assert.NoError(c, rErr) {
+			assert.NoError(c, resp.Body.Close())
+			assert.Equal(c, http.StatusOK, resp.StatusCode)
+		}
+	}, 10*time.Second, 10*time.Millisecond, "actor not ready in time")
+
+	//nolint:staticcheck
+	conn, err := grpc.DialContext(ctx, s.daprd.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	gclient := rtv1.NewDaprClient(conn)
+
+	const requested = 2 * time.Second
+
+	registeredAt := time.Now()
+	_, err = gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+		ActorType: "myactortype",
+		ActorId:   "myactorid",
+		Name:      "subsecond",
+		DueTime:   requested.String(),
+	})
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotZero(c, s.firedAt.Load(), "reminder did not fire")
+	}, requested+5*time.Second, 10*time.Millisecond)
+
+	elapsed := time.Unix(0, s.firedAt.Load()).Sub(registeredAt)
+
+	// The reminder must never fire before its requested due time. Prior
+	// to sub-second precision support, this assertion failed by up to
+	// ~1s because RegisteredTime was truncated to the previous whole
+	// second on the daprd side before being sent to the scheduler.
+	assert.GreaterOrEqual(t, elapsed, requested,
+		"reminder fired early: elapsed=%s, requested=%s", elapsed, requested)
+}

--- a/tests/integration/suite/daprd/workflow/timer/subsecond.go
+++ b/tests/integration/suite/daprd/workflow/timer/subsecond.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package timer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(subsecond))
+}
+
+// subsecond guards the regression in which short workflow timers fired
+// ahead of their requested duration because reminder timestamps were
+// serialized with whole-second precision and registration time was
+// truncated to the prior whole second.
+type subsecond struct {
+	workflow *workflow.Workflow
+}
+
+func (s *subsecond) Setup(t *testing.T) []framework.Option {
+	s.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *subsecond) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	const requested = 2 * time.Second
+
+	s.workflow.Registry().AddWorkflowN("subsecond-timer", func(wctx *task.WorkflowContext) (any, error) {
+		return nil, wctx.CreateTimer(requested).Await(nil)
+	})
+
+	client := s.workflow.BackendClient(t, ctx)
+
+	start := time.Now()
+	id, err := client.ScheduleNewWorkflow(ctx, "subsecond-timer", api.WithInstanceID("subsecond-timer"))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	// The timer must never fire before the requested duration. Prior to
+	// sub-second precision support, this assertion failed by up to ~1s
+	// because RegisteredTime was truncated to the previous whole second.
+	assert.GreaterOrEqual(t, elapsed, requested,
+		"workflow timer fired early: elapsed=%s, requested=%s", elapsed, requested)
+}


### PR DESCRIPTION
### Problem

Reminder and timer due/expiration times were serialized with `time.RFC3339` (whole-second resolution) and explicitly `Truncate(time.Second)`'d after parsing. This rounded the registered time down to the prior whole-second boundary, so short timers fired earlier than requested.

Concretely, a workflow timer registered at wall-clock `t = 10.8s` with a 3-second duration was stored as `t = 13.0s` instead of `t = 13.8s`, firing after only `2.2s`.

### Solution

Switch the reminder pipeline to `time.RFC3339Nano` (parse, format, and `String()`) and drop the explicit second-level truncation in `Reminder` / `ReminderTrack` JSON unmarshalling and in the duration-string parser. Backwards-compatible on the wire: `RFC3339Nano` accepts both fractional and non-fractional input, and emits plain RFC3339 when nanos are zero, so existing stored values keep working. The upstream cron scheduler already accepts fractional seconds via Go's lenient `time.Parse`, so no upstream change is needed.

### Example

```go
func TestWorkflow(ctx *workflow.WorkflowContext) (any, error) {
    return nil, ctx.CreateTimer(3 * time.Second).Await(nil)
}
```

|        | Measured duration                       |
| ------ | --------------------------------------- |
| Before | `2.1s` – `3.0s` (early by up to ~900ms) |
| After  | always ≥ `3.0s` (e.g. `3.018s`)         |
