### PR TITLE
Workflows: external workflow events unique ingestion timestamps

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -74,8 +74,9 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 	// already in history or the inbox by (event name, ingestion timestamp).
 	// duplicate the event in history; instead re-assert the wake-up reminder so
 	// a still-pending inbox row that lost its reminder gets re-driven. Distinct
-	// RaiseEvents carry distinct timestamps and fall through to be appended
-	// normally.
+	// RaiseEvents are guaranteed distinct timestamps by the backend at ingestion
+	// (Actors.uniqueEventTimestamp), so they fall through to be appended
+	// normally even when raced onto the same wall-clock nanosecond.
 	if dedup.IsDuplicateExternalEvent(e, state.History, state.Inbox) {
 		log.Debugf("Workflow actor '%s': dropping duplicate external event already present in history/inbox; re-asserting wake-up reminder so the inbox row is not stranded", o.actorID)
 		return o.assertNewEventReminder(ctx, e, state)

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -129,6 +129,13 @@ type Actors struct {
 	orchestrationWorkItemChan chan *backend.WorkflowWorkItem
 	activityWorkItemChan      chan *backend.ActivityWorkItem
 
+	// lastEventNano is the highest external-event ingestion timestamp (unix
+	// nanoseconds) this backend has issued. It is used to hand out strictly
+	// monotonic, process-unique timestamps to external events so that the
+	// inbox dedup (dedup.IsDuplicateExternalEvent, keyed on event name and
+	// timestamp) can tell two distinct concurrent RaiseEvent calls apart.
+	lastEventNano atomic.Int64
+
 	stopped atomic.Bool
 }
 
@@ -454,6 +461,18 @@ func (*Actors) AbandonWorkflowWorkItem(ctx context.Context, wi *backend.Workflow
 
 // AddNewWorkflowEvent implements backend.Backend and sends the event e to the workflow actor identified by id.
 func (abe *Actors) AddNewWorkflowEvent(ctx context.Context, id api.InstanceID, e *backend.HistoryEvent) error {
+	// External events (RaiseEvent) are stamped with a wall-clock timestamp by
+	// the caller and deduped downstream by (event name, timestamp). Two
+	// RaiseEvent calls racing on the same wall-clock nanosecond would then be
+	// indistinguishable and one would be wrongly dropped as a redelivery. Give
+	// each external event a strictly monotonic, process-unique ingestion
+	// timestamp here, at the single point where it enters the actor backend, so
+	// distinct events never collide while a genuine redelivery (the same
+	// already-marshalled bytes resent on actor-call retry) keeps its timestamp.
+	if e.GetEventRaised() != nil {
+		e.Timestamp = abe.uniqueEventTimestamp()
+	}
+
 	data, err := proto.Marshal(e)
 	if err != nil {
 		return err
@@ -496,6 +515,25 @@ func (abe *Actors) AddNewWorkflowEvent(ctx context.Context, id api.InstanceID, e
 	diag.DefaultWorkflowMonitoring.WorkflowOperationEvent(ctx, diag.AddEvent, diag.StatusSuccess, elapsed)
 
 	return nil
+}
+
+// uniqueEventTimestamp returns a timestamp that is strictly greater than any
+// previously returned by this backend, so that concurrently ingested external
+// events are never assigned the same value. It clamps to wall-clock time when
+// the clock has advanced and otherwise increments the last issued value by a
+// nanosecond, keeping drift negligible under contention.
+func (abe *Actors) uniqueEventTimestamp() *timestamppb.Timestamp {
+	now := time.Now().UnixNano()
+	for {
+		prev := abe.lastEventNano.Load()
+		next := now
+		if next <= prev {
+			next = prev + 1
+		}
+		if abe.lastEventNano.CompareAndSwap(prev, next) {
+			return timestamppb.New(time.Unix(0, next))
+		}
+	}
 }
 
 // CompleteActivityWorkItem implements backend.Backend

--- a/pkg/runtime/wfengine/backends/actors/actors_test.go
+++ b/pkg/runtime/wfengine/backends/actors/actors_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniqueEventTimestamp(t *testing.T) {
+	t.Run("sequential calls are strictly increasing", func(t *testing.T) {
+		abe := &Actors{}
+		prev := abe.uniqueEventTimestamp().AsTime().UnixNano()
+		for range 1000 {
+			next := abe.uniqueEventTimestamp().AsTime().UnixNano()
+			assert.Greater(t, next, prev)
+			prev = next
+		}
+	})
+
+	// Concurrent RaiseEvent ingestion must never hand out the same timestamp,
+	// otherwise dedup.IsDuplicateExternalEvent would drop a distinct event that
+	// happens to race onto the same wall-clock nanosecond.
+	t.Run("concurrent calls are all unique", func(t *testing.T) {
+		abe := &Actors{}
+		const n = 500
+		out := make([]int64, n)
+		var wg sync.WaitGroup
+		wg.Add(n)
+		for i := range n {
+			go func(i int) {
+				defer wg.Done()
+				out[i] = abe.uniqueEventTimestamp().AsTime().UnixNano()
+			}(i)
+		}
+		wg.Wait()
+
+		seen := make(map[int64]struct{}, n)
+		for _, v := range out {
+			_, dup := seen[v]
+			require.False(t, dup, "duplicate timestamp issued: %d", v)
+			seen[v] = struct{}{}
+		}
+	})
+}

--- a/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
+++ b/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
@@ -131,6 +131,9 @@ func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
 	require.EventuallyWithT(tt, func(c *assert.CollectT) {
 		meta, err := client.FetchWorkflowMetadata(ctx, id)
 		assert.NoError(c, err)
+		if !assert.NotNil(c, meta) {
+			return
+		}
 		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
 			return
 		}


### PR DESCRIPTION
External events (RaiseEvent) are deduplicated in the orchestrator inbox by (event name, timestamp) so that a redelivered event, e.g. an AddWorkflowEvent actor call retried under placement churn, is not appended to history twice. The timestamp is a plain time.Now() wall-clock read stamped by durabletask-go when the HistoryEvent is built, with no uniqueness guarantee.

When multiple RaiseEvent calls race onto the same wall-clock nanosecond they receive identical (name, timestamp) keys, so
dedup.IsDuplicateExternalEvent treats a genuinely distinct event as a redelivery and drops it. The workflow then waits forever for an event it never receives. This surfaced as a flaky continueasnew/raise integration test (50 concurrent same-named events).

Re-stamp EventRaised events with a strictly monotonic, process-unique timestamp at the single point where they enter the actor backend (Actors.AddNewWorkflowEvent), before the event is marshalled and sent. Distinct events can no longer share a key, while a genuine redelivery, which resends the same already-marshalled bytes, keeps its timestamp and is still deduplicated.