### PR TITLE
docs(injector): fix copy-pasted doc comment on AddressAllInstances

### DIFF
--- a/pkg/injector/patcher/services.go
+++ b/pkg/injector/patcher/services.go
@@ -62,7 +62,7 @@ func (svc Service) Address(namespace, clusterDomain string) string {
 	return fmt.Sprintf("%s.%s.svc.%s:%d", svc.name, namespace, clusterDomain, svc.port)
 }
 
-// Address returns the address of a Dapr control plane service
+// AddressAllInstances returns the addresses of all instances (one per replica) of a Dapr control plane service
 func (svc Service) AddressAllInstances(replicaCount int, namespace, clusterDomain string) []string {
 	allInstances := make([]string, 0, replicaCount)
 	for i := range replicaCount {


### PR DESCRIPTION


The doc comment on `Service.AddressAllInstances` in
`pkg/injector/patcher/services.go` was a verbatim copy of the comment on the
adjacent `Service.Address` method:

```go
// Address returns the address of a Dapr control plane service
func (svc Service) AddressAllInstances(replicaCount int, namespace, clusterDomain string) []string {
```

The two methods do different things:

- `Address` returns a single `string`: the address of the service
  (`<name>.<ns>.svc.<domain>:<port>`).
- `AddressAllInstances` returns a `[]string`: one address per replica, built with
  the StatefulSet ordinal pattern (`<name>-<i>.<name>.<ns>.svc.<domain>:<port>`).

This updates the comment to describe the actual all-instances (slice) behavior and
to start with the function name, per Go doc conventions. It is a comment-only
change with no behavior change.

```diff
-// Address returns the address of a Dapr control plane service
+// AddressAllInstances returns the addresses of all instances (one per replica) of a Dapr control plane service
 func (svc Service) AddressAllInstances(replicaCount int, namespace, clusterDomain string) []string {
```

## Issue reference

No issue: this is a trivial documentation fix found while reading the injector
patcher code. Happy to open a tracking issue first if the maintainers prefer.

## Checklist

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the dapr/docs repo
- [ ] Specification has been updated / Created issue in the dapr/docs repo
- [ ] Provided sample for the feature / Created issue in the dapr/docs repo

Notes on the unchecked items: this is a Go source doc-comment (godoc) fix with no
behavior change, so no new tests, no e2e, and no dapr/docs or spec update are
warranted. The existing package unit tests pass (`go test ./pkg/injector/patcher/...`).
