### PR TITLE
workflow: do not expose failure message as workflow output

### DIFF
--- a/pkg/runtime/wfengine/client.go
+++ b/pkg/runtime/wfengine/client.go
@@ -200,7 +200,11 @@ func (c *client) Get(ctx context.Context, req *workflows.GetRequest) (*workflows
 		res.Workflow.Properties["dapr.workflow.input"] = metadata.GetInput().GetValue()
 	}
 
-	if metadata.Output != nil {
+	// A failed workflow has no successful output: durabletask-go stores the
+	// failure message in the completed-event result (surfaced here as Output),
+	// but the failure is already reported via dapr.workflow.failure.* below, so
+	// it must not also be exposed as dapr.workflow.output.
+	if metadata.Output != nil && metadata.FailureDetails == nil {
 		res.Workflow.Properties["dapr.workflow.output"] = metadata.GetOutput().GetValue()
 	}
 

--- a/pkg/runtime/wfengine/client_test.go
+++ b/pkg/runtime/wfengine/client_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wfengine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+
+	"github.com/dapr/components-contrib/workflows"
+	"github.com/dapr/kit/logger"
+)
+
+// fakeTaskHubClient is a minimal backend.TaskHubClient whose only behaviour is
+// to return a pre-built WorkflowMetadata from FetchWorkflowMetadata. Every
+// other method is an unused no-op required to satisfy the interface.
+type fakeTaskHubClient struct {
+	metadata *backend.WorkflowMetadata
+}
+
+func (f *fakeTaskHubClient) FetchWorkflowMetadata(context.Context, api.InstanceID) (*backend.WorkflowMetadata, error) {
+	return f.metadata, nil
+}
+
+func (f *fakeTaskHubClient) ScheduleNewWorkflow(context.Context, any, ...api.NewWorkflowOptions) (api.InstanceID, error) {
+	return api.EmptyInstanceID, nil
+}
+
+func (f *fakeTaskHubClient) WaitForWorkflowStart(context.Context, api.InstanceID) (*backend.WorkflowMetadata, error) {
+	return nil, nil
+}
+
+func (f *fakeTaskHubClient) WaitForWorkflowCompletion(context.Context, api.InstanceID) (*backend.WorkflowMetadata, error) {
+	return nil, nil
+}
+
+func (f *fakeTaskHubClient) TerminateWorkflow(context.Context, api.InstanceID, ...api.TerminateOptions) error {
+	return nil
+}
+
+func (f *fakeTaskHubClient) RaiseEvent(context.Context, api.InstanceID, string, ...api.RaiseEventOptions) error {
+	return nil
+}
+
+func (f *fakeTaskHubClient) SuspendWorkflow(context.Context, api.InstanceID, string) error {
+	return nil
+}
+
+func (f *fakeTaskHubClient) ResumeWorkflow(context.Context, api.InstanceID, string) error {
+	return nil
+}
+
+func (f *fakeTaskHubClient) PurgeWorkflowState(context.Context, api.InstanceID, ...api.PurgeOptions) error {
+	return nil
+}
+
+func (f *fakeTaskHubClient) RerunWorkflowFromEvent(context.Context, api.InstanceID, uint32, ...api.RerunOptions) (api.InstanceID, error) {
+	return api.EmptyInstanceID, nil
+}
+
+// TestGetOutputOnFailure verifies that Get only exposes dapr.workflow.output for
+// workflows that did not fail. On failure durabletask-go stores the failure
+// message in the completed-event result (surfaced as Output), but that error is
+// already reported via dapr.workflow.failure.*, so it must not leak into output.
+func TestGetOutputOnFailure(t *testing.T) {
+	const errMsg = "Task 'SuperSlowActivity' (#0) failed with an unhandled exception: boom"
+
+	tests := map[string]struct {
+		metadata       *backend.WorkflowMetadata
+		expectOutput   bool
+		expectedOutput string
+	}{
+		"failed workflow omits output": {
+			metadata: &backend.WorkflowMetadata{
+				RuntimeStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+				Output:        wrapperspb.String(errMsg),
+				FailureDetails: &protos.TaskFailureDetails{
+					ErrorType:    "Exception",
+					ErrorMessage: errMsg,
+				},
+			},
+			expectOutput: false,
+		},
+		"completed workflow keeps output": {
+			metadata: &backend.WorkflowMetadata{
+				RuntimeStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+				Output:        wrapperspb.String(`{"result":42}`),
+			},
+			expectOutput:   true,
+			expectedOutput: `{"result":42}`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &client{
+				logger: logger.NewLogger("test"),
+				client: &fakeTaskHubClient{metadata: tc.metadata},
+			}
+
+			res, err := c.Get(context.Background(), &workflows.GetRequest{InstanceID: "wf1"})
+			require.NoError(t, err)
+			require.NotNil(t, res.Workflow)
+
+			output, ok := res.Workflow.Properties["dapr.workflow.output"]
+			if tc.expectOutput {
+				assert.True(t, ok, "expected dapr.workflow.output to be set")
+				assert.Equal(t, tc.expectedOutput, output)
+			} else {
+				assert.False(t, ok, "dapr.workflow.output must be omitted for a failed workflow")
+				// The failure message is still surfaced through the dedicated field.
+				assert.Equal(t, errMsg, res.Workflow.Properties["dapr.workflow.failure.error_message"])
+			}
+		})
+	}
+}

--- a/tests/integration/suite/daprd/workflow/failureoutput.go
+++ b/tests/integration/suite/daprd/workflow/failureoutput.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(failureoutput))
+}
+
+// failureoutput asserts the Get workflow API contract for a FAILED workflow:
+// the failure is reported through the dedicated dapr.workflow.failure.*
+// properties, and the failure message is NOT also surfaced as
+// dapr.workflow.output. A failed workflow has no successful output, so the
+// output property must be absent rather than carry a copy of the error.
+type failureoutput struct {
+	workflow *workflow.Workflow
+}
+
+func (f *failureoutput) Setup(t *testing.T) []framework.Option {
+	f.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(f.workflow),
+	}
+}
+
+func (f *failureoutput) Run(t *testing.T, ctx context.Context) {
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	client := f.workflow.BackendClient(t, ctx)
+
+	const activityErr = "activity failed on purpose"
+
+	f.workflow.Registry().AddActivityN("FailingActivity", func(task.ActivityContext) (any, error) {
+		return nil, errors.New(activityErr)
+	})
+	f.workflow.Registry().AddWorkflowN("FailingWorkflow", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("FailingActivity").Await(nil)
+	})
+
+	id, err := client.ScheduleNewWorkflow(ctx, "FailingWorkflow", api.WithInput("input value"))
+	require.NoError(t, err)
+	meta, err := client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED, meta.GetRuntimeStatus())
+
+	t.Run("client", func(t *testing.T) {
+		meta, err := client.FetchWorkflowMetadata(ctx, id, api.WithFetchPayloads(true))
+		require.NoError(t, err)
+		require.NotNil(t, meta.GetFailureDetails())
+		assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), activityErr)
+		// A failed workflow has no successful output.
+		assert.Empty(t, meta.GetOutput().GetValue())
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		gclient := f.workflow.GRPCClient(t, ctx)
+		resp, err := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        string(id),
+			WorkflowComponent: "dapr",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "FAILED", resp.GetRuntimeStatus())
+
+		props := resp.GetProperties()
+		assert.Contains(t, props["dapr.workflow.failure.error_message"], activityErr)
+		assert.NotEmpty(t, props["dapr.workflow.failure.error_type"])
+
+		// The failure message must be reported via the failure property only,
+		// never copied into the workflow output.
+		_, hasOutput := props["dapr.workflow.output"]
+		assert.False(t, hasOutput, "dapr.workflow.output must be absent for a failed workflow, got %q", props["dapr.workflow.output"])
+	})
+
+	t.Run("http", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx,
+			http.MethodGet,
+			fmt.Sprintf("http://%s/v1.0-beta1/workflows/dapr/%s", f.workflow.Dapr().HTTPAddress(), id),
+			nil,
+		)
+		require.NoError(t, err)
+
+		hresp, err := fclient.HTTP(t).Do(req)
+		require.NoError(t, err)
+
+		type wresp struct {
+			RuntimeStatus string            `json:"runtimeStatus"`
+			Properties    map[string]string `json:"properties"`
+		}
+		var w wresp
+		require.NoError(t, json.NewDecoder(hresp.Body).Decode(&w))
+		require.NoError(t, hresp.Body.Close())
+
+		assert.Equal(t, "FAILED", w.RuntimeStatus)
+		assert.Contains(t, w.Properties["dapr.workflow.failure.error_message"], activityErr)
+
+		_, hasOutput := w.Properties["dapr.workflow.output"]
+		assert.False(t, hasOutput, "dapr.workflow.output must be absent for a failed workflow, got %q", w.Properties["dapr.workflow.output"])
+	})
+}


### PR DESCRIPTION
# Description

A workflow that ends in `FAILED` was copying the failure message into the
`dapr.workflow.output` property returned by the workflow `Get` API. The failure
is already reported separately via `dapr.workflow.failure.error_message` and
`dapr.workflow.failure.error_type`, so the same error text was surfaced twice
and a failed workflow appeared to have a successful output.

Root cause: `durabletask-go` stores the failure message in the completed-event
result, which `runtimestate.Output()` returns. `pkg/runtime/wfengine/client.go`
`Get()` copied that value into `dapr.workflow.output` unconditionally.

The fix gates the `dapr.workflow.output` assignment on `metadata.FailureDetails
== nil`, which is exactly the "completed with failure" signal (it is nil for
`RUNNING` and for a successful `COMPLETED`, and is not set for `TERMINATED` /
`CANCELED`). So only the `FAILED` case changes: it no longer exposes the failure
text as output. The failure is still reported via the existing
`dapr.workflow.failure.*` properties immediately below the changed block.

Why fix it here rather than upstream in `durabletask-go`: Dapr owns the
`dapr.workflow.output` API contract. `durabletask-go` storing the error text in
the completed-event result is general behaviour shared by other consumers;
suppressing the duplicate at Dapr's response builder is self-contained and
avoids an upstream dependency change.

Before:

```json
"dapr.workflow.failure.error_message": "Task 'SuperSlowActivity' (#0) failed ... boom",
"dapr.workflow.output": "Task 'SuperSlowActivity' (#0) failed ... boom"
```

After: `dapr.workflow.output` is omitted for a failed workflow;
`dapr.workflow.failure.error_message` is unchanged.

RELEASE NOTE: **FIX** Do not set `dapr.workflow.output` to the failure message for failed workflows.

## Issue reference

Please reference the issue this PR will close: #9085

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
