### PR TITLE
docs: add v1.18.2 release note for Kafka connection timeouts, health check, and producer config

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -6,6 +6,7 @@ This update contains the following bug fixes:
 - [Actor reminders and jobs fail to register when their name or actor ID contains characters such as `|` or `@`](#actor-reminders-and-jobs-fail-to-register-when-their-name-or-actor-id-contains-characters-such-as--or-)
 - [IAM Roles Anywhere X.509 authentication breaks with certificate chains, SVID refresh, and missing SVIDs](#iam-roles-anywhere-x509-authentication-breaks-with-certificate-chains-svid-refresh-and-missing-svids)
 - [Redis components updated to go-redis v9.21.0](#redis-components-updated-to-go-redis-v9210)
+- [Kafka components lack connection timeouts, a broker health check, and tunable producer configuration](#kafka-components-lack-connection-timeouts-a-broker-health-check-and-tunable-producer-configuration)
 - [Sidecars restart when an unrelated Configuration is created or updated](#sidecars-restart-when-an-unrelated-configuration-is-created-or-updated)
 - [Sidecar reserves its internal gRPC port before initializing components](#sidecar-reserves-its-internal-grpc-port-before-initializing-components)
 - [A slow actor timer callback delays timers for every other actor](#a-slow-actor-timer-callback-delays-timers-for-every-other-actor)
@@ -136,6 +137,31 @@ When v9.21.0 added fields to `XMessage`, that conversion no longer compiled.
 
 The Redis client dependency is bumped to go-redis v9.21.0, and `XClaimResult` now assigns the `ID` and `Values` fields explicitly, matching the field-by-field pattern already used by `XReadGroupResult`.
 This keeps the conversion resilient to future field additions in the upstream `XMessage` type.
+
+## Kafka components lack connection timeouts, a broker health check, and tunable producer configuration
+
+### Problem
+
+The Kafka components (pub/sub and bindings, including the confluent and wurstmeister variants) are built on a shared Kafka component that uses the Sarama client with its default network configuration. The Sarama dial, read, write, and metadata timeouts were not exposed as component metadata, there was no way to probe broker reachability, and the producer's acknowledgement and retry settings were hard-coded. Against unreachable or slow brokers, operations — including component initialization — could block far longer than expected, with no health signal to surface that a broker had become unreachable.
+
+### Impact
+
+You were affected if you used the Kafka pub/sub or Kafka binding components. Connectivity problems could cause operations to hang and initialization to block on unreachable brokers, no built-in check existed to detect broker unavailability, and the producer's durability and retry behavior was fixed and could not be tuned.
+
+### Root Cause
+
+The shared Kafka component created its Sarama client with Sarama's default configuration and did not surface the `Net` dial, read, write, and metadata timeouts as component metadata, so callers could not bound how long operations waited on the network. No broker connectivity probe existed, and the producer's `RequiredAcks` and retry count were hard-coded when constructing the sync producer.
+
+### Solution
+
+The shared Kafka component now exposes tunable network timeouts and producer settings through component metadata, and adds a broker health check:
+
+- New network timeout metadata: `dialTimeout`, `readTimeout`, and `writeTimeout` (each default 30s), and `metadataTimeout` (default 0, meaning Sarama's own default applies). Invalid values fall back to the defaults.
+- New producer metadata: `producerRequiredAcks` (`all` (default), `local`, or `none`) and `producerRetryMax` (default 5), preserving the previous behavior when unset.
+- A broker connectivity probe that verifies the configured brokers are reachable. It disables metadata retries so it fails fast against an unhealthy cluster, honors the caller's context and timeout, and does not modify component state.
+- Component initialization no longer blocks indefinitely on unreachable brokers.
+
+All defaults preserve the previous behavior, so no configuration change is required.
 
 ## Sidecars restart when an unrelated Configuration is created or updated
 


### PR DESCRIPTION
Adds the missing v1.18.2 release note for the Kafka reliability changes brought in by the components-contrib v1.18.2 bump (#10201).

## What this adds

A `docs/release_notes/v1.18.2.md` entry (Problem / Impact / Root Cause / Solution) for the Kafka component hardening (dapr/components-contrib#4451):

- New network timeout metadata: `dialTimeout`, `readTimeout`, `writeTimeout` (default 30s each) and `metadataTimeout` (default 0 = Sarama default).
- New producer metadata: `producerRequiredAcks` (`all`/`local`/`none`, default `all`) and `producerRetryMax` (default 5).
- A broker connectivity health check that fails fast against unhealthy clusters.
- Initialization no longer blocks indefinitely on unreachable brokers.

Defaults preserve prior behavior. The contrib bump itself already merged in #10201; this only adds the release note that was not yet reflected at merge time.
