### PR TITLE
fix(resiliency): update circuit breaker state gauge on transitions

### DIFF
--- a/pkg/diagnostics/resiliency_monitoring.go
+++ b/pkg/diagnostics/resiliency_monitoring.go
@@ -117,24 +117,47 @@ func (m *resiliencyMetrics) PolicyWithStatusExecuted(resiliencyName, namespace s
 
 		// Record cb gauge, 4 metrics, one for each cb state, with the active state having a value of 1, otherwise 0
 		if policy == CircuitBreakerPolicy {
-			for _, s := range cbStatuses {
-				if s == status {
-					_ = stats.RecordWithOptions(
-						m.ctx,
-						stats.WithRecorder(m.meter),
-						stats.WithTags(diagUtils.WithTags(m.circuitbreakerState.Name(), append(commonTags, s)...)...),
-						stats.WithMeasurements(m.circuitbreakerState.M(1)),
-					)
-				} else {
-					_ = stats.RecordWithOptions(
-						m.ctx,
-						stats.WithRecorder(m.meter),
-						stats.WithTags(diagUtils.WithTags(m.circuitbreakerState.Name(), append(commonTags, s)...)...),
-						stats.WithMeasurements(m.circuitbreakerState.M(0)),
-					)
-				}
-			}
+			m.recordCircuitBreakerStateGauge(commonTags, status)
 		}
+	}
+}
+
+// RecordCircuitBreakerState updates the cb_state gauge to reflect a circuit
+// breaker's current state. It is used when the state changes during request
+// execution (e.g. half-open -> closed on a successful probe) so the gauge does
+// not stay stuck at the value that was snapshotted when the policy was
+// instantiated.
+func (m *resiliencyMetrics) RecordCircuitBreakerState(resiliencyName, namespace string, flowDirection PolicyFlowDirection, target string, status string) {
+	if m.enabled {
+		commonTags := []any{
+			appIDKey, m.appID,
+			resiliencyNameKey, resiliencyName,
+			policyKey, string(CircuitBreakerPolicy),
+			namespaceKey, namespace,
+			flowDirectionKey, string(flowDirection),
+			targetKey, target,
+			statusKey, // status appended on each recording
+		}
+		m.recordCircuitBreakerStateGauge(commonTags, status)
+	}
+}
+
+// recordCircuitBreakerStateGauge records the cb_state gauge as one series per
+// possible circuit breaker state, setting the active state to 1 and all others
+// to 0. commonTags must end with the statusKey tag key; the status value is
+// appended here for each recorded series.
+func (m *resiliencyMetrics) recordCircuitBreakerStateGauge(commonTags []any, status string) {
+	for _, s := range cbStatuses {
+		value := int64(0)
+		if s == status {
+			value = 1
+		}
+		_ = stats.RecordWithOptions(
+			m.ctx,
+			stats.WithRecorder(m.meter),
+			stats.WithTags(diagUtils.WithTags(m.circuitbreakerState.Name(), append(commonTags, s)...)...),
+			stats.WithMeasurements(m.circuitbreakerState.M(value)),
+		)
 	}
 }
 

--- a/pkg/diagnostics/resiliency_monitoring_test.go
+++ b/pkg/diagnostics/resiliency_monitoring_test.go
@@ -267,7 +267,43 @@ func TestResiliencyCountMonitoringCBStates(t *testing.T) {
 				diag.NewTag(diag.StatusKey.Name(), string(breaker.StateOpen)):     1,
 				diag.NewTag(diag.StatusKey.Name(), string(breaker.StateHalfOpen)): 1,
 			},
-			wantCbStateLastValue: diag.NewTag(diag.StatusKey.Name(), "half-open"),
+			// The failing probe trips the breaker back to open (half-open -> open).
+			// The gauge now tracks that transition (issue #10113); previously it
+			// stayed stuck at the "half-open" snapshot taken at instantiation.
+			wantCbStateLastValue: diag.NewTag(diag.StatusKey.Name(), "open"),
+		},
+		{
+			// Regression for #10113: when a circuit breaker recovers
+			// (half-open -> closed) during request execution, the cb_state gauge
+			// must reflect "closed". Previously the gauge was only snapshotted at
+			// policy instantiation, so a transition that happened mid-execution
+			// left the gauge stuck at the pre-transition state ("half-open").
+			name: "EndpointPolicyHalfOpenToClosedState",
+			unitFn: func() {
+				r := createTestResiliency(testResiliencyName, testResiliencyNamespace, "fakeStateStore")
+				for range 3 {
+					policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
+					policyRunner := resiliency.NewRunner[any](t.Context(), policyDef)
+					_, _ = policyRunner(func(ctx context.Context) (any, error) {
+						return nil, errors.New("fake error")
+					})
+				}
+				// let the circuit breaker go to half open state (>5x cb timeout)
+				time.Sleep(6 * testCBTimeout)
+				// a successful probe closes the breaker (MaxRequests == 1)
+				policyDef := r.EndpointPolicy("fakeApp", "fakeEndpoint")
+				policyRunner := resiliency.NewRunner[any](t.Context(), policyDef)
+				_, _ = policyRunner(func(ctx context.Context) (any, error) {
+					return nil, nil
+				})
+			},
+			wantNumberOfRows: 5,
+			wantCbStateTagCount: map[tag.Tag]int64{
+				diag.NewTag(diag.StatusKey.Name(), string(breaker.StateClosed)):   2,
+				diag.NewTag(diag.StatusKey.Name(), string(breaker.StateOpen)):     1,
+				diag.NewTag(diag.StatusKey.Name(), string(breaker.StateHalfOpen)): 1,
+			},
+			wantCbStateLastValue: diag.NewTag(diag.StatusKey.Name(), "closed"),
 		},
 	}
 

--- a/pkg/resiliency/resiliency.go
+++ b/pkg/resiliency/resiliency.go
@@ -578,7 +578,12 @@ func (r *Resiliency) addMetricsToPolicy(policyDef *PolicyDefinition, target stri
 	if policyDef.cb != nil {
 		diag.DefaultResiliencyMonitoring.PolicyWithStatusExecuted(r.name, r.namespace, diag.CircuitBreakerPolicy, direction, target, string(policyDef.cb.State()))
 		policyDef.addCBStateChangedMetric = func() {
-			diag.DefaultResiliencyMonitoring.PolicyWithStatusActivated(r.name, r.namespace, diag.CircuitBreakerPolicy, direction, target, string(policyDef.cb.State()))
+			state := string(policyDef.cb.State())
+			diag.DefaultResiliencyMonitoring.PolicyWithStatusActivated(r.name, r.namespace, diag.CircuitBreakerPolicy, direction, target, state)
+			// Update the cb_state gauge so it reflects the new state immediately,
+			// instead of staying stuck at the state snapshotted when the policy
+			// was instantiated (see issue #10113).
+			diag.DefaultResiliencyMonitoring.RecordCircuitBreakerState(r.name, r.namespace, direction, target, state)
 		}
 	}
 }

--- a/tests/integration/suite/daprd/metrics/resiliencycbstate.go
+++ b/tests/integration/suite/daprd/metrics/resiliencycbstate.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(resiliencycbstate))
+}
+
+// resiliencycbstate tests that dapr_resiliency_cb_state gauge updates immediately
+// on every circuit breaker state transition (fix for github.com/dapr/dapr/issues/10113).
+// Before the fix the gauge was only updated when the resiliency policy was next
+// instantiated, so it could remain stuck at "half-open" even after the probe
+// succeeded and the breaker had already closed.
+type resiliencycbstate struct {
+	daprdClient *daprd.Daprd
+	daprdServer *daprd.Daprd
+	callCount   atomic.Int32
+}
+
+func (r *resiliencycbstate) Setup(t *testing.T) []framework.Option {
+	testApp := app.New(t,
+		app.WithHandlerFunc("/cbtest", func(w http.ResponseWriter, _ *http.Request) {
+			if r.callCount.Add(1) <= 3 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	r.daprdServer = daprd.New(t,
+		daprd.WithAppPort(testApp.Port()),
+		daprd.WithAppID("cbstate-server"),
+	)
+
+	// timeout:1s keeps the test fast: the CB moves to half-open 1 second after
+	// opening, allowing us to send a probe without a long sleep.
+	resiliency := fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: cbstatepolicy
+spec:
+  policies:
+    circuitBreakers:
+      cbpolicy:
+        maxRequests: 1
+        interval: 0
+        timeout: 1s
+        trip: consecutiveFailures >= 3
+  targets:
+    apps:
+      %s:
+        circuitBreaker: cbpolicy
+`, r.daprdServer.AppID())
+
+	r.daprdClient = daprd.New(t,
+		daprd.WithAppPort(testApp.Port()),
+		daprd.WithAppID("cbstate-client"),
+		daprd.WithResourceFiles(resiliency),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(testApp, r.daprdServer, r.daprdClient),
+	}
+}
+
+func (r *resiliencycbstate) Run(t *testing.T, ctx context.Context) {
+	r.daprdClient.WaitUntilRunning(t, ctx)
+	r.daprdServer.WaitUntilAppHealth(t, ctx)
+
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/cbtest",
+		r.daprdClient.HTTPPort(), r.daprdServer.AppID())
+
+	cbStateKey := func(status string) string {
+		return fmt.Sprintf(
+			"dapr_resiliency_cb_state|app_id:cbstate-client|flow_direction:outbound|name:cbstatepolicy|namespace:|policy:circuitbreaker|status:%s|target:app_cbstate-server",
+			status,
+		)
+	}
+
+	t.Run("gauge shows open after consecutive failures", func(t *testing.T) {
+		for range 3 {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+			require.NoError(t, err)
+			resp, err := client.HTTP(t).Do(req)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+		}
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			mtc := r.daprdClient.Metrics(c, ctx).All()
+			assert.InDelta(c, float64(0), mtc[cbStateKey("closed")], 0)
+			assert.InDelta(c, float64(1), mtc[cbStateKey("open")], 0)
+		}, time.Second*4, 10*time.Millisecond)
+	})
+
+	t.Run("gauge immediately reflects closed after probe succeeds", func(t *testing.T) {
+		// Wait for the breaker's timeout so it enters half-open and allows one probe.
+		time.Sleep(2 * time.Second)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		require.NoError(t, err)
+		resp, err := client.HTTP(t).Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+
+		// The gauge must reflect "closed" without waiting for the next policy
+		// instantiation. Before fix #10113, it would stay stuck at "half-open"
+		// here even though the breaker had already transitioned to closed.
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			mtc := r.daprdClient.Metrics(c, ctx).All()
+			assert.InDelta(c, float64(0), mtc[cbStateKey("open")], 0)
+			assert.InDelta(c, float64(0), mtc[cbStateKey("half-open")], 0)
+			assert.InDelta(c, float64(1), mtc[cbStateKey("closed")], 0)
+		}, time.Second*4, 10*time.Millisecond)
+	})
+}

--- a/tests/integration/suite/daprd/resiliency/apps/defaultcircuitbreaker.go
+++ b/tests/integration/suite/daprd/resiliency/apps/defaultcircuitbreaker.go
@@ -175,11 +175,13 @@ func (d *defaultcircuitbreaker) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		require.NoError(t, resp.Body.Close())
 
-		// make sure gauge is half open
+		// The gauge must immediately update to "closed" once the probe succeeds
+		// (fix for #10113: the gauge previously stayed stuck at "half-open" until
+		// the next policy instantiation).
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			mtc := d.daprdClient.Metrics(c, ctx).All()
-			assert.InDelta(c, float64(0), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:open|target:app_server"], 0)
-			assert.InDelta(c, float64(1), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:half-open|target:app_server"], 0)
+			assert.InDelta(c, float64(0), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:half-open|target:app_server"], 0)
+			assert.InDelta(c, float64(1), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:closed|target:app_server"], 0)
 		}, time.Second*4, 10*time.Millisecond)
 
 		// Subsequent calls should succeed
@@ -189,13 +191,6 @@ func (d *defaultcircuitbreaker) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		require.NoError(t, resp.Body.Close())
-
-		// make sure gauge is closed
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			mtc := d.daprdClient.Metrics(c, ctx).All()
-			assert.InDelta(c, float64(0), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:half-open|target:app_server"], 0)
-			assert.InDelta(c, float64(1), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:closed|target:app_server"], 0)
-		}, time.Second*4, 10*time.Millisecond)
 
 		// Verify the total number of calls made to the server
 		assert.Equal(t, int32(5), d.callCount2.Load())


### PR DESCRIPTION
# Description

`dapr_resiliency_cb_state` is a gauge that is supposed to reflect a circuit breaker's current state. It was only written by `PolicyWithStatusExecuted`, which runs when a policy is instantiated and captures the breaker state at that moment. When a breaker changes state *during* request execution — most notably half-open → closed after a successful probe — the change was reported to the activations counter (`PolicyWithStatusActivated`) but the gauge was never updated. So the gauge stayed on the previously observed state (e.g. `half-open`) even though the runtime breaker had already recovered, until some later policy instantiation happened to observe the new state.

This records the gauge from the circuit breaker state-change callback (`pkg/resiliency/resiliency.go`) so it reflects the new state as soon as the transition happens. The gauge-writing loop in `PolicyWithStatusExecuted` is pulled into a small helper that the new `RecordCircuitBreakerState` method reuses; the execution counter is left untouched, so there is no double counting.

Tests:
- New regression case `EndpointPolicyHalfOpenToClosedState` drives a breaker open → half-open → closed and asserts the gauge ends on `closed`.
- The existing `EndpointPolicyHalfOpenState` case ends with the breaker tripping back to `open` (its probe fails). Its expected last value is updated from `half-open` to `open`, which is the breaker's real state — the old expectation was the stale-gauge behaviour this PR fixes.

`go test -tags unit ./pkg/diagnostics/... ./pkg/resiliency/...` passes locally.

## Issue reference

Please reference the issue this PR will close: #10113

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo
