### PR TITLE
fix: bump perf jobs app to golang:1.26.3

### DIFF
--- a/tests/apps/perf/jobs/Dockerfile
+++ b/tests/apps/perf/jobs/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.2 as build_env
+FROM golang:1.26.3 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app


### PR DESCRIPTION
# Description

The jobs perf app Dockerfile was missed when go.mod was bumped to go 1.26.3 (#9911), leaving it pinned at golang:1.26.2. With GOTOOLCHAIN=local the build fails:

    go: go.mod requires go >= 1.26.3 (running go 1.26.2)

This stayed dormant while the perf cache served a prebuilt image, and surfaced once #10024 changed jobs/go.mod and invalidated the cache, forcing a build from source.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
