### PR TITLE
Actors: gate Register/UnRegisterHosted on runtime init

### DIFF
--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -98,8 +98,8 @@ type Interface interface {
 	Reminders(context.Context) (reminders.Interface, error)
 	Placement(context.Context) (placement.Interface, error)
 	RuntimeStatus() *runtimev1pb.ActorRuntime
-	RegisterHosted(hostconfig.Config) error
-	UnRegisterHosted(actorTypes ...string)
+	RegisterHosted(context.Context, hostconfig.Config) error
+	UnRegisterHosted(ctx context.Context, actorTypes ...string) error
 	WaitForRegisteredHosts(ctx context.Context) error
 }
 
@@ -376,7 +376,7 @@ func (a *actors) waitForReady(ctx context.Context) error {
 	}
 }
 
-func (a *actors) RegisterHosted(cfg hostconfig.Config) error {
+func (a *actors) RegisterHosted(ctx context.Context, cfg hostconfig.Config) error {
 	defer func() {
 		a.registerDoneLock.Lock()
 		select {
@@ -387,7 +387,19 @@ func (a *actors) RegisterHosted(cfg hostconfig.Config) error {
 		a.registerDoneLock.Unlock()
 	}()
 
-	if err := a.disabled.Load(); err != nil {
+	if a.disabled.Load() != nil {
+		return nil
+	}
+
+	// Wait until Init has populated a.table. The API gRPC server starts
+	// before initActors runs (see pkg/runtime/runtime.go), so callers
+	// arriving via SubscribeActorEventsAlpha1 can otherwise race ahead of
+	// Init and dereference a nil table.
+	if err := a.waitForReady(ctx); err != nil {
+		return err
+	}
+
+	if a.disabled.Load() != nil {
 		return nil
 	}
 
@@ -486,13 +498,21 @@ func (a *actors) RegisterHosted(cfg hostconfig.Config) error {
 	return nil
 }
 
-func (a *actors) UnRegisterHosted(actorTypes ...string) {
-	if a.disabled.Load() != nil {
-		return
+func (a *actors) UnRegisterHosted(ctx context.Context, actorTypes ...string) error {
+	if len(actorTypes) == 0 {
+		return nil
 	}
 
-	if len(actorTypes) == 0 {
-		return
+	if a.disabled.Load() != nil {
+		return nil
+	}
+
+	if err := a.waitForReady(ctx); err != nil {
+		return err
+	}
+
+	if a.disabled.Load() != nil {
+		return nil
 	}
 
 	a.table.UnRegisterActorTypes(actorTypes...)
@@ -500,6 +520,8 @@ func (a *actors) UnRegisterHosted(actorTypes ...string) {
 	a.registerDoneLock.Lock()
 	a.registerDoneCh = make(chan struct{})
 	a.registerDoneLock.Unlock()
+
+	return nil
 }
 
 func (a *actors) WaitForRegisteredHosts(ctx context.Context) error {

--- a/pkg/actors/fake/fake.go
+++ b/pkg/actors/fake/fake.go
@@ -41,8 +41,8 @@ type Fake struct {
 	fnReminders              func(context.Context) (reminders.Interface, error)
 	fnPlacement              func(context.Context) (placement.Interface, error)
 	fnRuntimeStatus          func() *runtimev1pb.ActorRuntime
-	fnRegisterHosted         func(hostconfig.Config) error
-	fnUnRegisterHosted       func(actorTypes ...string)
+	fnRegisterHosted         func(context.Context, hostconfig.Config) error
+	fnUnRegisterHosted       func(ctx context.Context, actorTypes ...string) error
 	fnWaitForRegisteredHosts func(ctx context.Context) error
 }
 
@@ -75,10 +75,12 @@ func New() *Fake {
 		fnRuntimeStatus: func() *runtimev1pb.ActorRuntime {
 			return nil
 		},
-		fnRegisterHosted: func(hostconfig.Config) error {
+		fnRegisterHosted: func(context.Context, hostconfig.Config) error {
 			return nil
 		},
-		fnUnRegisterHosted: func(...string) {},
+		fnUnRegisterHosted: func(context.Context, ...string) error {
+			return nil
+		},
 		fnWaitForRegisteredHosts: func(context.Context) error {
 			return nil
 		},
@@ -130,12 +132,12 @@ func (f *Fake) WithRuntimeStatus(fn func() *runtimev1pb.ActorRuntime) *Fake {
 	return f
 }
 
-func (f *Fake) WithRegisterHosted(fn func(hostconfig.Config) error) *Fake {
+func (f *Fake) WithRegisterHosted(fn func(context.Context, hostconfig.Config) error) *Fake {
 	f.fnRegisterHosted = fn
 	return f
 }
 
-func (f *Fake) WithUnRegisterHosted(fn func(...string)) *Fake {
+func (f *Fake) WithUnRegisterHosted(fn func(context.Context, ...string) error) *Fake {
 	f.fnUnRegisterHosted = fn
 	return f
 }
@@ -181,14 +183,14 @@ func (f *Fake) RuntimeStatus() *runtimev1pb.ActorRuntime {
 	return f.fnRuntimeStatus()
 }
 
-func (f *Fake) RegisterHosted(cfg hostconfig.Config) error {
-	return f.fnRegisterHosted(cfg)
+func (f *Fake) RegisterHosted(ctx context.Context, cfg hostconfig.Config) error {
+	return f.fnRegisterHosted(ctx, cfg)
 }
 
 func (f *Fake) WaitForRegisteredHosts(ctx context.Context) error {
 	return f.fnWaitForRegisteredHosts(ctx)
 }
 
-func (f *Fake) UnRegisterHosted(ids ...string) {
-	f.fnUnRegisterHosted(ids...)
+func (f *Fake) UnRegisterHosted(ctx context.Context, ids ...string) error {
+	return f.fnUnRegisterHosted(ctx, ids...)
 }

--- a/pkg/api/grpc/actorcallbacks.go
+++ b/pkg/api/grpc/actorcallbacks.go
@@ -59,7 +59,7 @@ func (a *api) SubscribeActorEventsAlpha1(stream runtimev1pb.Dapr_SubscribeActorE
 	// transitions the actor runtime out of INITIALIZING, mirroring the
 	// HTTP /dapr/config 404 path — then register the stream connection
 	// with the manager for Send/Deliver routing.
-	if err := a.Actors().RegisterHosted(hostconfig.Config{
+	if err := a.Actors().RegisterHosted(stream.Context(), hostconfig.Config{
 		EntityConfigs:           cfg.EntityConfigs,
 		DrainRebalancedActors:   cfg.DrainRebalancedActors,
 		DrainOngoingCallTimeout: cfg.DrainOngoingCallTimeout,
@@ -74,9 +74,11 @@ func (a *api) SubscribeActorEventsAlpha1(stream runtimev1pb.Dapr_SubscribeActorE
 	// Cleanup runs as one deferred block so ordering is explicit: drop the
 	// actor types from the runtime table first so daprd routes no further
 	// new traffic to this connection, then close the connection to fail
-	// any in-flight Sends with ErrDisconnected.
+	// any in-flight Sends with ErrDisconnected. stream.Context() is already
+	// cancelled by the time this defer runs, so use Background; the actor
+	// runtime is observably ready since RegisterHosted above succeeded.
 	defer func() {
-		a.Actors().UnRegisterHosted(cfg.Entities...)
+		_ = a.Actors().UnRegisterHosted(context.Background(), cfg.Entities...)
 		mgr.Close(conn, nil)
 	}()
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -939,7 +939,7 @@ func (a *DaprRuntime) appHealthChanged(ctx context.Context, status *apphealth.St
 			log.Warnf("failed to subscribe to outbox topics: %s", err)
 		}
 
-		err = a.actors.RegisterHosted(hostconfig.Config{
+		err = a.actors.RegisterHosted(ctx, hostconfig.Config{
 			EntityConfigs:           a.appConfig.EntityConfigs,
 			DrainRebalancedActors:   a.appConfig.DrainRebalancedActors,
 			DrainOngoingCallTimeout: a.appConfig.DrainOngoingCallTimeout,
@@ -966,7 +966,9 @@ func (a *DaprRuntime) appHealthChanged(ctx context.Context, status *apphealth.St
 		a.processor.Subscriber().StopAppSubscriptions()
 		a.processor.Binding().StopReadingFromBindings(false)
 
-		a.actors.UnRegisterHosted(a.appConfig.Entities...)
+		if err := a.actors.UnRegisterHosted(ctx, a.appConfig.Entities...); err != nil {
+			log.Warnf("Failed to unregister hosted actors: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Gate registering/unregistering hosted actors on runtime init, to avoid panic.
