### PR TITLE
fix(workflow): include dash in invalid instance ID error message

### DIFF
--- a/pkg/api/universal/workflow_test.go
+++ b/pkg/api/universal/workflow_test.go
@@ -59,6 +59,12 @@ func TestStartWorkflowAPI(t *testing.T) {
 			expectedError:     messages.ErrInvalidInstanceID.WithFormat("invalid#12"),
 		},
 		{
+			testName:          "Instance ID with dashes is allowed in start request",
+			workflowComponent: fakeComponentName,
+			workflowName:      fakeWorkflowName,
+			instanceID:        "my-workflow-1",
+		},
+		{
 			testName:          "Too long instance ID provided in start request",
 			workflowComponent: fakeComponentName,
 			workflowName:      fakeWorkflowName,

--- a/pkg/messages/errorcodes/errorcodes.go
+++ b/pkg/messages/errorcodes/errorcodes.go
@@ -78,7 +78,7 @@ var (
 	WorkflowComponentNotFound         = ErrorCode{"ERR_WORKFLOW_COMPONENT_NOT_FOUND", "", CategoryWorkflow} // Workflow component not found
 	WorkflowEventNameMissing          = ErrorCode{"ERR_WORKFLOW_EVENT_NAME_MISSING", "", CategoryWorkflow}  // Missing workflow event name
 	WorkflowNameMissing               = ErrorCode{"ERR_WORKFLOW_NAME_MISSING", "", CategoryWorkflow}        // Workflow name not configured
-	WorkflowInstanceIDInvalid         = ErrorCode{"ERR_INSTANCE_ID_INVALID", "", CategoryWorkflow}          // Invalid workflow instance ID. (Only alphanumeric and underscore characters are allowed)
+	WorkflowInstanceIDInvalid         = ErrorCode{"ERR_INSTANCE_ID_INVALID", "", CategoryWorkflow}          // Invalid workflow instance ID. (Only alphanumeric, dash, and underscore characters are allowed)
 	WorkflowInstanceIDNotFound        = ErrorCode{"ERR_INSTANCE_ID_NOT_FOUND", "", CategoryWorkflow}        // Workflow instance ID not found
 	WorkflowInstanceIDProvidedMissing = ErrorCode{"ERR_INSTANCE_ID_PROVIDED_MISSING", "", CategoryWorkflow} // Missing workflow instance ID
 	WorkflowInstanceIDTooLong         = ErrorCode{"ERR_INSTANCE_ID_TOO_LONG", "", CategoryWorkflow}         // Workflow instance ID too long

--- a/pkg/messages/errorcodes/errorcodes.go
+++ b/pkg/messages/errorcodes/errorcodes.go
@@ -78,7 +78,7 @@ var (
 	WorkflowComponentNotFound         = ErrorCode{"ERR_WORKFLOW_COMPONENT_NOT_FOUND", "", CategoryWorkflow} // Workflow component not found
 	WorkflowEventNameMissing          = ErrorCode{"ERR_WORKFLOW_EVENT_NAME_MISSING", "", CategoryWorkflow}  // Missing workflow event name
 	WorkflowNameMissing               = ErrorCode{"ERR_WORKFLOW_NAME_MISSING", "", CategoryWorkflow}        // Workflow name not configured
-	WorkflowInstanceIDInvalid         = ErrorCode{"ERR_INSTANCE_ID_INVALID", "", CategoryWorkflow}          // Invalid workflow instance ID. (Only alphanumeric, dash, and underscore characters are allowed)
+	WorkflowInstanceIDInvalid         = ErrorCode{"ERR_INSTANCE_ID_INVALID", "", CategoryWorkflow}          // Invalid workflow instance ID. (Only alphanumeric characters, dashes, and underscores are allowed)
 	WorkflowInstanceIDNotFound        = ErrorCode{"ERR_INSTANCE_ID_NOT_FOUND", "", CategoryWorkflow}        // Workflow instance ID not found
 	WorkflowInstanceIDProvidedMissing = ErrorCode{"ERR_INSTANCE_ID_PROVIDED_MISSING", "", CategoryWorkflow} // Missing workflow instance ID
 	WorkflowInstanceIDTooLong         = ErrorCode{"ERR_INSTANCE_ID_TOO_LONG", "", CategoryWorkflow}         // Workflow instance ID too long

--- a/pkg/messages/predefined.go
+++ b/pkg/messages/predefined.go
@@ -125,7 +125,7 @@ var (
 	ErrWorkflowGetResponse           = APIError{"error while getting workflow info on instance '%s': %s", errorcodes.WorkflowGet, http.StatusInternalServerError, grpcCodes.Internal}
 	ErrWorkflowNameMissing           = APIError{"workflow name is not configured", errorcodes.WorkflowNameMissing, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrInstanceIDTooLong             = APIError{"workflow instance ID exceeds the max length of %d characters", errorcodes.WorkflowInstanceIDTooLong, http.StatusBadRequest, grpcCodes.InvalidArgument}
-	ErrInvalidInstanceID             = APIError{"workflow instance ID '%s' is invalid: only alphanumeric and underscore characters are allowed", errorcodes.WorkflowInstanceIDInvalid, http.StatusBadRequest, grpcCodes.InvalidArgument}
+	ErrInvalidInstanceID             = APIError{"workflow instance ID '%s' is invalid: only alphanumeric, dash, and underscore characters are allowed", errorcodes.WorkflowInstanceIDInvalid, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrWorkflowComponentDoesNotExist = APIError{"workflow component '%s' does not exist", errorcodes.WorkflowComponentNotFound, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrMissingOrEmptyInstance        = APIError{"no instance ID was provided", errorcodes.WorkflowInstanceIDProvidedMissing, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrWorkflowInstanceNotFound      = APIError{"unable to find workflow with the provided instance ID: %s", errorcodes.WorkflowInstanceIDNotFound, http.StatusNotFound, grpcCodes.NotFound}

--- a/pkg/messages/predefined.go
+++ b/pkg/messages/predefined.go
@@ -125,7 +125,7 @@ var (
 	ErrWorkflowGetResponse           = APIError{"error while getting workflow info on instance '%s': %s", errorcodes.WorkflowGet, http.StatusInternalServerError, grpcCodes.Internal}
 	ErrWorkflowNameMissing           = APIError{"workflow name is not configured", errorcodes.WorkflowNameMissing, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrInstanceIDTooLong             = APIError{"workflow instance ID exceeds the max length of %d characters", errorcodes.WorkflowInstanceIDTooLong, http.StatusBadRequest, grpcCodes.InvalidArgument}
-	ErrInvalidInstanceID             = APIError{"workflow instance ID '%s' is invalid: only alphanumeric, dash, and underscore characters are allowed", errorcodes.WorkflowInstanceIDInvalid, http.StatusBadRequest, grpcCodes.InvalidArgument}
+	ErrInvalidInstanceID             = APIError{"workflow instance ID '%s' is invalid: only alphanumeric characters, dashes, and underscores are allowed", errorcodes.WorkflowInstanceIDInvalid, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrWorkflowComponentDoesNotExist = APIError{"workflow component '%s' does not exist", errorcodes.WorkflowComponentNotFound, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrMissingOrEmptyInstance        = APIError{"no instance ID was provided", errorcodes.WorkflowInstanceIDProvidedMissing, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrWorkflowInstanceNotFound      = APIError{"unable to find workflow with the provided instance ID: %s", errorcodes.WorkflowInstanceIDNotFound, http.StatusNotFound, grpcCodes.NotFound}


### PR DESCRIPTION


The workflow instance ID validator accepts letters, digits, underscores, and
dashes, and its in-code comment documents exactly that:

```go
// pkg/api/universal/workflow.go
// Check to see if the instance ID contains invalid characters. Valid characters are letters, digits, dashes, and underscores.
// See https://github.com/dapr/dapr/issues/6156 for more context on why we check this.
for _, c := range instanceID {
    if !unicode.IsLetter(c) && c != '_' && c != '-' && !unicode.IsDigit(c) {
        return messages.ErrInvalidInstanceID.WithFormat(instanceID)
    }
}
```

The user-facing error, however, told users only alphanumeric and underscore
characters were allowed:

> workflow instance ID '%s' is invalid: only alphanumeric and underscore characters are allowed

That contradicts the validator (dashes are accepted) and misleads users into
thinking a valid character is forbidden. The matching error-code doc comment for
`ERR_INSTANCE_ID_INVALID` in `pkg/messages/errorcodes/errorcodes.go` had the same
inaccuracy.

This PR aligns both strings with what the validator actually accepts:

> workflow instance ID '%s' is invalid: only alphanumeric, dash, and underscore characters are allowed

No validation logic changes; this only corrects the diagnostic text so it matches
the code (and the accurate in-code comment). A regression test asserts that a
dash-containing instance ID (`my-workflow-1`) passes validation on start.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

No existing issue. This is a self-contained correctness fix for a user-facing
error message that contradicts the validator it describes; the validator's own
comment and issue #6156 (which introduced the check) confirm dashes are
intentionally allowed. Happy to file a tracking issue first if the maintainers
prefer.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_

<!--
Notes on the unchecked items (do NOT paste this comment into the PR; for review only):
- E2E: not run locally (requires the full Dapr E2E cluster/Docker setup). This is a
  string-only diagnostic change with unit coverage; E2E is validated by CI.
- Docs / spec / sample: not applicable. This corrects an inaccurate runtime error
  string; there is no API/behaviour/spec change and no reference doc pins this text.
-->
