### PR TITLE
docs: add workflow patterns, SDK stability, and doc links to the Durable Execution README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Instead of restarting from the beginning, execution picks up exactly where it le
 
 **Common use cases:** AI agents, customer onboarding, order processing, human-approval flows, document processing, and other multi-step business processes.
 
+Dapr supports common [workflow patterns](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-patterns/) out of the box — task chaining, fan-out/fan-in, monitors, external-event / human-in-the-loop approval gates, and child workflows — as well as **multi-application workflows** that orchestrate activities and child workflows across different applications. Workflow authoring is **stable** in the .NET, Java, Python, Go, and JavaScript SDKs.
+
+See the [workflow overview](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-overview/) and [workflow quickstart](https://docs.dapr.io/getting-started/quickstarts/workflow-quickstart/) to get started.
+
 ## Build Reliable AI Agents
 
 AI agents need far more than model inference. To run in production they need state, orchestration, recovery, secure communication, and governance.


### PR DESCRIPTION
## What this does

Adds one paragraph and a doc pointer to the **Durable Execution** section of the README (`README.md` only, +4 lines):

- Names the common [workflow patterns](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-patterns/) — task chaining, fan-out/fan-in, monitors, external-event / human-in-the-loop approval gates, and child workflows — and calls out **multi-application workflows** that orchestrate activities and child workflows across different applications.
- States the SDKs in which workflow authoring is **stable**: .NET, Java, Python, Go, and JavaScript (per the v1.15 release notes).
- Links the [workflow overview](https://docs.dapr.io/developing-applications/building-blocks/workflow/workflow-overview/) and [workflow quickstart](https://docs.dapr.io/getting-started/quickstarts/workflow-quickstart/) — the section currently links to no workflow documentation.

Doc links use unversioned `docs.dapr.io` paths so they don't go stale per release.

## History

As originally opened, this PR repositioned the previous README around Dapr Workflow (intro rewrite, dedicated workflow section, 1.15–1.18 milestone table, features-list entry). The README rewrite in #10115 made durable execution the headline of the whole page, which covers the bulk of that goal and conflicted with every hunk here. This PR is now rebased on the new README and slimmed down to the details the new text doesn't cover: pattern names, multi-application workflows, per-SDK workflow authoring stability, and workflow doc links.
