### PR TITLE
scheduler: allow special characters in actor reminder and job names

### DIFF
--- a/docs/release_notes/v1.16.15.md
+++ b/docs/release_notes/v1.16.15.md
@@ -1,0 +1,38 @@
+# Dapr 1.16.15
+
+This update contains the following bug fix:
+- [Actor reminders and jobs fail to register when their name or actor ID contains characters such as `|` or `@`](#actor-reminders-and-jobs-fail-to-register-when-their-name-or-actor-id-contains-characters-such-as--or-)
+
+## Actor reminders and jobs fail to register when their name or actor ID contains characters such as `|` or `@`
+
+### Problem
+
+Registering an actor reminder through the Scheduler service failed when the reminder name, or the actor ID it belongs to, contained certain characters such as the pipe `|` or at sign `@`.
+The same characters are accepted when invoking actors and when saving actor state, so an actor that worked everywhere else could not have a reminder created for it.
+
+The error returned in this case was also misleading:
+
+```
+a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+```
+
+It claimed only lowercase names were allowed even though uppercase names are in fact accepted, and it did not describe which characters were actually rejected.
+
+### Impact
+
+You were affected if you used Scheduler-backed actor reminders (the default since 1.15) and your reminder names, actor IDs, or scheduled job names contained characters outside the strict DNS-1123 set, for example `|`, `@`, or uppercase letters.
+
+### Root Cause
+
+The Scheduler composes each reminder or job into a single name of the form `actorreminder||<namespace>||<type>||<id>||<name>` (or `app||<namespace>||<appID>||<name>` for jobs), using `||` as an internal delimiter.
+Each `||`-delimited segment was then validated against Kubernetes' DNS-1123 subdomain rules, which only permit lowercase alphanumeric characters, `-`, and `.`.
+This was far stricter than the character set Dapr already accepts at its API edge, producing the inconsistency between actor invocation and reminder registration.
+Because the validator lowercased each segment before checking it, uppercase names passed in practice while the surfaced error still referred to lowercase-only RFC 1123 subdomains.
+
+### Solution
+
+The Scheduler now validates names using the same policy Dapr applies at its API edge, so anything accepted for actor invocation can also be used for a reminder or job.
+Reminder names, job names, and actor identifiers may now contain any character except `/`, `\`, `#`, `?`, control characters (including the NUL byte), and the exact path sequences `.` and `..`.
+Uppercase letters and characters such as `|` and `@` are allowed, and `||` continues to be accepted within actor IDs and names.
+Listing reminders for actors whose IDs contain `||` now also reports the correct actor metadata.
+Validation errors now describe the characters that are actually disallowed.

--- a/docs/release_notes/v1.17.11.md
+++ b/docs/release_notes/v1.17.11.md
@@ -1,0 +1,38 @@
+# Dapr 1.17.11
+
+This update contains the following bug fix:
+- [Actor reminders and jobs fail to register when their name or actor ID contains characters such as `|` or `@`](#actor-reminders-and-jobs-fail-to-register-when-their-name-or-actor-id-contains-characters-such-as--or-)
+
+## Actor reminders and jobs fail to register when their name or actor ID contains characters such as `|` or `@`
+
+### Problem
+
+Registering an actor reminder through the Scheduler service failed when the reminder name, or the actor ID it belongs to, contained certain characters such as the pipe `|` or at sign `@`.
+The same characters are accepted when invoking actors and when saving actor state, so an actor that worked everywhere else could not have a reminder created for it.
+
+The error returned in this case was also misleading:
+
+```
+a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+```
+
+It claimed only lowercase names were allowed even though uppercase names are in fact accepted, and it did not describe which characters were actually rejected.
+
+### Impact
+
+You were affected if you used Scheduler-backed actor reminders (the default since 1.15) and your reminder names, actor IDs, or scheduled job names contained characters outside the strict DNS-1123 set, for example `|`, `@`, or uppercase letters.
+
+### Root Cause
+
+The Scheduler composes each reminder or job into a single name of the form `actorreminder||<namespace>||<type>||<id>||<name>` (or `app||<namespace>||<appID>||<name>` for jobs), using `||` as an internal delimiter.
+Each `||`-delimited segment was then validated against Kubernetes' DNS-1123 subdomain rules, which only permit lowercase alphanumeric characters, `-`, and `.`.
+This was far stricter than the character set Dapr already accepts at its API edge, producing the inconsistency between actor invocation and reminder registration.
+Because the validator lowercased each segment before checking it, uppercase names passed in practice while the surfaced error still referred to lowercase-only RFC 1123 subdomains.
+
+### Solution
+
+The Scheduler now validates names using the same policy Dapr applies at its API edge, so anything accepted for actor invocation can also be used for a reminder or job.
+Reminder names, job names, and actor identifiers may now contain any character except `/`, `\`, `#`, `?`, control characters (including the NUL byte), and the exact path sequences `.` and `..`.
+Uppercase letters and characters such as `|` and `@` are allowed, and `||` continues to be accepted within actor IDs and names.
+Listing reminders for actors whose IDs contain `||` now also reports the correct actor metadata.
+Validation errors now describe the characters that are actually disallowed.

--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -3,6 +3,7 @@
 This update contains the following bug fixes:
 - [SPIFFE SVID component operation propagation](#spiffe-svid-component-operation-propagation)
 - [MCPServers with secret-referenced credentials reload every 60 seconds](#mcpservers-with-secret-referenced-credentials-reload-every-60-seconds)
+- [Actor reminders and jobs fail to register when their name or actor ID contains characters such as `|` or `@`](#actor-reminders-and-jobs-fail-to-register-when-their-name-or-actor-id-contains-characters-such-as--or-)
 
 ## SPIFFE SVID component operation propagation
 
@@ -46,3 +47,37 @@ For any secret-backed MCPServer the resolved value never matched the unresolved 
 
 The MCPServer reconciler now resolves the incoming resource's secret references before comparing it against the loaded copy, matching the behavior already used for components.
 An unchanged secret-backed MCPServer now compares equal and is left running, while a genuine change, including a rotated secret value, still triggers a reload.
+
+## Actor reminders and jobs fail to register when their name or actor ID contains characters such as `|` or `@`
+
+### Problem
+
+Registering an actor reminder through the Scheduler service failed when the reminder name, or the actor ID it belongs to, contained certain characters such as the pipe `|` or at sign `@`.
+The same characters are accepted when invoking actors and when saving actor state, so an actor that worked everywhere else could not have a reminder created for it.
+
+The error returned in this case was also misleading:
+
+```
+a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+```
+
+It claimed only lowercase names were allowed even though uppercase names are in fact accepted, and it did not describe which characters were actually rejected.
+
+### Impact
+
+You were affected if you used Scheduler-backed actor reminders (the default since 1.15) and your reminder names, actor IDs, or scheduled job names contained characters outside the strict DNS-1123 set, for example `|`, `@`, or uppercase letters.
+
+### Root Cause
+
+The Scheduler composes each reminder or job into a single name of the form `actorreminder||<namespace>||<type>||<id>||<name>` (or `app||<namespace>||<appID>||<name>` for jobs), using `||` as an internal delimiter.
+Each `||`-delimited segment was then validated against Kubernetes' DNS-1123 subdomain rules, which only permit lowercase alphanumeric characters, `-`, and `.`.
+This was far stricter than the character set Dapr already accepts at its API edge, producing the inconsistency between actor invocation and reminder registration.
+Because the validator lowercased each segment before checking it, uppercase names passed in practice while the surfaced error still referred to lowercase-only RFC 1123 subdomains.
+
+### Solution
+
+The Scheduler now validates names using the same policy Dapr applies at its API edge, so anything accepted for actor invocation can also be used for a reminder or job.
+Reminder names, job names, and actor identifiers may now contain any character except `/`, `\`, `#`, `?`, control characters (including the NUL byte), and the exact path sequences `.` and `..`.
+Uppercase letters and characters such as `|` and `@` are allowed, and `||` continues to be accepted within actor IDs and names.
+Listing reminders for actors whose IDs contain `||` now also reports the correct actor metadata.
+Validation errors now describe the characters that are actually disallowed.

--- a/go.mod
+++ b/go.mod
@@ -531,5 +531,10 @@ replace (
 // replace github.com/dapr/kit => ../kit
 // replace github.com/dapr/durabletask-go => ../durabletask-go
 //
+// Temporary local replace for testing the relaxed job name validator.
+// Remove and bump to a released go-etcd-cron version before merging.
+replace github.com/diagridio/go-etcd-cron => github.com/joshvanl/go-etcd-cron v0.0.0-20260622170753-d3925e25788a
+
+//
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dapr/components-contrib v1.18.0
 	github.com/dapr/durabletask-go v0.12.2-0.20260611114644-8a3fcf497ae0
 	github.com/dapr/kit v0.18.1
-	github.com/diagridio/go-etcd-cron v0.12.5
+	github.com/diagridio/go-etcd-cron v0.12.6
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/cors v1.2.1
@@ -530,11 +530,6 @@ replace (
 // replace github.com/dapr/components-contrib => ../components-contrib
 // replace github.com/dapr/kit => ../kit
 // replace github.com/dapr/durabletask-go => ../durabletask-go
-//
-// Temporary local replace for testing the relaxed job name validator.
-// Remove and bump to a released go-etcd-cron version before merging.
-replace github.com/diagridio/go-etcd-cron => github.com/joshvanl/go-etcd-cron v0.0.0-20260622170753-d3925e25788a
-
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/diagridio/go-etcd-cron v0.12.6 h1:8ruus+RCVLvmY0k/TQTLTW2voeSeQoxgpm89XhxXWzU=
+github.com/diagridio/go-etcd-cron v0.12.6/go.mod h1:Hj7WYwxoYBjV2sOc7ycOy/fZhFVHBetYSZ78C5PcoZc=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=
@@ -1101,8 +1103,6 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/joshvanl/go-etcd-cron v0.0.0-20260622170753-d3925e25788a h1:LWpexlaBJnX3tdlt76byspSuKISjSbX08ZjxfcbsEvg=
-github.com/joshvanl/go-etcd-cron v0.0.0-20260622170753-d3925e25788a/go.mod h1:Hj7WYwxoYBjV2sOc7ycOy/fZhFVHBetYSZ78C5PcoZc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/diagridio/go-etcd-cron v0.12.5 h1:3XQiCKgOqSJz2SjAKbXTqSSUpuqwuIRt3126AbGgE7E=
-github.com/diagridio/go-etcd-cron v0.12.5/go.mod h1:Hj7WYwxoYBjV2sOc7ycOy/fZhFVHBetYSZ78C5PcoZc=
 github.com/didip/tollbooth/v7 v7.0.1 h1:TkT4sBKoQoHQFPf7blQ54iHrZiTDnr8TceU+MulVAog=
 github.com/didip/tollbooth/v7 v7.0.1/go.mod h1:VZhDSGl5bDSPj4wPsih3PFa4Uh9Ghv8hgacaTm5PRT4=
 github.com/dimfeld/httptreemux v5.0.1+incompatible h1:Qj3gVcDNoOthBAqftuD596rm4wg/adLLz5xh5CmpiCA=
@@ -1103,6 +1101,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/go-etcd-cron v0.0.0-20260622170753-d3925e25788a h1:LWpexlaBJnX3tdlt76byspSuKISjSbX08ZjxfcbsEvg=
+github.com/joshvanl/go-etcd-cron v0.0.0-20260622170753-d3925e25788a/go.mod h1:Hj7WYwxoYBjV2sOc7ycOy/fZhFVHBetYSZ78C5PcoZc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/api/universal/jobs.go
+++ b/pkg/api/universal/jobs.go
@@ -16,7 +16,6 @@ package universal
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -71,7 +70,7 @@ func (a *Universal) scheduleJob(ctx context.Context, jobRequest *runtimev1pb.Sch
 		return &runtimev1pb.ScheduleJobResponse{}, apierrors.Empty("Job", errMetadata, errorcodes.SchedulerEmpty)
 	}
 
-	if job.GetName() == "" || strings.Contains(job.GetName(), "|") {
+	if job.GetName() == "" {
 		return &runtimev1pb.ScheduleJobResponse{}, apierrors.Empty("Name", errMetadata, errorcodes.SchedulerJobNameEmpty)
 	}
 

--- a/pkg/scheduler/server/api.go
+++ b/pkg/scheduler/server/api.go
@@ -169,6 +169,9 @@ func (s *Server) ListJobs(ctx context.Context, req *schedulerv1pb.ListJobsReques
 		}
 
 		composed := job.GetName()[strings.LastIndex(job.GetName(), "/")+1:]
+		if !strings.HasPrefix(composed, prefix) {
+			return nil, fmt.Errorf("job key %q does not match expected prefix %q from its metadata", job.GetName(), prefix)
+		}
 
 		j := job.GetJob()
 		jobs = append(jobs, &schedulerv1pb.NamedJob{

--- a/pkg/scheduler/server/api.go
+++ b/pkg/scheduler/server/api.go
@@ -149,15 +149,31 @@ func (s *Server) ListJobs(ctx context.Context, req *schedulerv1pb.ListJobsReques
 
 	jobs := make([]*schedulerv1pb.NamedJob, 0, len(list.GetJobs()))
 	for _, job := range list.GetJobs() {
-		meta, err := serialize.MetadataFromKey(job.GetName())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse job metadata: %w", err)
+		// Recover the metadata from the stored protobuf rather than re-parsing
+		// the job key. Re-splitting the key on "||" corrupts the namespace,
+		// actor type and id when any of those values themselves contain "||".
+		var meta schedulerv1pb.JobMetadata
+		if err := job.GetJob().GetMetadata().UnmarshalTo(&meta); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal job metadata: %w", err)
 		}
+
+		// Recover the reminder/job name by trimming the known key prefix built
+		// from the metadata. The cron key is "<etcdNamespace>/jobs/<composed>";
+		// names cannot contain '/', so the segment after the final '/' is the
+		// composed name. Trimming the metadata prefix off it then yields the
+		// reminder/job name unambiguously, even when the name or actor id
+		// contains "||".
+		prefix, err := serialize.PrefixFromMetadata(&meta)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build job key prefix: %w", err)
+		}
+
+		composed := job.GetName()[strings.LastIndex(job.GetName(), "/")+1:]
 
 		j := job.GetJob()
 		jobs = append(jobs, &schedulerv1pb.NamedJob{
-			Name:     job.GetName()[strings.LastIndex(job.GetName(), "||")+2:],
-			Metadata: meta,
+			Name:     strings.TrimPrefix(composed, prefix),
+			Metadata: &meta,
 			//nolint:protogetter
 			Job: &schedulerv1pb.Job{
 				Schedule:      j.Schedule,

--- a/pkg/scheduler/server/internal/serialize/names.go
+++ b/pkg/scheduler/server/internal/serialize/names.go
@@ -13,14 +13,6 @@ limitations under the License.
 
 package serialize
 
-import (
-	"fmt"
-	"path"
-	"strings"
-
-	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
-)
-
 // PrefixesFromNamespace returns key prefixes for all jobs types for a given
 // namespace.
 func PrefixesFromNamespace(namespace string) []string {
@@ -28,37 +20,4 @@ func PrefixesFromNamespace(namespace string) []string {
 		"actorreminder||" + namespace + "||",
 		"app||" + namespace + "||",
 	}
-}
-
-// MetadataFromKey returns the JobMetadata based on a raw job key.
-func MetadataFromKey(key string) (*schedulerv1pb.JobMetadata, error) {
-	seg := strings.Split(key, "||")
-
-	if len(seg) >= 5 && path.Base(seg[len(seg)-5]) == "actorreminder" {
-		seg = seg[len(seg)-4:]
-		return &schedulerv1pb.JobMetadata{
-			Namespace: seg[0],
-			Target: &schedulerv1pb.JobTargetMetadata{
-				Type: &schedulerv1pb.JobTargetMetadata_Actor{
-					Actor: &schedulerv1pb.TargetActorReminder{
-						Type: seg[1],
-						Id:   seg[2],
-					},
-				},
-			},
-		}, nil
-	}
-
-	if len(seg) >= 4 && path.Base(seg[len(seg)-4]) == "app" {
-		seg = seg[len(seg)-3:]
-		return &schedulerv1pb.JobMetadata{
-			Namespace: seg[0],
-			AppId:     seg[1],
-			Target: &schedulerv1pb.JobTargetMetadata{
-				Type: new(schedulerv1pb.JobTargetMetadata_Job),
-			},
-		}, nil
-	}
-
-	return nil, fmt.Errorf("invalid key: %s", key)
 }

--- a/pkg/scheduler/server/internal/serialize/names_test.go
+++ b/pkg/scheduler/server/internal/serialize/names_test.go
@@ -14,125 +14,113 @@ limitations under the License.
 package serialize
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/proto"
+	"github.com/stretchr/testify/require"
 
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 )
 
-func Test_MetadataFromKey(t *testing.T) {
+func actorMeta(namespace, actorType, actorID string) *schedulerv1pb.JobMetadata {
+	return &schedulerv1pb.JobMetadata{
+		Namespace: namespace,
+		Target: &schedulerv1pb.JobTargetMetadata{
+			Type: &schedulerv1pb.JobTargetMetadata_Actor{
+				Actor: &schedulerv1pb.TargetActorReminder{Type: actorType, Id: actorID},
+			},
+		},
+	}
+}
+
+func appMeta(namespace, appID string) *schedulerv1pb.JobMetadata {
+	return &schedulerv1pb.JobMetadata{
+		Namespace: namespace,
+		AppId:     appID,
+		Target:    &schedulerv1pb.JobTargetMetadata{Type: new(schedulerv1pb.JobTargetMetadata_Job)},
+	}
+}
+
+func Test_PrefixFromMetadata(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		key     string
-		expMeta *schedulerv1pb.JobMetadata
-		expErr  bool
+		meta      *schedulerv1pb.JobMetadata
+		expPrefix string
+		expErr    bool
 	}{
-		"an empty key should error": {
-			key:     "",
-			expMeta: nil,
-			expErr:  true,
+		"actor reminder": {
+			meta:      actorMeta("myns", "myactortype", "myactorid"),
+			expPrefix: "actorreminder||myns||myactortype||myactorid||",
 		},
-		"a random key should error": {
-			key:     "random",
-			expMeta: nil,
-			expErr:  true,
+		"app job": {
+			meta:      appMeta("myns", "myid"),
+			expPrefix: "app||myns||myid||",
 		},
-		"a bad reminder should error": {
-			key:     "foo||bar||actorreminde||myns||myactortype||myactorid||myremindername",
-			expMeta: nil,
-			expErr:  true,
+		"actor id containing the || delimiter and single pipes": {
+			meta:      actorMeta("myns", "SmokeDetectorActor", "nexus-fire-safety-api||SmokeDetectorGroupMonitorActor||Nexus|6671cfbe7f48af247700a24b||SmokeDetectorGroupInformation"),
+			expPrefix: "actorreminder||myns||SmokeDetectorActor||nexus-fire-safety-api||SmokeDetectorGroupMonitorActor||Nexus|6671cfbe7f48af247700a24b||SmokeDetectorGroupInformation||",
 		},
-		"a no-namespace actor reminder should return metadata": {
-			key: "actorreminder||myns||myactortype||myactorid||myremindername",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{
-					Type: &schedulerv1pb.JobTargetMetadata_Actor{
-						Actor: &schedulerv1pb.TargetActorReminder{
-							Id: "myactorid", Type: "myactortype",
-						},
-					},
-				},
-			},
-		},
-		"a namespace actor reminder should return metadata": {
-			key: "foo/bar/actorreminder||myns||myactortype||myactorid||myremindername",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{
-					Type: &schedulerv1pb.JobTargetMetadata_Actor{
-						Actor: &schedulerv1pb.TargetActorReminder{
-							Id: "myactorid", Type: "myactortype",
-						},
-					},
-				},
-			},
-		},
-		"a namespace (with separator) actor reminder should return metadata": {
-			key: "foo||bar/actorreminder||myns||myactortype||myactorid||myremindername",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{
-					Type: &schedulerv1pb.JobTargetMetadata_Actor{
-						Actor: &schedulerv1pb.TargetActorReminder{
-							Id: "myactorid", Type: "myactortype",
-						},
-					},
-				},
-			},
-		},
-		"a namespace (with separator 2) actor reminder should return metadata": {
-			key: "foo||bar||actorreminder||myns||myactortype||myactorid||myremindername",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{
-					Type: &schedulerv1pb.JobTargetMetadata_Actor{
-						Actor: &schedulerv1pb.TargetActorReminder{
-							Id: "myactorid", Type: "myactortype",
-						},
-					},
-				},
-			},
-		},
-		"a no-namespace job should return metadata": {
-			key: "app||myns||myid||jobname",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "myid", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{Type: new(schedulerv1pb.JobTargetMetadata_Job)},
-			},
-		},
-		"a namespace job should return metadata": {
-			key: "foo/bar/app||myns||myid||jobname",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "myid", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{Type: new(schedulerv1pb.JobTargetMetadata_Job)},
-			},
-		},
-		"a namespace (with separator) job should return metadata": {
-			key: "foo||bar/app||myns||myid||jobname",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "myid", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{Type: new(schedulerv1pb.JobTargetMetadata_Job)},
-			},
-		},
-		"a namespace (with separator 2) job should return metadata": {
-			key: "foo||bar||app||myns||myid||jobname",
-			expMeta: &schedulerv1pb.JobMetadata{
-				AppId: "myid", Namespace: "myns",
-				Target: &schedulerv1pb.JobTargetMetadata{Type: new(schedulerv1pb.JobTargetMetadata_Job)},
-			},
+		"unknown target type errors": {
+			meta:   &schedulerv1pb.JobMetadata{Namespace: "myns"},
+			expErr: true,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got, err := MetadataFromKey(test.key)
-			assert.Equal(t, test.expErr, err != nil)
-			assert.True(t, proto.Equal(test.expMeta, got), "expected: %v, got: %v", test.expMeta, got)
+			prefix, err := PrefixFromMetadata(test.meta)
+			assert.Equal(t, test.expErr, err != nil, "%v", err)
+			if !test.expErr {
+				assert.Equal(t, test.expPrefix, prefix)
+			}
 		})
 	}
 }
+
+// Test_PrefixFromMetadata_RoundTrip proves that trimming the prefix off a full
+// job key recovers the reminder name unambiguously, even when the actor id and
+// the reminder name themselves contain "|" and "||" (the field delimiter).
+func Test_PrefixFromMetadata_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]reqAdapter{
+		"simple actor reminder": {
+			name: "myremindername",
+			meta: actorMeta("myns", "myactortype", "myactorid"),
+		},
+		"schreder: pipes in id, pipe and at in name": {
+			name: "my@reminder|name",
+			meta: actorMeta("dapr-tests", "SmokeDetectorActor", "nexus-fire-safety-api||SmokeDetectorGroupMonitorActor||Nexus|6671cfbe7f48af247700a24b||SmokeDetectorGroupInformation"),
+		},
+		"app job with pipes in name": {
+			name: "my|job@name",
+			meta: appMeta("myns", "myappid"),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			fullKey, err := buildJobName(tc)
+			require.NoError(t, err)
+
+			prefix, err := PrefixFromMetadata(tc.meta)
+			require.NoError(t, err)
+
+			require.True(t, strings.HasPrefix(fullKey, prefix), "key %q must start with prefix %q", fullKey, prefix)
+			assert.Equal(t, tc.name, strings.TrimPrefix(fullKey, prefix))
+		})
+	}
+}
+
+type reqAdapter struct {
+	name string
+	meta *schedulerv1pb.JobMetadata
+}
+
+func (r reqAdapter) GetName() string                         { return r.name }
+func (r reqAdapter) GetMetadata() *schedulerv1pb.JobMetadata { return r.meta }

--- a/pkg/scheduler/server/internal/serialize/serialize.go
+++ b/pkg/scheduler/server/internal/serialize/serialize.go
@@ -133,6 +133,24 @@ func (j *Job) Metadata() *anypb.Any {
 	return j.meta
 }
 
+// PrefixFromMetadata returns the job key prefix (including the trailing "||"
+// delimiter) for a single stored job's metadata, without performing
+// authorization. The full job key equals this prefix concatenated with the
+// reminder/job name, so trimming this prefix from a key recovers that name.
+// This is robust even when the actor type or id themselves contain "||",
+// unlike re-splitting the key.
+func PrefixFromMetadata(meta *schedulerv1pb.JobMetadata) (string, error) {
+	switch t := meta.GetTarget(); t.GetType().(type) {
+	case *schedulerv1pb.JobTargetMetadata_Actor:
+		actor := t.GetActor()
+		return joinStrings("actorreminder", meta.GetNamespace(), actor.GetType(), actor.GetId()) + "||", nil
+	case *schedulerv1pb.JobTargetMetadata_Job:
+		return joinStrings("app", meta.GetNamespace(), meta.GetAppId()) + "||", nil
+	default:
+		return "", fmt.Errorf("unknown job type: %v", t)
+	}
+}
+
 func buildJobName(req Request) (string, error) {
 	name := req.GetName()
 	meta := req.GetMetadata()

--- a/tests/integration/suite/actors/reminders/invalidnames.go
+++ b/tests/integration/suite/actors/reminders/invalidnames.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(invalidnames))
+}
+
+// invalidnames asserts that reminder names and actor ids containing characters
+// that are unsafe in an etcd key or a callback URL are rejected. Names are
+// rejected at the API edge; actor ids are rejected by the scheduler validator.
+type invalidnames struct {
+	daprd *daprd.Daprd
+	place *placement.Placement
+	sched *scheduler.Scheduler
+}
+
+func (i *invalidnames) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"entities": ["myactortype"]}`))
+	})
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	i.place = placement.New(t)
+	i.sched = scheduler.New(t)
+	i.daprd = daprd.New(t,
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(i.place.Address()),
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithScheduler(i.sched),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(i.sched, i.place, srv, i.daprd),
+	}
+}
+
+func (i *invalidnames) Run(t *testing.T, ctx context.Context) {
+	i.place.WaitUntilRunning(t, ctx)
+	i.daprd.WaitUntilRunning(t, ctx)
+
+	//nolint:staticcheck
+	conn, err := grpc.DialContext(ctx, i.daprd.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(), //nolint:staticcheck
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	gclient := rtv1.NewDaprClient(conn)
+
+	cl := client.HTTP(t)
+	actorURL := "http://localhost:" + strconv.Itoa(i.daprd.HTTPPort()) + "/v1.0/actors/myactortype/myactorid"
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		req, rErr := http.NewRequestWithContext(ctx, http.MethodPost, actorURL+"/method/foo", nil)
+		require.NoError(c, rErr)
+		resp, rErr := cl.Do(req)
+		if assert.NoError(c, rErr) {
+			assert.NoError(c, resp.Body.Close())
+			assert.Equal(c, http.StatusOK, resp.StatusCode)
+		}
+	}, 10*time.Second, 10*time.Millisecond)
+
+	badNames := map[string]string{
+		"slash":       "bad/name",
+		"backslash":   "bad\\name",
+		"hash":        "bad#name",
+		"question":    "bad?name",
+		"nul":         "bad\x00name",
+		"newline":     "bad\nname",
+		"dot":         ".",
+		"double dot":  "..",
+		"over length": strings.Repeat("a", 600),
+	}
+	for name, reminder := range badNames {
+		t.Run("name/"+name, func(t *testing.T) {
+			_, rErr := gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+				ActorType: "myactortype",
+				ActorId:   "myactorid",
+				Name:      reminder,
+				DueTime:   "0ms",
+			})
+			require.Error(t, rErr)
+		})
+	}
+
+	badIDs := map[string]string{
+		"slash":     "bad/id",
+		"backslash": "bad\\id",
+		"hash":      "bad#id",
+		"question":  "bad?id",
+		"nul":       "bad\x00id",
+		"newline":   "bad\nid",
+	}
+	for name, id := range badIDs {
+		t.Run("id/"+name, func(t *testing.T) {
+			_, rErr := gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+				ActorType: "myactortype",
+				ActorId:   id,
+				Name:      "validname",
+				DueTime:   "0ms",
+			})
+			require.Error(t, rErr)
+		})
+	}
+}

--- a/tests/integration/suite/actors/reminders/specialchars.go
+++ b/tests/integration/suite/actors/reminders/specialchars.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(specialchars))
+}
+
+// specialchars verifies that actor reminders whose names and actor ids contain
+// special characters (pipe '|', the '||' delimiter, and '@') can be registered
+// through the scheduler service and fire. This covers the Schreder regression
+// where actor ids embed '||' and reminder names contain '|'/'@'.
+type specialchars struct {
+	daprd *daprd.Daprd
+	place *placement.Placement
+	sched *scheduler.Scheduler
+
+	lock        sync.Mutex
+	remindPaths []string
+	fired       atomic.Int64
+}
+
+func (s *specialchars) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"entities": ["myactortype"]}`))
+	})
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	// Catch-all so actor activation and reminder callbacks route regardless of
+	// the special characters in the actor id / reminder name path segments.
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/method/remind/") {
+			s.lock.Lock()
+			s.remindPaths = append(s.remindPaths, r.URL.Path)
+			s.lock.Unlock()
+			s.fired.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	s.place = placement.New(t)
+	s.sched = scheduler.New(t)
+	s.daprd = daprd.New(t,
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(s.place.Address()),
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithScheduler(s.sched),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.sched, s.place, srv, s.daprd),
+	}
+}
+
+func (s *specialchars) Run(t *testing.T, ctx context.Context) {
+	s.place.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	//nolint:staticcheck
+	conn, err := grpc.DialContext(ctx, s.daprd.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(), //nolint:staticcheck
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	gclient := rtv1.NewDaprClient(conn)
+
+	// Activate the actor so reminder callbacks have somewhere to land.
+	cl := client.HTTP(t)
+	actorURL := "http://localhost:" + strconv.Itoa(s.daprd.HTTPPort()) + "/v1.0/actors/myactortype/myactorid"
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		req, rErr := http.NewRequestWithContext(ctx, http.MethodPost, actorURL+"/method/foo", nil)
+		require.NoError(c, rErr)
+		resp, rErr := cl.Do(req)
+		if assert.NoError(c, rErr) {
+			assert.NoError(c, resp.Body.Close())
+			assert.Equal(c, http.StatusOK, resp.StatusCode)
+		}
+	}, 10*time.Second, 10*time.Millisecond, "actor not ready in time")
+
+	t.Run("reminder name with pipe and at sign registers and fires", func(t *testing.T) {
+		const reminderName = "remind|me@now"
+		_, err = gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "myactortype",
+			ActorId:   "myactorid",
+			Name:      reminderName,
+			DueTime:   "0ms",
+		})
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			s.lock.Lock()
+			defer s.lock.Unlock()
+			found := false
+			for _, p := range s.remindPaths {
+				if strings.HasSuffix(p, "/method/remind/"+reminderName) {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "reminder %q did not fire; paths seen: %v", reminderName, s.remindPaths)
+		}, 10*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("schreder-style actor id with || delimiter registers", func(t *testing.T) {
+		// Actor id embeds the '||' delimiter and single pipes, exactly the
+		// shape that previously failed RFC1123 validation in the scheduler.
+		_, err = gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "myactortype",
+			ActorId:   "nexus-fire-safety-api||SmokeDetectorGroupMonitorActor||Nexus|6671cfbe7f48af247700a24b||SmokeDetectorGroupInformation",
+			Name:      "deviceupdate",
+			DueTime:   "1000s",
+		})
+		require.NoError(t, err)
+	})
+}

--- a/tests/integration/suite/daprd/jobs/invalidnames.go
+++ b/tests/integration/suite/daprd/jobs/invalidnames.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(invalidnames))
+}
+
+// invalidnames asserts that job names containing characters that are unsafe in
+// an etcd key or a callback URL, or that exceed the length bound, are rejected
+// by the scheduler validator.
+type invalidnames struct {
+	daprd     *daprd.Daprd
+	scheduler *scheduler.Scheduler
+}
+
+func (i *invalidnames) Setup(t *testing.T) []framework.Option {
+	i.scheduler = scheduler.New(t)
+	srv := app.New(t)
+	i.daprd = daprd.New(t,
+		daprd.WithSchedulerAddresses(i.scheduler.Address()),
+		daprd.WithAppPort(srv.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(i.scheduler, i.daprd),
+	}
+}
+
+func (i *invalidnames) Run(t *testing.T, ctx context.Context) {
+	i.scheduler.WaitUntilRunning(t, ctx)
+	i.daprd.WaitUntilRunning(t, ctx)
+
+	client := i.daprd.GRPCClient(t, ctx)
+
+	badNames := map[string]string{
+		"slash":       "bad/name",
+		"backslash":   "bad\\name",
+		"hash":        "bad#name",
+		"question":    "bad?name",
+		"nul":         "bad\x00name",
+		"newline":     "bad\nname",
+		"over length": strings.Repeat("a", 600),
+	}
+
+	for name, jobName := range badNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := client.ScheduleJob(ctx, &runtimev1pb.ScheduleJobRequest{
+				Job: &runtimev1pb.Job{
+					Name:     jobName,
+					Schedule: new("@daily"),
+				},
+			})
+			require.Error(t, err)
+		})
+	}
+}

--- a/tests/integration/suite/daprd/jobs/specialchars.go
+++ b/tests/integration/suite/daprd/jobs/specialchars.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(specialchars))
+}
+
+// specialchars asserts that a job whose name contains characters such as '|'
+// and '@' can be scheduled, triggered, fetched and listed.
+type specialchars struct {
+	daprd     *daprd.Daprd
+	scheduler *scheduler.Scheduler
+	jobChan   chan *runtimev1pb.JobEventRequest
+}
+
+func (s *specialchars) Setup(t *testing.T) []framework.Option {
+	s.scheduler = scheduler.New(t)
+
+	s.jobChan = make(chan *runtimev1pb.JobEventRequest, 1)
+	srv := app.New(t,
+		app.WithOnJobEventFn(func(ctx context.Context, in *runtimev1pb.JobEventRequest) (*runtimev1pb.JobEventResponse, error) {
+			s.jobChan <- in
+			return new(runtimev1pb.JobEventResponse), nil
+		}),
+	)
+
+	s.daprd = daprd.New(t,
+		daprd.WithSchedulerAddresses(s.scheduler.Address()),
+		daprd.WithAppPort(srv.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.scheduler, srv, s.daprd),
+	}
+}
+
+func (s *specialchars) Run(t *testing.T, ctx context.Context) {
+	s.scheduler.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	client := s.daprd.GRPCClient(t, ctx)
+
+	const name = "my|job@name"
+
+	_, err := client.ScheduleJob(ctx, &runtimev1pb.ScheduleJobRequest{
+		Job: &runtimev1pb.Job{
+			Name:     name,
+			Schedule: new("@daily"),
+			DueTime:  new("0s"),
+		},
+	})
+	require.NoError(t, err)
+
+	select {
+	case job := <-s.jobChan:
+		assert.Equal(t, "job/"+name, job.GetMethod())
+	case <-time.After(time.Second * 3):
+		assert.Fail(t, "timed out waiting for triggered job")
+	}
+
+	got, err := client.GetJob(ctx, &runtimev1pb.GetJobRequest{Name: name})
+	require.NoError(t, err)
+	assert.Equal(t, name, got.GetJob().GetName())
+
+	resp, err := client.ListJobs(ctx, &runtimev1pb.ListJobsRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetJobs(), 1)
+	assert.Equal(t, name, resp.GetJobs()[0].GetName())
+}

--- a/tests/integration/suite/daprd/workflow/basic/specialchars.go
+++ b/tests/integration/suite/daprd/workflow/basic/specialchars.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(specialchars))
+}
+
+// specialchars asserts that a workflow whose instance id contains characters
+// such as '|' and '@' (which become part of the workflow actor's reminder
+// names) runs to completion.
+type specialchars struct {
+	daprd *daprd.Daprd
+	place *placement.Placement
+	sched *scheduler.Scheduler
+}
+
+func (s *specialchars) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(""))
+	})
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	s.sched = scheduler.New(t)
+	s.place = placement.New(t)
+	s.daprd = daprd.New(t,
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithPlacementAddresses(s.place.Address()),
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithSchedulerAddresses(s.sched.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.place, s.sched, srv, s.daprd),
+	}
+}
+
+func (s *specialchars) Run(t *testing.T, ctx context.Context) {
+	s.sched.WaitUntilRunning(t, ctx)
+	s.place.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	r := task.NewTaskRegistry()
+	r.AddWorkflowN("SpecialChars", func(ctx *task.WorkflowContext) (any, error) {
+		var input string
+		if err := ctx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		var output string
+		err := ctx.CallActivity("SayHello", task.WithActivityInput(input)).Await(&output)
+		return output, err
+	})
+	r.AddActivityN("SayHello", func(ctx task.ActivityContext) (any, error) {
+		var name string
+		if err := ctx.GetInput(&name); err != nil {
+			return nil, err
+		}
+		return fmt.Sprintf("Hello, %s!", name), nil
+	})
+
+	conn, err := grpc.DialContext(ctx, //nolint:staticcheck
+		s.daprd.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(), //nolint:staticcheck
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+
+	taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
+	require.NoError(t, backendClient.StartWorkItemListener(taskhubCtx, r))
+	t.Cleanup(cancelTaskhub)
+
+	id, err := backendClient.ScheduleNewWorkflow(ctx, "SpecialChars",
+		api.WithInstanceID("nexus-fire-safety-api||Nexus|6671cfbe@device"),
+		api.WithInput("Dapr"),
+	)
+	require.NoError(t, err)
+
+	metadata, err := backendClient.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
+	assert.Equal(t, `"Hello, Dapr!"`, metadata.GetOutput().GetValue())
+}


### PR DESCRIPTION
Actor reminders, scheduled jobs, and workflow instance ids could not use characters such as '|' and '@', even though those characters are accepted for actor invocation and state. Reminders embedded into the scheduler were validated against DNS-1123 per "||"-delimited segment, which is far stricter than the policy applied at the API edge, and the surfaced error ("a lowercase RFC 1123 subdomain ...") was misleading because uppercase is in fact accepted.

Bump go-etcd-cron to the release that validates job names with the same policy as the API edge: any character is allowed except '/', '\', '#', '?', control characters (including NUL), and the exact sequences "." and "..", with a length bound. "||" remains the reserved internal delimiter and is accepted within actor ids and names.

Alongside the dependency bump:

- ListJobs now recovers the namespace, actor type and id from the stored job metadata rather than re-splitting the key on "||", which corrupted those fields when an actor id itself contained "||". The reminder/job name is recovered by stripping the "<namespace>/jobs/" key prefix and then the metadata prefix, which is unambiguous even when the name contains "||". MetadataFromKey is removed as it is no longer used.

- The Jobs API no longer rejects '|' in job names. This was a separate edge check that returned a misleading "Name is empty" error and was inconsistent with reminders and workflows.