### PR TITLE
workflow: gate instance ID reuse on child workflows being terminal

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -9,6 +9,7 @@ This update contains the following bug fixes:
 - [Redis components updated to go-redis v9.21.0](#redis-components-updated-to-go-redis-v9210)
 - [Sidecar reserves its internal gRPC port before initializing components](#sidecar-reserves-its-internal-grpc-port-before-initializing-components)
 - [A slow actor timer callback delays timers for every other actor](#a-slow-actor-timer-callback-delays-timers-for-every-other-actor)
+- [Reusing a workflow instance ID while child workflows from the previous execution are still running](#reusing-a-workflow-instance-id-while-child-workflows-from-the-previous-execution-are-still-running)
 
 ## SPIFFE SVID component operation propagation
 
@@ -204,3 +205,27 @@ Due timers are now routed to a per-actor execution loop.
 Callbacks for the same actor still run one at a time in scheduled order, and a repeating timer is still re-armed only after its current callback returns, but callbacks for different actors now run concurrently, so a slow callback delays only its own actor's timers.
 Per-actor loops are created when an actor's first timer fires and are reclaimed once the actor has no registered timers and no outstanding fires.
 Deleting or replacing a timer now also cancels a fire that is already waiting behind a running callback for the same actor.
+
+## Reusing a workflow instance ID while child workflows from the previous execution are still running
+
+### Problem
+
+Creating a workflow with the instance ID of a completed, failed, or terminated workflow succeeded even while child workflows started by that previous execution were still running.
+A still-running child belongs to the old execution but reports its completion to the parent instance ID, so its events could be delivered into the new execution, and a new execution that pins the same child IDs could collide with the old execution's live children.
+
+### Impact
+
+You were affected if you reuse deterministic workflow instance IDs for workflows that create child workflows, and recreated a parent whose children had not finished.
+This arises when a parent completes without awaiting its children, or is terminated without recursion, leaving the children running.
+Workflows created with fresh or auto-generated instance IDs were not affected, and are not affected by the fix.
+
+### Root Cause
+
+The create path only checked the runtime status of the instance being recreated.
+Child workflows are independent instances that can outlive a terminal parent, and the ones recorded in the previous execution's history were never consulted.
+
+### Solution
+
+Recreating a terminal workflow now verifies that every child workflow of the previous execution, checked recursively and across app boundaries, is also in a terminal state or has been purged.
+If a descendant is still running or cannot be verified, the create request is rejected with a conflict error naming the blocking child workflow; purging the workflow continues to free its instance ID unconditionally.
+Creates with a fresh instance ID take the same path as before and perform no additional work.

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -17,12 +17,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
@@ -110,7 +112,15 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 	// workflow tree is terminal: a still-running descendant could deliver
 	// events from the old execution into the new one.
 	if err := o.childrenTerminalCheck(ctx, state); err != nil {
-		return status.Errorf(codes.AlreadyExists, "cannot recreate workflow with ID '%s': %s", o.actorID, err.Error())
+		// AlreadyExists only for the genuine not-terminal verdict. A failure
+		// to verify (child unreachable, context timeout) is Unavailable so
+		// callers retry rather than treat the ID as taken; reuse stays
+		// blocked either way.
+		code := codes.Unavailable
+		if strings.HasSuffix(err.Error(), api.ErrNotCompleted.Error()) {
+			code = codes.AlreadyExists
+		}
+		return status.Errorf(code, "cannot recreate workflow with ID '%s': %s", o.actorID, err.Error())
 	}
 
 	log.Infof("Workflow actor '%s': workflow was previously completed and is being recreated", o.actorID)

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -101,17 +101,29 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 		}
 		return status.Errorf(codes.AlreadyExists, "an active workflow with ID '%s' already exists", o.actorID)
 	}
+
 	if o.activityResultAwaited.Load() {
 		return fmt.Errorf("a terminated workflow with ID '%s' is already awaiting an activity result", o.actorID)
 	}
+
+	// An ID is reusable only once the previous execution's entire child
+	// workflow tree is terminal: a still-running descendant could deliver
+	// events from the old execution into the new one.
+	if err := o.childrenTerminalCheck(ctx, state); err != nil {
+		return status.Errorf(codes.AlreadyExists, "cannot recreate workflow with ID '%s': %s", o.actorID, err.Error())
+	}
+
 	log.Infof("Workflow actor '%s': workflow was previously completed and is being recreated", o.actorID)
+
 	state.Reset()
+
 	if propagatedHistory != nil {
 		if err := o.signing.VerifyAndAbsorbPropagatedHistory(propagatedHistory, state); err != nil {
 			return fmt.Errorf("workflow actor '%s': propagated history verification failed: %w", o.actorID, err)
 		}
 		state.SetIncomingHistory(propagatedHistory)
 	}
+
 	return o.scheduleWorkflowStart(ctx, startEvent, state)
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/stream.go
+++ b/pkg/actors/targets/workflow/orchestrator/stream.go
@@ -37,13 +37,29 @@ func (o *orchestrator) handleStream(ctx context.Context,
 
 	// Load state once and reuse for both the access policy check (workflow
 	// name) and the stream response.
-	_, ometa, err := o.loadInternalState(ctx)
+	state, ometa, err := o.loadInternalState(ctx)
 	if err != nil {
 		return false, err
 	}
 
 	if aerr := o.checkAccessPolicy(ctx, req.GetMessage().GetMethod(), req.GetMessage().GetData().GetValue(), nil, ometa, req.GetMetadata()); aerr != nil {
 		return false, aerr
+	}
+
+	// A caller gating instance ID reuse asks for the whole subtree to be
+	// verified terminal, not just this workflow: recurse into children before
+	// replying. Older daprds never send the flag and older callers are
+	// unaffected by it, so the recursion degrades to a direct status check
+	// across a version boundary rather than failing.
+	if v, ok := req.GetMetadata()[todo.MetadataCheckSubtreeTerminal]; ok && len(v.GetValues()) > 0 && v.GetValues()[0] == "true" {
+		resp, verr := o.subtreeTerminalResponse(ctx, state, ometa)
+		if verr != nil {
+			return false, verr
+		}
+		if resp != nil {
+			_, err = stream(resp)
+			return false, err
+		}
 	}
 
 	if ometa != nil {

--- a/pkg/actors/targets/workflow/orchestrator/terminalcheck.go
+++ b/pkg/actors/targets/workflow/orchestrator/terminalcheck.go
@@ -53,7 +53,10 @@ func (o *orchestrator) childrenTerminalCheck(ctx context.Context, state *wfengin
 		case errors.Is(err, api.ErrInstanceNotFound):
 			continue
 		case strings.HasSuffix(err.Error(), api.ErrNotCompleted.Error()):
-			return fmt.Errorf("child workflow '%s': %w", child.instanceID, api.ErrNotCompleted)
+			// Wrap rather than replace so a deep descendant's report keeps the
+			// full path, and the message keeps ending in api.ErrNotCompleted
+			// for suffix matching at the next level up.
+			return fmt.Errorf("child workflow '%s': %w", child.instanceID, err)
 		default:
 			return fmt.Errorf("failed to verify child workflow '%s' is in a terminal state: %w", child.instanceID, err)
 		}

--- a/pkg/actors/targets/workflow/orchestrator/terminalcheck.go
+++ b/pkg/actors/targets/workflow/orchestrator/terminalcheck.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+const childTerminalCheckTimeout = 5 * time.Second
+
+// childrenTerminalCheck verifies every child recorded in history is in a
+// terminal state, tolerating children that were purged out-of-band.
+func (o *orchestrator) childrenTerminalCheck(ctx context.Context, state *wfenginestate.State) error {
+	for _, child := range collectChildren(state.History) {
+		actorType := o.actorType
+		if child.targetAppID != "" && child.targetAppID != o.appID {
+			actorType = o.actorTypeBuilder.Workflow(child.targetAppID)
+		}
+
+		err := o.childTerminalCheck(ctx, actorType, child.instanceID)
+		if err == nil {
+			continue
+		}
+
+		switch {
+		case errors.Is(err, api.ErrInstanceNotFound):
+			continue
+		case strings.HasSuffix(err.Error(), api.ErrNotCompleted.Error()):
+			return fmt.Errorf("child workflow '%s': %w", child.instanceID, api.ErrNotCompleted)
+		default:
+			return fmt.Errorf("failed to verify child workflow '%s' is in a terminal state: %w", child.instanceID, err)
+		}
+	}
+
+	return nil
+}
+
+// childTerminalCheck reads the child's verdict from the first
+// WaitForRuntimeStatus stream response, ending the stream immediately rather
+// than waiting for a status change. The verdict rides in the response status
+// code rather than a handler error, since CallStream retries handler errors
+// via the built-in resiliency policy: 404 means the child was purged, 409
+// carries a non-terminal-subtree report, and anything else is the regular
+// metadata reply (the only reply an older daprd sends).
+func (o *orchestrator) childTerminalCheck(ctx context.Context, actorType, instanceID string) error {
+	ctx, cancel := context.WithTimeout(ctx, childTerminalCheckTimeout)
+	defer cancel()
+
+	req := internalsv1pb.
+		NewInternalInvokeRequest(todo.WaitForRuntimeStatus).
+		WithActor(actorType, instanceID).
+		WithContentType(invokev1.ProtobufContentType).
+		WithMetadata(map[string][]string{
+			todo.MetadataCheckSubtreeTerminal: {"true"},
+		})
+
+	var checkErr error
+	var complete bool
+	err := o.router.CallStream(ctx, req, func(resp *internalsv1pb.InternalInvokeResponse) (bool, error) {
+		switch resp.GetStatus().GetCode() {
+		case http.StatusNotFound:
+			checkErr = api.ErrInstanceNotFound
+
+		case http.StatusConflict:
+			var report wrapperspb.StringValue
+			if uerr := resp.GetMessage().GetData().UnmarshalTo(&report); uerr == nil && report.GetValue() != "" {
+				checkErr = errors.New(report.GetValue())
+			} else {
+				checkErr = api.ErrNotCompleted
+			}
+
+		default:
+			var meta backend.WorkflowMetadata
+			if uerr := resp.GetMessage().GetData().UnmarshalTo(&meta); uerr != nil {
+				return false, uerr
+			}
+			complete = api.WorkflowMetadataIsComplete(&meta)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	if checkErr != nil {
+		return checkErr
+	}
+	if !complete {
+		return api.ErrNotCompleted
+	}
+	return nil
+}
+
+// subtreeTerminalResponse resolves a WaitForRuntimeStatus call carrying the
+// subtree-terminal metadata flag.
+func (o *orchestrator) subtreeTerminalResponse(ctx context.Context, state *wfenginestate.State, ometa *backend.WorkflowMetadata) (*internalsv1pb.InternalInvokeResponse, error) {
+	if ometa == nil {
+		// Purged or never existed: nothing left to leak into a recreated ancestor.
+		return &internalsv1pb.InternalInvokeResponse{
+			Status: &internalsv1pb.Status{Code: http.StatusNotFound},
+		}, nil
+	}
+
+	if !api.WorkflowMetadataIsComplete(ometa) {
+		return nil, nil
+	}
+
+	cerr := o.childrenTerminalCheck(ctx, state)
+	if cerr == nil {
+		return nil, nil
+	}
+
+	report, err := anypb.New(wrapperspb.String(cerr.Error()))
+	if err != nil {
+		return nil, err
+	}
+	return &internalsv1pb.InternalInvokeResponse{
+		Status:  &internalsv1pb.Status{Code: http.StatusConflict},
+		Message: &commonv1pb.InvokeResponse{Data: report},
+	}, nil
+}

--- a/pkg/runtime/wfengine/todo/todo.go
+++ b/pkg/runtime/wfengine/todo/todo.go
@@ -36,6 +36,10 @@ const (
 	MetadataActivityReminderDueTime = "dueTime"
 	MetadataPurgeRetentionCall      = "PurgeRetentionCall"
 	MetadataPurgeForce              = "PurgeForce"
+	// Set on a WaitForRuntimeStatus call to request that a terminal workflow
+	// also verify all of its child workflows, recursively, are terminal
+	// before replying. Ignored by daprds that predate the flag.
+	MetadataCheckSubtreeTerminal = "CheckSubtreeTerminal"
 
 	ActorTypePrefix = "dapr.internal."
 )

--- a/tests/integration/suite/daprd/workflow/reuseid/childrunning.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/childrunning.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childrunning))
+}
+
+type childrunning struct {
+	workflow *workflow.Workflow
+}
+
+func (c *childrunning) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *childrunning) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "reuseid-childrunning"
+	const childID = parentID + "-child"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := c.workflow.Registry()
+
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		ctx.CallChildWorkflow("child", task.WithChildWorkflowInstanceID(childID))
+		return nil, nil
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+
+	client := c.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
+	assert.Contains(t, err.Error(), "cannot recreate workflow with ID '"+parentID+"'")
+	assert.Contains(t, err.Error(), "child workflow '"+childID+"'")
+
+	close(releaseCh)
+	_, err = client.WaitForWorkflowCompletion(ctx, childID)
+	require.NoError(t, err)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/crossapp.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/crossapp.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(crossapp))
+}
+
+type crossapp struct {
+	workflow *workflow.Workflow
+}
+
+func (c *crossapp) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t,
+		workflow.WithDaprds(2),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *crossapp) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "reuseid-crossapp"
+	const childID = parentID + "-child"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	app1AppID := c.workflow.DaprN(1).AppID()
+
+	c.workflow.Registry().AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowAppID(app1AppID),
+			task.WithChildWorkflowInstanceID(childID),
+		)
+		return nil, nil
+	})
+
+	app1Reg := c.workflow.RegistryN(1)
+	app1Reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	app1Reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+
+	client0 := c.workflow.BackendClient(t, ctx)
+	client1 := c.workflow.BackendClientN(t, ctx, 1)
+
+	_, err := client0.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client0.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10,
+		"cross-app child workflow should be running its blocking activity")
+
+	_, err = client0.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
+	assert.Contains(t, err.Error(), "cannot recreate workflow with ID '"+parentID+"'")
+	assert.Contains(t, err.Error(), "child workflow '"+childID+"'")
+
+	close(releaseCh)
+	_, err = client1.WaitForWorkflowCompletion(ctx, childID)
+	require.NoError(t, err)
+
+	_, err = client0.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client0.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/grandchild.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/grandchild.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(grandchild))
+}
+
+type grandchild struct {
+	workflow *workflow.Workflow
+}
+
+func (g *grandchild) Setup(t *testing.T) []framework.Option {
+	g.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(g.workflow),
+	}
+}
+
+func (g *grandchild) Run(t *testing.T, ctx context.Context) {
+	g.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "reuseid-grandchild"
+	const childID = parentID + "-child"
+	const grandchildID = parentID + "-grandchild"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := g.workflow.Registry()
+
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowInstanceID(childID),
+		).Await(nil)
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		ctx.CallChildWorkflow("grandchild", task.WithChildWorkflowInstanceID(grandchildID))
+		return nil, nil
+	})
+	reg.AddWorkflowN("grandchild", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+
+	client := g.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
+	assert.Contains(t, err.Error(), "cannot recreate workflow with ID '"+parentID+"'")
+	assert.Contains(t, err.Error(), "child workflow '"+childID+"'")
+
+	close(releaseCh)
+	_, err = client.WaitForWorkflowCompletion(ctx, grandchildID)
+	require.NoError(t, err)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/grandchild.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/grandchild.go
@@ -102,6 +102,7 @@ func (g *grandchild) Run(t *testing.T, ctx context.Context) {
 	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
 	assert.Contains(t, err.Error(), "cannot recreate workflow with ID '"+parentID+"'")
 	assert.Contains(t, err.Error(), "child workflow '"+childID+"'")
+	assert.Contains(t, err.Error(), "child workflow '"+grandchildID+"'")
 
 	close(releaseCh)
 	_, err = client.WaitForWorkflowCompletion(ctx, grandchildID)

--- a/tests/integration/suite/daprd/workflow/reuseid/purgedchild.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/purgedchild.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(purgedchild))
+}
+
+type purgedchild struct {
+	workflow *workflow.Workflow
+}
+
+func (p *purgedchild) Setup(t *testing.T) []framework.Option {
+	p.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(p.workflow),
+	}
+}
+
+func (p *purgedchild) Run(t *testing.T, ctx context.Context) {
+	p.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "reuseid-purgedchild"
+	const childID = parentID + "-child"
+
+	reg := p.workflow.Registry()
+
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowInstanceID(childID),
+		).Await(nil)
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	client := p.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+
+	require.NoError(t, client.PurgeWorkflowState(ctx, api.InstanceID(childID)))
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+
+	require.NoError(t, client.PurgeWorkflowState(ctx, api.InstanceID(parentID)))
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/retention.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/retention.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(retention))
+}
+
+type retention struct {
+	workflow *workflow.Workflow
+}
+
+func (r *retention) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t,
+		workflow.WithDaprdOptions(0, daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: wfpolicy
+spec:
+  workflow:
+    stateRetentionPolicy:
+      completed: "2s"
+`)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *retention) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	const instanceID = "reuseid-clock"
+
+	r.workflow.Registry().AddWorkflowN("foo", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("release", time.Minute*10).Await(nil)
+	})
+
+	client := r.workflow.BackendClient(t, ctx)
+
+	db := r.workflow.DB().GetConnection(t)
+	tableName := r.workflow.DB().TableName()
+	rowCount := func() int {
+		var count int
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
+		return count
+	}
+
+	retentionJobs := func() []string {
+		var jobs []string
+		for _, key := range r.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs") {
+			if strings.HasSuffix(key, "||retention") {
+				jobs = append(jobs, key)
+			}
+		}
+		return jobs
+	}
+
+	_, err := client.ScheduleNewWorkflow(ctx, "foo", api.WithInstanceID(instanceID))
+	require.NoError(t, err)
+	require.NoError(t, client.RaiseEvent(ctx, api.InstanceID(instanceID), "release"))
+	_, err = client.WaitForWorkflowCompletion(ctx, instanceID)
+	require.NoError(t, err)
+	require.NotEmpty(t, retentionJobs(), "run 1 should have queued a retention reminder")
+
+	_, err = client.ScheduleNewWorkflow(ctx, "foo", api.WithInstanceID(instanceID))
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Empty(c, retentionJobs(), "run 1's stale retention reminder should have fired and drained")
+	}, time.Second*10, time.Millisecond*10)
+
+	meta, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(instanceID))
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_RUNNING", meta.GetRuntimeStatus().String(),
+		"run 2 must survive run 1's retention deadline")
+	require.Positive(t, rowCount(), "run 2 state must not have been purged")
+
+	require.NoError(t, client.RaiseEvent(ctx, api.InstanceID(instanceID), "release"))
+	_, err = client.WaitForWorkflowCompletion(ctx, instanceID)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, retentionJobs(), "run 2 should have queued its own retention reminder")
+	require.Positive(t, rowCount(), "run 2 must not be purged before its own retention window elapses")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 0, rowCount())
+		assert.Empty(c, r.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/terminated.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/terminated.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(terminated))
+}
+
+type terminated struct {
+	workflow *workflow.Workflow
+}
+
+func (r *terminated) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *terminated) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "reuseid-terminated"
+	const childID = parentID + "-child"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := r.workflow.Registry()
+
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowInstanceID(childID),
+		).Await(nil)
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+
+	client := r.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10,
+		"child workflow should be running its blocking activity")
+
+	require.NoError(t, client.TerminateWorkflow(ctx, api.InstanceID(parentID),
+		api.WithRecursiveTerminate(false)))
+	meta, err := client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_TERMINATED", meta.GetRuntimeStatus().String())
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
+	assert.Contains(t, err.Error(), "cannot recreate workflow with ID '"+parentID+"'")
+	assert.Contains(t, err.Error(), "child workflow '"+childID+"'")
+
+	close(releaseCh)
+	_, err = client.WaitForWorkflowCompletion(ctx, childID)
+	require.NoError(t, err)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/records"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/rerun"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/retries"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reuseid"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/security"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/signing"


### PR DESCRIPTION
Creating a workflow with the instance ID of a completed, failed, or terminated workflow succeeded even while child workflows started by that previous execution were still running. A live child belongs to the old execution but reports its completion to the parent instance ID, so its events could be delivered into the new execution, and a new execution pinning the same child IDs could collide with the old execution's running children. The create path only checked the runtime status of the instance being recreated; the children recorded in its history were never consulted.

Recreating a terminal workflow now verifies that every child workflow of the previous execution, checked recursively and across app boundaries, is also in a terminal state or has been purged, before the state is reset. A still-running or unverifiable descendant rejects the create with AlreadyExists naming the blocking child. Purge continues to free an instance ID unconditionally, and creates with a fresh instance ID take the same path as before with no additional work.

The check is carried on the existing WaitForRuntimeStatus stream via a new request metadata flag rather than a new actor method, so it is compatible across a version boundary: an older daprd hosting a child ignores the flag and reports that child's own status, truncating the recursion there instead of failing the create. The verdict rides in the response status code (404 purged, 409 non-terminal subtree, 200 regular metadata) rather than a handler error, because CallStream retries handler errors through the built-in resiliency policy. Each per-child hop is bounded by a 5 second timeout because the walk runs under the creating actor's lock while an abandoned child may concurrently be delivering its completion back into the terminal parent; on timeout the create is rejected and can be retried.