### PR TITLE
Add spiffe source to context for all component operations

### DIFF
--- a/cmd/daprd/components/state_spiffeprobe.go
+++ b/cmd/daprd/components/state_spiffeprobe.go
@@ -1,0 +1,57 @@
+//go:build state_spiffeprobe
+
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"context"
+	"encoding/json"
+
+	contribstate "github.com/dapr/components-contrib/state"
+	inmemory "github.com/dapr/components-contrib/state/in-memory"
+	stateLoader "github.com/dapr/dapr/pkg/components/state"
+	spiffecontext "github.com/dapr/kit/crypto/spiffe/context"
+	"github.com/dapr/kit/logger"
+)
+
+// spiffeProbeStore is an integration-test-only state store that reports, via its
+// Get response, whether the workload's SPIFFE identity (the X.509 and JWT SVID
+// sources) reached the component operation context — letting a test assert the
+// injection end-to-end through the real daprd binary.
+//
+// It is gated behind the state_spiffeprobe build tag, set only for the
+// integration-test daprd binary and never for a released flavor, so it is never
+// shipped. It embeds the in-memory store to satisfy the full state.Store
+// interface for free, overriding only Get.
+type spiffeProbeStore struct {
+	contribstate.Store
+}
+
+// Get reports which SVID sources are present in ctx, ignoring any stored value.
+func (s *spiffeProbeStore) Get(ctx context.Context, _ *contribstate.GetRequest) (*contribstate.GetResponse, error) {
+	_, hasX509 := spiffecontext.X509From(ctx)
+	_, hasJWT := spiffecontext.JWTFrom(ctx)
+	data, err := json.Marshal(map[string]bool{"x509": hasX509, "jwt": hasJWT})
+	if err != nil {
+		return nil, err
+	}
+	return &contribstate.GetResponse{Data: data}, nil
+}
+
+func init() {
+	stateLoader.DefaultRegistry.RegisterComponent(func(log logger.Logger) contribstate.Store {
+		return &spiffeProbeStore{Store: inmemory.NewInMemoryStateStore(log)}
+	}, "spiffeprobe")
+}

--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -1,0 +1,22 @@
+# Dapr 1.18.2
+
+This update contains the following bug fixes:
+- [SPIFFE SVID component operation propagation](#spiffe-svid-component-operation-propagation)
+
+## SPIFFE SVID component operation propagation
+
+### Problem
+
+The SPIFFE SVID source was not propagated to component operation calls. As a result, any component that wanted to use the SPIFFE ID for authentication had to capture the source in its `init` method and manage it explicitly. SDKs such as the Azure SDK, which can transparently use the SPIFFE SVID source when it is present on the context, were unable to do so.
+
+### Impact
+
+Azure components could not leverage the SPIFFE ID for authentication without explicitly handling the source, and this also blocked future support for SPIFFE-based authentication in other components.
+
+### Root Cause
+
+The SPIFFE SVID source was attached only to the component's `init` method context, not to the context passed into operation calls.
+
+### Solution
+
+The SPIFFE SVID source is now attached to the context passed into operation calls, allowing components to use the SPIFFE ID for authentication on a per-operation basis.

--- a/pkg/api/grpc/spiffe_context_test.go
+++ b/pkg/api/grpc/spiffe_context_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/api/grpc/spiffe_context_test.go
+++ b/pkg/api/grpc/spiffe_context_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/pkg/api/universal"
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	securityfake "github.com/dapr/dapr/pkg/security/fake"
+	daprt "github.com/dapr/dapr/pkg/testing"
+	spiffecontext "github.com/dapr/kit/crypto/spiffe/context"
+	"github.com/dapr/kit/logger"
+)
+
+// fakeX509Source is a sentinel x509svid.Source. The test only checks that the
+// source reference reaches the component context, so the methods are stubs.
+type fakeX509Source struct{}
+
+func (fakeX509Source) GetX509SVID() (*x509svid.SVID, error) {
+	return nil, errors.New("not implemented")
+}
+
+// fakeJWTSource is a sentinel jwtsvid.Source.
+type fakeJWTSource struct{}
+
+func (fakeJWTSource) FetchJWTSVID(context.Context, jwtsvid.Params) (*jwtsvid.SVID, error) {
+	return nil, errors.New("not implemented")
+}
+
+// capturingStore records the context passed to Set and Get so the test can
+// assert what a building-block component observes during an operation.
+type capturedContexts struct {
+	mu     sync.Mutex
+	setCtx context.Context
+	getCtx context.Context
+}
+
+// newCapturingStore returns a mock state store that records the operation
+// context, registered under "store1".
+func newCapturingStore() (*daprt.MockStateStore, *capturedContexts) {
+	captured := &capturedContexts{}
+	store := &daprt.MockStateStore{}
+	store.On("Set", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured.mu.Lock()
+			captured.setCtx = args.Get(0).(context.Context)
+			captured.mu.Unlock()
+		}).Return(nil)
+	store.On("Get", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured.mu.Lock()
+			captured.getCtx = args.Get(0).(context.Context)
+			captured.mu.Unlock()
+		}).Return(&state.GetResponse{Data: []byte("ok")}, nil)
+	return store, captured
+}
+
+// stateRoundTrip wires the real gRPC API with the given resiliency provider and
+// drives a SaveState followed by a GetState against the capturing store.
+func stateRoundTrip(t *testing.T, ctx context.Context, res resiliency.Provider) *capturedContexts {
+	t.Helper()
+
+	store, captured := newCapturingStore()
+	compStore := compstore.New()
+	compStore.AddStateStore("store1", store)
+
+	fakeAPI := &api{
+		logger: logger.NewLogger("grpc.api.test"),
+		Universal: universal.New(universal.Options{
+			AppID:      "fakeAPI",
+			Logger:     logger.NewLogger("grpc.api.test"),
+			CompStore:  compStore,
+			Resiliency: res,
+		}),
+	}
+
+	lis := startDaprAPIServer(t, fakeAPI, "")
+	conn := createTestClient(lis)
+	t.Cleanup(func() { conn.Close() })
+	client := runtimev1pb.NewDaprClient(conn)
+
+	_, err := client.SaveState(ctx, &runtimev1pb.SaveStateRequest{
+		StoreName: "store1",
+		States:    []*commonv1pb.StateItem{{Key: "key1", Value: []byte("value1")}},
+	})
+	require.NoError(t, err)
+
+	_, err = client.GetState(ctx, &runtimev1pb.GetStateRequest{
+		StoreName: "store1",
+		Key:       "key1",
+	})
+	require.NoError(t, err)
+
+	return captured
+}
+
+// TestComponentOperationSVIDContext is an in-process integration test that
+// exercises the real request path (gRPC server -> universal API -> compStore ->
+// resiliency runner -> component) and asserts that the workload's SPIFFE
+// identity, injected via security.Handler.WithSVIDContext wired into the
+// resiliency provider, reaches the state store's Set/Get operation context.
+//
+// daprd runs the component in-process, so this verifies the in-memory SVID
+// sources that the cross-process integration suite (tests/integration) cannot
+// observe, because context values never serialize across a process boundary.
+func TestComponentOperationSVIDContext(t *testing.T) {
+	t.Run("sources reach the component operation context when wired", func(t *testing.T) {
+		// Mirror pkg/runtime/config.go: wire the security handler's
+		// WithSVIDContext as the component context decorator. The fake handler
+		// attaches the X.509 and JWT SVID sources exactly as the real handler's
+		// spiffecontext.WithSpiffe does.
+		sec := securityfake.New().WithSVIDContextFn(func(ctx context.Context) context.Context {
+			ctx = spiffecontext.WithX509(ctx, fakeX509Source{})
+			return spiffecontext.WithJWT(ctx, fakeJWTSource{})
+		})
+		res := resiliency.New(logger.NewLogger("grpc.api.test"))
+		res.SetComponentContextDecorator(sec.WithSVIDContext)
+
+		captured := stateRoundTrip(t, t.Context(), res)
+
+		captured.mu.Lock()
+		defer captured.mu.Unlock()
+
+		require.NotNil(t, captured.setCtx, "Set was not called")
+		_, ok := spiffecontext.X509From(captured.setCtx)
+		assert.True(t, ok, "Set context should carry the X.509 SVID source")
+		_, ok = spiffecontext.JWTFrom(captured.setCtx)
+		assert.True(t, ok, "Set context should carry the JWT SVID source")
+
+		require.NotNil(t, captured.getCtx, "Get was not called")
+		_, ok = spiffecontext.X509From(captured.getCtx)
+		assert.True(t, ok, "Get context should carry the X.509 SVID source")
+		_, ok = spiffecontext.JWTFrom(captured.getCtx)
+		assert.True(t, ok, "Get context should carry the JWT SVID source")
+	})
+
+	t.Run("no sources when the provider has no decorator", func(t *testing.T) {
+		// Without a decorator (e.g. mTLS/SPIFFE disabled) component contexts are
+		// left untouched, confirming the injection comes specifically from the
+		// wiring above and nothing leaks in by default.
+		res := resiliency.New(logger.NewLogger("grpc.api.test"))
+
+		captured := stateRoundTrip(t, t.Context(), res)
+
+		captured.mu.Lock()
+		defer captured.mu.Unlock()
+
+		require.NotNil(t, captured.setCtx, "Set was not called")
+		_, ok := spiffecontext.X509From(captured.setCtx)
+		assert.False(t, ok, "Set context must not carry an X.509 SVID source")
+		_, ok = spiffecontext.JWTFrom(captured.setCtx)
+		assert.False(t, ok, "Set context must not carry a JWT SVID source")
+	})
+}

--- a/pkg/resiliency/component_context_test.go
+++ b/pkg/resiliency/component_context_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resiliency
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type svidCtxKey struct{}
+
+// markSVID mimics security.Handler.WithSVIDContext: it attaches a value to the
+// context that components would read (e.g. the X.509/JWT SVID source).
+func markSVID(ctx context.Context) context.Context {
+	return context.WithValue(ctx, svidCtxKey{}, "svid-source")
+}
+
+func hasSVID(ctx context.Context) bool {
+	return ctx.Value(svidCtxKey{}) != nil
+}
+
+func TestComponentContextDecorator_AppliedForComponentPolicies(t *testing.T) {
+	r := New(testLog)
+	r.SetComponentContextDecorator(markSVID)
+
+	tests := map[string]*PolicyDefinition{
+		"outbound": r.ComponentOutboundPolicy("mystore", Statestore),
+		"inbound":  r.ComponentInboundPolicy("mypubsub", Pubsub),
+	}
+
+	for name, def := range tests {
+		t.Run(name, func(t *testing.T) {
+			// The decorator must be applied to the context the operation sees.
+			runner := NewRunner[bool](context.Background(), def)
+			seen, err := runner(func(ctx context.Context) (bool, error) {
+				return hasSVID(ctx), nil
+			})
+			assert.NoError(t, err)
+			assert.True(t, seen, "component operation context should carry the SVID source")
+
+			// ComponentContext is the same decoration used directly at non-runner
+			// seams (Subscribe/Read).
+			assert.True(t, hasSVID(def.ComponentContext(context.Background())))
+		})
+	}
+}
+
+func TestComponentContextDecorator_NotAppliedForNonComponentPolicies(t *testing.T) {
+	r := New(testLog)
+	r.addBuiltInPolicies()
+	r.SetComponentContextDecorator(markSVID)
+
+	// Non-component policies must never receive the component context decoration.
+	nonComponent := map[string]*PolicyDefinition{
+		"endpoint":     r.EndpointPolicy("myapp", "myapp"),
+		"actorPreLock": r.ActorPreLockPolicy("myactor", "id"),
+		"builtIn":      r.BuiltInPolicy(BuiltInServiceRetries),
+	}
+
+	for name, def := range nonComponent {
+		t.Run(name, func(t *testing.T) {
+			runner := NewRunner[bool](context.Background(), def)
+			seen, err := runner(func(ctx context.Context) (bool, error) {
+				return hasSVID(ctx), nil
+			})
+			assert.NoError(t, err)
+			assert.False(t, seen, "non-component operation context must not carry the SVID source")
+			assert.False(t, hasSVID(def.ComponentContext(context.Background())))
+		})
+	}
+}
+
+func TestComponentContextDecorator_NoOpWhenUnset(t *testing.T) {
+	// A provider without a decorator (the default) leaves component contexts
+	// untouched, preserving behaviour when mTLS/SPIFFE is disabled.
+	r := New(testLog)
+	def := r.ComponentOutboundPolicy("mystore", Statestore)
+
+	runner := NewRunner[bool](context.Background(), def)
+	seen, err := runner(func(ctx context.Context) (bool, error) {
+		return hasSVID(ctx), nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, seen)
+
+	// Nil receiver and nil fn are both safe.
+	assert.NotNil(t, def.ComponentContext(context.Background()))
+	var nilDef *PolicyDefinition
+	assert.NotNil(t, nilDef.ComponentContext(context.Background()))
+}

--- a/pkg/resiliency/component_context_test.go
+++ b/pkg/resiliency/component_context_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type svidCtxKey struct{}
@@ -48,7 +49,7 @@ func TestComponentContextDecorator_AppliedForComponentPolicies(t *testing.T) {
 			seen, err := runner(func(ctx context.Context) (bool, error) {
 				return hasSVID(ctx), nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.True(t, seen, "component operation context should carry the SVID source")
 
 			// ComponentContext is the same decoration used directly at non-runner
@@ -76,7 +77,7 @@ func TestComponentContextDecorator_NotAppliedForNonComponentPolicies(t *testing.
 			seen, err := runner(func(ctx context.Context) (bool, error) {
 				return hasSVID(ctx), nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.False(t, seen, "non-component operation context must not carry the SVID source")
 			assert.False(t, hasSVID(def.ComponentContext(context.Background())))
 		})
@@ -93,11 +94,9 @@ func TestComponentContextDecorator_NoOpWhenUnset(t *testing.T) {
 	seen, err := runner(func(ctx context.Context) (bool, error) {
 		return hasSVID(ctx), nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, seen)
 
-	// Nil receiver and nil fn are both safe.
+	// A nil decorator fn is safe: ComponentContext returns the context unchanged.
 	assert.NotNil(t, def.ComponentContext(context.Background()))
-	var nilDef *PolicyDefinition
-	assert.NotNil(t, nilDef.ComponentContext(context.Background()))
 }

--- a/pkg/resiliency/noop.go
+++ b/pkg/resiliency/noop.go
@@ -46,6 +46,11 @@ func (NoOp) ComponentOutboundPolicy(name string, componentName ComponentType) *P
 	return nil
 }
 
+// ComponentContextDecorator returns nil; NoOp never decorates component contexts.
+func (NoOp) ComponentContextDecorator() ComponentContextFn {
+	return nil
+}
+
 // BuiltInPolicy returns a NoOp policy definition for a built-in policy.
 func (NoOp) BuiltInPolicy(name BuiltInPolicyName) *PolicyDefinition {
 	return nil

--- a/pkg/resiliency/policy.go
+++ b/pkg/resiliency/policy.go
@@ -72,8 +72,8 @@ type PolicyDefinition struct {
 // its backing infrastructure; it is a no-op for every other policy. The Runner
 // applies this automatically, so call it directly only for component operations
 // that bypass the Runner (e.g. long-lived Subscribe/Read calls).
-func (p *PolicyDefinition) ComponentContext(ctx context.Context) context.Context {
-	if p == nil || p.componentCtxFn == nil {
+func (p PolicyDefinition) ComponentContext(ctx context.Context) context.Context {
+	if p.componentCtxFn == nil {
 		return ctx
 	}
 	return p.componentCtxFn(ctx)
@@ -121,11 +121,6 @@ func NewRunner[T any](ctx context.Context, def *PolicyDefinition) Runner[T] {
 
 // NewRunnerWithOptions is like NewRunner but allows setting additional options
 func NewRunnerWithOptions[T any](ctx context.Context, def *PolicyDefinition, opts RunnerOpts[T]) Runner[T] {
-	// For component policies this attaches the workload's SPIFFE identity to the
-	// context that every attempt (and the operation itself) derives from. It is
-	// a no-op for nil and non-component policies.
-	ctx = def.ComponentContext(ctx)
-
 	if def == nil {
 		return func(oper Operation[T]) (T, error) {
 			rRes, rErr := oper(ctx)
@@ -135,6 +130,11 @@ func NewRunnerWithOptions[T any](ctx context.Context, def *PolicyDefinition, opt
 			return rRes, rErr
 		}
 	}
+
+	// For component policies this attaches the workload's SPIFFE identity to the
+	// context that every attempt (and the operation itself) derives from. It is
+	// a no-op for non-component policies.
+	ctx = def.ComponentContext(ctx)
 
 	var zero T
 	timeoutMetricsActivated := atomic.Bool{}

--- a/pkg/resiliency/policy.go
+++ b/pkg/resiliency/policy.go
@@ -35,6 +35,12 @@ type (
 
 	// Runner represents a function to invoke `oper` with resiliency policies applied.
 	Runner[T any] func(oper Operation[T]) (T, error)
+
+	// ComponentContextFn decorates a context immediately before a component
+	// operation runs. Dapr uses it to attach the workload's SPIFFE identity
+	// (the X.509 and JWT SVID sources) to the context, so components can extract
+	// a credential to authenticate to their backing infrastructure service.
+	ComponentContextFn = func(context.Context) context.Context
 )
 
 type doneCh[T any] struct {
@@ -54,6 +60,23 @@ type PolicyDefinition struct {
 	addTimeoutActivatedMetric func()
 	addRetryActivatedMetric   func()
 	addCBStateChangedMetric   func()
+
+	// componentCtxFn decorates the operation context for component policies
+	// only. It is nil for all other policy kinds (service, actor, built-in).
+	componentCtxFn ComponentContextFn
+}
+
+// ComponentContext decorates ctx for this policy. For component policies (those
+// created by Resiliency.ComponentOutboundPolicy and ComponentInboundPolicy) it
+// attaches the workload's SPIFFE identity so the component can authenticate to
+// its backing infrastructure; it is a no-op for every other policy. The Runner
+// applies this automatically, so call it directly only for component operations
+// that bypass the Runner (e.g. long-lived Subscribe/Read calls).
+func (p *PolicyDefinition) ComponentContext(ctx context.Context) context.Context {
+	if p == nil || p.componentCtxFn == nil {
+		return ctx
+	}
+	return p.componentCtxFn(ctx)
 }
 
 // NewPolicyDefinition returns a PolicyDefinition object with the given parameters.
@@ -98,6 +121,11 @@ func NewRunner[T any](ctx context.Context, def *PolicyDefinition) Runner[T] {
 
 // NewRunnerWithOptions is like NewRunner but allows setting additional options
 func NewRunnerWithOptions[T any](ctx context.Context, def *PolicyDefinition, opts RunnerOpts[T]) Runner[T] {
+	// For component policies this attaches the workload's SPIFFE identity to the
+	// context that every attempt (and the operation itself) derives from. It is
+	// a no-op for nil and non-component policies.
+	ctx = def.ComponentContext(ctx)
+
 	if def == nil {
 		return func(oper Operation[T]) (T, error) {
 			rRes, rErr := oper(ctx)

--- a/pkg/resiliency/resiliency.go
+++ b/pkg/resiliency/resiliency.go
@@ -100,6 +100,11 @@ type (
 		ComponentOutboundPolicy(name string, componentType ComponentType) *PolicyDefinition
 		// ComponentInboundPolicy returns the inbound policy for a component.
 		ComponentInboundPolicy(name string, componentType ComponentType) *PolicyDefinition
+		// ComponentContextDecorator returns the function that decorates the
+		// context of component operations (e.g. attaching the workload's SPIFFE
+		// identity), or nil if none is configured. Use it for component calls
+		// that bypass the policy Runner (e.g. long-lived Subscribe/Read calls).
+		ComponentContextDecorator() ComponentContextFn
 		// BuiltInPolicy are used to replace existing retries in Dapr which may not bind specifically to one of the above categories.
 		BuiltInPolicy(name BuiltInPolicyName) *PolicyDefinition
 		// PolicyDefined returns true if there's policy that applies to the target.
@@ -128,6 +133,11 @@ type (
 		apps       map[string]PolicyNames
 		actors     map[string]ActorPolicies
 		components map[string]ComponentPolicyNames
+
+		// componentCtxFn decorates the context of every component operation
+		// (outbound and inbound). Dapr wires this to attach the workload's
+		// SPIFFE identity. Nil leaves component contexts untouched.
+		componentCtxFn ComponentContextFn
 	}
 
 	// circuitBreakerInstances stores circuit breaker state for components
@@ -320,6 +330,24 @@ func New(log logger.Logger) *Resiliency {
 		actors:     make(map[string]ActorPolicies),
 		components: make(map[string]ComponentPolicyNames),
 	}
+}
+
+// SetComponentContextDecorator sets the function used to decorate the context
+// of component operations (both outbound and inbound). Dapr wires this to
+// attach the workload's SPIFFE identity so components can authenticate to their
+// backing infrastructure. It should be called once during startup, before the
+// provider is used to create runners.
+func (r *Resiliency) SetComponentContextDecorator(fn ComponentContextFn) {
+	r.componentCtxFn = fn
+}
+
+// ComponentContextDecorator returns the configured component context decorator,
+// or nil if none is set.
+func (r *Resiliency) ComponentContextDecorator() ComponentContextFn {
+	if r == nil {
+		return nil
+	}
+	return r.componentCtxFn
 }
 
 // DecodeConfiguration reads in a single resiliency configuration.
@@ -803,8 +831,9 @@ func (r *Resiliency) ActorPostLockPolicy(actorType string, id string) *PolicyDef
 // ComponentOutboundPolicy returns the outbound policy for a component.
 func (r *Resiliency) ComponentOutboundPolicy(name string, componentType ComponentType) *PolicyDefinition {
 	policyDef := &PolicyDefinition{
-		log:  r.log,
-		name: "component[" + name + "] output",
+		log:            r.log,
+		name:           "component[" + name + "] output",
+		componentCtxFn: r.componentCtxFn,
 	}
 	componentPolicies, ok := r.components[name]
 	if ok {
@@ -842,8 +871,9 @@ func (r *Resiliency) ComponentOutboundPolicy(name string, componentType Componen
 // ComponentInboundPolicy returns the inbound policy for a component.
 func (r *Resiliency) ComponentInboundPolicy(name string, componentType ComponentType) *PolicyDefinition {
 	policyDef := &PolicyDefinition{
-		log:  r.log,
-		name: "component[" + name + "] input",
+		log:            r.log,
+		name:           "component[" + name + "] input",
+		componentCtxFn: r.componentCtxFn,
 	}
 	componentPolicies, ok := r.components[name]
 	if ok {

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -316,6 +316,17 @@ func FromConfig(ctx context.Context, cfg *Config) (*DaprRuntime, error) {
 		}
 	}
 
+	// Attach the workload's SPIFFE identity to the context of every component
+	// operation. The resiliency runner is the common chokepoint for component
+	// outbound/inbound calls, so injecting here reaches each building-block
+	// component (state, pubsub, bindings, secrets, etc.) regardless of whether
+	// the call originated from an API request or a background loop. Components
+	// extract the X.509/JWT SVID source from the context to authenticate to
+	// their backing infrastructure service.
+	if resiliencyProvider != nil && cfg.Security != nil {
+		resiliencyProvider.SetComponentContextDecorator(cfg.Security.WithSVIDContext)
+	}
+
 	accessControlList, err := acl.ParseAccessControlSpec(
 		globalConfig.Spec.AccessControlSpec,
 		intc.appConnectionConfig.Protocol.IsHTTP(),

--- a/pkg/runtime/mcp/auth/auth.go
+++ b/pkg/runtime/mcp/auth/auth.go
@@ -67,6 +67,13 @@ func BuildHTTPClient(
 	secrets *compstore.ComponentStore,
 	jwt security.Handler,
 ) (*http.Client, error) {
+	// Attach the workload's SPIFFE identity to the setup context so the one-shot
+	// secret-store fetch below authenticates like every other component
+	// operation (the resiliency Runner does the same for request-path calls).
+	if jwt != nil {
+		setupCtx = jwt.WithSVIDContext(setupCtx)
+	}
+
 	transportHeaders, authCfg := HTTPTransportConfig(server)
 
 	// Build the resolved-header map (processor has already resolved secretKeyRef/envRef).

--- a/pkg/runtime/mcp/auth/auth.go
+++ b/pkg/runtime/mcp/auth/auth.go
@@ -70,6 +70,9 @@ func BuildHTTPClient(
 	// Attach the workload's SPIFFE identity to the setup context so the one-shot
 	// secret-store fetch below authenticates like every other component
 	// operation (the resiliency Runner does the same for request-path calls).
+	// This is distinct from the jwtRoundTripper SPIFFE handling below: that
+	// injects a JWT into requests *to the MCP server* (transport auth), whereas
+	// this lets the secret-store component authenticate to *its own* backend.
 	if jwt != nil {
 		setupCtx = jwt.WithSVIDContext(setupCtx)
 	}

--- a/pkg/runtime/processor/binding/input/input.go
+++ b/pkg/runtime/processor/binding/input/input.go
@@ -31,6 +31,12 @@ type Options struct {
 	Name    string
 	Binding bindings.InputBinding
 	Handler func(context.Context, string, []byte, map[string]string) ([]byte, error)
+
+	// DecorateContext, when set, decorates the long-lived read-loop context
+	// before Read is invoked on the binding. Dapr uses it to attach the
+	// workload's SPIFFE identity so the binding can authenticate to its backing
+	// infrastructure service.
+	DecorateContext func(context.Context) context.Context
 }
 
 type Input struct {
@@ -46,6 +52,10 @@ type Input struct {
 
 func Run(opts Options) (*Input, error) {
 	ctx, cancel := context.WithCancel(context.Background())
+
+	if opts.DecorateContext != nil {
+		ctx = opts.DecorateContext(ctx)
+	}
 
 	i := &Input{
 		name:    opts.Name,

--- a/pkg/runtime/processor/binding/send.go
+++ b/pkg/runtime/processor/binding/send.go
@@ -121,6 +121,10 @@ func (b *binding) startInputBinding(comp componentsV1alpha1.Component, binding b
 		Name:    comp.Name,
 		Binding: binding,
 		Handler: b.sendBindingEventToApp,
+		// Read runs the binding directly on a long-lived loop rather than through
+		// a policy Runner, so decorate its context with the workload's SPIFFE
+		// identity just as the Runner does for other component operations.
+		DecorateContext: b.resiliency.ComponentContextDecorator(),
 	})
 	if err != nil {
 		log.Errorf("error reading from input binding %s: %s", comp.Name, err)

--- a/pkg/runtime/pubsub/outbox.go
+++ b/pkg/runtime/pubsub/outbox.go
@@ -59,6 +59,12 @@ type outboxImpl struct {
 	outboxStores          map[string]outboxConfig
 	lock                  sync.RWMutex
 	namespace             string
+
+	// componentCtxFn decorates the context used for the internal outbox
+	// subscription and its state operations. Dapr wires this to attach the
+	// workload's SPIFFE identity so the pubsub and state components can
+	// authenticate to their backing infrastructure service.
+	componentCtxFn func(context.Context) context.Context
 }
 
 type OptionsOutbox struct {
@@ -67,6 +73,7 @@ type OptionsOutbox struct {
 	GetStateFn            func(string) (state.Store, bool)
 	CloudEventExtractorFn func(map[string]any, string) string
 	Namespace             string
+	ComponentContextFn    func(context.Context) context.Context
 }
 
 // NewOutbox returns an instance of an Outbox.
@@ -78,7 +85,17 @@ func NewOutbox(opts OptionsOutbox) outbox.Outbox {
 		publisher:             opts.Publisher,
 		outboxStores:          make(map[string]outboxConfig),
 		namespace:             opts.Namespace,
+		componentCtxFn:        opts.ComponentContextFn,
 	}
+}
+
+// componentContext decorates ctx with the workload's SPIFFE identity for
+// component operations. It is a no-op when no decorator is configured.
+func (o *outboxImpl) componentContext(ctx context.Context) context.Context {
+	if o.componentCtxFn == nil {
+		return ctx
+	}
+	return o.componentCtxFn(ctx)
 }
 
 // AddOrUpdateOutbox examines a statestore for outbox properties and saves it for later usage in outbox operations.
@@ -265,9 +282,14 @@ func (o *outboxImpl) SubscribeToInternalTopics(ctx context.Context, appID string
 			continue
 		}
 
-		outboxPubsub.Subscribe(ctx, contribPubsub.SubscribeRequest{
+		outboxPubsub.Subscribe(o.componentContext(ctx), contribPubsub.SubscribeRequest{
 			Topic: outboxTopic(appID, c.publishTopic, o.namespace),
 		}, func(ctx context.Context, msg *contribPubsub.NewMessage) error {
+			// The per-message context originates from the pubsub component, so
+			// re-attach the workload's SPIFFE identity for the state operations
+			// (Get/Delete) this handler performs directly.
+			ctx = o.componentContext(ctx)
+
 			var cloudEvent map[string]any
 
 			err := json.Unmarshal(msg.Data, &cloudEvent)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -243,12 +243,16 @@ func newDaprRuntime(ctx context.Context,
 	pubsubAdapterStreamer := streamer.New(ctx, streamer.Options{
 		TracingSpec: globalConfig.Spec.TracingSpec,
 	})
+	// The outbox subscribes to its internal topic and performs state operations
+	// outside the resiliency Runner, so give it the SPIFFE identity decorator
+	// directly. Mirrors what the Runner does for other component operations.
 	outbox := pubsub.NewOutbox(pubsub.OptionsOutbox{
 		Publisher:             pubsubAdapter,
 		GetPubsubFn:           compStore.GetPubSubComponent,
 		GetStateFn:            compStore.GetStateStore,
 		CloudEventExtractorFn: pubsub.ExtractCloudEventProperty,
 		Namespace:             namespace,
+		ComponentContextFn:    resiliencyProvider.ComponentContextDecorator(),
 	})
 
 	actors := actors.New(actors.Options{

--- a/pkg/runtime/subscription/bulksubscription.go
+++ b/pkg/runtime/subscription/bulksubscription.go
@@ -213,6 +213,11 @@ func (s *Subscription) bulkSubscribeTopic(ctx context.Context, policyDef *resili
 		return bulkResponses, err
 	}
 
+	// BulkSubscribe establishes the consumer connection directly (it does not run
+	// through a policy Runner), so attach the workload's SPIFFE identity to its
+	// context here just as the Runner does for other component operations.
+	ctx = policyDef.ComponentContext(ctx)
+
 	if bulkSubscriber, ok := s.pubsub.Component.(contribpubsub.BulkSubscriber); ok {
 		return bulkSubscriber.BulkSubscribe(ctx, req, bulkHandler)
 	}

--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -142,7 +142,10 @@ func New(opts Options) (*Subscription, error) {
 		subscribeTopic = s.namespace + s.topic
 	}
 
-	err := s.pubsub.Component.Subscribe(ctx, contribpubsub.SubscribeRequest{
+	// Subscribe establishes the consumer connection directly (it does not run
+	// through a policy Runner), so attach the workload's SPIFFE identity to its
+	// context here just as the Runner does for other component operations.
+	err := s.pubsub.Component.Subscribe(policyDef.ComponentContext(ctx), contribpubsub.SubscribeRequest{
 		Topic:    subscribeTopic,
 		Metadata: routeMetadata,
 	}, func(ctx context.Context, msg *contribpubsub.NewMessage) error {

--- a/pkg/security/fake/fake.go
+++ b/pkg/security/fake/fake.go
@@ -46,6 +46,7 @@ type Fake struct {
 	grpcServerOptionMTLSFn             func() grpc.ServerOption
 	grpcServerOptionNoClientAuthFn     func() grpc.ServerOption
 	fetchJWTFn                         func(context.Context, string) (string, error)
+	withSVIDContextFn                  func(context.Context) context.Context
 }
 
 func New() *Fake {
@@ -89,6 +90,9 @@ func New() *Fake {
 		},
 		netDialerIDFn: func(context.Context, spiffeid.ID, time.Duration) func(network, addr string) (net.Conn, error) {
 			return net.Dial
+		},
+		withSVIDContextFn: func(ctx context.Context) context.Context {
+			return ctx
 		},
 		mtls: false,
 	}
@@ -213,8 +217,13 @@ func (f *Fake) WatchTrustAnchors(ctx context.Context, ch chan<- []byte) {
 	f.watchTrustAnchorsFn(ctx, ch)
 }
 
+func (f *Fake) WithSVIDContextFn(fn func(context.Context) context.Context) *Fake {
+	f.withSVIDContextFn = fn
+	return f
+}
+
 func (f *Fake) WithSVIDContext(ctx context.Context) context.Context {
-	return ctx
+	return f.withSVIDContextFn(ctx)
 }
 
 func (f *Fake) IdentityDir() *string {

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -41,6 +41,10 @@ var buildTags = []string{
 	"crypto_localstorage",
 	"middleware_http_routeralias",
 	"conversation_echo",
+	// state_spiffeprobe compiles in an integration-test-only state store that
+	// reports whether the SPIFFE identity reached the component operation
+	// context. Never set for released daprd flavors.
+	"state_spiffeprobe",
 }
 
 func BuildAll(t *testing.T) {

--- a/tests/integration/suite/daprd/mtls/standalone/svidcontext.go
+++ b/tests/integration/suite/daprd/mtls/standalone/svidcontext.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package standalone
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(svidcontext))
+}
+
+// svidcontext validates end-to-end, through the real daprd binary, that the
+// runtime injects the workload's SPIFFE identity (X.509 and JWT SVID sources)
+// into the context of building-block component operations.
+//
+// It relies on the `state.spiffeprobe` state store, an integration-only
+// component compiled into the test daprd via the `state_spiffeprobe` build tag
+// (see tests/integration/framework/binary and cmd/daprd/components), whose Get
+// reports which SVID sources were present in its operation context. We drive it
+// through the normal state API so the request travels the real path:
+// gRPC server -> universal API -> resiliency runner -> component.
+type svidcontext struct {
+	mtlsDaprd  *daprd.Daprd
+	plainDaprd *daprd.Daprd
+	sentry     *sentry.Sentry
+	placement  *placement.Placement
+	scheduler  *scheduler.Scheduler
+}
+
+const spiffeProbeComponent = `apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: spiffeprobe-store
+spec:
+  type: state.spiffeprobe
+  version: v1
+`
+
+func (s *svidcontext) Setup(t *testing.T) []framework.Option {
+	s.sentry = sentry.New(t)
+	bundle := s.sentry.CABundle()
+
+	taFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(taFile, bundle.X509.TrustAnchors, 0o600))
+
+	s.scheduler = scheduler.New(t,
+		scheduler.WithSentry(s.sentry),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+
+	s.placement = placement.New(t,
+		placement.WithEnableTLS(true),
+		placement.WithTrustAnchorsFile(taFile),
+		placement.WithSentryAddress(s.sentry.Address()),
+	)
+
+	// mTLS enabled: the workload has a SPIFFE identity, so component operations
+	// should carry the X.509 and JWT SVID sources.
+	s.mtlsDaprd = daprd.New(t,
+		daprd.WithAppID("mtls-app"),
+		daprd.WithMode("standalone"),
+		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(bundle.X509.TrustAnchors))),
+		daprd.WithSentryAddress(s.sentry.Address()),
+		daprd.WithPlacementAddresses(s.placement.Address()),
+		daprd.WithSchedulerAddresses(s.scheduler.Address()),
+		daprd.WithEnableMTLS(true),
+		daprd.WithResourceFiles(spiffeProbeComponent),
+	)
+
+	// mTLS disabled: WithSVIDContext is a no-op, so component operations must not
+	// carry any SVID source. This is the negative control proving the positive
+	// assertion is not vacuous.
+	s.plainDaprd = daprd.New(t,
+		daprd.WithAppID("plain-app"),
+		daprd.WithResourceFiles(spiffeProbeComponent),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.sentry, s.placement, s.scheduler, s.mtlsDaprd, s.plainDaprd),
+	}
+}
+
+func (s *svidcontext) Run(t *testing.T, ctx context.Context) {
+	s.sentry.WaitUntilRunning(t, ctx)
+	s.placement.WaitUntilRunning(t, ctx)
+	s.scheduler.WaitUntilRunning(t, ctx)
+	s.mtlsDaprd.WaitUntilRunning(t, ctx)
+	s.plainDaprd.WaitUntilRunning(t, ctx)
+
+	// probe reads back which SVID sources the component saw in its Get context.
+	probe := func(t *testing.T, d *daprd.Daprd) map[string]bool {
+		t.Helper()
+		resp, err := d.GRPCClient(t, ctx).GetState(ctx, &rtv1.GetStateRequest{
+			StoreName: "spiffeprobe-store",
+			Key:       "svid",
+		})
+		require.NoError(t, err)
+		var got map[string]bool
+		require.NoError(t, json.Unmarshal(resp.GetData(), &got))
+		return got
+	}
+
+	t.Run("with mTLS the component sees the SVID sources", func(t *testing.T) {
+		got := probe(t, s.mtlsDaprd)
+		assert.True(t, got["x509"], "X.509 SVID source should be in the component operation context")
+		assert.True(t, got["jwt"], "JWT SVID source should be in the component operation context")
+	})
+
+	t.Run("without mTLS the component sees no SVID sources", func(t *testing.T) {
+		got := probe(t, s.plainDaprd)
+		assert.False(t, got["x509"], "X.509 SVID source should be absent when mTLS is disabled")
+		assert.False(t, got["jwt"], "JWT SVID source should be absent when mTLS is disabled")
+	})
+}


### PR DESCRIPTION
Signed-off-by: Joni Collinge <joni@diagrid.io>

# Description
Currently the spiffe source that can provide access to the x509 or JWT credential is not propagatede into component operations and thus we rely on the component explicitlity caching the source in the `init` method and then using it. This means currently that most components cannot use the spiffe source and those that do are having to handle repeatative code to leverage it.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
