### PR TITLE
Sentry: fix OIDC X-Forwarded-Host issuer/jwks_uri injection

### DIFF
--- a/docs/release_notes/v1.17.8.md
+++ b/docs/release_notes/v1.17.8.md
@@ -65,7 +65,7 @@ Setting either `--jwt-issuer` or `--oidc-allowed-hosts` already mitigated the is
 ### Root Cause
 
 `handleDiscovery` in `pkg/sentry/server/oidc/oidc.go` derives the OIDC issuer dynamically when no static `--jwt-issuer` is configured, as a convenience for operators who have not yet pinned an external hostname.
-he derivation read `X-Forwarded-Host` unconditionally and substituted it for `r.Host` whenever the header was present, with no validation.
+The derivation read `X-Forwarded-Host` unconditionally and substituted it for `r.Host` whenever the header was present, with no validation.
 The companion `allowedHostsValidationHandler` middleware would have rejected unknown hosts, but is a no-op when `--oidc-allowed-hosts` is unset (the default), so neither layer authenticated the header in the default configuration.
 
 ### Solution

--- a/docs/release_notes/v1.17.8.md
+++ b/docs/release_notes/v1.17.8.md
@@ -1,7 +1,8 @@
 # Dapr 1.17.8
 
-This update contains the following bug fix:
+This update contains the following bug and security fix:
 - [Workflow stuck and unrecoverable after re-scheduling an instance ID that has already completed](#workflow-stuck-and-unrecoverable-after-re-scheduling-an-instance-id-that-has-already-completed)
+- [Security: Sentry OIDC discovery document poisonable via `X-Forwarded-Host` (CWE-346)](#security-sentry-oidc-discovery-document-poisonable-via-x-forwarded-host-cwe-346)
 
 ## Workflow stuck and unrecoverable after re-scheduling an instance ID that has already completed
 
@@ -39,3 +40,39 @@ Either way, the previous run's retention reminder is obsolete and the scheduler 
 
 Workflows already stuck in this state on existing 1.17 deployments recover automatically once the sidecar is upgraded to 1.17.8: the next retention reminder fire drains, the reminder is removed from the scheduler, and the workflow proceeds normally.
 No operator intervention or manual scheduler delete is required after the upgrade.
+
+## Security: Sentry OIDC discovery document poisonable via `X-Forwarded-Host` (CWE-346)
+
+### Problem
+
+When the Dapr Sentry OIDC HTTP server was started without a statically configured JWT issuer (`--jwt-issuer`) and without an allowed-hosts list (`--oidc-allowed-hosts`), the `X-Forwarded-Host` request header fully controlled the `issuer` and `jwks_uri` fields returned by `/.well-known/openid-configuration`.
+An attacker with network reach to the OIDC endpoint (typically via a reverse proxy or ingress that forwards `X-Forwarded-Host`) could inject an arbitrary issuer URL on a single request.
+Because the discovery response is served with `Cache-Control: public, max-age=3600`, the poisoned document could be cached by HTTP intermediaries for up to an hour.
+
+### Impact
+
+Any deployment that enabled the Sentry OIDC server (`--oidc-enabled --jwt-enabled`) without configuring either a static issuer (`--jwt-issuer`) or an allowed-hosts list (`--oidc-allowed-hosts`) was affected.
+This configuration is most likely on operators who turned on OIDC federation for Sentry-issued JWTs (e.g. to allow AWS IAM, GCP Workload Identity, or Azure AD relying parties to validate Dapr-issued tokens) without yet pinning the external hostname.
+
+Visible exposure included:
+
+- A discovery response whose `issuer` and `jwks_uri` pointed at an attacker-controlled host after a single request carrying `X-Forwarded-Host: attacker.example`.
+- Relying parties performing dynamic OIDC discovery (without a pinned expected issuer) fetching JWKS from the attacker's server, opening a window in which attacker-signed JWTs would validate against the attacker's keys.
+- HTTP intermediaries caching the poisoned response for up to an hour, amplifying the window beyond the original attack request.
+
+Setting either `--jwt-issuer` or `--oidc-allowed-hosts` already mitigated the issue on affected versions; relying parties that pinned the expected issuer rejected the forged token regardless.
+
+### Root Cause
+
+`handleDiscovery` in `pkg/sentry/server/oidc/oidc.go` derives the OIDC issuer dynamically when no static `--jwt-issuer` is configured, as a convenience for operators who have not yet pinned an external hostname.
+he derivation read `X-Forwarded-Host` unconditionally and substituted it for `r.Host` whenever the header was present, with no validation.
+The companion `allowedHostsValidationHandler` middleware would have rejected unknown hosts, but is a no-op when `--oidc-allowed-hosts` is unset (the default), so neither layer authenticated the header in the default configuration.
+
+### Solution
+
+`handleDiscovery` now only honors `X-Forwarded-Host` when `--oidc-allowed-hosts` is configured, i.e. when the allowed-hosts middleware has already validated the header against the operator's allowlist.
+With no allowlist, the issuer and `jwks_uri` are derived from `r.Host` only, and the header is ignored.
+
+Operators who deliberately rely on `X-Forwarded-Host` to advertise the proxy's public hostname in the discovery document should set `--oidc-allowed-hosts` to the set of hostnames they expect (e.g. `--oidc-allowed-hosts=sentry.example.com`); this is consistent with the existing guidance for reverse-proxy deployments and is now also the precondition for the header to influence the discovery document.
+
+Operators who cannot upgrade immediately can mitigate by setting either `--jwt-issuer` (preferred, pins the issuer statically) or `--oidc-allowed-hosts` (restricts which hostnames may be reflected back).

--- a/pkg/sentry/server/oidc/oidc.go
+++ b/pkg/sentry/server/oidc/oidc.go
@@ -351,9 +351,11 @@ func (s *Server) handleDiscovery(w http.ResponseWriter, r *http.Request) {
 
 		host := r.Host
 		// Only trust X-Forwarded-Host once the allowed-hosts middleware has
-		// validated it. Without an allowlist the header is attacker-controlled
-		// and would poison the issuer / jwks_uri (CWE-346).
-		if len(s.allowedHosts) > 0 {
+		// matched it against a concrete entry in the allowlist. A wildcard
+		// allowlist (`*`) lets any host through the middleware, so the header
+		// is still attacker-controlled in that case and would poison the
+		// issuer / jwks_uri (CWE-346).
+		if len(s.allowedHosts) > 0 && !slices.Contains(s.allowedHosts, "*") {
 			if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
 				host = forwardedHost
 			}

--- a/pkg/sentry/server/oidc/oidc.go
+++ b/pkg/sentry/server/oidc/oidc.go
@@ -350,8 +350,13 @@ func (s *Server) handleDiscovery(w http.ResponseWriter, r *http.Request) {
 		discovery = s.discovery.DeepCopy()
 
 		host := r.Host
-		if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
-			host = forwardedHost
+		// Only trust X-Forwarded-Host once the allowed-hosts middleware has
+		// validated it. Without an allowlist the header is attacker-controlled
+		// and would poison the issuer / jwks_uri (CWE-346).
+		if len(s.allowedHosts) > 0 {
+			if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
+				host = forwardedHost
+			}
 		}
 
 		scheme := r.URL.Scheme

--- a/tests/integration/suite/sentry/oidc/hostinjection.go
+++ b/tests/integration/suite/sentry/oidc/hostinjection.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(hostInjection))
+}
+
+// hostInjection asserts that an attacker-controlled X-Forwarded-Host header
+// cannot poison the OIDC discovery document when Sentry is started without a
+// static --jwt-issuer and without --oidc-allowed-hosts. The discovery
+// document's issuer and jwks_uri must reflect the real request host, not the
+// attacker-supplied header (CWE-346). This test fails against vulnerable code
+// that trusts X-Forwarded-Host unconditionally in handleDiscovery.
+type hostInjection struct {
+	sentry  *sentry.Sentry
+	baseURL string
+}
+
+func (h *hostInjection) Setup(t *testing.T) []framework.Option {
+	h.sentry = sentry.New(t,
+		sentry.WithMode("standalone"),
+		sentry.WithEnableJWT(true),
+		sentry.WithJWTTTL(2*time.Hour),
+		sentry.WithOIDCEnabled(true),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(h.sentry),
+	}
+}
+
+func (h *hostInjection) Run(t *testing.T, ctx context.Context) {
+	h.sentry.WaitUntilRunning(t, ctx)
+
+	port := h.sentry.OIDCPort(t)
+	h.baseURL = fmt.Sprintf("http://localhost:%d", port)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	t.Run("baseline discovery has expected issuer", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			h.baseURL+"/.well-known/openid-configuration", nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		t.Cleanup(func() { resp.Body.Close() })
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var doc map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
+
+		assert.Equal(t, h.baseURL, doc["issuer"],
+			"baseline issuer should match request host")
+		assert.Equal(t, h.baseURL+"/jwks.json", doc["jwks_uri"],
+			"baseline jwks_uri should match request host")
+	})
+
+	t.Run("X-Forwarded-Host must not control issuer or jwks_uri", func(t *testing.T) {
+		const attacker = "attacker.example.com"
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			h.baseURL+"/.well-known/openid-configuration", nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Forwarded-Host", attacker)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		t.Cleanup(func() { resp.Body.Close() })
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var doc map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
+
+		// Discovery fields must come from the real request, not from a
+		// client-supplied X-Forwarded-Host header. A relying party that performs
+		// dynamic discovery trusts these values to locate the signing keys, so an
+		// attacker who can set this header through a reverse proxy must not be
+		// able to redirect that lookup.
+		assert.NotContains(t, fmt.Sprint(doc["issuer"]), attacker,
+			"issuer must not echo X-Forwarded-Host (CWE-346)")
+		assert.NotContains(t, fmt.Sprint(doc["jwks_uri"]), attacker,
+			"jwks_uri must not echo X-Forwarded-Host (CWE-346)")
+		assert.Equal(t, h.baseURL, doc["issuer"],
+			"issuer must reflect the real request host")
+		assert.Equal(t, h.baseURL+"/jwks.json", doc["jwks_uri"],
+			"jwks_uri must reflect the real request host")
+	})
+}

--- a/tests/integration/suite/sentry/oidc/hostinjection/forwarded.go
+++ b/tests/integration/suite/sentry/oidc/hostinjection/forwarded.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package oidc
+package hostinjection
 
 import (
 	"context"
@@ -30,22 +30,22 @@ import (
 )
 
 func init() {
-	suite.Register(new(hostInjection))
+	suite.Register(new(forwarded))
 }
 
-// hostInjection asserts that an attacker-controlled X-Forwarded-Host header
-// cannot poison the OIDC discovery document when Sentry is started without a
-// static --jwt-issuer and without --oidc-allowed-hosts. The discovery
-// document's issuer and jwks_uri must reflect the real request host, not the
+// forwarded asserts that an attacker-controlled X-Forwarded-Host header cannot
+// poison the OIDC discovery document when Sentry is started without a static
+// --jwt-issuer and without --oidc-allowed-hosts. The discovery document's
+// issuer and jwks_uri must reflect the real request host, not the
 // attacker-supplied header (CWE-346). This test fails against vulnerable code
 // that trusts X-Forwarded-Host unconditionally in handleDiscovery.
-type hostInjection struct {
+type forwarded struct {
 	sentry  *sentry.Sentry
 	baseURL string
 }
 
-func (h *hostInjection) Setup(t *testing.T) []framework.Option {
-	h.sentry = sentry.New(t,
+func (f *forwarded) Setup(t *testing.T) []framework.Option {
+	f.sentry = sentry.New(t,
 		sentry.WithMode("standalone"),
 		sentry.WithEnableJWT(true),
 		sentry.WithJWTTTL(2*time.Hour),
@@ -53,21 +53,21 @@ func (h *hostInjection) Setup(t *testing.T) []framework.Option {
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(h.sentry),
+		framework.WithProcesses(f.sentry),
 	}
 }
 
-func (h *hostInjection) Run(t *testing.T, ctx context.Context) {
-	h.sentry.WaitUntilRunning(t, ctx)
+func (f *forwarded) Run(t *testing.T, ctx context.Context) {
+	f.sentry.WaitUntilRunning(t, ctx)
 
-	port := h.sentry.OIDCPort(t)
-	h.baseURL = fmt.Sprintf("http://localhost:%d", port)
+	port := f.sentry.OIDCPort(t)
+	f.baseURL = fmt.Sprintf("http://localhost:%d", port)
 
 	client := &http.Client{Timeout: 10 * time.Second}
 
 	t.Run("baseline discovery has expected issuer", func(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-			h.baseURL+"/.well-known/openid-configuration", nil)
+			f.baseURL+"/.well-known/openid-configuration", nil)
 		require.NoError(t, err)
 
 		resp, err := client.Do(req)
@@ -79,9 +79,9 @@ func (h *hostInjection) Run(t *testing.T, ctx context.Context) {
 		var doc map[string]any
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
 
-		assert.Equal(t, h.baseURL, doc["issuer"],
+		assert.Equal(t, f.baseURL, doc["issuer"],
 			"baseline issuer should match request host")
-		assert.Equal(t, h.baseURL+"/jwks.json", doc["jwks_uri"],
+		assert.Equal(t, f.baseURL+"/jwks.json", doc["jwks_uri"],
 			"baseline jwks_uri should match request host")
 	})
 
@@ -89,7 +89,7 @@ func (h *hostInjection) Run(t *testing.T, ctx context.Context) {
 		const attacker = "attacker.example.com"
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-			h.baseURL+"/.well-known/openid-configuration", nil)
+			f.baseURL+"/.well-known/openid-configuration", nil)
 		require.NoError(t, err)
 		req.Header.Set("X-Forwarded-Host", attacker)
 
@@ -111,9 +111,9 @@ func (h *hostInjection) Run(t *testing.T, ctx context.Context) {
 			"issuer must not echo X-Forwarded-Host (CWE-346)")
 		assert.NotContains(t, fmt.Sprint(doc["jwks_uri"]), attacker,
 			"jwks_uri must not echo X-Forwarded-Host (CWE-346)")
-		assert.Equal(t, h.baseURL, doc["issuer"],
+		assert.Equal(t, f.baseURL, doc["issuer"],
 			"issuer must reflect the real request host")
-		assert.Equal(t, h.baseURL+"/jwks.json", doc["jwks_uri"],
+		assert.Equal(t, f.baseURL+"/jwks.json", doc["jwks_uri"],
 			"jwks_uri must reflect the real request host")
 	})
 }

--- a/tests/integration/suite/sentry/oidc/hostinjection/wildcard.go
+++ b/tests/integration/suite/sentry/oidc/hostinjection/wildcard.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostinjection
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(wildcard))
+}
+
+// wildcard asserts that a wildcard --oidc-allowed-hosts="*" does not re-open
+// the X-Forwarded-Host injection path. The allowed-hosts middleware lets any
+// host through under a wildcard, so handleDiscovery must still derive the
+// issuer from r.Host rather than the attacker-supplied header (CWE-346).
+type wildcard struct {
+	sentry  *sentry.Sentry
+	baseURL string
+}
+
+func (w *wildcard) Setup(t *testing.T) []framework.Option {
+	w.sentry = sentry.New(t,
+		sentry.WithMode("standalone"),
+		sentry.WithEnableJWT(true),
+		sentry.WithJWTTTL(2*time.Hour),
+		sentry.WithOIDCEnabled(true),
+		sentry.WithOIDCAllowedHosts([]string{"*"}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(w.sentry),
+	}
+}
+
+func (w *wildcard) Run(t *testing.T, ctx context.Context) {
+	w.sentry.WaitUntilRunning(t, ctx)
+
+	port := w.sentry.OIDCPort(t)
+	w.baseURL = fmt.Sprintf("http://localhost:%d", port)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	const attacker = "attacker.example.com"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		w.baseURL+"/.well-known/openid-configuration", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Forwarded-Host", attacker)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"wildcard allowlist must allow the request through the middleware")
+
+	var doc map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
+
+	assert.NotContains(t, fmt.Sprint(doc["issuer"]), attacker,
+		"wildcard allowlist must not re-open X-Forwarded-Host injection (CWE-346)")
+	assert.NotContains(t, fmt.Sprint(doc["jwks_uri"]), attacker,
+		"wildcard allowlist must not re-open X-Forwarded-Host injection (CWE-346)")
+	assert.Equal(t, w.baseURL, doc["issuer"],
+		"issuer must reflect the real request host even under a wildcard allowlist")
+	assert.Equal(t, w.baseURL+"/jwks.json", doc["jwks_uri"],
+		"jwks_uri must reflect the real request host even under a wildcard allowlist")
+}

--- a/tests/integration/suite/sentry/oidc/oidc.go
+++ b/tests/integration/suite/sentry/oidc/oidc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oidc
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/sentry/oidc/hostinjection"
+)


### PR DESCRIPTION
handleDiscovery derives the OIDC issuer dynamically when --jwt-issuer is unset, as a convenience for operators behind a reverse proxy. The derivation read X-Forwarded-Host unconditionally, and the allowedHostsValidationHandler middleware that would have validated it is a no-op when --oidc-allowed-hosts is empty (the default). An attacker who could reach the OIDC endpoint via a proxy that forwards X-Forwarded-Host could therefore poison the issuer and jwks_uri fields in /.well-known/openid-configuration on a single request, with up to an hour of cache amplification from the Cache-Control header. Relying parties that perform dynamic OIDC discovery without pinning the expected issuer would then fetch JWKS from the attacker.

Only honor X-Forwarded-Host in handleDiscovery when s.allowedHosts is non-empty, i.e. when the middleware has actually validated the header against the operator's allowlist. With no allowlist, derive from r.Host only. Existing deployments that intentionally use X-Forwarded-Host to advertise the proxy's public hostname should set --oidc-allowed-hosts to the expected set of hostnames; this matches the pre-existing guidance for reverse-proxy deployments.

---

Thank you @geo-chen for reporting!