### PR TITLE
Fix/workflow save before dispatch

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/dispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/dispatch.go
@@ -54,17 +54,6 @@ func hasRemoteTasks(es []*backend.HistoryEvent) bool {
 	return false
 }
 
-// hasRemoteMessages reports whether any of the given outbound workflow
-// state messages targets a remote application.
-func hasRemoteMessages(msgs []*backend.WorkflowRuntimeStateMessage) bool {
-	for _, msg := range msgs {
-		if router := msg.GetHistoryEvent().GetRouter(); router != nil && router.TargetAppID != nil {
-			return true
-		}
-	}
-	return false
-}
-
 // isDispatchableEvent returns true for events that, when present in
 // rs.NewEvents on first execution, must be filtered out of the saved
 // history when their dispatch failed against an unreachable remote app

--- a/pkg/actors/targets/workflow/orchestrator/dispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/dispatch.go
@@ -15,7 +15,18 @@ package orchestrator
 
 import (
 	"errors"
+
+	"github.com/dapr/durabletask-go/backend"
 )
+
+// reminderNameDispatchRetry is the deterministic per-workflow safety
+// reminder created when an activity dispatch fails AFTER the workflow's
+// state was already persisted with the TaskScheduled event. The reminder
+// fires on a backoff, scans state for any TaskScheduled whose result is
+// not yet in history or inbox, and re-attempts dispatch. Idempotent by
+// design: the activity actor's run-activity reminder is upserted under a
+// fixed name, so re-dispatching an in-flight activity is a no-op.
+const reminderNameDispatchRetry = "dispatch-retry"
 
 type dispatchResult struct {
 	failedEventIDs map[int32]struct{}
@@ -28,4 +39,36 @@ func (r *dispatchResult) recordFailure(eventID int32, err error) {
 	}
 	r.failedEventIDs[eventID] = struct{}{}
 	r.err = errors.Join(r.err, err)
+}
+
+// hasRemoteTasks reports whether any of the given TaskScheduled events
+// targets a remote application. Used to detect when the legacy
+// "framing-only first-execution save" path (PR #9738) must be preserved
+// instead of save-before-dispatch.
+func hasRemoteTasks(es []*backend.HistoryEvent) bool {
+	for _, e := range es {
+		if router := e.GetRouter(); router != nil && router.TargetAppID != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRemoteMessages reports whether any of the given outbound workflow
+// state messages targets a remote application.
+func hasRemoteMessages(msgs []*backend.WorkflowRuntimeStateMessage) bool {
+	for _, msg := range msgs {
+		if router := msg.GetHistoryEvent().GetRouter(); router != nil && router.TargetAppID != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// isDispatchableEvent returns true for events that, when present in
+// rs.NewEvents on first execution, must be filtered out of the saved
+// history when their dispatch failed against an unreachable remote app
+// (so the next reminder fire re-emits and re-attempts them).
+func isDispatchableEvent(e *backend.HistoryEvent) bool {
+	return e.GetTaskScheduled() != nil || e.GetChildWorkflowInstanceCreated() != nil
 }

--- a/pkg/actors/targets/workflow/orchestrator/dispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/dispatch.go
@@ -15,8 +15,6 @@ package orchestrator
 
 import (
 	"errors"
-
-	"github.com/dapr/durabletask-go/backend"
 )
 
 type dispatchResult struct {
@@ -30,26 +28,4 @@ func (r *dispatchResult) recordFailure(eventID int32, err error) {
 	}
 	r.failedEventIDs[eventID] = struct{}{}
 	r.err = errors.Join(r.err, err)
-}
-
-func hasRemoteTasks(es []*backend.HistoryEvent) bool {
-	for _, e := range es {
-		if router := e.GetRouter(); router != nil && router.TargetAppID != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func hasRemoteMessages(msgs []*backend.WorkflowRuntimeStateMessage) bool {
-	for _, msg := range msgs {
-		if router := msg.GetHistoryEvent().GetRouter(); router != nil && router.TargetAppID != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func isDispatchableEvent(e *backend.HistoryEvent) bool {
-	return e.GetTaskScheduled() != nil || e.GetChildWorkflowInstanceCreated() != nil
 }

--- a/pkg/actors/targets/workflow/orchestrator/dispatch_retry.go
+++ b/pkg/actors/targets/workflow/orchestrator/dispatch_retry.go
@@ -24,6 +24,7 @@ import (
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
@@ -37,9 +38,12 @@ const dispatchRetryBackoff = time.Second
 // createDispatchRetryReminder schedules the per-workflow safety reminder
 // that re-attempts dispatch for any TaskScheduled whose result has not yet
 // arrived. The reminder name is deterministic so concurrent failures from
-// the same workflow collapse onto a single scheduler entry.
-func (o *orchestrator) createDispatchRetryReminder(ctx context.Context) error {
-	return o.createWorkflowReminder(ctx, reminderNameDispatchRetry, nil, time.Now().Add(dispatchRetryBackoff), o.appID, nil)
+// the same workflow collapse onto a single scheduler entry. The workflow
+// name is passed as the scheduler ConcurrencyKey so the reminder is
+// serialized against the workflow's other execution reminders
+// (start/new-event/timer), like every other workflow-execution reminder.
+func (o *orchestrator) createDispatchRetryReminder(ctx context.Context, workflowName string) error {
+	return o.createWorkflowReminder(ctx, reminderNameDispatchRetry, nil, time.Now().Add(dispatchRetryBackoff), o.appID, &workflowName)
 }
 
 // deleteDispatchRetryReminder removes the safety reminder. NotFound is
@@ -79,32 +83,7 @@ func (o *orchestrator) redispatchStranded(ctx context.Context, _ *actorapi.Remin
 		return o.deleteDispatchRetryReminder(ctx)
 	}
 
-	// Build the set of resolved TaskScheduled IDs from history and inbox.
-	// An ID is resolved if there is a TaskCompleted or TaskFailed event
-	// for it anywhere in either slice.
-	resolved := make(map[int32]struct{})
-	collectResolved(resolved, state.History)
-	collectResolved(resolved, state.Inbox)
-
-	// Collect unresolved TaskScheduled events in history order.
-	var unresolved []*backend.HistoryEvent
-	for _, e := range state.History {
-		ts := e.GetTaskScheduled()
-		if ts == nil {
-			continue
-		}
-		// Cross-app TaskScheduled retry is intentionally not handled here
-		// in this PR; see PR description for the rationale. Skip them so
-		// the safety reminder doesn't accidentally re-dispatch cross-app
-		// activities without propagated history.
-		if router := e.GetRouter(); router != nil && router.TargetAppID != nil {
-			continue
-		}
-		if _, ok := resolved[e.GetEventId()]; ok {
-			continue
-		}
-		unresolved = append(unresolved, e)
-	}
+	unresolved := unresolvedLocalTasks(state)
 
 	if len(unresolved) == 0 {
 		// Everything has been resolved (or the workflow is past these
@@ -145,6 +124,36 @@ func (o *orchestrator) redispatchStranded(ctx context.Context, _ *actorapi.Remin
 	// from this side is done; the activity actors' own run-activity
 	// reminders will deliver results back to the workflow inbox.
 	return o.deleteDispatchRetryReminder(ctx)
+}
+
+// unresolvedLocalTasks returns the local-target TaskScheduled events in
+// state.History whose completion (TaskCompleted/TaskFailed) is not yet
+// present in either history or inbox, in history order. Cross-app
+// TaskScheduled are excluded: their retry is intentionally not handled by
+// the dispatch-retry reminder in this PR (see PR description), as
+// re-dispatching them would lack propagated history.
+func unresolvedLocalTasks(state *wfenginestate.State) []*backend.HistoryEvent {
+	// Build the set of resolved TaskScheduled IDs from history and inbox.
+	// An ID is resolved if there is a TaskCompleted or TaskFailed event
+	// for it anywhere in either slice.
+	resolved := make(map[int32]struct{})
+	collectResolved(resolved, state.History)
+	collectResolved(resolved, state.Inbox)
+
+	var unresolved []*backend.HistoryEvent
+	for _, e := range state.History {
+		if e.GetTaskScheduled() == nil {
+			continue
+		}
+		if router := e.GetRouter(); router != nil && router.TargetAppID != nil {
+			continue
+		}
+		if _, ok := resolved[e.GetEventId()]; ok {
+			continue
+		}
+		unresolved = append(unresolved, e)
+	}
+	return unresolved
 }
 
 // collectResolved scans events for TaskCompleted/TaskFailed and records

--- a/pkg/actors/targets/workflow/orchestrator/dispatch_retry.go
+++ b/pkg/actors/targets/workflow/orchestrator/dispatch_retry.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+// dispatchRetryBackoff is the initial firing delay of the safety reminder.
+// FailurePolicy on the reminder retries at 1s after that until the handler
+// returns nil.
+const dispatchRetryBackoff = time.Second
+
+// createDispatchRetryReminder schedules the per-workflow safety reminder
+// that re-attempts dispatch for any TaskScheduled whose result has not yet
+// arrived. The reminder name is deterministic so concurrent failures from
+// the same workflow collapse onto a single scheduler entry.
+func (o *orchestrator) createDispatchRetryReminder(ctx context.Context) error {
+	return o.createWorkflowReminder(ctx, reminderNameDispatchRetry, nil, time.Now().Add(dispatchRetryBackoff), o.appID, nil)
+}
+
+// deleteDispatchRetryReminder removes the safety reminder. NotFound is
+// treated as already-deleted (idempotent on concurrent fires).
+func (o *orchestrator) deleteDispatchRetryReminder(ctx context.Context) error {
+	actorType := o.actorTypeBuilder.Workflow(o.appID)
+	err := o.reminders.Delete(ctx, &actorapi.DeleteReminderRequest{
+		Name:      reminderNameDispatchRetry,
+		ActorType: actorType,
+		ActorID:   o.actorID,
+	})
+	if err == nil {
+		return nil
+	}
+	if s, ok := grpcstatus.FromError(err); ok && s.Code() == codes.NotFound {
+		return nil
+	}
+	return fmt.Errorf("workflow actor '%s': failed to delete dispatch-retry reminder: %w", o.actorID, err)
+}
+
+// redispatchStranded re-attempts dispatch for every TaskScheduled in
+// state.History whose completion is not yet present in either history or
+// inbox. The retry is idempotent: the activity actor's run-activity
+// reminder is upserted under a fixed name, so re-dispatching an activity
+// that is currently in flight is a no-op.
+//
+// Returns nil (and deletes the reminder) when there is nothing left to
+// retry. Returns a recoverable error (leaving the reminder to fire again
+// via its FailurePolicy) when at least one dispatch is still failing.
+func (o *orchestrator) redispatchStranded(ctx context.Context, _ *actorapi.Reminder) error {
+	state, _, err := o.loadInternalState(ctx)
+	if err != nil {
+		return wferrors.NewRecoverable(fmt.Errorf("dispatch-retry: load state: %w", err))
+	}
+	if state == nil {
+		// Workflow has been purged; safety reminder is stale.
+		return o.deleteDispatchRetryReminder(ctx)
+	}
+
+	// Build the set of resolved TaskScheduled IDs from history and inbox.
+	// An ID is resolved if there is a TaskCompleted or TaskFailed event
+	// for it anywhere in either slice.
+	resolved := make(map[int32]struct{})
+	collectResolved(resolved, state.History)
+	collectResolved(resolved, state.Inbox)
+
+	// Collect unresolved TaskScheduled events in history order.
+	var unresolved []*backend.HistoryEvent
+	for _, e := range state.History {
+		ts := e.GetTaskScheduled()
+		if ts == nil {
+			continue
+		}
+		// Cross-app TaskScheduled retry is intentionally not handled here
+		// in this PR; see PR description for the rationale. Skip them so
+		// the safety reminder doesn't accidentally re-dispatch cross-app
+		// activities without propagated history.
+		if router := e.GetRouter(); router != nil && router.TargetAppID != nil {
+			continue
+		}
+		if _, ok := resolved[e.GetEventId()]; ok {
+			continue
+		}
+		unresolved = append(unresolved, e)
+	}
+
+	if len(unresolved) == 0 {
+		// Everything has been resolved (or the workflow is past these
+		// tasks); the safety reminder has done its job.
+		return o.deleteDispatchRetryReminder(ctx)
+	}
+
+	workflowName := o.getExecutionStartedEvent(state).GetName()
+	dueTime := time.Now()
+	if len(state.History) > 0 {
+		dueTime = state.History[0].GetTimestamp().AsTime()
+	}
+
+	var dispatchErrs []error
+	for _, e := range unresolved {
+		// ph is nil: the safety reminder does not carry propagated
+		// history. Local activities don't need it; cross-app TaskScheduled
+		// are filtered out above.
+		derr := o.callActivity(ctx, e, dueTime, state.Generation, nil, workflowName)
+		switch {
+		case derr == nil:
+			// Dispatch succeeded; the activity actor's run-activity
+			// reminder now owns delivery.
+		case errors.Is(derr, todo.ErrDuplicateInvocation):
+			// Activity actor already has an in-flight run-activity
+			// reminder for this task; nothing to do.
+		default:
+			dispatchErrs = append(dispatchErrs, fmt.Errorf("redispatch of TaskScheduled %d: %w", e.GetEventId(), derr))
+		}
+	}
+
+	if len(dispatchErrs) > 0 {
+		// Leave the reminder in place so its FailurePolicy fires again.
+		return wferrors.NewRecoverable(errors.Join(dispatchErrs...))
+	}
+
+	// All unresolved tasks have been (re-)dispatched. The reminder's job
+	// from this side is done; the activity actors' own run-activity
+	// reminders will deliver results back to the workflow inbox.
+	return o.deleteDispatchRetryReminder(ctx)
+}
+
+// collectResolved scans events for TaskCompleted/TaskFailed and records
+// their TaskScheduledId in the resolved set.
+func collectResolved(resolved map[int32]struct{}, events []*backend.HistoryEvent) {
+	for _, e := range events {
+		switch t := e.GetEventType().(type) {
+		case *protos.HistoryEvent_TaskCompleted:
+			resolved[t.TaskCompleted.GetTaskScheduledId()] = struct{}{}
+		case *protos.HistoryEvent_TaskFailed:
+			resolved[t.TaskFailed.GetTaskScheduledId()] = struct{}{}
+		}
+	}
+}

--- a/pkg/actors/targets/workflow/orchestrator/dispatch_retry_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/dispatch_retry_test.go
@@ -1,0 +1,411 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/fake"
+	"github.com/dapr/dapr/pkg/actors/reminders"
+	remindersfake "github.com/dapr/dapr/pkg/actors/reminders/fake"
+	"github.com/dapr/dapr/pkg/actors/router"
+	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
+	"github.com/dapr/dapr/pkg/actors/state"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/backend/runtimestate"
+)
+
+const dispatchRetryTestInstanceID = "dispatch-retry-test-wf"
+
+func executionStartedEvent(instanceID string) *backend.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name: "TestWorkflow",
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId: instanceID,
+				},
+			},
+		},
+	}
+}
+
+func taskScheduledEvent(id int32) *backend.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   id,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskScheduled{
+			TaskScheduled: &protos.TaskScheduledEvent{Name: "TestActivity"},
+		},
+	}
+}
+
+func remoteTaskScheduledEvent(id int32, targetAppID string) *backend.HistoryEvent {
+	e := taskScheduledEvent(id)
+	e.Router = &protos.TaskRouter{
+		SourceAppID: "testapp",
+		TargetAppID: &targetAppID,
+	}
+	return e
+}
+
+func taskCompletedEvent(taskScheduledID int32) *backend.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: taskScheduledID},
+		},
+	}
+}
+
+func taskFailedEvent(taskScheduledID int32) *backend.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{TaskScheduledId: taskScheduledID},
+		},
+	}
+}
+
+func newDispatchRetryTestState(history, inbox []*backend.HistoryEvent) *wfenginestate.State {
+	s := wfenginestate.NewState(wfenginestate.Options{
+		AppID:             "testapp",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+	})
+	for _, e := range history {
+		s.AddToHistory(e)
+	}
+	for _, e := range inbox {
+		s.AddToInbox(e)
+	}
+	return s
+}
+
+// dispatchRetryHarness wires an orchestrator against fake router, reminders,
+// and state, capturing the side effects the dispatch-retry logic produces.
+type dispatchRetryHarness struct {
+	o                *orchestrator
+	createdReminders []*actorapi.CreateReminderRequest
+	deletedReminders []*actorapi.DeleteReminderRequest
+	routerCalls      []*internalsv1pb.InternalInvokeRequest
+}
+
+// newDispatchRetryHarness builds the orchestrator harness. routerErr, when
+// non-nil, is returned by every fake router Call (i.e. every activity
+// dispatch fails with it). stateFake, when non-nil, replaces the default
+// fake actor state store.
+func newDispatchRetryHarness(t *testing.T, routerErr error, stateFake *statefake.Fake) *dispatchRetryHarness {
+	t.Helper()
+
+	h := &dispatchRetryHarness{}
+
+	routerF := routerfake.New().WithCallFn(func(_ context.Context, req *internalsv1pb.InternalInvokeRequest) (*internalsv1pb.InternalInvokeResponse, error) {
+		h.routerCalls = append(h.routerCalls, req)
+		if routerErr != nil {
+			return nil, routerErr
+		}
+		return &internalsv1pb.InternalInvokeResponse{}, nil
+	})
+
+	remindersF := remindersfake.New().
+		WithCreate(func(_ context.Context, req *actorapi.CreateReminderRequest) error {
+			h.createdReminders = append(h.createdReminders, req)
+			return nil
+		}).
+		WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			h.deletedReminders = append(h.deletedReminders, req)
+			return nil
+		})
+
+	if stateFake == nil {
+		stateFake = statefake.New().WithGetFn(func(context.Context, *actorapi.GetStateRequest, bool) (*actorapi.StateResponse, error) {
+			return &actorapi.StateResponse{}, nil
+		})
+	}
+
+	fact, err := New(t.Context(), Options{
+		AppID:             "testapp",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+		Scheduler:         func(context.Context, *backend.WorkflowWorkItem) error { return nil },
+		ActorTypeBuilder:  common.NewActorTypeBuilder("default"),
+		Actors: fake.New().
+			WithRouter(func(context.Context) (router.Interface, error) { return routerF, nil }).
+			WithReminders(func(context.Context) (reminders.Interface, error) { return remindersF, nil }).
+			WithState(func(context.Context) (state.Interface, error) { return stateFake, nil }),
+	})
+	require.NoError(t, err)
+
+	h.o = fact.GetOrCreate(dispatchRetryTestInstanceID).(*orchestrator)
+	return h
+}
+
+// setCachedState primes the orchestrator's in-memory cache so
+// loadInternalState returns the given state without touching the store.
+func (h *dispatchRetryHarness) setCachedState(s *wfenginestate.State) {
+	h.o.state = s
+	h.o.rstate = runtimestate.NewWorkflowRuntimeState(dispatchRetryTestInstanceID, nil, s.History)
+	h.o.ometa = h.o.ometaFromState(h.o.rstate, h.o.getExecutionStartedEvent(s))
+}
+
+func (h *dispatchRetryHarness) deletedReminderNames() []string {
+	names := make([]string, 0, len(h.deletedReminders))
+	for _, req := range h.deletedReminders {
+		names = append(names, req.Name)
+	}
+	return names
+}
+
+func Test_unresolvedLocalTasks(t *testing.T) {
+	start := executionStartedEvent(dispatchRetryTestInstanceID)
+
+	tests := map[string]struct {
+		history []*backend.HistoryEvent
+		inbox   []*backend.HistoryEvent
+		wantIDs []int32
+	}{
+		"no tasks scheduled": {
+			history: []*backend.HistoryEvent{start},
+			wantIDs: nil,
+		},
+		"unresolved local task is returned": {
+			history: []*backend.HistoryEvent{start, taskScheduledEvent(2)},
+			wantIDs: []int32{2},
+		},
+		"task completed in history is resolved": {
+			history: []*backend.HistoryEvent{start, taskScheduledEvent(2), taskCompletedEvent(2)},
+			wantIDs: nil,
+		},
+		"task failed in history is resolved": {
+			history: []*backend.HistoryEvent{start, taskScheduledEvent(2), taskFailedEvent(2)},
+			wantIDs: nil,
+		},
+		"task completed in inbox is resolved": {
+			history: []*backend.HistoryEvent{start, taskScheduledEvent(2)},
+			inbox:   []*backend.HistoryEvent{taskCompletedEvent(2)},
+			wantIDs: nil,
+		},
+		"cross-app task is excluded": {
+			history: []*backend.HistoryEvent{start, remoteTaskScheduledEvent(2, "otherapp")},
+			wantIDs: nil,
+		},
+		"mixed tasks preserve history order": {
+			history: []*backend.HistoryEvent{
+				start,
+				taskScheduledEvent(2),
+				taskScheduledEvent(3),
+				remoteTaskScheduledEvent(4, "otherapp"),
+				taskScheduledEvent(5),
+				taskCompletedEvent(3),
+			},
+			wantIDs: []int32{2, 5},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := newDispatchRetryTestState(tc.history, tc.inbox)
+
+			unresolved := unresolvedLocalTasks(s)
+
+			gotIDs := make([]int32, 0, len(unresolved))
+			for _, e := range unresolved {
+				gotIDs = append(gotIDs, e.GetEventId())
+			}
+			if tc.wantIDs == nil {
+				assert.Empty(t, gotIDs)
+			} else {
+				assert.Equal(t, tc.wantIDs, gotIDs)
+			}
+		})
+	}
+}
+
+func Test_redispatchStranded_deletesReminderWhenNothingUnresolved(t *testing.T) {
+	h := newDispatchRetryHarness(t, nil, nil)
+	h.setCachedState(newDispatchRetryTestState([]*backend.HistoryEvent{
+		executionStartedEvent(dispatchRetryTestInstanceID),
+		taskScheduledEvent(2),
+		taskCompletedEvent(2),
+	}, nil))
+
+	err := h.o.redispatchStranded(t.Context(), nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, h.routerCalls, "no activity should be re-dispatched")
+	assert.Equal(t, []string{reminderNameDispatchRetry}, h.deletedReminderNames())
+}
+
+func Test_redispatchStranded_skipsCrossAppTasks(t *testing.T) {
+	h := newDispatchRetryHarness(t, nil, nil)
+	h.setCachedState(newDispatchRetryTestState([]*backend.HistoryEvent{
+		executionStartedEvent(dispatchRetryTestInstanceID),
+		remoteTaskScheduledEvent(2, "otherapp"),
+	}, nil))
+
+	err := h.o.redispatchStranded(t.Context(), nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, h.routerCalls, "cross-app tasks must not be re-dispatched without propagated history")
+	assert.Equal(t, []string{reminderNameDispatchRetry}, h.deletedReminderNames())
+}
+
+func Test_redispatchStranded_redispatchesUnresolvedLocalTask(t *testing.T) {
+	h := newDispatchRetryHarness(t, nil, nil)
+	h.setCachedState(newDispatchRetryTestState([]*backend.HistoryEvent{
+		executionStartedEvent(dispatchRetryTestInstanceID),
+		taskScheduledEvent(2),
+	}, nil))
+
+	err := h.o.redispatchStranded(t.Context(), nil)
+
+	require.NoError(t, err)
+	require.Len(t, h.routerCalls, 1)
+	assert.Equal(t, todo.ExecuteActivityMethod, h.routerCalls[0].GetMessage().GetMethod())
+	assert.Equal(t, []string{reminderNameDispatchRetry}, h.deletedReminderNames())
+}
+
+func Test_redispatchStranded_toleratesDuplicateInvocation(t *testing.T) {
+	h := newDispatchRetryHarness(t, todo.ErrDuplicateInvocation, nil)
+	h.setCachedState(newDispatchRetryTestState([]*backend.HistoryEvent{
+		executionStartedEvent(dispatchRetryTestInstanceID),
+		taskScheduledEvent(2),
+	}, nil))
+
+	err := h.o.redispatchStranded(t.Context(), nil)
+
+	require.NoError(t, err, "an in-flight activity (duplicate invocation) is not a failure")
+	require.Len(t, h.routerCalls, 1)
+	assert.Equal(t, []string{reminderNameDispatchRetry}, h.deletedReminderNames())
+}
+
+func Test_redispatchStranded_keepsReminderOnDispatchFailure(t *testing.T) {
+	h := newDispatchRetryHarness(t, errors.New("activity actor unavailable"), nil)
+	h.setCachedState(newDispatchRetryTestState([]*backend.HistoryEvent{
+		executionStartedEvent(dispatchRetryTestInstanceID),
+		taskScheduledEvent(2),
+	}, nil))
+
+	err := h.o.redispatchStranded(t.Context(), nil)
+
+	require.Error(t, err)
+	assert.True(t, wferrors.IsRecoverable(err), "dispatch failure must be recoverable so the reminder fires again")
+	assert.Empty(t, h.deletedReminders, "the reminder must stay in place while dispatch keeps failing")
+}
+
+func Test_redispatchStranded_deletesReminderWhenStatePurged(t *testing.T) {
+	// No cached state and an empty fake store: loadInternalState returns a
+	// nil state, signaling the workflow has been purged.
+	h := newDispatchRetryHarness(t, nil, nil)
+
+	err := h.o.redispatchStranded(t.Context(), nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, h.routerCalls)
+	assert.Equal(t, []string{reminderNameDispatchRetry}, h.deletedReminderNames())
+}
+
+// storeFromState renders a saved workflow state into a fake actor state
+// store, so runWorkflow's empty-inbox reload path can read it back.
+func storeFromState(t *testing.T, s *wfenginestate.State) *statefake.Fake {
+	t.Helper()
+
+	req, err := s.GetSaveRequest(dispatchRetryTestInstanceID)
+	require.NoError(t, err)
+
+	kv := make(map[string][]byte)
+	for _, op := range req.Operations {
+		if up, ok := op.Request.(actorapi.TransactionalUpsert); ok {
+			switch v := up.Value.(type) {
+			case []byte:
+				kv[up.Key] = v
+			case string:
+				kv[up.Key] = []byte(v)
+			default:
+				t.Fatalf("unexpected upsert value type %T for key %s", up.Value, up.Key)
+			}
+		}
+	}
+
+	return statefake.New().
+		WithGetFn(func(_ context.Context, req *actorapi.GetStateRequest, _ bool) (*actorapi.StateResponse, error) {
+			return &actorapi.StateResponse{Data: kv[req.Key]}, nil
+		}).
+		WithGetBulkFn(func(_ context.Context, req *actorapi.GetBulkStateRequest, _ bool) (actorapi.BulkStateResponse, error) {
+			res := make(actorapi.BulkStateResponse, len(req.Keys))
+			for _, k := range req.Keys {
+				res[k] = actorapi.BulkStateEntry{Data: kv[k]}
+			}
+			return res, nil
+		})
+}
+
+func Test_runWorkflow_emptyInboxRecreatesDispatchRetryReminder(t *testing.T) {
+	// A running workflow with an empty inbox and a durable TaskScheduled
+	// whose result never arrived: the empty-inbox path must recreate the
+	// dispatch-retry safety reminder, serialized on the workflow name.
+	persisted := newDispatchRetryTestState([]*backend.HistoryEvent{
+		executionStartedEvent(dispatchRetryTestInstanceID),
+		taskScheduledEvent(2),
+	}, nil)
+	h := newDispatchRetryHarness(t, nil, storeFromState(t, persisted))
+
+	completed, err := h.o.runWorkflow(t.Context(), &actorapi.Reminder{Name: "new-event-recovery-test"})
+
+	require.NoError(t, err)
+	assert.Equal(t, todo.RunCompletedTrue, completed)
+
+	require.Len(t, h.createdReminders, 1)
+	created := h.createdReminders[0]
+	assert.Equal(t, reminderNameDispatchRetry, created.Name)
+	assert.Equal(t, dispatchRetryTestInstanceID, created.ActorID)
+	require.NotNil(t, created.ConcurrencyKey, "dispatch-retry must carry the workflow-name concurrency key")
+	assert.Equal(t, "TestWorkflow", *created.ConcurrencyKey)
+}
+
+func Test_runWorkflow_emptyInboxNoRecreateWhenTasksResolved(t *testing.T) {
+	// Same shape, but the task already has its completion in history: the
+	// empty-inbox path must stay a no-op and not create any reminder.
+	persisted := newDispatchRetryTestState([]*backend.HistoryEvent{
+		executionStartedEvent(dispatchRetryTestInstanceID),
+		taskScheduledEvent(2),
+		taskCompletedEvent(2),
+	}, nil)
+	h := newDispatchRetryHarness(t, nil, storeFromState(t, persisted))
+
+	completed, err := h.o.runWorkflow(t.Context(), &actorapi.Reminder{Name: "new-event-recovery-test"})
+
+	require.NoError(t, err)
+	assert.Equal(t, todo.RunCompletedTrue, completed)
+	assert.Empty(t, h.createdReminders)
+}

--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -137,6 +137,9 @@ func (o *orchestrator) handleReminder(ctx context.Context, reminder *actorapi.Re
 		}
 		return o.addWorkflowEvent(ctx, &ev)
 
+	case reminder.Name == reminderNameDispatchRetry:
+		return o.redispatchStranded(ctx, reminder)
+
 	default:
 		return fmt.Errorf("unable to handle reminder '%s' for workflow actor '%s': unknown reminder type", reminder.Name, o.actorID)
 	}

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -374,82 +375,128 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		}
 	}
 
-	// SAVE-BEFORE-DISPATCH.
+	// Dispatch-vs-save ordering:
 	//
-	// We must persist the workflow's runtime-state (TaskScheduled events for
-	// pending activities, TimerCreated, outbound messages etc.) BEFORE
-	// triggering any side effect (dispatch to activity actors, child
-	// workflows, AddEvent on remote workflow actors).
+	//   * Default path (no cross-app targets in this batch) uses
+	//     SAVE-BEFORE-DISPATCH. The workflow's full runtime-state
+	//     (TaskScheduled events, outbound messages, etc.) is persisted
+	//     BEFORE any side effect. This eliminates the "orphan-completion"
+	//     stall, where (under chaos) a successful dispatch's TaskCompleted
+	//     comes back to a workflow whose state save was rolled back:
+	//     history has no TaskScheduled to match the completion to, replay
+	//     re-emits ScheduleTask, the dispatcher's dedup check skips
+	//     dispatch, and the unconsumed TaskCompleted gets appended as an
+	//     orphan. With save-before-dispatch, if the save fails no side
+	//     effect happens, and the retry sees clean state.
 	//
-	// Why: dispatch creates durable reminders in the scheduler / activity
-	// actor (the activity actor's "run-activity" reminder, the child
-	// workflow's start reminder, the AddEvent inbox row on the recipient).
-	// These reminders OUTLIVE the workflow's local state and will fire
-	// regardless of whether the workflow's own save eventually commits.
-	//
-	// Under chaos (placement rebalance, state-store latency, peer ETag race),
-	// the legacy order (dispatch -> save) produces an "orphan-completion"
-	// failure:
-	//
-	//   1. Dispatch succeeds -> activity actor enqueues its "run-activity"
-	//      reminder durably in the scheduler.
-	//   2. Workflow's own state save fails (ETag mismatch, network drop).
-	//   3. Activity reminder fires anyway. Activity executes and posts
-	//      TaskCompleted back to the workflow via the activity-result
-	//      reminder, which writes the event into the workflow's inbox.
-	//   4. Workflow retries: loads state, history has NO TaskScheduled
-	//      because step 2 was rolled back, but inbox now has an unsolicited
-	//      TaskCompleted.
-	//   5. Workflow code replays, re-emits ScheduleTask with the same
-	//      EventId, and the dispatcher's IsTaskAlreadyResolved check
-	//      silently skips dispatch because TaskCompleted is already in
-	//      NewEvents (from the inbox).
-	//   6. ApplyRuntimeStateChanges appends the unconsumed TaskCompleted
-	//      to history as an "orphan" with no preceding TaskScheduled.
-	//      Workflow waits forever for an activity that will never be
-	//      re-dispatched.
-	//
-	// With save-before-dispatch, if step 2 fails the side effects in
-	// step 1 never happen, so no orphan can form. The retry sees the
-	// pre-chaos state and re-runs cleanly.
-	//
-	// Trade-off / known limitation:
-	//   * If the save succeeds and the dispatch fails (e.g. router.Call
-	//     rejects the activity actor invocation), the persisted
+	//     Cost: if the save succeeds and the dispatch fails (e.g. activity
+	//     actor type not registered during a placement rebalance), the
 	//     TaskScheduled is durable but no activity actor is running it.
-	//     The workflow's replay matches the TaskScheduled in OldEvents to
-	//     the CallActivity.Await(), but pendingTasks on subsequent runs
-	//     is empty (durabletask only populates it from actions emitted
-	//     by THIS execution). The workflow stalls.
-	//   * Dispatch is idempotent (activity actor's "run-activity" reminder
-	//     uses a fixed name + upsert-create semantics, inflight.Acquire
-	//     coalesces concurrent invocations), so the FIX is to detect
-	//     unfulfilled TaskScheduled events in history on workflow load and
-	//     re-dispatch them. That is the subject of a follow-up.
+	//     We close that gap below by creating a safety reminder
+	//     ([[reminderNameDispatchRetry]]) on dispatch failure; the
+	//     reminder fires on a backoff and re-attempts the dispatch
+	//     idempotently until it succeeds.
+	//
+	//   * Cross-app path (preserved from PR #9738): when any pending task
+	//     or outbound message targets a remote app, the legacy
+	//     "dispatch first, save framing only on first execution, no-save
+	//     on subsequent failed retries" path is taken. This keeps a
+	//     workflow whose remote app is offline from growing its history
+	//     on every retry cycle. Unifying this path with save-before-
+	//     dispatch + a cross-app-aware dispatch-retry reminder is
+	//     deferred to a follow-up (see PR description).
+	if hasRemoteTasks(pendingTasks) || hasRemoteMessages(createWorkflows) {
+		// PR #9738 cross-app path: dispatch first, then save selectively.
+		activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
+		addResult := o.callAddEventStateMessage(ctx, addWorkflows)
+		createResult := o.callCreateWorkflowStateMessage(ctx, createWorkflows)
 
-	state.ApplyRuntimeStateChanges(rs)
-	state.ClearInbox()
+		dispatchErr := errors.Join(activityResult.err, addResult.err, createResult.err)
+		if dispatchErr != nil {
+			if errors.Is(dispatchErr, errPayloadSizeExceeded) {
+				return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs,
+					protos.StalledReason_PAYLOAD_SIZE_EXCEEDED, dispatchErr.Error())
+			}
 
-	if err = o.signAndSaveState(ctx, state); err != nil {
-		return todo.RunCompletedFalse, err
-	}
+			if len(state.History) == 0 {
+				// First-execution-with-cross-app: save state without the
+				// events that failed to dispatch so the workflow
+				// transitions to RUNNING. Successfully dispatched items
+				// keep their events in history so they are not
+				// re-dispatched on retry. The inbox is preserved so the
+				// existing reminder retries the full execution.
+				allFailed := make(map[int32]struct{}, len(activityResult.failedEventIDs)+len(createResult.failedEventIDs)+len(addResult.failedEventIDs))
+				maps.Copy(allFailed, activityResult.failedEventIDs)
+				maps.Copy(allFailed, createResult.failedEventIDs)
+				maps.Copy(allFailed, addResult.failedEventIDs)
 
-	// Dispatch activities and messages now that state is durable. Any
-	// failure here leaves the persisted TaskScheduled in place and surfaces
-	// as a recoverable error so the workflow retries; re-dispatch is safe
-	// because of the idempotency guarantees described above.
-	activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
-	addResult := o.callAddEventStateMessage(ctx, addWorkflows)
-	createResult := o.callCreateWorkflowStateMessage(ctx, createWorkflows)
+				// Temporarily replace rs.NewEvents with a filtered copy that
+				// excludes failed dispatch events, then restore the original
+				// after ApplyRuntimeStateChanges. ApplyRuntimeStateChanges
+				// reads rs.NewEvents by reference (via GetNewEvents()) and
+				// appends directly to state.History; it does not copy or
+				// retain the slice.
+				origNewEvents := rs.NewEvents
+				filtered := origNewEvents[:0:0]
+				for _, e := range origNewEvents {
+					if isDispatchableEvent(e) {
+						if _, failed := allFailed[e.GetEventId()]; failed {
+							continue
+						}
+					}
+					filtered = append(filtered, e)
+				}
+				rs.NewEvents = filtered
+				state.ApplyRuntimeStateChanges(rs)
+				rs.NewEvents = origNewEvents
+				if err = o.signAndSaveState(ctx, state); err != nil {
+					return todo.RunCompletedFalse, err
+				}
+			}
 
-	dispatchErr := errors.Join(activityResult.err, addResult.err, createResult.err)
-	if dispatchErr != nil {
-		if errors.Is(dispatchErr, errPayloadSizeExceeded) {
-			return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs,
-				protos.StalledReason_PAYLOAD_SIZE_EXCEEDED, dispatchErr.Error())
+			executionStatus = diag.StatusRecoverable
+			return todo.RunCompletedFalse, wferrors.NewRecoverable(dispatchErr)
 		}
-		executionStatus = diag.StatusRecoverable
-		return todo.RunCompletedFalse, wferrors.NewRecoverable(dispatchErr)
+
+		state.ApplyRuntimeStateChanges(rs)
+		state.ClearInbox()
+
+		if err = o.signAndSaveState(ctx, state); err != nil {
+			return todo.RunCompletedFalse, err
+		}
+	} else {
+		// Default path: save-before-dispatch.
+		state.ApplyRuntimeStateChanges(rs)
+		state.ClearInbox()
+
+		if err = o.signAndSaveState(ctx, state); err != nil {
+			return todo.RunCompletedFalse, err
+		}
+
+		activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
+		addResult := o.callAddEventStateMessage(ctx, addWorkflows)
+		createResult := o.callCreateWorkflowStateMessage(ctx, createWorkflows)
+
+		dispatchErr := errors.Join(activityResult.err, addResult.err, createResult.err)
+		if dispatchErr != nil {
+			if errors.Is(dispatchErr, errPayloadSizeExceeded) {
+				return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs,
+					protos.StalledReason_PAYLOAD_SIZE_EXCEEDED, dispatchErr.Error())
+			}
+
+			// State is durable; the TaskScheduled rows are committed but
+			// at least one dispatch failed. Schedule the safety reminder
+			// so the workflow doesn't strand when no other reminder
+			// happens to fire later. The reminder is idempotent and
+			// deterministic in name, so repeated creates collapse onto
+			// one scheduler entry.
+			if rerr := o.createDispatchRetryReminder(ctx); rerr != nil {
+				log.Errorf("Workflow actor '%s': failed to create dispatch-retry reminder: %v", o.actorID, rerr)
+			}
+
+			executionStatus = diag.StatusRecoverable
+			return todo.RunCompletedFalse, wferrors.NewRecoverable(dispatchErr)
+		}
 	}
 
 	rstatus := runtimestate.RuntimeStatus(rs)

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -377,9 +377,9 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 
 	// Dispatch-vs-save ordering:
 	//
-	//   * Default path (no cross-app targets in this batch) uses
+	//   * Default path (activities-only batch with local targets) uses
 	//     SAVE-BEFORE-DISPATCH. The workflow's full runtime-state
-	//     (TaskScheduled events, outbound messages, etc.) is persisted
+	//     (TaskScheduled events, etc.) is persisted
 	//     BEFORE any side effect. This eliminates the "orphan-completion"
 	//     stall, where (under chaos) a successful dispatch's TaskCompleted
 	//     comes back to a workflow whose state save was rolled back:
@@ -397,15 +397,24 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	//     reminder fires on a backoff and re-attempts the dispatch
 	//     idempotently until it succeeds.
 	//
-	//   * Cross-app path (preserved from PR #9738): when any pending task
-	//     or outbound message targets a remote app, the legacy
-	//     "dispatch first, save framing only on first execution, no-save
-	//     on subsequent failed retries" path is taken. This keeps a
-	//     workflow whose remote app is offline from growing its history
-	//     on every retry cycle. Unifying this path with save-before-
-	//     dispatch + a cross-app-aware dispatch-retry reminder is
-	//     deferred to a follow-up (see PR description).
-	if hasRemoteTasks(pendingTasks) || hasRemoteMessages(createWorkflows) {
+	//   * Legacy path (preserved from PR #9738): when the batch carries
+	//     any outbound state message (child-workflow creation or child
+	//     completion/failure delivery, local or remote) or any pending
+	//     task targets a remote app, the legacy "dispatch first, save
+	//     framing only on first execution, no-save on subsequent failed
+	//     retries" path is taken. The dispatch-retry safety reminder
+	//     only knows how to re-dispatch local TaskScheduled events, so
+	//     save-before-dispatch is restricted to activities-only local
+	//     batches: persisting a state message's events (and clearing the
+	//     inbox) before delivery would otherwise strand the counterpart
+	//     workflow if the dispatch fails, with nothing left to retry it.
+	//     The legacy path instead keeps the inbox intact on failure so
+	//     the calling reminder re-executes and regenerates the messages.
+	//     It also keeps a workflow whose remote app is offline from
+	//     growing its history on every retry cycle. Unifying this path
+	//     with save-before-dispatch + a message-aware dispatch-retry
+	//     reminder is deferred to a follow-up (see PR description).
+	if len(addWorkflows) > 0 || len(createWorkflows) > 0 || hasRemoteTasks(pendingTasks) {
 		// PR #9738 cross-app path: dispatch first, then save selectively.
 		activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
 		addResult := o.callAddEventStateMessage(ctx, addWorkflows)
@@ -465,7 +474,10 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			return todo.RunCompletedFalse, err
 		}
 	} else {
-		// Default path: save-before-dispatch.
+		// Default path: save-before-dispatch. The batch carries no
+		// outbound state messages (gating above), so activities are the
+		// only side effect to dispatch — and the only kind the
+		// dispatch-retry safety reminder knows how to recover.
 		state.ApplyRuntimeStateChanges(rs)
 		state.ClearInbox()
 
@@ -473,11 +485,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			return todo.RunCompletedFalse, err
 		}
 
-		activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
-		addResult := o.callAddEventStateMessage(ctx, addWorkflows)
-		createResult := o.callCreateWorkflowStateMessage(ctx, createWorkflows)
-
-		dispatchErr := errors.Join(activityResult.err, addResult.err, createResult.err)
+		dispatchErr := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory).err
 		if dispatchErr != nil {
 			if errors.Is(dispatchErr, errPayloadSizeExceeded) {
 				return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs,

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"strings"
 	"time"
 
@@ -375,7 +374,70 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		}
 	}
 
-	// Dispatch activities and messages, collecting failures.
+	// SAVE-BEFORE-DISPATCH.
+	//
+	// We must persist the workflow's runtime-state (TaskScheduled events for
+	// pending activities, TimerCreated, outbound messages etc.) BEFORE
+	// triggering any side effect (dispatch to activity actors, child
+	// workflows, AddEvent on remote workflow actors).
+	//
+	// Why: dispatch creates durable reminders in the scheduler / activity
+	// actor (the activity actor's "run-activity" reminder, the child
+	// workflow's start reminder, the AddEvent inbox row on the recipient).
+	// These reminders OUTLIVE the workflow's local state and will fire
+	// regardless of whether the workflow's own save eventually commits.
+	//
+	// Under chaos (placement rebalance, state-store latency, peer ETag race),
+	// the legacy order (dispatch -> save) produces an "orphan-completion"
+	// failure:
+	//
+	//   1. Dispatch succeeds -> activity actor enqueues its "run-activity"
+	//      reminder durably in the scheduler.
+	//   2. Workflow's own state save fails (ETag mismatch, network drop).
+	//   3. Activity reminder fires anyway. Activity executes and posts
+	//      TaskCompleted back to the workflow via the activity-result
+	//      reminder, which writes the event into the workflow's inbox.
+	//   4. Workflow retries: loads state, history has NO TaskScheduled
+	//      because step 2 was rolled back, but inbox now has an unsolicited
+	//      TaskCompleted.
+	//   5. Workflow code replays, re-emits ScheduleTask with the same
+	//      EventId, and the dispatcher's IsTaskAlreadyResolved check
+	//      silently skips dispatch because TaskCompleted is already in
+	//      NewEvents (from the inbox).
+	//   6. ApplyRuntimeStateChanges appends the unconsumed TaskCompleted
+	//      to history as an "orphan" with no preceding TaskScheduled.
+	//      Workflow waits forever for an activity that will never be
+	//      re-dispatched.
+	//
+	// With save-before-dispatch, if step 2 fails the side effects in
+	// step 1 never happen, so no orphan can form. The retry sees the
+	// pre-chaos state and re-runs cleanly.
+	//
+	// Trade-off / known limitation:
+	//   * If the save succeeds and the dispatch fails (e.g. router.Call
+	//     rejects the activity actor invocation), the persisted
+	//     TaskScheduled is durable but no activity actor is running it.
+	//     The workflow's replay matches the TaskScheduled in OldEvents to
+	//     the CallActivity.Await(), but pendingTasks on subsequent runs
+	//     is empty (durabletask only populates it from actions emitted
+	//     by THIS execution). The workflow stalls.
+	//   * Dispatch is idempotent (activity actor's "run-activity" reminder
+	//     uses a fixed name + upsert-create semantics, inflight.Acquire
+	//     coalesces concurrent invocations), so the FIX is to detect
+	//     unfulfilled TaskScheduled events in history on workflow load and
+	//     re-dispatch them. That is the subject of a follow-up.
+
+	state.ApplyRuntimeStateChanges(rs)
+	state.ClearInbox()
+
+	if err = o.signAndSaveState(ctx, state); err != nil {
+		return todo.RunCompletedFalse, err
+	}
+
+	// Dispatch activities and messages now that state is durable. Any
+	// failure here leaves the persisted TaskScheduled in place and surfaces
+	// as a recoverable error so the workflow retries; re-dispatch is safe
+	// because of the idempotency guarantees described above.
 	activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
 	addResult := o.callAddEventStateMessage(ctx, addWorkflows)
 	createResult := o.callCreateWorkflowStateMessage(ctx, createWorkflows)
@@ -386,52 +448,8 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs,
 				protos.StalledReason_PAYLOAD_SIZE_EXCEEDED, dispatchErr.Error())
 		}
-		if len(state.History) == 0 && (hasRemoteTasks(pendingTasks) || hasRemoteMessages(createWorkflows)) {
-			// Save state without the events that failed to dispatch so the
-			// workflow transitions to RUNNING. Successfully dispatched items
-			// keep their events in history so they are not re-dispatched on
-			// retry. The inbox is preserved so the existing reminder retries
-			// the full execution.
-			allFailed := make(map[int32]struct{}, len(activityResult.failedEventIDs)+len(createResult.failedEventIDs)+len(addResult.failedEventIDs))
-			maps.Copy(allFailed, activityResult.failedEventIDs)
-			maps.Copy(allFailed, createResult.failedEventIDs)
-			maps.Copy(allFailed, addResult.failedEventIDs)
-
-			// Temporarily replace rs.NewEvents with a filtered copy that excludes
-			// failed dispatch events, then restore the original after
-			// ApplyRuntimeStateChanges. This works because ApplyRuntimeStateChanges
-			// reads rs.NewEvents by reference (via GetNewEvents()) and appends
-			// directly to state.History. It does not copy or retain the slice.
-			origNewEvents := rs.NewEvents
-			filtered := origNewEvents[:0:0]
-			for _, e := range origNewEvents {
-				if isDispatchableEvent(e) {
-					if _, failed := allFailed[e.GetEventId()]; failed {
-						continue
-					}
-				}
-				filtered = append(filtered, e)
-			}
-			rs.NewEvents = filtered
-			state.ApplyRuntimeStateChanges(rs)
-			rs.NewEvents = origNewEvents
-			if saveErr := o.signAndSaveState(ctx, state); saveErr != nil {
-				return todo.RunCompletedFalse, saveErr
-			}
-			executionStatus = diag.StatusRecoverable
-			return todo.RunCompletedFalse, wferrors.NewRecoverable(dispatchErr)
-		}
-
 		executionStatus = diag.StatusRecoverable
 		return todo.RunCompletedFalse, wferrors.NewRecoverable(dispatchErr)
-	}
-
-	state.ApplyRuntimeStateChanges(rs)
-	state.ClearInbox()
-
-	err = o.signAndSaveState(ctx, state)
-	if err != nil {
-		return todo.RunCompletedFalse, err
 	}
 
 	rstatus := runtimestate.RuntimeStatus(rs)

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -116,6 +116,22 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			if rerr := o.handleRetention(ctx, runtimestate.RuntimeStatus(o.rstate)); rerr != nil {
 				return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("failed to (re)create retention reminder on empty-inbox completion path: %w", rerr))
 			}
+		} else if unresolved := unresolvedLocalTasks(state); len(unresolved) > 0 {
+			// The workflow is running, the inbox is empty, but history
+			// holds local TaskScheduled events with no completion in
+			// sight. This recovers the dispatch-retry safety reminder
+			// when its Create was lost after a pre-save dispatch failure
+			// (e.g. scheduler unreachable, or the process died before the
+			// Create RPC). Without it the workflow has no wake-up left:
+			// the pre-save already cleared the inbox, so re-running this
+			// path is otherwise a no-op. Idempotent: the reminder name is
+			// deterministic, and if the tasks are merely in flight the
+			// fired reminder re-dispatches into ErrDuplicateInvocation
+			// and deletes itself.
+			wfName := o.getExecutionStartedEvent(state).GetName()
+			if rerr := o.createDispatchRetryReminder(ctx, wfName); rerr != nil {
+				return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("failed to (re)create dispatch-retry reminder on empty-inbox path: %w", rerr))
+			}
 		}
 		log.Debugf("Workflow actor '%s': ignoring run request for reminder '%s' because the workflow inbox is empty", o.actorID, reminder.Name)
 		return todo.RunCompletedTrue, nil
@@ -498,8 +514,15 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			// happens to fire later. The reminder is idempotent and
 			// deterministic in name, so repeated creates collapse onto
 			// one scheduler entry.
-			if rerr := o.createDispatchRetryReminder(ctx); rerr != nil {
-				log.Errorf("Workflow actor '%s': failed to create dispatch-retry reminder: %v", o.actorID, rerr)
+			//
+			// A creation failure is joined into the returned recoverable
+			// error so the calling reminder is not acked and gets
+			// redelivered; the empty-inbox path in this function then
+			// re-attempts creating the safety reminder for the stranded
+			// TaskScheduled (the inbox was already cleared by the
+			// pre-save, so re-execution alone would be a no-op).
+			if rerr := o.createDispatchRetryReminder(ctx, workflowName); rerr != nil {
+				dispatchErr = errors.Join(dispatchErr, fmt.Errorf("failed to create dispatch-retry reminder: %w", rerr))
 			}
 
 			executionStatus = diag.StatusRecoverable

--- a/tests/integration/suite/daprd/workflow/chaos/common.go
+++ b/tests/integration/suite/daprd/workflow/chaos/common.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+// activityResultDone is the canonical "the activity completed normally"
+// marker returned by the chaos suite's stub activities. Extracted as a
+// package constant because goconst flagged the repeated literal across
+// six test files.
+const activityResultDone = "done"

--- a/tests/integration/suite/daprd/workflow/chaos/etagattached.go
+++ b/tests/integration/suite/daprd/workflow/chaos/etagattached.go
@@ -119,7 +119,7 @@ func (e *etagattached) Run(t *testing.T, ctx context.Context) {
 
 	r := e.workflow.Registry()
 	require.NoError(t, r.AddActivityN("act", func(actx task.ActivityContext) (any, error) {
-		return "done", nil
+		return activityResultDone, nil
 	}))
 	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
 		var out string

--- a/tests/integration/suite/daprd/workflow/chaos/orphancompletion.go
+++ b/tests/integration/suite/daprd/workflow/chaos/orphancompletion.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(orphancompletion))
+}
+
+// orphancompletion exercises the failure mode in which the workflow's own
+// state save fails on the run that schedules an activity. Under the legacy
+// dispatch-before-save order, the activity actor has already been triggered
+// (and its "run-activity" reminder is durable in the scheduler) by the time
+// the rollback happens. The activity runs to completion, posts TaskCompleted
+// back to the workflow via the activity-result reminder which inserts it
+// into the workflow's inbox via addWorkflowEvent (a separate state-store
+// transaction that does not hit the injected fault, so it commits).
+//
+// On retry the workflow reloads: history has no TaskScheduled (rolled back)
+// but inbox carries an orphan TaskCompleted. The workflow code's
+// deterministic replay re-emits ScheduleTask with the same EventId, and the
+// dispatcher's IsTaskAlreadyResolved check silently skips the new dispatch
+// because the resolution is already present in NewEvents. The unconsumed
+// TaskCompleted is appended to history by ApplyRuntimeStateChanges, leaving
+// an out-of-order completion that the workflow can never match against an
+// await. The workflow stalls forever.
+//
+// With save-before-dispatch, the activity is not dispatched until the save
+// commits. A save failure cancels the run before any side effect, so no
+// orphan TaskCompleted can ever be produced. The workflow's reminder retry
+// re-runs the execution cleanly against the rolled-back state.
+//
+// The redispatch helper covers the complementary edge case where the save
+// succeeds but the dispatch call (router.Call) fails afterwards: the next
+// runWorkflow scans state.History for TaskScheduled without matching
+// TaskCompleted / TaskFailed and re-invokes the activity actor. Dispatch is
+// idempotent (fixed run-activity reminder name with upsert semantics +
+// inflight.Acquire coalescing).
+type orphancompletion struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *fault.Store
+}
+
+func (o *orphancompletion) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	o.store = fault.New(t)
+
+	sock := socket.New(t)
+	o.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(o.store),
+	)
+
+	o.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, o.ss.SocketName())),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(o.ss, o.workflow),
+	}
+}
+
+func (o *orphancompletion) Run(t *testing.T, ctx context.Context) {
+	o.workflow.WaitUntilRunning(t, ctx)
+
+	const wfID = "orphan-wf"
+
+	var activityRuns atomic.Int32
+	releaseActivity := make(chan struct{})
+
+	r := o.workflow.Registry()
+	require.NoError(t, r.AddActivityN("act", func(actx task.ActivityContext) (any, error) {
+		activityRuns.Add(1)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseActivity:
+			return activityResultDone, nil
+		}
+	}))
+
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		var out string
+		if err := octx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	o.workflow.BackendClient(t, ctx)
+	gclient := o.workflow.GRPCClient(t, ctx)
+
+	// Arm a single failure on the workflow's history- save. This is the
+	// save that captures the just-emitted TaskScheduled action. With
+	// save-before-dispatch, the activity is dispatched AFTER this save
+	// commits; the injected failure on the first attempt therefore prevents
+	// the dispatch entirely, and the retry runs cleanly against the
+	// rolled-back state.
+	failedCh := make(chan struct{})
+	o.store.ArmFailures(wfID+"||history-", 1, failedCh)
+
+	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "wf",
+		InstanceId:        wfID,
+	})
+	require.NoError(t, err)
+
+	// Wait until the injected save failure has fired at least once, then
+	// release the activity so the retry can complete.
+	select {
+	case <-failedCh:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "injected history-save failure never fired")
+	}
+	close(releaseActivity)
+
+	// Workflow must complete.  Pre-fix, the orphan TaskCompleted would
+	// strand the workflow in RUNNING forever and this assertion would time
+	// out.
+	assert.EventuallyWithT(t, func(co *assert.CollectT) {
+		resp, gerr := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        wfID,
+			WorkflowComponent: "dapr",
+		})
+		if assert.NoError(co, gerr) {
+			assert.Equal(co, "COMPLETED", resp.GetRuntimeStatus())
+		}
+	}, 45*time.Second, 100*time.Millisecond)
+
+	// The activity must have run AT LEAST once (it may run more if the
+	// retry path triggers re-dispatch). What matters is that exactly one
+	// TaskCompleted ends up matched against exactly one TaskScheduled in
+	// history; the workflow completes only if that pairing happens.
+	assert.GreaterOrEqual(t, activityRuns.Load(), int32(1),
+		"activity must have executed for the workflow to complete")
+
+	assert.GreaterOrEqual(t, o.store.FailedCount(), 1,
+		"expected the injected history-save failure to have fired")
+}

--- a/tests/integration/suite/daprd/workflow/chaos/reminderdedup.go
+++ b/tests/integration/suite/daprd/workflow/chaos/reminderdedup.go
@@ -100,7 +100,7 @@ func (s *reminderdedup) Run(t *testing.T, ctx context.Context) {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-releaseActivity:
-			return "done", nil
+			return activityResultDone, nil
 		}
 	}))
 

--- a/tests/integration/suite/daprd/workflow/chaos/remotestream.go
+++ b/tests/integration/suite/daprd/workflow/chaos/remotestream.go
@@ -94,7 +94,7 @@ func (r *remotestream) Run(t *testing.T, ctx context.Context) {
 			case <-time.After(20 * time.Millisecond):
 			}
 		}
-		return "done", nil
+		return activityResultDone, nil
 	}
 	workflowFn := func(octx *task.WorkflowContext) (any, error) {
 		var out string


### PR DESCRIPTION
# Description

Two related failure modes can leave a workflow permanently stuck in `RUNNING` after a transient infrastructure event (placement rebalance, peer write conflict, state-store latency spike, brief network drop):

1. **Orphan completion.** The orchestrator triggers side effects (activity dispatch, child-workflow start, cross-app events) before committing the workflow's own state. When the save then fails, the side effects keep running: the activity completes and posts its result back, but on replay the workflow has no record of the corresponding `TaskScheduled` — the unmatched completion can't be reconciled and the workflow stalls. **Fixed by saving first:** `runWorkflow` now persists `state.ApplyRuntimeStateChanges` + `signAndSaveState` *before* invoking `callActivities` / `callAddEventStateMessage` / `callCreateWorkflowStateMessage`. If the save fails, no side effects are triggered and the retried turn runs against clean state — the orphan can't form.

2. **Stranded `TaskScheduled`.** With save-first in place, a failed dispatch leaves a durable `TaskScheduled` in history with no activity actor running it — and no reminder left to wake the workflow: the retries triggered by the recoverable error process zero new actions, complete cleanly, and the reminder stops firing. **Fixed with a `dispatch-retry` safety reminder:** scheduled when a dispatch fails after a successful save, it re-attempts dispatch for every `TaskScheduled` whose result is not yet in history or inbox, retrying at a fixed 1s interval until it succeeds, then deletes itself (also cleaned up by `deleteAllReminders` on completion). Idempotent by design: the activity actor's `run-activity` reminder is upserted under a fixed name, so re-dispatching an in-flight activity is a no-op. The reminder name is deterministic, so concurrent failures collapse onto a single scheduler entry.

Cross-app batches (PR #9738) keep the legacy dispatch-then-save order: first-execution failures save framing-only, retry failures don't grow history. This keeps cross-app workflows from getting stuck in `PENDING` when the remote app is offline; existing `crossapp/pending` integration tests pass unmodified.

## Known limitation (follow-up)

The dispatch-retry reminder only re-attempts **local-target** `TaskScheduled`. Stranded cross-app dispatches are skipped: the reminder cannot reconstruct the `PropagatedHistory` chunk that cross-app dispatch requires. Unifying save-before-dispatch for cross-app needs a discussion of PR #9738's framing-only first-execution path first — will follow up with @joshvanl directly. External-event delivery has the analogous no-standing-reminder gap, addressed separately in #10072.

## Alternatives considered

| Approach | Why not |
|---|---|
| Re-inject the orphan completion as a new inbox event | Existing duplicate-event dedup blocks it; doesn't unstick the workflow |
| Filter unconsumed events from the history append | Violates the contract that history records every event the workflow received |
| Re-deliver the existing completion through the dispatcher | Requires either rewriting immutable history or accepting out-of-order replay; both break deterministic replay |
| Redispatch-on-every-wake helper (earlier revision of this PR) | Can't distinguish "activity in flight" from "dispatch never accepted" without additional state; re-dispatches an in-flight activity and causes duplicate execution (caught by `reconnect/deactivate/completion`) |

## Issue reference

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_