### PR TITLE
fix(workflow): trim whitespace from instance ID in HTTP APIs

### DIFF
--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -2686,6 +2686,80 @@ func TestV1Workflow(t *testing.T) {
 		// assert
 		assert.Nil(t, resp.ErrorBody)
 	})
+
+	/////////////////////////////////
+	// INSTANCE ID WHITESPACE TESTS //
+	/////////////////////////////////
+
+	// A trailing newline or space is easily pasted onto an instance ID by
+	// accident. Without trimming it is passed through verbatim and silently
+	// resolves to a non-existent instance. See issue #8971. These tests build
+	// the server with parameter unescaping enabled, mirroring how production
+	// registers routes that contain path parameters.
+
+	fakeServerUnescaped := func(t *testing.T) *fakeHTTPServer {
+		f := newFakeHTTPServer()
+		t.Cleanup(f.Shutdown)
+		f.StartServer(testAPI.constructWorkflowEndpoints(), &fakeHTTPServerOptions{unescapeParameters: true})
+		return f
+	}
+
+	t.Run("Start trims surrounding whitespace from instance ID", func(t *testing.T) {
+		var gotInstanceID string
+		wf.WithClient(func() workflows.Workflow {
+			return fake.NewClient().WithStart(func(ctx context.Context, req *workflows.StartRequest) (*workflows.StartResponse, error) {
+				require.NotNil(t, req.InstanceID)
+				gotInstanceID = *req.InstanceID
+				return &workflows.StartResponse{InstanceID: *req.InstanceID}, nil
+			})
+		})
+
+		// instanceID=myInstanceID%0A (trailing newline).
+		apiPath := "v1.0/workflows/dapr/workflowName/start?instanceID=myInstanceID%0A"
+		resp := fakeServerUnescaped(t).DoRequest("POST", apiPath, nil, nil)
+		assert.Equal(t, 202, resp.StatusCode)
+		assert.Nil(t, resp.ErrorBody)
+		assert.Equal(t, "myInstanceID", gotInstanceID)
+	})
+
+	t.Run("Get trims surrounding whitespace from instance ID", func(t *testing.T) {
+		var gotInstanceID string
+		wf.WithClient(func() workflows.Workflow {
+			return fake.NewClient().WithGet(func(ctx context.Context, req *workflows.GetRequest) (*workflows.StateResponse, error) {
+				gotInstanceID = req.InstanceID
+				return &workflows.StateResponse{
+					Workflow: &workflows.WorkflowState{
+						InstanceID: req.InstanceID,
+						Properties: map[string]string{},
+					},
+				}, nil
+			})
+		})
+
+		// Trailing space (%20) encoded in the path segment.
+		apiPath := "v1.0/workflows/dapr/myInstanceID%20"
+		resp := fakeServerUnescaped(t).DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Nil(t, resp.ErrorBody)
+		assert.Equal(t, "myInstanceID", gotInstanceID)
+	})
+
+	t.Run("Purge trims trailing whitespace from instance ID", func(t *testing.T) {
+		var gotInstanceID string
+		wf.WithClient(func() workflows.Workflow {
+			return fake.NewClient().WithPurge(func(ctx context.Context, req *workflows.PurgeRequest) error {
+				gotInstanceID = req.InstanceID
+				return nil
+			})
+		})
+
+		// Trailing newline (%0A) encoded in the path segment.
+		apiPath := "v1.0/workflows/dapr/myInstanceID%0A/purge"
+		resp := fakeServerUnescaped(t).DoRequest("POST", apiPath, nil, nil)
+		assert.Equal(t, 202, resp.StatusCode)
+		assert.Nil(t, resp.ErrorBody)
+		assert.Equal(t, "myInstanceID", gotInstanceID)
+	})
 }
 
 func buildHTTPPipeline(spec config.PipelineSpec) middleware.HTTP {
@@ -2862,6 +2936,10 @@ type fakeHTTPServerOptions struct {
 	spec     *config.TracingSpec
 	pipeline middleware.HTTP
 	apiAuth  bool
+	// unescapeParameters mirrors production, where routes containing path
+	// parameters are wrapped so chi URL params are URL-unescaped before the
+	// handler runs. Defaults to false to preserve existing test behavior.
+	unescapeParameters bool
 }
 
 func (f *fakeHTTPServer) StartServer(endpoints []endpoints.Endpoint, opts *fakeHTTPServerOptions) {
@@ -2871,7 +2949,7 @@ func (f *fakeHTTPServer) StartServer(endpoints []endpoints.Endpoint, opts *fakeH
 
 	f.ln = bufconn.Listen(bufconnBufSize)
 
-	r := f.getRouter(endpoints, opts.apiAuth)
+	r := f.getRouter(endpoints, opts.apiAuth, opts.unescapeParameters)
 	go func() {
 		var handler nethttp.Handler = r
 		if opts.pipeline != nil {
@@ -2903,7 +2981,7 @@ func (f *fakeHTTPServer) StartServer(endpoints []endpoints.Endpoint, opts *fakeH
 	}
 }
 
-func (f *fakeHTTPServer) getRouter(endpoints []endpoints.Endpoint, apiAuth bool) chi.Router {
+func (f *fakeHTTPServer) getRouter(endpoints []endpoints.Endpoint, apiAuth bool, unescapeParameters bool) chi.Router {
 	srv := &server{}
 
 	r := srv.getRouter()
@@ -2915,7 +2993,7 @@ func (f *fakeHTTPServer) getRouter(endpoints []endpoints.Endpoint, apiAuth bool)
 	for _, e := range endpoints {
 		path := fmt.Sprintf("/%s/%s", e.Version, e.Route)
 
-		srv.handle(e, path, r, false)
+		srv.handle(e, path, r, unescapeParameters)
 	}
 	return r
 }

--- a/pkg/api/http/workflow.go
+++ b/pkg/api/http/workflow.go
@@ -16,6 +16,7 @@ package http
 import (
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -274,7 +275,7 @@ func (a *api) onStartWorkflowHandler() http.HandlerFunc {
 			InModifier: func(r *http.Request, in *runtimev1pb.StartWorkflowRequest) (*runtimev1pb.StartWorkflowRequest, error) {
 				in.WorkflowName = chi.URLParam(r, workflowName)
 				in.WorkflowComponent = chi.URLParam(r, workflowComponent)
-				in.InstanceId = r.URL.Query().Get(instanceID)
+				in.InstanceId = strings.TrimSpace(r.URL.Query().Get(instanceID))
 
 				// We accept the HTTP request body as the input to the workflow
 				// without making any assumptions about its format.
@@ -311,7 +312,7 @@ func (a *api) onTerminateWorkflowHandler() http.HandlerFunc {
 		UniversalHTTPHandlerOpts[*runtimev1pb.TerminateWorkflowRequest, *emptypb.Empty]{
 			InModifier: func(r *http.Request, in *runtimev1pb.TerminateWorkflowRequest) (*runtimev1pb.TerminateWorkflowRequest, error) {
 				in.SetWorkflowComponent(chi.URLParam(r, workflowComponent))
-				in.SetInstanceId(chi.URLParam(r, instanceID))
+				in.SetInstanceId(strings.TrimSpace(chi.URLParam(r, instanceID)))
 				return in, nil
 			},
 			SuccessStatusCode: http.StatusAccepted,
@@ -326,7 +327,7 @@ func (a *api) onRaiseEventWorkflowHandler() http.HandlerFunc {
 			// We pass the input body manually rather than parsing it using protojson
 			SkipInputBody: true,
 			InModifier: func(r *http.Request, in *runtimev1pb.RaiseEventWorkflowRequest) (*runtimev1pb.RaiseEventWorkflowRequest, error) {
-				in.InstanceId = chi.URLParam(r, instanceID)
+				in.InstanceId = strings.TrimSpace(chi.URLParam(r, instanceID))
 				in.WorkflowComponent = chi.URLParam(r, workflowComponent)
 				in.EventName = chi.URLParam(r, eventName)
 
@@ -369,7 +370,7 @@ func (a *api) onPurgeWorkflowHandler() http.HandlerFunc {
 		UniversalHTTPHandlerOpts[*runtimev1pb.PurgeWorkflowRequest, *emptypb.Empty]{
 			InModifier: func(r *http.Request, in *runtimev1pb.PurgeWorkflowRequest) (*runtimev1pb.PurgeWorkflowRequest, error) {
 				in.SetWorkflowComponent(chi.URLParam(r, workflowComponent))
-				in.SetInstanceId(chi.URLParam(r, instanceID))
+				in.SetInstanceId(strings.TrimSpace(chi.URLParam(r, instanceID)))
 				return in, nil
 			},
 			SuccessStatusCode: http.StatusAccepted,
@@ -379,6 +380,6 @@ func (a *api) onPurgeWorkflowHandler() http.HandlerFunc {
 // Shared InModifier method for all universal handlers for workflows that adds the "WorkflowComponent" and "InstanceId" properties
 func workflowInModifier[T runtimev1pb.WorkflowRequests](r *http.Request, in T) (T, error) {
 	in.SetWorkflowComponent(chi.URLParam(r, workflowComponent))
-	in.SetInstanceId(chi.URLParam(r, instanceID))
+	in.SetInstanceId(strings.TrimSpace(chi.URLParam(r, instanceID)))
 	return in, nil
 }


### PR DESCRIPTION
# Description

The workflow HTTP handlers read the instance ID straight from the URL path or
query string without any normalization. A trailing newline or space accidentally
pasted onto an instance ID is preserved and never matches a stored instance, so
the request silently resolves to a non-existent workflow (for example a 404 on
get) instead of the intended one.

This applies `strings.TrimSpace` to the instance ID in every workflow HTTP
handler that reads one: start, get, terminate, raiseEvent, pause, resume, and
purge (get, pause, and resume go through the shared `workflowInModifier`). Only
the instance ID is trimmed; `workflowComponent`, `workflowName`, and `eventName`
are left untouched.

Trimming both ends (rather than only the trailing side) is safe here because a
valid instance ID cannot legitimately contain surrounding whitespace: instance
IDs are validated on creation to contain only letters, digits, `-`, and `_`, so
whitespace is never part of a real ID.

Tests: added regression subtests that send an instance ID with a trailing space
(`%20`) and a trailing newline (`%0A`) through the Start (query parameter), Get,
and Purge (path parameter) endpoints and assert the handler receives the trimmed
ID and the request succeeds. Because production wraps routes that contain path
parameters so their values are URL-unescaped before the handler runs, the test
server is given a small additive option to mirror that behavior for these cases;
it defaults to off, so existing tests are unaffected.

## Issue reference

Please reference the issue this PR will close: #8971

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
