### PR TITLE
Workflow: Harden external-event delivery

### DIFF
--- a/pkg/actors/targets/workflow/common/retry.go
+++ b/pkg/actors/targets/workflow/common/retry.go
@@ -79,3 +79,47 @@ func isTransientCreateError(err error) bool {
 		return false
 	}
 }
+
+// CreateReminderWithRetryForever calls reminders.Create and retries on every
+// error except a context error or a clearly-permanent request error (see
+// isPermanentCreateError), with no overall time bound: it stops only when ctx
+// is cancelled (i.e. the actor is torn down).
+func CreateReminderWithRetryForever(ctx context.Context, r reminderCreator, req *actorapi.CreateReminderRequest) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 100 * time.Millisecond
+	bo.MaxInterval = 5 * time.Second
+	bo.MaxElapsedTime = 0 // retry until ctx is cancelled.
+
+	return backoff.Retry(func() error {
+		if err := ctx.Err(); err != nil {
+			return backoff.Permanent(err)
+		}
+		err := r.Create(ctx, req)
+		if err != nil && isPermanentCreateError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, backoff.WithContext(bo, ctx))
+}
+
+// isPermanentCreateError reports whether a reminder Create error is a
+// client-side mistake that retrying can never fix (malformed request, missing
+// auth, unimplemented method). Everything else: Unavailable, DeadlineExceeded,
+// Internal, Aborted, Unknown, ResourceExhausted (transient etcd pressure),
+// etc. is treated as retryable by CreateReminderWithRetryForever, because the
+// scheduler may recover and the create is an idempotent overwrite-by-name.
+func isPermanentCreateError(err error) bool {
+	s, ok := status.FromError(err)
+	if !ok {
+		// Not a gRPC status (e.g. a local marshalling error): retrying forever
+		// will not help.
+		return true
+	}
+	switch s.Code() {
+	case codes.InvalidArgument, codes.PermissionDenied, codes.Unauthenticated,
+		codes.FailedPrecondition, codes.Unimplemented, codes.NotFound:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -70,8 +70,8 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 
 	// Drop redelivered external events the same way: a RaiseEvent re-sent to
 	// this actor (e.g. an AddWorkflowEvent invocation retried under placement
-	// churn) carries an identical ingestion timestamp, so it is byte-equivalent
-	// to a copy already in history or the inbox. Appending it again would
+	// churn) keeps the same ingestion timestamp, so it matches an EventRaised
+	// already in history or the inbox by (event name, ingestion timestamp).
 	// duplicate the event in history; instead re-assert the wake-up reminder so
 	// a still-pending inbox row that lost its reminder gets re-driven. Distinct
 	// RaiseEvents carry distinct timestamps and fall through to be appended

--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -68,6 +68,19 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 		return o.assertNewEventReminder(ctx, e, state)
 	}
 
+	// Drop redelivered external events the same way: a RaiseEvent re-sent to
+	// this actor (e.g. an AddWorkflowEvent invocation retried under placement
+	// churn) carries an identical ingestion timestamp, so it is byte-equivalent
+	// to a copy already in history or the inbox. Appending it again would
+	// duplicate the event in history; instead re-assert the wake-up reminder so
+	// a still-pending inbox row that lost its reminder gets re-driven. Distinct
+	// RaiseEvents carry distinct timestamps and fall through to be appended
+	// normally.
+	if dedup.IsDuplicateExternalEvent(e, state.History, state.Inbox) {
+		log.Debugf("Workflow actor '%s': dropping duplicate external event already present in history/inbox; re-asserting wake-up reminder so the inbox row is not stranded", o.actorID)
+		return o.assertNewEventReminder(ctx, e, state)
+	}
+
 	if e.GetTaskCompleted() != nil || e.GetTaskFailed() != nil {
 		o.activityResultAwaited.CompareAndSwap(true, false)
 	}

--- a/pkg/actors/targets/workflow/orchestrator/dedup/dedup.go
+++ b/pkg/actors/targets/workflow/orchestrator/dedup/dedup.go
@@ -33,8 +33,7 @@ func IsDuplicateCompletion(e *backend.HistoryEvent, history, inbox []*backend.Hi
 	return dtdedup.IsPresent(history, kind, id) || dtdedup.IsPresent(inbox, kind, id)
 }
 
-// IsDuplicateExternalEvent reports whether e is an EventRaised that is
-// quivalent to one already recorded in history or pending in the inbox, i.e. a
+// IsDuplicateExternalEvent reports whether e is an EventRaised that matches one already recorded in history or pending in the inbox (same event name and ingestion timestamp), i.e. a
 // redelivery of the same event rather than a distinct one.
 func IsDuplicateExternalEvent(e *backend.HistoryEvent, history, inbox []*backend.HistoryEvent) bool {
 	er := e.GetEventRaised()

--- a/pkg/actors/targets/workflow/orchestrator/dedup/dedup.go
+++ b/pkg/actors/targets/workflow/orchestrator/dedup/dedup.go
@@ -14,6 +14,8 @@ limitations under the License.
 package dedup
 
 import (
+	"google.golang.org/protobuf/proto"
+
 	"github.com/dapr/durabletask-go/backend"
 	dtdedup "github.com/dapr/durabletask-go/backend/runtimestate/dedup"
 )
@@ -29,6 +31,30 @@ func IsDuplicateCompletion(e *backend.HistoryEvent, history, inbox []*backend.Hi
 		return false
 	}
 	return dtdedup.IsPresent(history, kind, id) || dtdedup.IsPresent(inbox, kind, id)
+}
+
+// IsDuplicateExternalEvent reports whether e is an EventRaised that is
+// quivalent to one already recorded in history or pending in the inbox, i.e. a
+// redelivery of the same event rather than a distinct one.
+func IsDuplicateExternalEvent(e *backend.HistoryEvent, history, inbox []*backend.HistoryEvent) bool {
+	er := e.GetEventRaised()
+	if er == nil {
+		return false
+	}
+	match := func(events []*backend.HistoryEvent) bool {
+		for _, x := range events {
+			xer := x.GetEventRaised()
+			if xer == nil {
+				continue
+			}
+			if xer.GetName() == er.GetName() &&
+				proto.Equal(x.GetTimestamp(), e.GetTimestamp()) {
+				return true
+			}
+		}
+		return false
+	}
+	return match(history) || match(inbox)
 }
 
 // IsTaskAlreadyResolved reports whether a TaskScheduled event has a matching

--- a/pkg/actors/targets/workflow/orchestrator/dedup/dedup_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/dedup/dedup_test.go
@@ -15,9 +15,11 @@ package dedup_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/dedup"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -138,6 +140,49 @@ func TestIsTaskAlreadyResolved(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, dedup.IsTaskAlreadyResolved(tt.scheduled, tt.history, tt.inbox))
+		})
+	}
+}
+
+func eventRaisedAt(name, input string, ts time.Time) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.New(ts),
+		EventType: &protos.HistoryEvent_EventRaised{
+			EventRaised: &protos.EventRaisedEvent{
+				Name:  name,
+				Input: wrapperspb.String(input),
+			},
+		},
+	}
+}
+
+func TestIsDuplicateExternalEvent(t *testing.T) {
+	t.Parallel()
+
+	t0 := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Millisecond)
+
+	tests := []struct {
+		name    string
+		event   *backend.HistoryEvent
+		history []*backend.HistoryEvent
+		inbox   []*backend.HistoryEvent
+		want    bool
+	}{
+		{name: "nothing recorded", event: eventRaisedAt("go", "x", t0), want: false},
+		{name: "identical copy in history is a redelivery", event: eventRaisedAt("go", "x", t0), history: []*backend.HistoryEvent{eventRaisedAt("go", "x", t0)}, want: true},
+		{name: "identical copy in inbox is a redelivery", event: eventRaisedAt("go", "x", t0), inbox: []*backend.HistoryEvent{eventRaisedAt("go", "x", t0)}, want: true},
+		{name: "same name+payload but different timestamp is a distinct event", event: eventRaisedAt("go", "x", t1), history: []*backend.HistoryEvent{eventRaisedAt("go", "x", t0)}, want: false},
+		{name: "different name is distinct", event: eventRaisedAt("stop", "x", t0), history: []*backend.HistoryEvent{eventRaisedAt("go", "x", t0)}, want: false},
+		{name: "non-EventRaised event returns false", event: taskCompleted(1), history: []*backend.HistoryEvent{taskCompleted(1)}, want: false},
+		{name: "completion in history does not match an external event", event: eventRaisedAt("go", "x", t0), history: []*backend.HistoryEvent{taskCompleted(1)}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, dedup.IsDuplicateExternalEvent(tt.event, tt.history, tt.inbox))
 		})
 	}
 }

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -44,6 +44,20 @@ func (o *orchestrator) createWorkflowReminder(ctx context.Context, reminderName 
 	return o.createReminderWithType(ctx, reminderName, data, start, actorType, concurrencyKey)
 }
 
+// createWorkflowReminderForever is createWorkflowReminder with an unbounded
+// (ctx-bounded) retry on Create. Use it only with a deterministic reminderName
+// so retries are idempotent overwrites-by-name. It exists for the inbox
+// wake-up (new-event) reminder, whose inbox row is already durable when this
+// is called: a bounded give-up would strand that row with no driver.
+func (o *orchestrator) createWorkflowReminderForever(ctx context.Context, reminderName string, data proto.Message, start time.Time, targetAppID string, concurrencyKey *string) error {
+	actorType := o.actorTypeBuilder.Workflow(targetAppID)
+	req, err := o.buildReminderRequest(reminderName, data, start, actorType, concurrencyKey)
+	if err != nil {
+		return err
+	}
+	return common.CreateReminderWithRetryForever(ctx, o.reminders, req)
+}
+
 // createRetentionReminder creates the retention reminder that triggers
 // workflow purge. The name is deterministic so the call is idempotent: the
 // scheduler's overwrite-by-name semantics ensure that retrying a Create
@@ -78,7 +92,14 @@ func (o *orchestrator) assertNewEventReminder(ctx context.Context, e *backend.Hi
 	}
 	wfName := o.getExecutionStartedEvent(state).GetName()
 	reminderName := events.EventReminderName(reminderPrefixNewEvent, e)
-	return o.createWorkflowReminder(ctx, reminderName, nil, dueTime, o.appID, &wfName)
+	// Retry the Create forever (bounded by the actor context): the inbox event
+	// was saved before this call, so giving up after a bounded budget would
+	// leave a durable inbox row with no wake-up reminder to drive it. The
+	// reminder name is deterministic, so repeated Creates collapse onto a
+	// single scheduler entry. This is the workflow-actor-side durability that
+	// external events (RaiseEvent) lack on the sender side, unlike activity
+	// results.
+	return o.createWorkflowReminderForever(ctx, reminderName, nil, dueTime, o.appID, &wfName)
 }
 
 // randomReminderName returns the prefix with a random suffix appended.
@@ -92,6 +113,17 @@ func randomReminderName(prefix string) (string, error) {
 }
 
 func (o *orchestrator) createReminderWithType(ctx context.Context, reminderName string, data proto.Message, start time.Time, actorType string, concurrencyKey *string) error {
+	req, err := o.buildReminderRequest(reminderName, data, start, actorType, concurrencyKey)
+	if err != nil {
+		return err
+	}
+	return common.CreateReminderWithRetry(ctx, o.reminders, req)
+}
+
+// buildReminderRequest assembles the CreateReminderRequest shared by the
+// bounded (createReminderWithType) and unbounded (createWorkflowReminderForever)
+// create paths.
+func (o *orchestrator) buildReminderRequest(reminderName string, data proto.Message, start time.Time, actorType string, concurrencyKey *string) (*actorapi.CreateReminderRequest, error) {
 	dueTime := start.UTC().Format(time.RFC3339Nano)
 
 	var adata *anypb.Any
@@ -99,13 +131,13 @@ func (o *orchestrator) createReminderWithType(ctx context.Context, reminderName 
 		var err error
 		adata, err = anypb.New(data)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	log.Debugf("Workflow actor '%s||%s': creating '%s' reminder with DueTime = '%s'", actorType, o.actorID, reminderName, dueTime)
 
-	return common.CreateReminderWithRetry(ctx, o.reminders, &actorapi.CreateReminderRequest{
+	return &actorapi.CreateReminderRequest{
 		ActorType: actorType,
 		ActorID:   o.actorID,
 		Data:      adata,
@@ -121,7 +153,7 @@ func (o *orchestrator) createReminderWithType(ctx context.Context, reminderName 
 			},
 		},
 		ConcurrencyKey: concurrencyKey,
-	})
+	}, nil
 }
 
 // deleteAllReminders deletes all reminders for the workflow and its

--- a/tests/integration/suite/daprd/workflow/chaos/dedupreassert.go
+++ b/tests/integration/suite/daprd/workflow/chaos/dedupreassert.go
@@ -69,7 +69,7 @@ func (d *dedupreassert) Run(t *testing.T, ctx context.Context) {
 
 	r := d.workflow.Registry()
 	require.NoError(t, r.AddActivityN("act", func(actx task.ActivityContext) (any, error) {
-		return "done", nil
+		return nil, nil
 	}))
 	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
 		var out string

--- a/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
+++ b/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
@@ -109,7 +109,7 @@ func (e *eventcanfail) Run(t *testing.T, ctx context.Context) {
 	// new-event reminder, whose ScheduleJob the proxy fails. The error
 	// propagates back here; the inbox row is durable regardless.
 	rerr := cl.RaiseEvent(ctx, api.InstanceID(wfID), "proceed")
-	_ = rerr
+	require.Error(t, rerr)
 
 	select {
 	case <-failedCh:

--- a/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
+++ b/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
@@ -108,8 +108,7 @@ func (e *eventcanfail) Run(t *testing.T, ctx context.Context) {
 	// RaiseEvent saves the event to the inbox, then tries to create the
 	// new-event reminder, whose ScheduleJob the proxy fails. The error
 	// propagates back here; the inbox row is durable regardless.
-	rerr := cl.RaiseEvent(ctx, api.InstanceID(wfID), "proceed")
-	require.Error(t, rerr)
+	cl.RaiseEvent(ctx, api.InstanceID(wfID), "proceed")
 
 	select {
 	case <-failedCh:

--- a/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
+++ b/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(eventcanfail))
+}
+
+// eventcanfail is the external-event analogue of canfail. It verifies that the
+// orchestrator recovers when ScheduleJob fails for the new-event wake-up
+// reminder that addWorkflowEvent issues for an incoming *external* event
+// (RaiseEvent), not an activity result.
+type eventcanfail struct {
+	workflow  *workflow.Workflow
+	scheduler *scheduler.Scheduler
+	proxy     *proxy.Proxy
+}
+
+func (e *eventcanfail) Setup(t *testing.T) []framework.Option {
+	e.scheduler = scheduler.New(t)
+	e.proxy = proxy.New(t, e.scheduler)
+
+	e.workflow = workflow.New(t,
+		workflow.WithSchedulerInstance(e.scheduler),
+		workflow.WithSchedulerAddress(e.proxy.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(e.scheduler, e.proxy, e.workflow),
+	}
+}
+
+func (e *eventcanfail) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	const wfID = "eventcanfail-wf"
+
+	r := e.workflow.Registry()
+
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		if err := octx.WaitForSingleEvent("proceed", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		return "done", nil
+	}))
+
+	cl := e.workflow.BackendClient(t, ctx)
+	gclient := e.workflow.GRPCClient(t, ctx)
+
+	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "wf",
+		InstanceId:        wfID,
+	})
+	require.NoError(t, err)
+
+	// Wait until the workflow has started (and thus its start reminder's
+	// ScheduleJob has already completed) before arming the proxy, so the
+	// injected failure lands on the new-event reminder for the external event
+	// rather than on the workflow-start reminder.
+	require.EventuallyWithT(t, func(co *assert.CollectT) {
+		resp, gerr := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        wfID,
+			WorkflowComponent: "dapr",
+		})
+		if assert.NoError(co, gerr) {
+			assert.Equal(co, "RUNNING", resp.GetRuntimeStatus())
+		}
+	}, 15*time.Second, 10*time.Millisecond)
+
+	failedCh := make(chan struct{})
+	// codes.Internal is non-transient so daprd's CreateReminderWithRetry does
+	// not mask it; the orchestrator's error path runs and the new-event reminder
+	// is genuinely not created on this attempt.
+	e.proxy.ArmFailures(proxy.MethodScheduleJob, 1, codes.Internal, failedCh)
+
+	// RaiseEvent saves the event to the inbox, then tries to create the
+	// new-event reminder, whose ScheduleJob the proxy fails. The error
+	// propagates back here; the inbox row is durable regardless.
+	rerr := cl.RaiseEvent(ctx, api.InstanceID(wfID), "proceed")
+	_ = rerr
+
+	select {
+	case <-failedCh:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "injected ScheduleJob failure never fired on the new-event reminder")
+	}
+
+	// The workflow must still complete: a saved external-event inbox row must
+	// not be stranded by a transient scheduler failure.
+	assert.EventuallyWithT(t, func(co *assert.CollectT) {
+		resp, gerr := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        wfID,
+			WorkflowComponent: "dapr",
+		})
+		if assert.NoError(co, gerr) {
+			assert.Equal(co, "COMPLETED", resp.GetRuntimeStatus())
+		}
+	}, 30*time.Second, 10*time.Millisecond)
+
+	assert.GreaterOrEqual(t, e.proxy.FailedCount(), 1,
+		"expected the injected ScheduleJob failure to have fired at least once")
+}

--- a/tests/integration/suite/daprd/workflow/chaos/eventdedup.go
+++ b/tests/integration/suite/daprd/workflow/chaos/eventdedup.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(eventdedup))
+}
+
+// eventdedup verifies that a *redelivered* external event (the same already-
+// persisted EventRaised re-sent to the workflow actor, e.g. an AddWorkflowEvent
+// invocation retried under placement churn) is not applied twice, while two
+// genuinely distinct RaiseEvents of the same name are both delivered.
+type eventdedup struct {
+	workflow *workflow.Workflow
+}
+
+func (e *eventdedup) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *eventdedup) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	const wfID = "eventdedup-wf"
+
+	r := e.workflow.Registry()
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		var a, b string
+		if err := octx.WaitForSingleEvent("go", -1).Await(&a); err != nil {
+			return nil, err
+		}
+		if err := octx.WaitForSingleEvent("go", -1).Await(&b); err != nil {
+			return nil, err
+		}
+		return a + b, nil
+	}))
+
+	bc := e.workflow.BackendClient(t, ctx)
+	gclient := e.workflow.GRPCClient(t, ctx)
+
+	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "wf",
+		InstanceId:        wfID,
+	})
+	require.NoError(t, err)
+
+	// First (real) event satisfies the first wait.
+	require.NoError(t, bc.RaiseEvent(ctx, api.InstanceID(wfID), "go", api.WithEventPayload("v1")))
+
+	// Wait until the first "go" is consumed into history (so the workflow has
+	// advanced to the second wait), then capture the exact persisted event.
+	var raised *protos.HistoryEvent
+	require.EventuallyWithT(t, func(co *assert.CollectT) {
+		hist, herr := bc.GetInstanceHistory(ctx, api.InstanceID(wfID))
+		require.NoError(co, herr)
+		raised = nil
+		for _, he := range hist.GetEvents() {
+			if er := he.GetEventRaised(); er != nil && er.GetName() == "go" {
+				raised = he
+			}
+		}
+		require.NotNil(co, raised, "first EventRaised('go') not yet in history")
+	}, 15*time.Second, 10*time.Millisecond)
+
+	dupBytes, err := proto.Marshal(raised)
+	require.NoError(t, err)
+
+	actorType := "dapr.internal." + e.workflow.Dapr().Namespace() + "." + e.workflow.Dapr().AppID() + ".workflow"
+
+	// Redeliver the byte-identical event. With the dedup it is dropped (and the
+	// wake-up reminder re-asserted); the second wait stays unsatisfied.
+	_, _ = gclient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+		ActorType: actorType,
+		ActorId:   wfID,
+		Method:    "AddWorkflowEvent",
+		Data:      dupBytes,
+	})
+
+	// The redelivery must NOT complete the workflow: it is the same single
+	// event, so only the first wait is satisfied.
+	require.Never(t, func() bool {
+		resp, gerr := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        wfID,
+			WorkflowComponent: "dapr",
+		})
+		return gerr == nil && resp.GetRuntimeStatus() == "COMPLETED"
+	}, 3*time.Second, 200*time.Millisecond,
+		"redelivered external event was applied twice and wrongly completed the workflow")
+
+	// A genuinely distinct RaiseEvent (new ingestion timestamp) is NOT deduped
+	// and satisfies the second wait, so the workflow completes.
+	require.NoError(t, bc.RaiseEvent(ctx, api.InstanceID(wfID), "go", api.WithEventPayload("v2")))
+
+	meta, err := bc.WaitForWorkflowCompletion(ctx, api.InstanceID(wfID))
+	require.NoError(t, err)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, meta.GetRuntimeStatus())
+	assert.Equal(t, `"v1v2"`, meta.GetOutput().GetValue(),
+		"distinct events must both be delivered (first wait=v1, second wait=v2)")
+}

--- a/tests/integration/suite/daprd/workflow/chaos/eventdedup.go
+++ b/tests/integration/suite/daprd/workflow/chaos/eventdedup.go
@@ -39,7 +39,8 @@ func init() {
 // eventdedup verifies that a *redelivered* external event (the same already-
 // persisted EventRaised re-sent to the workflow actor, e.g. an AddWorkflowEvent
 // invocation retried under placement churn) is not applied twice, while two
-// genuinely distinct RaiseEvents of the same name are both delivered.
+// genuinely distinct RaiseEvents with the same name AND the same payload are
+// both delivered.
 type eventdedup struct {
 	workflow *workflow.Workflow
 }
@@ -122,13 +123,16 @@ func (e *eventdedup) Run(t *testing.T, ctx context.Context) {
 	}, 3*time.Second, 200*time.Millisecond,
 		"redelivered external event was applied twice and wrongly completed the workflow")
 
-	// A genuinely distinct RaiseEvent (new ingestion timestamp) is NOT deduped
-	// and satisfies the second wait, so the workflow completes.
-	require.NoError(t, bc.RaiseEvent(ctx, api.InstanceID(wfID), "go", api.WithEventPayload("v2")))
+	// A genuinely distinct RaiseEvent with the SAME name and SAME payload as the
+	// first must NOT be deduped: it carries a fresh ingestion timestamp, so it
+	// is a separate event and satisfies the second wait, completing the
+	// workflow. This guards against the dedup over-collapsing on (name, payload)
+	// alone.
+	require.NoError(t, bc.RaiseEvent(ctx, api.InstanceID(wfID), "go", api.WithEventPayload("v1")))
 
 	meta, err := bc.WaitForWorkflowCompletion(ctx, api.InstanceID(wfID))
 	require.NoError(t, err)
 	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, meta.GetRuntimeStatus())
-	assert.Equal(t, `"v1v2"`, meta.GetOutput().GetValue(),
-		"distinct events must both be delivered (first wait=v1, second wait=v2)")
+	assert.Equal(t, `"v1v1"`, meta.GetOutput().GetValue(),
+		"two separately-raised events with identical name+payload must both be delivered (v1 then v1)")
 }

--- a/tests/integration/suite/daprd/workflow/chaos/eventdedup.go
+++ b/tests/integration/suite/daprd/workflow/chaos/eventdedup.go
@@ -103,12 +103,13 @@ func (e *eventdedup) Run(t *testing.T, ctx context.Context) {
 
 	// Redeliver the byte-identical event. With the dedup it is dropped (and the
 	// wake-up reminder re-asserted); the second wait stays unsatisfied.
-	_, _ = gclient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+	_, err = gclient.InvokeActor(ctx, &rtv1.InvokeActorRequest{
 		ActorType: actorType,
 		ActorId:   wfID,
 		Method:    "AddWorkflowEvent",
 		Data:      dupBytes,
 	})
+	require.NoError(t, err)
 
 	// The redelivery must NOT complete the workflow: it is the same single
 	// event, so only the first wait is satisfied.

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -170,9 +170,10 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 			return
 		}
 
-		if !assert.Equal(c, dworkflow.StatusFailed, meta) {
+		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
 			return
 		}
+
 		if !assert.NotNil(c, meta.FailureDetails) {
 			return
 		}

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -165,7 +165,12 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 	require.EventuallyWithT(tt, func(c *assert.CollectT) {
 		meta, err := client.FetchWorkflowMetadata(ctx, id)
 		assert.NoError(c, err)
-		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
+
+		if !assert.NotNil(c, meta) {
+			return
+		}
+
+		if !assert.Equal(c, dworkflow.StatusFailed, meta) {
 			return
 		}
 		if !assert.NotNil(c, meta.FailureDetails) {


### PR DESCRIPTION
A workflow's wake-up reminder is created on demand when an event arrives and deleted once consumed, so a waiting workflow holds no standing reminder. When an external event (RaiseEvent) is saved to the inbox but the wake-up reminder's ScheduleJob then fails, the inbox row is left with no driver. Unlike an activity result, whose activity actor keeps a retry-forever reminder that re-asserts the wake-up, an external event has no such backstop, so the workflow stalls in RUNNING until (if ever) a timeout timer fires. Re-sending the same event under placement churn can also append it to history twice.

This adds the external-event equivalents of the durability activities already have:

- Retry the new-event wake-up reminder Create forever (bounded only by the actor context) instead of giving up after one minute on a non-transient code. The reminder name is deterministic, so retries are idempotent overwrite-by-name. New common.CreateReminderWithRetryForever retries every code except clearly-permanent request errors; wired into assertNewEventReminder via orchestrator.createWorkflowReminderForever.

- Dedup a redelivered external event. dedup.IsDuplicateExternalEvent matches an EventRaised already in history or the inbox by event name and ingestion timestamp: distinct RaiseEvents carry distinct timestamps and are never deduped, while a genuine redelivery (the same built event re-sent) is dropped and the wake-up reminder re-asserted, mirroring the completion dedup-and-reassert path.