### PR TITLE
fix: return AlreadyExists status code when creating a workflow with active instance ID

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
@@ -97,7 +99,7 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 				o.actorID, startEvent.GetExecutionStarted().GetParentInstance().GetWorkflowInstance().GetInstanceId())
 			return nil
 		}
-		return fmt.Errorf("an active workflow with ID '%s' already exists", o.actorID)
+		return status.Errorf(codes.AlreadyExists, "an active workflow with ID '%s' already exists", o.actorID)
 	}
 	if o.activityResultAwaited.Load() {
 		return fmt.Errorf("a terminated workflow with ID '%s' is already awaiting an activity result", o.actorID)

--- a/tests/integration/suite/daprd/workflow/reuse.go
+++ b/tests/integration/suite/daprd/workflow/reuse.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
@@ -74,8 +76,10 @@ func (r *reuse) Run(t *testing.T, ctx context.Context) {
 	assert.True(t, errs[0] != nil || errs[1] != nil, errs)
 	assert.True(t, errs[0] == nil || errs[1] == nil, errs)
 	if errs[0] != nil {
+		assert.Equal(t, codes.AlreadyExists, status.Code(errs[0]), errs[0])
 		assert.Contains(t, errs[0].Error(), "an active workflow with ID 'foo' already exists")
 	} else {
+		assert.Equal(t, codes.AlreadyExists, status.Code(errs[1]), errs[1])
 		assert.Contains(t, errs[1].Error(), "an active workflow with ID 'foo' already exists")
 	}
 
@@ -86,6 +90,7 @@ func (r *reuse) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	_, err = client.ScheduleNewWorkflow(ctx, "reuse", api.WithInstanceID("foo"))
 	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
 	assert.Contains(t, err.Error(), "an active workflow with ID 'foo' already exists")
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

This would make it easy for sdk to know the problem without inspect the message

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
