### PR TITLE
ci: add codespell spell-check for changed files

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,10 @@
+[codespell]
+# Generated code, vendored deps, checksums and frozen release notes are not
+# hand-authored, so exclude them from spell checking. Directory skips use a
+# trailing glob so they also apply when codespell is passed an explicit file
+# list, as the CI step does for the files changed in a pull request.
+skip = .git,*.pb.go,*.pb.json,go.mod,go.sum,*.sum,vendor/*,node_modules/*,docs/release_notes/*,*.svg
+# Words codespell flags that are correct here: Azure product names (AKS, ACI),
+# the HTTP "TE" header, the Kubernetes "NotIn" selector operator and the Grafana
+# "showIn" schema key.
+ignore-words-list = aks,aci,te,notin,showin

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -80,6 +80,14 @@ jobs:
             echo >&2
             exit 1
           fi
+      - name: Check spelling with codespell
+        if: github.event_name == 'pull_request'
+        run: |
+          # Only spell check files changed in the PR so the existing history is
+          # not gated retroactively; codespell reads config from .codespellrc.
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          git diff --name-only --diff-filter=ACMR FETCH_HEAD HEAD \
+            | xargs --no-run-if-empty pipx run codespell --
       - name: Check for disallowed changes in go.mod
         run: node ./.github/scripts/check_go_mod.mjs
       - name: Run go mod tidy check diff


### PR DESCRIPTION


Dapr currently has no automated spell checking: there is no `.codespellrc`,
no `.pre-commit-config.yaml`, and no codespell / typos / misspell reference in
any workflow or the Makefile. Identifier, header, message and comment typos are
only caught by chance during review.

This adds a `codespell` step to the existing `static checks` job in
`.github/workflows/dapr.yml`. To avoid retroactively gating the large body of
pre-existing typos, the step spell-checks only the files changed in the pull
request, mirroring the neighbouring "Check white space in .md files" step's
changed-files approach. It lands green on the current tree and blocks new typos
from being introduced going forward.

Details:

- New `.codespellrc` is the single source of truth for both CI and local runs.
  It skips generated code (`*.pb.go`, `*.pb.json`), checksums (`go.sum`,
  `*.sum`), `vendor/*`, `node_modules/*`, the frozen `docs/release_notes/*`, and
  `*.svg`. Skips are written as trailing globs so they still apply when codespell
  is given an explicit file list, as the CI step does.
- A short `ignore-words-list` (`aks`, `aci`, `te`, `notin`, `showin`) covers
  correct tokens codespell can flag: Azure product names (AKS, ACI), the HTTP
  `TE` header, the Kubernetes `NotIn` selector operator, and the Grafana
  `showIn` schema key. Each is a real token in the tree, not a typo.
- The step is gated `if: github.event_name == 'pull_request'` and runs
  `git diff --name-only --diff-filter=ACMR FETCH_HEAD HEAD | xargs
  --no-run-if-empty pipx run codespell --` after fetching the PR base. `pipx`
  and Python are preinstalled on `ubuntu-latest`.

I am happy to instead scope this to a filed issue first, or to adjust the
skip / ignore lists, if the maintainers prefer.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_

<!--
Note for reviewers: this is a CI/config-only change (a new .codespellrc and one
workflow step). There is no Go code to unit/e2e test; "Code compiles correctly"
is ticked because no Go changed. The spelling gate itself was exercised locally
against a real codespell binary (green on the PR's own files, fails on a planted
typo, skips generated/release-note/svg files). No docs or spec change is needed.
-->
