### PR TITLE
fix(api): standardize health API errors to gRPC rich error model

### DIFF
--- a/pkg/api/errors/health.go
+++ b/pkg/api/errors/health.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	kiterrors "github.com/dapr/kit/errors"
+)
+
+func HealthNotReady(targets string) error {
+	msg := "dapr is not ready"
+	if targets != "" {
+		msg = fmt.Sprintf("dapr is not ready: %s", targets)
+	}
+	return kiterrors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		msg,
+		"",
+		string(errorcodes.HealthNotReady.Category),
+	).
+		WithErrorInfo(errorcodes.HealthNotReady.Code, nil).
+		Build()
+}
+
+func HealthAppIDNotMatch() error {
+	return kiterrors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		"dapr app-id does not match",
+		"",
+		string(errorcodes.HealthAppidNotMatch.Category),
+	).
+		WithErrorInfo(errorcodes.HealthAppidNotMatch.Code, nil).
+		Build()
+}
+
+func HealthOutboundNotReady() error {
+	return kiterrors.NewBuilder(
+		codes.Internal,
+		http.StatusInternalServerError,
+		"dapr outbound is not ready",
+		"",
+		string(errorcodes.HealthOutboundNotReady.Category),
+	).
+		WithErrorInfo(errorcodes.HealthOutboundNotReady.Code, nil).
+		Build()
+}

--- a/pkg/api/http/healthz.go
+++ b/pkg/api/http/healthz.go
@@ -16,8 +16,8 @@ package http
 import (
 	"net/http"
 
+	apierrors "github.com/dapr/dapr/pkg/api/errors"
 	"github.com/dapr/dapr/pkg/api/http/endpoints"
-	"github.com/dapr/dapr/pkg/messages"
 )
 
 var endpointGroupHealthzV1 = &endpoints.EndpointGroup{
@@ -57,9 +57,9 @@ func (a *api) constructHealthzEndpoints() []endpoints.Endpoint {
 
 func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.healthz.IsReady() {
-		msg := messages.ErrHealthNotReady.WithFormat(a.healthz.GetUnhealthyTargets())
-		respondWithError(w, msg)
-		log.Debug(msg)
+		err := apierrors.HealthNotReady(a.healthz.GetUnhealthyTargets())
+		respondWithError(w, err)
+		log.Debug(err)
 		return
 	}
 
@@ -67,9 +67,9 @@ func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 	// This is used by some components (e.g. Consul nameresolver) to check if the app was replaced with a different one
 	qs := r.URL.Query()
 	if qs.Has("appid") && qs.Get("appid") != a.universal.AppID() {
-		msg := messages.ErrHealthAppIDNotMatch
-		respondWithError(w, msg)
-		log.Debug(msg)
+		err := apierrors.HealthAppIDNotMatch()
+		respondWithError(w, err)
+		log.Debug(err)
 		return
 	}
 
@@ -78,9 +78,9 @@ func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 
 func (a *api) onGetOutboundHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.outboundHealthz.IsReady() {
-		msg := messages.ErrOutboundHealthNotReady
-		respondWithError(w, msg)
-		log.Debug(msg)
+		err := apierrors.HealthOutboundNotReady()
+		respondWithError(w, err)
+		log.Debug(err)
 		return
 	}
 

--- a/tests/integration/suite/daprd/daprd.go
+++ b/tests/integration/suite/daprd/daprd.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/binding"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/config"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/conversation"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/health"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/httpendpoints"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/httpserver"

--- a/tests/integration/suite/daprd/health/errors.go
+++ b/tests/integration/suite/daprd/health/errors.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+const (
+	errInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
+)
+
+func init() {
+	suite.Register(new(errors))
+}
+
+type errors struct {
+	daprd *procdaprd.Daprd
+}
+
+func (e *errors) Setup(t *testing.T) []framework.Option {
+	e.daprd = procdaprd.New(t, procdaprd.WithAppID("my-test-app"))
+	return []framework.Option{
+		framework.WithProcesses(e.daprd),
+	}
+}
+
+func (e *errors) Run(t *testing.T, ctx context.Context) {
+	e.daprd.WaitUntilRunning(t, ctx)
+	httpClient := client.HTTP(t)
+
+	// Covers apierrors.HealthAppIDNotMatch: a caller checks the appid query
+	// param and gets an error if this daprd's app-id doesn't match.
+	t.Run("app id not match", func(t *testing.T) {
+		url := fmt.Sprintf("http://localhost:%d/v1.0/healthz?appid=wrong-app-id", e.daprd.HTTPPort())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var data map[string]any
+		require.NoError(t, json.Unmarshal(b, &data))
+
+		assert.Equal(t, "ERR_HEALTH_APPID_NOT_MATCH", data["errorCode"])
+		assert.Equal(t, "dapr app-id does not match", data["message"])
+
+		details, ok := data["details"].([]any)
+		require.True(t, ok, "details field missing or not an array")
+		require.NotEmpty(t, details)
+
+		var foundErrInfo bool
+		for _, d := range details {
+			dm, ok := d.(map[string]any)
+			if !ok {
+				continue
+			}
+			if dm["@type"] == errInfoType {
+				assert.Equal(t, "ERR_HEALTH_APPID_NOT_MATCH", dm["reason"])
+				foundErrInfo = true
+				break
+			}
+		}
+		require.True(t, foundErrInfo, "ErrorInfo detail not found in response")
+	})
+}


### PR DESCRIPTION
# Description

Replace the legacy `messages.ErrHealth*` predefined errors in the healthz HTTP handlers with rich errors built using the `pkg/api/errors` builder, following the pattern established for the State API ([#7257](https://github.com/dapr/dapr/pull/7257)) and PubSub API ([#7322](https://github.com/dapr/dapr/pull/7322)).

**New file:** `pkg/api/errors/health.go` — package-level functions (no receiver needed, as health checks have no store name):
- `HealthNotReady(targets string)` — `codes.Internal` / 500 / `ERR_HEALTH_NOT_READY`
- `HealthAppIDNotMatch()` — `codes.Internal` / 500 / `ERR_HEALTH_APPID_NOT_MATCH`
- `HealthOutboundNotReady()` — `codes.Internal` / 500 / `ERR_OUTBOUND_HEALTH_NOT_READY`

**Updated:** `pkg/api/http/healthz.go` — all three `messages.Err*` call sites replaced.

**Integration test** added covering `HealthAppIDNotMatch` — the only error triggerable without putting daprd itself into an unhealthy state during a test run.

## Issue reference

Please reference the issue this PR will close: #7488

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing (integration test added for app-id mismatch case; the not-ready cases require orchestrating an unhealthy daprd state)
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: n/a — no user-facing API change
- [ ] Specification has been updated: n/a
- [ ] Provided sample for the feature: n/a