### PR TITLE
[1.17] scheduler: reconnect on WatchHosts first-Recv error instead of tearing down daprd

### DIFF
--- a/docs/release_notes/v1.17.7.md
+++ b/docs/release_notes/v1.17.7.md
@@ -14,6 +14,7 @@ This update contains the following bug fixes:
 - [No observability for workflow payload proximity to the gRPC max body size before stalling](#no-observability-for-workflow-payload-proximity-to-the-grpc-max-body-size-before-stalling)
 - [Scheduler stops delivering job triggers after periodic etcd compaction under workflow load](#scheduler-stops-delivering-job-triggers-after-periodic-etcd-compaction-under-workflow-load)
 - [Workflows freeze in RUNNING after placement rebalance](#workflows-freeze-in-running-after-placement-rebalance)
+- [daprd shuts down and stays unready after a brief scheduler outage](#daprd-shuts-down-and-stays-unready-after-a-brief-scheduler-outage)
 
 ## Workflow GetWorkItems gRPC stream torn down when the history payload exceeds the max body size
 
@@ -483,3 +484,39 @@ Workflow state saves now use optimistic concurrency on a single version anchor: 
 - When a save returns `ETagMismatch`, the orchestrator invalidates its cached state and surfaces the error as recoverable.
   The existing reminder-retry path re-fires the operation, the next load reads fresh state with the new ETag, and the retry succeeds against the up-to-date base state.
 - After a successful save, the orchestrator refreshes the metadata ETag via a single-key Get so the next save has the correct token without paying for a full state reload.
+
+## daprd shuts down and stays unready after a brief scheduler outage
+
+### Problem
+
+When the scheduler control plane was unreachable at the moment daprd opened (or re-opened) its `WatchHosts` stream, the first response from the scheduler could be a gRPC error code such as `Unavailable`, `Internal`, or a server-side `Canceled` rather than a hosts list.
+The runtime's `WatchHosts` loop returned that error directly instead of treating it as a transient peer issue, so the failure propagated up the runtime's top-level `RunnerCloserManager`.
+Because that manager treats any runner exit as terminal for the whole process, daprd then tore down the actor runtime, the workflow backend, and the gRPC servers.
+
+If a closer on that path was waiting on a control-plane peer that was also still unreachable (placement, the state store, an actor halt), the shutdown did not complete cleanly.
+daprd stayed in the process table with its readiness probe failing on `dapr is not ready: [grpc-internal-server grpc-api-server]`, but never exited cleanly enough for Kubernetes to restart it on its own.
+
+### Impact
+
+Any deployment whose scheduler pods can experience a brief outage at the same time daprd happens to re-open its `WatchHosts` stream was affected.
+This was most visible during routine operations that disrupt the scheduler and placement control planes simultaneously, including rolling control-plane updates, node drains, OOM-driven control-plane restarts, and transient daprd-control-plane network instability.
+
+Visible symptoms included:
+
+- daprd logging `Actor runtime shutting down`, `Placement client shutting down`, and `Dapr is shutting down` shortly after the control plane became reachable again, despite no SIGTERM or explicit shutdown trigger from the operator.
+- Sidecar readiness probes failing with `dapr is not ready: [grpc-internal-server grpc-api-server]` and not recovering.
+
+### Root Cause
+
+`pkg/runtime/scheduler/internal/watchhosts/watchhosts.go` only recognised two gRPC status codes from the first `Recv()` on a freshly opened `WatchHosts` stream: `Unimplemented` (the old-server compatibility path) and `Canceled` (which it interpreted as the daprd-side context being cancelled).
+Every other code returned from the function.
+
+`Scheduler.Run` wrapped that loop in a plain `RunnerManager`, so the error reached the runtime's top-level `RunnerCloserManager` unmodified.
+The top-level manager treats any runner exit as terminal: every sibling runner was cancelled (`actors.Run`, `wfengine.Run`, `jobsManager.Run`, both gRPC servers), and the closer chain ran before the control plane finished stabilising.
+If the state store, placement loop, or actor table closers blocked waiting on a peer that was also still unreachable, the process stalled with its servers already torn down.
+
+### Solution
+
+`WatchHosts.Run` now treats any non-`Unimplemented` error from the first `Recv()` as a transient peer issue.
+The connection is closed and the loop reconnects after a one second pause, matching the existing behaviour for errors observed on the long-lived second `Recv()`.
+The loop only returns when daprd's own context is cancelled (real shutdown), so a brief scheduler outage no longer cascades into a runtime tear-down.

--- a/pkg/runtime/scheduler/internal/watchhosts/watchhosts.go
+++ b/pkg/runtime/scheduler/internal/watchhosts/watchhosts.go
@@ -86,9 +86,7 @@ func (w *WatchHosts) Run(ctx context.Context) error {
 		}
 
 		resp, err := stream.Recv()
-		code := status.Code(err)
-		switch code {
-		case codes.Unimplemented:
+		if status.Code(err) == codes.Unimplemented {
 			if err = w.clients.Reload(ctx, w.allAddrs); err != nil {
 				return err
 			}
@@ -102,14 +100,20 @@ func (w *WatchHosts) Run(ctx context.Context) error {
 			w.htarget.Ready()
 			<-ctx.Done()
 			return nil
-
-		case codes.Canceled:
-			return nil
 		}
 
 		if err != nil {
 			closeCon()
-			return err
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Warnf("Scheduler WatchHosts stream error, reconnecting: %s", err)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+				continue
+			}
 		}
 
 		gotAddrs := make([]string, 0, len(resp.GetHosts()))

--- a/tests/integration/framework/process/scheduler/proxy/proxy.go
+++ b/tests/integration/framework/process/scheduler/proxy/proxy.go
@@ -43,6 +43,7 @@ const (
 	MethodListJobs           = "ListJobs"
 	MethodDeleteByMetadata   = "DeleteByMetadata"
 	MethodDeleteByNamePrefix = "DeleteByNamePrefix"
+	MethodWatchHosts         = "WatchHosts"
 )
 
 type Proxy struct {
@@ -292,6 +293,10 @@ func (p *Proxy) WatchJobs(stream schedulerv1pb.Scheduler_WatchJobsServer) error 
 // real scheduler on every refresh. Without this rewrite daprd would bypass
 // the proxy as soon as the first host list arrived.
 func (p *Proxy) WatchHosts(req *schedulerv1pb.WatchHostsRequest, stream schedulerv1pb.Scheduler_WatchHostsServer) error {
+	if code, ok := p.takeFailure(MethodWatchHosts); ok {
+		return injected(MethodWatchHosts, code)
+	}
+
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 

--- a/tests/integration/suite/daprd/scheduler/watchhostsrecover.go
+++ b/tests/integration/suite/daprd/scheduler/watchhostsrecover.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(watchhostsrecover))
+}
+
+type watchhostsrecover struct {
+	daprd     *daprd.Daprd
+	scheduler *scheduler.Scheduler
+	proxy     *proxy.Proxy
+}
+
+func (w *watchhostsrecover) Setup(t *testing.T) []framework.Option {
+	w.scheduler = scheduler.New(t)
+	w.proxy = proxy.New(t, w.scheduler)
+
+	w.proxy.ArmFailures(proxy.MethodWatchHosts, 1, codes.Unavailable, nil)
+
+	w.daprd = daprd.New(t,
+		daprd.WithSchedulerAddresses(w.proxy.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(w.scheduler, w.proxy, w.daprd),
+	}
+}
+
+func (w *watchhostsrecover) Run(t *testing.T, ctx context.Context) {
+	w.daprd.WaitUntilRunning(t, ctx)
+
+	require.GreaterOrEqual(t, w.proxy.FailedCount(), 1,
+		"expected the injected WatchHosts failure to have fired at least once")
+
+	gclient := w.daprd.GRPCClient(t, ctx)
+	_, err := gclient.ScheduleJobAlpha1(ctx, &rtv1.ScheduleJobRequest{
+		Job: &rtv1.Job{
+			Name:     "watchhostsrecover-job",
+			Schedule: ptr.Of("@every 1s"),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, gerr := gclient.GetJobAlpha1(ctx, &rtv1.GetJobRequest{
+			Name: "watchhostsrecover-job",
+		})
+		assert.NoError(c, gerr)
+	}, 10*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
When the scheduler control plane is briefly unreachable at the moment daprd opens or re-opens its WatchHosts stream, the first Recv() can return a non-Canceled, non-Unimplemented status code (Unavailable, Internal, server-side Canceled, etc.). The runtime's WatchHosts loop returned that error directly, so it propagated up Scheduler.Run into the top-level RunnerCloserManager, which treats any runner exit as terminal and cancelled every sibling: the actor runtime, the workflow backend, both gRPC servers.

Now, always reconnect the stream to prevent going into zombie unready state.