### PR TITLE
fix: helm setup step in e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -129,6 +129,11 @@ jobs:
         echo "DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/${{ matrix.k8s-version }}_${{ matrix.mode }}" >> $GITHUB_ENV
         echo "DAPR_TEST_LOG_PATH=$GITHUB_WORKSPACE/test_logs/${{ matrix.k8s-version }}_${{ matrix.mode }}" >> $GITHUB_ENV
 
+        # Pre-create the log dirs so the always() compress/upload steps
+        # don't fail when the job aborts before any logs are written.
+        mkdir -p "$GITHUB_WORKSPACE/container_logs/${{ matrix.k8s-version }}_${{ matrix.mode }}" \
+                 "$GITHUB_WORKSPACE/test_logs/${{ matrix.k8s-version }}_${{ matrix.mode }}"
+
     - name: Create KinD Cluster
       uses: helm/kind-action@v1.13.0
       with:
@@ -159,7 +164,7 @@ jobs:
         docker network connect "kind" $REGISTRY_NAME
 
     - name: Setup Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@v5
       with:
         version: v3.3.4
 


### PR DESCRIPTION
# Description

Fixes helm issues like this one: 
<img width="1547" height="138" alt="image" src="https://github.com/user-attachments/assets/dd02694b-b252-4eca-a72a-f3a490a8b72a" />

The v5 downloads the .tar.gz (also verified to exist), retries failed downloads via the modern `@actions/tool-cache`, and runs natively on Node 24, which removes the deprecation warning for this action.