### PR TITLE
actors: allow actor callback stream without an app port

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -10,6 +10,7 @@ This update contains the following bug fixes:
 - [Sidecar reserves its internal gRPC port before initializing components](#sidecar-reserves-its-internal-grpc-port-before-initializing-components)
 - [A slow actor timer callback delays timers for every other actor](#a-slow-actor-timer-callback-delays-timers-for-every-other-actor)
 - [Reusing a workflow instance ID while child workflows from the previous execution are still running](#reusing-a-workflow-instance-id-while-child-workflows-from-the-previous-execution-are-still-running)
+- [gRPC streaming actor applications could not host actors without opening an app port](#grpc-streaming-actor-applications-could-not-host-actors-without-opening-an-app-port)
 
 ## SPIFFE SVID component operation propagation
 
@@ -221,11 +222,34 @@ Workflows created with fresh or auto-generated instance IDs were not affected, a
 
 ### Root Cause
 
-The create path only checked the runtime status of the instance being recreated.
-Child workflows are independent instances that can outlive a terminal parent, and the ones recorded in the previous execution's history were never consulted.
+The create path only checked the runtime status of the instance being recreated. Child workflows are independent instances that can outlive a terminal parent, and the ones recorded in the previous execution's history were never consulted.
 
 ### Solution
 
 Recreating a terminal workflow now verifies that every child workflow of the previous execution, checked recursively and across app boundaries, is also in a terminal state or has been purged.
 If a descendant is still running or cannot be verified, the create request is rejected with a conflict error naming the blocking child workflow; purging the workflow continues to free its instance ID unconditionally.
 Creates with a fresh instance ID take the same path as before and perform no additional work.
+
+## gRPC streaming actor applications could not host actors without opening an app port
+
+### Problem
+
+Dapr 1.18 introduced hosting actors over the app-initiated gRPC callback stream (`SubscribeActorEventsAlpha1`).
+A headline property of this feature is that the application dials the sidecar itself and therefore does not need to listen on any port.
+In practice, opening the stream against a sidecar started without `--app-port` failed immediately with a `FailedPrecondition` error stating that actor callback streaming requires a gRPC app channel.
+Applications were forced to open a local port and pass it to the sidecar via `--app-port` (or the `dapr.io/app-port` annotation) purely to satisfy the sidecar's channel setup, even though actor traffic never used that port.
+
+### Impact
+
+You were affected if you hosted actors over the streaming actor API and ran the sidecar without an app port configured.
+The callback stream was rejected before registration, so the application's actor types were never registered and no actor traffic could be served.
+
+### Root Cause
+
+The sidecar only creates its app channel when an app port is configured.
+Both the stream endpoint's guard and the actor transport selection obtained the callback stream manager by inspecting the gRPC app channel, so with no app port there was no channel to inspect and the stream was rejected as if the application were HTTP-based.
+
+### Solution
+
+The stream endpoint now serves the callback stream from the runtime-owned stream manager when no app channel exists, and actor registration passes that manager explicitly to the actor transport instead of deriving it from the app channel.
+A sidecar started without an app port now accepts the callback stream, registers the application's actor types, and routes invocations, reminders, timers, and deactivations over the stream, so the application does not need to listen on any port.

--- a/pkg/actors/actors.go
+++ b/pkg/actors/actors.go
@@ -460,12 +460,13 @@ func (a *actors) RegisterHosted(ctx context.Context, cfg hostconfig.Config) erro
 			Type:       actorType,
 			Reentrancy: reentrancy,
 			Factory: app.New(app.Options{
-				ActorType:   actorType,
-				AppChannel:  cfg.AppChannel,
-				Resiliency:  a.resiliency,
-				IdleTimeout: idleTimeout,
-				Reentrancy:  a.reentrancyStore,
-				Placement:   a.placement,
+				ActorType:      actorType,
+				AppChannel:     cfg.AppChannel,
+				CallbackStream: cfg.CallbackStream,
+				Resiliency:     a.resiliency,
+				IdleTimeout:    idleTimeout,
+				Reentrancy:     a.reentrancyStore,
+				Placement:      a.placement,
 			}),
 		})
 	}

--- a/pkg/actors/hostconfig/hostconfig.go
+++ b/pkg/actors/hostconfig/hostconfig.go
@@ -16,12 +16,17 @@ package hostconfig
 import (
 	"sync"
 
+	"github.com/dapr/dapr/pkg/actors/callbackstream"
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
 )
 
 type Config struct {
-	AppChannel              channel.AppChannel
+	AppChannel channel.AppChannel
+	// CallbackStream, when set, routes actor callbacks over the
+	// app-initiated SubscribeActorEventsAlpha1 stream instead of the app
+	// channel. This is how apps host actors without listening on a port.
+	CallbackStream          *callbackstream.Manager
 	EntityConfigs           []config.EntityConfig
 	DrainRebalancedActors   *bool
 	DrainOngoingCallTimeout string

--- a/pkg/actors/targets/app/factory.go
+++ b/pkg/actors/targets/app/factory.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/utils/clock"
 
 	"github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/callbackstream"
 	"github.com/dapr/dapr/pkg/actors/internal/placement"
 	"github.com/dapr/dapr/pkg/actors/internal/reentrancystore"
 	"github.com/dapr/dapr/pkg/actors/targets"
@@ -38,14 +39,18 @@ import (
 )
 
 type Options struct {
-	ActorType    string
-	AppChannel   channel.AppChannel
-	Resiliency   resiliency.Provider
-	IdleTimeout  time.Duration
-	clock        clock.Clock
-	Reentrancy   *reentrancystore.Store
-	Placement    placement.Interface
-	EntityConfig *api.EntityConfig
+	ActorType  string
+	AppChannel channel.AppChannel
+	// CallbackStream, when set, routes callbacks over the app-initiated
+	// SubscribeActorEventsAlpha1 stream. It takes precedence over the
+	// AppChannel-derived transport and requires no app port.
+	CallbackStream *callbackstream.Manager
+	Resiliency     resiliency.Provider
+	IdleTimeout    time.Duration
+	clock          clock.Clock
+	Reentrancy     *reentrancystore.Store
+	Placement      placement.Interface
+	EntityConfig   *api.EntityConfig
 }
 
 type factory struct {
@@ -72,7 +77,7 @@ func New(opts Options) targets.Factory {
 
 	f := &factory{
 		actorType:    opts.ActorType,
-		transport:    newInvoker(opts.AppChannel, opts.Resiliency, opts.ActorType),
+		transport:    newInvoker(opts.AppChannel, opts.CallbackStream, opts.Resiliency, opts.ActorType),
 		resiliency:   opts.Resiliency,
 		placement:    opts.Placement,
 		clock:        opts.clock,
@@ -89,16 +94,19 @@ func New(opts Options) targets.Factory {
 	return f
 }
 
-// newInvoker picks the right transport based on the concrete AppChannel
-// implementation. gRPC channels expose an ActorCallbackStream manager; when
-// present the streaming transport is used so callbacks reach the app
-// through the app-initiated SubscribeActorEventsAlpha1 stream. Anything
-// else falls through to the HTTP callback protocol.
-func newInvoker(ch channel.AppChannel, r resiliency.Provider, actorType string) transport.Invoker {
-	if g, ok := ch.(*grpcchannel.Channel); ok {
-		if mgr := g.ActorCallbackStream(); mgr != nil {
-			return grpctransport.New(mgr, r, actorType)
+// newInvoker picks the right transport. An explicit callback stream
+// manager wins: callbacks reach the app through the app-initiated
+// SubscribeActorEventsAlpha1 stream, which needs no app port or channel.
+// Otherwise gRPC channels expose an ActorCallbackStream manager, and
+// anything else falls through to the HTTP callback protocol.
+func newInvoker(ch channel.AppChannel, mgr *callbackstream.Manager, r resiliency.Provider, actorType string) transport.Invoker {
+	if mgr == nil {
+		if g, ok := ch.(*grpcchannel.Channel); ok {
+			mgr = g.ActorCallbackStream()
 		}
+	}
+	if mgr != nil {
+		return grpctransport.New(mgr, r, actorType)
 	}
 	return httptransport.New(ch, r, actorType)
 }

--- a/pkg/api/grpc/actorcallbacks.go
+++ b/pkg/api/grpc/actorcallbacks.go
@@ -67,6 +67,7 @@ func (a *api) SubscribeActorEventsAlpha1(stream runtimev1pb.Dapr_SubscribeActorE
 		DefaultIdleTimeout:      cfg.ActorIdleTimeout,
 		Reentrancy:              cfg.Reentrancy,
 		AppChannel:              a.channels.AppChannel(),
+		CallbackStream:          mgr,
 	}); err != nil {
 		return status.Errorf(codes.Internal, "failed to register hosted actors: %v", err)
 	}
@@ -183,15 +184,18 @@ func sendLoop(
 	}
 }
 
-// actorCallbackStream returns the stream manager owned by the gRPC app
-// channel, or nil if the channel is not gRPC-backed (e.g. HTTP app).
+// actorCallbackStream returns the stream manager serving the actor
+// callback stream, or nil if the app channel is HTTP-backed. When no app
+// channel exists at all (daprd was started without an app-port) the
+// runtime-owned manager is used directly: the callback stream is the
+// app's only connection to daprd and no app port is required.
 func (a *api) actorCallbackStream() *callbackstream.Manager {
 	if a.channels == nil {
 		return nil
 	}
 	ch := a.channels.AppChannel()
 	if ch == nil {
-		return nil
+		return a.channels.ActorCallbackStream()
 	}
 	gc, ok := ch.(*grpcchannel.Channel)
 	if !ok {

--- a/pkg/runtime/channels/channels.go
+++ b/pkg/runtime/channels/channels.go
@@ -175,6 +175,14 @@ func (c *Channels) AppChannel() channel.AppChannel {
 	return c.appChannel
 }
 
+// ActorCallbackStream returns the runtime-owned actor callback stream
+// manager. It is available even when no app channel exists (no app-port
+// configured): apps hosting actors over SubscribeActorEventsAlpha1 dial
+// daprd themselves and do not need to listen on any port.
+func (c *Channels) ActorCallbackStream() *callbackstream.Manager {
+	return c.actorCallbackStream
+}
+
 func (c *Channels) HTTPEndpointsAppChannel() channel.HTTPEndpointAppChannel {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/tests/integration/suite/actors/grpc/noappport.go
+++ b/tests/integration/suite/actors/grpc/noappport.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(noappport))
+}
+
+// noappport validates the headline property of the actor callback stream:
+// the application does not need to listen on any port. daprd is started
+// with no --app-port and no app process exists anywhere in this test. The
+// test itself plays the application: it dials daprd as a plain gRPC
+// client, registers an actor type over SubscribeActorEventsAlpha1, and
+// serves an actor invocation over that same stream.
+type noappport struct {
+	daprd *daprd.Daprd
+	place *placement.Placement
+}
+
+func (n *noappport) Setup(t *testing.T) []framework.Option {
+	n.place = placement.New(t)
+	n.daprd = daprd.New(t,
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(n.place.Address()),
+		daprd.WithAppProtocol("grpc"),
+		// Deliberately no WithAppPort: the app never listens anywhere.
+		daprd.WithLogLevel("info"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(n.place, n.daprd),
+	}
+}
+
+func (n *noappport) Run(t *testing.T, ctx context.Context) {
+	n.place.WaitUntilRunning(t, ctx)
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	conn, err := grpc.NewClient(n.daprd.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := rtv1.NewDaprClient(conn)
+
+	stream, err := client.SubscribeActorEventsAlpha1(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&rtv1.SubscribeActorEventsRequestAlpha1{
+		RequestType: &rtv1.SubscribeActorEventsRequestAlpha1_InitialRequest{
+			InitialRequest: &rtv1.SubscribeActorEventsRequestInitialAlpha1{
+				Entities: []string{"myactortype"},
+			},
+		},
+	}))
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetInitialResponse(),
+		"expected InitialResponse ack, got %T", resp.GetResponseType())
+
+	streamErr := make(chan error, 1)
+	go func() {
+		for {
+			msg, recvErr := stream.Recv()
+			if recvErr != nil {
+				streamErr <- recvErr
+				return
+			}
+			req := msg.GetInvokeRequest()
+			if req == nil {
+				continue
+			}
+			sendErr := stream.Send(&rtv1.SubscribeActorEventsRequestAlpha1{
+				RequestType: &rtv1.SubscribeActorEventsRequestAlpha1_InvokeResponse{
+					InvokeResponse: &rtv1.SubscribeActorEventsRequestInvokeResponseAlpha1{
+						Id:   req.GetId(),
+						Data: append([]byte("echo:"), req.GetData()...),
+					},
+				},
+			})
+			if sendErr != nil {
+				streamErr <- sendErr
+				return
+			}
+		}
+	}()
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		res := n.daprd.GetMetadata(c, ctx)
+		assert.True(c, res.ActorRuntime.HostReady)
+		assert.ElementsMatch(c, []*daprd.MetadataActorRuntimeActiveActor{
+			{Type: "myactortype"},
+		}, res.ActorRuntime.ActiveActors)
+	}, 10*time.Second, 10*time.Millisecond,
+		"stream registration not visible in metadata")
+
+	var invResp *rtv1.InvokeActorResponse
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var invErr error
+		invResp, invErr = client.InvokeActor(ctx, &rtv1.InvokeActorRequest{
+			ActorType: "myactortype",
+			ActorId:   "a1",
+			Method:    "ping",
+			Data:      []byte("hello"),
+		})
+		assert.NoError(c, invErr)
+	}, 20*time.Second, 10*time.Millisecond, "actor not ready")
+
+	require.NotNil(t, invResp)
+	assert.Equal(t, []byte("echo:hello"), invResp.GetData(),
+		"invocation must round-trip through the app's outbound stream")
+
+	select {
+	case sErr := <-streamErr:
+		require.FailNow(t, "actor callback stream failed", "%v", sErr)
+	default:
+	}
+}


### PR DESCRIPTION
The gRPC streaming actor protocol (SubscribeActorEventsAlpha1) promises that applications do not need to listen on a port: the app dials daprd and hosts actors over the stream. In practice daprd rejected the stream with FailedPrecondition when started without --app-port, because both the endpoint guard and the actor transport selection obtained the callback stream manager through the gRPC app channel, which is only created when an app port is configured.

Serve the stream from the runtime-owned callbackstream.Manager when no app channel exists, and pass the manager explicitly through hostconfig.Config into actor transport selection instead of checking the channel type. Streams opened while an HTTP app channel exists are still rejected, preserving the double-registration guard.