### PR TITLE
docs(diagnostics): fix copy-pasted doc comment on ConversationInvoked

### DIFF
--- a/pkg/diagnostics/component_monitoring.go
+++ b/pkg/diagnostics/component_monitoring.go
@@ -403,7 +403,7 @@ func (c *componentMetrics) ConfigurationInvoked(ctx context.Context, component, 
 	}
 }
 
-// SecretInvoked records the metrics for a secret event.
+// ConversationInvoked records the metrics for a conversation event.
 func (c *componentMetrics) ConversationInvoked(ctx context.Context, component string, success bool, elapsed float64) {
 	if c.enabled {
 		stats.RecordWithOptions(


### PR DESCRIPTION


The godoc on `componentMetrics.ConversationInvoked` in
`pkg/diagnostics/component_monitoring.go` read:

```go
// SecretInvoked records the metrics for a secret event.
func (c *componentMetrics) ConversationInvoked(ctx context.Context, component string, success bool, elapsed float64) {
```

That comment is a verbatim copy of the `SecretInvoked` doc comment (the method
records `conversationCount` / `conversationLatency`, not secret metrics). This
corrects it to describe the conversation event, matching the sibling
`StateInvoked`, `ConfigurationInvoked`, `SecretInvoked`, and `CryptoInvoked` doc
comments, which all read `// XxxInvoked records the metrics for a xxx event.`

Comment-only change; no behavior change.

## Issue reference

No issue: this is a trivial documentation-comment correction found while reading
the diagnostics package. Happy to open a tracking issue first if maintainers
prefer.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_

<!--
Notes on the unchecked boxes:
- Created/updated tests: not applicable; a godoc comment has no runnable
  behavior to test. Verified via build + existing unit tests + `go doc`.
- E2E: not applicable to a comment-only change.
- Docs/spec/sample repo: not applicable; this fixes an internal source comment,
  not user-facing docs, the spec, or a feature sample.
-->
