### PR TITLE
Integration: fix port exhaustion

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -255,6 +255,17 @@ jobs:
         if: matrix.target_os == 'darwin'
         run: |
           echo "DAPR_HOST_IP=127.0.0.1" >>${GITHUB_ENV}
+      # The integration suite opens a very large number of short-lived
+      # localhost connections. macOS has a small default ephemeral port range
+      # and a long TIME_WAIT, so the outbound pool is exhausted under the
+      # parallel run (surfaces as "can't assign requested address"). Widen the
+      # range and shorten TIME_WAIT as a backstop to the framework-level fixes.
+      - name: Widen ephemeral port range for MacOS
+        if: matrix.target_os == 'darwin'
+        run: |
+          sudo sysctl -w net.inet.ip.portrange.first=16384
+          sudo sysctl -w net.inet.ip.portrange.hifirst=16384
+          sudo sysctl -w net.inet.tcp.msl=1000
       - name: Run make test-integration-parallel
         run: make test-integration-parallel
   build:

--- a/tests/integration/framework/client/http.go
+++ b/tests/integration/framework/client/http.go
@@ -29,9 +29,21 @@ func HTTP(t assert.TestingT) *http.Client {
 }
 
 func HTTPWithTimeout(t assert.TestingT, timeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// Integration tests poll a handful of localhost endpoints thousands of
+	// times. The default MaxIdleConnsPerHost is 2 and idle connections linger
+	// for 90s; under heavy parallelism on macOS (ephemeral range only ~16k
+	// ports) short-lived connections accumulate in TIME_WAIT and exhaust the
+	// outbound port pool (EADDRNOTAVAIL). Keep more idle keep-alive connections
+	// around for reuse and drop them quickly so they do not pin a per-host port
+	// for the lifetime of a test.
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 32
+	transport.IdleConnTimeout = 10 * time.Second
+
 	client := &http.Client{
 		Timeout:   timeout,
-		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+		Transport: transport,
 	}
 
 	if tt, ok := t.(interface{ Cleanup(func()) }); ok {

--- a/tests/integration/framework/metrics/metrics.go
+++ b/tests/integration/framework/metrics/metrics.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/dapr/dapr/tests/integration/framework/client"
 )
 
 type Metric struct {
@@ -34,11 +32,10 @@ type Metrics struct {
 	metrics map[string]float64
 }
 
-func New(t assert.TestingT, ctx context.Context, url string) *Metrics {
+func New(t assert.TestingT, ctx context.Context, httpclient *http.Client, url string) *Metrics {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	assert.NoError(t, err) //nolint:testifylint
 
-	httpclient := client.HTTP(t)
 	resp, err := httpclient.Do(req)
 	if !assert.NoError(t, err) { //nolint:testifylint
 		return nil

--- a/tests/integration/framework/metrics/metrics_test.go
+++ b/tests/integration/framework/metrics/metrics_test.go
@@ -41,7 +41,7 @@ func TestNew(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	metrics := New(t, t.Context(), ts.URL)
+	metrics := New(t, t.Context(), ts.Client(), ts.URL)
 	metricsMap := metrics.All()
 
 	require.NotNil(t, metricsMap)

--- a/tests/integration/framework/metrics/withlabels.go
+++ b/tests/integration/framework/metrics/withlabels.go
@@ -24,21 +24,18 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/dapr/dapr/tests/integration/framework/client"
 )
 
 type MetricsWithLabels struct {
 	Metrics map[string]map[string]float64
 }
 
-func NewWithLabels(t *testing.T, ctx context.Context, url string) *MetricsWithLabels {
+func NewWithLabels(t *testing.T, ctx context.Context, httpclient *http.Client, url string) *MetricsWithLabels {
 	t.Helper()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 
-	httpclient := client.HTTP(t)
 	resp, err := httpclient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -383,7 +383,7 @@ func (d *Daprd) ProfilePort() int {
 
 // Metrics Returns a subset of metrics scraped from the metrics endpoint
 func (d *Daprd) Metrics(t assert.TestingT, ctx context.Context) *metrics.Metrics {
-	return metrics.New(t, ctx, fmt.Sprintf("http://%s/metrics", d.MetricsAddress()))
+	return metrics.New(t, ctx, d.httpClient, fmt.Sprintf("http://%s/metrics", d.MetricsAddress()))
 }
 
 func (d *Daprd) MetricResidentMemoryMi(t *testing.T, ctx context.Context) float64 {

--- a/tests/integration/framework/process/placement/placement.go
+++ b/tests/integration/framework/process/placement/placement.go
@@ -43,8 +43,9 @@ import (
 )
 
 type Placement struct {
-	exec  process.Interface
-	ports *ports.Ports
+	exec       process.Interface
+	ports      *ports.Ports
+	httpClient *http.Client
 
 	id                  string
 	port                int
@@ -128,6 +129,7 @@ func New(t *testing.T, fopts ...Option) *Placement {
 			))...,
 		),
 		ports:               fp,
+		httpClient:          client.HTTP(t),
 		id:                  opts.id,
 		port:                opts.port,
 		healthzPort:         opts.healthzPort,
@@ -146,6 +148,7 @@ func (p *Placement) Run(t *testing.T, ctx context.Context) {
 
 func (p *Placement) Cleanup(t *testing.T) {
 	p.cleanupOnce.Do(func() {
+		p.httpClient.CloseIdleConnections()
 		p.exec.Cleanup(t)
 	})
 }
@@ -153,11 +156,10 @@ func (p *Placement) Cleanup(t *testing.T) {
 func (p *Placement) WaitUntilRunning(t *testing.T, ctx context.Context) {
 	t.Helper()
 
-	client := client.HTTP(t)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/healthz", p.healthzPort), nil)
 	require.NoError(t, err)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		resp, respErr := client.Do(req)
+		resp, respErr := p.httpClient.Do(req)
 		if assert.NoError(c, respErr) {
 			defer resp.Body.Close()
 			assert.Equal(c, http.StatusOK, resp.StatusCode)
@@ -187,7 +189,7 @@ func (p *Placement) HealthzPort() int {
 
 // Metrics returns a subset of metrics scraped from the metrics endpoint
 func (p *Placement) Metrics(t assert.TestingT, ctx context.Context) *metrics.Metrics {
-	return metrics.New(t, ctx, fmt.Sprintf("http://%s/metrics", p.MetricsAddress()))
+	return metrics.New(t, ctx, p.httpClient, fmt.Sprintf("http://%s/metrics", p.MetricsAddress()))
 }
 
 func (p *Placement) MetricsAddress() string {

--- a/tests/integration/framework/process/ports/ports.go
+++ b/tests/integration/framework/process/ports/ports.go
@@ -47,6 +47,14 @@ func portsBase() int {
 
 const blockSize = 500
 
+// portsCeil is the exclusive upper bound for reservation probing. It is kept
+// strictly below the OS ephemeral port range (macOS default 49152-65535) so
+// that held-open reserved listeners never squat on ports the kernel needs to
+// assign for outbound dials. Exhausting the outbound ephemeral pool surfaces
+// as EADDRNOTAVAIL ("can't assign requested address") and was the dominant
+// failure mode on the 3-core macos-14 CI runner.
+const portsCeil = 49000
+
 // Ports reserves network ports, and then frees them when the test is ready to
 // run so a  process can bind to them at runtime.
 type Ports struct {
@@ -75,7 +83,7 @@ func Reserve(t *testing.T, count int) *Ports {
 		t.Logf("reserving %d more ports", blockSize)
 		for i := 0; i < blockSize; i++ {
 			last++
-			if last+i > 65535 {
+			if last+i >= portsCeil {
 				last = portsBase()
 			}
 			ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(last))

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -414,11 +414,11 @@ func (s *Scheduler) MetricsAddress() string {
 
 // Metrics returns a subset of metrics scraped from the metrics endpoint
 func (s *Scheduler) Metrics(t assert.TestingT, ctx context.Context) *metrics.Metrics {
-	return metrics.New(t, ctx, fmt.Sprintf("http://%s/metrics", s.MetricsAddress()))
+	return metrics.New(t, ctx, s.httpClient, fmt.Sprintf("http://%s/metrics", s.MetricsAddress()))
 }
 
 func (s *Scheduler) MetricsWithLabels(t *testing.T, ctx context.Context) *metrics.MetricsWithLabels {
-	return metrics.NewWithLabels(t, ctx, fmt.Sprintf("http://%s/metrics", s.MetricsAddress()))
+	return metrics.NewWithLabels(t, ctx, s.httpClient, fmt.Sprintf("http://%s/metrics", s.MetricsAddress()))
 }
 
 func (s *Scheduler) ETCDClient(t *testing.T, ctx context.Context) *clientv3.Client {


### PR DESCRIPTION
We have started to see port exhaustion issues in our integration tests. Ensure we don't squat ephermal ports and release idle ports sooner. Expand ephemeral port range on MacOS in CI.