### PR TITLE
[1.17] Fix workflow retention purge on Azure Cosmos DB

### DIFF
--- a/docs/release_notes/v1.17.9.md
+++ b/docs/release_notes/v1.17.9.md
@@ -1,0 +1,48 @@
+# Dapr 1.17.9
+
+This update contains the following bug fix:
+- [Workflow retention purge fails on Azure Cosmos DB when `customStatus` is not persisted](#workflow-retention-purge-fails-on-azure-cosmos-db-when-customstatus-is-not-persisted)
+
+## Workflow retention purge fails on Azure Cosmos DB when `customStatus` is not persisted
+
+### Problem
+
+A completed workflow whose `customStatus` row does not exist in the actor state store cannot be purged by the retention reminder when the state store is Azure Cosmos DB.
+The retention reminder fires every second indefinitely and the workflow stays in the `Completed` state past its configured retention TTL.
+
+### Impact
+
+Any deployment using the Azure Cosmos DB state store (`state.azure.cosmosdb`) for the workflow actor state store is affected whenever a workflow reaches a terminal state without a `customStatus` row persisted in the store.
+
+This includes:
+- Workflows that were first saved by a pre-`customStatus` daprd version and have since been upgraded.
+- Workflows whose `customStatus` row was removed out of band (manual cleanup, partial restore from backup, etc.).
+- Workflows scheduled but never advanced past the initial state, so no history delta ever triggered the `customStatus` upsert.
+
+Visible symptoms include:
+- A completed workflow stays in the `Completed` state past the configured `stateRetentionPolicy.anyTerminal` TTL.
+- The scheduler retains the retentioner reminder and re-fires it once per second indefinitely.
+- The `dapr_runtime_workflow_operation_count{operation=purge_workflow,status=failed}` metric increments once per second per affected workflow.
+- daprd logs `failed to invoke scheduled actor reminder named: retention due to: transaction failed` at one tick per second per affected workflow.
+- The workflow recovers only after an operator manually deletes the retentioner job out of the scheduler.
+
+### Root Cause
+
+`GetPurgeRequest` in `pkg/runtime/wfengine/state/state.go` unconditionally emitted a delete for the `customStatus` key alongside the metadata, inbox, and history deletes, regardless of whether the row was actually persisted.
+
+The Azure Cosmos DB state store (`components-contrib/state/azure/cosmosdb`) translates `state.TransactionalStore.Multi` into a single Cosmos transactional batch.
+Cosmos batches are atomic: if any operation in the batch fails, the whole batch is rolled back and every operation returns `FailedDependency`.
+A delete for a row that does not exist returns `NotFound` and aborts the batch.
+The state component's "tolerate `NotFound` on etag-less delete" path only applies to single-operation calls, not to batched ones, so the purge transaction was rolled back and the workflow state stayed in place.
+
+The retentioner reminder is created with a failure policy of `Constant{Interval: 1s, MaxRetries: nil}` (retry every second, forever), so the scheduler retried the same doomed batch once per second indefinitely.
+
+### Solution
+
+`State` now tracks `customStatusPersisted` as an explicit observation, set from the bulk-get ETag at load time and maintained in `ResetChangeTracking` to reflect whichever upserts the most recent save committed.
+`GetPurgeRequest` consults this flag and only emits the `customStatus` delete when the row is known to exist in the store.
+
+Workflows already stuck in this state on existing 1.17 deployments recover automatically once the sidecar is upgraded to 1.17.9.
+On the next retention reminder fire after restart, daprd reloads the workflow state from Cosmos, observes the missing `customStatus` row from its absent ETag, omits the delete, and Cosmos accepts the batch.
+The reminder drains and the workflow is purged in the normal way.
+No operator intervention or manual scheduler delete is required after the upgrade.

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -69,6 +69,18 @@ type State struct {
 	// only in the in-memory cache.
 	metadataETag *string
 
+	// customStatusPersisted is observed at load time from the state
+	// store's ETag for the customStatus key. It is the source of truth
+	// for "does this optional key currently exist in the store" at purge
+	// time, independent of whether the in-memory CustomStatus value is
+	// populated (the runtime upserts customStatus with an empty proto on
+	// every history delta, which loads as a nil CustomStatus).
+	// Including a delete for a key that does not exist in a transactional
+	// batch causes Azure Cosmos DB to abort the entire batch on the 404,
+	// which leaves workflow state unpurged and the retention reminder
+	// retrying forever.
+	customStatusPersisted bool
+
 	// change tracking
 	inboxAddedCount     int
 	inboxRemovedCount   int
@@ -105,6 +117,12 @@ func (s *State) Reset() {
 
 // ResetChangeTracking resets the change tracking counters. This should be called after a save request.
 func (s *State) ResetChangeTracking() {
+	// A save with any history delta upserts the customStatus key (see
+	// GetSaveRequest), so after a successful save it is now persisted.
+	if s.historyAddedCount > 0 || s.historyRemovedCount > 0 {
+		s.customStatusPersisted = true
+	}
+
 	s.inboxAddedCount = 0
 	s.inboxRemovedCount = 0
 	s.historyAddedCount = 0
@@ -396,6 +414,9 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 		wState.History = append(wState.History, &hist)
 	}
 
+	if bulkRes[customStatusKey].ETag != nil {
+		wState.customStatusPersisted = true
+	}
 	if len(bulkRes[customStatusKey].Data) > 0 {
 		wState.CustomStatus = &wrapperspb.StringValue{}
 		err = proto.Unmarshal(bulkRes[customStatusKey].Data, wState.CustomStatus)
@@ -432,16 +453,27 @@ func (s *State) GetPurgeRequest(actorID string) (*api.TransactionalRequest, erro
 		return nil, err
 	}
 
-	req.Operations = append(req.Operations,
-		api.TransactionalOperation{
+	// Only emit a delete for customStatus when we know the row exists. In
+	// an Azure Cosmos DB transactional batch a 404 on any delete aborts
+	// the whole batch (the etag-less delete tolerance in the state
+	// component only applies outside transactions), which would leave
+	// the workflow state in place and the retention reminder retrying
+	// forever. customStatus is upserted whenever history changes
+	// (possibly with an empty proto), so the in-memory CustomStatus
+	// pointer cannot disambiguate "persisted as empty" from "never
+	// persisted"; the persistence flag captured at load and save time
+	// is the source of truth.
+	if s.customStatusPersisted {
+		req.Operations = append(req.Operations, api.TransactionalOperation{
 			Operation: api.Delete,
 			Request:   api.TransactionalDelete{Key: customStatusKey},
-		},
-		api.TransactionalOperation{
-			Operation: api.Delete,
-			Request:   api.TransactionalDelete{Key: MetadataKey},
-		},
-	)
+		})
+	}
+
+	req.Operations = append(req.Operations, api.TransactionalOperation{
+		Operation: api.Delete,
+		Request:   api.TransactionalDelete{Key: MetadataKey},
+	})
 
 	return req, nil
 }

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/pkg/actors/api"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/kit/ptr"
+)
+
+func testOpts() Options {
+	return Options{
+		AppID:             "test-app",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+	}
+}
+
+func testEvent(id int32) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{},
+		},
+	}
+}
+
+func TestGetPurgeRequest_OmitsCustomStatusWhenNotPersisted(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+	s.AddToInbox(testEvent(0))
+	s.AddToHistory(testEvent(0))
+
+	req, err := s.GetPurgeRequest("actor1")
+	require.NoError(t, err)
+
+	deleteKeys := make(map[string]bool)
+	for _, op := range req.Operations {
+		if op.Operation == api.Delete {
+			if d, ok := op.Request.(api.TransactionalDelete); ok {
+				deleteKeys[d.Key] = true
+			}
+		}
+	}
+
+	assert.True(t, deleteKeys["inbox-000000"])
+	assert.True(t, deleteKeys["history-000000"])
+	assert.True(t, deleteKeys[MetadataKey])
+	assert.False(t, deleteKeys[customStatusKey],
+		"customStatus delete must be omitted when not persisted")
+}
+
+func TestGetPurgeRequest_IncludesCustomStatusWhenPersisted(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+	s.AddToInbox(testEvent(0))
+	s.AddToHistory(testEvent(0))
+	s.CustomStatus = wrapperspb.String("running")
+	// Simulate a successful save, which marks customStatus as persisted
+	// since a history delta is present.
+	s.ResetChangeTracking()
+
+	req, err := s.GetPurgeRequest("actor1")
+	require.NoError(t, err)
+
+	deleteKeys := make(map[string]bool)
+	for _, op := range req.Operations {
+		if op.Operation == api.Delete {
+			if d, ok := op.Request.(api.TransactionalDelete); ok {
+				deleteKeys[d.Key] = true
+			}
+		}
+	}
+
+	assert.True(t, deleteKeys[customStatusKey])
+	assert.True(t, deleteKeys[MetadataKey])
+}
+
+func TestResetChangeTracking_TracksCustomStatusPersistence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("history change marks customStatus persisted", func(t *testing.T) {
+		t.Parallel()
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		assert.False(t, s.customStatusPersisted)
+		s.ResetChangeTracking()
+		assert.True(t, s.customStatusPersisted)
+	})
+
+	t.Run("no history change leaves the flag unchanged", func(t *testing.T) {
+		t.Parallel()
+		s := NewState(testOpts())
+		s.AddToInbox(testEvent(0))
+		s.ResetChangeTracking()
+		assert.False(t, s.customStatusPersisted)
+	})
+}
+
+// TestLoadWorkflowState_SetsCustomStatusPersistedFromETag asserts that the
+// load-time observation path captures whether customStatus exists in the
+// store from the bulk-get ETag, independent of whether the in-memory
+// CustomStatus pointer ends up populated (a customStatus row persisted
+// with an empty proto loads as a non-nil ETag and a zero-length Data; the
+// persistence flag must be set even though CustomStatus stays nil).
+func TestLoadWorkflowState_SetsCustomStatusPersistedFromETag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                      string
+		customStatusETag          *string
+		wantCustomStatusPersisted bool
+		wantCustomStatusInPurge   bool
+	}{
+		{
+			name:                      "key absent",
+			customStatusETag:          nil,
+			wantCustomStatusPersisted: false,
+			wantCustomStatusInPurge:   false,
+		},
+		{
+			name:                      "key persisted with empty proto",
+			customStatusETag:          ptr.Of("etag-cs"),
+			wantCustomStatusPersisted: true,
+			wantCustomStatusInPurge:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const actorID = "wf-load-flag"
+
+			metaBytes, err := proto.Marshal(&backend.WorkflowStateMetadata{
+				HistoryLength: 1,
+				Generation:    1,
+			})
+			require.NoError(t, err)
+			histBytes, err := proto.Marshal(testEvent(0))
+			require.NoError(t, err)
+
+			// Empty Data is the realistic case for customStatus: the
+			// runtime upserts an empty StringValue, whose marshalled
+			// bytes are zero length, so the ETag is the only signal
+			// that the row exists in the store.
+			bulk := map[string]api.BulkStateEntry{
+				"history-000000": {Data: histBytes},
+				customStatusKey: {
+					Data: nil,
+					ETag: tc.customStatusETag,
+				},
+			}
+
+			store := statefake.New().
+				WithGetFn(func(_ context.Context, req *api.GetStateRequest, _ bool) (*api.StateResponse, error) {
+					if req.Key == MetadataKey {
+						return &api.StateResponse{Data: metaBytes}, nil
+					}
+					return &api.StateResponse{}, nil
+				}).
+				WithGetBulkFn(func(_ context.Context, req *api.GetBulkStateRequest, _ bool) (api.BulkStateResponse, error) {
+					out := api.BulkStateResponse{}
+					for _, k := range req.Keys {
+						out[k] = bulk[k]
+					}
+					return out, nil
+				})
+
+			got, err := LoadWorkflowState(t.Context(), store, actorID, Options{
+				WorkflowActorType: "workflow",
+				ActivityActorType: "activity",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, got)
+
+			assert.Equal(t, tc.wantCustomStatusPersisted, got.customStatusPersisted,
+				"customStatusPersisted")
+
+			req, err := got.GetPurgeRequest(actorID)
+			require.NoError(t, err)
+
+			deleteKeys := make(map[string]bool)
+			for _, op := range req.Operations {
+				if op.Operation == api.Delete {
+					if d, ok := op.Request.(api.TransactionalDelete); ok {
+						deleteKeys[d.Key] = true
+					}
+				}
+			}
+
+			assert.Equal(t, tc.wantCustomStatusInPurge, deleteKeys[customStatusKey],
+				"customStatus delete in purge")
+			assert.True(t, deleteKeys[MetadataKey], "metadata delete must always be in purge")
+		})
+	}
+}

--- a/tests/integration/framework/process/statestore/cosmosbatch/cosmosbatch.go
+++ b/tests/integration/framework/process/statestore/cosmosbatch/cosmosbatch.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cosmosbatch provides a state.Store implementation that wraps the
+// in-memory store and mirrors Azure Cosmos DB's transactional-batch
+// semantics: if any delete operation in a Multi targets a key that does not
+// exist, the whole batch is rejected with a generic "transaction failed"
+// error and none of the operations are applied. The real Cosmos DB component
+// (components-contrib/state/azure/cosmosdb) cannot tolerate a 404 on an
+// individual delete inside a batch even though the component is structured
+// to permit etag-less delete-on-missing outside transactions; tests use this
+// wrapper to reproduce that asymmetry without booting Cosmos.
+package cosmosbatch
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dapr/components-contrib/state"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"
+)
+
+// Store wraps an in-memory state store and rejects any Multi whose delete
+// operations reference a key not currently present in the store.
+type Store struct {
+	*inmemory.Wrapped
+
+	rejectedCount atomic.Int32
+}
+
+// New returns a Store backed by the integration framework's in-memory state
+// store with Cosmos-style batch semantics applied to Multi.
+func New(t *testing.T) *Store {
+	return &Store{
+		Wrapped: inmemory.New(t).(*inmemory.Wrapped),
+	}
+}
+
+// RejectedCount returns the number of Multi requests this Store has refused
+// because they contained a delete for a missing key.
+func (s *Store) RejectedCount() int { return int(s.rejectedCount.Load()) }
+
+// Multi implements state.TransactionalStore. Before delegating, every delete
+// in req is checked against the underlying store; if any references a key
+// that does not currently exist, the whole batch is rejected with the
+// "transaction failed" error that the real Cosmos component returns when an
+// operation fails with FailedDependency status code.
+func (s *Store) Multi(ctx context.Context, req *state.TransactionalStateRequest) error {
+	for _, op := range req.Operations {
+		del, ok := op.(state.DeleteRequest)
+		if !ok {
+			continue
+		}
+		res, err := s.Get(ctx, &state.GetRequest{Key: del.Key})
+		if err != nil {
+			return err
+		}
+		if res == nil || (len(res.Data) == 0 && res.ETag == nil) {
+			s.rejectedCount.Add(1)
+			return errors.New("transaction failed")
+		}
+	}
+
+	return s.Store.(state.TransactionalStore).Multi(ctx, req)
+}
+
+// MultiMaxSize advertises no per-transaction key limit; the cap is enforced
+// by the real Cosmos component and is not what this wrapper is exercising.
+func (s *Store) MultiMaxSize() int { return -1 }

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/config.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/config.go
@@ -15,4 +15,5 @@ package config
 
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/purge/retention/config/match"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/purge/retention/config/optionalkeys"
 )

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/optionalkeys/customstatus.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/optionalkeys/customstatus.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package optionalkeys
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/cosmosbatch"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(customstatus))
+}
+
+// customstatus covers the load-time half of the optional-key fix: the
+// retentioner reactivates an orchestrator that must observe a freshly-loaded
+// persistence flag for customStatus and skip the delete when the row does
+// not exist. The runtime's save path upserts customStatus on every history
+// delta (as an empty proto), so a workflow purged within the lifetime of the
+// daprd that ran it never reaches the "customStatus row missing in store"
+// branch; this test simulates that shape by deleting the customStatus row
+// out of band between daprd processes, which is the same observable state
+// as a workflow saved by a pre-customStatus daprd version.
+type customstatus struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *cosmosbatch.Store
+}
+
+func (c *customstatus) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	c.store = cosmosbatch.New(t)
+
+	sock := socket.New(t)
+	c.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(c.store),
+	)
+
+	c.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, c.ss.SocketName())),
+			// 15s gives the test enough buffer to kill daprd, delete the
+			// customStatus row from the underlying store and bring daprd back up
+			// before the retentioner reminder fires.
+			daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: wfpolicy
+spec:
+  workflow:
+    stateRetentionPolicy:
+      anyTerminal: "15s"
+`),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.ss, c.workflow),
+	}
+}
+
+func (c *customstatus) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("noop", func(*dworkflow.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(c.workflow.Dapr().GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	const instanceID = "customstatus-instance"
+	appID := c.workflow.Dapr().AppID()
+	retentionPrefix := fmt.Sprintf(
+		"dapr/jobs/actorreminder||default||dapr.internal.default.%s.retentioner||%s||",
+		appID, instanceID,
+	)
+	failedPurgeMetric := fmt.Sprintf(
+		"dapr_runtime_workflow_operation_count|app_id:%s|namespace:|operation:purge_workflow|status:failed",
+		appID,
+	)
+
+	id, err := client.ScheduleWorkflow(ctx, "noop", dworkflow.WithInstanceID(instanceID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	// The retention reminder is queued on completion; wait for it to appear
+	// in the scheduler so the manipulations below race against a real
+	// reminder rather than a missing one.
+	require.EventuallyWithT(t, func(co *assert.CollectT) {
+		keys := c.workflow.Scheduler().ListAllKeys(t, ctx, retentionPrefix)
+		assert.NotEmpty(co, keys, "retention reminder was never queued")
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Stop daprd so the orchestrator's in-memory State (which still has
+	// customStatusPersisted=true from the last save) is torn down. Once
+	// daprd is back the retentioner will reactivate the orchestrator,
+	// which will go through LoadWorkflowState against the freshly mutated
+	// store.
+	c.workflow.Dapr().Kill(t)
+
+	// Delete the customStatus row directly from the underlying in-memory
+	// store, before daprd reconnects. The actor state machinery stores
+	// rows under "<appID>||<actorType>||<actorID>||<key>".
+	actorType := fmt.Sprintf("dapr.internal.default.%s.workflow", appID)
+	csKey := strings.Join([]string{appID, actorType, instanceID, "customStatus"}, "||")
+	require.NoError(t, c.store.Delete(ctx, &state.DeleteRequest{Key: csKey}))
+
+	c.workflow.Dapr().Restart(t, ctx)
+	c.workflow.Dapr().WaitUntilRunning(t, ctx)
+
+	// After restart the retentioner reminder fires against the new daprd,
+	// the orchestrator reactivates, and LoadWorkflowState sees a nil ETag
+	// for customStatus. With the fix in place, customStatusPersisted is
+	// set to false from the load and GetPurgeRequest omits the customStatus
+	// delete, so the cosmos-batch wrapper accepts the batch and the
+	// reminder drains. Without the fix the unconditional customStatus
+	// delete would cause the wrapper to reject the batch and the reminder
+	// would retry forever.
+	require.EventuallyWithT(t, func(co *assert.CollectT) {
+		keys := c.workflow.Scheduler().ListAllKeys(t, ctx, retentionPrefix)
+		assert.Empty(co, keys, "retention reminder did not drain after purge")
+	}, 30*time.Second, 10*time.Millisecond)
+
+	assert.Zero(t, c.store.RejectedCount(),
+		"state store rejected a purge batch, meaning GetPurgeRequest emitted a delete for a non-persisted customStatus")
+
+	failed := int(c.workflow.Dapr().Metrics(t, ctx).All()[failedPurgeMetric])
+	assert.Zero(t, failed, "purge_workflow:failed metric must not have incremented")
+}


### PR DESCRIPTION
Workflow retention purge fails on Azure Cosmos DB when `customStatus` is not persisted

Problem

A completed workflow whose `customStatus` row does not exist in the actor state store cannot be purged by the retention reminder when the state store is Azure Cosmos DB. The retention reminder fires every second indefinitely and the workflow stays in the `Completed` state past its configured retention TTL.

Impact

Any deployment using the Azure Cosmos DB state store (`state.azure.cosmosdb`) for the workflow actor state store is affected whenever a workflow reaches a terminal state without a `customStatus` row persisted in the store.

This includes:
- Workflows that were first saved by a pre-`customStatus` daprd version and have since been upgraded.
- Workflows whose `customStatus` row was removed out of band (manual cleanup, partial restore from backup, etc.).
- Workflows scheduled but never advanced past the initial state, so no history delta ever triggered the `customStatus` upsert.

Visible symptoms include:
- A completed workflow stays in the `Completed` state past the configured `stateRetentionPolicy.anyTerminal` TTL.
- The scheduler retains the retentioner reminder and re-fires it once per second indefinitely.
- The `dapr_runtime_workflow_operation_count{operation=purge_workflow,status=failed}` metric increments once per second per affected workflow.
- daprd logs `failed to invoke scheduled actor reminder named: retention due to: transaction failed` at one tick per second per affected workflow.
- The workflow recovers only after an operator manually deletes the retentioner job out of the scheduler.

Root Cause

`GetPurgeRequest` in `pkg/runtime/wfengine/state/state.go` unconditionally emitted a delete for the `customStatus` key alongside the metadata, inbox, and history deletes, regardless of whether the row was actually persisted.

The Azure Cosmos DB state store (`components-contrib/state/azure/cosmosdb`) translates `state.TransactionalStore.Multi` into a single Cosmos transactional batch. Cosmos batches are atomic: if any operation in the batch fails, the whole batch is rolled back and every operation returns `FailedDependency`. A delete for a row that does not exist returns `NotFound` and aborts the batch. The state component's "tolerate `NotFound` on etag-less delete" path only applies to single-operation calls, not to batched ones, so the purge transaction was rolled back and the workflow state stayed in place.

The retentioner reminder is created with a failure policy of `Constant{Interval: 1s, MaxRetries: nil}` (retry every second, forever), so the scheduler retried the same doomed batch once per second indefinitely.

Solution

`State` now tracks `customStatusPersisted` as an explicit observation, set from the bulk-get ETag at load time and maintained in `ResetChangeTracking` to reflect whichever upserts the most recent save committed. `GetPurgeRequest` consults this flag and only emits the `customStatus` delete when the row is known to exist in the store.

Workflows already stuck in this state on existing 1.17 deployments recover automatically once the sidecar is upgraded to 1.17.9. On the next retention reminder fire after restart, daprd reloads the workflow state from Cosmos, observes the missing `customStatus` row from its absent ETag, omits the delete, and Cosmos accepts the batch. The reminder drains and the workflow is purged in the normal way. No operator intervention or manual scheduler delete is required after the upgrade.