### PR TITLE
workflow: persist terminal state before recursive terminate cascade

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -15,6 +15,7 @@ This update contains the following bug fixes:
 - [Parent workflow becomes stuck when creating a child workflow with an instance ID that is already in use](#parent-workflow-becomes-stuck-when-creating-a-child-workflow-with-an-instance-id-that-is-already-in-use)
 - [Sub-millisecond latencies are omitted from latency metrics](#sub-millisecond-latencies-are-omitted-from-latency-metrics)
 - [Querying workflow instance history crashes the sidecar when no actor state store is configured](#querying-workflow-instance-history-crashes-the-sidecar-when-no-actor-state-store-is-configured)
+- [Terminating a running workflow could leave it permanently stuck in RUNNING](#terminating-a-running-workflow-could-leave-it-permanently-stuck-in-running)
 
 ## SPIFFE SVID component operation propagation
 
@@ -343,3 +344,30 @@ The workflow read and purge paths in the actor backend (`GetInstanceHistory`, `l
 ### Solution
 
 The read and purge paths now return the same actionable error the write path already surfaces (`the state store is not configured to use the actor runtime. Have you set the - name: actorStateStore value: "true" in your state store component file?`) instead of dereferencing a nil state. The history query fails cleanly and the sidecar stays up.
+
+## Terminating a running workflow could leave it permanently stuck in RUNNING
+
+### Problem
+
+Terminating a running workflow that had fanned out to child workflows could leave the parent workflow permanently stuck in the RUNNING status.
+The termination event remained undrained in the workflow's inbox, no `ExecutionCompleted` event was written to history, and repeated `TerminateWorkflow` calls could hang.
+Restarting the application did not recover the instance; only purging it did.
+
+### Impact
+
+You were affected if you terminated running workflows that had child workflows, most likely under load or during transient Scheduler or host unavailability.
+Affected instances could never be terminated and reported RUNNING forever, even though the runtime logged them as terminated.
+Termination of sibling child workflows could also be delayed indefinitely while the parent retried.
+
+### Root Cause
+
+On a recursive terminate, the workflow engine delivered the termination event to every child workflow before the parent's own terminal state was persisted.
+If delivery to any child failed, for example an unreachable host or a transient Scheduler error while creating the child's wake-up reminder, the whole operation was rolled back, discarding the parent's computed terminal state, and every retry repeated the same failing sequence.
+Child delivery also ran while holding the parent workflow actor's lock, which could deadlock against children concurrently reporting their completion back to the parent, causing the terminate call to hang.
+
+### Solution
+
+The parent workflow now persists its terminal state and drains its inbox first, then delivers the termination to its children as a separate, idempotent step that is retried until every child is reached.
+Same-app children are terminated through a durable reminder carrying the termination event, which takes no actor locks and keeps retrying while a child's host is unavailable.
+Cross-app children continue to be terminated through the existing event delivery method.
+A failure to reach a child can no longer roll back the parent's terminal state or block its completion.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.18.1
-	github.com/dapr/durabletask-go v0.12.2-0.20260630111707-26034a1c0eef
+	github.com/dapr/durabletask-go v0.12.2
 	github.com/dapr/kit v0.18.2
 	github.com/diagridio/go-etcd-cron v0.12.6
 	github.com/evanphx/json-patch/v5 v5.9.0
@@ -532,6 +532,3 @@ replace (
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
-
-// TODO: remove before committing, bump durabletask-go instead.
-replace github.com/dapr/durabletask-go => github.com/joshvanl/durabletask-go v0.0.0-20260703151128-18fdfc4f85aa

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.18.1
-	github.com/dapr/durabletask-go v0.12.2
+	github.com/dapr/durabletask-go v0.12.2-0.20260720132056-79042da5fe61
 	github.com/dapr/kit v0.18.2
 	github.com/diagridio/go-etcd-cron v0.12.6
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.mod
+++ b/go.mod
@@ -532,3 +532,6 @@ replace (
 //
 // Then, run `make modtidy-all` in this repository.
 // This ensures that go.mod and go.sum are up-to-date for each go.mod file.
+
+// TODO: remove before committing, bump durabletask-go instead.
+replace github.com/dapr/durabletask-go => github.com/joshvanl/durabletask-go v0.0.0-20260703151128-18fdfc4f85aa

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,6 @@ github.com/dapr/components-contrib v1.18.1 h1:GgPuh60eBkVltg0Q+rsstHyzHvmk7XxUC/
 github.com/dapr/components-contrib v1.18.1/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.12.2-0.20260630111707-26034a1c0eef h1:a1SNnZiFlD+RXfo8s2L6b/W+UIVxnmKx/nI8jtwPiYA=
-github.com/dapr/durabletask-go v0.12.2-0.20260630111707-26034a1c0eef/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/dapr/kit v0.18.2 h1:nOhtpNz5U171Pl8R1hf+KKDNmkNkMUVYcb1x1mWIL1Q=
 github.com/dapr/kit v0.18.2/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1101,6 +1099,8 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/joshvanl/durabletask-go v0.0.0-20260703151128-18fdfc4f85aa h1:6/tbkOFyf0iCohwLv8v5WEzvHyDACI2c4JZfF4UgFzs=
+github.com/joshvanl/durabletask-go v0.0.0-20260703151128-18fdfc4f85aa/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,8 @@ github.com/dapr/components-contrib v1.18.1 h1:GgPuh60eBkVltg0Q+rsstHyzHvmk7XxUC/
 github.com/dapr/components-contrib v1.18.1/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
+github.com/dapr/durabletask-go v0.12.2 h1:PNahcqe7lvUsTcEAD/f5RHKHzYtTIJkEMShXmxKjYXg=
+github.com/dapr/durabletask-go v0.12.2/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/dapr/kit v0.18.2 h1:nOhtpNz5U171Pl8R1hf+KKDNmkNkMUVYcb1x1mWIL1Q=
 github.com/dapr/kit v0.18.2/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -1099,8 +1101,6 @@ github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbd
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/joshvanl/durabletask-go v0.0.0-20260703151128-18fdfc4f85aa h1:6/tbkOFyf0iCohwLv8v5WEzvHyDACI2c4JZfF4UgFzs=
-github.com/joshvanl/durabletask-go v0.0.0-20260703151128-18fdfc4f85aa/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/dapr/components-contrib v1.18.1 h1:GgPuh60eBkVltg0Q+rsstHyzHvmk7XxUC/
 github.com/dapr/components-contrib v1.18.1/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.12.2 h1:PNahcqe7lvUsTcEAD/f5RHKHzYtTIJkEMShXmxKjYXg=
-github.com/dapr/durabletask-go v0.12.2/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
+github.com/dapr/durabletask-go v0.12.2-0.20260720132056-79042da5fe61 h1:RR0Dw3bl/fPPGroVFuDvu/s2aT3a4DseBiB2cI27SRo=
+github.com/dapr/durabletask-go v0.12.2-0.20260720132056-79042da5fe61/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/dapr/kit v0.18.2 h1:nOhtpNz5U171Pl8R1hf+KKDNmkNkMUVYcb1x1mWIL1Q=
 github.com/dapr/kit v0.18.2/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -26,6 +26,9 @@ const (
 	reminderPrefixStart    = "start"
 	reminderPrefixNewEvent = "new-event"
 	reminderPrefixTimer    = "timer-"
+	// Created on each child workflow actor by a recursively-terminated
+	// parent, carrying the ExecutionTerminated event as reminder data.
+	reminderPrefixCascadeTerminate = "cascade-terminate"
 )
 
 func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryEvent) error {

--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -26,9 +26,9 @@ const (
 	reminderPrefixStart    = "start"
 	reminderPrefixNewEvent = "new-event"
 	reminderPrefixTimer    = "timer-"
-	// Created on each child workflow actor by a recursively-terminated
-	// parent, carrying the ExecutionTerminated event as reminder data.
-	reminderPrefixCascadeTerminate = "cascade-terminate"
+	// Created on each child workflow actor by a recursively-terminated parent,
+	// carrying the ExecutionTerminated event as reminder data.
+	reminderCascadeTerminate = "cascade-terminate"
 )
 
 func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryEvent) error {

--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -127,7 +127,8 @@ func (o *orchestrator) handleReminder(ctx context.Context, reminder *actorapi.Re
 	switch {
 	case strings.HasPrefix(reminder.Name, reminderPrefixStart),
 		strings.HasPrefix(reminder.Name, reminderPrefixNewEvent),
-		strings.HasPrefix(reminder.Name, reminderPrefixTimer):
+		strings.HasPrefix(reminder.Name, reminderPrefixTimer),
+		reminder.Name == reminderPrefixCascadeTerminate:
 		return o.runWorkflowFromReminder(ctx, reminder)
 
 	case strings.HasPrefix(reminder.Name, common.ReminderPrefixActivityResult):

--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -128,7 +128,7 @@ func (o *orchestrator) handleReminder(ctx context.Context, reminder *actorapi.Re
 	case strings.HasPrefix(reminder.Name, reminderPrefixStart),
 		strings.HasPrefix(reminder.Name, reminderPrefixNewEvent),
 		strings.HasPrefix(reminder.Name, reminderPrefixTimer),
-		reminder.Name == reminderPrefixCascadeTerminate:
+		reminder.Name == reminderCascadeTerminate:
 		return o.runWorkflowFromReminder(ctx, reminder)
 
 	case strings.HasPrefix(reminder.Name, common.ReminderPrefixActivityResult):

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -85,7 +85,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	// carrying the ExecutionTerminated event as data (see terminateChildren).
 	// Feed it into the inbox like a fired timer; if the workflow is already
 	// terminal the redelivery is skipped and the reminder deleted.
-	if reminder.Name == reminderPrefixCascadeTerminate && !runtimestate.IsCompleted(o.rstate) {
+	if reminder.Name == reminderCascadeTerminate && !runtimestate.IsCompleted(o.rstate) {
 		var cascadeEvent backend.HistoryEvent
 		if err = reminder.Data.UnmarshalTo(&cascadeEvent); err != nil {
 			return todo.RunCompletedTrue, err

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -81,6 +81,24 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		state.Inbox = append(state.Inbox, timerEvent)
 	}
 
+	// A recursively-terminated parent delivers its cascade via this reminder,
+	// carrying the ExecutionTerminated event as data (see terminateChildren).
+	// Feed it into the inbox like a fired timer; if the workflow is already
+	// terminal the redelivery is skipped and the reminder deleted.
+	if reminder.Name == reminderPrefixCascadeTerminate && !runtimestate.IsCompleted(o.rstate) {
+		var cascadeEvent backend.HistoryEvent
+		if err = reminder.Data.UnmarshalTo(&cascadeEvent); err != nil {
+			return todo.RunCompletedTrue, err
+		}
+		// Validate the event type. A crafted reminder could contain arbitrary
+		// event types to inject into the inbox.
+		if cascadeEvent.GetExecutionTerminated() == nil {
+			return todo.RunCompletedTrue, fmt.Errorf("workflow actor '%s': cascade-terminate reminder contains non-ExecutionTerminated event type %T", o.actorID, cascadeEvent.GetEventType())
+		}
+		cascadeEvent.Timestamp = timestamppb.Now()
+		state.Inbox = append(state.Inbox, &cascadeEvent)
+	}
+
 	if len(state.Inbox) == 0 && !runtimestate.IsCompleted(o.rstate) {
 		// The in-memory cache may be stale: during a placement cluster failure
 		// daprds will roll over the actor, so a peer host may have written a new
@@ -115,6 +133,12 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		if runtimestate.IsCompleted(o.rstate) {
 			if rerr := o.handleRetention(ctx, runtimestate.RuntimeStatus(o.rstate)); rerr != nil {
 				return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("failed to (re)create retention reminder on empty-inbox completion path: %w", rerr))
+			}
+			// Re-attempt the recursive terminate cascade idempotently: this is
+			// the retry path for terminateChildren failures on the completion
+			// path, since the inbox is drained by then.
+			if terr := o.terminateChildren(ctx, state); terr != nil {
+				return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("failed to (re)deliver recursive terminate to children on empty-inbox path: %w", terr))
 			}
 		}
 		log.Debugf("Workflow actor '%s': ignoring run request for reminder '%s' because the workflow inbox is empty", o.actorID, reminder.Name)
@@ -327,6 +351,11 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		case msg.GetHistoryEvent().GetChildWorkflowInstanceCompleted() != nil, msg.GetHistoryEvent().GetChildWorkflowInstanceFailed() != nil:
 			addWorkflows = append(addWorkflows, msg)
 
+		case msg.GetHistoryEvent().GetExecutionTerminated() != nil && runtimestate.IsCompleted(rs):
+			// Recursive-terminate cascade messages. Not dispatched here as this
+			// runs before the terminal state is persisted; terminateChildren
+			// delivers them after the save in the completion block below.
+
 		default:
 			return todo.RunCompletedTrue, fmt.Errorf("workflow actor '%s': don't know how to process outbound message '%v'", o.actorID, msg)
 		}
@@ -454,6 +483,13 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		// path.
 		if err = o.handleRetention(ctx, rstatus); err != nil {
 			return todo.RunCompletedFalse, err
+		}
+		// Deliver the recursive terminate to children only after the terminal
+		// state is persisted above, so a delivery failure retries via the
+		// wake-up reminder rather than rolling back the completion.
+		if err = o.terminateChildren(ctx, state); err != nil {
+			return todo.RunCompletedFalse, wferrors.NewRecoverable(
+				fmt.Errorf("failed to deliver recursive terminate to children: %w", err))
 		}
 		if hasUnfiredTimers(rs) {
 			if err = o.deleteAllReminders(ctx); err != nil {

--- a/pkg/actors/targets/workflow/orchestrator/terminate.go
+++ b/pkg/actors/targets/workflow/orchestrator/terminate.go
@@ -88,7 +88,7 @@ func (o *orchestrator) createCascadeTerminateReminder(ctx context.Context, child
 	return common.CreateReminderWithRetry(ctx, o.reminders, &actorapi.CreateReminderRequest{
 		ActorType: o.actorType,
 		ActorID:   child.instanceID,
-		Name:      reminderPrefixCascadeTerminate,
+		Name:      reminderCascadeTerminate,
 		Data:      data,
 		DueTime:   time.Now().UTC().Format(time.RFC3339Nano),
 		// One shot, retry forever, every second.

--- a/pkg/actors/targets/workflow/orchestrator/terminate.go
+++ b/pkg/actors/targets/workflow/orchestrator/terminate.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+// remoteChildTerminateTimeout bounds the cross-app delivery to a remote
+// child. This runs under the parent's actor lock while a terminating child
+// may be calling back into the parent, so the delivery must not block
+// indefinitely; the empty-inbox retry path redelivers.
+const remoteChildTerminateTimeout = 5 * time.Second
+
+// terminateChildren delivers a recursive ExecutionTerminated to every child
+// recorded in history. Called only after the terminal state has been
+// persisted, so a delivery failure can never roll the parent back; it is
+// re-derived from history and idempotent, so failures are retried via the
+// wake-up reminder through the empty-inbox path. No-op unless the workflow
+// was terminated with Recurse=true.
+func (o *orchestrator) terminateChildren(ctx context.Context, state *wfenginestate.State) error {
+	var term *protos.ExecutionTerminatedEvent
+	for _, e := range state.History {
+		if et := e.GetExecutionTerminated(); et != nil {
+			term = et
+			break
+		}
+	}
+	if term == nil || !term.GetRecurse() {
+		return nil
+	}
+
+	var errs []error
+	for _, child := range collectChildren(state.History) {
+		var err error
+		if child.targetAppID != "" && child.targetAppID != o.appID {
+			err = o.terminateRemoteChild(ctx, child, term)
+		} else {
+			err = o.createCascadeTerminateReminder(ctx, child, term)
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("child %q: %w", child.instanceID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// createCascadeTerminateReminder creates the cascade-terminate reminder on a
+// same-app child's workflow actor, carrying the ExecutionTerminated event as
+// data. A reminder rather than an actor invocation so no actor lock is taken
+// under the parent's lock, and delivery keeps retrying while the child is
+// unavailable.
+func (o *orchestrator) createCascadeTerminateReminder(ctx context.Context, child childRef, term *protos.ExecutionTerminatedEvent) error {
+	data, err := anypb.New(cascadeTerminateEvent(term))
+	if err != nil {
+		return err
+	}
+
+	return common.CreateReminderWithRetry(ctx, o.reminders, &actorapi.CreateReminderRequest{
+		ActorType: o.actorType,
+		ActorID:   child.instanceID,
+		Name:      reminderPrefixCascadeTerminate,
+		Data:      data,
+		DueTime:   time.Now().UTC().Format(time.RFC3339Nano),
+		// One shot, retry forever, every second.
+		FailurePolicy: &commonv1pb.JobFailurePolicy{
+			Policy: &commonv1pb.JobFailurePolicy_Constant{
+				Constant: &commonv1pb.JobFailurePolicyConstant{
+					Interval:   durationpb.New(time.Second),
+					MaxRetries: nil,
+				},
+			},
+		},
+	})
+}
+
+// terminateRemoteChild delivers the ExecutionTerminated to a cross-app child
+// via AddWorkflowEvent, since reminders cannot be created for non-hosted
+// actor types.
+func (o *orchestrator) terminateRemoteChild(ctx context.Context, child childRef, term *protos.ExecutionTerminatedEvent) error {
+	data, err := proto.Marshal(cascadeTerminateEvent(term))
+	if err != nil {
+		return err
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, remoteChildTerminateTimeout)
+	defer cancel()
+
+	_, err = o.router.Call(cctx, internalsv1pb.
+		NewInternalInvokeRequest(todo.AddWorkflowEventMethod).
+		WithActor(o.actorTypeBuilder.Workflow(child.targetAppID), child.instanceID).
+		WithData(data).
+		WithContentType(invokev1.OctetStreamContentType))
+	return err
+}
+
+func cascadeTerminateEvent(term *protos.ExecutionTerminatedEvent) *backend.HistoryEvent {
+	return &backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input:   term.GetInput(),
+				Recurse: true,
+			},
+		},
+	}
+}

--- a/tests/integration/suite/daprd/workflow/chaos/terminatecascade.go
+++ b/tests/integration/suite/daprd/workflow/chaos/terminatecascade.go
@@ -116,7 +116,9 @@ func (c *terminatecascade) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(co, int64(numChildren), blocked.Load())
 	}, time.Second*30, time.Millisecond*10)
 
-	require.NoError(t, cl.TerminateWorkflow(ctx, id))
+	termCtx, termCancel := context.WithTimeout(ctx, time.Second*20)
+	t.Cleanup(termCancel)
+	require.NoError(t, cl.TerminateWorkflow(termCtx, id))
 
 	failedCh := make(chan struct{}, numChildren)
 	c.proxy.ArmFailures(proxy.MethodScheduleJob, numChildren, codes.Internal, failedCh)

--- a/tests/integration/suite/daprd/workflow/chaos/terminatecascade.go
+++ b/tests/integration/suite/daprd/workflow/chaos/terminatecascade.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(terminatecascade))
+}
+
+type terminatecascade struct {
+	workflow  *workflow.Workflow
+	scheduler *scheduler.Scheduler
+	proxy     *proxy.Proxy
+}
+
+func (c *terminatecascade) Setup(t *testing.T) []framework.Option {
+	c.scheduler = scheduler.New(t)
+	c.proxy = proxy.New(t, c.scheduler)
+
+	c.workflow = workflow.New(t,
+		workflow.WithSchedulerInstance(c.scheduler),
+		workflow.WithSchedulerAddress(c.proxy.Address()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.scheduler, c.proxy, c.workflow),
+	}
+}
+
+func (c *terminatecascade) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const numChildren = 2
+
+	childID := func(i int) string {
+		return fmt.Sprintf("terminatecascade-child-%d", i)
+	}
+
+	holdCh := make(chan struct{})
+	var blocked atomic.Int64
+	t.Cleanup(func() {
+		select {
+		case <-holdCh:
+		default:
+			close(holdCh)
+		}
+	})
+
+	r := c.workflow.Registry()
+
+	require.NoError(t, r.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		blocked.Add(1)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-holdCh:
+			return nil, nil
+		}
+	}))
+
+	require.NoError(t, r.AddWorkflowN("child", func(wctx *task.WorkflowContext) (any, error) {
+		return nil, wctx.CallActivity("block").Await(nil)
+	}))
+
+	require.NoError(t, r.AddWorkflowN("root", func(wctx *task.WorkflowContext) (any, error) {
+		tasks := make([]task.Task, numChildren)
+		for i := range numChildren {
+			tasks[i] = wctx.CallChildWorkflow("child",
+				task.WithChildWorkflowInstanceID(childID(i)),
+			)
+		}
+		for _, tk := range tasks {
+			if err := tk.Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}))
+
+	cl := c.workflow.BackendClient(t, ctx)
+
+	id, err := cl.ScheduleNewWorkflow(ctx, "root", api.WithInstanceID("terminatecascade-root"))
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(co *assert.CollectT) {
+		assert.Equal(co, int64(numChildren), blocked.Load())
+	}, time.Second*30, time.Millisecond*10)
+
+	require.NoError(t, cl.TerminateWorkflow(ctx, id))
+
+	failedCh := make(chan struct{}, numChildren)
+	c.proxy.ArmFailures(proxy.MethodScheduleJob, numChildren, codes.Internal, failedCh)
+
+	for range numChildren {
+		select {
+		case <-failedCh:
+		case <-time.After(time.Second * 15):
+			require.Fail(t, "injected ScheduleJob failures never fired")
+		}
+	}
+
+	require.EventuallyWithT(t, func(co *assert.CollectT) {
+		meta, merr := cl.FetchWorkflowMetadata(ctx, id)
+		if !assert.NoError(co, merr) {
+			return
+		}
+		assert.Equal(co, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+	}, time.Second*30, time.Millisecond*10)
+
+	for i := range numChildren {
+		require.EventuallyWithT(t, func(co *assert.CollectT) {
+			meta, merr := cl.FetchWorkflowMetadata(ctx, api.InstanceID(childID(i)))
+			if !assert.NoError(co, merr) {
+				return
+			}
+			assert.Equal(co, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+		}, time.Second*60, time.Millisecond*10)
+	}
+
+	assert.GreaterOrEqual(t, c.proxy.FailedCount(), numChildren)
+}

--- a/tests/integration/suite/daprd/workflow/terminate/fanout.go
+++ b/tests/integration/suite/daprd/workflow/terminate/fanout.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terminate
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(fanout))
+}
+
+type fanout struct {
+	workflow *workflow.Workflow
+}
+
+func (f *fanout) Setup(t *testing.T) []framework.Option {
+	f.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(f.workflow),
+	}
+}
+
+func (f *fanout) Run(t *testing.T, ctx context.Context) {
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	const (
+		numChildren        = 8
+		activitiesPerChild = 6
+		blockStep          = activitiesPerChild - 1
+	)
+
+	childID := func(i int) string {
+		return fmt.Sprintf("fanout-root-child-%d", i)
+	}
+
+	holdCh := make(chan struct{})
+	var blocked atomic.Int64
+	t.Cleanup(func() {
+		select {
+		case <-holdCh:
+		default:
+			close(holdCh)
+		}
+	})
+
+	r := f.workflow.Registry()
+
+	require.NoError(t, r.AddActivityN("step", func(actx task.ActivityContext) (any, error) {
+		var step int
+		if err := actx.GetInput(&step); err != nil {
+			return nil, err
+		}
+		if step == blockStep {
+			blocked.Add(1)
+			<-holdCh
+		}
+		return nil, nil
+	}))
+
+	require.NoError(t, r.AddWorkflowN("child", func(wctx *task.WorkflowContext) (any, error) {
+		for s := range activitiesPerChild {
+			if err := wctx.CallActivity("step", task.WithActivityInput(s)).Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}))
+
+	require.NoError(t, r.AddWorkflowN("root", func(wctx *task.WorkflowContext) (any, error) {
+		tasks := make([]task.Task, numChildren)
+		for i := range numChildren {
+			tasks[i] = wctx.CallChildWorkflow("child",
+				task.WithChildWorkflowInstanceID(childID(i)),
+			)
+		}
+		for _, tk := range tasks {
+			if err := tk.Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}))
+
+	cl := f.workflow.BackendClient(t, ctx)
+
+	id, err := cl.ScheduleNewWorkflow(ctx, "root", api.WithInstanceID("fanout-root"))
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(numChildren), blocked.Load())
+	}, time.Second*60, time.Millisecond*10)
+
+	termErr := make(chan error, 1)
+	go func() { termErr <- cl.TerminateWorkflow(ctx, id) }()
+	select {
+	case err = <-termErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "TerminateWorkflow hung and never returned")
+	}
+
+	// Children stay blocked through the terminate so each must end up
+	// TERMINATED, never COMPLETED. holdCh is closed in the t.Cleanup above.
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err, "root never reached a terminal state")
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+
+	for i := range numChildren {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			cmeta, cerr := cl.FetchWorkflowMetadata(ctx, api.InstanceID(childID(i)))
+			if !assert.NoError(c, cerr) {
+				return
+			}
+			assert.Equal(c, api.RUNTIME_STATUS_TERMINATED.String(), cmeta.GetRuntimeStatus().String())
+		}, time.Second*60, time.Millisecond*10)
+	}
+
+	gotMeta, err := cl.FetchWorkflowMetadata(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), gotMeta.GetRuntimeStatus().String())
+
+	termErr2 := make(chan error, 1)
+	go func() { termErr2 <- cl.TerminateWorkflow(ctx, id) }()
+	select {
+	case err = <-termErr2:
+		require.NoError(t, err)
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "repeated TerminateWorkflow on a terminated workflow hung")
+	}
+}

--- a/tests/integration/suite/daprd/workflow/terminate/fanout.go
+++ b/tests/integration/suite/daprd/workflow/terminate/fanout.go
@@ -116,14 +116,9 @@ func (f *fanout) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(c, int64(numChildren), blocked.Load())
 	}, time.Second*60, time.Millisecond*10)
 
-	termErr := make(chan error, 1)
-	go func() { termErr <- cl.TerminateWorkflow(ctx, id) }()
-	select {
-	case err = <-termErr:
-		require.NoError(t, err)
-	case <-time.After(time.Second * 20):
-		require.Fail(t, "TerminateWorkflow hung and never returned")
-	}
+	termCtx, termCancel := context.WithTimeout(ctx, time.Second*20)
+	t.Cleanup(termCancel)
+	require.NoError(t, cl.TerminateWorkflow(termCtx, id))
 
 	// Children stay blocked through the terminate so each must end up
 	// TERMINATED, never COMPLETED. holdCh is closed in the t.Cleanup above.
@@ -145,12 +140,8 @@ func (f *fanout) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), gotMeta.GetRuntimeStatus().String())
 
-	termErr2 := make(chan error, 1)
-	go func() { termErr2 <- cl.TerminateWorkflow(ctx, id) }()
-	select {
-	case err = <-termErr2:
-		require.NoError(t, err)
-	case <-time.After(time.Second * 20):
-		require.Fail(t, "repeated TerminateWorkflow on a terminated workflow hung")
-	}
+	// A repeated terminate on a terminated workflow is an idempotent no-op.
+	retermCtx, retermCancel := context.WithTimeout(ctx, time.Second*20)
+	t.Cleanup(retermCancel)
+	require.NoError(t, cl.TerminateWorkflow(retermCtx, id))
 }

--- a/tests/integration/suite/daprd/workflow/terminate/zombiechilddown.go
+++ b/tests/integration/suite/daprd/workflow/terminate/zombiechilddown.go
@@ -80,7 +80,9 @@ func (z *zombiechilddown) Run(t *testing.T, ctx context.Context) {
 	// cannot be delivered.
 	z.workflow.DaprN(1).Kill(t)
 
-	require.NoError(t, parent.TerminateWorkflow(ctx, parentID))
+	termCtx, termCancel := context.WithTimeout(ctx, time.Second*20)
+	t.Cleanup(termCancel)
+	require.NoError(t, parent.TerminateWorkflow(termCtx, parentID))
 
 	// The parent must still durably finalize as TERMINATED.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/tests/integration/suite/daprd/workflow/terminate/zombiechilddown.go
+++ b/tests/integration/suite/daprd/workflow/terminate/zombiechilddown.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terminate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(zombiechilddown))
+}
+
+type zombiechilddown struct {
+	workflow *workflow.Workflow
+}
+
+func (z *zombiechilddown) Setup(t *testing.T) []framework.Option {
+	z.workflow = workflow.New(t, workflow.WithDaprds(2))
+	return []framework.Option{
+		framework.WithProcesses(z.workflow),
+	}
+}
+
+func (z *zombiechilddown) Run(t *testing.T, ctx context.Context) {
+	z.workflow.WaitUntilRunning(t, ctx)
+
+	const childInstanceID = "zombiechilddown-child"
+
+	z.workflow.Registry().AddWorkflowN("Parent", func(wctx *task.WorkflowContext) (any, error) {
+		return nil, wctx.CallChildWorkflow("Child",
+			task.WithChildWorkflowAppID(z.workflow.DaprN(1).AppID()),
+			task.WithChildWorkflowInstanceID(childInstanceID),
+		).Await(nil)
+	})
+
+	z.workflow.RegistryN(1).AddWorkflowN("Child", func(wctx *task.WorkflowContext) (any, error) {
+		return nil, wctx.CreateTimer(time.Hour).Await(nil)
+	})
+
+	parent := z.workflow.BackendClient(t, ctx)
+	child := z.workflow.BackendClientN(t, ctx, 1)
+
+	parentID, err := parent.ScheduleNewWorkflow(ctx, "Parent", api.WithInstanceID("zombiechilddown-parent"))
+	require.NoError(t, err)
+
+	_, err = parent.WaitForWorkflowStart(ctx, parentID)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		meta, merr := child.FetchWorkflowMetadata(ctx, api.InstanceID(childInstanceID))
+		if !assert.NoError(c, merr) {
+			return
+		}
+		assert.Equal(c, api.RUNTIME_STATUS_RUNNING.String(), meta.GetRuntimeStatus().String())
+	}, time.Second*30, time.Millisecond*10)
+
+	// Kill the app hosting the child so the recursive ExecutionTerminated
+	// cannot be delivered.
+	z.workflow.DaprN(1).Kill(t)
+
+	require.NoError(t, parent.TerminateWorkflow(ctx, parentID))
+
+	// The parent must still durably finalize as TERMINATED.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		meta, merr := parent.FetchWorkflowMetadata(ctx, parentID)
+		if !assert.NoError(c, merr) {
+			return
+		}
+		assert.Equal(c, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+	}, time.Second*30, time.Millisecond*50)
+}


### PR DESCRIPTION
Terminating a running workflow with child workflows could leave the parent permanently stuck in RUNNING. The engine delivered the recursive ExecutionTerminated to every child inline, before the parent's terminal state was persisted, so one failed child delivery (unreachable host, transient scheduler error on the child's wake-up reminder create) abandoned the work item and rolled back the parent's completion. The ExecutionTerminated stayed undrained in the parent's inbox, no ExecutionCompleted was written to history, and every reactivation repeated the same failing fan-out; only a purge could clear the instance. The fan-out also ran while holding the parent actor's lock, deadlocking against children concurrently reporting their completion back to the parent, which could hang the TerminateWorkflow call itself.

durabletask-go now emits the cascading messages instead of delivering them inline. The workflow actor persists its terminal state and drains its cascade as a separate idempotent step, re-derived from durable history and retried through the empty-inboeached. Same-app children receive a cascade-terminate reminder carrying the event as data (like timer reminderkes no actor locks and keeps retrying while the child is unavailable; the reminder is created and consumed bire format crosses a version boundary. Cross-app children keep the existing AddWorkflowEvent delivery, bounded parent/child lock cycle resolves and retries.

Fixes #10154