### PR TITLE
fix(workflow): drop extra arg on ErrWorkflowInstanceNotFound format

### DIFF
--- a/pkg/api/universal/workflow.go
+++ b/pkg/api/universal/workflow.go
@@ -134,7 +134,7 @@ func (a *Universal) TerminateWorkflow(ctx context.Context, in *runtimev1pb.Termi
 	}
 	if err := a.workflowEngine.Client().Terminate(ctx, req); err != nil {
 		if errors.Is(err, api.ErrInstanceNotFound) {
-			err = messages.ErrWorkflowInstanceNotFound.WithFormat(in.GetInstanceId(), err)
+			err = messages.ErrWorkflowInstanceNotFound.WithFormat(in.GetInstanceId())
 		} else {
 			err = messages.ErrTerminateWorkflow.WithFormat(in.GetInstanceId(), err)
 		}
@@ -243,7 +243,7 @@ func (a *Universal) PurgeWorkflow(ctx context.Context, in *runtimev1pb.PurgeWork
 
 	if err := a.workflowEngine.Client().Purge(ctx, &req); err != nil {
 		if errors.Is(err, api.ErrInstanceNotFound) {
-			err = messages.ErrWorkflowInstanceNotFound.WithFormat(in.GetInstanceId(), err)
+			err = messages.ErrWorkflowInstanceNotFound.WithFormat(in.GetInstanceId())
 		} else {
 			err = messages.ErrPurgeWorkflow.WithFormat(in.GetInstanceId(), err)
 		}

--- a/pkg/api/universal/workflow_test.go
+++ b/pkg/api/universal/workflow_test.go
@@ -25,6 +25,7 @@ import (
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/fake"
+	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/kit/logger"
 )
 
@@ -365,4 +366,53 @@ func TestResumeWorkflowApi(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWorkflowInstanceNotFoundError verifies that the Terminate and Purge
+// handlers format ErrWorkflowInstanceNotFound with a single argument. The
+// message template has one verb, so passing the sentinel error as an extra
+// argument used to append a "%!(EXTRA ...)" formatting marker to the message.
+// ErrorIs cannot catch this because APIError.Is ignores the message, so the
+// exact message is asserted here.
+func TestWorkflowInstanceNotFoundError(t *testing.T) {
+	expectedMessage := messages.ErrWorkflowInstanceNotFound.WithFormat(fakeInstanceID).Message()
+
+	fakeAPI := &Universal{
+		logger:     logger.NewLogger("test"),
+		resiliency: resiliency.New(nil),
+		workflowEngine: fake.New().WithClient(func() workflows.Workflow {
+			return fake.NewClient().
+				WithTerminate(func(ctx context.Context, req *workflows.TerminateRequest) error {
+					return api.ErrInstanceNotFound
+				}).
+				WithPurge(func(ctx context.Context, req *workflows.PurgeRequest) error {
+					return api.ErrInstanceNotFound
+				})
+		}),
+		actors: actorsfake.New(),
+	}
+
+	t.Run("Terminate returns the not-found error without extra formatting", func(t *testing.T) {
+		_, err := fakeAPI.TerminateWorkflow(t.Context(), &runtimev1pb.TerminateWorkflowRequest{
+			WorkflowComponent: fakeComponentName,
+			InstanceId:        fakeInstanceID,
+		})
+		require.ErrorIs(t, err, messages.ErrWorkflowInstanceNotFound)
+		var apiErr messages.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, expectedMessage, apiErr.Message())
+		require.NotContains(t, apiErr.Message(), "%!(EXTRA")
+	})
+
+	t.Run("Purge returns the not-found error without extra formatting", func(t *testing.T) {
+		_, err := fakeAPI.PurgeWorkflow(t.Context(), &runtimev1pb.PurgeWorkflowRequest{
+			WorkflowComponent: fakeComponentName,
+			InstanceId:        fakeInstanceID,
+		})
+		require.ErrorIs(t, err, messages.ErrWorkflowInstanceNotFound)
+		var apiErr messages.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, expectedMessage, apiErr.Message())
+		require.NotContains(t, apiErr.Message(), "%!(EXTRA")
+	})
 }


### PR DESCRIPTION


`TerminateWorkflow` and `PurgeWorkflow` in `pkg/api/universal/workflow.go` build
the not-found error like this:

```go
if errors.Is(err, api.ErrInstanceNotFound) {
    err = messages.ErrWorkflowInstanceNotFound.WithFormat(in.GetInstanceId(), err)
}
```

`ErrWorkflowInstanceNotFound` (`pkg/messages/predefined.go`) has a single verb:

```
"unable to find workflow with the provided instance ID: %s"
```

`APIError.WithFormat` calls `fmt.Sprintf(msg, a...)`, so passing a second
argument to a one-verb template makes `Sprintf` append a `%!(EXTRA ...)` marker.
A not-found terminate or purge therefore returns a message like:

```
unable to find workflow with the provided instance ID: wf-123%!(EXTRA *errors.errorString=no such instance exists)
```

This drops the redundant second argument so the call matches the single-verb
template and the correct usage already present in the HTTP handler
(`pkg/api/http/workflow.go`, `GetWorkflow`). The extra argument was
`api.ErrInstanceNotFound`, the exact sentinel the `errors.Is` guard just
matched, so it adds no information and nothing is lost by removing it.

A regression test covering both handlers is added. `errors.Is` alone cannot
catch this defect because `APIError.Is` compares only the error code / gRPC /
HTTP status and ignores the message, so the test asserts the exact formatted
message and that it contains no `%!(EXTRA` marker.

## Issue reference

Found by inspection; no existing issue. Happy to open a tracking issue first if
maintainers prefer that flow.

Please reference the issue this PR will close: #_N/A_

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_N/A_
- [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_N/A_
- [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_N/A_

(Docs/spec/sample/e2e unchecked: this is an internal error-message formatting
fix with no API, behavior-contract, or documented-surface change; the gRPC/HTTP
status code and error code are unchanged. Covered by the added unit test.)
