### PR TITLE
messaging: stamp caller/callee headers on self-invocation

### DIFF
--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -277,6 +277,21 @@ func (d *directMessaging) invokeLocal(ctx context.Context, req *invokev1.InvokeM
 		return nil, errors.New("cannot invoke local endpoint: app channel not initialized")
 	}
 
+	// A self-invocation bypasses invokeRemote, so stamp the caller/callee
+	// identity headers here too. caller == callee == this app. Any
+	// caller-supplied identity headers are stripped first and re-stamped
+	// unconditionally, mirroring invokeRemote, so an app cannot spoof its own
+	// identity headers on the local leg. The strip is case-insensitive because
+	// HTTP-origin metadata retains the request's original header casing.
+	md := req.Metadata()
+	for k := range md {
+		switch strings.ToLower(k) {
+		case invokev1.CallerIDHeader, invokev1.CallerNamespaceHeader, invokev1.CalleeIDHeader:
+			delete(md, k)
+		}
+	}
+	d.addCallerAndCalleeAppIDHeaderToMetadata(d.namespace, d.appID, d.appID, req)
+
 	return appChannel.InvokeMethod(ctx, req, "")
 }
 

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/dapr/dapr/pkg/channel"
+	channelfake "github.com/dapr/dapr/pkg/channel/fake"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
@@ -69,6 +70,81 @@ func TestCallerAndCalleeHeaders(t *testing.T) {
 		assert.Equal(t, callerNamespace, actualCallerNamespace.GetValues()[0])
 		assert.Equal(t, callerAppID, actualCallerAppID.GetValues()[0])
 		assert.Equal(t, calleeAppID, actualCalleeAppID.GetValues()[0])
+	})
+}
+
+func TestInvokeLocalCallerAndCalleeHeaders(t *testing.T) {
+	const appID = "myapp"
+	const namespace = "myns"
+
+	invokeSelf := func(t *testing.T, req *invokev1.InvokeMethodRequest) *invokev1.InvokeMethodRequest {
+		t.Helper()
+		var got *invokev1.InvokeMethodRequest
+		appChannel := channelfake.New().WithInvokeMethod(func(ctx context.Context, r *invokev1.InvokeMethodRequest, _ string) (*invokev1.InvokeMethodResponse, error) {
+			got = r
+			return invokev1.NewInvokeMethodResponse(200, "OK", nil), nil
+		})
+		dm := &directMessaging{
+			appID:     appID,
+			namespace: namespace,
+			channels:  new(channels.Channels).WithAppChannel(appChannel),
+		}
+		_, err := dm.invokeLocal(t.Context(), req)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		return got
+	}
+
+	t.Run("self-invocation stamps caller and callee headers", func(t *testing.T) {
+		req := invokev1.NewInvokeMethodRequest("GET").
+			WithMetadata(map[string][]string{})
+		defer req.Close()
+
+		got := invokeSelf(t, req)
+		assert.Equal(t, namespace, got.Metadata()[invokev1.CallerNamespaceHeader].GetValues()[0])
+		assert.Equal(t, appID, got.Metadata()[invokev1.CallerIDHeader].GetValues()[0])
+		assert.Equal(t, appID, got.Metadata()[invokev1.CalleeIDHeader].GetValues()[0])
+	})
+
+	t.Run("overwrites spoofed caller and callee headers", func(t *testing.T) {
+		req := invokev1.NewInvokeMethodRequest("GET").
+			WithMetadata(map[string][]string{
+				invokev1.CallerNamespaceHeader: {"spoofed-ns"},
+				invokev1.CallerIDHeader:        {"spoofed-app"},
+				invokev1.CalleeIDHeader:        {"spoofed-callee"},
+			})
+		defer req.Close()
+
+		got := invokeSelf(t, req)
+		require.Len(t, got.Metadata()[invokev1.CallerNamespaceHeader].GetValues(), 1)
+		require.Len(t, got.Metadata()[invokev1.CallerIDHeader].GetValues(), 1)
+		require.Len(t, got.Metadata()[invokev1.CalleeIDHeader].GetValues(), 1)
+		assert.Equal(t, namespace, got.Metadata()[invokev1.CallerNamespaceHeader].GetValues()[0])
+		assert.Equal(t, appID, got.Metadata()[invokev1.CallerIDHeader].GetValues()[0])
+		assert.Equal(t, appID, got.Metadata()[invokev1.CalleeIDHeader].GetValues()[0])
+	})
+
+	t.Run("overwrites spoofed caller and callee headers with canonical HTTP casing", func(t *testing.T) {
+		// HTTP-origin metadata retains the request's original header casing, so
+		// a caller could try to smuggle identity headers past a case-sensitive
+		// strip. Ensure the strip is case-insensitive and leaves no duplicates.
+		req := invokev1.NewInvokeMethodRequest("GET").
+			WithMetadata(map[string][]string{
+				"Dapr-Caller-Namespace": {"spoofed-ns"},
+				"Dapr-Caller-App-Id":    {"spoofed-app"},
+				"Dapr-Callee-App-Id":    {"spoofed-callee"},
+			})
+		defer req.Close()
+
+		got := invokeSelf(t, req)
+		_, hasCanonicalCaller := got.Metadata()["Dapr-Caller-App-Id"]
+		assert.False(t, hasCanonicalCaller, "spoofed canonical-cased header must be stripped")
+		require.Len(t, got.Metadata()[invokev1.CallerNamespaceHeader].GetValues(), 1)
+		require.Len(t, got.Metadata()[invokev1.CallerIDHeader].GetValues(), 1)
+		require.Len(t, got.Metadata()[invokev1.CalleeIDHeader].GetValues(), 1)
+		assert.Equal(t, namespace, got.Metadata()[invokev1.CallerNamespaceHeader].GetValues()[0])
+		assert.Equal(t, appID, got.Metadata()[invokev1.CallerIDHeader].GetValues()[0])
+		assert.Equal(t, appID, got.Metadata()[invokev1.CalleeIDHeader].GetValues()[0])
 	})
 }
 

--- a/tests/integration/suite/daprd/serviceinvocation/http/selfheaders.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/selfheaders.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(selfheaders))
+}
+
+// selfheaders asserts that a self-invocation (invoking one's own app ID, which
+// short-circuits to invokeLocal) stamps the caller/callee identity headers the
+// same way a cross-app invocation does, and that a caller cannot spoof those
+// headers on the local leg.
+type selfheaders struct {
+	daprd *daprd.Daprd
+	ch    chan http.Header
+}
+
+func (s *selfheaders) Setup(t *testing.T) []framework.Option {
+	s.ch = make(chan http.Header, 1)
+	app := app.New(t,
+		app.WithHandlerFunc("/helloworld", func(w http.ResponseWriter, r *http.Request) {
+			s.ch <- r.Header
+		}),
+	)
+
+	s.daprd = daprd.New(t,
+		daprd.WithAppID("app-self"),
+		daprd.WithNamespace("app-self-namespace"),
+		daprd.WithAppPort(app.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, s.daprd),
+	}
+}
+
+func (s *selfheaders) Run(t *testing.T, ctx context.Context) {
+	s.daprd.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilAppHealth(t, ctx)
+
+	httpClient := client.HTTP(t)
+	reqURL := fmt.Sprintf("http://localhost:%d/v1.0/invoke/%s/method/helloworld", s.daprd.HTTPPort(), s.daprd.AppID())
+
+	invoke := func(t *testing.T, headers map[string]string) http.Header {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		require.NoError(t, err)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		select {
+		case header := <-s.ch:
+			return header
+		case <-time.After(10 * time.Second):
+			assert.Fail(t, "timed out waiting for app to receive request")
+			return nil
+		}
+	}
+
+	t.Run("self-invocation stamps caller and callee headers", func(t *testing.T) {
+		header := invoke(t, nil)
+		assert.Equal(t, "app-self-namespace", header.Get("dapr-caller-namespace"))
+		assert.Equal(t, "app-self", header.Get("dapr-caller-app-id"))
+		assert.Equal(t, "app-self", header.Get("dapr-callee-app-id"))
+	})
+
+	t.Run("self-invocation overwrites spoofed caller and callee headers", func(t *testing.T) {
+		header := invoke(t, map[string]string{
+			"dapr-caller-namespace": "spoofed-namespace",
+			"dapr-caller-app-id":    "spoofed-app",
+			"dapr-callee-app-id":    "spoofed-callee",
+		})
+		assert.Equal(t, "app-self-namespace", header.Get("dapr-caller-namespace"))
+		assert.Equal(t, "app-self", header.Get("dapr-caller-app-id"))
+		assert.Equal(t, "app-self", header.Get("dapr-callee-app-id"))
+	})
+}


### PR DESCRIPTION
# Description

Service invocation to your own app id (`POST /v1.0/invoke/<own-app-id>/method/<m>`)
short-circuits to `invokeLocal`, which dispatched straight to the app channel
without setting any caller/callee identity headers. Only `invokeRemote` calls
`addCallerAndCalleeAppIDHeaderToMetadata`, so a self-invoke reached the app with
none of `dapr-caller-app-id`, `dapr-caller-namespace` or `dapr-callee-app-id`,
while cross-app invocations carry them. Services that allowlist by
`dapr-caller-app-id` therefore reject only the self leg.

This stamps the same headers in `invokeLocal` (caller == callee == this app,
own namespace), preserving any caller already stamped upstream so the local leg
sees the same headers as a cross-app call. It mirrors `invokeRemote` and the
actor router's `stampLocalCallerIdentity`.

## Issue reference

Please reference the issue this PR will close: #10061

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [x] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: n/a - behaviour now matches the documented headers
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: n/a - no API change
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: n/a - bug fix

## Release note

```release-note
FIX: self-invocation now stamps dapr-caller-app-id, dapr-caller-namespace and dapr-callee-app-id, matching cross-app service invocation.
```
