### PR TITLE
fix(api): standardize distributed lock API errors to gRPC rich error model

### DIFF
--- a/pkg/api/errors/lock.go
+++ b/pkg/api/errors/lock.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	kiterrors "github.com/dapr/kit/errors"
+)
+
+type LockStoreError struct {
+	name string
+}
+
+func LockStore(name string) *LockStoreError {
+	return &LockStoreError{name: name}
+}
+
+func (l *LockStoreError) NotConfigured() error {
+	return kiterrors.NewBuilder(
+		codes.FailedPrecondition,
+		http.StatusInternalServerError,
+		"lock store is not configured",
+		"",
+		string(errorcodes.LockStoreNotConfigured.Category),
+	).
+		WithErrorInfo(errorcodes.LockStoreNotConfigured.Code, nil).
+		Build()
+}
+
+func (l *LockStoreError) NotFound() error {
+	return kiterrors.NewBuilder(
+		codes.InvalidArgument,
+		http.StatusBadRequest,
+		fmt.Sprintf("lock store %s not found", l.name),
+		"",
+		string(errorcodes.LockStoreNotFound.Category),
+	).
+		WithErrorInfo(errorcodes.LockStoreNotFound.Code, map[string]string{"store": l.name}).
+		Build()
+}
+
+func (l *LockStoreError) ResourceIDEmpty() error {
+	return kiterrors.NewBuilder(
+		codes.InvalidArgument,
+		http.StatusBadRequest,
+		fmt.Sprintf("ResourceId is empty in lock store %s", l.name),
+		"",
+		string(errorcodes.CommonMalformedRequest.Category),
+	).
+		WithErrorInfo(errorcodes.CommonMalformedRequest.Code, map[string]string{"store": l.name}).
+		Build()
+}
+
+func (l *LockStoreError) LockOwnerEmpty() error {
+	return kiterrors.NewBuilder(
+		codes.InvalidArgument,
+		http.StatusBadRequest,
+		fmt.Sprintf("LockOwner is empty in lock store %s", l.name),
+		"",
+		string(errorcodes.CommonMalformedRequest.Category),
+	).
+		WithErrorInfo(errorcodes.CommonMalformedRequest.Code, map[string]string{"store": l.name}).
+		Build()
+}
+
+func (l *LockStoreError) ExpiryInSecondsNotPositive() error {
+	return kiterrors.NewBuilder(
+		codes.InvalidArgument,
+		http.StatusBadRequest,
+		fmt.Sprintf("ExpiryInSeconds is not positive in lock store %s", l.name),
+		"",
+		string(errorcodes.CommonMalformedRequest.Category),
+	).
+		WithErrorInfo(errorcodes.CommonMalformedRequest.Code, map[string]string{"store": l.name}).
+		Build()
+}
+
+func (l *LockStoreError) TryLockFailed(err error) error {
+	msg := "failed to try acquiring lock"
+	if err != nil {
+		msg = fmt.Sprintf("failed to try acquiring lock: %s", err.Error())
+	}
+	return kiterrors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		msg,
+		"",
+		string(errorcodes.LockTry.Category),
+	).
+		WithErrorInfo(errorcodes.LockTry.Code, map[string]string{"store": l.name}).
+		Build()
+}
+
+func (l *LockStoreError) UnlockFailed(err error) error {
+	msg := "failed to release lock"
+	if err != nil {
+		msg = fmt.Sprintf("failed to release lock: %s", err.Error())
+	}
+	return kiterrors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		msg,
+		"",
+		string(errorcodes.LockUnlock.Category),
+	).
+		WithErrorInfo(errorcodes.LockUnlock.Code, map[string]string{"store": l.name}).
+		Build()
+}

--- a/pkg/api/universal/lock.go
+++ b/pkg/api/universal/lock.go
@@ -17,8 +17,8 @@ import (
 	"context"
 
 	"github.com/dapr/components-contrib/lock"
+	apierrors "github.com/dapr/dapr/pkg/api/errors"
 	lockLoader "github.com/dapr/dapr/pkg/components/lock"
-	"github.com/dapr/dapr/pkg/messages"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 )
@@ -26,7 +26,7 @@ import (
 func (a *Universal) TryLockAlpha1(ctx context.Context, req *runtimev1pb.TryLockRequest) (*runtimev1pb.TryLockResponse, error) {
 	// 1. validate and find lock component
 	if req.GetExpiryInSeconds() <= 0 {
-		err := messages.ErrExpiryInSecondsNotPositive.WithFormat(req.GetStoreName())
+		err := apierrors.LockStore(req.GetStoreName()).ExpiryInSecondsNotPositive()
 		a.logger.Debug(err)
 		return &runtimev1pb.TryLockResponse{}, err
 	}
@@ -44,9 +44,9 @@ func (a *Universal) TryLockAlpha1(ctx context.Context, req *runtimev1pb.TryLockR
 	// modify key
 	compReq.ResourceID, err = lockLoader.GetModifiedLockKey(compReq.ResourceID, req.GetStoreName(), a.appID)
 	if err != nil {
-		err = messages.ErrTryLockFailed.WithFormat(err)
-		a.logger.Debug(err)
-		return &runtimev1pb.TryLockResponse{}, err
+		richErr := apierrors.LockStore(req.GetStoreName()).TryLockFailed(err)
+		a.logger.Debug(richErr)
+		return &runtimev1pb.TryLockResponse{}, richErr
 	}
 
 	// 3. delegate to the component
@@ -57,9 +57,9 @@ func (a *Universal) TryLockAlpha1(ctx context.Context, req *runtimev1pb.TryLockR
 		return store.TryLock(ctx, compReq)
 	})
 	if err != nil {
-		err = messages.ErrTryLockFailed.WithFormat(err)
-		a.logger.Debug(err)
-		return &runtimev1pb.TryLockResponse{}, err
+		richErr := apierrors.LockStore(req.GetStoreName()).TryLockFailed(err)
+		a.logger.Debug(richErr)
+		return &runtimev1pb.TryLockResponse{}, richErr
 	}
 
 	// 4. convert response
@@ -88,9 +88,9 @@ func (a *Universal) UnlockAlpha1(ctx context.Context, req *runtimev1pb.UnlockReq
 	// modify key
 	compReq.ResourceID, err = lockLoader.GetModifiedLockKey(compReq.ResourceID, req.GetStoreName(), a.appID)
 	if err != nil {
-		err = messages.ErrUnlockFailed.WithFormat(err)
-		a.logger.Debug(err)
-		return newInternalErrorUnlockResponse(), err
+		richErr := apierrors.LockStore(req.GetStoreName()).UnlockFailed(err)
+		a.logger.Debug(richErr)
+		return newInternalErrorUnlockResponse(), richErr
 	}
 
 	// 3. delegate to the component
@@ -101,9 +101,9 @@ func (a *Universal) UnlockAlpha1(ctx context.Context, req *runtimev1pb.UnlockReq
 		return store.Unlock(ctx, compReq)
 	})
 	if err != nil {
-		err = messages.ErrUnlockFailed.WithFormat(err)
-		a.logger.Debug(err)
-		return newInternalErrorUnlockResponse(), err
+		richErr := apierrors.LockStore(req.GetStoreName()).UnlockFailed(err)
+		a.logger.Debug(richErr)
+		return newInternalErrorUnlockResponse(), richErr
 	}
 
 	// 4. convert response
@@ -125,20 +125,18 @@ type tryLockUnlockRequest interface {
 
 // Internal method that checks if the request is for a lock store component.
 func (a *Universal) lockValidateRequest(req tryLockUnlockRequest) (lock.Store, error) {
-	var err error
-
 	if a.compStore.LocksLen() == 0 {
-		err = messages.ErrLockStoresNotConfigured
+		err := apierrors.LockStore(req.GetStoreName()).NotConfigured()
 		a.logger.Debug(err)
 		return nil, err
 	}
 	if req.GetResourceId() == "" {
-		err = messages.ErrResourceIDEmpty.WithFormat(req.GetStoreName())
+		err := apierrors.LockStore(req.GetStoreName()).ResourceIDEmpty()
 		a.logger.Debug(err)
 		return nil, err
 	}
 	if req.GetLockOwner() == "" {
-		err = messages.ErrLockOwnerEmpty.WithFormat(req.GetStoreName())
+		err := apierrors.LockStore(req.GetStoreName()).LockOwnerEmpty()
 		a.logger.Debug(err)
 		return nil, err
 	}
@@ -146,7 +144,7 @@ func (a *Universal) lockValidateRequest(req tryLockUnlockRequest) (lock.Store, e
 	// 2. find lock component
 	store, ok := a.compStore.GetLock(req.GetStoreName())
 	if !ok {
-		err = messages.ErrLockStoreNotFound.WithFormat(req.GetStoreName())
+		err := apierrors.LockStore(req.GetStoreName()).NotFound()
 		a.logger.Debug(err)
 		return nil, err
 	}

--- a/tests/integration/suite/daprd/daprd.go
+++ b/tests/integration/suite/daprd/daprd.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/httpendpoints"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/httpserver"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/jobs"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/lock"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/mcpserver"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metadata"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/metrics"

--- a/tests/integration/suite/daprd/lock/grpc/errors.go
+++ b/tests/integration/suite/daprd/lock/grpc/errors.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	grpcCodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(errors))
+}
+
+// errors tests the rich error responses for the Distributed Lock gRPC API.
+// Only errors that can be triggered without an external lock store backend are
+// covered here (store-level errors require a real lock store component).
+type errors struct {
+	daprd *procdaprd.Daprd
+}
+
+func (e *errors) Setup(t *testing.T) []framework.Option {
+	e.daprd = procdaprd.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.daprd),
+	}
+}
+
+func (e *errors) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+	client := e.daprd.GRPCClient(t, ctx)
+
+	t.Run("expiry in seconds not positive", func(t *testing.T) {
+		_, err := client.TryLockAlpha1(ctx, &rtv1.TryLockRequest{
+			StoreName:       "mystore",
+			ResourceId:      "resource",
+			LockOwner:       "owner",
+			ExpiryInSeconds: 0,
+		})
+		require.Error(t, err)
+
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, grpcCodes.InvalidArgument, s.Code())
+		require.Equal(t, "ExpiryInSeconds is not positive in lock store mystore", s.Message())
+		require.Len(t, s.Details(), 1)
+		errInfo, ok := s.Details()[0].(*errdetails.ErrorInfo)
+		require.True(t, ok)
+		require.Equal(t, "ERR_MALFORMED_REQUEST", errInfo.GetReason())
+		require.Equal(t, "dapr.io", errInfo.GetDomain())
+	})
+
+	t.Run("lock store not configured", func(t *testing.T) {
+		_, err := client.TryLockAlpha1(ctx, &rtv1.TryLockRequest{
+			StoreName:       "mystore",
+			ResourceId:      "resource",
+			LockOwner:       "owner",
+			ExpiryInSeconds: 10,
+		})
+		require.Error(t, err)
+
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, grpcCodes.FailedPrecondition, s.Code())
+		require.Equal(t, "lock store is not configured", s.Message())
+		require.Len(t, s.Details(), 1)
+		errInfo, ok := s.Details()[0].(*errdetails.ErrorInfo)
+		require.True(t, ok)
+		require.Equal(t, "ERR_LOCK_STORE_NOT_CONFIGURED", errInfo.GetReason())
+		require.Equal(t, "dapr.io", errInfo.GetDomain())
+	})
+
+	t.Run("unlock lock store not configured", func(t *testing.T) {
+		_, err := client.UnlockAlpha1(ctx, &rtv1.UnlockRequest{
+			StoreName:  "mystore",
+			ResourceId: "resource",
+			LockOwner:  "owner",
+		})
+		require.Error(t, err)
+
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, grpcCodes.FailedPrecondition, s.Code())
+		require.Equal(t, "lock store is not configured", s.Message())
+		require.Len(t, s.Details(), 1)
+		errInfo, ok := s.Details()[0].(*errdetails.ErrorInfo)
+		require.True(t, ok)
+		require.Equal(t, "ERR_LOCK_STORE_NOT_CONFIGURED", errInfo.GetReason())
+		require.Equal(t, "dapr.io", errInfo.GetDomain())
+	})
+}

--- a/tests/integration/suite/daprd/lock/http/errors.go
+++ b/tests/integration/suite/daprd/lock/http/errors.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+const (
+	ErrInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
+)
+
+func init() {
+	suite.Register(new(errors))
+}
+
+// errors tests the rich error responses for the Distributed Lock HTTP API.
+// Only errors that can be triggered without an external lock store backend are
+// covered here (store-level errors require a real lock store component).
+type errors struct {
+	daprd *procdaprd.Daprd
+}
+
+func (e *errors) Setup(t *testing.T) []framework.Option {
+	e.daprd = procdaprd.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.daprd),
+	}
+}
+
+func (e *errors) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+	httpClient := client.HTTP(t)
+
+	t.Run("expiry in seconds not positive", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0-alpha1/lock/mystore", e.daprd.HTTPPort())
+		body := `{"resourceId":"resource","lockOwner":"owner","expiryInSeconds":0}`
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var data map[string]any
+		require.NoError(t, json.Unmarshal(b, &data))
+
+		assert.Equal(t, "ERR_MALFORMED_REQUEST", data["errorCode"])
+		assert.Equal(t, "ExpiryInSeconds is not positive in lock store mystore", data["message"])
+
+		details, ok := data["details"].([]any)
+		require.True(t, ok)
+		require.NotEmpty(t, details)
+
+		var errInfo map[string]any
+		for _, d := range details {
+			dm, ok := d.(map[string]any)
+			if !ok {
+				continue
+			}
+			if dm["@type"] == ErrInfoType {
+				errInfo = dm
+				break
+			}
+		}
+		require.NotNil(t, errInfo, "ErrorInfo detail not found")
+		assert.Equal(t, "ERR_MALFORMED_REQUEST", errInfo["reason"])
+	})
+
+	t.Run("lock store not configured", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0-alpha1/lock/mystore", e.daprd.HTTPPort())
+		body := `{"resourceId":"resource","lockOwner":"owner","expiryInSeconds":10}`
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var data map[string]any
+		require.NoError(t, json.Unmarshal(b, &data))
+
+		assert.Equal(t, "ERR_LOCK_STORE_NOT_CONFIGURED", data["errorCode"])
+		assert.Equal(t, "lock store is not configured", data["message"])
+
+		details, ok := data["details"].([]any)
+		require.True(t, ok)
+		require.NotEmpty(t, details)
+
+		var errInfo map[string]any
+		for _, d := range details {
+			dm, ok := d.(map[string]any)
+			if !ok {
+				continue
+			}
+			if dm["@type"] == ErrInfoType {
+				errInfo = dm
+				break
+			}
+		}
+		require.NotNil(t, errInfo, "ErrorInfo detail not found")
+		assert.Equal(t, "ERR_LOCK_STORE_NOT_CONFIGURED", errInfo["reason"])
+	})
+
+	t.Run("unlock lock store not configured", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0-alpha1/unlock/mystore", e.daprd.HTTPPort())
+		body := `{"resourceId":"resource","lockOwner":"owner"}`
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var data map[string]any
+		require.NoError(t, json.Unmarshal(b, &data))
+
+		assert.Equal(t, "ERR_LOCK_STORE_NOT_CONFIGURED", data["errorCode"])
+		assert.Equal(t, "lock store is not configured", data["message"])
+	})
+}

--- a/tests/integration/suite/daprd/lock/http/errors.go
+++ b/tests/integration/suite/daprd/lock/http/errors.go
@@ -163,5 +163,23 @@ func (e *errors) Run(t *testing.T, ctx context.Context) {
 
 		assert.Equal(t, "ERR_LOCK_STORE_NOT_CONFIGURED", data["errorCode"])
 		assert.Equal(t, "lock store is not configured", data["message"])
+
+		details, ok := data["details"].([]any)
+		require.True(t, ok)
+		require.NotEmpty(t, details)
+
+		var errInfo map[string]any
+		for _, d := range details {
+			dm, ok := d.(map[string]any)
+			if !ok {
+				continue
+			}
+			if dm["@type"] == ErrInfoType {
+				errInfo = dm
+				break
+			}
+		}
+		require.NotNil(t, errInfo, "ErrorInfo detail not found")
+		assert.Equal(t, "ERR_LOCK_STORE_NOT_CONFIGURED", errInfo["reason"])
 	})
 }

--- a/tests/integration/suite/daprd/lock/lock.go
+++ b/tests/integration/suite/daprd/lock/lock.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/lock/grpc"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/lock/http"
+)


### PR DESCRIPTION
# Description

Replace the legacy `messages.Err*` predefined errors in the distributed lock API with rich errors built using the `pkg/api/errors` builder, following the pattern established for the State API ([#7257](https://github.com/dapr/dapr/pull/7257)) and PubSub API ([#7322](https://github.com/dapr/dapr/pull/7322)).

**New file:** `pkg/api/errors/lock.go` — introduces `LockStoreError` covering all seven error conditions:
- `NotConfigured` — `codes.FailedPrecondition` / 500 / `ERR_LOCK_STORE_NOT_CONFIGURED`
- `NotFound` — `codes.InvalidArgument` / 400 / `ERR_LOCK_STORE_NOT_FOUND`
- `ResourceIDEmpty` — `codes.InvalidArgument` / 400 / `ERR_MALFORMED_REQUEST`
- `LockOwnerEmpty` — `codes.InvalidArgument` / 400 / `ERR_MALFORMED_REQUEST`
- `ExpiryInSecondsNotPositive` — `codes.InvalidArgument` / 400 / `ERR_MALFORMED_REQUEST`
- `TryLockFailed` — `codes.Internal` / 500 / `ERR_TRY_LOCK`
- `UnlockFailed` — `codes.Internal` / 500 / `ERR_UNLOCK`

**Updated:** `pkg/api/universal/lock.go` — all `messages.Err*` call sites replaced with the new rich errors.

**Integration tests** added under `tests/integration/suite/daprd/lock/` (gRPC + HTTP) covering the errors that can be triggered without an external lock store backend (`NotConfigured`, `ExpiryInSecondsNotPositive`). Tests for `ResourceIDEmpty`, `LockOwnerEmpty`, and `NotFound` require a pluggable in-memory lock store component (not yet available in the test framework) and are left for a follow-up.

## Issue reference

Please reference the issue this PR will close: #7486

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing (integration tests added; full E2E requires a real lock store backend)
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: n/a — no user-facing API change
- [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: n/a
- [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: n/a