### PR TITLE
fix(runtime): ensure outbound healthz locks on component load failure

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -723,6 +723,10 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 		log.Error(err.Error())
 	}
 
+	// Register a health target tracking component initialization status.
+	// This forces /healthz to return a failure status until this target is marked Ready.
+	componentTarget := a.runtimeConfig.outboundHealthz.AddTarget("components")
+
 	// Start proxy
 	a.initProxy()
 
@@ -742,6 +746,8 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	if err = a.flushOutstandingComponents(ctx); err != nil {
 		return err
 	}
+	// Components loaded and flushed successfully; unlock the health target gate.
+	componentTarget.Ready()
 
 	err = a.loadHTTPEndpoints(ctx)
 	if err != nil {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -724,8 +724,9 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 	}
 
 	// Register a health target tracking component initialization status.
-	// This forces /healthz to return a failure status until this target is marked Ready.
+	// This forces /v1.0/healthz/outbound to return a failure status until this target is marked Ready.
 	componentTarget := a.runtimeConfig.outboundHealthz.AddTarget("components")
+	appTarget := a.runtimeConfig.outboundHealthz.AddTarget("app")
 
 	// Start proxy
 	a.initProxy()
@@ -866,7 +867,7 @@ func (a *DaprRuntime) initRuntime(ctx context.Context) error {
 		return err
 	}
 
-	a.runtimeConfig.outboundHealthz.AddTarget("app").Ready()
+	appTarget.Ready()
 
 	if err := a.blockUntilAppIsReady(ctx); err != nil {
 		return err

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2549,3 +2549,41 @@ func TestOtelResourceDetection(t *testing.T) {
 		})
 	}
 }
+
+func TestInitRuntime_ComponentInitializationFailure_LocksHealth(t *testing.T) {
+	// Arrange: Create a dedicated health registry instance to inspect
+	testHealthz := healthz.New()
+
+	// Arrange: Intentionally configure the runtime to point to a non-existent directory
+	testConfig := NewTestDaprRuntimeConfig(t, modes.StandaloneMode, string(protocol.HTTPProtocol), 1024)
+	testConfig.outboundHealthz = testHealthz
+	testConfig.standalone = modeconfig.StandaloneConfig{
+		ResourcesPath: []string{filepath.Join(t.TempDir(), "non-existent")},
+	}
+
+	// Act 1: Construct the runtime (this should succeed without error)
+	rt, err := newDaprRuntime(t.Context(), testSecurity(t), testConfig,
+		&config.Configuration{}, &config.AccessControlList{},
+		resiliency.New(logger.NewLogger("test")), nil, nil)
+	require.NoError(t, err)
+
+	// Act 2: Run the runtime with a short timeout to trigger initialization and check the error.
+	// Since component loading fails, this will fail fast and return the error.
+	runCtx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+	defer cancel()
+
+	runErr := rt.Run(runCtx)
+
+	// Assert: The initialization sequence should report a loading failure error
+	require.Error(t, runErr)
+	assert.Contains(t, runErr.Error(), "failed to load components")
+
+	// Assert: Verify our architectural gatekeeper successfully blocked the probe.
+	// Since components failed, the "components" target must exist but NOT be ready.
+	assert.Contains(
+		t,
+		testHealthz.GetUnhealthyTargets(),
+		"components",
+		"Health probe must lock 'components' to unhealthy if components fail to load",
+	)
+}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2567,12 +2567,10 @@ func TestInitRuntime_ComponentInitializationFailure_LocksHealth(t *testing.T) {
 		resiliency.New(logger.NewLogger("test")), nil, nil)
 	require.NoError(t, err)
 
-	// Act 2: Run the runtime with a short timeout to trigger initialization and check the error.
-	// Since component loading fails, this will fail fast and return the error.
-	runCtx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
-	defer cancel()
-
-	runErr := rt.Run(runCtx)
+	// Act 2: Run initialization (should fail fast during component loading)
+	runErr := rt.initRuntime(t.Context())
+	// Best-effort cleanup for anything init started/registered before failing
+	_ = rt.runnerCloser.Close()
 
 	// Assert: The initialization sequence should report a loading failure error
 	require.Error(t, runErr)


### PR DESCRIPTION
If component loading failed during runtime initialization, the outbound healthcheck (`/healthz/outbound`) did not correctly register or mark the `components` target as unhealthy. This could cause the sidecar to report a healthy state incorrectly or bypass the check.

This change:
- Configures `outboundHealthz` instead of the general `healthz` registry for the components target.
- Ensures the `components` target is registered and correctly set to unhealthy on component loading failures.
- Adds `TestInitRuntime_ComponentInitializationFailure_LocksHealth` to verify this behavior.

# Description

<!--
Please explain the changes you've made.
-->

## Closes #7326

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[7362]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
