### PR TITLE
[1.18] Workflows no longer hang when a completion crosses a ContinueAsNew

### DIFF
--- a/docs/release_notes/v1.18.1.md
+++ b/docs/release_notes/v1.18.1.md
@@ -4,6 +4,7 @@ This update contains the following bug fixes:
 - [Workflow event-timer reminders leak when the same event name is awaited repeatedly](#workflow-event-timer-reminders-leak-when-the-same-event-name-is-awaited-repeatedly)
 - [Workflow sidecars become permanently unavailable after a configuration reload](#workflow-sidecars-become-permanently-unavailable-after-a-configuration-reload)
 - [Sidecars restart unnecessarily on operator configuration resyncs](#sidecars-restart-unnecessarily-on-operator-configuration-resyncs)
+- [Workflows hang in RUNNING when a child workflow completion crosses a ContinueAsNew boundary](#workflows-hang-in-running-when-a-child-workflow-completion-crosses-a-continueasnew-boundary)
 
 ## Workflow event-timer reminders leak when the same event name is awaited repeatedly
 
@@ -91,3 +92,37 @@ The operator forwarded these no-op replays verbatim, and the sidecar's SIGHUP re
 The operator now drops informer events whose `resourceVersion` is unchanged before streaming them to sidecars.
 A genuine change always advances the `resourceVersion`, so real updates are still delivered and hot reload continues to work; only the no-op resync and reconnect replays are suppressed.
 Sidecars no longer restart on routine operator resyncs.
+
+## Workflows hang in RUNNING when a child workflow completion crosses a ContinueAsNew boundary
+
+### Problem
+
+A workflow that uses ContinueAsNew and child workflows (or activities) can permanently hang in the RUNNING state.
+A child workflow or activity visibly completes on the application side, but the parent never observes the completion and waits forever. The daprd log shows the workflow execution returning `ORCHESTRATION_STATUS_RUNNING` followed later by:
+
+```
+Workflow actor '<id>': dropping duplicate completion event already present in history/inbox
+Workflow actor '<id>': ignoring run request for reminder 'new-event-...' because the workflow inbox is empty
+```
+
+### Impact
+
+Affected workflows freeze indefinitely and never complete, fail, or time out.
+The failure is timing dependent and intermittent: it occurs when a child workflow or activity started before a ContinueAsNew completes after it.
+Agentic workflows are particularly exposed, as they commonly loop via ContinueAsNew while running child workflows and activities with variable latency.
+
+### Root Cause
+
+ContinueAsNew resets the workflow's task ID sequence.
+When a child workflow or activity abandoned by a previous generation completes after the ContinueAsNew, its completion event carries a task ID from the old sequence.
+The new generation has no matching scheduled operation, so the workflow execution consumes the event without effect and it is persisted into history as an orphan.
+
+When the new generation later schedules its own operation, that operation legitimately reuses the same task ID.
+Its real completion event is then matched against the orphaned event in history by the completion deduplication added in v1.18.0-rc.3 (intended to drop redelivered completions), and is discarded as a duplicate.
+The sender is acknowledged, so the event is never redelivered, and the re-asserted wake-up reminder fires against an empty inbox and is deleted.
+The workflow is left RUNNING with nothing to drive it.
+
+### Solution
+
+The workflow actor no longer persists resolution events (task or child workflow completions and failures) that match no operation scheduled in history.
+Stale cross-generation completions are discarded with a warning at the point they are consumed instead of being written into history, so the completion deduplication can no longer mistake a later, legitimate completion for a duplicate. Completions for operations of the current generation are unaffected.

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -282,6 +282,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		return todo.RunCompletedFalse, err
 	}
 	compactPatches(rs)
+	o.stripUnmatchedResolutions(state, rs)
 
 	runtimeStatus := runtimestate.RuntimeStatus(rs)
 	log.Debugf("Workflow actor '%s': workflow execution returned with status '%s' instanceId '%s'", o.actorID, runtimeStatus.String(), wi.InstanceID)
@@ -554,6 +555,73 @@ func (o *orchestrator) handleRetention(ctx context.Context, status protos.Orches
 	log.Debugf("Workflow actor '%s': setting retention reminder for status '%s' with due time '%v'", o.actorID, status.String(), dueTime)
 	_, err = o.createRetentionReminder(ctx, retentionReminderName, completedAt.Add(*dueTime))
 	return err
+}
+
+// stripUnmatchedResolutions removes from rs.NewEvents any task or child
+// workflow resolution event that resolves nothing: no matching TaskScheduled
+// or ChildWorkflowInstanceCreated with the same event ID exists in persisted
+// history or among this execution's new events. The app-side SDK silently
+// ignores such events, so without this they would be persisted into history
+// with no effect, where they poison dedup.IsDuplicateCompletion for a later
+// operation that legitimately reuses the same event ID (the ID sequence resets
+// on ContinueAsNew, so a straggler completion from an abandoned
+// previous-generation child collides with the current generation's
+// operations). Timer events are not stripped: stale timer firings are already
+// rejected by the generation check on the timer reminder path.
+func (o *orchestrator) stripUnmatchedResolutions(state *wfenginestate.State, rs *backend.WorkflowRuntimeState) {
+	scheduledTaskIDs := make(map[int32]struct{})
+	createdChildIDs := make(map[int32]struct{})
+	index := func(events []*backend.HistoryEvent) {
+		for _, e := range events {
+			switch {
+			case e.GetTaskScheduled() != nil:
+				scheduledTaskIDs[e.GetEventId()] = struct{}{}
+			case e.GetChildWorkflowInstanceCreated() != nil:
+				createdChildIDs[e.GetEventId()] = struct{}{}
+			}
+		}
+	}
+	index(state.History)
+	index(rs.GetNewEvents())
+
+	matched := func(e *backend.HistoryEvent) bool {
+		switch {
+		case e.GetTaskCompleted() != nil:
+			_, ok := scheduledTaskIDs[e.GetTaskCompleted().GetTaskScheduledId()]
+			return ok
+		case e.GetTaskFailed() != nil:
+			_, ok := scheduledTaskIDs[e.GetTaskFailed().GetTaskScheduledId()]
+			return ok
+		case e.GetChildWorkflowInstanceCompleted() != nil:
+			_, ok := createdChildIDs[e.GetChildWorkflowInstanceCompleted().GetTaskScheduledId()]
+			return ok
+		case e.GetChildWorkflowInstanceFailed() != nil:
+			_, ok := createdChildIDs[e.GetChildWorkflowInstanceFailed().GetTaskScheduledId()]
+			return ok
+		default:
+			return true
+		}
+	}
+
+	events := rs.GetNewEvents()
+	for _, e := range events {
+		if matched(e) {
+			continue
+		}
+
+		// At least one orphan: rebuild into a fresh backing array so callers
+		// holding the original slice are unaffected.
+		filtered := make([]*backend.HistoryEvent, 0, len(events)-1)
+		for _, ev := range events {
+			if !matched(ev) {
+				log.Warnf("Workflow actor '%s': discarding resolution event %T that matches no operation scheduled in persisted history or in this execution (stale event from a previous generation?)", o.actorID, ev.GetEventType())
+				continue
+			}
+			filtered = append(filtered, ev)
+		}
+		rs.NewEvents = filtered
+		return
+	}
 }
 
 // filterValidInboxEvents returns inbox events that pass validation. Result

--- a/tests/integration/suite/daprd/workflow/agentloop.go
+++ b/tests/integration/suite/daprd/workflow/agentloop.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(agentloop))
+}
+
+type agentloop struct {
+	workflow *workflow.Workflow
+}
+
+func (a *agentloop) Setup(t *testing.T) []framework.Option {
+	a.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *agentloop) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	const (
+		iterations  = 8
+		instances   = 3
+		eventName   = "agent-event"
+		waitTimeout = 30 * time.Second
+	)
+
+	var raiseClient atomic.Pointer[client.TaskHubGrpcClient]
+
+	r := a.workflow.Registry()
+
+	require.NoError(t, r.AddActivityN("step", func(actx task.ActivityContext) (any, error) {
+		var in struct {
+			Instance string `json:"instance"`
+			Iter     int    `json:"iter"`
+		}
+		if err := actx.GetInput(&in); err != nil {
+			return nil, err
+		}
+		time.Sleep(time.Duration(100+(in.Iter%4)*100) * time.Millisecond)
+		if err := raiseClient.Load().RaiseEvent(actx.Context(), api.InstanceID(in.Instance), eventName); err != nil {
+			return nil, err
+		}
+		return in.Iter, nil
+	}))
+
+	require.NoError(t, r.AddWorkflowN("agent", func(octx *task.WorkflowContext) (any, error) {
+		total := 0
+		for i := range iterations {
+			if err := octx.WaitForSingleEvent(eventName, 15*time.Second).Await(nil); err != nil {
+				return nil, err
+			}
+			var out int
+			if err := octx.CallActivity("step", task.WithActivityInput(struct {
+				Instance string `json:"instance"`
+				Iter     int    `json:"iter"`
+			}{Instance: string(octx.ID), Iter: i})).Await(&out); err != nil {
+				return nil, err
+			}
+			total += out
+		}
+		return total, nil
+	}))
+
+	cl := a.workflow.BackendClient(t, ctx)
+	raiseClient.Store(cl)
+
+	for inst := range instances {
+		id, err := cl.ScheduleNewWorkflow(ctx, "agent",
+			api.WithInstanceID(api.InstanceID(fmt.Sprintf("agentloop-%d", inst))),
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, cl.RaiseEvent(ctx, id, eventName))
+
+		waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+		meta, err := cl.WaitForWorkflowCompletion(waitCtx, id)
+		cancel()
+		require.NoErrorf(t, err, "instance %d: agent loop hung (event or activity completion lost)", inst)
+		require.Equalf(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String(),
+			"instance %d: %v", inst, meta.GetFailureDetails())
+	}
+}

--- a/tests/integration/suite/daprd/workflow/childcompletions.go
+++ b/tests/integration/suite/daprd/workflow/childcompletions.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childcompletions))
+}
+
+type childcompletions struct {
+	workflow *workflow.Workflow
+}
+
+func (c *childcompletions) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *childcompletions) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	r := c.workflow.Registry()
+
+	require.NoError(t, r.AddActivityN("think", func(actx task.ActivityContext) (any, error) {
+		var ms int
+		if err := actx.GetInput(&ms); err != nil {
+			return nil, err
+		}
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+		return ms, nil
+	}))
+
+	require.NoError(t, r.AddWorkflowN("agent", func(octx *task.WorkflowContext) (any, error) {
+		var ms int
+		if err := octx.GetInput(&ms); err != nil {
+			return nil, err
+		}
+		var out int
+		if err := octx.CallActivity("think", task.WithActivityInput(ms)).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	require.NoError(t, r.AddWorkflowN("loop", func(octx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := octx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+
+		if gen == 0 {
+			timer := octx.CreateTimer(100 * time.Millisecond)
+			octx.CallChildWorkflow("agent",
+				task.WithChildWorkflowInput(2000),
+				task.WithChildWorkflowInstanceID("childcompletions-straggler"),
+			)
+			if err := timer.Await(nil); err != nil {
+				return nil, err
+			}
+			octx.ContinueAsNew(1)
+			return nil, nil
+		}
+
+		var out int
+		if err := octx.CallActivity("think", task.WithActivityInput(4000)).Await(&out); err != nil {
+			return nil, err
+		}
+		if err := octx.CallChildWorkflow("agent",
+			task.WithChildWorkflowInput(200),
+			task.WithChildWorkflowInstanceID("childcompletions-real"),
+		).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	client := c.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewWorkflow(ctx, "loop",
+		api.WithInstanceID("childcompletions-parent"),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, id)
+	require.NoError(t, err, "parent did not complete: child workflow completion was lost")
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String(),
+		"failure details: %v", meta.GetFailureDetails())
+}


### PR DESCRIPTION
* fix: Workflows no longer hang when a completion crosses a ContinueAsNew boundary

ContinueAsNew resets the workflow's task ID sequence, but a child workflow or activity abandoned by the previous generation keeps running. When it completes after the CAN, its completion event carries a task ID from the old sequence. The new generation has no matching scheduled operation, so the SDK consumes the event without effect and it is persisted into history as an orphan.

When the new generation later schedules its own operation, that operation legitimately reuses the same task ID. Its real completion is then matched against the orphaned event in history by the completion dedup in addWorkflowEvent  and dropped as a redelivery. The sender is acked so it never retries, the re-asserted wake-up reminder fires against an empty inbox and is deleted, and the workflow is left RUNNING forever:

```
  dropping duplicate completion event already present in history/inbox
  ignoring run request for reminder 'new-event-...' because the
  workflow inbox is empty
```

Agentic workflows are particularly exposed, as they loop via ContinueAsNew while running children and activities with variable latency. Before the dedup landed, the redelivery re-appended the event to the inbox and the workflow self-healed once the new generation's operation was persisted; the dedup turned that recovery path into a permanent loss.

Fix: after the engine callback, strip from the execution's new events any task or child workflow resolution whose TaskScheduled or ChildWorkflowInstanceCreated counterpart exists neither in persisted history nor among the new events, logging a warning. Orphans never reach history, so the dedup can no longer mistake a later legitimate completion for a duplicate. Completions for operations of the current generation are unaffected. Timer events are excluded: stale timer firings are already rejected by the generation check on the timer reminder path.


Backport of https://github.com/dapr/dapr/pull/10097