### PR TITLE
workflow: save inbox event before creating wake-up reminder

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -98,25 +98,37 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 		return api.ErrInstanceNotFound
 	}
 
-	// Create the wake-up reminder BEFORE mutating any state. If reminder
-	// creation fails we return without touching the in-memory inbox, so a
-	// retry sees clean state and dedup stays exact. If we instead saved
-	// first and then failed to create the reminder, the event would be
-	// durable but un-driven; if we mutated the in-memory inbox before save
-	// and then failed, a retry would see the orphan event in the cached
-	// inbox, dedup would drop it, and cron would auto-delete the reminder.
+	// Save the inbox event BEFORE creating the wake-up reminder. The
+	// reminder's dueTime is anchored at the workflow's start timestamp
+	// (state.History[0].Timestamp), which is in the past, so the scheduler
+	// fires it immediately on Create. Under placement rebalance the firing
+	// daprd may not be the host that ran AddWorkflowEvent: it loads the
+	// store, sees no inbox event, acks SUCCESS, and the scheduler deletes
+	// the reminder. By the time the save eventually commits the inbox row
+	// is stranded with no driver, and the activity actor's publishResult
+	// already returned nil so its retry-forever 'run-activity' reminder
+	// no longer fires. The workflow freezes in RUNNING.
+	//
+	// Saving first inverts the failure mode into something the existing
+	// recovery paths already handle: if signAndSaveState succeeds but the
+	// reminder Create then crashes / times out, the activity actor's
+	// publishResult sees the RPC error and its retry-forever reminder
+	// re-fires, the next AddWorkflowEvent hits dedup.IsDuplicateCompletion
+	// (the row is already in inbox), and the dedup branch above calls
+	// assertNewEventReminder which deterministically re-creates the
+	// reminder. The inbox is never stranded.
 	//
 	// The reminder must target the local actor (o.appID), not the router's
 	// source app. For cross-app events (e.g. ExecutionTerminated from a
 	// parent in another app), router.SourceAppID is the sender's app and
 	// would route the reminder to a non-existent remote actor.
-	if err := o.assertNewEventReminder(ctx, e, state); err != nil {
-		return err
-	}
-
 	log.Debugf("Workflow actor '%s': adding event to the workflow inbox", o.actorID)
 	state.AddToInbox(e)
 	if err := o.signAndSaveState(ctx, state); err != nil {
+		return err
+	}
+
+	if err := o.assertNewEventReminder(ctx, e, state); err != nil {
 		return err
 	}
 

--- a/tests/integration/framework/process/statestore/fault/fault.go
+++ b/tests/integration/framework/process/statestore/fault/fault.go
@@ -40,8 +40,20 @@ type Store struct {
 
 	failKeySubstring string
 	failRemaining    int
+	failErr          error
 	failNotifyCh     chan struct{}
 	failedCount      atomic.Int32
+
+	multiObserver func(*state.TransactionalStateRequest)
+}
+
+// SetMultiObserver registers a callback invoked synchronously on every Multi
+// before delegation. Tests use it to inspect the ETag of specific upserts.
+// nil clears any previously registered observer.
+func (s *Store) SetMultiObserver(fn func(*state.TransactionalStateRequest)) {
+	s.mu.Lock()
+	s.multiObserver = fn
+	s.mu.Unlock()
 }
 
 // New returns a Store that is functionally identical to the in-memory store
@@ -52,15 +64,30 @@ func New(t *testing.T) *Store {
 	}
 }
 
-// ArmFailures arms the store to return an injected transient error on the next
+// ArmFailures arms the store to return a synthetic transient error on the next
 // n transactional Multi requests whose operation keys contain keySubstring.
 // n=1 produces a one-shot failure, n=0 disarms. If notify is non-nil it is
 // closed the FIRST time a matching Multi is failed, so callers can synchronise
 // on the failure firing.
 func (s *Store) ArmFailures(keySubstring string, n int, notify chan struct{}) {
+	s.armWith(keySubstring, n, errors.New("fault.Store: injected transient failure"), notify)
+}
+
+// ArmETagMismatch arms the store to return a state.ETagError of kind
+// ETagMismatch on the next n matching Multi requests. Use this when a test
+// wants to exercise the orchestrator's peer-write recovery path rather than
+// a generic transient error.
+func (s *Store) ArmETagMismatch(keySubstring string, n int, notify chan struct{}) {
+	s.armWith(keySubstring, n,
+		state.NewETagError(state.ETagMismatch, errors.New("fault.Store: injected etag mismatch")),
+		notify)
+}
+
+func (s *Store) armWith(keySubstring string, n int, err error, notify chan struct{}) {
 	s.mu.Lock()
 	s.failKeySubstring = keySubstring
 	s.failRemaining = n
+	s.failErr = err
 	s.failNotifyCh = notify
 	s.mu.Unlock()
 }
@@ -71,10 +98,14 @@ func (s *Store) FailedCount() int { return int(s.failedCount.Load()) }
 
 // Multi implements state.TransactionalStore. If the store is armed and the
 // request touches a key containing the armed substring, the request is failed
-// with a synthetic transient error; otherwise the request is delegated to the
-// underlying in-memory store.
+// with the armed error; otherwise the request is delegated to the underlying
+// in-memory store.
 func (s *Store) Multi(ctx context.Context, req *state.TransactionalStateRequest) error {
 	s.mu.Lock()
+
+	if obs := s.multiObserver; obs != nil {
+		obs(req)
+	}
 
 	keys := make([]string, 0, len(req.Operations))
 	for _, op := range req.Operations {
@@ -87,10 +118,14 @@ func (s *Store) Multi(ctx context.Context, req *state.TransactionalStateRequest)
 	}
 
 	shouldFail := s.failKeySubstring != "" && s.failRemaining > 0 && anyHasSubstring(keys, s.failKeySubstring)
-	var notify chan struct{}
+	var (
+		notify chan struct{}
+		err    error
+	)
 	if shouldFail {
 		s.failRemaining--
 		s.failedCount.Add(1)
+		err = s.failErr
 		if s.failNotifyCh != nil {
 			notify = s.failNotifyCh
 			s.failNotifyCh = nil
@@ -102,7 +137,7 @@ func (s *Store) Multi(ctx context.Context, req *state.TransactionalStateRequest)
 		if notify != nil {
 			close(notify)
 		}
-		return errors.New("fault.Store: injected transient failure")
+		return err
 	}
 	return s.Wrapped.Store.(state.TransactionalStore).Multi(ctx, req)
 }

--- a/tests/integration/framework/process/statestore/fault/fault.go
+++ b/tests/integration/framework/process/statestore/fault/fault.go
@@ -102,11 +102,14 @@ func (s *Store) FailedCount() int { return int(s.failedCount.Load()) }
 // in-memory store.
 func (s *Store) Multi(ctx context.Context, req *state.TransactionalStateRequest) error {
 	s.mu.Lock()
+	obs := s.multiObserver
+	s.mu.Unlock()
 
-	if obs := s.multiObserver; obs != nil {
+	if obs != nil {
 		obs(req)
 	}
 
+	s.mu.Lock()
 	keys := make([]string, 0, len(req.Operations))
 	for _, op := range req.Operations {
 		switch v := op.(type) {

--- a/tests/integration/suite/daprd/workflow/chaos/etagattached.go
+++ b/tests/integration/suite/daprd/workflow/chaos/etagattached.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(etagattached))
+}
+
+// etagattached verifies that the orchestrator's transactional save attaches
+// the cached metadata ETag to the metadata row's Upsert on every save after
+// the first. This is the optimistic-concurrency anchor that prevents a
+// split-brain peer write from clobbering history rows: a stale ETag aborts the
+// entire Multi.
+type etagattached struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *fault.Store
+}
+
+func (e *etagattached) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	e.store = fault.New(t)
+
+	sock := socket.New(t)
+	e.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(e.store),
+	)
+
+	e.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, e.ss.SocketName())),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(e.ss, e.workflow),
+	}
+}
+
+func (e *etagattached) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	const wfID = "etagattached-wf"
+
+	var (
+		mu         sync.Mutex
+		metaEtags  []*string
+		wantSuffix = wfID + "||metadata"
+	)
+	e.store.SetMultiObserver(func(req *state.TransactionalStateRequest) {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, op := range req.Operations {
+			s, ok := op.(state.SetRequest)
+			if !ok || !strings.HasSuffix(s.Key, wantSuffix) {
+				continue
+			}
+			if s.ETag == nil {
+				metaEtags = append(metaEtags, nil)
+			} else {
+				v := *s.ETag
+				metaEtags = append(metaEtags, &v)
+			}
+		}
+	})
+
+	r := e.workflow.Registry()
+	require.NoError(t, r.AddActivityN("act", func(actx task.ActivityContext) (any, error) {
+		return "done", nil
+	}))
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		var out string
+		if err := octx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		if err := octx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	bc := e.workflow.BackendClient(t, ctx)
+	gclient := e.workflow.GRPCClient(t, ctx)
+
+	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "wf",
+		InstanceId:        wfID,
+	})
+	require.NoError(t, err)
+
+	meta, err := bc.WaitForWorkflowCompletion(ctx, api.InstanceID(wfID))
+	require.NoError(t, err)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, meta.GetRuntimeStatus())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(metaEtags), 2, "expected at least two metadata Upserts")
+	assert.Nil(t, metaEtags[0], "first metadata Upsert (workflow create) must have no ETag")
+	hasEtag := false
+	for _, e := range metaEtags[1:] {
+		if e != nil && *e != "" {
+			hasEtag = true
+			break
+		}
+	}
+	assert.True(t, hasEtag,
+		"at least one post-create metadata Upsert must carry an ETag for optimistic concurrency")
+}

--- a/tests/integration/suite/daprd/workflow/chaos/etagconflict.go
+++ b/tests/integration/suite/daprd/workflow/chaos/etagconflict.go
@@ -15,63 +15,85 @@ package chaos
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/durabletask-go/task"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
-	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
 
 func init() {
-	suite.Register(new(canfail))
+	suite.Register(new(etagconflict))
 }
 
-// canfail verifies that the orchestrator recovers when ScheduleJob (the gRPC
-// the scheduler uses to register a reminder) fails for the new-event wake-up
-// reminder that addWorkflowEvent issues for an incoming activity result.
-// The failure is injected via a proxy that fronts the real scheduler so
-// the test can arm specific gRPC failures on specific methods, much like
-// the pluggable state-store fault wrapper does for state.Multi.
-type canfail struct {
-	workflow  *workflow.Workflow
-	scheduler *scheduler.Scheduler
-	proxy     *proxy.Proxy
+// etagconflict verifies that when the orchestrator's transactional save
+// aborts with state.ETagMismatch (a peer host wrote to the workflow's
+// metadata row between this daprd's load and save), signAndSaveState
+// invalidates the cached state and the activity actor's reminder retry
+// drives a fresh load that converges on the up-to-date base state.
+type etagconflict struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *fault.Store
 }
 
-func (c *canfail) Setup(t *testing.T) []framework.Option {
-	c.scheduler = scheduler.New(t)
-	c.proxy = proxy.New(t, c.scheduler)
+func (e *etagconflict) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
 
-	c.workflow = workflow.New(t,
-		workflow.WithSchedulerInstance(c.scheduler),
-		workflow.WithSchedulerAddress(c.proxy.Address()),
+	e.store = fault.New(t)
+
+	sock := socket.New(t)
+	e.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(e.store),
+	)
+
+	e.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, e.ss.SocketName())),
+		),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(c.scheduler, c.proxy, c.workflow),
+		framework.WithProcesses(e.ss, e.workflow),
 	}
 }
 
-func (c *canfail) Run(t *testing.T, ctx context.Context) {
-	c.workflow.WaitUntilRunning(t, ctx)
+func (e *etagconflict) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
 
-	const wfID = "canfail-wf"
+	const wfID = "etagconflict-wf"
 
 	activityStarted := make(chan struct{}, 1)
 	releaseActivity := make(chan struct{})
 
-	r := c.workflow.Registry()
-
+	r := e.workflow.Registry()
 	require.NoError(t, r.AddActivityN("act", func(actx task.ActivityContext) (any, error) {
 		activityStarted <- struct{}{}
 		select {
@@ -81,7 +103,6 @@ func (c *canfail) Run(t *testing.T, ctx context.Context) {
 			return nil, nil
 		}
 	}))
-
 	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
 		var out string
 		if err := octx.CallActivity("act").Await(&out); err != nil {
@@ -90,8 +111,8 @@ func (c *canfail) Run(t *testing.T, ctx context.Context) {
 		return out, nil
 	}))
 
-	c.workflow.BackendClient(t, ctx)
-	gclient := c.workflow.GRPCClient(t, ctx)
+	e.workflow.BackendClient(t, ctx)
+	gclient := e.workflow.GRPCClient(t, ctx)
 
 	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
 		WorkflowComponent: "dapr",
@@ -100,27 +121,23 @@ func (c *canfail) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 
-	// Wait until the activity is in flight before arming the proxy, so the
-	// failure lands on the ScheduleJob that addWorkflowEvent makes for the
-	// activity-result wake-up reminder rather than on the workflow-start
-	// or activity-schedule reminders.
 	select {
 	case <-activityStarted:
 	case <-time.After(15 * time.Second):
 		require.Fail(t, "activity did not start")
 	}
 
-	failedCh := make(chan struct{})
-	// codes.Internal is non-transient so daprd's CreateReminderWithRetry
-	// does not mask it; the orchestrator's error path runs.
-	c.proxy.ArmFailures(proxy.MethodScheduleJob, 1, codes.Internal, failedCh)
+	// Arm the addWorkflowEvent save to fail with ETagMismatch, simulating a
+	// concurrent peer write to the workflow's metadata row.
+	conflictCh := make(chan struct{})
+	e.store.ArmETagMismatch(wfID+"||inbox-", 1, conflictCh)
 
 	close(releaseActivity)
 
 	select {
-	case <-failedCh:
+	case <-conflictCh:
 	case <-time.After(15 * time.Second):
-		require.Fail(t, "injected ScheduleJob failure never fired")
+		require.Fail(t, "injected etag mismatch never fired")
 	}
 
 	assert.EventuallyWithT(t, func(co *assert.CollectT) {
@@ -131,8 +148,8 @@ func (c *canfail) Run(t *testing.T, ctx context.Context) {
 		if assert.NoError(co, gerr) {
 			assert.Equal(co, "COMPLETED", resp.GetRuntimeStatus())
 		}
-	}, 30*time.Second, 100*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 
-	assert.GreaterOrEqual(t, c.proxy.FailedCount(), 1,
-		"expected the injected ScheduleJob failure to have fired at least once")
+	assert.GreaterOrEqual(t, e.store.FailedCount(), 1,
+		"expected the injected etag mismatch to have fired")
 }

--- a/tests/integration/suite/daprd/workflow/chaos/savefirst.go
+++ b/tests/integration/suite/daprd/workflow/chaos/savefirst.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(savefirst))
+}
+
+// savefirst verifies that addWorkflowEvent saves the inbox event to the
+// state store BEFORE creating the wake-up reminder. The reminder's dueTime
+// is anchored at the workflow's start (in the past), so the scheduler fires
+// it immediately on Create. Under placement rebalance the firing daprd may
+// not be the host that ran AddWorkflowEvent, and an empty-inbox SUCCESS ack
+// would delete the reminder before the save commits, stranding the inbox row.
+//
+// With save-first, an inbox-save failure must NOT leave an orphan reminder
+// in the scheduler. The recovery path is the activity actor's retry-forever
+// run-activity reminder, which re-fires AddWorkflowEvent until the save lands.
+type savefirst struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *fault.Store
+	sched    *scheduler.Scheduler
+}
+
+func (s *savefirst) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	s.store = fault.New(t)
+
+	sock := socket.New(t)
+	s.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(s.store),
+	)
+
+	s.sched = scheduler.New(t)
+
+	s.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithSchedulerInstance(s.sched),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, s.ss.SocketName())),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.sched, s.ss, s.workflow),
+	}
+}
+
+func (s *savefirst) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	const wfID = "savefirst-wf"
+
+	activityStarted := make(chan struct{}, 1)
+	releaseActivity := make(chan struct{})
+
+	r := s.workflow.Registry()
+	require.NoError(t, r.AddActivityN("act", func(actx task.ActivityContext) (any, error) {
+		activityStarted <- struct{}{}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseActivity:
+			return nil, nil
+		}
+	}))
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		var out string
+		if err := octx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	s.workflow.BackendClient(t, ctx)
+	gclient := s.workflow.GRPCClient(t, ctx)
+
+	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "wf",
+		InstanceId:        wfID,
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-activityStarted:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "activity did not start")
+	}
+
+	failedCh := make(chan struct{})
+	s.store.ArmFailures(wfID+"||inbox-", 1, failedCh)
+
+	close(releaseActivity)
+
+	select {
+	case <-failedCh:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "injected inbox-save failure never fired")
+	}
+
+	// At the moment the inbox save just failed, no wake-up reminder for the
+	// activity-result event may exist in the scheduler. Reminder-first
+	// ordering would have already registered new-event-tc-0 by this point.
+	ns := s.workflow.Dapr().Namespace()
+	appID := s.workflow.Dapr().AppID()
+	prefix := fmt.Sprintf(
+		"dapr/jobs/actorreminder||%s||dapr.internal.%s.%s.workflow||%s||new-event-tc-",
+		ns, ns, appID, wfID,
+	)
+	require.Empty(t, s.sched.ListAllKeys(t, ctx, prefix),
+		"wake-up reminder must not exist while inbox save is unwritten")
+
+	assert.EventuallyWithT(t, func(co *assert.CollectT) {
+		resp, gerr := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        wfID,
+			WorkflowComponent: "dapr",
+		})
+		if assert.NoError(co, gerr) {
+			assert.Equal(co, "COMPLETED", resp.GetRuntimeStatus())
+		}
+	}, 30*time.Second, 10*time.Millisecond)
+
+	assert.GreaterOrEqual(t, s.store.FailedCount(), 1,
+		"expected the injected save failure to have fired")
+}

--- a/tests/integration/suite/daprd/workflow/chaos/savefirst.go
+++ b/tests/integration/suite/daprd/workflow/chaos/savefirst.go
@@ -157,8 +157,11 @@ func (s *savefirst) Run(t *testing.T, ctx context.Context) {
 		"dapr/jobs/actorreminder||%s||dapr.internal.%s.%s.workflow||%s||new-event-tc-",
 		ns, ns, appID, wfID,
 	)
-	require.Empty(t, s.sched.ListAllKeys(t, ctx, prefix),
-		"wake-up reminder must not exist while inbox save is unwritten")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Empty(c, s.sched.ListAllKeys(t, ctx, prefix),
+			"wake-up reminder must not exist while inbox save is unwritten")
+	}, 30*time.Second, 10*time.Millisecond)
 
 	assert.EventuallyWithT(t, func(co *assert.CollectT) {
 		resp, gerr := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{


### PR DESCRIPTION
addWorkflowEvent created the new-event-tc-<id> reminder before it committed the corresponding inbox row. The reminder's DueTime is anchored at the workflow's start timestamp (in the past), so the scheduler fires it immediately on Create. Under a placement rebalance the firing daprd was not always the host that ran AddWorkflowEvent: it loaded the store, saw an empty inbox, acked SUCCESS, and the scheduler deleted the reminder. The save then committed the inbox row with no driver, and the activity actor's publishResult had already returned nil so its retry-forever run-activity reminder no longer fired. The workflow froze in RUNNING.

The recovery path is the activity actor's retry-forever run-activity reminder. Save the inbox row first; if the reminder Create then fails or the process crashes, publishResult sees the RPC error and the next reminder retry hits addWorkflowEvent again, dedup.IsDuplicateCompletion fires (the event is already in inbox), and the dedup branch's assertNewEventReminder deterministically re-creates the reminder under its idempotent name. The inbox is never stranded.