### PR TITLE
tests: wait for workflow actor registration

### DIFF
--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -263,6 +263,41 @@ func (d *Daprd) WaitUntilRunning(t *testing.T, ctx context.Context) {
 	}, 30*time.Second, 10*time.Millisecond)
 }
 
+func (d *Daprd) WaitUntilActorTypesHosted(t *testing.T, ctx context.Context, actorTypes ...string) {
+	t.Helper()
+	require.NotEmpty(t, actorTypes)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		md := d.GetMetadata(c, ctx)
+		if !assert.NotNil(c, md) {
+			return
+		}
+		assert.Truef(c, actorRuntimeHostsTypes(md.ActorRuntime, actorTypes...),
+			"actor runtime did not host actor types %v", actorTypes)
+	}, 60*time.Second, 10*time.Millisecond)
+}
+
+func actorRuntimeHostsTypes(actorRuntime *MetadataActorRuntime, actorTypes ...string) bool {
+	if actorRuntime == nil || actorRuntime.RuntimeStatus != rtv1.ActorRuntime_RUNNING.String() || !actorRuntime.HostReady {
+		return false
+	}
+
+	hosted := make(map[string]struct{}, len(actorRuntime.ActiveActors))
+	for _, active := range actorRuntime.ActiveActors {
+		if active != nil {
+			hosted[active.Type] = struct{}{}
+		}
+	}
+
+	for _, actorType := range actorTypes {
+		if _, ok := hosted[actorType]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (d *Daprd) WaitUntilAppHealth(t *testing.T, ctx context.Context) {
 	switch d.appProtocol {
 	case "http":

--- a/tests/integration/framework/process/daprd/daprd_test.go
+++ b/tests/integration/framework/process/daprd/daprd_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daprd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+)
+
+func TestActorRuntimeHostsTypes(t *testing.T) {
+	tests := map[string]struct {
+		actorRuntime *MetadataActorRuntime
+		actorTypes   []string
+		exp          bool
+	}{
+		"nil runtime": {
+			actorTypes: []string{"workflow"},
+		},
+		"not ready": {
+			actorRuntime: &MetadataActorRuntime{
+				RuntimeStatus: rtv1.ActorRuntime_RUNNING.String(),
+				HostReady:     false,
+				ActiveActors: []*MetadataActorRuntimeActiveActor{
+					{Type: "workflow"},
+				},
+			},
+			actorTypes: []string{"workflow"},
+		},
+		"missing actor type": {
+			actorRuntime: &MetadataActorRuntime{
+				RuntimeStatus: rtv1.ActorRuntime_RUNNING.String(),
+				HostReady:     true,
+				ActiveActors: []*MetadataActorRuntimeActiveActor{
+					{Type: "workflow"},
+				},
+			},
+			actorTypes: []string{"workflow", "activity"},
+		},
+		"all actor types hosted": {
+			actorRuntime: &MetadataActorRuntime{
+				RuntimeStatus: rtv1.ActorRuntime_RUNNING.String(),
+				HostReady:     true,
+				ActiveActors: []*MetadataActorRuntimeActiveActor{
+					{Type: "activity"},
+					{Type: "workflow"},
+				},
+			},
+			actorTypes: []string{"workflow", "activity"},
+			exp:        true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.exp, actorRuntimeHostsTypes(tc.actorRuntime, tc.actorTypes...))
+		})
+	}
+}

--- a/tests/integration/framework/process/daprd/daprd_test.go
+++ b/tests/integration/framework/process/daprd/daprd_test.go
@@ -40,6 +40,16 @@ func TestActorRuntimeHostsTypes(t *testing.T) {
 			},
 			actorTypes: []string{"workflow"},
 		},
+		"host ready but runtime not running": {
+			actorRuntime: &MetadataActorRuntime{
+				RuntimeStatus: rtv1.ActorRuntime_INITIALIZING.String(),
+				HostReady:     true,
+				ActiveActors: []*MetadataActorRuntimeActiveActor{
+					{Type: "workflow"},
+				},
+			},
+			actorTypes: []string{"workflow"},
+		},
 		"missing actor type": {
 			actorRuntime: &MetadataActorRuntime{
 				RuntimeStatus: rtv1.ActorRuntime_RUNNING.String(),

--- a/tests/integration/framework/process/daprd/daprd_test.go
+++ b/tests/integration/framework/process/daprd/daprd_test.go
@@ -45,10 +45,11 @@ func TestActorRuntimeHostsTypes(t *testing.T) {
 				RuntimeStatus: rtv1.ActorRuntime_INITIALIZING.String(),
 				HostReady:     true,
 				ActiveActors: []*MetadataActorRuntimeActiveActor{
+					{Type: "activity"},
 					{Type: "workflow"},
 				},
 			},
-			actorTypes: []string{"workflow"},
+			actorTypes: []string{"workflow", "activity"},
 		},
 		"missing actor type": {
 			actorRuntime: &MetadataActorRuntime{

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -15,6 +15,7 @@ package signing
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,6 +121,7 @@ func (s *signatureStripped) scheduleAndComplete(t *testing.T, ctx context.Contex
 	})
 	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
 	require.NoError(t, client.StartWorker(ctx, reg))
+	s.waitForWorkflowActorHosted(t, ctx)
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-stripped")
 	require.NoError(t, err)
@@ -137,7 +139,15 @@ func (s *signatureStripped) assertLoadFails(t *testing.T, ctx context.Context, i
 
 	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
 	require.NoError(t, client.StartWorker(ctx, dworkflow.NewRegistry()))
+	s.waitForWorkflowActorHosted(t, ctx)
 
 	_, err := client.FetchWorkflowMetadata(ctx, id)
 	require.Error(t, err)
+}
+
+func (s *signatureStripped) waitForWorkflowActorHosted(t *testing.T, ctx context.Context) {
+	t.Helper()
+	s.daprd.WaitUntilActorTypesHosted(t, ctx,
+		fmt.Sprintf("dapr.internal.%s.%s.workflow", s.daprd.Namespace(), s.daprd.AppID()),
+	)
 }


### PR DESCRIPTION
## Summary

Fixes #9927.

This updates the flaky `workflow/signing/signatureStripped` integration test to wait until the workflow actor type is actually hosted after `daprd` restart and SDK worker startup.

`WaitUntilRunning` only waits for `/v1.0/healthz`, but workflow actor registration can still be propagating. If `ScheduleWorkflow` runs during that window, workflow reminder setup can fail with:

`operations on actor reminders are only possible on hosted actor types`

## Changes

- Added `Daprd.WaitUntilActorTypesHosted` to poll metadata until the actor runtime is running, host-ready, and includes the expected actor type.
- Updated `signatureStripped` to wait for the workflow actor type after `StartWorker`.
- Added unit coverage for the actor-runtime hosted-type readiness predicate.

## Testing

- `go test ./tests/integration/framework/process/daprd -count=1`
- `go test -tags integration ./tests/integration -run Test_Integration -count=1 -timeout 30m -args -focus signatureStripped -integration-parallel=false`