### PR TITLE
fix(grpc): release app-concurrency semaphore once per invoke

### DIFF
--- a/pkg/channel/grpc/grpc_channel_test.go
+++ b/pkg/channel/grpc/grpc_channel_test.go
@@ -138,6 +138,64 @@ func TestInvokeMethod(t *testing.T) {
 	})
 }
 
+func TestInvokeMethodMaxConcurrency(t *testing.T) {
+	// Regression test: with app-max-concurrency set, g.ch is used as a
+	// buffered-channel semaphore. invokeMethodV1 must acquire one token and
+	// release exactly one; a double release underflows the buffer and blocks
+	// the deferred receive forever, hanging service invocation.
+	conn := createConnection(t)
+	defer closeConnection(t, conn)
+
+	// Ensure a successful (non-error) invoke path; TestHealthProbe may have
+	// left mockServer.Error set depending on test ordering.
+	prevErr := mockServer.Error
+	mockServer.Error = nil
+	t.Cleanup(func() { mockServer.Error = prevErr })
+
+	c := Channel{
+		baseAddress: "localhost:9998",
+		connFn: func() (*grpc.ClientConn, func(bool), error) {
+			return conn, func(bool) {}, nil
+		},
+		appMetadataToken:   "token1",
+		maxRequestBodySize: 4 << 20,
+		ch:                 make(chan struct{}, 1),
+	}
+	ctx := t.Context()
+
+	invoke := func() error {
+		req := invokev1.NewInvokeMethodRequest("method").
+			WithHTTPExtension(http.MethodPost, "")
+		defer req.Close()
+		response, err := c.InvokeMethod(ctx, req, "")
+		if response != nil {
+			response.Close()
+		}
+		return err
+	}
+
+	// Call twice sequentially: the first release leaves the semaphore empty,
+	// so a double release both hangs the first call and (if it returned) would
+	// break the second by stealing a token that was never acquired.
+	for i := range 2 {
+		done := make(chan error, 1)
+		go func() {
+			done <- invoke()
+		}()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("InvokeMethod did not return within timeout on call %d; the concurrency semaphore was released more than once", i+1)
+		}
+	}
+
+	// The token acquired for each call must have been released exactly once,
+	// leaving the semaphore empty and ready for the next request.
+	assert.Empty(t, c.ch, "concurrency semaphore should be drained after invocation")
+}
+
 func TestHealthProbe(t *testing.T) {
 	conn := createConnection(t)
 	c := Channel{


### PR DESCRIPTION


`Channel.invokeMethodV1` in `pkg/channel/grpc/grpc_channel.go` uses the buffered
channel `g.ch` (capacity = app-max-concurrency) as a concurrency-limiting
semaphore. It acquires one token by sending on `g.ch`, but released two: a
deferred receive, plus a leftover manual receive right after the `OnInvoke` call.

The deferred release was added later to also cover the early-return error paths,
but the pre-existing manual receive was never removed. So a single acquire mapped
to two receives from the buffered channel.

Effect when a positive `--app-max-concurrency` is set on a gRPC app:

- With `--app-max-concurrency=1`, the first `InvokeMethod` deadlocks. The send
  fills the buffer (len 1), the manual receive empties it (len 0), then the
  deferred receive blocks forever on the now-empty buffer. `invokeMethodV1` never
  returns, the service-invocation call hangs, and the goroutine leaks.
- With N > 1, the extra receive steals a token from a concurrently in-flight
  request, so the channel over-admits past the configured limit and eventually
  blocks/leaks once the buffer underflows.

The bug is dormant by default because `app-max-concurrency` defaults to `-1`, in
which case `g.ch` is nil (`CreateLocalChannel` only allocates the channel when
`maxConcurrency > 0`) and both `if g.ch != nil` guards are false. It triggers only
for gRPC apps that set a positive `--app-max-concurrency`.

The fix removes the manual receive so the token is released exactly once, via the
`defer`, which already fires on every return path (both error returns and the
success return). This matches the sibling `sendJob` method in the same file, which
acquires once and releases once in a `defer` only. Error-path behaviour is
unchanged: the removed block sat after `OnInvoke` but before the error handling, so
the early-return error paths never reached it and always released through the defer.

Added a regression test, `TestInvokeMethodMaxConcurrency`, that constructs a
`Channel` with a semaphore of capacity 1, invokes twice sequentially against the
existing mock app server, and asserts each call returns within a timeout and that
the semaphore is drained afterwards. On the unpatched code the test times out on
the first call; with the fix it passes.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

No linked issue.