### PR TITLE
Reserve GRPC port early

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -7,6 +7,7 @@ This update contains the following bug fixes:
 - [Sidecars restart when an unrelated Configuration is created or updated](#sidecars-restart-when-an-unrelated-configuration-is-created-or-updated)
 - [IAM Roles Anywhere X.509 authentication breaks with certificate chains, SVID refresh, and missing SVIDs](#iam-roles-anywhere-x509-authentication-breaks-with-certificate-chains-svid-refresh-and-missing-svids)
 - [Redis components updated to go-redis v9.21.0](#redis-components-updated-to-go-redis-v9210)
+- [Sidecar reserves its internal gRPC port before initializing components](#sidecar-reserves-its-internal-grpc-port-before-initializing-components)
 
 ## SPIFFE SVID component operation propagation
 
@@ -157,3 +158,24 @@ When v9.21.0 added fields to `XMessage`, that conversion no longer compiled.
 
 The Redis client dependency is bumped to go-redis v9.21.0, and `XClaimResult` now assigns the `ID` and `Values` fields explicitly, matching the field-by-field pattern already used by `XReadGroupResult`.
 This keeps the conversion resilient to future field additions in the upstream `XMessage` type.
+
+## Sidecar reserves its internal gRPC port before initializing components
+
+### Problem
+
+A Dapr sidecar (`daprd`) could randomly fail to start with `bind: address already in use` on its internal gRPC port (default `50002`), even though no other process was using it.
+
+### Impact
+
+You were affected if your sidecars loaded components that open outbound connections during initialization (Redis-backed state stores, pub/sub, configuration stores, or locks). It was most likely on Linux and got more frequent with more components and more frequent pod restarts.
+
+### Root Cause
+
+The sidecar initialized its components before binding its internal gRPC port. Component initialization opens outbound connections, and the OS can assign the internal gRPC port as the connection's ephemeral source port (the default `50002` falls inside the Linux ephemeral range `32768`–`60999`), so the sidecar's later attempt to listen on that port failed.
+
+### Solution
+
+The sidecar now binds its internal gRPC port at the very start of runtime initialization, before any component is initialized, and hands that already-bound listener to the internal gRPC server rather than binding the port a second time.
+Because the sidecar holds the port from the outset, the operating system will not hand it out as an ephemeral source port, so component connections can no longer take it and the sidecar starts reliably.
+If initialization fails before the internal gRPC server starts, the reserved port is released.
+No configuration change is required. If you previously set the `dapr.io/internal-grpc-port` annotation to a value outside the dynamic range (for example `61002`) as a workaround, you can keep or remove it.

--- a/pkg/api/grpc/server.go
+++ b/pkg/api/grpc/server.go
@@ -79,6 +79,11 @@ type OptionsInternal struct {
 	Security    security.Handler
 	Proxy       messaging.Proxy
 	Healthz     healthz.Healthz
+	// Listener, when set, is served directly instead of binding Config.Port.
+	// It lets the runtime reserve the internal gRPC port early (before
+	// components are initialized) and hand the already-bound listener to the
+	// server, avoiding an ephemeral-source-port collision.
+	Listener net.Listener
 }
 
 type server struct {
@@ -98,6 +103,9 @@ type server struct {
 	sec            security.Handler
 	wg             sync.WaitGroup
 	htarget        healthz.Target
+	// listener, when set, is served directly instead of binding config.Port.
+	// See OptionsInternal.Listener and issue #6023.
+	listener net.Listener
 }
 
 var (
@@ -190,6 +198,7 @@ func NewInternalServer(opts OptionsInternal) Server {
 		proxy:          opts.Proxy,
 		sec:            opts.Security,
 		htarget:        opts.Healthz.AddTarget("grpc-internal-server"),
+		listener:       opts.Listener,
 	}
 }
 
@@ -204,6 +213,10 @@ func (s *server) StartNonBlocking(ctx context.Context) error {
 		}
 		s.logger.Infof("gRPC server listening on UNIX socket: %s", socket)
 		listeners = append(listeners, l)
+	} else if s.listener != nil {
+		// The port was reserved earlier and the bound listener handed to us.
+		s.logger.Infof("gRPC server listening on pre-bound TCP address: %s", s.listener.Addr())
+		listeners = append(listeners, s.listener)
 	} else {
 		for _, apiListenAddress := range s.config.APIListenAddresses {
 			addr := apiListenAddress + ":" + strconv.Itoa(s.config.Port)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -690,15 +690,20 @@ func createOtelResource(ctx context.Context, defaultServiceName string) *resourc
 func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	var err error
 
-	// Reserve the internal gRPC port before initializing components (or
-	// anything else that dials out). Otherwise a component's outbound
-	// connection can be assigned this port as an ephemeral source port,
-	// causing the internal gRPC server to later fail to bind. See issue #6023.
-	if err = a.reserveInternalGRPCServerPort(ctx); err != nil {
-		return fmt.Errorf("failed to reserve internal gRPC server port: %w", err)
+	// Reserve the internal gRPC port before initializing components so that a
+	// component's outbound connection cannot be assigned this port as an
+	// ephemeral source port (see issue #6023). This is best-effort: the
+	// internal gRPC server still binds the port itself in
+	// startGRPCInternalServer (which retries), so failing to reserve here must
+	// not be fatal. In particular, during a SIGHUP restart the port can be
+	// momentarily held by the previous runtime's teardown; falling through to
+	// the later bind lets it succeed once the port frees, as it did before the
+	// reservation was introduced.
+	if rerr := a.reserveInternalGRPCServerPort(ctx); rerr != nil {
+		log.Warnf("could not reserve internal gRPC port before component initialization; it will be bound when the internal gRPC server starts: %v", rerr)
 	}
-	// Release the reserved port if init returns before the internal gRPC
-	// server is started to take ownership of the listener.
+	// If the port was reserved but init returns before the internal gRPC
+	// server takes ownership of the listener, release it.
 	defer func() {
 		if cerr := a.closeUnstartedInternalGRPCListener(); cerr != nil {
 			log.Warnf("failed to close reserved internal gRPC listener: %v", cerr)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -49,6 +49,7 @@ import (
 	"github.com/dapr/dapr/pkg/api/grpc/manager"
 	"github.com/dapr/dapr/pkg/api/grpc/proxy/codec"
 	"github.com/dapr/dapr/pkg/api/http"
+	"github.com/dapr/dapr/pkg/api/listen"
 	"github.com/dapr/dapr/pkg/api/universal"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
@@ -130,6 +131,10 @@ type DaprRuntime struct {
 
 	grpcAPIServer      grpc.Server
 	grpcInternalServer grpc.Server
+	// grpcInternalServerListener is bound early (before components are
+	// initialized) to reserve the internal gRPC port, then handed to the
+	// internal gRPC server. See reserveInternalGRPCServerPort and issue #6023.
+	grpcInternalServerListener net.Listener
 
 	// Used for testing.
 	initComplete chan struct{}
@@ -445,6 +450,10 @@ func newDaprRuntime(ctx context.Context,
 			<-ctx.Done()
 
 			if server := rt.grpcInternalServer; server != nil {
+				// Closing the server also closes the reserved listener it was
+				// handed. If the server was never started, initRuntime's defer
+				// (closeUnstartedInternalGRPCListener) releases the reserved
+				// listener instead.
 				return server.Close()
 			}
 
@@ -680,6 +689,22 @@ func createOtelResource(ctx context.Context, defaultServiceName string) *resourc
 
 func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	var err error
+
+	// Reserve the internal gRPC port before initializing components (or
+	// anything else that dials out). Otherwise a component's outbound
+	// connection can be assigned this port as an ephemeral source port,
+	// causing the internal gRPC server to later fail to bind. See issue #6023.
+	if err = a.reserveInternalGRPCServerPort(ctx); err != nil {
+		return fmt.Errorf("failed to reserve internal gRPC server port: %w", err)
+	}
+	// Release the reserved port if init returns before the internal gRPC
+	// server is started to take ownership of the listener.
+	defer func() {
+		if cerr := a.closeUnstartedInternalGRPCListener(); cerr != nil {
+			log.Warnf("failed to close reserved internal gRPC listener: %v", cerr)
+		}
+	}()
+
 	if a.hostAddress, err = utils.GetHostAddress(); err != nil {
 		return fmt.Errorf("failed to determine host address: %w", err)
 	}
@@ -1076,10 +1101,42 @@ func (a *DaprRuntime) startHTTPServer(ctx context.Context) error {
 	return nil
 }
 
+// reserveInternalGRPCServerPort binds the internal gRPC listener early, before
+// components are initialized, to reserve the port. Otherwise a component's
+// outbound connection (e.g. to Redis) can be assigned this port as an
+// ephemeral source port, causing the internal gRPC server to later fail to
+// bind with "address already in use" (see issue #6023). The listener is then
+// handed to the internal gRPC server in startGRPCInternalServer.
+func (a *DaprRuntime) reserveInternalGRPCServerPort(ctx context.Context) error {
+	addr := a.runtimeConfig.internalGRPCListenAddress + ":" + strconv.Itoa(a.runtimeConfig.internalGRPCPort)
+	ln, err := listen.TCP(ctx, addr)
+	if err != nil {
+		return err
+	}
+	a.grpcInternalServerListener = ln
+	// If the configured port was 0 (dynamic), record the port the OS assigned
+	// so that name resolution and actors advertise the real port.
+	a.runtimeConfig.internalGRPCPort = ln.Addr().(*net.TCPAddr).Port
+	return nil
+}
+
+// closeUnstartedInternalGRPCListener releases the reserved internal gRPC
+// listener when the internal gRPC server was never started (e.g. init failed
+// before startGRPCInternalServer). Once the server has started it owns the
+// listener and closes it on shutdown, so this is a no-op. Called from
+// initRuntime's defer, on the same goroutine that starts the server, so it
+// cannot race startGRPCInternalServer.
+func (a *DaprRuntime) closeUnstartedInternalGRPCListener() error {
+	if a.grpcInternalServer != nil || a.grpcInternalServerListener == nil {
+		return nil
+	}
+	return a.grpcInternalServerListener.Close()
+}
+
 func (a *DaprRuntime) startGRPCInternalServer(ctx context.Context, api grpc.API) error {
 	// Since GRPCInteralServer is encrypted & authenticated, it is safe to listen on *
 	serverConf := a.getNewServerConfig([]string{a.runtimeConfig.internalGRPCListenAddress}, a.runtimeConfig.internalGRPCPort)
-	a.grpcInternalServer = grpc.NewInternalServer(grpc.OptionsInternal{
+	server := grpc.NewInternalServer(grpc.OptionsInternal{
 		API:         api,
 		Config:      serverConf,
 		TracingSpec: a.globalConfig.GetTracingSpec(),
@@ -1087,12 +1144,18 @@ func (a *DaprRuntime) startGRPCInternalServer(ctx context.Context, api grpc.API)
 		Security:    a.sec,
 		Proxy:       a.proxy,
 		Healthz:     a.runtimeConfig.healthz,
+		// Serve the listener reserved before component initialization rather
+		// than binding the port again here. See reserveInternalGRPCServerPort.
+		Listener: a.grpcInternalServerListener,
 	})
 
-	err := a.grpcInternalServer.StartNonBlocking(ctx)
-	if err != nil {
+	if err := server.StartNonBlocking(ctx); err != nil {
 		return err
 	}
+
+	// Only record the server (and hence take ownership of the reserved
+	// listener) once it has successfully started serving.
+	a.grpcInternalServer = server
 
 	return nil
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1015,6 +1015,32 @@ func TestCloseUnstartedInternalGRPCListenerNoopWhenStarted(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestStartGRPCInternalServerBindsWithoutReservation verifies the fallback
+// path used when the internal gRPC port was not reserved ahead of time (for
+// example, reserving it failed during a SIGHUP restart): startGRPCInternalServer
+// binds the port itself rather than requiring a pre-bound listener.
+func TestStartGRPCInternalServerBindsWithoutReservation(t *testing.T) {
+	rt, err := NewTestDaprRuntime(t, modes.StandaloneMode)
+	require.NoError(t, err)
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCPort = port
+
+	// No reservation was made, so the server must bind the port itself.
+	require.Nil(t, rt.grpcInternalServerListener)
+	require.NoError(t, rt.startGRPCInternalServer(t.Context(), nil))
+	require.NotNil(t, rt.grpcInternalServer)
+	t.Cleanup(func() {
+		require.NoError(t, rt.grpcInternalServer.Close())
+	})
+
+	// The port is held by the running server.
+	_, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.Error(t, err)
+}
+
 func TestGracefulShutdown(t *testing.T) {
 	r, err := NewTestDaprRuntime(t, modes.StandaloneMode)
 	require.NoError(t, err)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -914,6 +914,107 @@ func NewTestDaprRuntimeConfig(t *testing.T, mode modes.DaprMode, appProtocol str
 	}
 }
 
+// TestReserveInternalGRPCServerPort verifies that the internal gRPC port is
+// reserved before components are initialized. Otherwise a component's
+// outbound connection (e.g. to Redis) can be assigned this port as an
+// ephemeral source port, causing the internal gRPC server to later fail to
+// bind with "address already in use" (see issue #6023).
+func TestReserveInternalGRPCServerPort(t *testing.T) {
+	rt, err := NewTestDaprRuntime(t, modes.StandaloneMode)
+	require.NoError(t, err)
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCPort = port
+
+	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
+	require.NotNil(t, rt.grpcInternalServerListener)
+	t.Cleanup(func() {
+		require.NoError(t, rt.grpcInternalServerListener.Close())
+	})
+
+	// The reserved listener is bound to the configured port.
+	assert.Equal(t, port, rt.grpcInternalServerListener.Addr().(*net.TCPAddr).Port)
+
+	// The port is now held: nothing else (including an ephemeral source port
+	// picked by a component's outbound connection) can claim it.
+	_, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.Error(t, err)
+}
+
+// TestStartGRPCInternalServerReusesReservedListener verifies that the internal
+// gRPC server binds to the listener reserved by reserveInternalGRPCServerPort,
+// rather than trying to bind the port a second time. Binding again would fail
+// because the reserved listener already holds the port (see issue #6023).
+func TestStartGRPCInternalServerReusesReservedListener(t *testing.T) {
+	rt, err := NewTestDaprRuntime(t, modes.StandaloneMode)
+	require.NoError(t, err)
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCPort = port
+
+	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
+
+	require.NoError(t, rt.startGRPCInternalServer(t.Context(), nil))
+	require.NotNil(t, rt.grpcInternalServer)
+	t.Cleanup(func() {
+		require.NoError(t, rt.grpcInternalServer.Close())
+	})
+}
+
+// TestCloseUnstartedInternalGRPCListenerReleasesPort verifies that the port
+// reserved by reserveInternalGRPCServerPort is released when the internal gRPC
+// server is never started (e.g. initRuntime fails before
+// startGRPCInternalServer). Otherwise the reserved port would stay held after
+// init returns (see issue #6023).
+func TestCloseUnstartedInternalGRPCListenerReleasesPort(t *testing.T) {
+	rt, err := NewTestDaprRuntime(t, modes.StandaloneMode)
+	require.NoError(t, err)
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCPort = port
+
+	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
+
+	// The internal gRPC server was never started, so releasing must free the
+	// reserved port.
+	require.NoError(t, rt.closeUnstartedInternalGRPCListener())
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err)
+	require.NoError(t, ln.Close())
+}
+
+// TestCloseUnstartedInternalGRPCListenerNoopWhenStarted verifies that once the
+// internal gRPC server has started and owns the listener, releasing the
+// unstarted listener is a no-op that does not disturb the running server.
+func TestCloseUnstartedInternalGRPCListenerNoopWhenStarted(t *testing.T) {
+	rt, err := NewTestDaprRuntime(t, modes.StandaloneMode)
+	require.NoError(t, err)
+
+	port, err := freeport.GetFreePort()
+	require.NoError(t, err)
+	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCPort = port
+
+	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
+	require.NoError(t, rt.startGRPCInternalServer(t.Context(), nil))
+	t.Cleanup(func() {
+		require.NoError(t, rt.grpcInternalServer.Close())
+	})
+
+	require.NoError(t, rt.closeUnstartedInternalGRPCListener())
+
+	// The running server still holds the port.
+	_, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.Error(t, err)
+}
+
 func TestGracefulShutdown(t *testing.T) {
 	r, err := NewTestDaprRuntime(t, modes.StandaloneMode)
 	require.NoError(t, err)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -876,7 +876,7 @@ func NewTestDaprRuntimeConfig(t *testing.T, mode modes.DaprMode, appProtocol str
 			Protocol:       protocol.Protocol(appProtocol),
 			Port:           appPort,
 			MaxConcurrency: -1,
-			ChannelAddress: "127.0.0.1",
+			ChannelAddress: DefaultChannelAddress,
 		},
 		mode:                         mode,
 		httpPort:                     DefaultDaprHTTPPort,
@@ -925,7 +925,7 @@ func TestReserveInternalGRPCServerPort(t *testing.T) {
 
 	port, err := freeport.GetFreePort()
 	require.NoError(t, err)
-	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCListenAddress = DefaultChannelAddress
 	rt.runtimeConfig.internalGRPCPort = port
 
 	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
@@ -939,7 +939,7 @@ func TestReserveInternalGRPCServerPort(t *testing.T) {
 
 	// The port is now held: nothing else (including an ephemeral source port
 	// picked by a component's outbound connection) can claim it.
-	_, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	_, err = net.Listen("tcp", fmt.Sprintf("%s:%d", DefaultChannelAddress, port))
 	require.Error(t, err)
 }
 
@@ -953,7 +953,7 @@ func TestStartGRPCInternalServerReusesReservedListener(t *testing.T) {
 
 	port, err := freeport.GetFreePort()
 	require.NoError(t, err)
-	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCListenAddress = DefaultChannelAddress
 	rt.runtimeConfig.internalGRPCPort = port
 
 	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
@@ -976,7 +976,7 @@ func TestCloseUnstartedInternalGRPCListenerReleasesPort(t *testing.T) {
 
 	port, err := freeport.GetFreePort()
 	require.NoError(t, err)
-	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCListenAddress = DefaultChannelAddress
 	rt.runtimeConfig.internalGRPCPort = port
 
 	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
@@ -985,7 +985,7 @@ func TestCloseUnstartedInternalGRPCListenerReleasesPort(t *testing.T) {
 	// reserved port.
 	require.NoError(t, rt.closeUnstartedInternalGRPCListener())
 
-	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", DefaultChannelAddress, port))
 	require.NoError(t, err)
 	require.NoError(t, ln.Close())
 }
@@ -999,7 +999,7 @@ func TestCloseUnstartedInternalGRPCListenerNoopWhenStarted(t *testing.T) {
 
 	port, err := freeport.GetFreePort()
 	require.NoError(t, err)
-	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCListenAddress = DefaultChannelAddress
 	rt.runtimeConfig.internalGRPCPort = port
 
 	require.NoError(t, rt.reserveInternalGRPCServerPort(t.Context()))
@@ -1011,7 +1011,7 @@ func TestCloseUnstartedInternalGRPCListenerNoopWhenStarted(t *testing.T) {
 	require.NoError(t, rt.closeUnstartedInternalGRPCListener())
 
 	// The running server still holds the port.
-	_, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	_, err = net.Listen("tcp", fmt.Sprintf("%s:%d", DefaultChannelAddress, port))
 	require.Error(t, err)
 }
 
@@ -1025,7 +1025,7 @@ func TestStartGRPCInternalServerBindsWithoutReservation(t *testing.T) {
 
 	port, err := freeport.GetFreePort()
 	require.NoError(t, err)
-	rt.runtimeConfig.internalGRPCListenAddress = "127.0.0.1"
+	rt.runtimeConfig.internalGRPCListenAddress = DefaultChannelAddress
 	rt.runtimeConfig.internalGRPCPort = port
 
 	// No reservation was made, so the server must bind the port itself.
@@ -1037,7 +1037,7 @@ func TestStartGRPCInternalServerBindsWithoutReservation(t *testing.T) {
 	})
 
 	// The port is held by the running server.
-	_, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	_, err = net.Listen("tcp", fmt.Sprintf("%s:%d", DefaultChannelAddress, port))
 	require.Error(t, err)
 }
 
@@ -2007,7 +2007,7 @@ func TestGetComponentsCapabilitiesMap(t *testing.T) {
 }
 
 func runGRPCApp(port int) (func(), error) {
-	serverListener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	serverListener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", DefaultChannelAddress, port))
 	if err != nil {
 		return func() {}, err
 	}

--- a/tests/integration/suite/ports/internalgrpc.go
+++ b/tests/integration/suite/ports/internalgrpc.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ports
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(internalgrpc))
+}
+
+// internalgrpc verifies that daprd reserves (binds) its internal gRPC port
+// before it initializes components. Otherwise a component's outbound
+// connection can be assigned this port as an ephemeral source port.
+type internalgrpc struct {
+	daprd       *procdaprd.Daprd
+	initEntered chan struct{}
+	release     chan struct{}
+}
+
+func (i *internalgrpc) Setup(t *testing.T) []framework.Option {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping unix socket based test on windows")
+	}
+
+	i.initEntered = make(chan struct{})
+	i.release = make(chan struct{})
+
+	sock := socket.New(t)
+	store := statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(&blockingStore{
+			Store:       inmemory.New(t),
+			initEntered: i.initEntered,
+			release:     i.release,
+		}),
+	)
+
+	i.daprd = procdaprd.New(t,
+		procdaprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+`, store.SocketName())),
+		procdaprd.WithSocket(t, sock),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(store, i.daprd),
+	}
+}
+
+func (i *internalgrpc) Run(t *testing.T, ctx context.Context) {
+	// Wait until daprd is blocked inside the component's Init: component
+	// initialization has started but not yet completed.
+	select {
+	case <-i.initEntered:
+	case <-time.After(time.Second * 30):
+		t.Fatal("timed out waiting for component Init to be entered")
+	}
+
+	// The internal gRPC port must already be listening even though component
+	// initialization has not finished.
+	addr := fmt.Sprintf("localhost:%d", i.daprd.InternalGRPCPort())
+	dialer := net.Dialer{Timeout: time.Second}
+	assert.Eventuallyf(t, func() bool {
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return false
+		}
+		require.NoError(t, conn.Close())
+		return true
+	}, time.Second*10, 10*time.Millisecond, "internal gRPC port (%s) was not reserved before component init", addr)
+
+	// Unblock initialization and confirm daprd finishes starting up.
+	close(i.release)
+	i.daprd.WaitUntilRunning(t, ctx)
+}
+
+// blockingStore wraps a state store and blocks in Init until released,
+// signalling initEntered the first time Init is called.
+type blockingStore struct {
+	state.Store
+	initEntered chan struct{}
+	release     chan struct{}
+	once        sync.Once
+}
+
+func (b *blockingStore) Init(ctx context.Context, meta state.Metadata) error {
+	// The test framework calls Init once during its own setup with empty
+	// metadata (see statestore.go). Only gate the Init initiated by daprd over
+	// the pluggable gRPC channel, which always carries a non-empty component
+	// name (see the pluggable statestore component wrapper).
+	if meta.Name == "" {
+		return b.Store.Init(ctx, meta)
+	}
+	b.once.Do(func() { close(b.initEntered) })
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return b.Store.Init(ctx, meta)
+}


### PR DESCRIPTION
# Description

daprd could randomly fail at startup with "bind: address already in use" on its internal gRPC port due to ephemeral being used already.

This PR reserves the port early before components are loaded, so the port won't be used by any of the components.

## Issue reference

Closes https://github.com/dapr/dapr/issues/6023