### PR TITLE
diagnostics: bound reminder/timer span names to fix high cardinality

### DIFF
--- a/pkg/api/http/actors.go
+++ b/pkg/api/http/actors.go
@@ -53,7 +53,7 @@ var endpointGroupActorV1State = &endpoints.EndpointGroup{
 var endpointGroupActorV1Misc = &endpoints.EndpointGroup{
 	Name:                 endpoints.EndpointGroupActors,
 	Version:              endpoints.EndpointGroupVersion1,
-	AppendSpanAttributes: nil, // TODO
+	AppendSpanAttributes: appendActorReminderTimerSpanAttributesFn,
 }
 
 func appendActorStateSpanAttributesFn(r *http.Request, m map[string]string) {
@@ -71,6 +71,19 @@ func appendActorInvocationSpanAttributesFn(r *http.Request, m map[string]string)
 	m[diagConsts.GrpcServiceSpanAttributeKey] = "ServiceInvocation"
 	m[diagConsts.NetPeerNameSpanAttributeKey] = actorTypeID
 	m[diagConsts.DaprAPISpanNameInternal] = "CallActor/" + actorType + "/" + chi.URLParam(r, "method")
+}
+
+// appendActorReminderTimerSpanAttributesFn sets a bounded span name for the
+// reminder and timer endpoints. The raw request path embeds the unbounded
+// actorId and reminder/timer name, so it must not be used as the span name
+// (it causes a tracing cardinality explosion, see issue #4703). The bounded
+// endpoint name and actorType are used instead, dropping actorId and name.
+func appendActorReminderTimerSpanAttributesFn(r *http.Request, m map[string]string) {
+	actorType := chi.URLParam(r, actorTypeParam)
+	m[diagConsts.DaprAPIActorTypeID] = actorType + "." + chi.URLParam(r, actorIDParam)
+
+	endpointData, _ := r.Context().Value(endpoints.EndpointCtxKey{}).(*endpoints.EndpointCtxData)
+	m[diagConsts.DaprAPISpanNameInternal] = endpointData.GetEndpointName() + "/" + actorType
 }
 
 func actorInvocationMethodNameWithIDFn(r *http.Request) string {

--- a/pkg/api/http/actors_tracing_test.go
+++ b/pkg/api/http/actors_tracing_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/pkg/api/http/endpoints"
+	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
+)
+
+// TestAppendActorReminderTimerSpanAttributesFn verifies that the reminder and
+// timer endpoints emit a bounded span name that keeps only the (bounded)
+// actorType, dropping the unbounded actorId and reminder/timer name. Using the
+// raw request path produced one span name per actor instance per reminder,
+// blowing up tracing cardinality.
+//
+// Regression test for https://github.com/dapr/dapr/issues/4703
+func TestAppendActorReminderTimerSpanAttributesFn(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		endpointName string
+		wantSpan     string
+	}{
+		{"create reminder", http.MethodPost, "/v1.0/actors/OrderActor/order-123/reminders/CancelOrder", "RegisterActorReminder", "RegisterActorReminder/OrderActor"},
+		{"delete reminder", http.MethodDelete, "/v1.0/actors/OrderActor/order-123/reminders/CancelOrder", "UnregisterActorReminder", "UnregisterActorReminder/OrderActor"},
+		{"get reminder", http.MethodGet, "/v1.0/actors/OrderActor/order-123/reminders/CancelOrder", "GetActorReminder", "GetActorReminder/OrderActor"},
+		{"create timer", http.MethodPost, "/v1.0/actors/OrderActor/order-123/timers/Refresh", "RegisterActorTimer", "RegisterActorTimer/OrderActor"},
+		{"delete timer", http.MethodDelete, "/v1.0/actors/OrderActor/order-123/timers/Refresh", "UnregisterActorTimer", "UnregisterActorTimer/OrderActor"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chiCtx := chi.NewRouteContext()
+			chiCtx.URLParams.Add(actorTypeParam, "OrderActor")
+			chiCtx.URLParams.Add(actorIDParam, "order-123")
+			chiCtx.URLParams.Add(nameParam, "CancelOrder")
+
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, chiCtx)
+			ctx = context.WithValue(ctx, endpoints.EndpointCtxKey{}, &endpoints.EndpointCtxData{
+				Settings: endpoints.EndpointSettings{Name: tc.endpointName},
+			})
+			req = req.WithContext(ctx)
+
+			m := map[string]string{}
+			appendActorReminderTimerSpanAttributesFn(req, m)
+
+			span := m[diagConsts.DaprAPISpanNameInternal]
+			assert.Equal(t, tc.wantSpan, span)
+			assert.NotContains(t, span, "order-123", "span name must not contain unbounded actorId")
+			assert.NotContains(t, span, "CancelOrder", "span name must not contain unbounded reminder/timer name")
+			assert.Equal(t, "OrderActor.order-123", m[diagConsts.DaprAPIActorTypeID])
+		})
+	}
+}

--- a/tests/integration/suite/daprd/tracing/actors/actors.go
+++ b/tests/integration/suite/daprd/tracing/actors/actors.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/otel"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(actors))
+}
+
+// actors verifies that the reminder and timer HTTP endpoints emit bounded
+// trace span names. The raw request path embeds the unbounded actorId and
+// reminder/timer name, so using it as the span name exploded tracing
+// cardinality (one distinct span name per actor instance per reminder). The
+// span name must keep only the bounded actorType.
+//
+// Regression test for https://github.com/dapr/dapr/issues/4703
+type actors struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *scheduler.Scheduler
+	collector *otel.Collector
+}
+
+func (a *actors) Setup(t *testing.T) []framework.Option {
+	a.collector = otel.New(t)
+	a.scheduler = scheduler.New(t)
+	a.place = placement.New(t)
+
+	srv := app.New(
+		t,
+		app.WithHandlerFunc("/actors/myactortype/myactorid", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/actors/myactortype/myactorid/method/foo", func(http.ResponseWriter, *http.Request) {}),
+		app.WithConfig(`{"entities": ["myactortype"]}`),
+	)
+
+	tracingConfig := fmt.Sprintf(`apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: tracing
+spec:
+  tracing:
+    samplingRate: "1.0"
+    otel:
+      endpointAddress: %s
+      protocol: grpc
+      isSecure: false
+`, a.collector.OTLPGRPCAddress())
+
+	a.daprd = daprd.New(
+		t,
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithSchedulerAddresses(a.scheduler.Address()),
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithConfigManifests(t, tracingConfig),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.collector, a.scheduler, a.place, srv, a.daprd),
+	}
+}
+
+func (a *actors) Run(t *testing.T, ctx context.Context) {
+	a.collector.WaitUntilRunning(t, ctx)
+	a.scheduler.WaitUntilRunning(t, ctx)
+	a.place.WaitUntilRunning(t, ctx)
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	client := fclient.HTTP(t)
+	baseURL := "http://localhost:" + strconv.Itoa(a.daprd.HTTPPort()) + "/v1.0/actors/myactortype/myactorid"
+
+	// Wait for the actor to be hosted before registering reminders/timers.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/method/foo", nil)
+		require.NoError(c, err)
+		resp, err := client.Do(req)
+		if assert.NoError(c, err) {
+			assert.NoError(c, resp.Body.Close())
+			assert.Equal(c, http.StatusOK, resp.StatusCode)
+		}
+	}, 10*time.Second, 10*time.Millisecond, "actor not ready in time")
+
+	// Exercise every reminder/timer endpoint in endpointGroupActorV1Misc. A far
+	// future dueTime keeps the reminder/timer from firing during the test. The
+	// traceparent forces the span to be sampled (and thus named + exported).
+	do := func(method, path, body string) {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, method, baseURL+path, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("traceparent", "00-00000000000000000000000000000001-0000000000000001-01")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.GreaterOrEqual(t, resp.StatusCode, http.StatusOK)
+		assert.Less(t, resp.StatusCode, http.StatusMultipleChoices)
+	}
+
+	do(http.MethodPost, "/reminders/myremindername", `{"dueTime": "10000s"}`)
+	do(http.MethodGet, "/reminders/myremindername", "")
+	do(http.MethodDelete, "/reminders/myremindername", "")
+	do(http.MethodPost, "/timers/mytimername", `{"dueTime": "10000s"}`)
+	do(http.MethodDelete, "/timers/mytimername", "")
+
+	expected := []string{
+		"RegisterActorReminder/myactortype",
+		"GetActorReminder/myactortype",
+		"UnregisterActorReminder/myactortype",
+		"RegisterActorTimer/myactortype",
+		"UnregisterActorTimer/myactortype",
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		names := spanNames(a.collector.GetSpans())
+		for _, exp := range expected {
+			assert.Contains(c, names, exp)
+		}
+	}, 20*time.Second, 100*time.Millisecond, "did not receive bounded reminder/timer span names")
+
+	// The unbounded actorId and reminder/timer name must never leak into a span
+	// name (that is the high-cardinality regression this guards against).
+	for _, name := range spanNames(a.collector.GetSpans()) {
+		assert.NotContains(t, name, "myactorid", "span name must not contain the unbounded actorId")
+		assert.NotContains(t, name, "myremindername", "span name must not contain the unbounded reminder name")
+		assert.NotContains(t, name, "mytimername", "span name must not contain the unbounded timer name")
+	}
+}
+
+func spanNames(spans []*tracepb.ResourceSpans) []string {
+	var names []string
+	for _, rs := range spans {
+		for _, ss := range rs.GetScopeSpans() {
+			for _, s := range ss.GetSpans() {
+				names = append(names, s.GetName())
+			}
+		}
+	}
+	return names
+}

--- a/tests/integration/suite/daprd/tracing/tracing.go
+++ b/tests/integration/suite/daprd/tracing/tracing.go
@@ -15,6 +15,7 @@ limitations under the License.
 package tracing
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/tracing/actors"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/tracing/baggage"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/tracing/binding"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/tracing/otel"


### PR DESCRIPTION
# Description

Actor reminder and timer HTTP endpoints (`endpointGroupActorV1Misc`) set no span name, so the tracing middleware fell back to the raw request path. That path embeds the unbounded `actorId` and reminder/timer `name`, so every actor instance and every reminder produced a distinct span name, exploding tracing cardinality.

This sets a bounded span name for the reminder/timer endpoint group, mirroring the actor invocation group's existing `CallActor/<type>/<method>` convention. The new name is `<operation>Actor<Reminder|Timer>/<actorType>` (e.g. `RegisterActorReminder/OrderActor`, `UnregisterActorTimer/OrderActor`), keeping only the bounded `actorType` and dropping the unbounded `actorId` and name. The `AppendSpanAttributes: nil, // TODO` on that group is replaced with the new function.

```
RELEASE NOTE: FIX Actor reminder and timer HTTP endpoints no longer emit high-cardinality trace span names (the unbounded actorId and reminder/timer name are dropped; span name is now <operation>Actor<Reminder|Timer>/<actorType>).
```

## Issue reference

Please reference the issue this PR will close: #4703

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_  (n/a: internal span naming, no API/spec change)
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_  (n/a)
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_  (n/a: bug fix)
