### PR TITLE
fix(subscriptions): align empty-status fallthrough in Deliver with DeliverBulk

### DIFF
--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -130,8 +130,9 @@ func (h *http) Deliver(ctx context.Context, msg *pubsub.SubscribedMessage) error
 
 		switch appResponse.Status {
 		case "":
-			// Consider empty status field as success
-			fallthrough
+			// Consider empty status field as retry to match DeliverBulk.
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.PubSub, strings.ToLower(string(contribpubsub.Retry)), "", msg.Topic, elapsed)
+			return fmt.Errorf("empty status returned from app while processing pub/sub event %v: %w", cloudEvent[contribpubsub.IDField], rterrors.NewRetriable(nil))
 		case contribpubsub.Success:
 			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.PubSub, strings.ToLower(string(contribpubsub.Success)), "", msg.Topic, elapsed)
 			return nil

--- a/pkg/runtime/subscription/postman/http/http_test.go
+++ b/pkg/runtime/subscription/postman/http/http_test.go
@@ -183,7 +183,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		WithCustomHTTPMetadata(testPubSubMessage.Metadata)
 	defer fakeReq.Close()
 
-	t.Run("succeeded to publish message to user app with empty response", func(t *testing.T) {
+	t.Run("retry to publish message to user app with empty response", func(t *testing.T) {
 		mockAppChannel := new(channelt.MockAppChannel)
 		h := New(Options{
 			Channels: new(channels.Channels).WithAppChannel(mockAppChannel),
@@ -201,7 +201,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), fakeReq).Return(fakeResp, nil)
 
-		require.NoError(t, h.Deliver(t.Context(), testPubSubMessage))
+		require.Error(t, h.Deliver(t.Context(), testPubSubMessage))
 		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 	})
 


### PR DESCRIPTION
Fixes #8737

Deliver and DeliverBulk in the http postman both handle an empty AppResponse.Status, but in opposite directions: Deliver fell through to success, DeliverBulk to retry. Same response, same status code, two different outcomes.

This aligns them. Empty status now falls through to retry in both paths — if the app didn't say success, treat it as a retryable error and let the resiliency policy decide.