### PR TITLE
fix: bump Go to 1.26.4 to resolve govulncheck stdlib vulnerabilities

### DIFF
--- a/.build-tools/go.mod
+++ b/.build-tools/go.mod
@@ -1,6 +1,6 @@
 module build-tools
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/go-containerregistry v0.21.6

--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ MODFILES := $(shell find . -name go.mod)
 define modtidy-target
 .PHONY: modtidy-$(1)
 modtidy-$(1):
-	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.26.3; cd -
+	cd $(shell dirname $(1)); CGO_ENABLED=$(CGO) go mod tidy -compat=1.26.4; cd -
 endef
 
 # Generate modtidy target action for each go.mod file

--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -1,6 +1,6 @@
 # current directory must be ./dist
 
-FROM golang:1.26.3
+FROM golang:1.26.4
 
 ARG PKG_FILES
 RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,7 +1,7 @@
 # Based on https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/go/.devcontainer/base.Dockerfile
 
-# [Choice] Go version: 1, 1.26.3, etc
-ARG GOVERSION=1.26.3
+# [Choice] Go version: 1, 1.26.4, etc
+ARG GOVERSION=1.26.4
 FROM golang:${GOVERSION}-bullseye
 
 # [Option] Install zsh

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ This includes dockerfiles to build Dapr release and debug images and development
 
 The Dev Container can be rebuilt with custom options. Relevant args (and their default values) include:
 
-* `GOVERSION` (default: `1.26.3`)
+* `GOVERSION` (default: `1.26.4`)
 * `INSTALL_ZSH` (default: `true`)
 * `KUBECTL_VERSION` (default: `latest`)
 * `HELM_VERSION` (default: `latest`)

--- a/docs/development/setup-dapr-development-env.md
+++ b/docs/development/setup-dapr-development-env.md
@@ -23,7 +23,7 @@ This document helps you get started developing Dapr. If you find any problems wh
 
 ## Go (Golang)
 
-1. Download and install [Go 1.26.3 or later](https://golang.org/doc/install#tarball).
+1. Download and install [Go 1.26.4 or later](https://golang.org/doc/install#tarball).
 
 2. Install [Delve](https://github.com/go-delve/delve/tree/master/Documentation/installation) for Go debugging, if desired.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr
 
-go 1.26.3
+go 1.26.4
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/tests/apps/actorload/Dockerfile
+++ b/tests/apps/actorload/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3
+FROM golang:1.26.4
 WORKDIR /actorload/
 COPY . .
 RUN make build

--- a/tests/apps/actorload/go.mod
+++ b/tests/apps/actorload/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/actorload
 
-go 1.26.3
+go 1.26.4
 
 require (
 	fortio.org/fortio v1.6.8

--- a/tests/apps/crypto/Dockerfile
+++ b/tests/apps/crypto/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.3 as build_env
+FROM golang:1.26.4 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/crypto/go.mod
+++ b/tests/apps/crypto/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/crypto
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/go-sdk v1.8.0

--- a/tests/apps/perf/actor-activation-locker/Dockerfile
+++ b/tests/apps/perf/actor-activation-locker/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.3 as build_env
+FROM golang:1.26.4 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/actor-activation-locker/go.mod
+++ b/tests/apps/perf/actor-activation-locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/actor-activation-locker
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/bsm/redislock v0.8.2

--- a/tests/apps/perf/actorfeatures/Dockerfile
+++ b/tests/apps/perf/actorfeatures/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.26.3-bookworm as build_env
+FROM golang:1.26.4-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod go.sum ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.26.3-bookworm as fortio_build_env
+FROM golang:1.26.4-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/actorfeatures/go.mod
+++ b/tests/apps/perf/actorfeatures/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v1.13.4

--- a/tests/apps/perf/jobs/Dockerfile
+++ b/tests/apps/perf/jobs/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.3 as build_env
+FROM golang:1.26.4 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/jobs/go.mod
+++ b/tests/apps/perf/jobs/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/jobs
 
-go 1.26.3
+go 1.26.4

--- a/tests/apps/perf/k6-custom/Dockerfile
+++ b/tests/apps/perf/k6-custom/Dockerfile
@@ -1,5 +1,5 @@
 # Build the k6 binary with the extension
-FROM golang:1.26.3 AS builder
+FROM golang:1.26.4 AS builder
 
 WORKDIR $GOPATH/src/go.k6.io/k6
 

--- a/tests/apps/perf/service_invocation_grpc/Dockerfile
+++ b/tests/apps/perf/service_invocation_grpc/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.3 as build_env
+FROM golang:1.26.4 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_grpc/go.mod
+++ b/tests/apps/perf/service_invocation_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_grpc
 
-go 1.26.3
+go 1.26.4
 
 require github.com/dapr/go-sdk v1.8.0
 

--- a/tests/apps/perf/service_invocation_http/Dockerfile
+++ b/tests/apps/perf/service_invocation_http/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.3 as build_env
+FROM golang:1.26.4 as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/perf/service_invocation_http/go.mod
+++ b/tests/apps/perf/service_invocation_http/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/service_invocation_http
 
-go 1.26.3
+go 1.26.4

--- a/tests/apps/perf/tester/Dockerfile
+++ b/tests/apps/perf/tester/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.26.3-bookworm as build_env
+FROM golang:1.26.4-bookworm as build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY *.go go.mod ./
 RUN go get -d -v && go build -o tester .
 
-FROM golang:1.26.3-bookworm as fortio_build_env
+FROM golang:1.26.4-bookworm as fortio_build_env
 
 WORKDIR /fortio
 ADD "https://api.github.com/repos/dapr/fortio/branches/v1.38.4-dapr" skipcache

--- a/tests/apps/perf/tester/go.mod
+++ b/tests/apps/perf/tester/go.mod
@@ -1,3 +1,3 @@
 module github.com/dapr/dapr/tests/apps/perf/tester
 
-go 1.26.3
+go 1.26.4

--- a/tests/apps/pluggable_kafka-bindings/go.mod
+++ b/tests/apps/pluggable_kafka-bindings/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/kafka-bindings
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-pubsub/go.mod
+++ b/tests/apps/pluggable_redis-pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-pubsub
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pluggable_redis-statestore/go.mod
+++ b/tests/apps/pluggable_redis-statestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pluggable_redis-statestore
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr-sandbox/components-go-sdk v0.0.0-20221213200551-bd485eb929ff

--- a/tests/apps/pubsub-publisher-streaming/Dockerfile
+++ b/tests/apps/pubsub-publisher-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.3 AS build_env
+FROM golang:1.26.4 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-publisher-streaming/go.mod
+++ b/tests/apps/pubsub-publisher-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-publisher-streaming
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/pubsub-subscriber-streaming/Dockerfile
+++ b/tests/apps/pubsub-subscriber-streaming/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.26.3 AS build_env
+FROM golang:1.26.4 AS build_env
 
 ENV CGO_ENABLED=0
 WORKDIR /app

--- a/tests/apps/pubsub-subscriber-streaming/go.mod
+++ b/tests/apps/pubsub-subscriber-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/pubsub-subscriber-streaming
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v1.15.4

--- a/tests/apps/resiliencyapp/go.mod
+++ b/tests/apps/resiliencyapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v0.0.0

--- a/tests/apps/resiliencyapp_grpc/go.mod
+++ b/tests/apps/resiliencyapp_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp_grpc
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v1.7.4

--- a/tests/apps/service_invocation_grpc_proxy_client/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_client/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_client
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v0.0.0-00010101000000-000000000000

--- a/tests/apps/service_invocation_grpc_proxy_server/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_server/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_server
 
-go 1.26.3
+go 1.26.4
 
 require (
 	google.golang.org/grpc v1.80.0

--- a/tests/integration/framework/binary/helpers/helmtemplate/go.mod
+++ b/tests/integration/framework/binary/helpers/helmtemplate/go.mod
@@ -1,6 +1,6 @@
 module helm
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/spf13/pflag v1.0.5

--- a/tests/integration/framework/binary/helpers/mcpstdioserver/go.mod
+++ b/tests/integration/framework/binary/helpers/mcpstdioserver/go.mod
@@ -1,6 +1,6 @@
 module mcpstdioserver
 
-go 1.26.3
+go 1.26.4
 
 require github.com/modelcontextprotocol/go-sdk v1.6.0
 


### PR DESCRIPTION
# Description

The Dependency Review (govulncheck) CI job fails on PRs because the Go 1.26.3 toolchain (pinned via go.mod / go-version-file with GOTOOLCHAIN=local) is affected by three standard-library vulnerabilities, all fixed in Go 1.26.4:

  - GO-2026-5039  net/textproto: arbitrary inputs in errors without escaping
  - GO-2026-5038  mime: quadratic complexity in WordDecoder.DecodeHeader
  - GO-2026-5037  crypto/x509: inefficient candidate hostname parsing

Bump every Go version reference 1.26.3 -> 1.26.4 (root go.mod, .build-tools, Makefile -compat, all Dockerfiles, all test-app go.mod, and dev docs) and run `make modtidy-all`. Verified locally: govulncheck now reports 0 affecting vulnerabilities.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
