### PR TITLE
MCPServer: fix re-reconcile every 60s

### DIFF
--- a/cmd/daprd/app/app.go
+++ b/cmd/daprd/app/app.go
@@ -172,6 +172,7 @@ func runWithContext(ctx context.Context, opts *options.Options) error {
 				AppID:                         opts.AppID,
 				ActorsService:                 opts.ActorsService,
 				ActorsDisseminationTimeout:    opts.ActorsDisseminationTimeout,
+				HotReloadReconcileInterval:    opts.HotReloadReconcileInterval,
 				RemindersService:              opts.RemindersService,
 				SchedulerAddress:              opts.SchedulerAddress,
 				SchedulerStreams:              opts.SchedulerJobStreams,

--- a/cmd/daprd/options/options.go
+++ b/cmd/daprd/options/options.go
@@ -68,6 +68,7 @@ type Options struct {
 	DaprBlockShutdownDuration     *time.Duration
 	ActorsService                 string
 	ActorsDisseminationTimeout    time.Duration
+	HotReloadReconcileInterval    time.Duration
 	RemindersService              string
 	SchedulerAddress              []string
 	SchedulerJobStreams           uint
@@ -178,6 +179,7 @@ func New(origArgs []string) (*Options, error) {
 	fs.StringSliceVar(&opts.SchedulerAddress, "scheduler-host-address", nil, "Addresses of the Scheduler service instance(s), as comma separated host:port pairs")
 	fs.UintVar(&opts.SchedulerJobStreams, "scheduler-job-streams", 3, "The number of active job streams to connect to the Scheduler service")
 	fs.DurationVar(&opts.ActorsDisseminationTimeout, "actors-disseminate-timeout", runtime.DefaultActorsDisseminationTimeout, "Timeout for the daprd-side actor placement dissemination round; if exceeded, daprd resets its placement stream and halts hosted actors. Should be greater than the placement service --disseminate-timeout (default 8s).")
+	fs.DurationVar(&opts.HotReloadReconcileInterval, "hot-reload-reconcile-interval", 0, "Period of the hot-reload backup reconcile that lists resources and reconciles any the event watch missed, e.g. '30s'. Zero uses the default (60s)")
 
 	// DEPRECATED.
 	fs.StringVar(&opts.RemindersService, "reminders-service", "", "Type and address of the reminders service, in the format 'type:address'")

--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -2,6 +2,7 @@
 
 This update contains the following bug fixes:
 - [SPIFFE SVID component operation propagation](#spiffe-svid-component-operation-propagation)
+- [MCPServers with secret-referenced credentials reload every 60 seconds](#mcpservers-with-secret-referenced-credentials-reload-every-60-seconds)
 
 ## SPIFFE SVID component operation propagation
 
@@ -20,3 +21,25 @@ The SPIFFE SVID source was attached only to the component's `init` method contex
 ### Solution
 
 The SPIFFE SVID source is now attached to the context passed into operation calls, allowing components to use the SPIFFE ID for authentication on a per-operation basis.
+
+## MCPServers with secret-referenced credentials reload every 60 seconds
+
+### Problem
+
+An MCPServer whose transport credentials come from a secret (a `secretKeyRef` or `envRef` in `spec.endpoint.streamableHTTP.headers`, `spec.endpoint.sse.headers`, or `spec.endpoint.stdio.env`) was closed and reloaded roughly every 60 seconds, even when nothing about the resource had changed.
+
+### Impact
+
+You were affected if you ran one or more MCPServers whose headers or stdio environment referenced a secret.
+Plain MCPServers with no secret references were not affected.
+
+### Root Cause
+
+Alongside the event-driven watch, the hot-reload reconciler runs a periodic backup reconcile (about every 60 seconds) that lists resources from the control plane and compares them against the copy the sidecar currently has loaded.
+The loaded copy has its secret references resolved to their values, but the incoming copy was compared without resolving its secret references first.
+For any secret-backed MCPServer the resolved value never matched the unresolved reference, so the comparison always reported a difference and the server was reloaded on every cycle.
+
+### Solution
+
+The MCPServer reconciler now resolves the incoming resource's secret references before comparing it against the loaded copy, matching the behavior already used for components.
+An unchanged secret-backed MCPServer now compares equal and is left running, while a genuine change, including a rotated secret value, still triggers a reload.

--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -33,6 +33,9 @@ An MCPServer whose transport credentials come from a secret (a `secretKeyRef` or
 You were affected if you ran one or more MCPServers whose headers or stdio environment referenced a secret.
 Plain MCPServers with no secret references were not affected.
 
+Note: auth.oauth2.secretKeyRef is not affected.
+The OAuth2 client secret is fetched at connection time and never written into the spec, so it never took part in the comparison and did not churn.
+
 ### Root Cause
 
 Alongside the event-driven watch, the hot-reload reconciler runs a periodic backup reconcile (about every 60 seconds) that lists resources from the control plane and compares them against the copy the sidecar currently has loaded.

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -136,6 +136,9 @@ type Config struct {
 	Healthz                       healthz.Healthz
 	WorkflowEventSink             orchestrator.EventSink
 	DisableInitEndpoints          []string
+	// HotReloadReconcileInterval overrides the hot-reload backup reconcile
+	// period. Zero uses the reconciler default (60s).
+	HotReloadReconcileInterval time.Duration
 }
 
 type internalConfig struct {
@@ -175,6 +178,7 @@ type internalConfig struct {
 	outboundHealthz              healthz.Healthz
 	workflowEventSink            orchestrator.EventSink
 	disableInitEndpoints         []string
+	hotReloadReconcileInterval   time.Duration
 }
 
 func (i internalConfig) SchedulerEnabled() bool {
@@ -373,6 +377,7 @@ func (c *Config) toInternal() (*internalConfig, error) {
 		blockShutdownDuration:      c.DaprBlockShutdownDuration,
 		actorsService:              c.ActorsService,
 		actorsDisseminationTimeout: c.ActorsDisseminationTimeout,
+		hotReloadReconcileInterval: c.HotReloadReconcileInterval,
 		remindersService:           c.RemindersService,
 		schedulerAddress:           c.SchedulerAddress,
 		schedulerStreams:           c.SchedulerStreams,

--- a/pkg/runtime/hotreload/hotreload.go
+++ b/pkg/runtime/hotreload/hotreload.go
@@ -15,6 +15,7 @@ package hotreload
 
 import (
 	"context"
+	"time"
 
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
@@ -47,6 +48,9 @@ type OptionsReloaderDisk struct {
 	Authorizer     *authorizer.Authorizer
 	Processor      *processor.Processor
 	Healthz        healthz.Healthz
+	// ReconcileInterval overrides the backup reconcile period. Zero uses the
+	// reconciler default (60s).
+	ReconcileInterval time.Duration
 }
 
 type OptionsReloaderOperator struct {
@@ -57,6 +61,9 @@ type OptionsReloaderOperator struct {
 	Authorizer     *authorizer.Authorizer
 	Processor      *processor.Processor
 	Healthz        healthz.Healthz
+	// ReconcileInterval overrides the backup reconcile period. Zero uses the
+	// reconciler default (60s).
+	ReconcileInterval time.Duration
 }
 
 type Reloader struct {
@@ -96,25 +103,28 @@ func NewDisk(opts OptionsReloaderDisk) (*Reloader, error) {
 		isEnabled: isEnabled,
 		loader:    loader,
 		componentsReconciler: reconciler.NewComponents(reconciler.Options[compapi.Component]{
-			Loader:     loader,
-			CompStore:  opts.ComponentStore,
-			Processor:  opts.Processor,
-			Authorizer: opts.Authorizer,
-			Healthz:    opts.Healthz,
+			Loader:            loader,
+			CompStore:         opts.ComponentStore,
+			Processor:         opts.Processor,
+			Authorizer:        opts.Authorizer,
+			Healthz:           opts.Healthz,
+			ReconcileInterval: opts.ReconcileInterval,
 		}),
 		subscriptionsReconciler: reconciler.NewSubscriptions(reconciler.Options[subapi.Subscription]{
-			Loader:     loader,
-			CompStore:  opts.ComponentStore,
-			Processor:  opts.Processor,
-			Authorizer: opts.Authorizer,
-			Healthz:    opts.Healthz,
+			Loader:            loader,
+			CompStore:         opts.ComponentStore,
+			Processor:         opts.Processor,
+			Authorizer:        opts.Authorizer,
+			Healthz:           opts.Healthz,
+			ReconcileInterval: opts.ReconcileInterval,
 		}),
 		mcpServersReconciler: reconciler.NewMCPServers(reconciler.Options[mcpserverapi.MCPServer]{
-			Loader:     loader,
-			CompStore:  opts.ComponentStore,
-			Processor:  opts.Processor,
-			Authorizer: opts.Authorizer,
-			Healthz:    opts.Healthz,
+			Loader:            loader,
+			CompStore:         opts.ComponentStore,
+			Processor:         opts.Processor,
+			Authorizer:        opts.Authorizer,
+			Healthz:           opts.Healthz,
+			ReconcileInterval: opts.ReconcileInterval,
 		}),
 		configurationsReconciler: reconciler.NewSIGHUPConfigurations(reconciler.Options[configapi.Configuration]{
 			Loader:    loader,
@@ -151,25 +161,28 @@ func NewOperator(opts OptionsReloaderOperator) *Reloader {
 		isEnabled: isEnabled,
 		loader:    loader,
 		componentsReconciler: reconciler.NewComponents(reconciler.Options[compapi.Component]{
-			Loader:     loader,
-			CompStore:  opts.ComponentStore,
-			Processor:  opts.Processor,
-			Authorizer: opts.Authorizer,
-			Healthz:    opts.Healthz,
+			Loader:            loader,
+			CompStore:         opts.ComponentStore,
+			Processor:         opts.Processor,
+			Authorizer:        opts.Authorizer,
+			Healthz:           opts.Healthz,
+			ReconcileInterval: opts.ReconcileInterval,
 		}),
 		subscriptionsReconciler: reconciler.NewSubscriptions(reconciler.Options[subapi.Subscription]{
-			Loader:     loader,
-			CompStore:  opts.ComponentStore,
-			Processor:  opts.Processor,
-			Authorizer: opts.Authorizer,
-			Healthz:    opts.Healthz,
+			Loader:            loader,
+			CompStore:         opts.ComponentStore,
+			Processor:         opts.Processor,
+			Authorizer:        opts.Authorizer,
+			Healthz:           opts.Healthz,
+			ReconcileInterval: opts.ReconcileInterval,
 		}),
 		mcpServersReconciler: reconciler.NewMCPServers(reconciler.Options[mcpserverapi.MCPServer]{
-			Loader:     loader,
-			CompStore:  opts.ComponentStore,
-			Processor:  opts.Processor,
-			Authorizer: opts.Authorizer,
-			Healthz:    opts.Healthz,
+			Loader:            loader,
+			CompStore:         opts.ComponentStore,
+			Processor:         opts.Processor,
+			Authorizer:        opts.Authorizer,
+			Healthz:           opts.Healthz,
+			ReconcileInterval: opts.ReconcileInterval,
 		}),
 		configurationsReconciler: reconciler.NewSIGHUPConfigurations(reconciler.Options[configapi.Configuration]{
 			Loader:    loader,

--- a/pkg/runtime/hotreload/reconciler/mcpserver.go
+++ b/pkg/runtime/hotreload/reconciler/mcpserver.go
@@ -31,10 +31,6 @@ type mcpservers struct {
 	loader.Loader[mcpserverapi.MCPServer]
 }
 
-// The go linter does not yet understand that these functions are being used by
-// the generic reconciler.
-//
-//nolint:unused
 func (m *mcpservers) update(ctx context.Context, server mcpserverapi.MCPServer) {
 	if !m.auth.IsObjectAuthorized(server) {
 		log.Warnf("Received unauthorized MCPServer update, ignored: %s", server.LogName())
@@ -47,7 +43,21 @@ func (m *mcpservers) update(ctx context.Context, server mcpserverapi.MCPServer) 
 	// failing add silently; a valid update would re-call
 	// wfengine.EnsureActorsRegistered, leaking per-name workflow registrations.
 	if existing, ok := m.store.GetMCPServer(server.Name); ok {
-		if differ.AreSame(existing, server) {
+		// Resolve the incoming spec's secretKeyRef/envRef values before
+		// comparing. The stored copy was resolved when it was loaded
+		// (ProcessMCPServerSecrets), so comparing it against the raw incoming
+		// spec would always differ for a secret-ref header and reload on every
+		// reconcile tick. Comparing resolved-vs-resolved skips a genuine no-op
+		// while still reloading on a real secret rotation (same secretKeyRef, new
+		// value). Mirrors the Component reconciler (see components.go).
+		//
+		// Resolve a copy, not server itself: the raw spec must reach
+		// AddPendingMCPServer below so the processor resolves it exactly once on
+		// reload (resolving in place would have the processor decode an
+		// already-decoded value).
+		resolved := server.DeepCopy()
+		m.proc.ProcessMCPServerSecrets(ctx, resolved)
+		if differ.AreSame(existing, *resolved) {
 			log.Debugf("MCPServer update skipped: no changes detected: %s", server.LogName())
 			return
 		}
@@ -59,6 +69,9 @@ func (m *mcpservers) update(ctx context.Context, server mcpserverapi.MCPServer) 
 	m.proc.AddPendingMCPServer(ctx, server)
 }
 
+// The go linter does not understand that delete is used by the generic
+// reconciler via the manager interface.
+//
 //nolint:unused
 func (m *mcpservers) delete(ctx context.Context, server mcpserverapi.MCPServer) {
 	log.Infof("MCPServer deleted via hot-reload: %s", server.LogName())

--- a/pkg/runtime/hotreload/reconciler/mcpserver_test.go
+++ b/pkg/runtime/hotreload/reconciler/mcpserver_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
+	mcpserverapi "github.com/dapr/dapr/pkg/apis/mcpserver/v1alpha1"
+	"github.com/dapr/dapr/pkg/config"
+	"github.com/dapr/dapr/pkg/modes"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/authorizer"
+	"github.com/dapr/dapr/pkg/runtime/channels"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/dapr/pkg/runtime/hotreload/differ"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+	rtmock "github.com/dapr/dapr/pkg/runtime/mock"
+	"github.com/dapr/dapr/pkg/runtime/processor"
+	"github.com/dapr/dapr/pkg/runtime/registry"
+	securityfake "github.com/dapr/dapr/pkg/security/fake"
+)
+
+const mcpSecretStoreName = "mysecretstore"
+
+// mcpServerSecretRef builds an MCPServer whose Authorization header resolves
+// from a secretKeyRef in the mock secret store (key1 -> "value1"). When value is
+// non-empty it is set as the (already-resolved) header value, modelling the copy
+// stored in compstore after load.
+func mcpServerSecretRef(value string) mcpserverapi.MCPServer {
+	storeName := mcpSecretStoreName
+	header := commonapi.NameValuePair{
+		Name:         "Authorization",
+		SecretKeyRef: commonapi.SecretKeyRef{Name: "mysecret", Key: "key1"},
+	}
+	if value != "" {
+		header.Value = commonapi.DynamicValue{JSON: apiextv1.JSON{Raw: []byte(value)}}
+	}
+	return mcpserverapi.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "weather-mcp"},
+		Spec: mcpserverapi.MCPServerSpec{
+			IgnoreErrors: true,
+			Endpoint: mcpserverapi.MCPEndpoint{
+				StreamableHTTP: &mcpserverapi.MCPStreamableHTTP{
+					URL:     "http://example.com/mcp",
+					Auth:    &mcpserverapi.MCPAuth{SecretStore: &storeName},
+					Headers: []commonapi.NameValuePair{header},
+				},
+			},
+		},
+	}
+}
+
+func newMCPGuardManager(t *testing.T) (*mcpservers, *processor.Processor, *compstore.ComponentStore) {
+	t.Helper()
+
+	cs := compstore.New()
+	cs.AddSecretStore(mcpSecretStoreName, rtmock.NewMockKubernetesStore())
+
+	reg := registry.New(registry.NewOptions())
+	proc := processor.New(processor.Options{
+		ID:             "id",
+		Namespace:      "test",
+		Registry:       reg,
+		ComponentStore: cs,
+		Meta:           meta.New(meta.Options{ID: "id", Namespace: "test", Mode: modes.StandaloneMode}),
+		Resiliency:     resiliency.New(log),
+		Mode:           modes.StandaloneMode,
+		Channels:       new(channels.Channels),
+		GlobalConfig:   new(config.Configuration),
+		Security:       securityfake.New(),
+		Reporter:       reg.Reporter(),
+	})
+
+	m := &mcpservers{
+		store: cs,
+		proc:  proc,
+		auth:  authorizer.New(authorizer.Options{ID: "id"}),
+	}
+	return m, proc, cs
+}
+
+// Test_mcpservers_update_resolvesIncomingBeforeCompare verifies the hot-reload
+// guard: the incoming spec's secrets are resolved (on a copy) before comparing
+// against the already-resolved stored copy, so an unchanged secret-ref server is
+// not reloaded while a rotated secret value still is. This is what stops the
+// backup reconcile from churning secret-backed MCPServers every tick.
+func Test_mcpservers_update_resolvesIncomingBeforeCompare(t *testing.T) {
+	t.Run("unchanged secret-ref server is not reloaded", func(t *testing.T) {
+		m, proc, cs := newMCPGuardManager(t)
+		ctx := t.Context()
+
+		// Stored copy is the resolved form, as written on load.
+		stored := mcpServerSecretRef("")
+		proc.ProcessMCPServerSecrets(ctx, &stored)
+		require.True(t, stored.Spec.Endpoint.StreamableHTTP.Headers[0].HasValue())
+		cs.AddMCPServer(stored)
+
+		// Reconcile delivers the raw operator-form spec (secretKeyRef, no value).
+		// The guard resolves a copy, finds it equal, and skips. Without the guard
+		// update would delete the server and block on AddPendingMCPServer.
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			m.update(ctx, mcpServerSecretRef(""))
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second * 10):
+			t.Fatal("update did not return: the no-op was treated as a reload")
+		}
+
+		got, ok := cs.GetMCPServer("weather-mcp")
+		require.True(t, ok)
+		assert.True(t, differ.AreSame(stored, got), "secret-ref server must be left untouched")
+	})
+
+	t.Run("rotated secret value triggers a reload", func(t *testing.T) {
+		m, proc, cs := newMCPGuardManager(t)
+		ctx, cancel := context.WithCancel(t.Context())
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- proc.Process(ctx) }()
+		t.Cleanup(func() {
+			cancel()
+			select {
+			case <-errCh:
+			case <-time.After(time.Second * 5):
+				t.Error("processor did not return in time")
+			}
+		})
+
+		// Stored copy holds a stale resolved value; the live secret is "value1".
+		cs.AddMCPServer(mcpServerSecretRef("stalevalue"))
+
+		m.update(ctx, mcpServerSecretRef(""))
+
+		// The guard resolves the incoming spec to "value1", sees it differs from
+		// the stale stored value, and reloads: the processor re-stores "value1".
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			got, ok := cs.GetMCPServer("weather-mcp")
+			assert.True(c, ok)
+			if ok {
+				assert.Equal(c, "value1", got.Spec.Endpoint.StreamableHTTP.Headers[0].Value.String())
+			}
+		}, time.Second*10, time.Millisecond*50)
+	})
+}

--- a/pkg/runtime/hotreload/reconciler/reconciler.go
+++ b/pkg/runtime/hotreload/reconciler/reconciler.go
@@ -41,21 +41,36 @@ var (
 	loopFactory = loop.New[Event](16)
 )
 
+// defaultReconcileInterval is the period of the backup reconcile that lists all
+// resources and diffs them against the loaded set, catching anything the
+// event-driven watch missed. Configurable via Options.ReconcileInterval, mainly
+// so integration tests can exercise the reconcile deterministically.
+const defaultReconcileInterval = time.Second * 60
+
 type Options[T differ.Resource] struct {
-	Loader     loader.Interface
-	CompStore  *compstore.ComponentStore
-	Processor  *processor.Processor
-	Authorizer *authorizer.Authorizer
-	Healthz    healthz.Healthz
+	Loader            loader.Interface
+	CompStore         *compstore.ComponentStore
+	Processor         *processor.Processor
+	Authorizer        *authorizer.Authorizer
+	Healthz           healthz.Healthz
+	ReconcileInterval time.Duration
 }
 
 type Reconciler[T differ.Resource] struct {
-	kind    string
-	manager manager[T]
-	htarget healthz.Target
+	kind     string
+	manager  manager[T]
+	htarget  healthz.Target
+	interval time.Duration
 
 	clock clock.WithTicker
 	loop  loop.Interface[Event]
+}
+
+func reconcileIntervalOrDefault(d time.Duration) time.Duration {
+	if d <= 0 {
+		return defaultReconcileInterval
+	}
+	return d
 }
 
 type manager[T differ.Resource] interface {
@@ -66,9 +81,10 @@ type manager[T differ.Resource] interface {
 
 func NewComponents(opts Options[compapi.Component]) *Reconciler[compapi.Component] {
 	r := &Reconciler[compapi.Component]{
-		kind:    compapi.Kind,
-		htarget: opts.Healthz.AddTarget("component-reconciler"),
-		clock:   clock.RealClock{},
+		kind:     compapi.Kind,
+		htarget:  opts.Healthz.AddTarget("component-reconciler"),
+		interval: opts.ReconcileInterval,
+		clock:    clock.RealClock{},
 		manager: &components{
 			Loader: opts.Loader.Components(),
 			store:  opts.CompStore,
@@ -82,9 +98,10 @@ func NewComponents(opts Options[compapi.Component]) *Reconciler[compapi.Componen
 
 func NewMCPServers(opts Options[mcpserverapi.MCPServer]) *Reconciler[mcpserverapi.MCPServer] {
 	r := &Reconciler[mcpserverapi.MCPServer]{
-		kind:    mcpserverapi.Kind,
-		htarget: opts.Healthz.AddTarget("mcpserver-reconciler"),
-		clock:   clock.RealClock{},
+		kind:     mcpserverapi.Kind,
+		htarget:  opts.Healthz.AddTarget("mcpserver-reconciler"),
+		interval: opts.ReconcileInterval,
+		clock:    clock.RealClock{},
 		manager: &mcpservers{
 			Loader: opts.Loader.MCPServers(),
 			store:  opts.CompStore,
@@ -98,9 +115,10 @@ func NewMCPServers(opts Options[mcpserverapi.MCPServer]) *Reconciler[mcpserverap
 
 func NewSubscriptions(opts Options[subapi.Subscription]) *Reconciler[subapi.Subscription] {
 	r := &Reconciler[subapi.Subscription]{
-		kind:    subapi.Kind,
-		htarget: opts.Healthz.AddTarget("subscription-reconciler"),
-		clock:   clock.RealClock{},
+		kind:     subapi.Kind,
+		htarget:  opts.Healthz.AddTarget("subscription-reconciler"),
+		interval: opts.ReconcileInterval,
+		clock:    clock.RealClock{},
 		manager: &subscriptions{
 			Loader: opts.Loader.Subscriptions(),
 			store:  opts.CompStore,
@@ -136,7 +154,7 @@ func (r *Reconciler[T]) Run(ctx context.Context) error {
 }
 
 func (r *Reconciler[T]) watchTicker(ctx context.Context) error {
-	ticker := r.clock.NewTicker(time.Second * 60)
+	ticker := r.clock.NewTicker(reconcileIntervalOrDefault(r.interval))
 	defer ticker.Stop()
 
 	for {

--- a/pkg/runtime/processor/mcpservers.go
+++ b/pkg/runtime/processor/mcpservers.go
@@ -144,6 +144,10 @@ func (p *Processor) DeleteMCPServer(serverName string) {
 // internally and resolves what it can; it does not return an error. Unresolvable
 // secretKeyRef values remain as empty strings.
 //
+// This does NOT resolve auth.oauth2.secretKeyRef: the OAuth2 client secret is
+// fetched at connection time by the MCP worker (see pkg/runtime/mcp/auth) and is
+// never written into the spec, so it does not take part in the hot-reload diff.
+//
 // The hot-reload reconciler also calls this on a copy of an incoming spec before
 // comparing it against the already-resolved stored copy, so an unchanged
 // secret-ref server is not needlessly reloaded while a rotated secret value

--- a/pkg/runtime/processor/mcpservers.go
+++ b/pkg/runtime/processor/mcpservers.go
@@ -81,7 +81,7 @@ func (p *Processor) processMCPServers(ctx context.Context) error {
 			return nil
 		}
 
-		p.processMCPServerSecrets(ctx, &s)
+		p.ProcessMCPServerSecrets(ctx, &s)
 
 		select {
 		case <-ctx.Done():
@@ -135,14 +135,19 @@ func (p *Processor) DeleteMCPServer(serverName string) {
 	}
 }
 
-// processMCPServerSecrets resolves secretKeyRef and envRef entries in the
+// ProcessMCPServerSecrets resolves secretKeyRef and envRef entries in the
 // transport headers (spec.endpoint.streamableHTTP.headers or spec.endpoint.sse.headers)
 // and spec.endpoint.stdio.env using the configured secret store.
 // Unlike components, MCPServer resources load after all secret store components are initialized,
 // so secrets are available immediately.
 // ProcessResource logs errors internally and resolves what it can; it does not
 // return an error. Unresolvable secretKeyRef values remain as empty strings.
-func (p *Processor) processMCPServerSecrets(ctx context.Context, s *mcpserverapi.MCPServer) {
+//
+// The hot-reload reconciler also calls this on a copy of an incoming spec before
+// comparing it against the already-resolved stored copy, so an unchanged
+// secret-ref server is not needlessly reloaded while a rotated secret value
+// still triggers a reload.
+func (p *Processor) ProcessMCPServerSecrets(ctx context.Context, s *mcpserverapi.MCPServer) {
 	// Resolve transport headers (envRef + secretKeyRef).
 	p.secret.ProcessResource(ctx, s)
 

--- a/pkg/runtime/processor/mcpservers.go
+++ b/pkg/runtime/processor/mcpservers.go
@@ -140,8 +140,9 @@ func (p *Processor) DeleteMCPServer(serverName string) {
 // and spec.endpoint.stdio.env using the configured secret store.
 // Unlike components, MCPServer resources load after all secret store components are initialized,
 // so secrets are available immediately.
-// ProcessResource logs errors internally and resolves what it can; it does not
-// return an error. Unresolvable secretKeyRef values remain as empty strings.
+// The underlying p.secret.ProcessResource (the secret manager) logs errors
+// internally and resolves what it can; it does not return an error. Unresolvable
+// secretKeyRef values remain as empty strings.
 //
 // The hot-reload reconciler also calls this on a copy of an incoming spec before
 // comparing it against the already-resolved stored copy, so an unchanged

--- a/pkg/runtime/processor/mcpservers_test.go
+++ b/pkg/runtime/processor/mcpservers_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package processor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/components-contrib/secretstores"
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	mcpserverapi "github.com/dapr/dapr/pkg/apis/mcpserver/v1alpha1"
+	rtmock "github.com/dapr/dapr/pkg/runtime/mock"
+	"github.com/dapr/kit/logger"
+)
+
+// TestProcessMCPServerResolvesSecrets verifies that loading a secret-backed
+// MCPServer resolves its secretKeyRef header into the stored copy. The
+// hot-reload reconciler relies on this: it resolves an incoming spec the same
+// way (ProcessMCPServerSecrets) before comparing it against this stored copy, so
+// an unchanged secret-ref server is not reloaded on every reconcile tick.
+func TestProcessMCPServerResolvesSecrets(t *testing.T) {
+	proc, reg := newTestProc()
+
+	reg.SecretStores().RegisterComponent(
+		func(_ logger.Logger) secretstores.SecretStore {
+			return rtmock.NewMockKubernetesStore()
+		},
+		"kubernetesMock",
+	)
+
+	require.NoError(t, proc.processComponentAndDependents(t.Context(), componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysecretstore"},
+		Spec: componentsapi.ComponentSpec{
+			Type:    "secretstores.kubernetesMock",
+			Version: "v1",
+		},
+	}))
+
+	storeName := "mysecretstore"
+	server := mcpserverapi.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "weather-mcp", Namespace: "test"},
+		Spec: mcpserverapi.MCPServerSpec{
+			IgnoreErrors: true,
+			Endpoint: mcpserverapi.MCPEndpoint{
+				StreamableHTTP: &mcpserverapi.MCPStreamableHTTP{
+					URL:  "http://example.com/mcp",
+					Auth: &mcpserverapi.MCPAuth{SecretStore: &storeName},
+					Headers: []commonapi.NameValuePair{{
+						Name:         "Authorization",
+						SecretKeyRef: commonapi.SecretKeyRef{Name: "mysecret", Key: "key1"},
+					}},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error)
+	go func() { errCh <- proc.Process(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "timeout waiting for processor to return")
+		}
+	})
+
+	require.True(t, proc.AddPendingMCPServer(ctx, server))
+
+	var stored mcpserverapi.MCPServer
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		s, ok := proc.compStore.GetMCPServer("weather-mcp")
+		assert.True(c, ok)
+		stored = s
+	}, 5*time.Second, 10*time.Millisecond)
+
+	storedHeader := stored.Spec.Endpoint.StreamableHTTP.Headers[0]
+	assert.True(t, storedHeader.HasValue(), "stored MCPServer header must carry the resolved secret value")
+	assert.Equal(t, "value1", storedHeader.Value.String())
+	// secretKeyRef is retained so the reconciler can re-resolve the incoming spec.
+	assert.Equal(t, "mysecret", storedHeader.SecretKeyRef.Name)
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -302,23 +302,25 @@ func newDaprRuntime(ctx context.Context,
 	switch runtimeConfig.mode {
 	case modes.KubernetesMode:
 		reloader = hotreload.NewOperator(hotreload.OptionsReloaderOperator{
-			Namespace:      namespace,
-			Client:         operatorClient,
-			Config:         globalConfig,
-			ComponentStore: compStore,
-			Authorizer:     authz,
-			Processor:      processor,
-			Healthz:        runtimeConfig.healthz,
+			Namespace:         namespace,
+			Client:            operatorClient,
+			Config:            globalConfig,
+			ComponentStore:    compStore,
+			Authorizer:        authz,
+			Processor:         processor,
+			Healthz:           runtimeConfig.healthz,
+			ReconcileInterval: runtimeConfig.hotReloadReconcileInterval,
 		})
 	case modes.StandaloneMode:
 		reloader, err = hotreload.NewDisk(hotreload.OptionsReloaderDisk{
-			Config:         globalConfig,
-			Dirs:           runtimeConfig.standalone.ResourcesPath,
-			ComponentStore: compStore,
-			Authorizer:     authz,
-			Processor:      processor,
-			AppID:          runtimeConfig.id,
-			Healthz:        runtimeConfig.healthz,
+			Config:            globalConfig,
+			Dirs:              runtimeConfig.standalone.ResourcesPath,
+			ComponentStore:    compStore,
+			Authorizer:        authz,
+			Processor:         processor,
+			AppID:             runtimeConfig.id,
+			Healthz:           runtimeConfig.healthz,
+			ReconcileInterval: runtimeConfig.hotReloadReconcileInterval,
 		})
 		if err != nil {
 			return nil, err

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -155,6 +155,9 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	if opts.actorsDisseminateTimeout != nil {
 		args = append(args, "--actors-disseminate-timeout="+opts.actorsDisseminateTimeout.String())
 	}
+	if opts.hotReloadReconcileInterval != nil {
+		args = append(args, "--hot-reload-reconcile-interval="+opts.hotReloadReconcileInterval.String())
+	}
 	if len(opts.schedulerAddresses) > 0 {
 		args = append(args, "--scheduler-host-address="+strings.Join(opts.schedulerAddresses, ","))
 	}

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -38,39 +38,40 @@ type Option func(*options)
 type options struct {
 	execOpts []exec.Option
 
-	appID                     string
-	namespace                 *string
-	appPort                   *int
-	grpcPort                  int
-	httpPort                  int
-	internalGRPCPort          int
-	publicPort                int
-	metricsPort               int
-	profilePort               int
-	appProtocol               string
-	appHealthCheck            bool
-	appHealthCheckPath        string
-	appHealthProbeInterval    int
-	appHealthProbeThreshold   int
-	resourceFiles             []string
-	resourceDirs              []string
-	configs                   []string
-	placementAddresses        []string
-	logLevel                  string
-	mode                      string
-	enableMTLS                bool
-	sentryAddress             string
-	sentryRequestJwtAudiences []string
-	controlPlaneAddress       string
-	disableK8sSecretStore     *bool
-	gracefulShutdownSeconds   *int
-	blockShutdownDuration     *string
-	actorsDisseminateTimeout  *time.Duration
-	controlPlaneTrustDomain   *string
-	schedulerAddresses        []string
-	disableInitEndpoints      []string
-	maxBodySize               *string
-	allowedOrigins            *string
+	appID                      string
+	namespace                  *string
+	appPort                    *int
+	grpcPort                   int
+	httpPort                   int
+	internalGRPCPort           int
+	publicPort                 int
+	metricsPort                int
+	profilePort                int
+	appProtocol                string
+	appHealthCheck             bool
+	appHealthCheckPath         string
+	appHealthProbeInterval     int
+	appHealthProbeThreshold    int
+	resourceFiles              []string
+	resourceDirs               []string
+	configs                    []string
+	placementAddresses         []string
+	logLevel                   string
+	mode                       string
+	enableMTLS                 bool
+	sentryAddress              string
+	sentryRequestJwtAudiences  []string
+	controlPlaneAddress        string
+	disableK8sSecretStore      *bool
+	gracefulShutdownSeconds    *int
+	blockShutdownDuration      *string
+	actorsDisseminateTimeout   *time.Duration
+	hotReloadReconcileInterval *time.Duration
+	controlPlaneTrustDomain    *string
+	schedulerAddresses         []string
+	disableInitEndpoints       []string
+	maxBodySize                *string
+	allowedOrigins             *string
 }
 
 func WithExecOptions(execOptions ...exec.Option) Option {
@@ -322,6 +323,12 @@ func WithDaprBlockShutdownDuration(duration string) Option {
 func WithActorsDisseminateTimeout(timeout time.Duration) Option {
 	return func(o *options) {
 		o.actorsDisseminateTimeout = &timeout
+	}
+}
+
+func WithHotReloadReconcileInterval(interval time.Duration) Option {
+	return func(o *options) {
+		o.hotReloadReconcileInterval = &interval
 	}
 }
 

--- a/tests/integration/suite/daprd/hotreload/operator/mcpserverchurn.go
+++ b/tests/integration/suite/daprd/hotreload/operator/mcpserverchurn.go
@@ -43,13 +43,12 @@ func init() {
 
 // mcpserverchurn is a regression test for the 60s hot-reload churn of
 // secret-backed MCPServers. The operator resolves a secretKeyRef header into a
-// base64+JSON value; daprd decodes it to plaintext to use the connection. The
-// copy daprd keeps in compstore must remain the operator (encoded) form,
-// otherwise every reconcile diffs the locally decoded value against the
-// operator's encoded value and reloads the server. This test drives the same
-// differ.AreSame(stored, operatorForm) comparison the 60s reconcile uses by
-// re-sending an identical UPDATE event: with the fix daprd reports the update as
-// a no-op; without it daprd closes and reloads the server.
+// base64+JSON value; daprd decodes it to plaintext when loading, so the copy in
+// compstore holds the resolved value. The fix resolves the incoming spec the
+// same way before diffing, so an unchanged secret-backed server compares equal
+// instead of stored-plaintext vs incoming-encoded. This test drives that
+// comparison by re-sending an identical UPDATE event: with the fix daprd reports
+// the update as a no-op; without it daprd closes and reloads the server.
 type mcpserverchurn struct {
 	daprd    *daprd.Daprd
 	operator *operator.Operator
@@ -127,7 +126,7 @@ func (m *mcpserverchurn) Run(t *testing.T, ctx context.Context) {
 		assert.Len(c, servers, 1)
 	}, 10*time.Second, 10*time.Millisecond)
 
-	// Re-send the identical (operator-form) resource. This is the same
+	// Re-send the identical resource. This is the same
 	// comparison the periodic reconcile performs. With the fix the stored copy
 	// equals this resource and the update is a no-op.
 	m.operator.MCPServerUpdateEvent(t, ctx, &operator.MCPServerUpdateEvent{

--- a/tests/integration/suite/daprd/hotreload/operator/mcpserverchurn.go
+++ b/tests/integration/suite/daprd/hotreload/operator/mcpserverchurn.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
+	mcpserverapi "github.com/dapr/dapr/pkg/apis/mcpserver/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(mcpserverchurn))
+}
+
+// mcpserverchurn is a regression test for the 60s hot-reload churn of
+// secret-backed MCPServers. The operator resolves a secretKeyRef header into a
+// base64+JSON value; daprd decodes it to plaintext to use the connection. The
+// copy daprd keeps in compstore must remain the operator (encoded) form,
+// otherwise every reconcile diffs the locally decoded value against the
+// operator's encoded value and reloads the server. This test drives the same
+// differ.AreSame(stored, operatorForm) comparison the 60s reconcile uses by
+// re-sending an identical UPDATE event: with the fix daprd reports the update as
+// a no-op; without it daprd closes and reloads the server.
+type mcpserverchurn struct {
+	daprd    *daprd.Daprd
+	operator *operator.Operator
+	logline  *logline.LogLine
+}
+
+func (m *mcpserverchurn) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t)
+
+	m.logline = logline.New(t, logline.WithStdoutLineContains(
+		"MCPServer update skipped: no changes detected",
+	))
+
+	m.operator = operator.New(t,
+		operator.WithSentry(sentry),
+	)
+
+	m.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithLogLevel("debug"),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(m.operator.Address(t)),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithExecOptions(
+			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors)),
+			exec.WithStdout(m.logline.Stdout()),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, m.operator, m.logline, m.daprd),
+	}
+}
+
+func (m *mcpserverchurn) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	// Operator form of a secret-backed MCPServer: the Authorization header
+	// carries a secretKeyRef plus the value the operator resolved for it, i.e.
+	// a base64-encoded secret wrapped as a JSON string (see
+	// pkg/operator/api/components.go getSecret). daprd in kubernetes mode
+	// base64-decodes this inline value when loading the server.
+	encoded, err := json.Marshal(base64.StdEncoding.EncodeToString([]byte("supersecret")))
+	require.NoError(t, err)
+
+	server := mcpserverapi.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "weather-mcp", Namespace: "default"},
+		Spec: mcpserverapi.MCPServerSpec{
+			// example.com is never dialed: no in-process workflow engine is wired
+			// up here, so the connection is skipped. IgnoreErrors keeps daprd up.
+			IgnoreErrors: true,
+			Endpoint: mcpserverapi.MCPEndpoint{
+				StreamableHTTP: &mcpserverapi.MCPStreamableHTTP{
+					URL: "http://example.com/mcp",
+					Headers: []commonapi.NameValuePair{{
+						Name:         "Authorization",
+						SecretKeyRef: commonapi.SecretKeyRef{Name: "weather-secret", Key: "token"},
+						Value:        commonapi.DynamicValue{JSON: apiextv1.JSON{Raw: encoded}},
+					}},
+				},
+			},
+		},
+	}
+
+	m.operator.AddMCPServers(server)
+	m.operator.MCPServerUpdateEvent(t, ctx, &operator.MCPServerUpdateEvent{
+		MCPServer: &server,
+		EventType: operatorv1.ResourceEventType_CREATED,
+	})
+
+	// Wait until the server is loaded into compstore before re-sending it, so
+	// the second event hits the existing-resource comparison path.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		servers := m.daprd.GetMetaMCPServers(c, ctx)
+		assert.Len(c, servers, 1)
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Re-send the identical (operator-form) resource. This is the same
+	// comparison the periodic reconcile performs. With the fix the stored copy
+	// equals this resource and the update is a no-op.
+	m.operator.MCPServerUpdateEvent(t, ctx, &operator.MCPServerUpdateEvent{
+		MCPServer: &server,
+		EventType: operatorv1.ResourceEventType_UPDATED,
+	})
+
+	m.logline.EventuallyFoundAll(t)
+}

--- a/tests/integration/suite/daprd/hotreload/operator/mcpserverreconcile.go
+++ b/tests/integration/suite/daprd/hotreload/operator/mcpserverreconcile.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
+	mcpserverapi "github.com/dapr/dapr/pkg/apis/mcpserver/v1alpha1"
+	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/operator"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(mcpserverreconcile))
+}
+
+// mcpserverreconcile is a regression test for the 60s hot-reload churn driven by
+// the backup reconciler: the periodic reconcile lists all MCPServers from the
+// operator and diffs them against the copy daprd holds in compstore. Using the
+// --hot-reload-reconcile-interval flag the interval is shortened to 1s (the
+// default is 60s) so the reconcile is exercised deterministically, mirroring the
+// operator's --cache-sync-period test pattern. With the churn fix the stored
+// copy keeps the operator (encoded) form, so each reconcile is a no-op; without
+// it the reconcile reloads the server on every tick.
+type mcpserverreconcile struct {
+	daprd    *daprd.Daprd
+	operator *operator.Operator
+	daprdLog *log.Log
+}
+
+func (m *mcpserverreconcile) Setup(t *testing.T) []framework.Option {
+	sentry := sentry.New(t)
+
+	m.daprdLog = log.New()
+
+	m.operator = operator.New(t,
+		operator.WithSentry(sentry),
+	)
+
+	m.daprd = daprd.New(t,
+		daprd.WithMode("kubernetes"),
+		daprd.WithLogLevel("debug"),
+		daprd.WithHotReloadReconcileInterval(time.Second),
+		daprd.WithSentryAddress(sentry.Address()),
+		daprd.WithControlPlaneAddress(m.operator.Address(t)),
+		daprd.WithDisableK8sSecretStore(true),
+		daprd.WithExecOptions(
+			exec.WithEnvVars(t, "DAPR_TRUST_ANCHORS", string(sentry.CABundle().X509.TrustAnchors)),
+			exec.WithStdout(m.daprdLog),
+			exec.WithStderr(m.daprdLog),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(sentry, m.operator, m.daprd),
+	}
+}
+
+func (m *mcpserverreconcile) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	// Operator form of a secret-backed MCPServer: the Authorization header
+	// carries a secretKeyRef plus the value the operator resolved for it (a
+	// base64-encoded secret wrapped as a JSON string). daprd base64-decodes this
+	// inline value when loading the server.
+	encoded, err := json.Marshal(base64.StdEncoding.EncodeToString([]byte("supersecret")))
+	require.NoError(t, err)
+
+	server := mcpserverapi.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "weather-mcp", Namespace: "default"},
+		Spec: mcpserverapi.MCPServerSpec{
+			IgnoreErrors: true,
+			Endpoint: mcpserverapi.MCPEndpoint{
+				StreamableHTTP: &mcpserverapi.MCPStreamableHTTP{
+					URL: "http://example.com/mcp",
+					Headers: []commonapi.NameValuePair{{
+						Name:         "Authorization",
+						SecretKeyRef: commonapi.SecretKeyRef{Name: "weather-secret", Key: "token"},
+						Value:        commonapi.DynamicValue{JSON: apiextv1.JSON{Raw: encoded}},
+					}},
+				},
+			},
+		},
+	}
+
+	// AddMCPServers makes the resource visible to the backup reconcile's
+	// ListMCPServers; the event loads it into compstore initially.
+	m.operator.AddMCPServers(server)
+	m.operator.MCPServerUpdateEvent(t, ctx, &operator.MCPServerUpdateEvent{
+		MCPServer: &server,
+		EventType: operatorv1.ResourceEventType_CREATED,
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		servers := m.daprd.GetMetaMCPServers(c, ctx)
+		assert.Len(c, servers, 1)
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Confirm the backup reconcile actually runs in the window (interval is 1s),
+	// so the assert.Never below is meaningful and not vacuous.
+	require.Eventually(t, func() bool {
+		return m.daprdLog.Contains("Running scheduled MCPServer reconcile")
+	}, 10*time.Second, 10*time.Millisecond, "backup reconcile did not run")
+
+	// Over several reconcile cycles the secret-backed server must never be
+	// reloaded: the stored operator-form copy equals what ListMCPServers returns.
+	assert.Never(t, func() bool {
+		return m.daprdLog.Contains("Closing existing MCPServer to reload")
+	}, 10*time.Second, 100*time.Millisecond,
+		"secret-backed MCPServer was reloaded by the backup reconciler (churn)")
+}

--- a/tests/integration/suite/daprd/hotreload/operator/mcpserverreconcile.go
+++ b/tests/integration/suite/daprd/hotreload/operator/mcpserverreconcile.go
@@ -46,9 +46,10 @@ func init() {
 // operator and diffs them against the copy daprd holds in compstore. Using the
 // --hot-reload-reconcile-interval flag the interval is shortened to 1s (the
 // default is 60s) so the reconcile is exercised deterministically, mirroring the
-// operator's --cache-sync-period test pattern. With the churn fix the stored
-// copy keeps the operator (encoded) form, so each reconcile is a no-op; without
-// it the reconcile reloads the server on every tick.
+// operator's --cache-sync-period test pattern. daprd decodes the operator's
+// secret value to plaintext on load; the fix resolves the incoming spec the same
+// way before diffing, so each reconcile of an unchanged server is a no-op.
+// Without it the reconcile reloads the server on every tick.
 type mcpserverreconcile struct {
 	daprd    *daprd.Daprd
 	operator *operator.Operator
@@ -130,7 +131,8 @@ func (m *mcpserverreconcile) Run(t *testing.T, ctx context.Context) {
 	}, 10*time.Second, 10*time.Millisecond, "backup reconcile did not run")
 
 	// Over several reconcile cycles the secret-backed server must never be
-	// reloaded: the stored operator-form copy equals what ListMCPServers returns.
+	// reloaded: resolving the incoming spec before diffing makes it equal to the
+	// stored resolved copy.
 	assert.Never(t, func() bool {
 		return m.daprdLog.Contains("Closing existing MCPServer to reload")
 	}, 10*time.Second, 100*time.Millisecond,


### PR DESCRIPTION
MCPServers with secret-referenced credentials reload every 60 seconds

Problem

An MCPServer whose transport credentials come from a secret (a `secretKeyRef` or `envRef` in `spec.endpoint.streamableHTTP.headers`, `spec.endpoint.sse.headers`, or `spec.endpoint.stdio.env`) was closed and reloaded roughly every 60 seconds, even when nothing about the resource had changed.

Impact

You were affected if you ran one or more MCPServers whose headers or stdio environment referenced a secret. Plain MCPServers with no secret references were not affected.
Note: auth.oauth2.secretKeyRef is not affected.
The OAuth2 client secret is fetched at connection time and never written into the spec, so it never took part in the comparison and did not churn.

Root Cause

Alongside the event-driven watch, the hot-reload reconciler runs a periodic backup reconcile (about every 60 seconds) that lists resources from the control plane and compares them against the copy the sidecar currently has loaded. The loaded copy has its secret references resolved to their values, but the incoming copy was compared without resolving its secret references first. For any secret-backed MCPServer the resolved value never matched the unresolved reference, so the comparison always reported a difference and the server was reloaded on every cycle.

Solution

The MCPServer reconciler now resolves the incoming resource's secret references before comparing it against the loaded copy, matching the behavior already used for components. An unchanged secret-backed MCPServer now compares equal and is left running, while a genuine change, including a rotated secret value, still triggers a reload.