### PR TITLE
auto open issue on ci failure during release

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -806,7 +806,7 @@ jobs:
     permissions:
       issues: write
       actions: read
-    uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@master
+    uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@main
     with:
       title: "Release publish failed: ${{ github.workflow }} (${{ github.ref_name }})"
       labels: "release,ci/publish-failure"

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -796,3 +796,20 @@ jobs:
         run: |
           gh api repos/dapr/test-infra/actions/workflows/version-update.yml/dispatches \
             -X POST -f ref="master" -f 'inputs[rel_version]=${{ env.REL_VERSION }}'
+
+  # Opens (or comments on) a tracking issue when a tagged release fails
+  # anywhere in the build/publish/docker/helm chain (binaries, container
+  # images, Helm chart, and GitHub release assets).
+  notify-on-failure:
+    needs: [build, publish, docker-publish, helm, helmpublish]
+    if: failure() && startswith(github.ref, 'refs/tags/v') && github.repository_owner == 'dapr'
+    permissions:
+      issues: write
+      actions: read
+    uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@master
+    with:
+      title: "Release publish failed: ${{ github.workflow }} (${{ github.ref_name }})"
+      labels: "release,ci/publish-failure"
+      mention: "@dapr/maintainers-dapr @dapr/approvers-dapr"
+    secrets:
+      dapr_bot_token: ${{ secrets.DAPR_BOT_TOKEN }}

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -797,19 +797,18 @@ jobs:
           gh api repos/dapr/test-infra/actions/workflows/version-update.yml/dispatches \
             -X POST -f ref="master" -f 'inputs[rel_version]=${{ env.REL_VERSION }}'
 
-  # Opens (or comments on) a tracking issue when a tagged release fails
-  # anywhere in the build/publish/docker/helm chain (binaries, container
-  # images, Helm chart, and GitHub release assets).
+  # Opens (or comments on) a tracking issue only when a publish job itself fails:
+  # publish (release binaries/assets), docker-publish (images), or helmpublish
+  # (Helm chart). Upstream build failures skip these jobs, whose result is then
+  # 'skipped' (not 'failure'), so CI flakes never open issues.
   notify-on-failure:
-    needs: [build, publish, docker-publish, helm, helmpublish]
-    if: failure() && startswith(github.ref, 'refs/tags/v') && github.repository_owner == 'dapr'
+    needs: [publish, docker-publish, helmpublish]
+    if: always() && startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'dapr' && (needs.publish.result == 'failure' || needs['docker-publish'].result == 'failure' || needs.helmpublish.result == 'failure')
     permissions:
       issues: write
       actions: read
     uses: dapr/.github/.github/workflows/open-issue-on-failure.yml@main
     with:
-      title: "Release publish failed: ${{ github.workflow }} (${{ github.ref_name }})"
-      labels: "release,ci/publish-failure"
+      title: "Release workflow failed: ${{ github.workflow }} (${{ github.ref_name }})"
+      labels: "release,ci/release-failure"
       mention: "@dapr/maintainers-dapr @dapr/approvers-dapr"
-    secrets:
-      dapr_bot_token: ${{ secrets.DAPR_BOT_TOKEN }}


### PR DESCRIPTION
Reusable workflow_call that opens (or comments on) a tracking issue in the caller repo when a release/publish job fails, with links to the failed jobs and a maintainer @-mention.

[Needs this PR merged first.](https://github.com/dapr/.github/pull/14)