### PR TITLE
[1.18] Workflow: Fail child when target child ID is already in use (#10197)

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -14,6 +14,7 @@ This update contains the following bug fixes:
 - [gRPC streaming actor applications could not host actors without opening an app port](#grpc-streaming-actor-applications-could-not-host-actors-without-opening-an-app-port)
 - [go-chi updated to v5.2.4 for CVE-2025-69725](#go-chi-updated-to-v524-for-cve-2025-69725)
 - [mongo-driver updated to v1.17.7 for CVE-2026-2303](#mongo-driver-updated-to-v1177-for-cve-2026-2303)
+- [Parent workflow becomes stuck when creating a child workflow with an instance ID that is already in use](#parent-workflow-becomes-stuck-when-creating-a-child-workflow-with-an-instance-id-that-is-already-in-use)
 
 ## SPIFFE SVID component operation propagation
 
@@ -317,3 +318,35 @@ The `go.mongodb.org/mongo-driver` dependency predated the upstream fix released 
 ### Solution
 
 `go.mongodb.org/mongo-driver` is updated to v1.17.7, and the `github.com/dapr/components-contrib` dependency is bumped to v1.18.3 to carry the same driver update on the component side. Both resolve CVE-2026-2303. The upgrade stays within the driver's v1 line, so it is a dependency-only change with no behavioral impact.
+
+## Parent workflow becomes stuck when creating a child workflow with an instance ID that is already in use
+
+### Problem
+
+A workflow that created a child workflow with an explicit instance ID already belonging to another active workflow never advanced.
+The runtime retried creating the child indefinitely, the parent stayed in `RUNNING` forever, and no error was surfaced to the workflow code.
+The sidecar logged a retry warning on every attempt:
+
+```
+Workflow actor 'parent': execution failed with a recoverable error and will be retried later:
+'failed to invoke method 'CreateWorkflowInstance' on actor 'child-id':
+rpc error: code = AlreadyExists desc = an active workflow with ID 'child-id' already exists'
+```
+
+### Impact
+
+You were affected if your workflows create child workflows with deterministic or user-provided instance IDs that can collide with a live workflow instance.
+The parent workflow hung indefinitely and had to be terminated manually.
+Child workflows with auto-generated instance IDs were not affected.
+
+### Root Cause
+
+When dispatching a child workflow creation, the parent's workflow actor treated every failure as transient and retried it through its wake-up reminder.
+The `AlreadyExists` rejection from the target instance is not transient while the occupying workflow remains active, so the retry loop never succeeded and the failure was never reported back to the awaited child workflow task.
+
+### Solution
+
+The child workflow task now fails immediately with an error naming the conflict (`an active workflow with ID '<id>' already exists`) instead of being retried by the runtime.
+The parent advances: workflow code can handle the error and continue, propagate it to fail the parent, or attach a retry policy to the child workflow call, in which case the creation is re-attempted and succeeds once the instance ID becomes free.
+The same handling applies when the target ID belongs to a terminal workflow whose child workflow tree is not yet terminal, to cross-app child workflows, and to child workflows re-driven by a workflow rerun.
+The workflow occupying the instance ID is never affected by the rejected creation.

--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/dedup"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/events"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/messages"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
@@ -34,7 +35,7 @@ import (
 	"github.com/dapr/durabletask-go/backend"
 )
 
-func (o *orchestrator) callActivities(ctx context.Context, es []*backend.HistoryEvent, state *wfenginestate.State, rs *backend.WorkflowRuntimeState, outgoingHistory map[int32]*protos.PropagatedHistory) dispatchResult {
+func (o *orchestrator) callActivities(ctx context.Context, es []*backend.HistoryEvent, state *wfenginestate.State, rs *backend.WorkflowRuntimeState, outgoingHistory map[int32]*protos.PropagatedHistory) messages.DispatchResult {
 	var dueTime time.Time
 	if len(state.History) > 0 {
 		dueTime = state.History[0].GetTimestamp().AsTime()
@@ -44,7 +45,7 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 
 	workflowName := o.getExecutionStartedEvent(state).GetName()
 
-	var result dispatchResult
+	var result messages.DispatchResult
 	for _, e := range es {
 		// Don't redispatch activities whose resolution is already known to the
 		// current generation's runtime state. We check rs.OldEvents/NewEvents
@@ -65,7 +66,7 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 				continue
 			}
 
-			result.recordFailure(e.GetEventId(), err)
+			result.RecordFailure(e.GetEventId(), err)
 			continue
 		}
 	}
@@ -124,7 +125,7 @@ func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent
 	if err != nil {
 		// If the call was denied by a workflow access policy, fail the
 		// activity task immediately rather than retrying.
-		if isPermissionDenied(err) {
+		if messages.IsPermissionDenied(err) {
 			log.Errorf("Workflow actor '%s': activity '%s' denied by workflow access policy: %v", o.actorID, ts.GetName(), err)
 			return o.failActivityACL(ctx, e)
 		}
@@ -146,7 +147,7 @@ func (o *orchestrator) failActivityACL(ctx context.Context, e *backend.HistoryEv
 	failedEvent := &protos.HistoryEvent{
 		EventId:   -1,
 		Timestamp: timestamppb.New(time.Now()),
-		EventType: events.NewTaskFailedEventType(e.GetEventId(), "WorkflowAccessPolicyDenied", "access denied by workflow access policy", false),
+		EventType: events.NewTaskFailedEventType(e.GetEventId(), messages.ErrorTypeAccessPolicyDenied, messages.ErrorMessageAccessPolicyDenied, false),
 	}
 
 	reminderName, err := randomReminderName(common.ReminderPrefixActivityResult)

--- a/pkg/actors/targets/workflow/orchestrator/childwf.go
+++ b/pkg/actors/targets/workflow/orchestrator/childwf.go
@@ -20,14 +20,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/events"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/messages"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
@@ -38,6 +37,7 @@ import (
 func (o *orchestrator) callChildWorkflows(ctx context.Context, startEventName string, es []*protos.HistoryEvent, outgoingHistory map[int32]*protos.PropagatedHistory) error {
 	log.Debugf("Workflow actor '%s': calling %d child workflows", o.actorID, len(es))
 
+	var errs []error
 	for _, e := range es {
 		createSO := e.GetChildWorkflowInstanceCreated()
 
@@ -77,7 +77,8 @@ func (o *orchestrator) callChildWorkflows(ctx context.Context, startEventName st
 
 		reqP, err := proto.Marshal(createReq)
 		if err != nil {
-			return fmt.Errorf("failed to marshal child workflow request: %w", err)
+			errs = append(errs, fmt.Errorf("failed to marshal child workflow request: %w", err))
+			continue
 		}
 
 		id := e.GetChildWorkflowInstanceCreated().GetInstanceId()
@@ -90,56 +91,44 @@ func (o *orchestrator) callChildWorkflows(ctx context.Context, startEventName st
 		if err != nil {
 			// If the call was denied by a workflow access policy, fail the
 			// child orchestration immediately rather than retrying.
-			if isPermissionDenied(err) {
-				return o.failChildWorkflowACL(ctx, e.GetEventId(), err)
+			if messages.IsPermissionDenied(err) {
+				log.Warnf("Workflow actor '%s': child workflow denied by access policy: %v", o.actorID, err)
+				if ferr := o.failChildWorkflowTask(ctx, e.GetEventId(), messages.ErrorTypeAccessPolicyDenied, messages.ErrorMessageAccessPolicyDenied); ferr != nil {
+					errs = append(errs, ferr)
+				}
+				continue
 			}
-			return fmt.Errorf("failed to call child workflow '%s': %w", id, err)
+			// The target instance ID is occupied by another workflow. Fail the
+			// awaited child task rather than retrying forever.
+			if messages.IsAlreadyExists(err) {
+				log.Warnf("Workflow actor '%s': child workflow instance ID '%s' already exists: %v", o.actorID, id, err)
+				if ferr := o.failChildWorkflowTask(ctx, e.GetEventId(), messages.ErrorTypeAlreadyExists, messages.GRPCStatusMessage(err)); ferr != nil {
+					errs = append(errs, ferr)
+				}
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to call child workflow '%s': %w", id, err))
+			continue
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
-// isPermissionDenied checks whether the error (possibly wrapped) contains a
-// gRPC PermissionDenied status code. Walks both single-error and multi-error
-// chains.
-func isPermissionDenied(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// Try direct gRPC status extraction.
-	if st, ok := status.FromError(err); ok && st.Code() == codes.PermissionDenied {
-		return true
-	}
-
-	// Walk the full error chain. errors.As traverses both Unwrap() error
-	// and Unwrap() []error chains (multi-error wrappers like errors.Join).
-	var wrapped interface{ GRPCStatus() *status.Status }
-	if errors.As(err, &wrapped) {
-		if wrapped.GRPCStatus().Code() == codes.PermissionDenied {
-			return true
-		}
-	}
-
-	return false
-}
-
-// failChildWorkflowACL creates a ChildWorkflowInstanceFailed event on the
-// parent orchestrator when the child workflow call is rejected by a
-// WorkflowAccessPolicy. It uses a reminder-based approach to deliver the
+// failChildWorkflowTask creates a ChildWorkflowInstanceFailed event on the
+// parent orchestrator when the child workflow creation cannot succeed (e.g.
+// rejected by a WorkflowAccessPolicy, or the target instance ID is already
+// taken by another workflow). It uses a reminder-based approach to deliver the
 // failure event in a fresh execution cycle, avoiding conflicts with the current
 // run loop's ClearInbox/saveInternalState calls.
 // taskScheduledID is the correlation ID that the parent orchestrator engine
 // uses to match this failure with the original sub-orchestration request.
-func (o *orchestrator) failChildWorkflowACL(ctx context.Context, taskScheduledID int32, callErr error) error {
+func (o *orchestrator) failChildWorkflowTask(ctx context.Context, taskScheduledID int32, errorType, errorMessage string) error {
 	failedEvent := &protos.HistoryEvent{
 		EventId:   -1,
 		Timestamp: timestamppb.New(time.Now()),
-		EventType: events.NewChildWorkflowFailedEventType(taskScheduledID, "WorkflowAccessPolicyDenied", "access denied by workflow access policy", false),
+		EventType: events.NewChildWorkflowFailedEventType(taskScheduledID, errorType, errorMessage, false),
 	}
-
-	log.Warnf("Workflow actor '%s': child workflow denied by access policy: %v", o.actorID, callErr)
 
 	// Create a reminder that carries the failure event. When this
 	// reminder fires (in a fresh execution cycle after the current run

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -101,7 +101,7 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 				o.actorID, startEvent.GetExecutionStarted().GetParentInstance().GetWorkflowInstance().GetInstanceId())
 			return nil
 		}
-		return fmt.Errorf("an active workflow with ID '%s' already exists", o.actorID)
+		return status.Errorf(codes.AlreadyExists, "an active workflow with ID '%s' already exists", o.actorID)
 	}
 
 	if o.activityResultAwaited.Load() {

--- a/pkg/actors/targets/workflow/orchestrator/dispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/dispatch.go
@@ -14,23 +14,8 @@ limitations under the License.
 package orchestrator
 
 import (
-	"errors"
-
 	"github.com/dapr/durabletask-go/backend"
 )
-
-type dispatchResult struct {
-	failedEventIDs map[int32]struct{}
-	err            error
-}
-
-func (r *dispatchResult) recordFailure(eventID int32, err error) {
-	if r.failedEventIDs == nil {
-		r.failedEventIDs = make(map[int32]struct{})
-	}
-	r.failedEventIDs[eventID] = struct{}{}
-	r.err = errors.Join(r.err, err)
-}
 
 func hasRemoteTasks(es []*backend.HistoryEvent) bool {
 	for _, e := range es {

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors/targets"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common/lock"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/messages"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/signing"
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/resiliency"
@@ -181,6 +182,16 @@ func (f *factory) initOrchestrator(o any, actorID string) *orchestrator {
 		ActorType:         f.actorType,
 		ActivityActorType: f.activityActorType,
 		Reminders:         f.reminders,
+	}
+
+	or.messages = &messages.Messages{
+		AppID:                 f.appID,
+		ActorID:               actorID,
+		ActorType:             f.actorType,
+		Router:                f.router,
+		ActorTypeBuilder:      f.actorTypeBuilder,
+		Signer:                f.signer,
+		FailChildWorkflowTask: or.failChildWorkflowTask,
 	}
 
 	// Reset the cache state to force a reload from the state store

--- a/pkg/actors/targets/workflow/orchestrator/messages/messages.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/messages.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package orchestrator
+package messages
 
 import (
 	"context"
@@ -20,13 +20,35 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/dapr/dapr/pkg/actors/router"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/kit/crypto/spiffe/signer"
+	"github.com/dapr/kit/logger"
 )
 
-func (o *orchestrator) callCreateWorkflowStateMessage(ctx context.Context, events []*backend.WorkflowRuntimeStateMessage) dispatchResult {
+var log = logger.NewLogger("dapr.runtime.actors.targets.orchestrator.messages")
+
+// Messages dispatches outbound workflow runtime state messages (child
+// workflow creations and child workflow completion events) to their target
+// workflow actors.
+type Messages struct {
+	AppID            string
+	ActorID          string
+	ActorType        string
+	Router           router.Interface
+	ActorTypeBuilder *common.ActorTypeBuilder
+	Signer           *signer.Signer
+
+	// FailChildWorkflowTask records a ChildWorkflowInstanceFailed event on
+	// the parent orchestrator when a child workflow creation cannot succeed.
+	FailChildWorkflowTask func(ctx context.Context, taskScheduledID int32, errorType, errorMessage string) error
+}
+
+func (m *Messages) CallCreateWorkflowStateMessage(ctx context.Context, events []*backend.WorkflowRuntimeStateMessage) DispatchResult {
 	msgs := make([]proto.Message, len(events))
 	historyEvents := make([]*backend.HistoryEvent, len(events))
 	targets := make([]string, len(events))
@@ -35,8 +57,8 @@ func (o *orchestrator) callCreateWorkflowStateMessage(ctx context.Context, event
 	for i, msg := range events {
 		req := &backend.CreateWorkflowInstanceRequest{StartEvent: msg.GetHistoryEvent()}
 		if ph := msg.GetPropagatedHistory(); ph != nil {
-			if o.signer == nil {
-				log.Warnf("Workflow actor '%s': propagating unsigned workflow history to child workflow '%s' (signing is not configured; chunks cannot be cryptographically verified by the receiver)", o.actorID, msg.GetTargetInstanceId())
+			if m.Signer == nil {
+				log.Warnf("Workflow actor '%s': propagating unsigned workflow history to child workflow '%s' (signing is not configured; chunks cannot be cryptographically verified by the receiver)", m.ActorID, msg.GetTargetInstanceId())
 			}
 			req.PropagatedHistory = ph
 		}
@@ -50,10 +72,10 @@ func (o *orchestrator) callCreateWorkflowStateMessage(ctx context.Context, event
 		}
 	}
 
-	return o.callStateMessages(ctx, msgs, historyEvents, targets, actionIDs, todo.CreateWorkflowInstanceMethod)
+	return m.callStateMessages(ctx, msgs, historyEvents, targets, actionIDs, todo.CreateWorkflowInstanceMethod)
 }
 
-func (o *orchestrator) callAddEventStateMessage(ctx context.Context, events []*backend.WorkflowRuntimeStateMessage) dispatchResult {
+func (m *Messages) CallAddEventStateMessage(ctx context.Context, events []*backend.WorkflowRuntimeStateMessage) DispatchResult {
 	msgs := make([]proto.Message, len(events))
 	historyEvents := make([]*backend.HistoryEvent, len(events))
 	targets := make([]string, len(events))
@@ -64,43 +86,43 @@ func (o *orchestrator) callAddEventStateMessage(ctx context.Context, events []*b
 		targets[i] = msg.GetTargetInstanceId()
 	}
 
-	return o.callStateMessages(ctx, msgs, historyEvents, targets, nil, todo.AddWorkflowEventMethod)
+	return m.callStateMessages(ctx, msgs, historyEvents, targets, nil, todo.AddWorkflowEventMethod)
 }
 
-func (o *orchestrator) callStateMessages(ctx context.Context, msgs []proto.Message, historyEvents []*backend.HistoryEvent, targets []string, actionIDs []int32, method string) dispatchResult {
-	var result dispatchResult
+func (m *Messages) callStateMessages(ctx context.Context, msgs []proto.Message, historyEvents []*backend.HistoryEvent, targets []string, actionIDs []int32, method string) DispatchResult {
+	var result DispatchResult
 	for i, msg := range msgs {
-		if err := o.callStateMessage(ctx, msg, historyEvents[i], targets[i], method); err != nil {
+		if err := m.callStateMessage(ctx, msg, historyEvents[i], targets[i], method); err != nil {
 			eventID := historyEvents[i].GetEventId()
 			if actionIDs != nil {
 				eventID = actionIDs[i]
 			}
-			result.recordFailure(eventID, err)
+			result.RecordFailure(eventID, err)
 			continue
 		}
 	}
 	return result
 }
 
-func (o *orchestrator) callStateMessage(ctx context.Context, m proto.Message, historyEvent *backend.HistoryEvent, target string, method string) error {
-	b, err := proto.Marshal(m)
+func (m *Messages) callStateMessage(ctx context.Context, msg proto.Message, historyEvent *backend.HistoryEvent, target string, method string) error {
+	b, err := proto.Marshal(msg)
 	if err != nil {
 		return err
 	}
-	actorType := o.actorType
+	actorType := m.ActorType
 
 	if historyEvent != nil && historyEvent.GetRouter() != nil {
 		router := historyEvent.GetRouter()
 		log.Debugf("Cross-app child workflow call: target appID=%s, source appID=%s", router.GetTargetAppID(), router.GetSourceAppID())
 
-		switch m := m.(type) {
+		switch msg := msg.(type) {
 		case *backend.CreateWorkflowInstanceRequest:
 			if router.TargetAppID != nil {
-				actorType = o.actorTypeBuilder.Workflow(router.GetTargetAppID())
+				actorType = m.ActorTypeBuilder.Workflow(router.GetTargetAppID())
 			}
 		case *backend.HistoryEvent:
 			var routeAppID string
-			if m.GetChildWorkflowInstanceCompleted() != nil || m.GetChildWorkflowInstanceFailed() != nil {
+			if msg.GetChildWorkflowInstanceCompleted() != nil || msg.GetChildWorkflowInstanceFailed() != nil {
 				if router.TargetAppID == nil {
 					return errors.New("child workflow completion events should have a target appID")
 				}
@@ -109,26 +131,35 @@ func (o *orchestrator) callStateMessage(ctx context.Context, m proto.Message, hi
 				routeAppID = router.GetSourceAppID()
 			}
 
-			if routeAppID != "" && routeAppID != o.appID {
-				actorType = o.actorTypeBuilder.Workflow(routeAppID)
+			if routeAppID != "" && routeAppID != m.AppID {
+				actorType = m.ActorTypeBuilder.Workflow(routeAppID)
 			}
 		}
 	}
 
-	log.Debugf("Workflow actor '%s': invoking method '%s' on workflow actor '%s||%s'", o.actorID, method, actorType, target)
+	log.Debugf("Workflow actor '%s': invoking method '%s' on workflow actor '%s||%s'", m.ActorID, method, actorType, target)
 
-	if _, err = o.router.Call(ctx, internalsv1pb.
+	if _, err = m.Router.Call(ctx, internalsv1pb.
 		NewInternalInvokeRequest(method).
 		WithActor(actorType, target).
 		WithData(b).
 		WithContentType(invokev1.ProtobufContentType),
 	); err != nil {
-		// If the call was denied by a workflow access policy, fail the child
+		// If the call was denied by a workflow access policy or the target
+		// instance ID is already taken by another workflow, fail the child
 		// orchestration immediately rather than retrying. Only do this when
 		// we can correlate the failure to a parent task via ParentInstance.
-		if isPermissionDenied(err) && historyEvent != nil {
+		permissionDenied := IsPermissionDenied(err)
+		if (permissionDenied || IsAlreadyExists(err)) && historyEvent != nil {
 			if es := historyEvent.GetExecutionStarted(); es != nil && es.GetParentInstance() != nil {
-				if fErr := o.failChildWorkflowACL(ctx, es.GetParentInstance().GetTaskScheduledId(), err); fErr != nil {
+				errorType := ErrorTypeAlreadyExists
+				errorMessage := GRPCStatusMessage(err)
+				if permissionDenied {
+					errorType = ErrorTypeAccessPolicyDenied
+					errorMessage = ErrorMessageAccessPolicyDenied
+				}
+				log.Warnf("Workflow actor '%s': failing child workflow task for '%s': %v", m.ActorID, target, err)
+				if fErr := m.FailChildWorkflowTask(ctx, es.GetParentInstance().GetTaskScheduledId(), errorType, errorMessage); fErr != nil {
 					return fmt.Errorf("failed to record child workflow failure: %w (original: %v)", fErr, err)
 				}
 				return nil

--- a/pkg/actors/targets/workflow/orchestrator/messages/result.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/result.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package messages
+
+import (
+	"errors"
+)
+
+// DispatchResult accumulates per-event failures from dispatching a batch of
+// outbound workflow messages or activity invocations.
+type DispatchResult struct {
+	FailedEventIDs map[int32]struct{}
+	Err            error
+}
+
+func (r *DispatchResult) RecordFailure(eventID int32, err error) {
+	if r.FailedEventIDs == nil {
+		r.FailedEventIDs = make(map[int32]struct{})
+	}
+	r.FailedEventIDs[eventID] = struct{}{}
+	r.Err = errors.Join(r.Err, err)
+}

--- a/pkg/actors/targets/workflow/orchestrator/messages/status.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/status.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package messages
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	ErrorTypeAccessPolicyDenied    = "WorkflowAccessPolicyDenied"
+	ErrorMessageAccessPolicyDenied = "access denied by workflow access policy"
+	ErrorTypeAlreadyExists         = "WorkflowInstanceAlreadyExists"
+)
+
+func IsPermissionDenied(err error) bool {
+	return hasGRPCStatusCode(err, codes.PermissionDenied)
+}
+
+func IsAlreadyExists(err error) bool {
+	return hasGRPCStatusCode(err, codes.AlreadyExists)
+}
+
+// hasGRPCStatusCode checks whether the error (possibly wrapped) contains the
+// given gRPC status code. Walks both single-error and multi-error chains.
+func hasGRPCStatusCode(err error, code codes.Code) bool {
+	if err == nil {
+		return false
+	}
+
+	// Try direct gRPC status extraction.
+	if st, ok := status.FromError(err); ok && st.Code() == code {
+		return true
+	}
+
+	// Walk the full error chain. errors.As traverses both Unwrap() error
+	// and Unwrap() []error chains (multi-error wrappers like errors.Join).
+	var wrapped interface{ GRPCStatus() *status.Status }
+	if errors.As(err, &wrapped) {
+		if wrapped.GRPCStatus().Code() == code {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GRPCStatusMessage returns the message of the first gRPC status found in the
+// error chain (including wrapped or joined errors), so surfaced failure
+// messages are stable even when the original status error is wrapped.
+func GRPCStatusMessage(err error) string {
+	var gs interface{ GRPCStatus() *status.Status }
+	if errors.As(err, &gs) {
+		return gs.GRPCStatus().Message()
+	}
+	return err.Error()
+}

--- a/pkg/actors/targets/workflow/orchestrator/messages/status.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/status.go
@@ -62,6 +62,9 @@ func hasGRPCStatusCode(err error, code codes.Code) bool {
 // error chain (including wrapped or joined errors), so surfaced failure
 // messages are stable even when the original status error is wrapped.
 func GRPCStatusMessage(err error) string {
+	if err == nil {
+		return ""
+	}
 	var gs interface{ GRPCStatus() *status.Status }
 	if errors.As(err, &gs) {
 		return gs.GRPCStatus().Message()

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -23,6 +23,7 @@ import (
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common/lock"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/messages"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/signing"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
@@ -51,7 +52,8 @@ type orchestrator struct {
 	streamFns map[int64]*streamFn
 	streamIDx int64
 
-	signing *signing.Signing
+	signing  *signing.Signing
+	messages *messages.Messages
 }
 
 type streamFn struct {

--- a/pkg/actors/targets/workflow/orchestrator/rerun.go
+++ b/pkg/actors/targets/workflow/orchestrator/rerun.go
@@ -203,7 +203,7 @@ func (o *orchestrator) rerunWorkflowInstanceRequest(ctx context.Context, request
 
 	if err = errors.Join(
 		o.callChildWorkflows(ctx, startedEvent.GetName(), childWFs, outgoingChildPropHist),
-		o.callActivities(ctx, activities, newState, rerunRS, outgoingActPropHist).err,
+		o.callActivities(ctx, activities, newState, rerunRS, outgoingActPropHist).Err,
 		o.createTimers(ctx, timers, newState.Generation),
 	); err != nil {
 		return err

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -378,6 +378,9 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 
 	// Dispatch activities and messages, collecting failures.
 	activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
+	if o.messages == nil {
+		return todo.RunCompletedFalse, errors.New("messages dispatcher is not initialized")
+	}
 	addResult := o.messages.CallAddEventStateMessage(ctx, addWorkflows)
 	createResult := o.messages.CallCreateWorkflowStateMessage(ctx, createWorkflows)
 

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -378,10 +378,10 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 
 	// Dispatch activities and messages, collecting failures.
 	activityResult := o.callActivities(ctx, pendingTasks, state, rs, wi.OutgoingHistory)
-	addResult := o.callAddEventStateMessage(ctx, addWorkflows)
-	createResult := o.callCreateWorkflowStateMessage(ctx, createWorkflows)
+	addResult := o.messages.CallAddEventStateMessage(ctx, addWorkflows)
+	createResult := o.messages.CallCreateWorkflowStateMessage(ctx, createWorkflows)
 
-	dispatchErr := errors.Join(activityResult.err, addResult.err, createResult.err)
+	dispatchErr := errors.Join(activityResult.Err, addResult.Err, createResult.Err)
 	if dispatchErr != nil {
 		if errors.Is(dispatchErr, errPayloadSizeExceeded) {
 			return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs,
@@ -393,10 +393,10 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			// keep their events in history so they are not re-dispatched on
 			// retry. The inbox is preserved so the existing reminder retries
 			// the full execution.
-			allFailed := make(map[int32]struct{}, len(activityResult.failedEventIDs)+len(createResult.failedEventIDs)+len(addResult.failedEventIDs))
-			maps.Copy(allFailed, activityResult.failedEventIDs)
-			maps.Copy(allFailed, createResult.failedEventIDs)
-			maps.Copy(allFailed, addResult.failedEventIDs)
+			allFailed := make(map[int32]struct{}, len(activityResult.FailedEventIDs)+len(createResult.FailedEventIDs)+len(addResult.FailedEventIDs))
+			maps.Copy(allFailed, activityResult.FailedEventIDs)
+			maps.Copy(allFailed, createResult.FailedEventIDs)
+			maps.Copy(allFailed, addResult.FailedEventIDs)
 
 			// Temporarily replace rs.NewEvents with a filtered copy that excludes
 			// failed dispatch events, then restore the original after

--- a/tests/integration/suite/daprd/workflow/reuseid/occupied/basic.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/occupied/basic.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package occupied
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+type basic struct {
+	workflow *workflow.Workflow
+}
+
+func (o *basic) Setup(t *testing.T) []framework.Option {
+	o.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(o.workflow),
+	}
+}
+
+func (o *basic) Run(t *testing.T, ctx context.Context) {
+	o.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "reuseid-basic"
+	const occupantID = parentID + "-taken"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := o.workflow.Registry()
+
+	reg.AddWorkflowN("occupant", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowInstanceID(occupantID),
+		).Await(nil)
+	})
+
+	client := o.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(occupantID))
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err, "parent never reached a terminal state; stuck retrying the child creation")
+	assert.Equal(t, api.RUNTIME_STATUS_FAILED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), "already exists")
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(occupantID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "occupant", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client.WaitForWorkflowCompletion(ctx, occupantID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/occupied/crossapp.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/occupied/crossapp.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package occupied
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(crossapp))
+}
+
+type crossapp struct {
+	workflow *workflow.Workflow
+}
+
+func (c *crossapp) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t,
+		workflow.WithDaprds(2),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *crossapp) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "occupied-crossapp"
+	const occupantID = parentID + "-taken"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	app1AppID := c.workflow.DaprN(1).AppID()
+
+	c.workflow.Registry().AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowAppID(app1AppID),
+			task.WithChildWorkflowInstanceID(occupantID),
+		).Await(nil)
+	})
+
+	app1Reg := c.workflow.RegistryN(1)
+	app1Reg.AddWorkflowN("occupant", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	app1Reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	app1Reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+
+	client0 := c.workflow.BackendClient(t, ctx)
+	client1 := c.workflow.BackendClientN(t, ctx, 1)
+
+	_, err := client1.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(occupantID))
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client0.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client0.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_FAILED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), "already exists")
+
+	ometa, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(occupantID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "occupant", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client1.WaitForWorkflowCompletion(ctx, occupantID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/occupied/fanout.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/occupied/fanout.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package occupied
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(fanout))
+}
+
+type fanout struct {
+	workflow *workflow.Workflow
+}
+
+func (f *fanout) Setup(t *testing.T) []framework.Option {
+	f.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(f.workflow),
+	}
+}
+
+func (f *fanout) Run(t *testing.T, ctx context.Context) {
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "occupied-fanout"
+	const occupantID = parentID + "-taken"
+	const c1ID = parentID + "-c1"
+	const c3ID = parentID + "-c3"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := f.workflow.Registry()
+
+	reg.AddWorkflowN("occupant", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		t1 := ctx.CallChildWorkflow("child", task.WithChildWorkflowInstanceID(c1ID))
+		t2 := ctx.CallChildWorkflow("child", task.WithChildWorkflowInstanceID(occupantID))
+		t3 := ctx.CallChildWorkflow("child", task.WithChildWorkflowInstanceID(c3ID))
+		err1 := t1.Await(nil)
+		err2 := t2.Await(nil)
+		err3 := t3.Await(nil)
+		if err1 != nil || err3 != nil {
+			return nil, errors.Join(err1, err3)
+		}
+		if err2 == nil {
+			return nil, errors.New("expected occupied child workflow creation to fail")
+		}
+		return err2.Error(), nil
+	})
+
+	client := f.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(occupantID))
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetOutput().GetValue(), "already exists")
+
+	for _, id := range []string{c1ID, c3ID} {
+		cmeta, cerr := client.FetchWorkflowMetadata(ctx, api.InstanceID(id))
+		require.NoError(t, cerr)
+		assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), cmeta.GetRuntimeStatus().String())
+	}
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(occupantID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "occupant", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client.WaitForWorkflowCompletion(ctx, occupantID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/occupied/handled.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/occupied/handled.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package occupied
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(handled))
+}
+
+type handled struct {
+	workflow *workflow.Workflow
+}
+
+func (h *handled) Setup(t *testing.T) []framework.Option {
+	h.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(h.workflow),
+	}
+}
+
+func (h *handled) Run(t *testing.T, ctx context.Context) {
+	h.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "occupied-handled"
+	const occupantID = parentID + "-taken"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := h.workflow.Registry()
+
+	reg.AddWorkflowN("occupant", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		err := ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowInstanceID(occupantID),
+		).Await(nil)
+		if err == nil {
+			return nil, errors.New("expected child workflow creation to fail")
+		}
+		return err.Error(), nil
+	})
+
+	client := h.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(occupantID))
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetOutput().GetValue(), "already exists")
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(occupantID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "occupant", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client.WaitForWorkflowCompletion(ctx, occupantID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/occupied/rerun.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/occupied/rerun.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package occupied
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(rerun))
+}
+
+type rerun struct {
+	workflow *workflow.Workflow
+}
+
+func (r *rerun) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *rerun) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "occupied-rerun"
+	const rerunID = parentID + "-new"
+	const occupantID = rerunID + ":0000"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := r.workflow.Registry()
+
+	reg.AddWorkflowN("occupant", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		c1 := ctx.CallChildWorkflow("child")
+		c2 := ctx.CallChildWorkflow("child")
+		if err := c1.Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, c2.Await(nil)
+	})
+
+	client := r.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+	meta, err := client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+
+	_, err = client.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(occupantID))
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	newID, err := client.RerunWorkflowFromEvent(ctx, parentID, 1, api.WithRerunNewInstanceID(rerunID))
+	require.NoError(t, err)
+	require.Equal(t, rerunID, string(newID))
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err = client.WaitForWorkflowCompletion(waitCtx, rerunID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_FAILED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), "already exists")
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(occupantID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "occupant", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client.WaitForWorkflowCompletion(ctx, occupantID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/occupied/retrypolicy.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/occupied/retrypolicy.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package occupied
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(retrypolicy))
+}
+
+type retrypolicy struct {
+	workflow *workflow.Workflow
+}
+
+func (r *retrypolicy) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *retrypolicy) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "occupied-retrypolicy"
+	const occupantID = parentID + "-taken"
+
+	var inActivity atomic.Bool
+	var childFailed atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := r.workflow.Registry()
+
+	reg.AddWorkflowN("occupant", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowInstanceID(occupantID),
+			task.WithChildWorkflowRetryPolicy(&task.RetryPolicy{
+				MaxAttempts:          20,
+				InitialRetryInterval: time.Millisecond * 500,
+				Handle: func(err error) bool {
+					childFailed.Store(true)
+					return true
+				},
+			}),
+		).Await(nil)
+	})
+
+	client := r.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(occupantID))
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	require.Eventually(t, childFailed.Load, time.Second*10, time.Millisecond*10)
+	close(releaseCh)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(occupantID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "child", ometa.GetName())
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/occupied/subtree.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/occupied/subtree.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package occupied
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(subtree))
+}
+
+type subtree struct {
+	workflow *workflow.Workflow
+}
+
+func (s *subtree) Setup(t *testing.T) []framework.Option {
+	s.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *subtree) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "occupied-subtree"
+	const occupantID = parentID + "-taken"
+	const grandchildID = occupantID + "-grandchild"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := s.workflow.Registry()
+
+	reg.AddWorkflowN("occupant", func(ctx *task.WorkflowContext) (any, error) {
+		ctx.CallChildWorkflow("occupantchild",
+			task.WithChildWorkflowInstanceID(grandchildID),
+		)
+		return nil, nil
+	})
+	reg.AddWorkflowN("occupantchild", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("child", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("child",
+			task.WithChildWorkflowInstanceID(occupantID),
+		).Await(nil)
+	})
+
+	client := s.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(occupantID))
+	require.NoError(t, err)
+	ometa, err := client.WaitForWorkflowCompletion(ctx, occupantID)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_FAILED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), "cannot recreate workflow with ID '"+occupantID+"'")
+
+	close(releaseCh)
+	_, err = client.WaitForWorkflowCompletion(ctx, grandchildID)
+	require.NoError(t, err)
+
+	_, err = client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID+"-second"))
+	require.NoError(t, err)
+	meta, err = client.WaitForWorkflowCompletion(ctx, parentID+"-second")
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/workflow.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/workflow.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reuseid/occupied"
+)


### PR DESCRIPTION
[supersede this PR](https://github.com/dapr/dapr/pull/10212) bc it had conflicts & [cherrypick in this PR manually](https://github.com/dapr/dapr/pull/10197)