### PR TITLE
feat: skip starting a workflow when the instance already exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.18.1
-	github.com/dapr/durabletask-go v0.12.2-0.20260803222509-354104514c67
+	github.com/dapr/durabletask-go v0.12.2-0.20260804142359-efda4a9c2e41
 	github.com/dapr/kit v0.18.3-0.20260727141402-dd127582d044
 	github.com/diagridio/go-etcd-cron v0.12.7
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/dapr/components-contrib v1.18.1 h1:GgPuh60eBkVltg0Q+rsstHyzHvmk7XxUC/
 github.com/dapr/components-contrib v1.18.1/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.12.2-0.20260803222509-354104514c67 h1:4/gSFNoWdW49awHAsfVfgfBSuylqSbMyQxP6kI+QCh0=
-github.com/dapr/durabletask-go v0.12.2-0.20260803222509-354104514c67/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
+github.com/dapr/durabletask-go v0.12.2-0.20260804142359-efda4a9c2e41 h1:G+7BshQYeS76SnR6F60mqPdJ/ksQ6dvyZupPq1rsoJE=
+github.com/dapr/durabletask-go v0.12.2-0.20260804142359-efda4a9c2e41/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/dapr/kit v0.18.3-0.20260727141402-dd127582d044 h1:++C9fyLCEIZr5k8lnlWJo+Zmyalk7Y1mMVwLZpkfB88=
 github.com/dapr/kit v0.18.3-0.20260727141402-dd127582d044/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -85,6 +85,12 @@ func (o *orchestrator) createWorkflowInstance(ctx context.Context, request []byt
 		return o.scheduleWorkflowStart(ctx, startEvent, state)
 	}
 
+	// orchestration already existed: the caller requires a unique instance ID,
+	// so reject the create regardless of the existing instance's runtime status
+	if createWorkflowInstanceRequest.GetEnforceUniqueInstanceId() {
+		return status.Errorf(codes.AlreadyExists, "a workflow with ID '%s' already exists", o.actorID)
+	}
+
 	// orchestration already existed: create instance only if previous one is completed
 	return o.createIfCompleted(ctx, o.rstate, state, startEvent, propagatedHistory)
 }

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -361,14 +361,14 @@ func (abe *Actors) RerunWorkflowFromEvent(ctx context.Context, req *backend.Reru
 // Internally, creating a workflow instance also creates a new actor with the same ID. The create
 // request is saved into the actor's "inbox" and then executed via a reminder thread. If the app is
 // scaled out across multiple replicas, the actor might get assigned to a replicas other than this one.
-func (abe *Actors) CreateWorkflowInstance(ctx context.Context, e *backend.HistoryEvent) error {
+func (abe *Actors) CreateWorkflowInstance(ctx context.Context, createReq *backend.CreateWorkflowInstanceRequest) error {
 	if err := abe.requireActorStateStore(); err != nil {
 		return err
 	}
 
 	var workflowInstanceID string
 
-	if es := e.GetExecutionStarted(); es == nil {
+	if es := createReq.GetStartEvent().GetExecutionStarted(); es == nil {
 		return errors.New("the history event must be an ExecutionStartedEvent")
 	} else if oi := es.GetWorkflowInstance(); oi == nil {
 		return errors.New("the ExecutionStartedEvent did not contain orchestration instance information")
@@ -376,9 +376,7 @@ func (abe *Actors) CreateWorkflowInstance(ctx context.Context, e *backend.Histor
 		workflowInstanceID = oi.GetInstanceId()
 	}
 
-	requestBytes, err := proto.Marshal(&backend.CreateWorkflowInstanceRequest{
-		StartEvent: e,
-	})
+	requestBytes, err := proto.Marshal(createReq)
 	if err != nil {
 		return fmt.Errorf("failed to marshal CreateWorkflowInstanceRequest: %w", err)
 	}

--- a/tests/integration/suite/daprd/workflow/enforceuniqueinstanceid.go
+++ b/tests/integration/suite/daprd/workflow/enforceuniqueinstanceid.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(enforceuniqueinstanceid))
+}
+
+type enforceuniqueinstanceid struct {
+	workflow *workflow.Workflow
+}
+
+func (e *enforceuniqueinstanceid) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *enforceuniqueinstanceid) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	e.workflow.Registry().AddWorkflowN("unique", func(ctx *task.WorkflowContext) (any, error) {
+		var input string
+		if err := ctx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		if err := ctx.WaitForSingleEvent("continue", time.Minute).Await(nil); err != nil {
+			return nil, err
+		}
+		return input, nil
+	})
+
+	client := e.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewWorkflow(ctx, "unique", api.WithInstanceID("foo"), api.WithInput("first"))
+	require.NoError(t, err)
+
+	// Scheduling with the flag while the instance is active fails with an
+	// ALREADY_EXISTS error.
+	_, err = client.ScheduleNewWorkflow(ctx, "unique", api.WithInstanceID("foo"), api.WithInput("second"), api.WithEnforceUniqueInstanceID())
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
+
+	require.NoError(t, client.RaiseEvent(ctx, id, "continue"))
+	meta, err := client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, meta.GetRuntimeStatus())
+	assert.Equal(t, `"first"`, meta.GetOutput().GetValue())
+
+	// Scheduling with the flag after completion also fails: the completed
+	// instance is not reset and re-run.
+	_, err = client.ScheduleNewWorkflow(ctx, "unique", api.WithInstanceID("foo"), api.WithInput("third"), api.WithEnforceUniqueInstanceID())
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), err)
+
+	meta, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, meta.GetRuntimeStatus())
+	assert.Equal(t, `"first"`, meta.GetOutput().GetValue())
+
+	// Without the flag, scheduling over the completed instance still resets and
+	// re-runs it (existing behavior is unchanged).
+	_, err = client.ScheduleNewWorkflow(ctx, "unique", api.WithInstanceID("foo"), api.WithInput("fourth"))
+	require.NoError(t, err)
+	require.NoError(t, client.RaiseEvent(ctx, id, "continue"))
+	meta, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, `"fourth"`, meta.GetOutput().GetValue())
+}


### PR DESCRIPTION
# Description

If the instance already exists no matter the state the action just returns without throwing an error

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
