### PR TITLE
Added child workflow retries parent instanceID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.18.1
-	github.com/dapr/durabletask-go v0.12.2-0.20260611114644-8a3fcf497ae0
+	github.com/dapr/durabletask-go v0.12.2-0.20260630111707-26034a1c0eef
 	github.com/dapr/kit v0.18.2
 	github.com/diagridio/go-etcd-cron v0.12.6
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/dapr/components-contrib v1.18.1 h1:GgPuh60eBkVltg0Q+rsstHyzHvmk7XxUC/
 github.com/dapr/components-contrib v1.18.1/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.12.2-0.20260611114644-8a3fcf497ae0 h1:HFIdxtXKhmHAMj/Q/wkdoLVPBVakxmG7K9vM9goh/EM=
-github.com/dapr/durabletask-go v0.12.2-0.20260611114644-8a3fcf497ae0/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
+github.com/dapr/durabletask-go v0.12.2-0.20260630111707-26034a1c0eef h1:a1SNnZiFlD+RXfo8s2L6b/W+UIVxnmKx/nI8jtwPiYA=
+github.com/dapr/durabletask-go v0.12.2-0.20260630111707-26034a1c0eef/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/dapr/kit v0.18.2 h1:nOhtpNz5U171Pl8R1hf+KKDNmkNkMUVYcb1x1mWIL1Q=
 github.com/dapr/kit v0.18.2/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/tests/integration/framework/workflow/retries.go
+++ b/tests/integration/framework/workflow/retries.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+// ChildWorkflowRetryChains groups the ChildWorkflowInstanceCreatedEvents in a
+// workflow history into retry chains. Each event is keyed by its retry-chain
+// correlation key: RetryParentInstanceInfo.InstanceID when set (a retry
+// attempt), otherwise the event's own InstanceId (the first attempt). This is
+// exactly how a consumer correlates a child call's retry attempts with their
+// originating attempt. Events within each chain preserve their history
+// (chronological) order.
+func ChildWorkflowRetryChains(events []*protos.HistoryEvent) map[string][]*protos.ChildWorkflowInstanceCreatedEvent {
+	chains := make(map[string][]*protos.ChildWorkflowInstanceCreatedEvent)
+	for _, ev := range events {
+		cc := ev.GetChildWorkflowInstanceCreated()
+		if cc == nil {
+			continue
+		}
+		key := cc.GetInstanceId()
+		if rp := cc.GetRetryParentInstanceInfo(); rp != nil {
+			key = rp.GetInstanceID()
+		}
+		chains[key] = append(chains[key], cc)
+	}
+	return chains
+}

--- a/tests/integration/suite/daprd/workflow/retries/childworkflow.go
+++ b/tests/integration/suite/daprd/workflow/retries/childworkflow.go
@@ -16,6 +16,8 @@ package retries
 import (
 	"context"
 	"errors"
+	"maps"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,6 +27,7 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -93,4 +96,23 @@ func (e *childworkflow) Run(t *testing.T, ctx context.Context) {
 	// Child fails on first attempt, succeeds on second, so there should be
 	// exactly 1 retry timer.
 	assert.Equal(t, 1, childWorkflowRetryTimers)
+
+	// The child fails on its first attempt and succeeds on its second, so its
+	// two ChildWorkflowInstanceCreated events correlate into a single retry
+	// chain of [first attempt, retry attempt].
+	chains := fworkflow.ChildWorkflowRetryChains(hist.GetEvents())
+	require.Len(t, chains, 1)
+	chain := slices.Collect(maps.Values(chains))[0]
+	require.Len(t, chain, 2)
+	first, retry := chain[0], chain[1]
+
+	// The first attempt carries no correlation info; the retry attempt points
+	// back at the first attempt's instance ID while keeping its own distinct
+	// instance ID.
+	assert.Equal(t, "child", first.GetName())
+	assert.Nil(t, first.GetRetryParentInstanceInfo())
+	assert.Equal(t, "child", retry.GetName())
+	require.NotNil(t, retry.GetRetryParentInstanceInfo())
+	assert.Equal(t, first.GetInstanceId(), retry.GetRetryParentInstanceInfo().GetInstanceID())
+	assert.NotEqual(t, first.GetInstanceId(), retry.GetInstanceId())
 }

--- a/tests/integration/suite/daprd/workflow/retries/childworkflowdistinct.go
+++ b/tests/integration/suite/daprd/workflow/retries/childworkflowdistinct.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retries
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childworkflowdistinct))
+}
+
+// childworkflowdistinct exercises retry-chain correlation for two child
+// workflows with different names AND different inputs, awaited at once so they
+// run in parallel. One child fails twice and succeeds on its third attempt
+// (producing a three-attempt retry chain); the other succeeds on its first
+// attempt (a single-attempt chain with no RetryParentInstanceInfo). The test
+// verifies each chain correlates only to its own first attempt and carries the
+// expected name and input.
+type childworkflowdistinct struct {
+	workflow *workflow.Workflow
+}
+
+func (e *childworkflowdistinct) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *childworkflowdistinct) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	retry := task.WithChildWorkflowRetryPolicy(&task.RetryPolicy{
+		MaxAttempts:          3,
+		InitialRetryInterval: 10 * time.Millisecond,
+	})
+
+	e.workflow.Registry().AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		// Schedule both children before awaiting either, so they run in
+		// parallel. Different names, different inputs.
+		cFail := ctx.CallChildWorkflow("childFail", task.WithChildWorkflowInput("fail-input"), retry)
+		cOk := ctx.CallChildWorkflow("childOk", task.WithChildWorkflowInput("ok-input"), retry)
+		return nil, errors.Join(cFail.Await(nil), cOk.Await(nil))
+	})
+
+	// childFail fails its first two attempts and succeeds on the third.
+	var failCalls atomic.Int64
+	e.workflow.Registry().AddWorkflowN("childFail", func(ctx *task.WorkflowContext) (any, error) {
+		if failCalls.Add(1) <= 2 {
+			return nil, errors.New("childFail failure")
+		}
+		return nil, nil
+	})
+
+	// childOk succeeds on its first attempt and is never retried.
+	e.workflow.Registry().AddWorkflowN("childOk", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "parent")
+	require.NoError(t, err)
+
+	_, err = cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	hist, err := cl.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	// Only childFail retries (twice); childOk never does.
+	var childWorkflowRetryTimers int
+	for _, ev := range hist.GetEvents() {
+		if cwr := ev.GetTimerCreated().GetChildWorkflowRetry(); cwr != nil {
+			childWorkflowRetryTimers++
+			assert.NotEmpty(t, cwr.GetInstanceId())
+		}
+	}
+	assert.Equal(t, 2, childWorkflowRetryTimers)
+
+	chains := fworkflow.ChildWorkflowRetryChains(hist.GetEvents())
+	require.Len(t, chains, 2)
+
+	var sawFail, sawOk bool
+	for key, chain := range chains {
+		switch chain[0].GetName() {
+		case "childFail":
+			sawFail = true
+			require.Lenf(t, chain, 3, "childFail chain %q should have two retries", key)
+			for _, cc := range chain {
+				assert.Equal(t, "childFail", cc.GetName())
+				assert.Equal(t, `"fail-input"`, cc.GetInput().GetValue())
+			}
+		case "childOk":
+			sawOk = true
+			require.Lenf(t, chain, 1, "childOk chain %q should have a single attempt", key)
+			assert.Equal(t, `"ok-input"`, chain[0].GetInput().GetValue())
+			assert.Nil(t, chain[0].GetRetryParentInstanceInfo())
+		default:
+			t.Fatalf("unexpected child workflow name %q", chain[0].GetName())
+		}
+	}
+	assert.True(t, sawFail, "expected a childFail retry chain")
+	assert.True(t, sawOk, "expected a childOk chain")
+}

--- a/tests/integration/suite/daprd/workflow/retries/childworkflowparallel.go
+++ b/tests/integration/suite/daprd/workflow/retries/childworkflowparallel.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retries
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childworkflowparallel))
+}
+
+// childworkflowparallel exercises retry-chain correlation for two child
+// workflows that share the same name AND the same input and are awaited at
+// once, so they run in parallel. Because the two children are indistinguishable
+// from the child function's point of view (identical name + input), both behave
+// identically and fail every attempt. With MaxAttempts=3 each child therefore
+// fails three times, producing two independent three-attempt retry chains. The
+// test verifies the runtime keeps the two chains correctly correlated and never
+// crosses their instance IDs even though the children look identical.
+type childworkflowparallel struct {
+	workflow *workflow.Workflow
+}
+
+func (e *childworkflowparallel) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *childworkflowparallel) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	retry := task.WithChildWorkflowRetryPolicy(&task.RetryPolicy{
+		MaxAttempts:          3,
+		InitialRetryInterval: 10 * time.Millisecond,
+	})
+
+	e.workflow.Registry().AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		// Schedule both children before awaiting either, so they are dispatched
+		// in the same orchestration turn and run in parallel. Same name, same
+		// input.
+		c1 := ctx.CallChildWorkflow("child", task.WithChildWorkflowInput("same-input"), retry)
+		c2 := ctx.CallChildWorkflow("child", task.WithChildWorkflowInput("same-input"), retry)
+		// Both children exhaust their retries and fail; the parent swallows the
+		// errors so it completes and we can inspect the recorded history.
+		_ = c1.Await(nil)
+		_ = c2.Await(nil)
+		return nil, nil
+	})
+
+	e.workflow.Registry().AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, errors.New("child always fails")
+	})
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "parent")
+	require.NoError(t, err)
+
+	_, err = cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	hist, err := cl.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	// Two children, each attempted 3 times and failing, produce 4 retry timers
+	// (two per child).
+	var childWorkflowRetryTimers int
+	for _, ev := range hist.GetEvents() {
+		if cwr := ev.GetTimerCreated().GetChildWorkflowRetry(); cwr != nil {
+			childWorkflowRetryTimers++
+			assert.NotEmpty(t, cwr.GetInstanceId())
+		}
+	}
+	assert.Equal(t, 4, childWorkflowRetryTimers)
+
+	// Grouping the child-created events by correlation key must yield exactly
+	// two distinct chains (one per parallel child, with different keys), each
+	// with three attempts carrying the identical name and input. A crossed or
+	// missing RetryParentInstanceInfo would change the number of chains or their
+	// lengths.
+	chains := fworkflow.ChildWorkflowRetryChains(hist.GetEvents())
+	require.Len(t, chains, 2)
+
+	for key, chain := range chains {
+		require.Lenf(t, chain, 3, "chain %q should have one initial attempt and two retries", key)
+		for _, cc := range chain {
+			assert.Equal(t, "child", cc.GetName())
+			assert.Equal(t, `"same-input"`, cc.GetInput().GetValue())
+		}
+	}
+}

--- a/tests/integration/suite/daprd/workflow/retries/childworkflowparallelmixed.go
+++ b/tests/integration/suite/daprd/workflow/retries/childworkflowparallelmixed.go
@@ -109,7 +109,7 @@ func (e *childworkflowparallelmixed) Run(t *testing.T, ctx context.Context) {
 	chains := fworkflow.ChildWorkflowRetryChains(hist.GetEvents())
 	require.Len(t, chains, 2)
 
-	var lengths []int
+	lengths := make([]int, 0, len(chains))
 	for _, chain := range chains {
 		lengths = append(lengths, len(chain))
 		for _, cc := range chain {

--- a/tests/integration/suite/daprd/workflow/retries/childworkflowparallelmixed.go
+++ b/tests/integration/suite/daprd/workflow/retries/childworkflowparallelmixed.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retries
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childworkflowparallelmixed))
+}
+
+// childworkflowparallelmixed exercises retry-chain correlation for two child
+// workflows that share the same name AND the same input, awaited at once so
+// they run in parallel, where one fails (and is retried) while the other does
+// not. Because identical name+input children are indistinguishable to the child
+// function, and each retry attempt is a brand new instance, the outcome is
+// driven purely by execution order: only the globally first attempt fails, so
+// exactly one of the two children is retried once and the other succeeds
+// immediately. The test asserts the correlation still produces one two-attempt
+// chain and one single-attempt chain, with distinct, non-crossed instance IDs.
+type childworkflowparallelmixed struct {
+	workflow *workflow.Workflow
+}
+
+func (e *childworkflowparallelmixed) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *childworkflowparallelmixed) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	retry := task.WithChildWorkflowRetryPolicy(&task.RetryPolicy{
+		MaxAttempts:          3,
+		InitialRetryInterval: 10 * time.Millisecond,
+	})
+
+	e.workflow.Registry().AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		// Schedule both children before awaiting either, so they run in
+		// parallel. Same name, same input.
+		c1 := ctx.CallChildWorkflow("child", task.WithChildWorkflowInput("same-input"), retry)
+		c2 := ctx.CallChildWorkflow("child", task.WithChildWorkflowInput("same-input"), retry)
+		return nil, errors.Join(c1.Await(nil), c2.Await(nil))
+	})
+
+	// Only the globally first attempt fails; every later attempt (the retry of
+	// whichever child failed, and the other child's single attempt) succeeds.
+	// The result is deterministic in shape regardless of scheduling: exactly one
+	// child is retried once and the other succeeds on its first attempt.
+	var calls atomic.Int64
+	e.workflow.Registry().AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		if calls.Add(1) == 1 {
+			return nil, errors.New("child failure")
+		}
+		return nil, nil
+	})
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "parent")
+	require.NoError(t, err)
+
+	_, err = cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	hist, err := cl.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	// Exactly one child is retried, exactly once.
+	var childWorkflowRetryTimers int
+	for _, ev := range hist.GetEvents() {
+		if cwr := ev.GetTimerCreated().GetChildWorkflowRetry(); cwr != nil {
+			childWorkflowRetryTimers++
+			assert.NotEmpty(t, cwr.GetInstanceId())
+		}
+	}
+	assert.Equal(t, 1, childWorkflowRetryTimers)
+
+	// Two distinct chains: the retried child has two attempts, the other has a
+	// single attempt. Both share the same name and input.
+	chains := fworkflow.ChildWorkflowRetryChains(hist.GetEvents())
+	require.Len(t, chains, 2)
+
+	var lengths []int
+	for _, chain := range chains {
+		lengths = append(lengths, len(chain))
+		for _, cc := range chain {
+			assert.Equal(t, "child", cc.GetName())
+			assert.Equal(t, `"same-input"`, cc.GetInput().GetValue())
+		}
+	}
+	// One child is retried once (a two-attempt chain); the other succeeds on its
+	// first attempt (a single-attempt chain).
+	slices.Sort(lengths)
+	assert.Equal(t, []int{1, 2}, lengths)
+}

--- a/tests/integration/suite/daprd/workflow/retries/childworkflowsequential.go
+++ b/tests/integration/suite/daprd/workflow/retries/childworkflowsequential.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retries
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childworkflowsequential))
+}
+
+// childworkflowsequential verifies that calling a child workflow with the same
+// name twice in sequence is supported and that each invocation gets its own,
+// correctly correlated retry chain. The child fails on odd invocations and
+// succeeds on even ones; because the calls are sequential each child is
+// attempted twice (fail then succeed), producing two independent two-attempt
+// retry chains that must not be conflated despite sharing the same name.
+type childworkflowsequential struct {
+	workflow *workflow.Workflow
+}
+
+func (e *childworkflowsequential) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *childworkflowsequential) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	retry := task.WithChildWorkflowRetryPolicy(&task.RetryPolicy{
+		MaxAttempts:          3,
+		InitialRetryInterval: 10 * time.Millisecond,
+	})
+
+	e.workflow.Registry().AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		// Two child workflows with the same name, run one after the other.
+		if err := ctx.CallChildWorkflow("child", task.WithChildWorkflowInput("seq"), retry).Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.CallChildWorkflow("child", task.WithChildWorkflowInput("seq"), retry).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+
+	// Sequential execution gives a deterministic invocation order: the first
+	// child is attempt #1 (fail) then #2 (succeed); the second child is
+	// attempt #3 (fail) then #4 (succeed). Failing on odd invocations therefore
+	// makes each sequential child fail exactly once before succeeding.
+	var calls atomic.Int64
+	e.workflow.Registry().AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		if calls.Add(1)%2 == 1 {
+			return nil, errors.New("child failure on odd attempt")
+		}
+		return nil, nil
+	})
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "parent")
+	require.NoError(t, err)
+
+	_, err = cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	hist, err := cl.GetInstanceHistory(ctx, id)
+	require.NoError(t, err)
+
+	// Each of the two sequential children retries once, so there are 2 retry
+	// timers in total.
+	var childWorkflowRetryTimers int
+	for _, ev := range hist.GetEvents() {
+		if cwr := ev.GetTimerCreated().GetChildWorkflowRetry(); cwr != nil {
+			childWorkflowRetryTimers++
+			assert.NotEmpty(t, cwr.GetInstanceId())
+		}
+	}
+	assert.Equal(t, 2, childWorkflowRetryTimers)
+
+	// Two distinct retry chains, one per sequential call, each with a first
+	// attempt and a single retry. The chains must have different correlation
+	// keys even though both children share the same name.
+	chains := fworkflow.ChildWorkflowRetryChains(hist.GetEvents())
+	require.Len(t, chains, 2)
+	for key, chain := range chains {
+		require.Lenf(t, chain, 2, "chain %q should have one initial attempt and one retry", key)
+		for _, cc := range chain {
+			assert.Equal(t, "child", cc.GetName())
+			assert.Equal(t, `"seq"`, cc.GetInput().GetValue())
+		}
+	}
+}


### PR DESCRIPTION
Close: https://github.com/dapr/dapr/issues/10135

- Update durabletask to include the changes from https://github.com/dapr/durabletask-go/pull/109
- Covers the new functionality with integration tests.