### PR TITLE
feat: register nameformat nameresolution component

### DIFF
--- a/cmd/daprd/components/nameresolution_nameformat.go
+++ b/cmd/daprd/components/nameresolution_nameformat.go
@@ -1,0 +1,26 @@
+//go:build allcomponents
+
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"github.com/dapr/components-contrib/nameresolution/nameformat"
+	nrLoader "github.com/dapr/dapr/pkg/components/nameresolution"
+)
+
+func init() {
+	nrLoader.DefaultRegistry.RegisterComponent(nameformat.NewResolver, "nameformat")
+}
+

--- a/cmd/daprd/components/nameresolution_nameformat.go
+++ b/cmd/daprd/components/nameresolution_nameformat.go
@@ -23,4 +23,3 @@ import (
 func init() {
 	nrLoader.DefaultRegistry.RegisterComponent(nameformat.NewResolver, "nameformat")
 }
-


### PR DESCRIPTION
# Description

Registers the `nameformat` nameresolution component from components-contrib (added in dapr/components-contrib#3867) so it's available at runtime. Without this, daprd cannot resolve services using the `nameformat` resolver despite the component existing in contrib. This is part of my endgame task to double check component registration across contrib and runtime :) 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
