### PR TITLE
chore: bump components-contrib to v1.18.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/dapr/components-contrib v1.18.1
+	github.com/dapr/components-contrib v1.18.2
 	github.com/dapr/durabletask-go v0.12.1
 	github.com/dapr/kit v0.18.2
 	github.com/diagridio/go-etcd-cron v0.12.6

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.18.1 h1:GgPuh60eBkVltg0Q+rsstHyzHvmk7XxUC/NgEoFh3Vw=
-github.com/dapr/components-contrib v1.18.1/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
+github.com/dapr/components-contrib v1.18.2 h1:b1aCmQfmd9+gJx2EcdUXKRg3e00/5RjBpgvJsz7MwWY=
+github.com/dapr/components-contrib v1.18.2/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
 github.com/dapr/durabletask-go v0.12.1 h1:CIqG2HJGnU7kRtHICuRSSSO9RdHax99HdvHEaxRGE04=


### PR DESCRIPTION
Bumps `github.com/dapr/components-contrib` from v1.18.1 to v1.18.2 on `release-1.18`, and adds the corresponding v1.18.2 release note.

## What's included

components-contrib v1.18.2 backports the Kafka reliability hardening (dapr/components-contrib#4451): connection timeouts, a broker health check, and tunable producer configuration for the shared Kafka component.

## Changes

- `go.mod` / `go.sum`: bump components-contrib v1.18.1 → v1.18.2. `go mod tidy` introduces no transitive dependency churn (contrib's own `go.mod` hash is unchanged).
- `docs/release_notes/v1.18.2.md`: add the Kafka release note (connection timeouts, broker health check, tunable producer config).

## Verification

- `go build ./pkg/...` and `go mod verify` pass locally.

Release: https://github.com/dapr/components-contrib/releases/tag/v1.18.2
