### PR TITLE
[release-1.18] fix: bump go-chi to v5.2.4 and mongo-driver to v1.17.7

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -12,6 +12,8 @@ This update contains the following bug fixes:
 - [A slow actor timer callback delays timers for every other actor](#a-slow-actor-timer-callback-delays-timers-for-every-other-actor)
 - [Reusing a workflow instance ID while child workflows from the previous execution are still running](#reusing-a-workflow-instance-id-while-child-workflows-from-the-previous-execution-are-still-running)
 - [gRPC streaming actor applications could not host actors without opening an app port](#grpc-streaming-actor-applications-could-not-host-actors-without-opening-an-app-port)
+- [go-chi updated to v5.2.4 for CVE-2025-69725](#go-chi-updated-to-v524-for-cve-2025-69725)
+- [mongo-driver updated to v1.17.7 for CVE-2026-2303](#mongo-driver-updated-to-v1177-for-cve-2026-2303)
 
 ## SPIFFE SVID component operation propagation
 
@@ -279,3 +281,39 @@ Both the stream endpoint's guard and the actor transport selection obtained the 
 
 The stream endpoint now serves the callback stream from the runtime-owned stream manager when no app channel exists, and actor registration passes that manager explicitly to the actor transport instead of deriving it from the app channel.
 A sidecar started without an app port now accepts the callback stream, registers the application's actor types, and routes invocations, reminders, timers, and deactivations over the stream, so the application does not need to listen on any port.
+
+## go-chi updated to v5.2.4 for CVE-2025-69725
+
+### Problem
+
+The Dapr HTTP server depends on `github.com/go-chi/chi/v5`, which was pinned to v5.2.2. That version is affected by CVE-2025-69725.
+
+### Impact
+
+You are affected if you run daprd. Dependency scanners report CVE-2025-69725 against the sidecar binary while it is built against go-chi v5.2.2.
+
+### Root Cause
+
+The `github.com/go-chi/chi/v5` dependency predated the upstream fix released in v5.2.4.
+
+### Solution
+
+`github.com/go-chi/chi/v5` is updated to v5.2.4, which resolves CVE-2025-69725. This is a dependency-only change with no behavioral impact.
+
+## mongo-driver updated to v1.17.7 for CVE-2026-2303
+
+### Problem
+
+The MongoDB Go driver `go.mongodb.org/mongo-driver` was pinned to v1.14.0, which is affected by CVE-2026-2303. It is used directly by the actor reminder subsystem and by the MongoDB components in components-contrib.
+
+### Impact
+
+You are affected if you run daprd, and in particular if you use the MongoDB state store. Dependency scanners report CVE-2026-2303 against the sidecar binary while it is built against mongo-driver v1.14.0.
+
+### Root Cause
+
+The `go.mongodb.org/mongo-driver` dependency predated the upstream fix released in v1.17.7, both in the runtime and in the components-contrib dependency.
+
+### Solution
+
+`go.mongodb.org/mongo-driver` is updated to v1.17.7, and the `github.com/dapr/components-contrib` dependency is bumped to v1.18.3 to carry the same driver update on the component side. Both resolve CVE-2026-2303. The upgrade stays within the driver's v1 line, so it is a dependency-only change with no behavioral impact.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dapr/kit v0.18.2
 	github.com/diagridio/go-etcd-cron v0.12.6
 	github.com/evanphx/json-patch/v5 v5.9.0
-	github.com/go-chi/chi/v5 v5.2.2
+	github.com/go-chi/chi/v5 v5.2.4
 	github.com/go-chi/cors v1.2.1
 	github.com/go-logr/logr v1.4.3
 	github.com/golang/mock v1.7.0-rc.1
@@ -52,7 +52,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.21
 	go.etcd.io/etcd/client/v3 v3.5.21
 	go.etcd.io/etcd/server/v3 v3.5.21
-	go.mongodb.org/mongo-driver v1.14.0
+	go.mongodb.org/mongo-driver v1.17.7
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
@@ -367,7 +367,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
-	github.com/montanaflynn/stats v0.7.0 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/mrz1836/postmark v1.6.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/dapr/components-contrib v1.18.2
+	github.com/dapr/components-contrib v1.18.3
 	github.com/dapr/durabletask-go v0.12.1
 	github.com/dapr/kit v0.18.2
 	github.com/diagridio/go-etcd-cron v0.12.6

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVy
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/dancannon/gorethink v4.0.0+incompatible h1:KFV7Gha3AuqT+gr0B/eKvGhbjmUv0qGF43aKCIKVE9A=
 github.com/dancannon/gorethink v4.0.0+incompatible/go.mod h1:BLvkat9KmZc1efyYwhz3WnybhRZtgF1K929FD8z1avU=
-github.com/dapr/components-contrib v1.18.2 h1:b1aCmQfmd9+gJx2EcdUXKRg3e00/5RjBpgvJsz7MwWY=
-github.com/dapr/components-contrib v1.18.2/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
+github.com/dapr/components-contrib v1.18.3 h1:eLtaIAZvMsN8JfM61+QVECnQsxv/46JfxWTM40S7uJ4=
+github.com/dapr/components-contrib v1.18.3/go.mod h1:4MZlbYqyytdQIol9VF59uzhX4NJsa0xZlgr2faQq59o=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
 github.com/dapr/durabletask-go v0.12.1 h1:CIqG2HJGnU7kRtHICuRSSSO9RdHax99HdvHEaxRGE04=

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
-github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
-github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.2.4 h1:WtFKPHwlywe8Srng8j2BhOD9312j9cGUxG1SP4V2cR4=
+github.com/go-chi/chi/v5 v5.2.4/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
 github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-co-op/gocron v1.9.0/go.mod h1:DbJm9kdgr1sEvWpHCA7dFFs/PGHPMil9/97EXCRPr4k=
@@ -1309,8 +1309,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
-github.com/montanaflynn/stats v0.7.0 h1:r3y12KyNxj/Sb/iOE46ws+3mS1+MZca1wlHQFPsY/JU=
-github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.1.0 h1:vBBl0pUnvi/Je71dsRrhMBtreIqNMYErSAbEeb8jrXQ=
 github.com/morikuni/aec v1.1.0/go.mod h1:xDRgiq/iw5l+zkao76YTKzKttOp2cwPEne25HDkJnBw=
 github.com/moul/http2curl v1.0.0 h1:dRMWoAtb+ePxMlLkrCbAqh4TlPHXvoGUSQ323/9Zahs=
@@ -1835,8 +1835,8 @@ go.etcd.io/etcd/server/v3 v3.5.0-alpha.0/go.mod h1:tsKetYpt980ZTpzl/gb+UOJj9RkIy
 go.etcd.io/etcd/server/v3 v3.5.21 h1:9w0/k12majtgarGmlMVuhwXRI2ob3/d1Ik3X5TKo0yU=
 go.etcd.io/etcd/server/v3 v3.5.21/go.mod h1:G1mOzdwuzKT1VRL7SqRchli/qcFrtLBTAQ4lV20sXXo=
 go.mongodb.org/mongo-driver v1.12.0/go.mod h1:AZkxhPnFJUoH7kZlFkVKucV20K387miPfm7oimrSmK0=
-go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
-go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
+go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
+go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
## Description

Backports two security dependency bumps to `release-1.18`, requested by a customer for the 1.18 line:

| Dependency | From | To | CVE |
| --- | --- | --- | --- |
| `github.com/go-chi/chi/v5` | v5.2.2 | v5.2.4 | CVE-2025-69725 |
| `go.mongodb.org/mongo-driver` | v1.14.0 | v1.17.7 | CVE-2026-2303 |

`go mod tidy` also bumps the `github.com/montanaflynn/stats` transitive dependency (`v0.7.0` → `v0.7.1`).

Both bumps are already on `master` via #10188. mongo-driver stays within its v1 line (no v2 migration), so no source changes are required.

## Issue reference

Backport for #10203

## Testing

- `go build ./...` — passes
- `go test -tags=unit ./pkg/api/http/...` (go-chi consumer) — passes
- `go test -tags=unit ./pkg/actors/api/...` (mongo-driver consumer) — passes
- `go mod tidy` clean; `go.sum` consistent
