### PR TITLE
[1.17] cherrypicks & use latest contrib 1.17.7 patch

### DIFF
--- a/docs/release_notes/v1.17.10.md
+++ b/docs/release_notes/v1.17.10.md
@@ -1,0 +1,32 @@
+# Dapr 1.17.10
+
+This update contains the following bug fix:
+- [Resiliency retry `matching` is ignored on the pubsub publish path](#resiliency-retry-matching-is-ignored-on-the-pubsub-publish-path)
+
+## Resiliency retry `matching` is ignored on the pubsub publish path
+
+### Problem
+
+A resiliency retry policy that configures `matching` (`httpStatusCodes` / `gRPCStatusCodes`) on a pubsub component's outbound policy has no effect on publish.
+Every `Publish` / `BulkPublish` error is retried up to `maxRetries` regardless of the configured codes, so non-retriable (terminal) errors are retried wastefully and the configured `matching` is silently ignored.
+
+### Impact
+
+Any deployment with a `Resiliency` configuration that sets `matching` on a retry policy targeting a pubsub component's `outbound` retry is affected.
+
+Visible symptoms include:
+- A clearly terminal publish error (for example an invalid topic or an unauthorized request) is retried up to `maxRetries` instead of failing fast.
+- The status codes listed in `matching.httpStatusCodes` / `matching.gRPCStatusCodes` have no effect on which publish errors are retried.
+
+### Root Cause
+
+The retry runner in `pkg/resiliency/policy.go` only consults the configured codes when the operation error is a `resiliency.CodeError`.
+Every other policy runner — service invocation, the gRPC proxy, output bindings, and inbound subscriber delivery — constructs a `CodeError` before handing the error to the runner, but the component-outbound publish path returned the broker's plain error verbatim.
+As a result the publish error was never recognized as a `CodeError`, the configured codes were never consulted, and it fell through to the runner as an ordinary retryable error.
+
+### Solution
+
+The `Publish` and `BulkPublish` paths now wrap the component error in a `resiliency.CodeError` when it carries a gRPC status (via `status.FromError`), mirroring the other policy runners.
+Errors that do not carry a status are returned unchanged and keep retrying exactly as before, so behavior is unchanged unless retry `matching` is configured.
+
+This is the runtime half of the fix; pubsub components in `components-contrib` emit gRPC status codes on publish errors so the runtime can classify them as retriable or terminal.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr
 
-go 1.26.3
+go 1.26.4
 
 require (
 	connectrpc.com/connect v1.19.1
@@ -11,7 +11,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/dapr/components-contrib v1.17.6
+	github.com/dapr/components-contrib v1.17.7
 	github.com/dapr/durabletask-go v0.11.5
 	github.com/dapr/kit v0.17.1
 	github.com/diagridio/go-etcd-cron v0.12.5

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.17.6 h1:QUSp3cLBsjgeCOSUNBHkkAb98LCeDePEkGKykJ84tTc=
-github.com/dapr/components-contrib v1.17.6/go.mod h1:lVPRj9ywzkUWoKXxRTAJbvS+Vg8A882av/nynGstNE4=
+github.com/dapr/components-contrib v1.17.7 h1:WqVcCaUcE3VycaPARJfqFpQQQPMURsTFFUx2P1j67BY=
+github.com/dapr/components-contrib v1.17.7/go.mod h1:lVPRj9ywzkUWoKXxRTAJbvS+Vg8A882av/nynGstNE4=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
 github.com/dapr/durabletask-go v0.11.5 h1:+6QYX3Vit3GTFzLA8vNrd+AfQBSU4P07EdGBreHqSL8=

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -230,7 +230,7 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 	}
 
 	start := time.Now()
-	err := a.pubsubAdapter.Publish(ctx, &req)
+	err := a.pubsubAdapter.Publish(ctx, &req, runtimePubsub.TransportModeGRPC)
 	elapsed := diag.ElapsedSince(start)
 
 	diag.DefaultComponentMonitoring.PubsubEgressEvent(context.Background(), pubsubName, topic, err == nil, elapsed)
@@ -461,7 +461,7 @@ func (a *api) bulkPublishEvent(ctx context.Context, in *runtimev1pb.BulkPublishR
 	start := time.Now()
 	// err is only nil if all entries are successfully published.
 	// For partial success, err is not nil and res contains the failed entries.
-	res, err := a.pubsubAdapter.BulkPublish(ctx, &req)
+	res, err := a.pubsubAdapter.BulkPublish(ctx, &req, runtimePubsub.TransportModeGRPC)
 
 	elapsed := diag.ElapsedSince(start)
 	eventsPublished := int64(len(req.Entries))

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -1185,7 +1185,7 @@ func (a *api) onPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	start := time.Now()
-	err := a.pubsubAdapter.Publish(r.Context(), &req)
+	err := a.pubsubAdapter.Publish(r.Context(), &req, runtimePubsub.TransportModeHTTP)
 	elapsed := diag.ElapsedSince(start)
 
 	diag.DefaultComponentMonitoring.PubsubEgressEvent(context.Background(), pubsubName, topic, err == nil, elapsed)
@@ -1350,7 +1350,7 @@ func (a *api) onBulkPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	start := time.Now()
-	res, err := a.pubsubAdapter.BulkPublish(r.Context(), &req)
+	res, err := a.pubsubAdapter.BulkPublish(r.Context(), &req, runtimePubsub.TransportModeHTTP)
 	elapsed := diag.ElapsedSince(start)
 
 	// BulkPublishResponse contains all failed entries from the request.

--- a/pkg/runtime/pubsub/adapter.go
+++ b/pkg/runtime/pubsub/adapter.go
@@ -39,8 +39,8 @@ type ConnectionID uint64
 
 // Adapter is the interface for message buses.
 type Adapter interface {
-	Publish(context.Context, *contribPubsub.PublishRequest) error
-	BulkPublish(context.Context, *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error)
+	Publish(context.Context, *contribPubsub.PublishRequest, TransportMode) error
+	BulkPublish(context.Context, *contribPubsub.BulkPublishRequest, TransportMode) (contribPubsub.BulkPublishResponse, error)
 }
 
 type AdapterStreamer interface {

--- a/pkg/runtime/pubsub/bulkpublish_resiliency.go
+++ b/pkg/runtime/pubsub/bulkpublish_resiliency.go
@@ -27,6 +27,7 @@ import (
 func ApplyBulkPublishResiliency(ctx context.Context, req *contribPubsub.BulkPublishRequest,
 	policyDef *resiliency.PolicyDefinition,
 	bulkPublisher contribPubsub.BulkPublisher,
+	mode TransportMode,
 ) (contribPubsub.BulkPublishResponse, error) {
 	// Contains the latest request entries to be sent to the component
 	var requestEntries atomic.Pointer[[]contribPubsub.BulkMessageEntry]
@@ -59,8 +60,7 @@ func ApplyBulkPublishResiliency(ctx context.Context, req *contribPubsub.BulkPubl
 		res, err := bulkPublisher.BulkPublish(ctx, newReq)
 		if err != nil {
 			if st, ok := status.FromError(err); ok {
-				//nolint:gosec
-				return res, resiliency.NewCodeError(int32(st.Code()), err)
+				return res, NewPublishResiliencyError(mode, st.Code(), err)
 			}
 		}
 		return res, err

--- a/pkg/runtime/pubsub/bulkpublish_resiliency.go
+++ b/pkg/runtime/pubsub/bulkpublish_resiliency.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"sync/atomic"
 
+	"google.golang.org/grpc/status"
+
 	contribPubsub "github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/utils"
@@ -53,7 +55,15 @@ func ApplyBulkPublishResiliency(ctx context.Context, req *contribPubsub.BulkPubl
 			Entries:    newEntries,
 			Metadata:   req.Metadata,
 		}
-		return bulkPublisher.BulkPublish(ctx, newReq)
+
+		res, err := bulkPublisher.BulkPublish(ctx, newReq)
+		if err != nil {
+			if st, ok := status.FromError(err); ok {
+				//nolint:gosec
+				return res, resiliency.NewCodeError(int32(st.Code()), err)
+			}
+		}
+		return res, err
 	})
 	// If final error is timeout, CB open or CB too many requests, return the current request entries as failed
 	if err != nil &&
@@ -71,5 +81,6 @@ func extractEntryIds(failedEntries []contribPubsub.BulkPublishResponseFailedEntr
 	for _, failedEntry := range failedEntries {
 		entryIds[failedEntry.EntryId] = struct{}{}
 	}
+
 	return entryIds
 }

--- a/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
+++ b/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
@@ -15,13 +15,17 @@ package pubsub
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	contribPubsub "github.com/dapr/components-contrib/pubsub"
 	resiliencyV1alpha "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
@@ -648,6 +652,78 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		assert.Len(t, res.FailedEntries, 6)
 		// Not aaserting the number of called times since it may or may not be updated(component called) in actually code.
 		// In above case, it is not updated.
+	})
+}
+
+// statusBulkPublisher is a BulkPublisher whose BulkPublish returns a configurable
+// error per call, used to verify retry `matching` on the bulk publish path.
+type statusBulkPublisher struct {
+	calls  atomic.Int32
+	bulkFn func(call int32) error
+}
+
+func (m *statusBulkPublisher) BulkPublish(ctx context.Context, req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
+	return contribPubsub.BulkPublishResponse{}, m.bulkFn(m.calls.Add(1))
+}
+
+// TestBulkPublishMatching verifies that, on the bulk publish path, a component error
+// carrying a gRPC status is wrapped in a resiliency.CodeError so the configured retry
+// `matching` is consulted — and that errors without a status keep retrying as before.
+func TestBulkPublishMatching(t *testing.T) {
+	ctx := t.Context()
+	pubsubName := "test-pubsub"
+	// Only gRPC code 14 (Unavailable) is configured as retriable
+	matching := &resiliencyV1alpha.RetryMatching{GRPCStatusCodes: "14"}
+
+	policyDefFor := func(maxRetries int) *resiliency.PolicyDefinition {
+		retry := resiliencyV1alpha.Retry{
+			Policy:     "constant",
+			Duration:   "1ms",
+			MaxRetries: new(maxRetries),
+			Matching:   matching,
+		}
+		provider := createResPolicyProvider(resiliencyV1alpha.CircuitBreaker{}, "10s", retry)
+		return provider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
+	}
+
+	req := &contribPubsub.BulkPublishRequest{PubsubName: pubsubName, Topic: "test-topic"}
+
+	t.Run("non-retriable gRPC status code is not retried", func(t *testing.T) {
+		bp := &statusBulkPublisher{bulkFn: func(int32) error {
+			return status.Error(codes.InvalidArgument, "bad request")
+		}}
+
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp)
+
+		require.Error(t, err)
+		assert.Equal(t, int32(1), bp.calls.Load())
+	})
+
+	t.Run("retriable gRPC status code is retried until success", func(t *testing.T) {
+		bp := &statusBulkPublisher{bulkFn: func(call int32) error {
+			if call <= 2 {
+				return status.Error(codes.Unavailable, "try later")
+			}
+			return nil
+		}}
+
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp)
+
+		require.NoError(t, err)
+		// 2 failures then success = 3 calls
+		assert.Equal(t, int32(3), bp.calls.Load())
+	})
+
+	t.Run("plain error without status still retries (no regression)", func(t *testing.T) {
+		bp := &statusBulkPublisher{bulkFn: func(int32) error {
+			return errors.New("boom")
+		}}
+
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(3), bp)
+
+		require.Error(t, err)
+		// No gRPC status = retried up to maxRetries (initial + 3)
+		assert.Equal(t, int32(4), bp.calls.Load())
 	})
 }
 

--- a/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
+++ b/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
@@ -190,7 +190,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// expecting no final error, the events will pass in the second try
@@ -222,7 +222,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// Expect final error from the bulk publisher
@@ -256,7 +256,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// expecting no final error, all the events will pass in the second try
@@ -288,7 +288,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// expecting no final error, all the events will pass in a single try
@@ -324,7 +324,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -355,7 +355,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		// Act
 
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -378,7 +378,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -412,7 +412,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -435,7 +435,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -469,7 +469,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.NoError(t, err)
@@ -512,7 +512,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -539,7 +539,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		// Act
 		// mock bulk publisher will fail the request only twice,
 		// the circuitBreaker will be half-open now and then after request served will be closed
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.NoError(t, err)
@@ -584,7 +584,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -595,7 +595,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -633,7 +633,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -644,7 +644,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -693,7 +693,7 @@ func TestBulkPublishMatching(t *testing.T) {
 			return status.Error(codes.InvalidArgument, "bad request")
 		}}
 
-		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp)
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp, TransportModeGRPC)
 
 		require.Error(t, err)
 		assert.Equal(t, int32(1), bp.calls.Load())
@@ -707,7 +707,7 @@ func TestBulkPublishMatching(t *testing.T) {
 			return nil
 		}}
 
-		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp)
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp, TransportModeGRPC)
 
 		require.NoError(t, err)
 		// 2 failures then success = 3 calls
@@ -719,7 +719,7 @@ func TestBulkPublishMatching(t *testing.T) {
 			return errors.New("boom")
 		}}
 
-		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(3), bp)
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(3), bp, TransportModeGRPC)
 
 		require.Error(t, err)
 		// No gRPC status = retried up to maxRetries (initial + 3)

--- a/pkg/runtime/pubsub/outbox.go
+++ b/pkg/runtime/pubsub/outbox.go
@@ -231,7 +231,7 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 				PubsubName: c.outboxPubsub,
 				Data:       data,
 				Topic:      outboxTopic(source, c.publishTopic, o.namespace),
-			})
+			}, TransportModeGRPC)
 			if err != nil {
 				return nil, err
 			}
@@ -326,7 +326,7 @@ func (o *outboxImpl) SubscribeToInternalTopics(ctx context.Context, appID string
 				Data:        b,
 				Topic:       c.publishTopic,
 				ContentType: &contentType,
-			})
+			}, TransportModeGRPC)
 			if err != nil {
 				return err
 			}

--- a/pkg/runtime/pubsub/publish_resiliency.go
+++ b/pkg/runtime/pubsub/publish_resiliency.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"google.golang.org/grpc/codes"
+
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/pubsub/transport"
+)
+
+// TransportMode aliases transport.Mode so callers can keep using
+// rtpubsub.TransportMode. The concrete type lives in the leaf transport package
+// to avoid an import cycle with the Adapter fakes/mocks.
+type TransportMode = transport.Mode
+
+const (
+	// TransportModeGRPC matches broker errors against `gRPCStatusCodes`, using the
+	// component's native gRPC status code. Passed by the gRPC publish API and by
+	// internal republish paths (dead-letter, outbox).
+	TransportModeGRPC TransportMode = iota
+	// TransportModeHTTP matches broker errors against `httpStatusCodes`, mapping the
+	// component's gRPC status code to its HTTP equivalent. Passed by the HTTP
+	// publish API.
+	TransportModeHTTP
+)
+
+// NewPublishResiliencyError wraps a pub/sub component (bulk) publish error in a
+// resiliency.CodeError so retry `matching` can evaluate it. For HTTP publishes
+// the gRPC status code is mapped to its HTTP equivalent (matched against
+// `httpStatusCodes`); otherwise the gRPC code is used (matched against
+// `gRPCStatusCodes`).
+func NewPublishResiliencyError(mode TransportMode, code codes.Code, err error) resiliency.CodeError {
+	//nolint:gosec // gRPC status codes (0-16) fit in int32.
+	statusCode := int32(code)
+	if mode == TransportModeHTTP {
+		//nolint:gosec // HTTP status codes (100-599) fit in int32.
+		statusCode = int32(invokev1.HTTPStatusFromCode(code))
+	}
+	return resiliency.NewCodeError(statusCode, err)
+}

--- a/pkg/runtime/pubsub/publish_resiliency_test.go
+++ b/pkg/runtime/pubsub/publish_resiliency_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+// TestNewPublishResiliencyError asserts the broker's gRPC status code is kept
+// as-is for gRPC publishes (matched against gRPCStatusCodes) and mapped to its
+// HTTP equivalent for HTTP publishes (matched against httpStatusCodes).
+func TestNewPublishResiliencyError(t *testing.T) {
+	baseErr := errors.New("broker boom")
+
+	tests := []struct {
+		name     string
+		mode     TransportMode
+		code     codes.Code
+		wantCode int32
+	}{
+		// gRPC transport keeps the native gRPC code (0-16 -> gRPCStatusCodes).
+		{"grpc retriable keeps Unavailable", TransportModeGRPC, codes.Unavailable, int32(codes.Unavailable)},
+		{"grpc terminal keeps FailedPrecondition", TransportModeGRPC, codes.FailedPrecondition, int32(codes.FailedPrecondition)},
+		// HTTP transport maps the gRPC code to its HTTP status (100-599 -> httpStatusCodes).
+		{"http maps Unavailable to 503", TransportModeHTTP, codes.Unavailable, 503},
+		{"http maps FailedPrecondition to 400", TransportModeHTTP, codes.FailedPrecondition, 400},
+		{"http maps ResourceExhausted to 429", TransportModeHTTP, codes.ResourceExhausted, 429},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cErr := NewPublishResiliencyError(tt.mode, tt.code, baseErr)
+			assert.Equal(t, tt.wantCode, cErr.StatusCode)
+			// The original error is preserved for callers/logging.
+			require.ErrorIs(t, cErr, baseErr)
+		})
+	}
+}

--- a/pkg/runtime/pubsub/publisher/fake/fake.go
+++ b/pkg/runtime/pubsub/publisher/fake/fake.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	contribPubsub "github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/runtime/pubsub/transport"
 )
 
 // Fake is a fake publisher
@@ -46,10 +47,10 @@ func (f *Fake) WithBulkPublishFn(fn func(context.Context, *contribPubsub.BulkPub
 	return f
 }
 
-func (f *Fake) Publish(ctx context.Context, req *contribPubsub.PublishRequest) error {
+func (f *Fake) Publish(ctx context.Context, req *contribPubsub.PublishRequest, _ transport.Mode) error {
 	return f.publishFn(ctx, req)
 }
 
-func (f *Fake) BulkPublish(ctx context.Context, req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
+func (f *Fake) BulkPublish(ctx context.Context, req *contribPubsub.BulkPublishRequest, _ transport.Mode) (contribPubsub.BulkPublishResponse, error) {
 	return f.bulkPublishFn(ctx, req)
 }

--- a/pkg/runtime/pubsub/publisher/publisher.go
+++ b/pkg/runtime/pubsub/publisher/publisher.go
@@ -53,8 +53,9 @@ func New(opts Options) rtpubsub.Adapter {
 
 // Publish is an adapter method for the runtime to pre-validate publish requests
 // And then forward them to the Pub/Sub component.
-// This method is used by the HTTP and gRPC APIs.
-func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishRequest) error {
+// This method is used by the HTTP and gRPC APIs. mode selects which retry
+// `matching` list a broker error is evaluated against (http vs gRPC status codes).
+func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishRequest, mode rtpubsub.TransportMode) error {
 	pubsub, ok := p.getpubsubFn(req.PubsubName)
 	if !ok {
 		return rtpubsub.NotFoundError{PubsubName: req.PubsubName}
@@ -75,8 +76,7 @@ func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishReque
 		err := pubsub.Component.Publish(ctx, req)
 		if err != nil {
 			if st, ok := status.FromError(err); ok {
-				//nolint:gosec
-				return nil, resiliency.NewCodeError(int32(st.Code()), err)
+				return nil, rtpubsub.NewPublishResiliencyError(mode, st.Code(), err)
 			}
 		}
 		return nil, err
@@ -84,7 +84,7 @@ func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishReque
 	return err
 }
 
-func (p *publisher) BulkPublish(ctx context.Context, req *contribpubsub.BulkPublishRequest) (contribpubsub.BulkPublishResponse, error) {
+func (p *publisher) BulkPublish(ctx context.Context, req *contribpubsub.BulkPublishRequest, mode rtpubsub.TransportMode) (contribpubsub.BulkPublishResponse, error) {
 	pubsub, ok := p.getpubsubFn(req.PubsubName)
 	if !ok {
 		return contribpubsub.BulkPublishResponse{}, rtpubsub.NotFoundError{PubsubName: req.PubsubName}
@@ -101,11 +101,11 @@ func (p *publisher) BulkPublish(ctx context.Context, req *contribpubsub.BulkPubl
 	policyDef := p.resiliency.ComponentOutboundPolicy(req.PubsubName, resiliency.Pubsub)
 
 	if contribpubsub.FeatureBulkPublish.IsPresent(pubsub.Component.Features()) {
-		return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, pubsub.Component.(contribpubsub.BulkPublisher))
+		return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, pubsub.Component.(contribpubsub.BulkPublisher), mode)
 	}
 
 	log.Debugf("pubsub %s does not implement the BulkPublish API; falling back to publishing messages individually", req.PubsubName)
 	defaultBulkPublisher := rtpubsub.NewDefaultBulkPublisher(pubsub.Component)
 
-	return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, defaultBulkPublisher)
+	return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, defaultBulkPublisher, mode)
 }

--- a/pkg/runtime/pubsub/publisher/publisher.go
+++ b/pkg/runtime/pubsub/publisher/publisher.go
@@ -16,6 +16,8 @@ package publisher
 import (
 	"context"
 
+	"google.golang.org/grpc/status"
+
 	contribpubsub "github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/resiliency"
 	rtpubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
@@ -70,7 +72,14 @@ func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishReque
 		p.resiliency.ComponentOutboundPolicy(req.PubsubName, resiliency.Pubsub),
 	)
 	_, err := policyRunner(func(ctx context.Context) (any, error) {
-		return nil, pubsub.Component.Publish(ctx, req)
+		err := pubsub.Component.Publish(ctx, req)
+		if err != nil {
+			if st, ok := status.FromError(err); ok {
+				//nolint:gosec
+				return nil, resiliency.NewCodeError(int32(st.Code()), err)
+			}
+		}
+		return nil, err
 	})
 	return err
 }

--- a/pkg/runtime/pubsub/publisher/publisher_test.go
+++ b/pkg/runtime/pubsub/publisher/publisher_test.go
@@ -63,7 +63,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -84,7 +84,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -117,7 +117,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -142,7 +142,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -174,7 +174,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 
@@ -194,7 +194,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 	})
@@ -225,7 +225,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 
@@ -245,7 +245,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 	})
@@ -268,7 +268,7 @@ func TestPublish(t *testing.T) {
 			PubsubName: TestPubsubName,
 			Topic:      "topic0",
 			Metadata:   md,
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 
@@ -278,7 +278,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.NoError(t, err)
 	})
 
@@ -300,7 +300,7 @@ func TestPublish(t *testing.T) {
 			PubsubName: TestPubsubName,
 			Topic:      "topic0",
 			Metadata:   md,
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.NoError(t, err)
 
 		compStore.AddPubSub(TestSecondPubsubName, &rtpubsub.PubsubItem{
@@ -311,7 +311,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.NoError(t, err)
 	})
 
@@ -333,7 +333,7 @@ func TestPublish(t *testing.T) {
 		err := ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestPubsubName,
 			Topic:      "topic5",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 
 		compStore.AddPubSub(TestSecondPubsubName, &rtpubsub.PubsubItem{
@@ -343,7 +343,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic5",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 	})
 
@@ -365,7 +365,7 @@ func TestPublish(t *testing.T) {
 		err := ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 
 		compStore.AddPubSub(TestSecondPubsubName, &rtpubsub.PubsubItem{
@@ -375,7 +375,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 	})
 }
@@ -396,7 +396,7 @@ func TestNamespacedPublisher(t *testing.T) {
 	err := ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 		PubsubName: TestPubsubName,
 		Topic:      "topic0",
-	})
+	}, rtpubsub.TransportModeGRPC)
 	require.NoError(t, err)
 
 	pubSub, ok := compStore.GetPubSub(TestPubsubName)
@@ -427,7 +427,7 @@ func TestNamespacedBulkPublisher(t *testing.T) {
 				ContentType: "text/plain",
 			},
 		},
-	})
+	}, rtpubsub.TransportModeGRPC)
 	require.NoError(t, err)
 	assert.Empty(t, res.FailedEntries)
 
@@ -593,7 +593,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return status.Error(codes.InvalidArgument, "bad request")
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.Error(t, err)
 		// Code 3 is not in the retriable list, so matching breaks the retry loop after 1 try
@@ -608,7 +608,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return nil
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		// 2 failures then success = 3 calls
@@ -620,7 +620,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return errors.New("boom")
 		}}
 
-		err := newPublisher(ps, 3).Publish(t.Context(), req)
+		err := newPublisher(ps, 3).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.Error(t, err)
 		// No gRPC status = retried up to maxRetries (initial + 3)
@@ -632,7 +632,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return status.Error(codes.FailedPrecondition, "invalid topic")
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.Error(t, err)
 		assert.Equal(t, int32(1), ps.calls.Load())
@@ -646,7 +646,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return nil
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Equal(t, int32(3), ps.calls.Load())
@@ -679,7 +679,7 @@ func TestPubsubWithResiliency(t *testing.T) {
 			PubsubName: "failPubsub",
 			Topic:      "failingTopic",
 		}
-		err := ps.Publish(t.Context(), req)
+		err := ps.Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Equal(t, 2, failingPubsub.Failure.CallCount("failingTopic"))
@@ -712,7 +712,7 @@ func TestPubsubWithResiliency(t *testing.T) {
 		}
 
 		start := time.Now()
-		err := ps.Publish(t.Context(), req)
+		err := ps.Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 		end := time.Now()
 
 		require.Error(t, err)

--- a/pkg/runtime/pubsub/publisher/publisher_test.go
+++ b/pkg/runtime/pubsub/publisher/publisher_test.go
@@ -15,19 +15,24 @@ package publisher
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	contribpubsub "github.com/dapr/components-contrib/pubsub"
+	resiliencyV1alpha "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rtpubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
 	daprt "github.com/dapr/dapr/pkg/testing"
 	"github.com/dapr/kit/logger"
+	"github.com/dapr/kit/ptr"
 )
 
 const (
@@ -501,6 +506,151 @@ func (m *mockPublishPubSub) Close() error {
 
 func (m *mockPublishPubSub) Features() []contribpubsub.Feature {
 	return nil
+}
+
+// matchingPubSub is a pubsub mock whose Publish returns a configurable error per
+// call, used to verify that retry `matching` is honored on the publish path.
+type matchingPubSub struct {
+	calls     atomic.Int32
+	publishFn func(call int32) error
+}
+
+func (m *matchingPubSub) Init(ctx context.Context, metadata contribpubsub.Metadata) error {
+	return nil
+}
+
+func (m *matchingPubSub) Publish(ctx context.Context, req *contribpubsub.PublishRequest) error {
+	return m.publishFn(m.calls.Add(1))
+}
+
+func (m *matchingPubSub) BulkPublish(ctx context.Context, req *contribpubsub.BulkPublishRequest) (contribpubsub.BulkPublishResponse, error) {
+	return contribpubsub.BulkPublishResponse{}, m.publishFn(m.calls.Add(1))
+}
+
+func (m *matchingPubSub) Subscribe(_ context.Context, req contribpubsub.SubscribeRequest, handler contribpubsub.Handler) error {
+	return nil
+}
+
+func (m *matchingPubSub) BulkSubscribe(ctx context.Context, req contribpubsub.SubscribeRequest, handler contribpubsub.BulkHandler) (contribpubsub.BulkSubscribeResponse, error) {
+	return contribpubsub.BulkSubscribeResponse{}, nil
+}
+
+func (m *matchingPubSub) Close() error {
+	return nil
+}
+
+func (m *matchingPubSub) Features() []contribpubsub.Feature {
+	return nil
+}
+
+// matchingResiliency builds a provider whose pubsub outbound policy retries up to
+// maxRetries with the given `matching` rules applied to component "failPubsub".
+func matchingResiliency(maxRetries int, matching *resiliencyV1alpha.RetryMatching) resiliency.Provider {
+	cfg := &resiliencyV1alpha.Resiliency{
+		Spec: resiliencyV1alpha.ResiliencySpec{
+			Policies: resiliencyV1alpha.Policies{
+				Retries: map[string]resiliencyV1alpha.Retry{
+					"pubsubRetry": {
+						MaxRetries: ptr.Of(maxRetries),
+						Policy:     "constant",
+						Duration:   "1ms",
+						Matching:   matching,
+					},
+				},
+			},
+			Targets: resiliencyV1alpha.Targets{
+				Components: map[string]resiliencyV1alpha.ComponentPolicyNames{
+					"failPubsub": {
+						Outbound: resiliencyV1alpha.PolicyNames{Retry: "pubsubRetry"},
+					},
+				},
+			},
+		},
+	}
+	return resiliency.FromConfigurations(logger.NewLogger("test"), cfg)
+}
+
+// TestPubsubPublishMatching verifies that, on the publish path, a component error
+// carrying a gRPC status is wrapped in a resiliency.CodeError so the configured retry
+// `matching` is consulted — and that errors without a status keep retrying as before.
+func TestPubsubPublishMatching(t *testing.T) {
+	// Only gRPC code 14 (Unavailable) is configured as retriable.
+	matching := &resiliencyV1alpha.RetryMatching{GRPCStatusCodes: "14"}
+
+	newPublisher := func(ps contribpubsub.PubSub, maxRetries int) rtpubsub.Adapter {
+		compStore := compstore.New()
+		compStore.AddPubSub("failPubsub", &rtpubsub.PubsubItem{Component: ps})
+		return New(Options{
+			GetPubSubFn: compStore.GetPubSub,
+			Resiliency:  matchingResiliency(maxRetries, matching),
+		})
+	}
+
+	req := &contribpubsub.PublishRequest{PubsubName: "failPubsub", Topic: "topic"}
+
+	t.Run("non-retriable gRPC status code is not retried", func(t *testing.T) {
+		ps := &matchingPubSub{publishFn: func(int32) error {
+			return status.Error(codes.InvalidArgument, "bad request")
+		}}
+
+		err := newPublisher(ps, 5).Publish(t.Context(), req)
+
+		require.Error(t, err)
+		// Code 3 is not in the retriable list, so matching breaks the retry loop after 1 try
+		assert.Equal(t, int32(1), ps.calls.Load())
+	})
+
+	t.Run("retriable gRPC status code is retried until success", func(t *testing.T) {
+		ps := &matchingPubSub{publishFn: func(call int32) error {
+			if call <= 2 {
+				return status.Error(codes.Unavailable, "try later")
+			}
+			return nil
+		}}
+
+		err := newPublisher(ps, 5).Publish(t.Context(), req)
+
+		require.NoError(t, err)
+		// 2 failures then success = 3 calls
+		assert.Equal(t, int32(3), ps.calls.Load())
+	})
+
+	t.Run("plain error without status still retries (no regression)", func(t *testing.T) {
+		ps := &matchingPubSub{publishFn: func(int32) error {
+			return errors.New("boom")
+		}}
+
+		err := newPublisher(ps, 3).Publish(t.Context(), req)
+
+		require.Error(t, err)
+		// No gRPC status = retried up to maxRetries (initial + 3)
+		assert.Equal(t, int32(4), ps.calls.Load())
+	})
+
+	t.Run("terminal code (FailedPrecondition) is not retried", func(t *testing.T) {
+		ps := &matchingPubSub{publishFn: func(int32) error {
+			return status.Error(codes.FailedPrecondition, "invalid topic")
+		}}
+
+		err := newPublisher(ps, 5).Publish(t.Context(), req)
+
+		require.Error(t, err)
+		assert.Equal(t, int32(1), ps.calls.Load())
+	})
+
+	t.Run("retriable code (Unavailable) is retried until success", func(t *testing.T) {
+		ps := &matchingPubSub{publishFn: func(call int32) error {
+			if call <= 2 {
+				return status.Error(codes.Unavailable, "broker unavailable")
+			}
+			return nil
+		}}
+
+		err := newPublisher(ps, 5).Publish(t.Context(), req)
+
+		require.NoError(t, err)
+		assert.Equal(t, int32(3), ps.calls.Load())
+	})
 }
 
 func TestPubsubWithResiliency(t *testing.T) {

--- a/pkg/runtime/pubsub/transport/transport.go
+++ b/pkg/runtime/pubsub/transport/transport.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+type Mode int

--- a/pkg/runtime/subscription/bulksubscription.go
+++ b/pkg/runtime/subscription/bulksubscription.go
@@ -289,7 +289,7 @@ func (s *Subscription) sendBulkToDeadLetter(ctx context.Context,
 		Metadata:   msg.Metadata,
 	}
 
-	_, err := s.adapter.BulkPublish(ctx, req)
+	_, err := s.adapter.BulkPublish(ctx, req, rtpubsub.TransportModeGRPC)
 	if err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %w", msg.Topic, deadLetterTopic, err)
 	}

--- a/pkg/runtime/subscription/postman/grpc/grpc.go
+++ b/pkg/runtime/subscription/postman/grpc/grpc.go
@@ -335,7 +335,7 @@ func (g *grpc) sendToDeadLetter(ctx context.Context, name string, msg *contribpu
 		ContentType: msg.ContentType,
 	}
 
-	if err := g.adapter.Publish(ctx, req); err != nil {
+	if err := g.adapter.Publish(ctx, req, pubsub.TransportModeGRPC); err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %w", msg.Topic, deadLetterTopic, err)
 		return err
 	}

--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -376,7 +376,8 @@ func (h *http) sendBulkToDeadLetter(ctx context.Context,
 		Metadata:   msg.Metadata,
 	}
 
-	_, err := h.adapter.BulkPublish(ctx, req)
+	// Internal dead-letter republish (not an HTTP/gRPC publish API call), so match broker errors on native gRPC status codes.
+	_, err := h.adapter.BulkPublish(ctx, req, pubsub.TransportModeGRPC)
 	if err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %w", msg.Topic, deadLetterTopic, err)
 	}
@@ -393,7 +394,8 @@ func (h *http) sendToDeadLetter(ctx context.Context, name string, msg *contribpu
 		ContentType: msg.ContentType,
 	}
 
-	if err := h.adapter.Publish(ctx, req); err != nil {
+	// Internal dead-letter republish (not an HTTP/gRPC publish API call), so match broker errors on native gRPC status codes.
+	if err := h.adapter.Publish(ctx, req, pubsub.TransportModeGRPC); err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %w", msg.Topic, deadLetterTopic, err)
 		return err
 	}

--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -489,7 +489,7 @@ func (s *Subscription) sendToDeadLetter(ctx context.Context, name string, msg *c
 		ContentType: msg.ContentType,
 	}
 
-	if err := s.adapter.Publish(ctx, req); err != nil {
+	if err := s.adapter.Publish(ctx, req, rtpubsub.TransportModeGRPC); err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %w", msg.Topic, deadLetterTopic, err)
 		return err
 	}

--- a/pkg/testing/pubsubadapter_mock.go
+++ b/pkg/testing/pubsubadapter_mock.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/runtime/pubsub/transport"
 )
 
 // MockPubSubAdapter is mock for PubSubAdapter
@@ -30,13 +31,13 @@ type MockPubSubAdapter struct {
 // Publish is an adapter method for the runtime to pre-validate publish requests
 // And then forward them to the Pub/Sub component.
 // This method is used by the HTTP and gRPC APIs.
-func (a *MockPubSubAdapter) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
+func (a *MockPubSubAdapter) Publish(ctx context.Context, req *pubsub.PublishRequest, _ transport.Mode) error {
 	return a.PublishFn(ctx, req)
 }
 
 // Publish is an adapter method for the runtime to pre-validate publish requests
 // And then forward them to the Pub/Sub component.
 // This method is used by the HTTP and gRPC APIs.
-func (a *MockPubSubAdapter) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
+func (a *MockPubSubAdapter) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest, _ transport.Mode) (pubsub.BulkPublishResponse, error) {
 	return a.BulkPublishFn(ctx, req)
 }

--- a/tests/apps/resiliencyapp/go.mod
+++ b/tests/apps/resiliencyapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v0.0.0

--- a/tests/apps/resiliencyapp_grpc/go.mod
+++ b/tests/apps/resiliencyapp_grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/resiliencyapp_grpc
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v1.7.4

--- a/tests/apps/service_invocation_grpc_proxy_client/go.mod
+++ b/tests/apps/service_invocation_grpc_proxy_client/go.mod
@@ -1,6 +1,6 @@
 module github.com/dapr/dapr/tests/apps/service_invocation_grpc_proxy_client
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/dapr/dapr v0.0.0-00010101000000-000000000000

--- a/tests/integration/suite/daprd/resiliency/publish/grpc.go
+++ b/tests/integration/suite/daprd/resiliency/publish/grpc.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package publish
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	contribpubsub "github.com/dapr/components-contrib/pubsub"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub"
+	inmemory "github.com/dapr/dapr/tests/integration/framework/process/pubsub/in-memory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(grpc))
+}
+
+// grpc verifies resiliency retry `matching` on the publish path. "pubsub-match" retries
+// only gRPCStatusCodes "14". "pubsub-nomatch" has no matching and retries everything — so
+// the same FailedPrecondition error is the control: dropped under matching, retried without.
+type grpc struct {
+	daprd    *daprd.Daprd
+	counters sync.Map
+}
+
+func (g *grpc) Setup(t *testing.T) []framework.Option {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping unix socket based test on windows")
+	}
+
+	publishFn := func(ctx context.Context, req *contribpubsub.PublishRequest) error {
+		c, _ := g.counters.LoadOrStore(req.Topic, &atomic.Int32{})
+		c.(*atomic.Int32).Add(1)
+		switch {
+		case req.Topic == "retriable":
+			return status.Error(codes.Unavailable, "broker unavailable")
+		case strings.HasPrefix(req.Topic, "terminal"):
+			return status.Error(codes.FailedPrecondition, "invalid topic")
+		default:
+			return nil
+		}
+	}
+
+	sock := socket.New(t)
+	comp := pubsub.New(t,
+		pubsub.WithSocket(sock),
+		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t,
+			inmemory.WithFeatures(),
+			inmemory.WithPublishFn(publishFn),
+		)),
+	)
+
+	g.daprd = daprd.New(t,
+		daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: myresiliency
+spec:
+  policies:
+    retries:
+      matchRetry:
+        policy: constant
+        duration: 10ms
+        maxRetries: 3
+        matching:
+          gRPCStatusCodes: "14"
+      noMatchRetry:
+        policy: constant
+        duration: 10ms
+        maxRetries: 3
+  targets:
+    components:
+      pubsub-match:
+        outbound:
+          retry: matchRetry
+      pubsub-nomatch:
+        outbound:
+          retry: noMatchRetry
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub-match
+spec:
+  type: pubsub.%[1]s
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub-nomatch
+spec:
+  type: pubsub.%[1]s
+  version: v1
+`, comp.SocketName())),
+		daprd.WithSocket(t, sock),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(comp, g.daprd),
+	}
+}
+
+func (g *grpc) count(topic string) int {
+	c, ok := g.counters.Load(topic)
+	if !ok {
+		return 0
+	}
+	return int(c.(*atomic.Int32).Load())
+}
+
+func (g *grpc) Run(t *testing.T, ctx context.Context) {
+	g.daprd.WaitUntilRunning(t, ctx)
+
+	client := g.daprd.GRPCClient(t, ctx)
+
+	t.Run("matching: retriable code is retried up to maxRetries", func(t *testing.T) {
+		_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+			PubsubName: "pubsub-match", Topic: "retriable",
+			Data: []byte(`{"id":1}`),
+		})
+		require.Error(t, err)
+		assert.Equal(t, 4, g.count("retriable"))
+	})
+
+	t.Run("matching: non-retriable code is not retried", func(t *testing.T) {
+		_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+			PubsubName: "pubsub-match", Topic: "terminal",
+			Data: []byte(`{"id":1}`),
+		})
+		require.Error(t, err)
+		assert.Equal(t, 1, g.count("terminal"))
+	})
+
+	t.Run("no matching: every error is retried regardless of code", func(t *testing.T) {
+		_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+			PubsubName: "pubsub-nomatch", Topic: "terminalnomatcherrcode",
+			Data: []byte(`{"id":1}`),
+		})
+		require.Error(t, err)
+		assert.Equal(t, 4, g.count("terminalnomatcherrcode"))
+	})
+}

--- a/tests/integration/suite/daprd/resiliency/publish/http.go
+++ b/tests/integration/suite/daprd/resiliency/publish/http.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package publish
+
+import (
+	"context"
+	"fmt"
+	stdhttp "net/http"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	contribpubsub "github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub"
+	inmemory "github.com/dapr/dapr/tests/integration/framework/process/pubsub/in-memory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(http))
+}
+
+// http is the HTTP-API equivalent of grpc: the same `matching` checks, but publishing via
+// the /v1.0/publish HTTP endpoint instead of the gRPC API.
+type http struct {
+	daprd    *daprd.Daprd
+	counters sync.Map
+}
+
+func (h *http) Setup(t *testing.T) []framework.Option {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping unix socket based test on windows")
+	}
+
+	publishFn := func(ctx context.Context, req *contribpubsub.PublishRequest) error {
+		c, _ := h.counters.LoadOrStore(req.Topic, &atomic.Int32{})
+		c.(*atomic.Int32).Add(1)
+		switch {
+		case req.Topic == "retriable":
+			return status.Error(codes.Unavailable, "broker unavailable")
+		case strings.HasPrefix(req.Topic, "terminal"):
+			return status.Error(codes.FailedPrecondition, "invalid topic")
+		default:
+			return nil
+		}
+	}
+
+	sock := socket.New(t)
+	comp := pubsub.New(t,
+		pubsub.WithSocket(sock),
+		pubsub.WithPubSub(inmemory.NewWrappedInMemory(t,
+			inmemory.WithFeatures(),
+			inmemory.WithPublishFn(publishFn),
+		)),
+	)
+
+	h.daprd = daprd.New(t,
+		daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: myresiliency
+spec:
+  policies:
+    retries:
+      matchRetry:
+        policy: constant
+        duration: 10ms
+        maxRetries: 3
+        matching:
+          gRPCStatusCodes: "14"
+      noMatchRetry:
+        policy: constant
+        duration: 10ms
+        maxRetries: 3
+  targets:
+    components:
+      pubsub-match:
+        outbound:
+          retry: matchRetry
+      pubsub-nomatch:
+        outbound:
+          retry: noMatchRetry
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub-match
+spec:
+  type: pubsub.%[1]s
+  version: v1
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub-nomatch
+spec:
+  type: pubsub.%[1]s
+  version: v1
+`, comp.SocketName())),
+		daprd.WithSocket(t, sock),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(comp, h.daprd),
+	}
+}
+
+func (h *http) count(topic string) int {
+	c, ok := h.counters.Load(topic)
+	if !ok {
+		return 0
+	}
+	return int(c.(*atomic.Int32).Load())
+}
+
+func (h *http) publish(t *testing.T, ctx context.Context, httpClient *stdhttp.Client, pubsubName, topic string) {
+	t.Helper()
+	reqURL := fmt.Sprintf("http://%s/v1.0/publish/%s/%s", h.daprd.HTTPAddress(), pubsubName, topic)
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, reqURL, strings.NewReader(`{"id":1}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.NotEqual(t, stdhttp.StatusNoContent, resp.StatusCode, reqURL)
+}
+
+func (h *http) Run(t *testing.T, ctx context.Context) {
+	h.daprd.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+
+	t.Run("matching: retriable code is retried up to maxRetries", func(t *testing.T) {
+		h.publish(t, ctx, httpClient, "pubsub-match", "retriable")
+		assert.Equal(t, 4, h.count("retriable"))
+	})
+
+	t.Run("matching: non-retriable code is not retried", func(t *testing.T) {
+		h.publish(t, ctx, httpClient, "pubsub-match", "terminal")
+		assert.Equal(t, 1, h.count("terminal"))
+	})
+
+	t.Run("no matching: every error is retried regardless of code", func(t *testing.T) {
+		h.publish(t, ctx, httpClient, "pubsub-nomatch", "terminalnomatcherrcode")
+		assert.Equal(t, 4, h.count("terminalnomatcherrcode"))
+	})
+}

--- a/tests/integration/suite/daprd/resiliency/publish/http.go
+++ b/tests/integration/suite/daprd/resiliency/publish/http.go
@@ -42,8 +42,10 @@ func init() {
 	suite.Register(new(http))
 }
 
-// http is the HTTP-API equivalent of grpc: the same `matching` checks, but publishing via
-// the /v1.0/publish HTTP endpoint instead of the gRPC API.
+// http verifies retry `matching` on the HTTP publish API. Broker gRPC codes are mapped to
+// their HTTP equivalents (Unavailable->503, ResourceExhausted->429, FailedPrecondition->400)
+// and matched against `httpStatusCodes: "429,500-599"`, exercising a range match (503), a
+// single-code match (429), and a non-match (400) that is dropped.
 type http struct {
 	daprd    *daprd.Daprd
 	counters sync.Map
@@ -59,8 +61,13 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		c.(*atomic.Int32).Add(1)
 		switch {
 		case req.Topic == "retriable":
+			// Unavailable -> HTTP 503, matched by the "500-599" range.
 			return status.Error(codes.Unavailable, "broker unavailable")
+		case req.Topic == "toomany":
+			// ResourceExhausted -> HTTP 429, matched by the "429" single code.
+			return status.Error(codes.ResourceExhausted, "slow down")
 		case strings.HasPrefix(req.Topic, "terminal"):
+			// FailedPrecondition -> HTTP 400, not in "429,500-599" -> not retried.
 			return status.Error(codes.FailedPrecondition, "invalid topic")
 		default:
 			return nil
@@ -90,7 +97,7 @@ spec:
         duration: 10ms
         maxRetries: 3
         matching:
-          gRPCStatusCodes: "14"
+          httpStatusCodes: "429,500-599"
       noMatchRetry:
         policy: constant
         duration: 10ms
@@ -153,12 +160,17 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 
-	t.Run("matching: retriable code is retried up to maxRetries", func(t *testing.T) {
+	t.Run("matching: code in range (503) is retried up to maxRetries", func(t *testing.T) {
 		h.publish(t, ctx, httpClient, "pubsub-match", "retriable")
 		assert.Equal(t, 4, h.count("retriable"))
 	})
 
-	t.Run("matching: non-retriable code is not retried", func(t *testing.T) {
+	t.Run("matching: comma-separated single code (429) is retried up to maxRetries", func(t *testing.T) {
+		h.publish(t, ctx, httpClient, "pubsub-match", "toomany")
+		assert.Equal(t, 4, h.count("toomany"))
+	})
+
+	t.Run("matching: code outside range (400) is not retried", func(t *testing.T) {
 		h.publish(t, ctx, httpClient, "pubsub-match", "terminal")
 		assert.Equal(t, 1, h.count("terminal"))
 	})

--- a/tests/integration/suite/daprd/resiliency/resiliency.go
+++ b/tests/integration/suite/daprd/resiliency/resiliency.go
@@ -16,5 +16,6 @@ package resiliency
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/apps"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/daprd"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/publish"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/resiliency/subscriptions"
 )


### PR DESCRIPTION
[supercede this PR ](https://github.com/dapr/dapr/pull/10069) & [this PR](https://github.com/dapr/dapr/pull/10080) & fix conflicts and use latest 1.17.7 patch from contrib