### PR TITLE
fix(conversation): surface the reason in invalid params errors

### DIFF
--- a/pkg/api/universal/conversation.go
+++ b/pkg/api/universal/conversation.go
@@ -15,7 +15,6 @@ package universal
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/tmc/langchaingo/llms"
@@ -227,7 +226,7 @@ func (a *Universal) ConverseAlpha2(ctx context.Context, req *runtimev1pb.Convers
 			)
 
 			if message.GetMessageTypes() == nil {
-				err = messages.ErrConversationInvalidParams.WithFormat(req.GetName(), errors.New("message type cannot be nil"))
+				err = messages.ErrConversationInvalidParams.WithFormat(req.GetName(), "message type cannot be nil")
 				a.logger.Debug(err)
 				return nil, err
 			}
@@ -339,7 +338,7 @@ func (a *Universal) ConverseAlpha2(ctx context.Context, req *runtimev1pb.Convers
 
 				for _, tool := range msg.OfAssistant.GetToolCalls() {
 					if tool.ToolTypes == nil {
-						err = messages.ErrConversationInvalidParams.WithFormat(req.GetName(), errors.New("tool types cannot be nil"))
+						err = messages.ErrConversationInvalidParams.WithFormat(req.GetName(), "tool types cannot be nil")
 						a.logger.Debug(err)
 						return nil, err
 					}
@@ -403,7 +402,7 @@ func (a *Universal) ConverseAlpha2(ctx context.Context, req *runtimev1pb.Convers
 				}
 
 			default:
-				err = messages.ErrConversationInvalidParams.WithFormat(req.GetName())
+				err = messages.ErrConversationInvalidParams.WithFormat(req.GetName(), "unsupported message type")
 				a.logger.Debug(err)
 				return nil, err
 			}

--- a/pkg/api/universal/conversation_test.go
+++ b/pkg/api/universal/conversation_test.go
@@ -5,6 +5,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tmc/langchaingo/llms"
+
+	"github.com/dapr/components-contrib/conversation/echo"
+	"github.com/dapr/dapr/pkg/messages"
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/kit/ptr"
 )
 
 func TestMapRoleToChatMessageType(t *testing.T) {
@@ -28,6 +35,105 @@ func TestMapRoleToChatMessageType(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			result := mapRoleToChatMessageType(tc.input)
 			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestConverseAlpha2InvalidParams asserts that every ErrConversationInvalidParams
+// branch returns an actionable message that includes the concrete reason and does
+// not leak Go's %!(EXTRA ...) formatting sentinel. Passing an extra argument to a
+// single-verb format template appended that sentinel to the caller-facing error.
+func TestConverseAlpha2InvalidParams(t *testing.T) {
+	const componentName = "test-echo"
+
+	compStore := compstore.New()
+	compStore.AddConversation(componentName, echo.NewEcho(testLogger))
+
+	fakeAPI := &Universal{
+		logger:     testLogger,
+		resiliency: resiliency.New(nil),
+		compStore:  compStore,
+	}
+
+	tests := map[string]struct {
+		req            *runtimev1pb.ConversationRequestAlpha2
+		expectedReason string
+	}{
+		"nil message type": {
+			req: &runtimev1pb.ConversationRequestAlpha2{
+				Name: componentName,
+				Inputs: []*runtimev1pb.ConversationInputAlpha2{{
+					Messages: []*runtimev1pb.ConversationMessage{{}},
+				}},
+			},
+			expectedReason: "message type cannot be nil",
+		},
+		"nil tool types": {
+			req: &runtimev1pb.ConversationRequestAlpha2{
+				Name: componentName,
+				Inputs: []*runtimev1pb.ConversationInputAlpha2{{
+					Messages: []*runtimev1pb.ConversationMessage{{
+						MessageTypes: &runtimev1pb.ConversationMessage_OfAssistant{
+							OfAssistant: &runtimev1pb.ConversationMessageOfAssistant{
+								ToolCalls: []*runtimev1pb.ConversationToolCalls{{}},
+							},
+						},
+					}},
+				}},
+			},
+			expectedReason: "tool types cannot be nil",
+		},
+		"tool choice required without tools": {
+			req: &runtimev1pb.ConversationRequestAlpha2{
+				Name:       componentName,
+				ToolChoice: ptr.Of("required"),
+				Inputs: []*runtimev1pb.ConversationInputAlpha2{{
+					Messages: []*runtimev1pb.ConversationMessage{{
+						MessageTypes: &runtimev1pb.ConversationMessage_OfUser{
+							OfUser: &runtimev1pb.ConversationMessageOfUser{
+								Content: []*runtimev1pb.ConversationMessageContent{{Text: "hello"}},
+							},
+						},
+					}},
+				}},
+			},
+			expectedReason: "tool choice must be 'auto', 'none', 'required', or a specific tool name matching the tools available to be used",
+		},
+		"tool choice name not found": {
+			req: &runtimev1pb.ConversationRequestAlpha2{
+				Name:       componentName,
+				ToolChoice: ptr.Of("missing_tool"),
+				Tools: []*runtimev1pb.ConversationTools{{
+					ToolTypes: &runtimev1pb.ConversationTools_Function{
+						Function: &runtimev1pb.ConversationToolsFunction{Name: "other_tool"},
+					},
+				}},
+				Inputs: []*runtimev1pb.ConversationInputAlpha2{{
+					Messages: []*runtimev1pb.ConversationMessage{{
+						MessageTypes: &runtimev1pb.ConversationMessage_OfUser{
+							OfUser: &runtimev1pb.ConversationMessageOfUser{
+								Content: []*runtimev1pb.ConversationMessageContent{{Text: "hello"}},
+							},
+						},
+					}},
+				}},
+			},
+			expectedReason: "tool choice selected was not found. Must be 'auto', 'none', 'required', or a specific tool name matching the tools available to be used",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := fakeAPI.ConverseAlpha2(t.Context(), tc.req)
+			require.Error(t, err)
+			require.ErrorIs(t, err, messages.ErrConversationInvalidParams)
+
+			var apiErr messages.APIError
+			require.ErrorAs(t, err, &apiErr)
+			msg := apiErr.Message()
+			require.NotContains(t, msg, "%!", "error message must not leak an fmt error verb such as %%!(EXTRA ...): %q", msg)
+			require.Contains(t, msg, componentName)
+			require.Contains(t, msg, tc.expectedReason)
 		})
 	}
 }

--- a/pkg/messages/predefined.go
+++ b/pkg/messages/predefined.go
@@ -139,7 +139,7 @@ var (
 
 	// Conversation
 	ErrConversationNotFound      = APIError{"failed finding conversation component %s", errorcodes.ConversationNotFound, http.StatusBadRequest, grpcCodes.InvalidArgument}
-	ErrConversationInvalidParams = APIError{"failed conversing with component %s: invalid params", errorcodes.ConversationInvalidParms, http.StatusBadRequest, grpcCodes.InvalidArgument}
+	ErrConversationInvalidParams = APIError{"failed conversing with component %s: invalid params: %s", errorcodes.ConversationInvalidParms, http.StatusBadRequest, grpcCodes.InvalidArgument}
 	ErrConversationInvoke        = APIError{"failed conversing with component %s: %s", errorcodes.ConversationInvoke, http.StatusInternalServerError, grpcCodes.Internal}
 	ErrConversationMissingInputs = APIError{"failed conversing with component %s: missing inputs in request", errorcodes.ConversationMissingInputs, http.StatusBadRequest, grpcCodes.InvalidArgument}
 )


### PR DESCRIPTION


`ErrConversationInvalidParams` has a single `%s` verb:

```go
ErrConversationInvalidParams = APIError{"failed conversing with component %s: invalid params", ...}
```

but four call sites in `ConverseAlpha2` (`pkg/api/universal/conversation.go`) pass
a **second** argument to `WithFormat`: the nil-cause (`message type cannot be nil`,
`tool types cannot be nil`) or the valid tool-choice detail.
`APIError.WithFormat` forwards every argument to `fmt.Sprintf`
(`pkg/messages/api_error.go`), and formatting a one-verb template with two
arguments makes Go append its `%!(EXTRA ...)` sentinel and drop the intended
detail. gRPC/HTTP callers therefore received a garbled, non-actionable error:

```
failed conversing with component mycomponent: invalid params%!(EXTRA string=message type cannot be nil)
```

`go vet` does not catch this because the format string is a struct field, not a
string literal.

This adds a second verb to the template so the concrete reason is shown and
passes a reason string at every call site (including the previously detail-less
`default` branch, which passed only the component name and so showed no reason).
It mirrors the sibling `ErrConversationInvoke` (`"%s: %s"`) pattern, keeping the
"invalid params" classification while making the message actionable.

Before:

```
failed conversing with component mycomponent: invalid params%!(EXTRA string=message type cannot be nil)
```

After:

```
failed conversing with component mycomponent: invalid params: message type cannot be nil
```

Covered with a regression test (`TestConverseAlpha2InvalidParams`) exercising each
invalid-params branch (nil message type; nil tool types; tool choice `required`
with no tools; tool choice name not found) and asserting the message contains the
component name and the concrete reason and never leaks an fmt error verb (`%!`).

## Issue reference

<!-- No existing tracking issue; this is a defect found by inspection. See note. -->
Please reference the issue this PR will close: #_[issue number]_

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: n/a (bug fix, no API/spec change; error text only)
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: n/a (no API change)
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: n/a (bug fix)

## Release note

```release-note
FIX: The conversation ConverseAlpha2 invalid-params error no longer leaks a Go %!(EXTRA ...) formatting sentinel; it now shows the concrete reason, e.g. "failed conversing with component <name>: invalid params: <reason>".
```
