### PR TITLE
fix: improve error message when conversation component type not found

### DIFF
--- a/pkg/runtime/processor/conversation/conversation.go
+++ b/pkg/runtime/processor/conversation/conversation.go
@@ -17,6 +17,7 @@ package conversation
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	contribconversation "github.com/dapr/components-contrib/conversation"
@@ -59,7 +60,7 @@ func (c *conversation) Init(ctx context.Context, comp compapi.Component) error {
 	}
 
 	if conversate == nil {
-		return rterrors.NewInit(rterrors.CreateComponentFailure, fName, err)
+		return rterrors.NewInit(rterrors.CreateComponentFailure, fName, fmt.Errorf("conversation component type %s not found", comp.Spec.Type))
 	}
 
 	// initialization

--- a/pkg/runtime/processor/conversation/conversation.go
+++ b/pkg/runtime/processor/conversation/conversation.go
@@ -60,7 +60,7 @@ func (c *conversation) Init(ctx context.Context, comp compapi.Component) error {
 	}
 
 	if conversate == nil {
-		return rterrors.NewInit(rterrors.CreateComponentFailure, fName, fmt.Errorf("conversation component type %s not found", comp.Spec.Type))
+		return rterrors.NewInit(rterrors.CreateComponentFailure, fName, fmt.Errorf("conversation component %s returned a nil instance", comp.Spec.Type))
 	}
 
 	// initialization


### PR DESCRIPTION
## Summary

When registry.Create returns nil, nil for an unrecognized conversation component type, the error message was wrapping a nil error which produced a confusing message containing "<nil>".

Now returns a clear error message: "conversation component type X not found".

This helps operators quickly identify that the component type is not registered, rather than seeing a nil error.