### PR TITLE
[1.18] Fix workflow sidecar outage on configuration hot-reload (#10100)

### DIFF
--- a/cmd/operator/app/app.go
+++ b/cmd/operator/app/app.go
@@ -68,6 +68,7 @@ func Run() {
 		APIListenAddress:                    opts.APIListenAddress,
 		WebhookServerPort:                   opts.WebhookServerPort,
 		WebhookServerListenAddress:          opts.WebhookServerListenAddress,
+		CacheSyncPeriod:                     opts.CacheSyncPeriod,
 		Healthz:                             healthz,
 	})
 	if err != nil {

--- a/cmd/operator/options/options.go
+++ b/cmd/operator/options/options.go
@@ -58,6 +58,7 @@ type Options struct {
 	HealthzListenAddress               string
 	WebhookServerPort                  int
 	WebhookServerListenAddress         string
+	CacheSyncPeriod                    time.Duration
 }
 
 func New() *Options {
@@ -87,6 +88,7 @@ func New() *Options {
 	flag.StringVar(&opts.HealthzListenAddress, "healthz-listen-address", "", "The listening address for the healthz server")
 	flag.IntVar(&opts.WebhookServerPort, "webhook-server-port", 19443, "The port for the webhook server to listen on")
 	flag.StringVar(&opts.WebhookServerListenAddress, "webhook-server-listen-address", "", "The listening address for the webhook server")
+	flag.DurationVar(&opts.CacheSyncPeriod, "cache-sync-period", 0, "Resync period for the controller-runtime informer cache, e.g. '10h'. Zero uses the controller-runtime default")
 
 	opts.Logger = logger.DefaultOptions()
 	opts.Logger.AttachCmdFlags(flag.StringVar, flag.BoolVar)

--- a/docs/release_notes/v1.18.1.md
+++ b/docs/release_notes/v1.18.1.md
@@ -1,7 +1,9 @@
 # Dapr 1.18.1
 
-This update contains the following bug fix:
+This update contains the following bug fixes:
 - [Workflow event-timer reminders leak when the same event name is awaited repeatedly](#workflow-event-timer-reminders-leak-when-the-same-event-name-is-awaited-repeatedly)
+- [Workflow sidecars become permanently unavailable after a configuration reload](#workflow-sidecars-become-permanently-unavailable-after-a-configuration-reload)
+- [Sidecars restart unnecessarily on operator configuration resyncs](#sidecars-restart-unnecessarily-on-operator-configuration-resyncs)
 
 ## Workflow event-timer reminders leak when the same event name is awaited repeatedly
 
@@ -32,3 +34,60 @@ The event-to-timer pairing is now replayed deterministically over the full histo
 Pairings driven by events already in history reproduce the cancellations performed by previous runs, and only timers consumed by the current run's new events trigger reminder deletions.
 The created-before constraint additionally guarantees that a timer guarding a still-armed wait is never deleted ahead of its own event, which the previous pairing could do when an event and the next wait's timer were persisted in the same run.
 Timers with non-event origins (`CreateTimer`, `ActivityRetry`, `ChildWorkflowRetry`) remain excluded from the pairing regardless of name collisions.
+
+## Workflow sidecars become permanently unavailable after a configuration reload
+
+### Problem
+
+A Dapr sidecar that hosts workflows could become permanently unavailable after a configuration hot-reload (SIGHUP).
+Once the sidecar entered this state, every workflow operation failed and the only way to recover was to restart the pod.
+
+You were affected if all of the following were true:
+- You were running Dapr 1.18.0.
+- Your application used workflows, so a workflow worker was connected to the sidecar.
+- Hot reload was enabled (the default), so routine `Configuration` changes, including no-op resyncs from the Kubernetes operator informer, triggered a reload.
+
+### Impact
+
+After any configuration reload, an affected sidecar kept running but never came back to a usable state.
+
+Visible symptoms include:
+- The sidecar health endpoint reports `NotReady` indefinitely.
+- The Dapr gRPC API (port `50001`) stops accepting connections, so workflow calls fail with errors such as `14 UNAVAILABLE: No connection established. Last error: connect ECONNREFUSED 127.0.0.1:50001`.
+- Sidecar logs show the workflow engine stopping during the reload but never logging it starting again (the `API gRPC server is running on port 50001` and `Registering workflow engine for gRPC endpoint` lines never reappear).
+- The condition persists until the pod is manually restarted.
+
+### Root Cause
+
+A configuration reload restarts the Dapr runtime, and the new runtime cannot start until the previous one has fully shut down.
+Shutdown waits for in-flight gRPC calls to drain gracefully, but a connected workflow worker holds a long-lived `GetWorkItems` streaming connection.
+The workflow engine never signalled that stream to close, so the graceful shutdown blocked on it and the runtime never finished restarting, leaving the API server and workflow engine down.
+With workflow SDK clients that automatically reconnect, the stream was continually re-established, so the sidecar stayed stuck for as long as a worker was connected.
+
+### Solution
+
+The workflow engine now signals all connected `GetWorkItems` streams to close as part of shutdown, before draining the worker, so graceful shutdown completes promptly instead of blocking on those streams.
+After a configuration reload the runtime restarts cleanly: the sidecar returns to `Ready`, the gRPC API rebinds on port `50001`, and connected workflow clients reconnect automatically with no manual intervention.
+In-flight work items are not lost; undelivered items are re-dispatched from the durable actor backend after the restart.
+
+## Sidecars restart unnecessarily on operator configuration resyncs
+
+### Problem
+
+In Kubernetes mode, a Dapr sidecar would perform a full runtime restart (SIGHUP) in response to operator events that carried no actual change.
+
+### Impact
+
+Long-running sidecars restarted their runtime periodically with no configuration change and no human action.
+
+### Root Cause
+
+The operator's informer streams resource events for the whole namespace to every connected sidecar.
+The Kubernetes informer periodically resyncs, re-delivering every cached object as an `UPDATED` event with an unchanged `resourceVersion`, and also re-delivers on reconnect.
+The operator forwarded these no-op replays verbatim, and the sidecar's SIGHUP reconciler restarts the runtime.
+
+### Solution
+
+The operator now drops informer events whose `resourceVersion` is unchanged before streaming them to sidecars.
+A genuine change always advances the `resourceVersion`, so real updates are still delivered and hot reload continues to work; only the no-op resync and reconnect replays are suppressed.
+Sidecars no longer restart on routine operator resyncs.

--- a/pkg/operator/api/informer/informer.go
+++ b/pkg/operator/api/informer/informer.go
@@ -159,6 +159,18 @@ func (i *informer[T]) WatchUpdates(ctx context.Context, ns string) (<-chan *Even
 }
 
 func (i *informer[T]) handleEvent(ctx context.Context, oldObj, newObj any, eventType operatorv1.ResourceEventType) {
+	if eventType == operatorv1.ResourceEventType_UPDATED && oldObj != nil {
+		oldMeta, oerr := apimeta.Accessor(oldObj)
+		newMeta, nerr := apimeta.Accessor(newObj)
+		if oerr == nil && nerr == nil &&
+			oldMeta.GetResourceVersion() != "" &&
+			oldMeta.GetResourceVersion() == newMeta.GetResourceVersion() {
+			i.log.Debugf("Ignoring resync event for %s/%s: resourceVersion %s unchanged",
+				newMeta.GetNamespace(), newMeta.GetName(), newMeta.GetResourceVersion())
+			return
+		}
+	}
+
 	newT, ok := i.anyToT(newObj)
 	if !ok {
 		return

--- a/pkg/operator/api/informer/informer_test.go
+++ b/pkg/operator/api/informer/informer_test.go
@@ -146,6 +146,75 @@ func Test_WatchUpdates(t *testing.T) {
 	})
 }
 
+func Test_handleEvent_resyncDedup(t *testing.T) {
+	appID := spiffeid.RequireFromString("spiffe://example.org/ns/ns1/app1")
+	serverID := spiffeid.RequireFromString("spiffe://example.org/ns/dapr-system/dapr-operator")
+	pki := test.GenPKI(t, test.PKIOptions{LeafID: serverID, ClientID: appID})
+
+	comp := func(rv string, typ string) *compapi.Component {
+		return &compapi.Component{
+			ObjectMeta: metav1.ObjectMeta{Name: "comp1", Namespace: "ns1", ResourceVersion: rv},
+			Spec:       compapi.ComponentSpec{Type: typ},
+		}
+	}
+
+	tests := map[string]struct {
+		old       *compapi.Component
+		new       *compapi.Component
+		eventType operator.ResourceEventType
+		expFwd    bool
+	}{
+		"UPDATED with equal non-empty resourceVersion is dropped (resync replay)": {
+			old:       comp("100", "bindings.redis"),
+			new:       comp("100", "bindings.redis"),
+			eventType: operator.ResourceEventType_UPDATED,
+			expFwd:    false,
+		},
+		"UPDATED with changed resourceVersion is forwarded": {
+			old:       comp("100", "bindings.redis"),
+			new:       comp("101", "bindings.kafka"),
+			eventType: operator.ResourceEventType_UPDATED,
+			expFwd:    true,
+		},
+		"UPDATED with empty resourceVersions is forwarded (back-compat)": {
+			old:       comp("", "bindings.redis"),
+			new:       comp("", "bindings.redis"),
+			eventType: operator.ResourceEventType_UPDATED,
+			expFwd:    true,
+		},
+		"CREATED with equal resourceVersion is forwarded (only UPDATED is deduped)": {
+			old:       nil,
+			new:       comp("100", "bindings.redis"),
+			eventType: operator.ResourceEventType_CREATED,
+			expFwd:    true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			i := New[compapi.Component](Options{}).(*informer[compapi.Component])
+
+			appCh, cancel, err := i.WatchUpdates(pki.ClientGRPCCtx(t), "ns1")
+			require.NoError(t, err)
+			t.Cleanup(cancel)
+
+			var oldObj any
+			if test.old != nil {
+				oldObj = test.old
+			}
+			i.handleEvent(t.Context(), oldObj, test.new, test.eventType)
+
+			select {
+			case event := <-appCh:
+				assert.True(t, test.expFwd, "event was forwarded but expected it to be dropped")
+				assert.Equal(t, test.new.Spec.Type, event.Manifest.Spec.Type)
+			case <-time.After(500 * time.Millisecond):
+				assert.False(t, test.expFwd, "event was dropped but expected it to be forwarded")
+			}
+		})
+	}
+}
+
 func Test_Run(t *testing.T) {
 	t.Run("NoKindMatchError should not return error", func(t *testing.T) {
 		i := New[compapi.Component](Options{

--- a/pkg/operator/cache/cache.go
+++ b/pkg/operator/cache/cache.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"time"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +40,7 @@ var (
 // to limit what items end up in the cache. The following is removed/clear from the resources:
 // - pods -> managed fields, status (we care for spec to find out containers, the rests are set to empty)
 // - deploy/sts -> template.spec, status, managedfields (we only care about template/metadata except for injector deployment)
-func GetFilteredCache(namespace string, podSelector labels.Selector) cache.NewCacheFunc {
+func GetFilteredCache(namespace string, podSelector labels.Selector, syncPeriod *time.Duration) cache.NewCacheFunc {
 	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 		// The only pods we are interested are in watchdog. we don't need to
 		// list/watch pods that we are almost sure have dapr sidecar already.
@@ -47,6 +49,11 @@ func GetFilteredCache(namespace string, podSelector labels.Selector) cache.NewCa
 			opts.DefaultNamespaces = map[string]cache.Config{
 				namespace: {},
 			}
+		}
+		// Override the informer resync period when configured. Zero/nil leaves
+		// the controller-runtime default (10h) in place.
+		if syncPeriod != nil {
+			opts.SyncPeriod = syncPeriod
 		}
 		return cache.New(config, opts)
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -82,6 +82,11 @@ type Options struct {
 	WebhookServerPort                   int
 	WebhookServerListenAddress          string
 	Healthz                             healthz.Healthz
+
+	// CacheSyncPeriod optionally overrides the controller-runtime informer
+	// resync period (default 10h). Zero leaves the default in place. Primarily
+	// used by integration tests to exercise resync behaviour deterministically.
+	CacheSyncPeriod time.Duration
 }
 
 type operator struct {
@@ -130,6 +135,11 @@ func NewOperator(ctx context.Context, opts Options) (Operator, error) {
 
 	watchdogPodSelector := getSideCarInjectedNotExistsSelector()
 
+	var cacheSyncPeriod *time.Duration
+	if opts.CacheSyncPeriod > 0 {
+		cacheSyncPeriod = &opts.CacheSyncPeriod
+	}
+
 	scheme, err := buildScheme(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build operator scheme: %w", err)
@@ -159,7 +169,7 @@ func NewOperator(ctx context.Context, opts Options) (Operator, error) {
 		},
 		LeaderElection:                opts.LeaderElection,
 		LeaderElectionID:              "operator.dapr.io",
-		NewCache:                      operatorcache.GetFilteredCache(opts.WatchNamespace, watchdogPodSelector),
+		NewCache:                      operatorcache.GetFilteredCache(opts.WatchNamespace, watchdogPodSelector, cacheSyncPeriod),
 		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -120,6 +120,11 @@ type engine struct {
 	inProcessExec *inprocess.Executor
 	compStore     *compstore.ComponentStore
 
+	// streamShutdownCh is closed during shutdown to tell all connected
+	// GetWorkItems streams to terminate, so the gRPC API server's GracefulStop
+	// can complete promptly instead of blocking on long-lived worker streams.
+	streamShutdownCh chan any
+
 	registerGrpcServerFn func(grpcServer grpc.ServiceRegistrar)
 }
 
@@ -164,12 +169,13 @@ func New(opts Options) (Interface, error) {
 	}
 
 	wfe := &engine{
-		appID:         opts.AppID,
-		namespace:     opts.Namespace,
-		actors:        opts.Actors,
-		backend:       abackend,
-		inProcessExec: inProcessExec,
-		compStore:     opts.ComponentStore,
+		appID:            opts.AppID,
+		namespace:        opts.Namespace,
+		actors:           opts.Actors,
+		backend:          abackend,
+		inProcessExec:    inProcessExec,
+		compStore:        opts.ComponentStore,
+		streamShutdownCh: make(chan any),
 	}
 
 	// Keep the actor refcount balanced when Executor.Run tears holders down
@@ -226,6 +232,7 @@ func New(opts Options) (Interface, error) {
 			return nil
 		}),
 		backend.WithStreamSendTimeout(time.Second*10),
+		backend.WithStreamShutdownChannel(wfe.streamShutdownCh),
 	)
 
 	var topts []backend.NewTaskWorkerOptions
@@ -350,6 +357,11 @@ func (wfe *engine) Run(ctx context.Context) error {
 
 	log.Info("Workflow engine started")
 	<-ctx.Done()
+
+	// Signal all connected GetWorkItems streams to terminate before draining the
+	// worker, so the gRPC API server's GracefulStop does not block on them during
+	// shutdown or a SIGHUP reload.
+	close(wfe.streamShutdownCh)
 
 	if err := wfe.worker.Shutdown(context.Background()); err != nil {
 		return fmt.Errorf("failed to shutdown the workflow worker: %w", err)

--- a/tests/integration/framework/process/operator/operator.go
+++ b/tests/integration/framework/process/operator/operator.go
@@ -93,6 +93,10 @@ func New(t *testing.T, fopts ...Option) *Operator {
 		args = append(args, "-config-path="+*opts.configPath)
 	}
 
+	if opts.cacheSyncPeriod != nil {
+		args = append(args, "-cache-sync-period="+opts.cacheSyncPeriod.String())
+	}
+
 	return &Operator{
 		exec: exec.New(t,
 			binary.EnvValue("operator"), args,

--- a/tests/integration/framework/process/operator/options.go
+++ b/tests/integration/framework/process/operator/options.go
@@ -14,6 +14,8 @@ limitations under the License.
 package operator
 
 import (
+	"time"
+
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 )
 
@@ -30,6 +32,7 @@ type options struct {
 	configPath            *string
 	disableLeaderElection bool
 	trustAnchorsFile      *string
+	cacheSyncPeriod       *time.Duration
 }
 
 // Option is a function that configures the process.
@@ -92,5 +95,13 @@ func WithTrustAnchorsFile(path string) Option {
 func WithNamespace(namespace string) Option {
 	return func(o *options) {
 		o.namespace = &namespace
+	}
+}
+
+// WithCacheSyncPeriod sets the controller-runtime informer cache resync period.
+// A short period lets tests exercise resync behaviour deterministically.
+func WithCacheSyncPeriod(d time.Duration) Option {
+	return func(o *options) {
+		o.cacheSyncPeriod = &d
 	}
 }

--- a/tests/integration/suite/daprd/hotreload/operator/informer/resync.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/resync.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/store"
+	"github.com/dapr/dapr/tests/integration/framework/process/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(resync))
+}
+
+type resync struct {
+	daprd      *daprd.Daprd
+	kubeapi    *kubernetes.Kubernetes
+	operator   *operator.Operator
+	daprdLog   *log.Log
+	sentryAddr string
+}
+
+func (r *resync) appConfig() *configapi.Configuration {
+	return &configapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Configuration"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "appconfig", ResourceVersion: "1"},
+		Spec: configapi.ConfigurationSpec{
+			MTLSSpec: &configapi.MTLSSpec{
+				ControlPlaneTrustDomain: "integration.test.dapr.io",
+				SentryAddress:           r.sentryAddr,
+			},
+		},
+	}
+}
+
+func (r *resync) Setup(t *testing.T) []framework.Option {
+	r.daprdLog = log.New()
+
+	snt := sentry.New(t, sentry.WithTrustDomain("integration.test.dapr.io"))
+	r.sentryAddr = snt.Address()
+
+	cfgStore := store.New(metav1.GroupVersionKind{
+		Group: "dapr.io", Version: "v1alpha1", Kind: "Configuration",
+	})
+	cfgStore.Add(r.appConfig(), &configapi.Configuration{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "Configuration"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "other", ResourceVersion: "1"},
+		Spec:       configapi.ConfigurationSpec{TracingSpec: &configapi.TracingSpec{SamplingRate: "0"}},
+	})
+
+	r.kubeapi = kubernetes.New(t,
+		kubernetes.WithBaseOperatorAPI(t,
+			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+			"default",
+			snt.Port(),
+		),
+		kubernetes.WithClusterDaprConfigurationListFromStore(t, cfgStore),
+	)
+
+	r.operator = operator.New(t,
+		operator.WithNamespace("default"),
+		operator.WithKubeconfigPath(r.kubeapi.KubeconfigPath(t)),
+		operator.WithTrustAnchorsFile(snt.TrustAnchorsFile(t)),
+		// Force the informer to resync every second so the resync drop path is
+		// exercised deterministically instead of on the 10h default.
+		operator.WithCacheSyncPeriod(time.Second),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithConfigs("appconfig"),
+		daprd.WithSentryAddress(snt.Address()),
+		daprd.WithControlPlaneAddress(r.operator.Address()),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithEnableMTLS(true),
+		daprd.WithNamespace("default"),
+		daprd.WithControlPlaneTrustDomain("integration.test.dapr.io"),
+		daprd.WithExecOptions(
+			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(snt.CABundle().X509.TrustAnchors)),
+			exec.WithStdout(r.daprdLog),
+			exec.WithStderr(r.daprdLog),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(snt, r.kubeapi, r.operator, r.daprd),
+	}
+}
+
+func (r *resync) Run(t *testing.T, ctx context.Context) {
+	r.operator.WaitUntilRunning(t, ctx)
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	assert.Never(t, func() bool {
+		return r.daprdLog.Contains("UPDATED event: other") ||
+			r.daprdLog.Contains("Received signal 'hangup'")
+	}, time.Second*15, time.Millisecond*100,
+		"expected the operator to drop resync replays so the sidecar never sees the foreign config or restarts")
+}

--- a/tests/integration/suite/daprd/workflow/hotreload/sighup.go
+++ b/tests/integration/suite/daprd/workflow/hotreload/sighup.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hotreload
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(sighup))
+}
+
+type sighup struct {
+	workflow   *workflow.Workflow
+	configFile string
+}
+
+func (s *sighup) Setup(t *testing.T) []framework.Option {
+	s.configFile = os.WriteFileYaml(t, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: wfsighup
+spec:
+  metrics:
+    http:
+      increasedCardinality: false
+`)
+
+	s.workflow = workflow.New(t,
+		workflow.WithDaprdOptions(0, daprd.WithConfigs(s.configFile)),
+		workflow.WithAddActivityN(t, 0, "SayHello", func(ctx task.ActivityContext) (any, error) {
+			var name string
+			if err := ctx.GetInput(&name); err != nil {
+				return nil, err
+			}
+			return fmt.Sprintf("Hello, %s!", name), nil
+		}),
+		workflow.WithAddWorkflowN(t, 0, "SingleActivity", func(ctx *task.WorkflowContext) (any, error) {
+			var input string
+			if err := ctx.GetInput(&input); err != nil {
+				return nil, err
+			}
+			var output string
+			err := ctx.CallActivity("SayHello", task.WithActivityInput(input)).Await(&output)
+			return output, err
+		}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *sighup) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	client := s.workflow.BackendClient(t, ctx)
+	id, err := client.ScheduleNewWorkflow(ctx, "SingleActivity", api.WithInput("Dapr"))
+	require.NoError(t, err)
+	meta, err := client.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(meta))
+	assert.Equal(t, `"Hello, Dapr!"`, meta.GetOutput().GetValue())
+
+	os.WriteFileTo(t, s.configFile, `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: wfsighup
+spec:
+  metrics:
+    http:
+      increasedCardinality: true
+`)
+	s.workflow.Dapr().SignalHUP(t)
+
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	client = s.workflow.BackendClient(t, ctx)
+	id, err = client.ScheduleNewWorkflow(ctx, "SingleActivity", api.WithInput("Dapr"))
+	require.NoError(t, err)
+	meta, err = client.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(meta))
+	assert.Equal(t, `"Hello, Dapr!"`, meta.GetOutput().GetValue())
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/externalevent"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/get"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/globalmaxconcurrent"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/hotreload"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/list"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/listener"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/loadbalance"


### PR DESCRIPTION
A Configuration hot-reload (SIGHUP) could leave a workflow-hosting sidecar permanently unavailable: the API gRPC server and workflow engine never restarted, health stayed NotReady, and workflow calls failed with ECONNREFUSED until the pod was restarted.

The workflow engine now closes its GetWorkItems streams on shutdown (via a stream-shutdown channel) before draining the worker, so shutdown completes promptly and the runtime restarts cleanly.

The operator now drops informer events whose resourceVersion is unchanged; a genuine change always advances the resourceVersion, so real updates and hot reload are unaffected.

Backport of https://github.com/dapr/dapr/pull/10100