### PR TITLE
Fix workflows becoming permanently unrecoverable after a save with a timer in the inbox

### DIFF
--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -412,6 +412,28 @@ func (s *State) ClearInbox() {
 	s.inboxAddedCount = 0
 }
 
+// persistableInbox returns the inbox without timer events, which are never
+// written as inbox keys. Unlike app-delivered events (whose durable home is
+// their inbox row, written before their trigger reminder), a TimerFired's
+// durable home is the scheduler job itself: the job carries the full event
+// payload and is only acked — and deleted — after the run that consumed the
+// event has committed it to history. Until then any failure or stall leaves
+// the job un-acked and the scheduler re-delivers it, so an inbox row would be
+// a second delivery source for the same event, not added durability.
+// Timer events can still sit in s.Inbox when a save happens mid-run (workflow
+// stall, abandoned continue-as-new); persisting or counting them would declare
+// inbox keys that don't exist in the store, making every subsequent
+// LoadWorkflowState fail.
+func (s *State) persistableInbox() []*backend.HistoryEvent {
+	persistable := make([]*backend.HistoryEvent, 0, len(s.Inbox))
+	for _, e := range s.Inbox {
+		if e.GetTimerFired() == nil {
+			persistable = append(persistable, e)
+		}
+	}
+	return persistable
+}
+
 func (s *State) GetSaveRequest(actorID string) (*api.TransactionalRequest, error) {
 	// TODO: Batching up the save requests into smaller chunks to avoid batch size limits in Dapr state stores.
 	opsCapacity := s.inboxAddedCount + s.inboxRemovedCount +
@@ -426,7 +448,8 @@ func (s *State) GetSaveRequest(actorID string) (*api.TransactionalRequest, error
 		Operations: make([]api.TransactionalOperation, 0, opsCapacity),
 	}
 
-	if err := addStateOperations(req, inboxKeyPrefix, s.Inbox, s.inboxAddedCount, s.inboxRemovedCount); err != nil {
+	inbox := s.persistableInbox()
+	if err := addStateOperations(req, inboxKeyPrefix, inbox, s.inboxAddedCount, s.inboxRemovedCount); err != nil {
 		return nil, err
 	}
 
@@ -487,7 +510,7 @@ func (s *State) GetSaveRequest(actorID string) (*api.TransactionalRequest, error
 	}
 
 	metaProto, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
-		InboxLength:                      uint64(len(s.Inbox)),
+		InboxLength:                      uint64(len(inbox)),
 		HistoryLength:                    uint64(len(s.History)),
 		Generation:                       s.Generation,
 		SignatureLength:                  uint64(len(s.Signatures)),

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -318,6 +319,53 @@ func TestGetSaveRequest_HistoryWithoutMarshaledBytes(t *testing.T) {
 
 	require.NotNil(t, historyOp, "expected history-000000 upsert")
 	assert.Equal(t, expected, historyOp.Value)
+}
+
+func TestGetSaveRequest_InboxExcludesUnpersistedTimerEvents(t *testing.T) {
+	t.Parallel()
+
+	s := NewState(testOpts())
+
+	s.AddToInbox(testEvent(0))
+
+	// A timer wake appends TimerFired directly to the in-memory inbox
+	// without going through AddToInbox (orchestrator run path); it is never
+	// persisted as an inbox key. A save taken while it is still in the inbox
+	// (workflow stall, abandoned continue-as-new) must not count it.
+	s.Inbox = append(s.Inbox, &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TimerFired{
+			TimerFired: &protos.TimerFiredEvent{TimerId: 1},
+		},
+	})
+
+	req, err := s.GetSaveRequest("actor1")
+	require.NoError(t, err)
+
+	var inboxKeys []string
+	var metadata *backend.BackendWorkflowStateMetadata
+	for _, op := range req.Operations {
+		if op.Operation != api.Upsert {
+			continue
+		}
+		u, ok := op.Request.(api.TransactionalUpsert)
+		if !ok {
+			continue
+		}
+		switch {
+		case u.Key == MetadataKey:
+			metadata = new(backend.BackendWorkflowStateMetadata)
+			require.NoError(t, proto.Unmarshal(u.Value.([]byte), metadata))
+		case strings.HasPrefix(u.Key, inboxKeyPrefix):
+			inboxKeys = append(inboxKeys, u.Key)
+		}
+	}
+
+	require.NotNil(t, metadata, "expected a metadata upsert")
+	assert.Equal(t, []string{"inbox-000000"}, inboxKeys, "only the non-timer event should be persisted")
+	assert.Equal(t, uint64(1), metadata.GetInboxLength(),
+		"metadata must declare exactly the inbox keys that exist in the store, or the next load will fail on a phantom key")
 }
 
 func TestGetSaveRequest_SigningDataOperations(t *testing.T) {

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(timerinbox))
+}
+
+// timerinbox stalls a workflow on the wake of a durable timer and asserts
+// that the workflow remains fully manageable afterwards: the state-store
+// metadata stays consistent with the persisted inbox keys, status queries
+// keep working, and the instance can still be purged.
+//
+// A TimerFired event woken by a timer reminder is appended to the in-memory
+// inbox but is by design never persisted as an inbox-NNNNNN key. Any save
+// performed while that event is still in the inbox (such as the stall save)
+// must therefore not count it in the metadata inboxLength either, or every
+// subsequent load of the workflow state will fail on the phantom inbox key,
+// leaving the instance permanently unqueryable and unpurgeable.
+type timerinbox struct {
+	workflow *workflow.Workflow
+}
+
+func (d *timerinbox) Setup(t *testing.T) []framework.Option {
+	d.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(d.workflow),
+	}
+}
+
+func (d *timerinbox) Run(t *testing.T, ctx context.Context) {
+	d.workflow.WaitUntilRunning(t, ctx)
+
+	d.workflow.Registry().AddVersionedWorkflowN("workflow", "v1", true, func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CreateTimer(time.Second * 4).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+
+	clientCtx, cancelClient := context.WithCancel(ctx)
+	defer cancelClient()
+	client := d.workflow.BackendClient(t, clientCtx)
+	id, err := client.ScheduleNewWorkflow(ctx, "workflow")
+	require.NoError(t, err)
+
+	// Wait for the first execution to be persisted so the durable timer
+	// exists before the v1 worker goes away.
+	wf.WaitForWorkflowStartedEvent(t, ctx, client, id)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotNil(c, wf.GetLastHistoryEventOfType[protos.HistoryEvent_TimerCreated](t, ctx, client, id))
+	}, time.Second*20, time.Millisecond*10)
+
+	// Replace the worker with one that only knows v2, so when the durable
+	// timer fires the engine stalls the workflow with VERSION_NOT_AVAILABLE.
+	d.workflow.ResetRegistry(t)
+	cancelClient()
+	d.workflow.WaitForNoConnectedWorkers(t, ctx)
+
+	d.workflow.Registry().AddVersionedWorkflowN("workflow", "v2", true, func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CreateTimer(time.Second * 4).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	clientCtx, cancelClient = context.WithCancel(ctx)
+	defer cancelClient()
+	client = d.workflow.BackendClient(t, clientCtx)
+
+	// Wait until the stall has been persisted. The stall is deliberately
+	// detected through the state store rather than through the workflow API:
+	// that the API keeps working for a stalled workflow is exactly what is
+	// asserted below.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var found bool
+		for _, raw := range d.workflow.DB().ReadStateValues(t, ctx, string(id), "history") {
+			var event protos.HistoryEvent
+			if proto.Unmarshal(raw, &event) == nil && event.GetExecutionStalled() != nil {
+				found = true
+				break
+			}
+		}
+		assert.True(c, found, "expected an ExecutionStalled event to be persisted to the state store")
+	}, time.Second*40, time.Millisecond*50)
+
+	// The stall save ran while the in-memory inbox still held the TimerFired
+	// event that woke the workflow. TimerFired events are never written as
+	// inbox-NNNNNN keys, so the metadata must not count them either.
+	_, metaRaw := d.workflow.DB().ReadStateValue(t, ctx, string(id), "metadata")
+	var metadata backend.BackendWorkflowStateMetadata
+	require.NoError(t, proto.Unmarshal(metaRaw, &metadata))
+	inboxKeys := len(d.workflow.DB().ReadStateValues(t, ctx, string(id), "inbox"))
+	assert.Equal(t, inboxKeys, int(metadata.GetInboxLength()), //nolint:gosec
+		"metadata inboxLength must match the number of persisted inbox-* keys")
+
+	// A stalled workflow must still answer status queries.
+	md, err := client.FetchWorkflowMetadata(ctx, id)
+	if assert.NoError(t, err, "fetching the metadata of a stalled workflow must succeed") {
+		assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED.String(), md.RuntimeStatus.String())
+	}
+
+	// A normal purge of a stalled workflow must be rejected because it is
+	// stalled, not because its state can no longer be loaded.
+	err = client.PurgeWorkflowState(ctx, id)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "stalled")
+	}
+
+	// A stalled workflow must still be force-purgeable.
+	assert.NoError(t, client.PurgeWorkflowState(ctx, id, api.WithForcePurge(true)),
+		"force purging a stalled workflow must succeed")
+}

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
@@ -62,8 +62,8 @@ func (d *timerinbox) Run(t *testing.T, ctx context.Context) {
 	d.workflow.WaitUntilRunning(t, ctx)
 
 	d.workflow.Registry().AddVersionedWorkflowN("workflow", "v1", true, func(ctx *task.WorkflowContext) (any, error) {
-		if err := ctx.CreateTimer(time.Second * 4).Await(nil); err != nil {
-			return nil, err
+		if timerErr := ctx.CreateTimer(time.Second * 4).Await(nil); timerErr != nil {
+			return nil, timerErr
 		}
 		return nil, nil
 	})
@@ -88,8 +88,8 @@ func (d *timerinbox) Run(t *testing.T, ctx context.Context) {
 	d.workflow.WaitForNoConnectedWorkers(t, ctx)
 
 	d.workflow.Registry().AddVersionedWorkflowN("workflow", "v2", true, func(ctx *task.WorkflowContext) (any, error) {
-		if err := ctx.CreateTimer(time.Second * 4).Await(nil); err != nil {
-			return nil, err
+		if timerErr := ctx.CreateTimer(time.Second * 4).Await(nil); timerErr != nil {
+			return nil, timerErr
 		}
 		return nil, nil
 	})

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
@@ -119,8 +119,8 @@ func (d *timerinbox) Run(t *testing.T, ctx context.Context) {
 	_, metaRaw := d.workflow.DB().ReadStateValue(t, ctx, string(id), "metadata")
 	var metadata backend.BackendWorkflowStateMetadata
 	require.NoError(t, proto.Unmarshal(metaRaw, &metadata))
-	inboxKeys := len(d.workflow.DB().ReadStateValues(t, ctx, string(id), "inbox"))
-	assert.Equal(t, inboxKeys, int(metadata.GetInboxLength()), //nolint:gosec
+	inboxKeys := d.workflow.DB().ReadStateValues(t, ctx, string(id), "inbox")
+	assert.Equal(t, uint64(len(inboxKeys)), metadata.GetInboxLength(),
 		"metadata inboxLength must match the number of persisted inbox-* keys")
 
 	// A stalled workflow must still answer status queries.

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/timerinbox.go
@@ -122,6 +122,11 @@ func (d *timerinbox) Run(t *testing.T, ctx context.Context) {
 	inboxKeys := d.workflow.DB().ReadStateValues(t, ctx, string(id), "inbox")
 	assert.Equal(t, uint64(len(inboxKeys)), metadata.GetInboxLength(),
 		"metadata inboxLength must match the number of persisted inbox-* keys")
+	for _, raw := range inboxKeys {
+		var event protos.HistoryEvent
+		require.NoError(t, proto.Unmarshal(raw, &event))
+		assert.Nil(t, event.GetTimerFired(), "TimerFired events must never be persisted as inbox-* keys")
+	}
 
 	// A stalled workflow must still answer status queries.
 	md, err := client.FetchWorkflowMetadata(ctx, id)


### PR DESCRIPTION
`TimerFired` events are appended to the in-memory inbox when a timer reminder fires, but are by design never persisted as `inbox-NNNNNN` keys, their durable home is the scheduler job, which is only acked once the run that consumed them commits. `GetSaveRequest` however counted them in the metadata `inboxLength` and in the upsert index math.

Any save taken while a timer event was still in the inbox, a workflow stall (version mismatch or payload oversize) on a timer wake, or an abandoned ContinueAsNew, therefore declared an inbox key that was never written. Since #10058 made a metadata/key mismatch a hard load error, every subsequent load fails: status queries error, the wake-up reminder retries forever, and both normal and force purge fail because they load state first. The instance is permanently stuck, with no recovery short of manual state-store surgery. The index shift could also persist the timer event at the wrong key and silently drop a real event added while the timer sat in the inbox.

The fix: `GetSaveRequest` now builds its inbox view via `persistableInbox()`, excluding timer events from both the persisted operations and the metadata count, the same rule `ClearInbox` already applied.