### PR TITLE
fix: preserve sub-millisecond latency precision

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -12,6 +12,7 @@ This update contains the following bug fixes:
 - [Reusing a workflow instance ID while child workflows from the previous execution are still running](#reusing-a-workflow-instance-id-while-child-workflows-from-the-previous-execution-are-still-running)
 - [gRPC streaming actor applications could not host actors without opening an app port](#grpc-streaming-actor-applications-could-not-host-actors-without-opening-an-app-port)
 - [Parent workflow becomes stuck when creating a child workflow with an instance ID that is already in use](#parent-workflow-becomes-stuck-when-creating-a-child-workflow-with-an-instance-id-that-is-already-in-use)
+- [Sub-millisecond latencies are omitted from latency metrics](#sub-millisecond-latencies-are-omitted-from-latency-metrics)
 
 ## SPIFFE SVID component operation propagation
 
@@ -287,3 +288,21 @@ The parent advances: workflow code can handle the error and continue, propagate 
 The same handling applies when the target ID belongs to a terminal workflow whose child workflow tree is not yet terminal, to cross-app child workflows, and to child workflows re-driven by a workflow rerun.
 A detached workflow spawn onto an occupied instance ID is dropped with a warning, matching its fire-and-forget semantics.
 The workflow occupying the instance ID is never affected by the rejected creation.
+
+## Sub-millisecond latencies are omitted from latency metrics
+
+### Problem
+
+Latency measurements below one millisecond were omitted from latency histograms.
+
+### Impact
+
+Operations completing in less than one millisecond were not represented in the affected latency histograms, causing low-latency observations to be undercounted.
+
+### Root Cause
+
+`ElapsedSince` divided `time.Duration` values before converting the result to `float64`, truncating sub-millisecond durations to zero. Existing positive-latency guards then skipped those observations.
+
+### Solution
+
+`ElapsedSince` now converts durations to floating-point milliseconds before division, preserving fractional milliseconds and allowing sub-millisecond latency observations to be recorded.

--- a/pkg/diagnostics/component_monitoring.go
+++ b/pkg/diagnostics/component_monitoring.go
@@ -490,5 +490,9 @@ func (c *componentMetrics) jobTriggered(ctx context.Context, operation string, s
 
 // ElapsedSince returns the given time in milliseconds.
 func ElapsedSince(start time.Time) float64 {
-	return float64(time.Since(start) / time.Millisecond)
+	return durationInMilliseconds(time.Since(start))
+}
+
+func durationInMilliseconds(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
 }

--- a/pkg/diagnostics/component_monitoring.go
+++ b/pkg/diagnostics/component_monitoring.go
@@ -488,7 +488,8 @@ func (c *componentMetrics) jobTriggered(ctx context.Context, operation string, s
 	}
 }
 
-// ElapsedSince returns the given time in milliseconds.
+// ElapsedSince returns the elapsed duration since start in milliseconds,
+// including fractional milliseconds.
 func ElapsedSince(start time.Time) float64 {
 	return durationInMilliseconds(time.Since(start))
 }

--- a/pkg/diagnostics/component_monitoring_test.go
+++ b/pkg/diagnostics/component_monitoring_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
 
 	"github.com/dapr/dapr/pkg/config"
@@ -324,4 +325,34 @@ func TestElapsedSince(t *testing.T) {
 
 	elapsed := ElapsedSince(start)
 	assert.GreaterOrEqual(t, elapsed, float64(1000))
+}
+
+func TestDurationInMilliseconds(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected float64
+	}{
+		{
+			name:     "sub-millisecond",
+			duration: 500 * time.Microsecond,
+			expected: 0.5,
+		},
+		{
+			name:     "multiple milliseconds",
+			duration: 1500 * time.Microsecond,
+			expected: 1.5,
+		},
+		{
+			name:     "zero",
+			duration: 0,
+			expected: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.InDelta(t, test.expected, durationInMilliseconds(test.duration), 1e-9)
+		})
+	}
 }


### PR DESCRIPTION
# Description

Preserve fractional milliseconds in `ElapsedSince` instead of truncating durations through integer division. This allows existing positive-latency guards to record sub-millisecond observations and adds deterministic coverage for fractional conversion.

Validation:
- `go test -tags=unit,allcomponents -count=1 ./pkg/diagnostics`
- `golangci-lint run --build-tags=allcomponents,subtlecrypto ./pkg/diagnostics/...` (v2.10.1, 0 issues)

## Issue reference

Closes #10214

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo