### PR TITLE
ci(version-skew): patch v1.17 framework with actors-disseminate-timeout

### DIFF
--- a/.github/scripts/version-skew-test-patches/integration/release-1.17/dapr-sidecar-master/004-clamp-disseminate-timeout.patch
+++ b/.github/scripts/version-skew-test-patches/integration/release-1.17/dapr-sidecar-master/004-clamp-disseminate-timeout.patch
@@ -1,0 +1,126 @@
+diff --git a/tests/integration/framework/process/daprd/daprd.go b/tests/integration/framework/process/daprd/daprd.go
+index a2836a509..df440617d 100644
+--- a/tests/integration/framework/process/daprd/daprd.go
++++ b/tests/integration/framework/process/daprd/daprd.go
+@@ -152,6 +152,9 @@ func New(t *testing.T, fopts ...Option) *Daprd {
+ 	if len(opts.schedulerAddresses) > 0 {
+ 		args = append(args, "--scheduler-host-address="+strings.Join(opts.schedulerAddresses, ","))
+ 	}
++	if opts.actorsDisseminateTimeout != nil {
++		args = append(args, "--actors-disseminate-timeout="+opts.actorsDisseminateTimeout.String())
++	}
+ 	if opts.controlPlaneTrustDomain != nil {
+ 		args = append(args, "--control-plane-trust-domain="+*opts.controlPlaneTrustDomain)
+ 	}
+diff --git a/tests/integration/framework/process/daprd/options.go b/tests/integration/framework/process/daprd/options.go
+index ab81632a2..6b5d3cae0 100644
+--- a/tests/integration/framework/process/daprd/options.go
++++ b/tests/integration/framework/process/daprd/options.go
+@@ -18,6 +18,7 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 	"testing"
++	"time"
+ 
+ 	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
+@@ -68,6 +69,7 @@ type options struct {
+ 	disableInitEndpoints    []string
+ 	maxBodySize             *string
+ 	allowedOrigins          *string
++	actorsDisseminateTimeout *time.Duration
+ }
+ 
+ func WithExecOptions(execOptions ...exec.Option) Option {
+@@ -307,6 +309,16 @@ func WithDaprBlockShutdownDuration(duration string) Option {
+ 	}
+ }
+ 
++// WithActorsDisseminateTimeout sets the --actors-disseminate-timeout daprd flag.
++// Backported into the latest-release framework via the version-skew patch so the
++// 1.18-era clamp tests can drive a small dissemination budget against a 1.17 daprd
++// framework checkout.
++func WithActorsDisseminateTimeout(timeout time.Duration) Option {
++	return func(o *options) {
++		o.actorsDisseminateTimeout = &timeout
++	}
++}
++
+ func WithControlPlaneTrustDomain(trustDomain string) Option {
+ 	return func(o *options) {
+ 		o.controlPlaneTrustDomain = &trustDomain
+diff --git a/tests/integration/suite/actors/dissemination/drain/clamp/clamp.go b/tests/integration/suite/actors/dissemination/drain/clamp/clamp.go
+index ea2930423..a2f93672a 100644
+--- a/tests/integration/suite/actors/dissemination/drain/clamp/clamp.go
++++ b/tests/integration/suite/actors/dissemination/drain/clamp/clamp.go
+@@ -76,6 +76,7 @@ func (c *clamp) Setup(t *testing.T) []framework.Option {
+ 		actors.WithActorTypeHandler("abc", handler),
+ 		actors.WithDrainOngoingCallTimeout(time.Minute),
+ 		actors.WithDaprdOptions(
++			daprd.WithActorsDisseminateTimeout(time.Second*4),
+ 			daprd.WithLogLineStdout(c.ll),
+ 		),
+ 	)
+@@ -85,6 +86,9 @@ func (c *clamp) Setup(t *testing.T) []framework.Option {
+ 		actors.WithActorTypes("abc"),
+ 		actors.WithActorTypeHandler("abc", handler),
+ 		actors.WithDrainOngoingCallTimeout(time.Minute),
++		actors.WithDaprdOptions(
++			daprd.WithActorsDisseminateTimeout(time.Second*4),
++		),
+ 	)
+ 
+ 	return []framework.Option{
+diff --git a/tests/integration/suite/actors/dissemination/drain/clamp/clampentity.go b/tests/integration/suite/actors/dissemination/drain/clamp/clampentity.go
+index 3fc5d8a01..b1d78a7f9 100644
+--- a/tests/integration/suite/actors/dissemination/drain/clamp/clampentity.go
++++ b/tests/integration/suite/actors/dissemination/drain/clamp/clampentity.go
+@@ -79,6 +79,7 @@ func (c *clampentity) Setup(t *testing.T) []framework.Option {
+ 			actors.WithEntityConfigDrainOngoingCallTimeout(time.Minute),
+ 		),
+ 		actors.WithDaprdOptions(
++			daprd.WithActorsDisseminateTimeout(time.Second*4),
+ 			daprd.WithLogLineStdout(c.ll),
+ 		),
+ 	)
+@@ -91,6 +92,9 @@ func (c *clampentity) Setup(t *testing.T) []framework.Option {
+ 			actors.WithEntityConfigEntities("abc"),
+ 			actors.WithEntityConfigDrainOngoingCallTimeout(time.Minute),
+ 		),
++		actors.WithDaprdOptions(
++			daprd.WithActorsDisseminateTimeout(time.Second*4),
++		),
+ 	)
+ 
+ 	return []framework.Option{
+diff --git a/tests/integration/suite/actors/dissemination/drain/clamp/timeout.go b/tests/integration/suite/actors/dissemination/drain/clamp/timeout.go
+index 0315e54df..4c1ad51c7 100644
+--- a/tests/integration/suite/actors/dissemination/drain/clamp/timeout.go
++++ b/tests/integration/suite/actors/dissemination/drain/clamp/timeout.go
+@@ -60,7 +60,7 @@ func (c *timeout) Setup(t *testing.T) []framework.Option {
+ 
+ 	c.ll = logline.New(t,
+ 		logline.WithStdoutLineContains(
+-			"Timed out waiting for actor in-flight lock claims to be released",
++			"Timed out waiting for actor type 'abc' in-flight lock claims to be released",
+ 		),
+ 	)
+ 
+@@ -77,6 +77,7 @@ func (c *timeout) Setup(t *testing.T) []framework.Option {
+ 			actors.WithEntityConfigDrainOngoingCallTimeout(time.Second*2),
+ 		),
+ 		actors.WithDaprdOptions(
++			daprd.WithActorsDisseminateTimeout(time.Second*4),
+ 			daprd.WithLogLineStdout(c.ll),
+ 		),
+ 	)
+@@ -89,6 +90,9 @@ func (c *timeout) Setup(t *testing.T) []framework.Option {
+ 			actors.WithEntityConfigEntities("abc"),
+ 			actors.WithEntityConfigDrainOngoingCallTimeout(time.Second*2),
+ 		),
++		actors.WithDaprdOptions(
++			daprd.WithActorsDisseminateTimeout(time.Second*4),
++		),
+ 	)
+ 
+ 	return []framework.Option{

--- a/.github/workflows/version-skew.yaml
+++ b/.github/workflows/version-skew.yaml
@@ -63,11 +63,11 @@ jobs:
     - name: Set up for Dapr lastest release
       run: |
         echo "DAPR_PREV_VERSION=$(curl -s https://api.github.com/repos/dapr/dapr/releases/latest | jq -r '.tag_name' | cut -c 2-)" >> $GITHUB_ENV
-    - name: Set up for master
+    - name: Set up for push/dispatch
       if: github.event_name != 'repository_dispatch'
       run: |
         echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
-        echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
+        echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
       shell: bash
     - name: Setup test output
       shell: bash
@@ -245,11 +245,11 @@ jobs:
     - name: Set up for Dapr lastest release
       run: |
         echo "DAPR_PREV_VERSION=$(curl -s https://api.github.com/repos/dapr/dapr/releases/latest | jq -r '.tag_name' | cut -c 2-)" >> $GITHUB_ENV
-    - name: Set up for master
+    - name: Set up for push/dispatch
       if: github.event_name != 'repository_dispatch'
       run: |
         echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
-        echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
+        echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
       shell: bash
     - name: Parse test payload
       if: github.event_name == 'repository_dispatch'


### PR DESCRIPTION
Master companion to #9996 (which targets release-1.18). Same diff, branch lives on the upstream repo so the Version Skew workflow can be triggered manually via `workflow_dispatch`.

## What

Adds `004-clamp-disseminate-timeout.patch` to the `dapr-sidecar-master` version-skew patch set for `release-1.17`. The patch backports `daprd.WithActorsDisseminateTimeout` into the v1.17 test framework and updates all three actor drain clamp tests (`clamp.go`, `clampentity.go`, `timeout.go`) to set a 4s disseminate timeout — mirroring the equivalent change already present on master.

Also fixes the Version Skew workflow so `workflow_dispatch` honors the dispatched ref (was previously hardcoded to `refs/heads/master`, which silently ignored any patches on a feature branch when dispatched manually).

## Why

The Version Skew workflow has been red on `master` (and `release-1.18`) since 2026-05-12, exclusively on the `dapr-sidecar-master` axis. The failing tests are:

- `Test_Integration/actors/dissemination/drain/clamp/clamp`
- `Test_Integration/actors/dissemination/drain/clamp/clampentity`
- `Test_Integration/actors/dissemination/drain/clamp/timeout`

All three time out with:
> `call should be cancelled after the clamped drain timeout, not the configured 60s`

### Root cause

The clamp feature (#9897) was backported to v1.17.7 via #9916, so both v1.17.7 and master daprd implement the clamp. After v1.17.7 shipped, master picked up updates to `clamp.go`, `clampentity.go`, and `timeout.go` that add `daprd.WithActorsDisseminateTimeout(time.Second*4)` to both daprds in each test.

The version-skew runner mounts the v1.17.7 source into `latest-release/` and runs **that** test source against the master daprd binary. The v1.17.7 test source doesn't include the timeout override, so placement is launched with its default `--disseminate-timeout=30s`. The 80% clamp lands at ~24s while the test's `assert.Eventually(..., 20*time.Second, ...)` deadline is 20s, so the clamp fires *after* the deadline and the assertion fails.

### The fix

This patch teaches the v1.17.7 framework about `WithActorsDisseminateTimeout` (adds the option field, the `With…` helper, and the corresponding `--actors-disseminate-timeout` arg generation in `daprd.go`), then updates all three clamp tests to pass a 4s timeout to both daprds. The clamp now lands at ~3.2s, well inside the 20s test deadline.

The `timeout.go` test also expects the per-type log line (`"Timed out waiting for actor type 'abc' in-flight lock claims to be released"`) that master daprd emits; this patch updates the expected substring accordingly.

## Test plan

- [ ] Trigger Version Skew via workflow_dispatch against this branch
- [ ] Confirm `dapr-sidecar-master` integration leg goes green for v1.17.7
- [ ] Confirm `control-plane-master` axis remains green
- [ ] Confirm `clamp/timeout` no longer fails on the OLD log-line expectation
- [ ] Other patches in the same directory continue to apply cleanly

Locally verified: `git apply --check --ignore-space-change --ignore-whitespace` succeeds against a fresh v1.17.7 checkout, and `go build ./tests/integration/suite/actors/dissemination/drain/clamp/...` compiles cleanly after the patch is applied.