### PR TITLE
Match HTTP publish retries against httpStatusCodes

### DIFF
--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -234,7 +234,7 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 	}
 
 	start := time.Now()
-	err := a.pubsubAdapter.Publish(ctx, &req)
+	err := a.pubsubAdapter.Publish(ctx, &req, runtimePubsub.TransportModeGRPC)
 	elapsed := diag.ElapsedSince(start)
 
 	diag.DefaultComponentMonitoring.PubsubEgressEvent(context.Background(), pubsubName, topic, err == nil, elapsed)
@@ -465,7 +465,7 @@ func (a *api) bulkPublishEvent(ctx context.Context, in *runtimev1pb.BulkPublishR
 	start := time.Now()
 	// err is only nil if all entries are successfully published.
 	// For partial success, err is not nil and res contains the failed entries.
-	res, err := a.pubsubAdapter.BulkPublish(ctx, &req)
+	res, err := a.pubsubAdapter.BulkPublish(ctx, &req, runtimePubsub.TransportModeGRPC)
 
 	elapsed := diag.ElapsedSince(start)
 	eventsPublished := int64(len(req.Entries))

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -1178,7 +1178,7 @@ func (a *api) onPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	start := time.Now()
-	err := a.pubsubAdapter.Publish(r.Context(), &req)
+	err := a.pubsubAdapter.Publish(r.Context(), &req, runtimePubsub.TransportModeHTTP)
 	elapsed := diag.ElapsedSince(start)
 
 	diag.DefaultComponentMonitoring.PubsubEgressEvent(context.Background(), pubsubName, topic, err == nil, elapsed)
@@ -1343,7 +1343,7 @@ func (a *api) onBulkPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 
 	start := time.Now()
-	res, err := a.pubsubAdapter.BulkPublish(r.Context(), &req)
+	res, err := a.pubsubAdapter.BulkPublish(r.Context(), &req, runtimePubsub.TransportModeHTTP)
 	elapsed := diag.ElapsedSince(start)
 
 	// BulkPublishResponse contains all failed entries from the request.

--- a/pkg/runtime/pubsub/adapter.go
+++ b/pkg/runtime/pubsub/adapter.go
@@ -40,8 +40,8 @@ type ConnectionID uint64
 
 // Adapter is the interface for message buses.
 type Adapter interface {
-	Publish(context.Context, *contribPubsub.PublishRequest) error
-	BulkPublish(context.Context, *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error)
+	Publish(context.Context, *contribPubsub.PublishRequest, TransportMode) error
+	BulkPublish(context.Context, *contribPubsub.BulkPublishRequest, TransportMode) (contribPubsub.BulkPublishResponse, error)
 }
 
 type AdapterStreamer interface {

--- a/pkg/runtime/pubsub/bulkpublish_resiliency.go
+++ b/pkg/runtime/pubsub/bulkpublish_resiliency.go
@@ -27,6 +27,7 @@ import (
 func ApplyBulkPublishResiliency(ctx context.Context, req *contribPubsub.BulkPublishRequest,
 	policyDef *resiliency.PolicyDefinition,
 	bulkPublisher contribPubsub.BulkPublisher,
+	mode TransportMode,
 ) (contribPubsub.BulkPublishResponse, error) {
 	// Contains the latest request entries to be sent to the component
 	var requestEntries atomic.Pointer[[]contribPubsub.BulkMessageEntry]
@@ -60,8 +61,7 @@ func ApplyBulkPublishResiliency(ctx context.Context, req *contribPubsub.BulkPubl
 		res, err := bulkPublisher.BulkPublish(ctx, newReq)
 		if err != nil {
 			if st, ok := status.FromError(err); ok {
-				//nolint:gosec
-				return res, resiliency.NewCodeError(int32(st.Code()), err)
+				return res, NewPublishResiliencyError(mode, st.Code(), err)
 			}
 		}
 		return res, err

--- a/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
+++ b/pkg/runtime/pubsub/bulkpublish_resiliency_test.go
@@ -192,7 +192,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// expecting no final error, the events will pass in the second try
@@ -224,7 +224,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// Expect final error from the bulk publisher
@@ -258,7 +258,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// expecting no final error, all the events will pass in the second try
@@ -290,7 +290,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		// expecting no final error, all the events will pass in a single try
@@ -326,7 +326,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		policyDef := policyProvider.ComponentOutboundPolicy(pubsubName, resiliency.Pubsub)
 
 		// Act
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -357,7 +357,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		// Act
 
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -380,7 +380,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -414,7 +414,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -437,7 +437,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -471,7 +471,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.NoError(t, err)
@@ -514,7 +514,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -541,7 +541,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 		// Act
 		// mock bulk publisher will fail the request only twice,
 		// the circuitBreaker will be half-open now and then after request served will be closed
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.NoError(t, err)
@@ -585,7 +585,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -596,7 +596,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -634,7 +634,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Make the request twice to make sure circuitBreaker is exhausted
-		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err := ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -645,7 +645,7 @@ func TestApplyBulkPublishResiliency(t *testing.T) {
 
 		// Act
 		// Here the circuitBreaker is open and it will short the request, so the bulkPublisher will not be called
-		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher)
+		res, err = ApplyBulkPublishResiliency(ctx, req, policyDef, bulkPublisher, TransportModeGRPC)
 
 		// Assert
 		require.Error(t, err)
@@ -694,7 +694,7 @@ func TestBulkPublishMatching(t *testing.T) {
 			return status.Error(codes.InvalidArgument, "bad request")
 		}}
 
-		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp)
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp, TransportModeGRPC)
 
 		require.Error(t, err)
 		assert.Equal(t, int32(1), bp.calls.Load())
@@ -708,7 +708,7 @@ func TestBulkPublishMatching(t *testing.T) {
 			return nil
 		}}
 
-		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp)
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(5), bp, TransportModeGRPC)
 
 		require.NoError(t, err)
 		// 2 failures then success = 3 calls
@@ -720,7 +720,7 @@ func TestBulkPublishMatching(t *testing.T) {
 			return errors.New("boom")
 		}}
 
-		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(3), bp)
+		_, err := ApplyBulkPublishResiliency(ctx, req, policyDefFor(3), bp, TransportModeGRPC)
 
 		require.Error(t, err)
 		// No gRPC status = retried up to maxRetries (initial + 3)

--- a/pkg/runtime/pubsub/outbox.go
+++ b/pkg/runtime/pubsub/outbox.go
@@ -238,7 +238,7 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 				PubsubName: c.outboxPubsub,
 				Data:       data,
 				Topic:      outboxTopic(source, c.publishTopic, o.namespace),
-			})
+			}, TransportModeGRPC)
 			if err != nil {
 				return nil, err
 			}
@@ -334,7 +334,7 @@ func (o *outboxImpl) SubscribeToInternalTopics(ctx context.Context, appID string
 				Data:        b,
 				Topic:       c.publishTopic,
 				ContentType: &contentType,
-			})
+			}, TransportModeGRPC)
 			if err != nil {
 				return err
 			}

--- a/pkg/runtime/pubsub/publish_resiliency.go
+++ b/pkg/runtime/pubsub/publish_resiliency.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"google.golang.org/grpc/codes"
+
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/pubsub/transport"
+)
+
+// TransportMode aliases transport.Mode so callers can keep using
+// rtpubsub.TransportMode. The concrete type lives in the leaf transport package
+// to avoid an import cycle with the Adapter fakes/mocks.
+type TransportMode = transport.Mode
+
+const (
+	// TransportModeGRPC matches broker errors against `gRPCStatusCodes`, using the
+	// component's native gRPC status code. Passed by the gRPC publish API and by
+	// internal republish paths (dead-letter, outbox).
+	TransportModeGRPC TransportMode = iota
+	// TransportModeHTTP matches broker errors against `httpStatusCodes`, mapping the
+	// component's gRPC status code to its HTTP equivalent. Passed by the HTTP
+	// publish API.
+	TransportModeHTTP
+)
+
+// NewPublishResiliencyError wraps a pub/sub component (bulk) publish error in a
+// resiliency.CodeError so retry `matching` can evaluate it. For HTTP publishes
+// the gRPC status code is mapped to its HTTP equivalent (matched against
+// `httpStatusCodes`); otherwise the gRPC code is used (matched against
+// `gRPCStatusCodes`).
+func NewPublishResiliencyError(mode TransportMode, code codes.Code, err error) resiliency.CodeError {
+	//nolint:gosec
+	statusCode := int32(code)
+	if mode == TransportModeHTTP {
+		statusCode = int32(invokev1.HTTPStatusFromCode(code))
+	}
+	return resiliency.NewCodeError(statusCode, err)
+}

--- a/pkg/runtime/pubsub/publish_resiliency.go
+++ b/pkg/runtime/pubsub/publish_resiliency.go
@@ -43,9 +43,10 @@ const (
 // `httpStatusCodes`); otherwise the gRPC code is used (matched against
 // `gRPCStatusCodes`).
 func NewPublishResiliencyError(mode TransportMode, code codes.Code, err error) resiliency.CodeError {
-	//nolint:gosec
+	//nolint:gosec // gRPC status codes (0-16) fit in int32.
 	statusCode := int32(code)
 	if mode == TransportModeHTTP {
+		//nolint:gosec // HTTP status codes (100-599) fit in int32.
 		statusCode = int32(invokev1.HTTPStatusFromCode(code))
 	}
 	return resiliency.NewCodeError(statusCode, err)

--- a/pkg/runtime/pubsub/publish_resiliency_test.go
+++ b/pkg/runtime/pubsub/publish_resiliency_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pubsub
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+// TestNewPublishResiliencyError asserts the broker's gRPC status code is kept
+// as-is for gRPC publishes (matched against gRPCStatusCodes) and mapped to its
+// HTTP equivalent for HTTP publishes (matched against httpStatusCodes).
+func TestNewPublishResiliencyError(t *testing.T) {
+	baseErr := errors.New("broker boom")
+
+	tests := []struct {
+		name     string
+		mode     TransportMode
+		code     codes.Code
+		wantCode int32
+	}{
+		// gRPC transport keeps the native gRPC code (0-16 -> gRPCStatusCodes).
+		{"grpc retriable keeps Unavailable", TransportModeGRPC, codes.Unavailable, int32(codes.Unavailable)},
+		{"grpc terminal keeps FailedPrecondition", TransportModeGRPC, codes.FailedPrecondition, int32(codes.FailedPrecondition)},
+		// HTTP transport maps the gRPC code to its HTTP status (100-599 -> httpStatusCodes).
+		{"http maps Unavailable to 503", TransportModeHTTP, codes.Unavailable, 503},
+		{"http maps FailedPrecondition to 400", TransportModeHTTP, codes.FailedPrecondition, 400},
+		{"http maps ResourceExhausted to 429", TransportModeHTTP, codes.ResourceExhausted, 429},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cErr := NewPublishResiliencyError(tt.mode, tt.code, baseErr)
+			assert.Equal(t, tt.wantCode, cErr.StatusCode)
+			// The original error is preserved for callers/logging.
+			require.ErrorIs(t, cErr, baseErr)
+		})
+	}
+}

--- a/pkg/runtime/pubsub/publisher/fake/fake.go
+++ b/pkg/runtime/pubsub/publisher/fake/fake.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	contribPubsub "github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/runtime/pubsub/transport"
 )
 
 // Fake is a fake publisher
@@ -46,10 +47,10 @@ func (f *Fake) WithBulkPublishFn(fn func(context.Context, *contribPubsub.BulkPub
 	return f
 }
 
-func (f *Fake) Publish(ctx context.Context, req *contribPubsub.PublishRequest) error {
+func (f *Fake) Publish(ctx context.Context, req *contribPubsub.PublishRequest, _ transport.Mode) error {
 	return f.publishFn(ctx, req)
 }
 
-func (f *Fake) BulkPublish(ctx context.Context, req *contribPubsub.BulkPublishRequest) (contribPubsub.BulkPublishResponse, error) {
+func (f *Fake) BulkPublish(ctx context.Context, req *contribPubsub.BulkPublishRequest, _ transport.Mode) (contribPubsub.BulkPublishResponse, error) {
 	return f.bulkPublishFn(ctx, req)
 }

--- a/pkg/runtime/pubsub/publisher/publisher.go
+++ b/pkg/runtime/pubsub/publisher/publisher.go
@@ -53,8 +53,9 @@ func New(opts Options) rtpubsub.Adapter {
 
 // Publish is an adapter method for the runtime to pre-validate publish requests
 // And then forward them to the Pub/Sub component.
-// This method is used by the HTTP and gRPC APIs.
-func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishRequest) error {
+// This method is used by the HTTP and gRPC APIs. mode selects which retry
+// `matching` list a broker error is evaluated against (http vs gRPC status codes).
+func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishRequest, mode rtpubsub.TransportMode) error {
 	pubsub, ok := p.getpubsubFn(req.PubsubName)
 	if !ok {
 		return rtpubsub.NotFoundError{PubsubName: req.PubsubName}
@@ -75,8 +76,7 @@ func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishReque
 		err := pubsub.Component.Publish(ctx, req)
 		if err != nil {
 			if st, ok := status.FromError(err); ok {
-				//nolint:gosec
-				return nil, resiliency.NewCodeError(int32(st.Code()), err)
+				return nil, rtpubsub.NewPublishResiliencyError(mode, st.Code(), err)
 			}
 		}
 		return nil, err
@@ -85,7 +85,7 @@ func (p *publisher) Publish(ctx context.Context, req *contribpubsub.PublishReque
 	return err
 }
 
-func (p *publisher) BulkPublish(ctx context.Context, req *contribpubsub.BulkPublishRequest) (contribpubsub.BulkPublishResponse, error) {
+func (p *publisher) BulkPublish(ctx context.Context, req *contribpubsub.BulkPublishRequest, mode rtpubsub.TransportMode) (contribpubsub.BulkPublishResponse, error) {
 	pubsub, ok := p.getpubsubFn(req.PubsubName)
 	if !ok {
 		return contribpubsub.BulkPublishResponse{}, rtpubsub.NotFoundError{PubsubName: req.PubsubName}
@@ -102,12 +102,12 @@ func (p *publisher) BulkPublish(ctx context.Context, req *contribpubsub.BulkPubl
 	policyDef := p.resiliency.ComponentOutboundPolicy(req.PubsubName, resiliency.Pubsub)
 
 	if contribpubsub.FeatureBulkPublish.IsPresent(pubsub.Component.Features()) {
-		return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, pubsub.Component.(contribpubsub.BulkPublisher))
+		return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, pubsub.Component.(contribpubsub.BulkPublisher), mode)
 	}
 
 	log.Debugf("pubsub %s does not implement the BulkPublish API; falling back to publishing messages individually", req.PubsubName)
 
 	defaultBulkPublisher := rtpubsub.NewDefaultBulkPublisher(pubsub.Component)
 
-	return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, defaultBulkPublisher)
+	return rtpubsub.ApplyBulkPublishResiliency(ctx, req, policyDef, defaultBulkPublisher, mode)
 }

--- a/pkg/runtime/pubsub/publisher/publisher_test.go
+++ b/pkg/runtime/pubsub/publisher/publisher_test.go
@@ -63,7 +63,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -84,7 +84,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -117,7 +117,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -142,7 +142,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Empty(t, res.FailedEntries)
@@ -174,7 +174,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 
@@ -194,7 +194,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 	})
@@ -225,7 +225,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 
@@ -245,7 +245,7 @@ func TestPublish(t *testing.T) {
 					ContentType: "text/plain",
 				},
 			},
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 		assert.Empty(t, res)
 	})
@@ -268,7 +268,7 @@ func TestPublish(t *testing.T) {
 			PubsubName: TestPubsubName,
 			Topic:      "topic0",
 			Metadata:   md,
-		})
+		}, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 
@@ -278,7 +278,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.NoError(t, err)
 	})
 
@@ -300,7 +300,7 @@ func TestPublish(t *testing.T) {
 			PubsubName: TestPubsubName,
 			Topic:      "topic0",
 			Metadata:   md,
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.NoError(t, err)
 
 		compStore.AddPubSub(TestSecondPubsubName, &rtpubsub.PubsubItem{
@@ -311,7 +311,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.NoError(t, err)
 	})
 
@@ -333,7 +333,7 @@ func TestPublish(t *testing.T) {
 		err := ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestPubsubName,
 			Topic:      "topic5",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 
 		compStore.AddPubSub(TestSecondPubsubName, &rtpubsub.PubsubItem{
@@ -343,7 +343,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic5",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 	})
 
@@ -365,7 +365,7 @@ func TestPublish(t *testing.T) {
 		err := ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 
 		compStore.AddPubSub(TestSecondPubsubName, &rtpubsub.PubsubItem{
@@ -375,7 +375,7 @@ func TestPublish(t *testing.T) {
 		err = ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 			PubsubName: TestSecondPubsubName,
 			Topic:      "topic1",
-		})
+		}, rtpubsub.TransportModeGRPC)
 		require.Error(t, err)
 	})
 }
@@ -396,7 +396,7 @@ func TestNamespacedPublisher(t *testing.T) {
 	err := ps.Publish(t.Context(), &contribpubsub.PublishRequest{
 		PubsubName: TestPubsubName,
 		Topic:      "topic0",
-	})
+	}, rtpubsub.TransportModeGRPC)
 	require.NoError(t, err)
 
 	pubSub, ok := compStore.GetPubSub(TestPubsubName)
@@ -427,7 +427,7 @@ func TestNamespacedBulkPublisher(t *testing.T) {
 				ContentType: "text/plain",
 			},
 		},
-	})
+	}, rtpubsub.TransportModeGRPC)
 	require.NoError(t, err)
 	assert.Empty(t, res.FailedEntries)
 
@@ -593,7 +593,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return status.Error(codes.InvalidArgument, "bad request")
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.Error(t, err)
 		// Code 3 is not in the retriable list, so matching breaks the retry loop after 1 try
@@ -608,7 +608,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return nil
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		// 2 failures then success = 3 calls
@@ -620,7 +620,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return errors.New("boom")
 		}}
 
-		err := newPublisher(ps, 3).Publish(t.Context(), req)
+		err := newPublisher(ps, 3).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.Error(t, err)
 		// No gRPC status = retried up to maxRetries (initial + 3)
@@ -632,7 +632,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return status.Error(codes.FailedPrecondition, "invalid topic")
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.Error(t, err)
 		assert.Equal(t, int32(1), ps.calls.Load())
@@ -646,7 +646,7 @@ func TestPubsubPublishMatching(t *testing.T) {
 			return nil
 		}}
 
-		err := newPublisher(ps, 5).Publish(t.Context(), req)
+		err := newPublisher(ps, 5).Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Equal(t, int32(3), ps.calls.Load())
@@ -679,7 +679,7 @@ func TestPubsubWithResiliency(t *testing.T) {
 			PubsubName: "failPubsub",
 			Topic:      "failingTopic",
 		}
-		err := ps.Publish(t.Context(), req)
+		err := ps.Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 
 		require.NoError(t, err)
 		assert.Equal(t, 2, failingPubsub.Failure.CallCount("failingTopic"))
@@ -712,7 +712,7 @@ func TestPubsubWithResiliency(t *testing.T) {
 		}
 
 		start := time.Now()
-		err := ps.Publish(t.Context(), req)
+		err := ps.Publish(t.Context(), req, rtpubsub.TransportModeGRPC)
 		end := time.Now()
 
 		require.Error(t, err)

--- a/pkg/runtime/pubsub/transport/transport.go
+++ b/pkg/runtime/pubsub/transport/transport.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+type Mode int

--- a/pkg/runtime/subscription/bulksubscription.go
+++ b/pkg/runtime/subscription/bulksubscription.go
@@ -351,7 +351,7 @@ func (s *Subscription) sendBulkToDeadLetter(ctx context.Context,
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deadLetterPublishTimeout)
 	defer cancel()
 
-	_, err := s.adapter.BulkPublish(pubCtx, req)
+	_, err := s.adapter.BulkPublish(pubCtx, req, rtpubsub.TransportModeGRPC)
 	if err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %v", msg.Topic, deadLetterTopic, err)
 	}

--- a/pkg/runtime/subscription/postman/grpc/grpc.go
+++ b/pkg/runtime/subscription/postman/grpc/grpc.go
@@ -384,7 +384,7 @@ func (g *grpc) sendToDeadLetter(ctx context.Context, name string, msg *contribpu
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deadLetterPublishTimeout)
 	defer cancel()
 
-	err := g.adapter.Publish(pubCtx, req)
+	err := g.adapter.Publish(pubCtx, req, pubsub.TransportModeGRPC)
 	if err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %v", msg.Topic, deadLetterTopic, err)
 		return err

--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -440,7 +440,8 @@ func (h *http) sendBulkToDeadLetter(ctx context.Context,
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deadLetterPublishTimeout)
 	defer cancel()
 
-	_, err := h.adapter.BulkPublish(pubCtx, req)
+	// Internal dead-letter republish (not an HTTP/gRPC publish API call), so match broker errors on native gRPC status codes.
+	_, err := h.adapter.BulkPublish(pubCtx, req, pubsub.TransportModeGRPC)
 	if err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %v", msg.Topic, deadLetterTopic, err)
 	}
@@ -468,7 +469,8 @@ func (h *http) sendToDeadLetter(ctx context.Context, name string, msg *contribpu
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deadLetterPublishTimeout)
 	defer cancel()
 
-	err := h.adapter.Publish(pubCtx, req)
+	// Internal dead-letter republish (not an HTTP/gRPC publish API call), so match broker errors on native gRPC status codes.
+	err := h.adapter.Publish(pubCtx, req, pubsub.TransportModeGRPC)
 	if err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %v", msg.Topic, deadLetterTopic, err)
 		return err

--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -550,7 +550,7 @@ func (s *Subscription) sendToDeadLetter(ctx context.Context, name string, msg *c
 	// detached publish so it cannot block indefinitely.
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deadLetterPublishTimeout)
 	defer cancel()
-	err := s.adapter.Publish(pubCtx, req)
+	err := s.adapter.Publish(pubCtx, req, rtpubsub.TransportModeGRPC)
 	if err != nil {
 		log.Errorf("error sending message to dead letter, origin topic: %s dead letter topic %s err: %v", msg.Topic, deadLetterTopic, err)
 		return err

--- a/pkg/testing/pubsubadapter_mock.go
+++ b/pkg/testing/pubsubadapter_mock.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/dapr/pkg/runtime/pubsub/transport"
 )
 
 // MockPubSubAdapter is mock for PubSubAdapter
@@ -30,13 +31,13 @@ type MockPubSubAdapter struct {
 // Publish is an adapter method for the runtime to pre-validate publish requests
 // And then forward them to the Pub/Sub component.
 // This method is used by the HTTP and gRPC APIs.
-func (a *MockPubSubAdapter) Publish(ctx context.Context, req *pubsub.PublishRequest) error {
+func (a *MockPubSubAdapter) Publish(ctx context.Context, req *pubsub.PublishRequest, _ transport.Mode) error {
 	return a.PublishFn(ctx, req)
 }
 
 // Publish is an adapter method for the runtime to pre-validate publish requests
 // And then forward them to the Pub/Sub component.
 // This method is used by the HTTP and gRPC APIs.
-func (a *MockPubSubAdapter) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest) (pubsub.BulkPublishResponse, error) {
+func (a *MockPubSubAdapter) BulkPublish(ctx context.Context, req *pubsub.BulkPublishRequest, _ transport.Mode) (pubsub.BulkPublishResponse, error) {
 	return a.BulkPublishFn(ctx, req)
 }

--- a/tests/integration/suite/daprd/resiliency/publish/http.go
+++ b/tests/integration/suite/daprd/resiliency/publish/http.go
@@ -42,8 +42,10 @@ func init() {
 	suite.Register(new(http))
 }
 
-// http is the HTTP-API equivalent of grpc: the same `matching` checks, but publishing via
-// the /v1.0/publish HTTP endpoint instead of the gRPC API.
+// http verifies retry `matching` on the HTTP publish API. Broker gRPC codes are mapped to
+// their HTTP equivalents (Unavailable->503, ResourceExhausted->429, FailedPrecondition->400)
+// and matched against `httpStatusCodes: "429,500-599"`, exercising a range match (503), a
+// single-code match (429), and a non-match (400) that is dropped.
 type http struct {
 	daprd    *daprd.Daprd
 	counters sync.Map
@@ -59,8 +61,13 @@ func (h *http) Setup(t *testing.T) []framework.Option {
 		c.(*atomic.Int32).Add(1)
 		switch {
 		case req.Topic == "retriable":
+			// Unavailable -> HTTP 503, matched by the "500-599" range.
 			return status.Error(codes.Unavailable, "broker unavailable")
+		case req.Topic == "toomany":
+			// ResourceExhausted -> HTTP 429, matched by the "429" single code.
+			return status.Error(codes.ResourceExhausted, "slow down")
 		case strings.HasPrefix(req.Topic, "terminal"):
+			// FailedPrecondition -> HTTP 400, not in "429,500-599" -> not retried.
 			return status.Error(codes.FailedPrecondition, "invalid topic")
 		default:
 			return nil
@@ -90,7 +97,7 @@ spec:
         duration: 10ms
         maxRetries: 3
         matching:
-          gRPCStatusCodes: "14"
+          httpStatusCodes: "429,500-599"
       noMatchRetry:
         policy: constant
         duration: 10ms
@@ -153,12 +160,17 @@ func (h *http) Run(t *testing.T, ctx context.Context) {
 
 	httpClient := client.HTTP(t)
 
-	t.Run("matching: retriable code is retried up to maxRetries", func(t *testing.T) {
+	t.Run("matching: code in range (503) is retried up to maxRetries", func(t *testing.T) {
 		h.publish(t, ctx, httpClient, "pubsub-match", "retriable")
 		assert.Equal(t, 4, h.count("retriable"))
 	})
 
-	t.Run("matching: non-retriable code is not retried", func(t *testing.T) {
+	t.Run("matching: comma-separated single code (429) is retried up to maxRetries", func(t *testing.T) {
+		h.publish(t, ctx, httpClient, "pubsub-match", "toomany")
+		assert.Equal(t, 4, h.count("toomany"))
+	})
+
+	t.Run("matching: code outside range (400) is not retried", func(t *testing.T) {
 		h.publish(t, ctx, httpClient, "pubsub-match", "terminal")
 		assert.Equal(t, 1, h.count("terminal"))
 	})


### PR DESCRIPTION
Match HTTP publish retries against httpStatusCodes - Pubsub publish retry `matching` is now transport aware. Publishes made over http are matched against `httpStatusCodes` and publishes over grpc are matched against its corresponding yaml: `grpcStatusCodes`