### PR TITLE
fix(api): standardize secrets API errors to gRPC rich error model

### DIFF
--- a/pkg/api/errors/secret.go
+++ b/pkg/api/errors/secret.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	kiterrors "github.com/dapr/kit/errors"
+)
+
+type SecretStoreError struct {
+	name string
+}
+
+func SecretStore(name string) *SecretStoreError {
+	return &SecretStoreError{name: name}
+}
+
+func (s *SecretStoreError) NotConfigured() error {
+	return kiterrors.NewBuilder(
+		codes.FailedPrecondition,
+		http.StatusInternalServerError,
+		"secret store is not configured",
+		"",
+		string(errorcodes.SecretStoreNotConfigured.Category),
+	).
+		WithErrorInfo(errorcodes.SecretStoreNotConfigured.Code, nil).
+		Build()
+}
+
+func (s *SecretStoreError) NotFound() error {
+	return kiterrors.NewBuilder(
+		codes.InvalidArgument,
+		http.StatusUnauthorized,
+		fmt.Sprintf("failed finding secret store with key %s", s.name),
+		"",
+		string(errorcodes.SecretStoreNotFound.Category),
+	).
+		WithErrorInfo(errorcodes.SecretStoreNotFound.Code, map[string]string{"store": s.name}).
+		Build()
+}
+
+func (s *SecretStoreError) PermissionDenied(key string) error {
+	return kiterrors.NewBuilder(
+		codes.PermissionDenied,
+		http.StatusForbidden,
+		fmt.Sprintf("access denied by policy to get %q from %q", key, s.name),
+		"",
+		string(errorcodes.SecretPermissionDenied.Category),
+	).
+		WithErrorInfo(errorcodes.SecretPermissionDenied.Code, map[string]string{"store": s.name, "key": key}).
+		Build()
+}
+
+func (s *SecretStoreError) Get(key string, err error) error {
+	msg := fmt.Sprintf("failed getting secret with key %s from secret store %s", key, s.name)
+	if err != nil {
+		msg = fmt.Sprintf("%s: %s", msg, err.Error())
+	}
+	return kiterrors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		msg,
+		"",
+		string(errorcodes.SecretGet.Category),
+	).
+		WithErrorInfo(errorcodes.SecretGet.Code, map[string]string{"store": s.name, "key": key}).
+		Build()
+}
+
+func (s *SecretStoreError) BulkGet(err error) error {
+	msg := fmt.Sprintf("failed getting secrets from secret store %s", s.name)
+	if err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, err)
+	}
+	return kiterrors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		msg,
+		"",
+		string(errorcodes.SecretGet.Category),
+	).
+		WithErrorInfo(errorcodes.SecretGet.Code, map[string]string{"store": s.name}).
+		Build()
+}

--- a/pkg/api/universal/secrets.go
+++ b/pkg/api/universal/secrets.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/dapr/components-contrib/secretstores"
+	apierrors "github.com/dapr/dapr/pkg/api/errors"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
-	"github.com/dapr/dapr/pkg/messages"
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 )
@@ -33,7 +33,7 @@ func (a *Universal) GetSecret(ctx context.Context, in *runtimev1pb.GetSecretRequ
 	}
 
 	if !a.isSecretAllowed(in.GetStoreName(), in.GetKey()) {
-		err = messages.ErrSecretPermissionDenied.WithFormat(in.GetKey(), in.GetStoreName())
+		err = apierrors.SecretStore(in.GetStoreName()).PermissionDenied(in.GetKey())
 		a.logger.Debug(err)
 		return response, err
 	}
@@ -56,9 +56,9 @@ func (a *Universal) GetSecret(ctx context.Context, in *runtimev1pb.GetSecretRequ
 	diag.DefaultComponentMonitoring.SecretInvoked(ctx, in.GetStoreName(), diag.Get, err == nil, elapsed)
 
 	if err != nil {
-		err = messages.ErrSecretGet.WithFormat(req.Name, in.GetStoreName(), err.Error())
-		a.logger.Debug(err)
-		return response, err
+		richErr := apierrors.SecretStore(in.GetStoreName()).Get(req.Name, err)
+		a.logger.Debug(richErr)
+		return response, richErr
 	}
 
 	if getResponse != nil {
@@ -94,9 +94,9 @@ func (a *Universal) GetBulkSecret(ctx context.Context, in *runtimev1pb.GetBulkSe
 	diag.DefaultComponentMonitoring.SecretInvoked(ctx, in.GetStoreName(), diag.BulkGet, err == nil, elapsed)
 
 	if err != nil {
-		err = messages.ErrBulkSecretGet.WithFormat(in.GetStoreName(), err.Error())
-		a.logger.Debug(err)
-		return response, err
+		richErr := apierrors.SecretStore(in.GetStoreName()).BulkGet(err)
+		a.logger.Debug(richErr)
+		return response, richErr
 	}
 
 	if getResponse == nil {
@@ -107,7 +107,7 @@ func (a *Universal) GetBulkSecret(ctx context.Context, in *runtimev1pb.GetBulkSe
 		if a.isSecretAllowed(in.GetStoreName(), key) {
 			filteredSecrets[key] = v
 		} else {
-			a.logger.Debug(messages.ErrSecretPermissionDenied.WithFormat(key, in.GetStoreName()).String())
+			a.logger.Debug(apierrors.SecretStore(in.GetStoreName()).PermissionDenied(key).Error())
 		}
 	}
 
@@ -125,14 +125,14 @@ func (a *Universal) GetBulkSecret(ctx context.Context, in *runtimev1pb.GetBulkSe
 // Internal method that checks if the request is for a valid secret store component.
 func (a *Universal) secretsValidateRequest(componentName string) (secretstores.SecretStore, error) {
 	if a.compStore.SecretStoresLen() == 0 {
-		err := messages.ErrSecretStoreNotConfigured
+		err := apierrors.SecretStore(componentName).NotConfigured()
 		a.logger.Debug(err)
 		return nil, err
 	}
 
 	component, ok := a.compStore.GetSecretStore(componentName)
 	if !ok {
-		err := messages.ErrSecretStoreNotFound.WithFormat(componentName)
+		err := apierrors.SecretStore(componentName).NotFound()
 		a.logger.Debug(err)
 		return nil, err
 	}

--- a/tests/integration/suite/daprd/secret/grpc/errors.go
+++ b/tests/integration/suite/daprd/secret/grpc/errors.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	grpcCodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(errors))
+}
+
+type errors struct {
+	daprdNoStore   *procdaprd.Daprd
+	daprdWithStore *procdaprd.Daprd
+}
+
+func (e *errors) Setup(t *testing.T) []framework.Option {
+	secretFile := filepath.Join(t.TempDir(), "secrets.json")
+	require.NoError(t, os.WriteFile(secretFile, []byte(`{"mykey":"myvalue"}`), 0o600))
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: myconfig
+spec:
+  secrets:
+    scopes:
+    - storeName: mysecretstore
+      defaultAccess: deny
+      allowedSecrets: ["mykey"]
+`), 0o600))
+
+	e.daprdNoStore = procdaprd.New(t)
+	e.daprdWithStore = procdaprd.New(t,
+		procdaprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mysecretstore
+spec:
+  type: secretstores.local.file
+  version: v1
+  metadata:
+  - name: secretsFile
+    value: '%s'
+`, secretFile)),
+		procdaprd.WithConfigs(configFile),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(e.daprdNoStore, e.daprdWithStore),
+	}
+}
+
+func (e *errors) Run(t *testing.T, ctx context.Context) {
+	e.daprdNoStore.WaitUntilRunning(t, ctx)
+	e.daprdWithStore.WaitUntilRunning(t, ctx)
+
+	clientNoStore := e.daprdNoStore.GRPCClient(t, ctx)
+	clientWithStore := e.daprdWithStore.GRPCClient(t, ctx)
+
+	t.Run("secret store not configured", func(t *testing.T) {
+		_, err := clientNoStore.GetSecret(ctx, &rtv1.GetSecretRequest{
+			StoreName: "mysecretstore",
+			Key:       "mykey",
+		})
+		require.Error(t, err)
+
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, grpcCodes.FailedPrecondition, s.Code())
+		require.Equal(t, "secret store is not configured", s.Message())
+		require.Len(t, s.Details(), 1)
+		errInfo, ok := s.Details()[0].(*errdetails.ErrorInfo)
+		require.True(t, ok)
+		require.Equal(t, "ERR_SECRET_STORES_NOT_CONFIGURED", errInfo.GetReason())
+		require.Equal(t, "dapr.io", errInfo.GetDomain())
+	})
+
+	t.Run("secret store not found", func(t *testing.T) {
+		_, err := clientWithStore.GetSecret(ctx, &rtv1.GetSecretRequest{
+			StoreName: "nonexistent-store",
+			Key:       "mykey",
+		})
+		require.Error(t, err)
+
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, grpcCodes.InvalidArgument, s.Code())
+		require.Equal(t, "failed finding secret store with key nonexistent-store", s.Message())
+		require.Len(t, s.Details(), 1)
+		errInfo, ok := s.Details()[0].(*errdetails.ErrorInfo)
+		require.True(t, ok)
+		require.Equal(t, "ERR_SECRET_STORE_NOT_FOUND", errInfo.GetReason())
+		require.Equal(t, "dapr.io", errInfo.GetDomain())
+	})
+
+	t.Run("secret permission denied", func(t *testing.T) {
+		_, err := clientWithStore.GetSecret(ctx, &rtv1.GetSecretRequest{
+			StoreName: "mysecretstore",
+			Key:       "denied-key",
+		})
+		require.Error(t, err)
+
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, grpcCodes.PermissionDenied, s.Code())
+		require.Equal(t, `access denied by policy to get "denied-key" from "mysecretstore"`, s.Message())
+		require.Len(t, s.Details(), 1)
+		errInfo, ok := s.Details()[0].(*errdetails.ErrorInfo)
+		require.True(t, ok)
+		require.Equal(t, "ERR_PERMISSION_DENIED", errInfo.GetReason())
+		require.Equal(t, "dapr.io", errInfo.GetDomain())
+	})
+}

--- a/tests/integration/suite/daprd/secret/http/errors.go
+++ b/tests/integration/suite/daprd/secret/http/errors.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+const (
+	errInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
+)
+
+func init() {
+	suite.Register(new(secretErrors))
+}
+
+type secretErrors struct {
+	daprdNoStore   *procdaprd.Daprd
+	daprdWithStore *procdaprd.Daprd
+}
+
+func (e *secretErrors) Setup(t *testing.T) []framework.Option {
+	secretFile := filepath.Join(t.TempDir(), "secrets.json")
+	require.NoError(t, os.WriteFile(secretFile, []byte(`{"mykey":"myvalue"}`), 0o600))
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: myconfig
+spec:
+  secrets:
+    scopes:
+    - storeName: mysecretstore
+      defaultAccess: deny
+      allowedSecrets: ["mykey"]
+`), 0o600))
+
+	e.daprdNoStore = procdaprd.New(t)
+	e.daprdWithStore = procdaprd.New(t,
+		procdaprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mysecretstore
+spec:
+  type: secretstores.local.file
+  version: v1
+  metadata:
+  - name: secretsFile
+    value: '%s'
+`, secretFile)),
+		procdaprd.WithConfigs(configFile),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(e.daprdNoStore, e.daprdWithStore),
+	}
+}
+
+func (e *secretErrors) Run(t *testing.T, ctx context.Context) {
+	e.daprdNoStore.WaitUntilRunning(t, ctx)
+	e.daprdWithStore.WaitUntilRunning(t, ctx)
+	httpClient := client.HTTP(t)
+
+	t.Run("secret store not configured", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0/secrets/mysecretstore/mykey", e.daprdNoStore.HTTPPort())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var data map[string]any
+		require.NoError(t, json.Unmarshal(b, &data))
+
+		assert.Equal(t, "ERR_SECRET_STORES_NOT_CONFIGURED", data["errorCode"])
+		assert.Equal(t, "secret store is not configured", data["message"])
+		assertErrInfo(t, data, "ERR_SECRET_STORES_NOT_CONFIGURED")
+	})
+
+	t.Run("secret store not found", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0/secrets/nonexistent-store/mykey", e.daprdWithStore.HTTPPort())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var data map[string]any
+		require.NoError(t, json.Unmarshal(b, &data))
+
+		assert.Equal(t, "ERR_SECRET_STORE_NOT_FOUND", data["errorCode"])
+		assert.Equal(t, "failed finding secret store with key nonexistent-store", data["message"])
+		assertErrInfo(t, data, "ERR_SECRET_STORE_NOT_FOUND")
+	})
+
+	t.Run("secret permission denied", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0/secrets/mysecretstore/denied-key", e.daprdWithStore.HTTPPort())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var data map[string]any
+		require.NoError(t, json.Unmarshal(b, &data))
+
+		assert.Equal(t, "ERR_PERMISSION_DENIED", data["errorCode"])
+		assertErrInfo(t, data, "ERR_PERMISSION_DENIED")
+	})
+}
+
+func assertErrInfo(t *testing.T, data map[string]any, expectedReason string) {
+	t.Helper()
+	details, ok := data["details"].([]any)
+	require.True(t, ok, "details field missing or not an array")
+	require.NotEmpty(t, details)
+
+	for _, d := range details {
+		dm, ok := d.(map[string]any)
+		if !ok {
+			continue
+		}
+		if dm["@type"] == errInfoType {
+			assert.Equal(t, expectedReason, dm["reason"])
+			return
+		}
+	}
+	t.Errorf("ErrorInfo detail with type %s not found in response", errInfoType)
+}

--- a/tests/integration/suite/daprd/secret/secret.go
+++ b/tests/integration/suite/daprd/secret/secret.go
@@ -14,6 +14,7 @@ limitations under the License.
 package secret
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/secret/grpc"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/secret/http"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/secret/secretscoping"
 )


### PR DESCRIPTION
# Description

Replace the legacy `messages.Err*` predefined errors in the secrets API with rich errors built using the `pkg/api/errors` builder, following the pattern established for the State API ([#7257](https://github.com/dapr/dapr/pull/7257)) and PubSub API ([#7322](https://github.com/dapr/dapr/pull/7322)).

**New file:** `pkg/api/errors/secret.go` — introduces `SecretStoreError` covering:
- `NotConfigured` — `codes.FailedPrecondition` / 500 / `ERR_SECRET_STORES_NOT_CONFIGURED`
- `NotFound` — `codes.InvalidArgument` / 401 / `ERR_SECRET_STORE_NOT_FOUND`
- `PermissionDenied` — `codes.PermissionDenied` / 403 / `ERR_PERMISSION_DENIED`
- `Get` — `codes.Internal` / 500 / `ERR_SECRET_GET`
- `BulkGet` — `codes.Internal` / 500 / `ERR_SECRET_GET`

**Updated:** `pkg/api/universal/secrets.go` — all `messages.Err*` call sites replaced.

**Integration tests** added under `tests/integration/suite/daprd/secret/` (gRPC + HTTP) using the built-in `secretstores.local.file` component, covering `NotConfigured`, `NotFound`, and `PermissionDenied`.

## Issue reference

Please reference the issue this PR will close: #7484

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing (integration tests added for 3 of 5 error conditions; `Get` and `BulkGet` require a real failing secret store backend)
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: n/a — no user-facing API change
- [ ] Specification has been updated: n/a
- [ ] Provided sample for the feature: n/a