### PR TITLE
fix(wfengine): do not unregister workflow actor types on SDK stream disconnect

### DIFF
--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -208,21 +208,23 @@ func New(opts Options) (Interface, error) {
 			wfe.actorRegLock.Lock()
 			defer wfe.actorRegLock.Unlock()
 
-			if ctx.Err() != nil {
-				ctx = context.Background()
-			}
+			wfe.getWorkItemsCount.Add(-1)
 
-			if wfe.getWorkItemsCount.Add(-1) == 0 && wfe.mcpRegistrationCount.Load() == 0 && wfe.actorsRegistered {
-				log.Debug("Unregistering workflow actors")
-				// Reset unconditionally: UnRegisterActors removes types from the
-				// table before HaltAll, so an error here still means they're gone.
-				err := abackend.UnRegisterActors(ctx)
-				wfe.actorsRegistered = false
-				if err != nil {
-					return err
-				}
-			}
-
+			// Intentionally do NOT call UnRegisterActors here. The SDK's
+			// work-item gRPC stream churns under transient infrastructure
+			// pressure (network latency, gRPC keepalive timeout, app
+			// container restart) and reconnects within milliseconds.
+			// Eagerly unregistering workflow/activity/retentioner actor
+			// types on every disconnect produces a window where the
+			// placement table still reports this daprd as hosting those
+			// types — peer daprds keep routing dispatch calls here — but
+			// the local actor table has dropped the factories. Every such
+			// dispatch fails locally with "actor type ... not registered",
+			// the orchestrator's recoverable retries hit the same wall,
+			// and affected workflows strand indefinitely. Actor types now
+			// persist for the daprd's lifetime once registered;
+			// UnRegisterActors is still invoked from the MCP teardown
+			// path and on daprd shutdown.
 			return nil
 		}),
 		backend.WithStreamSendTimeout(time.Second*10),


### PR DESCRIPTION

# Description

The OnGetWorkItemsDisconnect callback previously unregistered the workflow/activity/retentioner actor types from the local actor table whenever the SDK's work-item gRPC stream worker count hit zero. Under transient infrastructure pressure (network latency, gRPC keepalive timeout, app container restart) that stream churns and reconnects within milliseconds, but during the disconnect window:

  - the placement table still reports this daprd as hosting those actor types (placement has no visibility into the local table)
  - peer daprds keep routing dispatch calls here based on placement
  - every such dispatch fails locally with "actor type ... not registered"
  - the orchestrator's recoverable retries hit the same wall and workflows whose activity dispatch happened to land in the window strand indefinitely

The race is timing-sensitive. With a single brief disconnect a small fraction of workflows strands; under sustained stream churn the fraction grows toward 100%. Either way it requires the actor-table state to diverge from the placement view, which is the underlying defect.

Keep the actor-type registrations for the daprd's lifetime once established. UnRegisterActors still runs from the MCP teardown path and on daprd shutdown, which are the paths that should actually drop the types.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
