### PR TITLE
workflow: stop losing scheduler reminders under chaos

### DIFF
--- a/pkg/actors/targets/workflow/activity/activity.go
+++ b/pkg/actors/targets/workflow/activity/activity.go
@@ -71,7 +71,6 @@ func (a *activity) InvokeTimer(ctx context.Context, reminder *actorapi.Reminder)
 // DeactivateActor implements actors.InternalActor
 func (a *activity) Deactivate(context.Context) error {
 	a.table.Delete(a.actorID)
-	activityCache.Put(a)
 	return nil
 }
 

--- a/pkg/actors/targets/workflow/activity/factory.go
+++ b/pkg/actors/targets/workflow/activity/factory.go
@@ -33,12 +33,10 @@ import (
 	"github.com/dapr/kit/crypto/spiffe/signer"
 )
 
-var activityCache = &sync.Pool{
-	New: func() any {
-		return &activity{
-			lock: lock.New(),
-		}
-	},
+func newActivity() *activity {
+	return &activity{
+		lock: lock.New(),
+	}
 }
 
 type Options struct {
@@ -138,24 +136,13 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 func (f *factory) GetOrCreate(actorID string) targets.Interface {
 	a, ok := f.table.Load(actorID)
 	if !ok {
-		newActivity := f.initActivity(activityCache.Get(), actorID)
-		var loaded bool
-		a, loaded = f.table.LoadOrStore(actorID, newActivity)
-		if loaded {
-			activityCache.Put(newActivity)
-		}
+		fresh := newActivity()
+		fresh.factory = f
+		fresh.actorID = actorID
+		a, _ = f.table.LoadOrStore(actorID, fresh)
 	}
 
 	return a.(*activity)
-}
-
-func (f *factory) initActivity(a any, actorID string) *activity {
-	act := a.(*activity)
-
-	act.factory = f
-	act.actorID = actorID
-
-	return act
 }
 
 func (f *factory) HaltAll(ctx context.Context) error {

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -107,7 +107,6 @@ func (e *executor) Deactivate(_ context.Context) error {
 	close(e.closeCh)
 	e.table.Delete(e.actorID)
 	e.wg.Wait()
-	executorCache.Put(e)
 	return nil
 }
 

--- a/pkg/actors/targets/workflow/executor/factory.go
+++ b/pkg/actors/targets/workflow/executor/factory.go
@@ -25,12 +25,10 @@ import (
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 )
 
-var executorCache = &sync.Pool{
-	New: func() any {
-		return &executor{
-			lock: lock.New(),
-		}
-	},
+func newExecutor() *executor {
+	return &executor{
+		lock: lock.New(),
+	}
 }
 
 type Options struct {
@@ -72,12 +70,8 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 func (f *factory) GetOrCreate(actorID string) targets.Interface {
 	a, ok := f.table.Load(actorID)
 	if !ok {
-		newActivity := f.initExecutor(executorCache.Get(), actorID)
-		var loaded bool
-		a, loaded = f.table.LoadOrStore(actorID, newActivity)
-		if loaded {
-			executorCache.Put(newActivity)
-		}
+		fresh := f.initExecutor(newExecutor(), actorID)
+		a, _ = f.table.LoadOrStore(actorID, fresh)
 	}
 
 	return a.(*executor)

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -36,12 +36,10 @@ import (
 	"github.com/dapr/kit/crypto/spiffe/signer"
 )
 
-var orchestratorCache = sync.Pool{
-	New: func() any {
-		return &orchestrator{
-			lock: lock.NewStallable(),
-		}
-	},
+func newOrchestrator() *orchestrator {
+	return &orchestrator{
+		lock: lock.NewStallable(),
+	}
 }
 
 type Options struct {
@@ -151,12 +149,8 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 func (f *factory) GetOrCreate(actorID string) targets.Interface {
 	o, ok := f.table.Load(actorID)
 	if !ok {
-		newO := f.initOrchestrator(orchestratorCache.Get(), actorID)
-		var loaded bool
-		o, loaded = f.table.LoadOrStore(actorID, newO)
-		if loaded {
-			orchestratorCache.Put(newO)
-		}
+		fresh := f.initOrchestrator(newOrchestrator(), actorID)
+		o, _ = f.table.LoadOrStore(actorID, fresh)
 	}
 
 	return o.(*orchestrator)

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -129,7 +129,6 @@ func (o *orchestrator) Deactivate(ctx context.Context) error {
 	clear(o.streamFns)
 	o.signing.Reset()
 	o.wg.Wait()
-	orchestratorCache.Put(o)
 
 	return nil
 }

--- a/pkg/actors/targets/workflow/retentioner/factory.go
+++ b/pkg/actors/targets/workflow/retentioner/factory.go
@@ -15,7 +15,6 @@ package retentioner
 
 import (
 	"context"
-	"sync"
 
 	"github.com/dapr/dapr/pkg/actors"
 	"github.com/dapr/dapr/pkg/actors/api"
@@ -24,12 +23,10 @@ import (
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common/lock"
 )
 
-var retentionerCache = &sync.Pool{
-	New: func() any {
-		return &retentioner{
-			lock: lock.New(),
-		}
-	},
+func newRetentioner() *retentioner {
+	return &retentioner{
+		lock: lock.New(),
+	}
 }
 
 type Options struct {
@@ -59,7 +56,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 }
 
 func (f *factory) GetOrCreate(actorID string) targets.Interface {
-	r := retentionerCache.Get().(*retentioner)
+	r := newRetentioner()
 	r.factory = f
 	r.actorID = actorID
 	return r

--- a/pkg/actors/targets/workflow/retentioner/retentioner.go
+++ b/pkg/actors/targets/workflow/retentioner/retentioner.go
@@ -76,7 +76,6 @@ func (r *retentioner) InvokeTimer(ctx context.Context, reminder *actorapi.Remind
 }
 
 func (r *retentioner) Deactivate(context.Context) error {
-	retentionerCache.Put(r)
 	return nil
 }
 

--- a/pkg/runtime/scheduler/internal/cluster/streamer.go
+++ b/pkg/runtime/scheduler/internal/cluster/streamer.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	workflowacl "github.com/dapr/dapr/pkg/acl/workflow"
 	"github.com/dapr/dapr/pkg/actors/api"
 	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
 	"github.com/dapr/dapr/pkg/actors/router"
@@ -134,6 +135,8 @@ func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsRe
 		return schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS
 
 	case *schedulerv1pb.JobTargetMetadata_Actor:
+		actorType := meta.GetTarget().GetActor().GetType()
+
 		err := s.invokeActorReminder(ctx, job)
 		if err == nil {
 			return schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS
@@ -150,13 +153,20 @@ func (s *streamer) handleJob(ctx context.Context, job *schedulerv1pb.WatchJobsRe
 		}
 
 		// If the actor was hosted on another instance, the error will be a gRPC status error,
-		// so we need to unwrap it and match on the error message
+		// so we need to unwrap it and match on the error message.
 		if st, ok := status.FromError(err); ok {
 			if st.Code() == codes.FailedPrecondition {
 				return schedulerv1pb.WatchJobsRequestResultStatus_FAILED
 			}
 
-			if st.Message() == actorerrors.ErrReminderCanceled.Error() {
+			// Recognise the user-app "cancel this reminder" signal that crossed a
+			// daprd-to-daprd boundary: app.go raises ErrReminderCanceled when the
+			// app responded with the X-Daprremindercancel header, and gRPC strips
+			// the sentinel wrapping so we only see the message text on this side.
+			// Map it to SUCCESS so the scheduler deletes the recurring job rather
+			// than retrying forever.
+			_, isInternalActor := workflowacl.ParseActorType(actorType)
+			if !isInternalActor && st.Message() == actorerrors.ErrReminderCanceled.Error() {
 				return schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS
 			}
 		}

--- a/pkg/runtime/scheduler/internal/cluster/streamer_test.go
+++ b/pkg/runtime/scheduler/internal/cluster/streamer_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
+	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	wfenginefake "github.com/dapr/dapr/pkg/runtime/wfengine/fake"
+)
+
+func Test_handleJob_ErrReminderCanceled_remoteGRPC(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workflowActorType = "dapr.internal.default.myapp.workflow"
+		activityActorType = "dapr.internal.default.myapp.activity"
+		userActorType     = "myactortype"
+	)
+
+	cases := map[string]struct {
+		actorType string
+		want      schedulerv1pb.WatchJobsRequestResultStatus
+	}{
+		"user actor with ErrReminderCanceled message: SUCCESS (delete)": {
+			actorType: userActorType,
+			want:      schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS,
+		},
+		"internal workflow actor with ErrReminderCanceled message: FAILED (retry)": {
+			actorType: workflowActorType,
+			want:      schedulerv1pb.WatchJobsRequestResultStatus_FAILED,
+		},
+		"internal activity actor with ErrReminderCanceled message: FAILED (retry)": {
+			actorType: activityActorType,
+			want:      schedulerv1pb.WatchJobsRequestResultStatus_FAILED,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actors := routerfake.New().WithCallReminderFn(
+				func(context.Context, *actorapi.Reminder) error {
+					return status.Error(codes.Unknown, actorerrors.ErrReminderCanceled.Error())
+				},
+			)
+
+			s := &streamer{
+				actors:   actors,
+				wfengine: wfenginefake.New(),
+			}
+
+			job := &schedulerv1pb.WatchJobsResponse{
+				Name: "test-job",
+				Metadata: &schedulerv1pb.JobMetadata{
+					Target: &schedulerv1pb.JobTargetMetadata{
+						Type: &schedulerv1pb.JobTargetMetadata_Actor{
+							Actor: &schedulerv1pb.TargetActorReminder{
+								Type: tc.actorType,
+								Id:   "instance-1",
+							},
+						},
+					},
+				},
+			}
+
+			got := s.handleJob(t.Context(), job)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_handleJob_ErrReminderCanceled_localSentinel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		actorType string
+	}{
+		"user actor":              {actorType: "myactortype"},
+		"internal workflow actor": {actorType: "dapr.internal.default.myapp.workflow"},
+		"internal activity actor": {actorType: "dapr.internal.default.myapp.activity"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actors := routerfake.New().WithCallReminderFn(
+				func(context.Context, *actorapi.Reminder) error {
+					return actorerrors.ErrReminderCanceled
+				},
+			)
+
+			s := &streamer{
+				actors:   actors,
+				wfengine: wfenginefake.New(),
+			}
+
+			job := &schedulerv1pb.WatchJobsResponse{
+				Name: "test-job",
+				Metadata: &schedulerv1pb.JobMetadata{
+					Target: &schedulerv1pb.JobTargetMetadata{
+						Type: &schedulerv1pb.JobTargetMetadata_Actor{
+							Actor: &schedulerv1pb.TargetActorReminder{
+								Type: tc.actorType,
+								Id:   "instance-1",
+							},
+						},
+					},
+				},
+			}
+
+			got := s.handleJob(t.Context(), job)
+			assert.Equal(t, schedulerv1pb.WatchJobsRequestResultStatus_SUCCESS, got)
+		})
+	}
+}


### PR DESCRIPTION
Two paths silently dropped one-shot reminders, leaving workflows stuck forever:

1. The activity, orchestrator, executor and retentioner factories recycled actor targets via sync.Pool. Under placement re-balance Deactivate could return an *activity to the pool while a router dispatch was still holding a pointer to it; the next GetOrCreate overwrote the actorID, so the in-flight invocation ran against the wrong workflow and the right workflow's reminder was acked SUCCESS without ever executing. Always allocate fresh.

2. The streamer mapped any remote gRPC error whose message text matched ErrReminderCanceled to SUCCESS, but only the user-app X-Daprremindercancel header raises that sentinel; internal workflow and activity actors never do. A remote error whose text happened to match could silently delete a one-shot reminder that never ran. Restrict the mapping to non-internal actors.