### PR TITLE
fix: Event timers are now deleted correctly when using the same name

### DIFF
--- a/docs/release_notes/v1.18.1.md
+++ b/docs/release_notes/v1.18.1.md
@@ -1,0 +1,34 @@
+# Dapr 1.18.1
+
+This update contains the following bug fix:
+- [Workflow event-timer reminders leak when the same event name is awaited repeatedly](#workflow-event-timer-reminders-leak-when-the-same-event-name-is-awaited-repeatedly)
+
+## Workflow event-timer reminders leak when the same event name is awaited repeatedly
+
+### Problem
+
+When a workflow waits on an external event and the event arrives before the wait's timeout timer fires, the timer's reminder is supposed to be deleted, since it no longer serves a purpose.
+To find which reminder to delete, the runtime paired each newly arrived event against the oldest unfired event timer of the same name found anywhere in the workflow's history.
+A timer cancelled in a previous run is indistinguishable in history from a pending one — its `TimerCreated` is persisted and its `TimerFired` never arrives — so for workflows that wait on the same event name repeatedly (for example agent-style loops of `waitForExternalEvent` plus an activity per turn), those dead timers sat at the head of the per-name FIFO forever.
+Every new event re-deleted the first turn's long-gone timer reminder while the reminder of the timer actually cancelled that turn was never deleted.
+
+### Impact
+
+Any workflow that awaits the same external event name more than once is affected.
+
+Visible symptoms include:
+- One leaked timer reminder in the scheduler per satisfied wait after the first. For indefinite waits (no timeout) these are far-future one-shots that never fire and only get cleaned up by the reminder sweep at workflow completion; long-running instances accumulate them for their entire lifetime.
+- For finite timeouts, the leaked reminder eventually fires, causing a spurious workflow wake-up and a stray `TimerFired` event that the SDK then discards as unexpected.
+- Debug logs showing the same `deleting cancelled event timer reminder 'timer-N'` line (always the oldest dead timer) on every turn.
+
+### Root Cause
+
+`deleteCancelledEventTimers` built the set of unfired event timers from the full history but only consumed entries for events arriving in the current run.
+Events already in history — which had performed their cancellations in previous runs — never advanced the FIFO, so previously cancelled timers permanently shadowed the timer each new event had actually cancelled.
+
+### Solution
+
+The event-to-timer pairing is now replayed deterministically over the full history in chronological order: each `EventRaised` consumes the oldest unfired event timer of the same name created before it.
+Pairings driven by events already in history reproduce the cancellations performed by previous runs, and only timers consumed by the current run's new events trigger reminder deletions.
+The created-before constraint additionally guarantees that a timer guarding a still-armed wait is never deleted ahead of its own event, which the previous pairing could do when an event and the next wait's timer were persisted in the same run.
+Timers with non-event origins (`CreateTimer`, `ActivityRetry`, `ChildWorkflowRetry`) remain excluded from the pairing regardless of name collisions.

--- a/pkg/actors/targets/workflow/orchestrator/timer.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer.go
@@ -70,6 +70,21 @@ func timerReminderName(timerID int32) string {
 	return reminderPrefixTimer + strconv.Itoa(int(timerID))
 }
 
+// eventTimerName extracts the external-event name an event timer guards,
+// or ok=false for timers not associated with a WaitForSingleEvent.
+func eventTimerName(tc *protos.TimerCreatedEvent) (string, bool) {
+	if ee := tc.GetExternalEvent(); ee != nil {
+		return strings.ToUpper(ee.GetName()), true
+	}
+	if tc.Name != nil && tc.GetOrigin() == nil {
+		// TODO: We're doing `Name` matching for backwards compatibility.
+		// By around v1.19 we should only match with
+		// `origin.external_event` and remove the fallback logic.
+		return strings.ToUpper(tc.GetName()), true
+	}
+	return "", false
+}
+
 func (o *orchestrator) createTimer(ctx context.Context, e *backend.HistoryEvent, generation uint64) error {
 	ts := e.GetTimerFired()
 	if ts == nil {
@@ -123,13 +138,13 @@ func (o *orchestrator) createTimerReminder(ctx context.Context, name string, dat
 // before the timer fired, and deletes those now-unnecessary timer reminders.
 // 1. Find all TimerCreated events associated with external events (origin.external_event or legacy Name field)
 // 2. Remove any that have already fired (matching TimerFired events)
-// 3. For each new EventRaised, consume one matching unfired timer (FIFO order)
-// 4. Delete the timer reminders for consumed timers
+// 3. For each EventRaised, consume the oldest matching unfired timer created before it (FIFO order)
+// 4. Delete the timer reminders for timers consumed by new EventRaised events
 //
-// Only EventRaised events in NewEvents are considered as triggers for
-// cancellation, since events in OldEvents were already processed in a
-// previous execution. TimerCreated and TimerFired are scanned across both
-// OldEvents and NewEvents.
+// EventRaised events in OldEvents participate in the pairing — reproducing
+// the cancellations already performed by previous runs — but only timers
+// consumed by EventRaised events in NewEvents trigger deletions. TimerCreated
+// and TimerFired are scanned across both OldEvents and NewEvents.
 func (o *orchestrator) deleteCancelledEventTimers(ctx context.Context, rs *protos.WorkflowRuntimeState) error {
 	newEvents := rs.GetNewEvents()
 
@@ -146,66 +161,59 @@ func (o *orchestrator) deleteCancelledEventTimers(ctx context.Context, rs *proto
 		return nil
 	}
 
-	// Build the set of unfired event-associated timers from full history.
-	// pendingEventTimers: event name (uppercase) -> list of timer IDs (creation order)
+	// Each EventRaised consumes the oldest unfired event timer of the same
+	// name created before it, in history order. Old-event pairings reproduce
+	// cancellations done by previous runs; only timers consumed by this run's
+	// new events are deleted. Without the replay, previously cancelled timers
+	// would sit at the head of the FIFO and absorb every new cancellation,
+	// leaking the reminder of the timer actually cancelled this run. The
+	// created-before constraint ensures a timer guarding a still-armed wait
+	// is never consumed ahead of its own event.
 	pendingEventTimers := make(map[string][]int32)
-	firedTimerIDs := make(map[int32]bool)
-
-	for _, events := range [2][]*protos.HistoryEvent{
-		rs.GetOldEvents(),
-		newEvents,
-	} {
-		for _, e := range events {
-			if tc := e.GetTimerCreated(); tc != nil {
-				var name *string
-				if ee := tc.GetExternalEvent(); ee != nil {
-					name = new(ee.GetName())
-				} else if tc.Name != nil && tc.GetOrigin() == nil {
-					// TODO: We're doing `Name` matching for backwards compatibility.
-					// By around v1.19 we should only match with
-					// `origin.external_event` and remove the fallback logic.
-					name = new(tc.GetName())
-				}
-				if name != nil {
-					key := strings.ToUpper(*name)
-					pendingEventTimers[key] = append(pendingEventTimers[key], e.GetEventId())
-				}
-			} else if tf := e.GetTimerFired(); tf != nil {
-				firedTimerIDs[tf.GetTimerId()] = true
-			}
-		}
-	}
-
-	// Remove already-fired timers from the pending map.
-	for key, timerIDs := range pendingEventTimers {
-		filtered := timerIDs[:0]
-		for _, id := range timerIDs {
-			if !firedTimerIDs[id] {
-				filtered = append(filtered, id)
-			}
-		}
-		if len(filtered) == 0 {
-			delete(pendingEventTimers, key)
-		} else {
-			pendingEventTimers[key] = filtered
-		}
-	}
-
-	// For each new EventRaised, consume one matching unfired timer (FIFO).
+	timerNameByID := make(map[int32]string)
 	var cancelledTimerIDs []int32
-	for _, e := range newEvents {
-		if er := e.GetEventRaised(); er != nil {
-			key := strings.ToUpper(er.GetName())
-			if timerIDs, ok := pendingEventTimers[key]; ok && len(timerIDs) > 0 {
-				cancelledTimerIDs = append(cancelledTimerIDs, timerIDs[0])
-				if len(timerIDs) == 1 {
-					delete(pendingEventTimers, key)
-				} else {
-					pendingEventTimers[key] = timerIDs[1:]
+
+	pair := func(events []*protos.HistoryEvent, collect bool) {
+		for _, e := range events {
+			switch {
+			case e.GetTimerCreated() != nil:
+				if name, ok := eventTimerName(e.GetTimerCreated()); ok {
+					pendingEventTimers[name] = append(pendingEventTimers[name], e.GetEventId())
+					timerNameByID[e.GetEventId()] = name
+				}
+
+			case e.GetTimerFired() != nil:
+				id := e.GetTimerFired().GetTimerId()
+				name, ok := timerNameByID[id]
+				if !ok {
+					continue
+				}
+				delete(timerNameByID, id)
+				ids := pendingEventTimers[name]
+				for i, tid := range ids {
+					if tid == id {
+						pendingEventTimers[name] = append(ids[:i], ids[i+1:]...)
+						break
+					}
+				}
+
+			case e.GetEventRaised() != nil:
+				name := strings.ToUpper(e.GetEventRaised().GetName())
+				ids := pendingEventTimers[name]
+				if len(ids) == 0 {
+					continue
+				}
+				id := ids[0]
+				pendingEventTimers[name] = ids[1:]
+				delete(timerNameByID, id)
+				if collect {
+					cancelledTimerIDs = append(cancelledTimerIDs, id)
 				}
 			}
 		}
 	}
+	pair(rs.GetOldEvents(), false)
+	pair(newEvents, true)
 
 	if len(cancelledTimerIDs) == 0 {
 		return nil

--- a/pkg/actors/targets/workflow/orchestrator/timer_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/timer_test.go
@@ -451,6 +451,41 @@ func Test_deleteCancelledEventTimers(t *testing.T) {
 		assert.False(t, deleteCalled)
 	})
 
+	t.Run("user timer with CreateTimer origin is not cancelled by EventRaised", func(t *testing.T) {
+		t.Parallel()
+		deleteCalled := false
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			deleteCalled = true
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		// A user durable timer named identically to the event. Pairing is
+		// keyed on origin.external_event, not Name, so it must not be consumed.
+		matchingName := "bar"
+		rs := &protos.WorkflowRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				{
+					EventId: 0,
+					EventType: &protos.HistoryEvent_TimerCreated{
+						TimerCreated: &protos.TimerCreatedEvent{
+							Name: &matchingName,
+							Origin: &protos.TimerCreatedEvent_CreateTimer{
+								CreateTimer: &protos.TimerOriginCreateTimer{},
+							},
+						},
+					},
+				},
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+	})
+
 	t.Run("timer with ChildWorkflowRetry origin is not cancelled by EventRaised", func(t *testing.T) {
 		t.Parallel()
 		deleteCalled := false
@@ -762,6 +797,83 @@ func Test_deleteCancelledEventTimers(t *testing.T) {
 				timerCreated(0, eventName("bar")),
 				timerFired(0),
 				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.False(t, deleteCalled)
+	})
+
+	t.Run("timer cancelled in a previous run does not absorb a new cancellation", func(t *testing.T) {
+		t.Parallel()
+		// Same-name waits across runs: timer-1 was already cancelled when the
+		// old event was consumed. The new event must cancel timer-4, not
+		// re-delete the long-dead timer-1.
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.WorkflowRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(1, eventName("bar")),
+				eventRaised("bar"),
+				timerCreated(4, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timer-4"}, deletedNames)
+	})
+
+	t.Run("old event preceding its wait's timer defers pairing to the next event", func(t *testing.T) {
+		t.Parallel()
+		// An event buffered before its wait was armed precedes the wait's
+		// TimerCreated in history. It must not consume that later timer; the
+		// next new event picks it up instead.
+		var deletedNames []string
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			deletedNames = append(deletedNames, req.Name)
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.WorkflowRuntimeState{
+			OldEvents: []*protos.HistoryEvent{
+				timerCreated(1, eventName("bar")),
+				eventRaised("bar"),
+				eventRaised("bar"),
+				timerCreated(4, eventName("bar")),
+			},
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+			},
+		}
+		err := o.deleteCancelledEventTimers(t.Context(), rs)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timer-4"}, deletedNames)
+	})
+
+	t.Run("timer created after the new event in the same run is not deleted", func(t *testing.T) {
+		t.Parallel()
+		// A timer created after the event guards a still-armed wait, so its
+		// reminder must survive.
+		deleteCalled := false
+		reminders := remindersfake.New().WithDelete(func(_ context.Context, _ *actorapi.DeleteReminderRequest) error {
+			deleteCalled = true
+			return nil
+		})
+		o := newOrchestrator(reminders)
+
+		rs := &protos.WorkflowRuntimeState{
+			NewEvents: []*protos.HistoryEvent{
+				eventRaised("bar"),
+				timerCreated(2, eventName("bar")),
 			},
 		}
 		err := o.deleteCancelledEventTimers(t.Context(), rs)

--- a/tests/integration/suite/daprd/workflow/raise/deletetimer/samename.go
+++ b/tests/integration/suite/daprd/workflow/raise/deletetimer/samename.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletetimer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(samename))
+}
+
+// samename covers sequential waits on the SAME event name. Timers cancelled
+// in earlier turns look like pending ones in history (TimerCreated, no
+// TimerFired), so they must not absorb later cancellations and leak the live
+// timer's reminder. Asserted mid-flight: the completion-path cleanup would
+// mask the leak if only checked at the end.
+type samename struct {
+	workflow *workflow.Workflow
+}
+
+func (d *samename) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *samename) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddWorkflowN("foo", func(ctx *task.WorkflowContext) (any, error) {
+		for range 3 {
+			if err := ctx.WaitForSingleEvent("bar", time.Minute).Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+
+	cl := d.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "foo")
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-0")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	// First event: cancels timer-0, arms the second wait (timer-1).
+	require.NoError(t, cl.RaiseEvent(ctx, id, "bar"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-1")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	// Second event: must cancel timer-1, not re-target the long-gone timer-0
+	// and leak timer-1.
+	require.NoError(t, cl.RaiseEvent(ctx, id, "bar"))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		keys := d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs")
+		if assert.Len(c, keys, 1) {
+			assert.Contains(c, keys[0], "timer-2")
+		}
+	}, time.Second*20, 10*time.Millisecond)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "bar"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, d.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*20, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Description

`deleteCancelledEventTimers` deletes the timer reminder of a `WaitForSingleEvent` timer when the event wins the race against the timeout. It paired every *new* `EventRaised` against the oldest unfired event timer of the same name found anywhere in history.

A timer cancelled in a previous run is indistinguishable in history from a pending one — its `TimerCreated` is persisted and its `TimerFired` never arrives. With workflows that wait on the **same event name repeatedly** (e.g. agent-style loops of `waitForExternalEvent("x")` + activity), those dead timers sit at the head of the per-name FIFO forever:

- every new event re-deleted the *first* turn's long-gone timer (visible as `deleting cancelled event timer reminder 'timer-1'` on every turn in debug logs, including NotFound on the scheduler), and
- the reminder of the timer *actually* cancelled that turn leaked in the scheduler until workflow completion. For indefinite waits these are far-future (year-9999) one-shots, one leaked per satisfied wait.

### Fix

Replay the event→timer pairing deterministically over the **full history in chronological order**: each `EventRaised` consumes the oldest unfired event timer of the same name **created before it**. Pairings driven by events already in history reproduce the cancellations performed by previous runs; only timers consumed by this run's new events trigger reminder deletions.

The created-before constraint also fixes a latent edge in the old code: with `NewEvents = [EventRaised, TimerCreated#k]` and no dead timers, the old pairing could consume the just-armed wait's own timeout timer and delete a *live* timer's reminder.