### PR TITLE
scheduler: recover triggered reminder/job name from metadata prefix

### DIFF
--- a/pkg/api/universal/actors.go
+++ b/pkg/api/universal/actors.go
@@ -141,6 +141,12 @@ func (a *Universal) RegisterActorReminder(ctx context.Context, in *runtimev1pb.R
 		}
 	}
 
+	if in.GetName() == "" {
+		err = messages.ErrBadRequest.WithFormat("reminder name cannot be empty")
+		a.logger.Debug(err)
+		return nil, err
+	}
+
 	if vErr := method.ValidateName(in.GetName()); vErr != nil {
 		vErr = messages.ErrBadRequest.WithFormat(vErr)
 		a.logger.Debug(vErr)

--- a/pkg/scheduler/server/internal/cron/cron.go
+++ b/pkg/scheduler/server/internal/cron/cron.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dapr/dapr/pkg/scheduler/monitoring"
 	"github.com/dapr/dapr/pkg/scheduler/server/internal/etcd"
 	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool"
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/serialize"
 	"github.com/dapr/kit/concurrency"
 	"github.com/dapr/kit/events/broadcaster"
 	"github.com/dapr/kit/events/loop"
@@ -235,19 +236,38 @@ func (c *cron) triggerHandler(req *api.TriggerRequest, fn func(*api.TriggerRespo
 		return
 	}
 
-	idx := strings.LastIndex(req.GetName(), "||")
-	if idx == -1 || len(req.GetName()) <= idx+2 {
-		log.Errorf("Job name is malformed: %s", req.GetName())
+	name, err := nameFromKey(req.GetName(), &meta)
+	if err != nil {
+		log.Errorf("Job name is malformed: %s", err)
 		fn(&api.TriggerResponse{Result: api.TriggerResponseResult_UNDELIVERABLE})
 		return
 	}
 
 	c.connectionPool.Trigger(&internalsv1pb.JobEvent{
 		Key:      req.GetName(),
-		Name:     req.GetName()[idx+2:],
+		Name:     name,
 		Data:     req.GetPayload(),
 		Metadata: &meta,
 	}, c.respHandler(req.GetName(), &meta, fn))
+}
+
+// nameFromKey recovers the reminder/job name delivered to the app from the
+// stored job key. The key is the metadata prefix (built by serialize) followed
+// by the name, so the name is recovered by trimming that prefix rather than by
+// re-splitting the key on the last "||". This is unambiguous even when the name
+// (or the actor id) itself contains "||", which is a permitted character, and
+// it does not drop names that end in "||".
+func nameFromKey(key string, meta *schedulerv1pb.JobMetadata) (string, error) {
+	prefix, err := serialize.PrefixFromMetadata(meta)
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasPrefix(key, prefix) {
+		return "", fmt.Errorf("key %q does not match expected prefix %q from its metadata", key, prefix)
+	}
+
+	return strings.TrimPrefix(key, prefix), nil
 }
 
 func (c *cron) respHandler(name string, meta *schedulerv1pb.JobMetadata, fn func(*api.TriggerResponse)) func(api.TriggerResponseResult) {

--- a/pkg/scheduler/server/internal/cron/cron_test.go
+++ b/pkg/scheduler/server/internal/cron/cron_test.go
@@ -152,3 +152,90 @@ func embeddedEtcdClient(t *testing.T) *clientv3.Client {
 
 	return cl
 }
+
+// Test_nameFromKey asserts that the reminder/job name delivered to the app is
+// recovered from the stored job key by trimming the metadata prefix, not by
+// splitting on the last "||". "||" is a permitted character inside reminder and
+// job names, so splitting truncates names that contain it and drops names that
+// end in it.
+func Test_nameFromKey(t *testing.T) {
+	t.Parallel()
+
+	actorMeta := func(actorType, actorID string) *schedulerv1pb.JobMetadata {
+		return &schedulerv1pb.JobMetadata{
+			Namespace: "myns",
+			Target: &schedulerv1pb.JobTargetMetadata{
+				Type: &schedulerv1pb.JobTargetMetadata_Actor{
+					Actor: &schedulerv1pb.TargetActorReminder{Type: actorType, Id: actorID},
+				},
+			},
+		}
+	}
+	jobMeta := func(appID string) *schedulerv1pb.JobMetadata {
+		return &schedulerv1pb.JobMetadata{
+			Namespace: "myns", AppId: appID,
+			Target: &schedulerv1pb.JobTargetMetadata{
+				Type: &schedulerv1pb.JobTargetMetadata_Job{Job: new(schedulerv1pb.TargetJob)},
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		key     string
+		meta    *schedulerv1pb.JobMetadata
+		expName string
+		expErr  bool
+	}{
+		"job name without delimiter": {
+			key:     "app||myns||myapp||myjob",
+			meta:    jobMeta("myapp"),
+			expName: "myjob",
+		},
+		"job name containing the || delimiter is not truncated": {
+			key:     "app||myns||myapp||foo||bar",
+			meta:    jobMeta("myapp"),
+			expName: "foo||bar",
+		},
+		"job name with multiple || delimiters is not truncated": {
+			key:     "app||myns||myapp||a||b||c",
+			meta:    jobMeta("myapp"),
+			expName: "a||b||c",
+		},
+		"job name ending in || is not dropped": {
+			key:     "app||myns||myapp||myjob||",
+			meta:    jobMeta("myapp"),
+			expName: "myjob||",
+		},
+		"actor reminder name containing the || delimiter is not truncated": {
+			key:     "actorreminder||myns||mytype||myid||foo||bar",
+			meta:    actorMeta("mytype", "myid"),
+			expName: "foo||bar",
+		},
+		"actor id containing || does not corrupt the recovered name": {
+			key:     "actorreminder||myns||mytype||my||id||myreminder",
+			meta:    actorMeta("mytype", "my||id"),
+			expName: "myreminder",
+		},
+		"key not matching the metadata prefix is an error": {
+			key:    "app||otherns||myapp||myjob",
+			meta:   jobMeta("myapp"),
+			expErr: true,
+		},
+		"unknown target type is an error": {
+			key:    "app||myns||myapp||myjob",
+			meta:   new(schedulerv1pb.JobMetadata),
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := nameFromKey(test.key, test.meta)
+			assert.Equal(t, test.expErr, err != nil, "unexpected error state: %v", err)
+			if !test.expErr {
+				assert.Equal(t, test.expName, got)
+			}
+		})
+	}
+}

--- a/tests/integration/suite/actors/reminders/invalidnames.go
+++ b/tests/integration/suite/actors/reminders/invalidnames.go
@@ -101,6 +101,7 @@ func (i *invalidnames) Run(t *testing.T, ctx context.Context) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	badNames := map[string]string{
+		"empty":       "",
 		"slash":       "bad/name",
 		"backslash":   "bad\\name",
 		"hash":        "bad#name",

--- a/tests/integration/suite/actors/reminders/specialchars.go
+++ b/tests/integration/suite/actors/reminders/specialchars.go
@@ -140,6 +140,33 @@ func (s *specialchars) Run(t *testing.T, ctx context.Context) {
 		}, 10*time.Second, 10*time.Millisecond)
 	})
 
+	t.Run("reminder name with the || delimiter fires with its full name", func(t *testing.T) {
+		// '||' is the scheduler's reserved internal key delimiter. A reminder
+		// name that contains it must be delivered to the app in full, not
+		// truncated on the last '||'.
+		const reminderName = "remind||me||now"
+		_, err = gclient.RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+			ActorType: "myactortype",
+			ActorId:   "myactorid",
+			Name:      reminderName,
+			DueTime:   "0ms",
+		})
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			s.lock.Lock()
+			defer s.lock.Unlock()
+			found := false
+			for _, p := range s.remindPaths {
+				if strings.HasSuffix(p, "/method/remind/"+reminderName) {
+					found = true
+					break
+				}
+			}
+			assert.True(c, found, "reminder %q did not fire with its full name; paths seen: %v", reminderName, s.remindPaths)
+		}, 10*time.Second, 10*time.Millisecond)
+	})
+
 	t.Run("schreder-style actor id with || delimiter registers", func(t *testing.T) {
 		// Actor id embeds the '||' delimiter and single pipes, exactly the
 		// shape that previously failed RFC1123 validation in the scheduler.

--- a/tests/integration/suite/daprd/jobs/specialchars.go
+++ b/tests/integration/suite/daprd/jobs/specialchars.go
@@ -33,8 +33,11 @@ func init() {
 	suite.Register(new(specialchars))
 }
 
-// specialchars asserts that a job whose name contains characters such as '|'
-// and '@' can be scheduled, triggered, fetched and listed.
+// specialchars asserts that a job whose name contains characters such as '|',
+// the '||' delimiter and '@' can be scheduled, triggered, fetched and listed.
+// The '||' sequence is the scheduler's reserved internal key delimiter, so a
+// name containing it must survive the round trip to the triggered app callback
+// rather than being truncated on the last '||'.
 type specialchars struct {
 	daprd     *daprd.Daprd
 	scheduler *scheduler.Scheduler
@@ -69,7 +72,7 @@ func (s *specialchars) Run(t *testing.T, ctx context.Context) {
 
 	client := s.daprd.GRPCClient(t, ctx)
 
-	const name = "my|job@name"
+	const name = "my||job@name"
 
 	_, err := client.ScheduleJob(ctx, &runtimev1pb.ScheduleJobRequest{
 		Job: &runtimev1pb.Job{


### PR DESCRIPTION

The scheduler stores each job under a key built by `serialize.buildJobName`
as `"<prefix>||<name>"`, where the prefix is derived from the job metadata
(`actorreminder||<ns>||<type>||<id>` for actor reminders, `app||<ns>||<appid>`
for jobs). When a job fires, `triggerHandler` recovered the reminder/job name to
deliver to the app by splitting the key on the **last** `||` and taking the
trailing segment.

`||` is a permitted character inside reminder and job names: the API edge
(`method.ValidateName`) rejects only `/`, `\`, `#`, `?`, NUL, control characters
and the exact sequences `.` and `..`, and #10120 deliberately made `||` legal
within names. Splitting on the last `||` therefore corrupts any name that itself
contains `||`:

- `foo||bar` was delivered to the app as `bar`
- `a||b||c` was delivered as `c`
- a name ending in `||` (e.g. `name||`) tripped the malformed-name guard and was
  returned `UNDELIVERABLE`, so a validly registered reminder silently never
  fired.

The `ListJobs` read path already moved away from this key splitting in #10120
and recovers the name via `serialize.PrefixFromMetadata` + `strings.TrimPrefix`.
This applies the same approach in the trigger/delivery path, so the delivered
name is unambiguous even when the name (or the actor id) contains `||`, and names
ending in `||` are no longer dropped. `serialize.PrefixFromMetadata` is already
exported and used by the `ListJobs` path, so no new API surface is added.

Only the delivered **name** was affected: actor type, actor id and namespace are
taken from the protobuf `JobMetadata`, not from the key, so they were already
correct.

### Tests

- New unit test `Test_nameFromKey` (`pkg/scheduler/server/internal/cron/cron_test.go`)
  covering names that contain `||`, names ending in `||`, an actor id that
  itself contains `||`, and the error cases (key not matching the metadata
  prefix, unknown target type). This is a regression guard: it fails on the old
  `strings.LastIndex` logic and passes with the fix.
- Extended `tests/integration/suite/daprd/jobs/specialchars.go` to schedule a job
  named `my||job@name` and assert the triggered app callback is
  `job/my||job@name` (previously these suites only exercised a single `|`).
- Extended `tests/integration/suite/actors/reminders/specialchars.go` with a
  subtest that fires a reminder named `remind||me||now` and asserts the app
  receives `/method/remind/remind||me||now`.

## Issue reference

Please reference the issue this PR will close: #_[issue number]_
<!-- fill in with the bug issue filed per Step 0 above -->

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
  <!-- the daprd/jobs and actors/reminders specialchars integration suites pass
       locally in-process (no Docker); full E2E/CI runs on the PR -->
- [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
  <!-- not needed: bug fix, no user-facing API or behavior-contract change (names
       containing "||" were already meant to be legal per #10120) -->
- [ ] Specification has been updated / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
  <!-- not needed: no spec change -->
- [ ] Provided sample for the feature / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
  <!-- not needed: bug fix, no new feature -->
```

---

## Diff summary (what ships)

4 files, +142/-7 (net; unit test +87, cron.go +28/-7, two integration suites +36/-3):

- `pkg/scheduler/server/internal/cron/cron.go` (+28/-7)
  `triggerHandler` now derives the delivered name via a new unexported helper
  `nameFromKey(key, meta)` that does
  `serialize.PrefixFromMetadata(meta)` -> `HasPrefix` guard -> `strings.TrimPrefix`,
  replacing `strings.LastIndex(name, "||")` + slice + the `len<=idx+2` guard.
  Adds one import (`.../internal/serialize`); `fmt` and `strings` were already
  imported.
- `pkg/scheduler/server/internal/cron/cron_test.go` (+87, new test only)
  `Test_nameFromKey`, 8 table cases.
- `tests/integration/suite/daprd/jobs/specialchars.go` (+9/-3)
  job name `my|job@name` -> `my||job@name`; callback assertion updated; doc
  comment updated.
- `tests/integration/suite/actors/reminders/specialchars.go` (+27)
  new firing subtest for reminder name `remind||me||now`.

## Verification (from the independent verify phase; re-confirmed at draft)

- Unit: `go test ./pkg/scheduler/server/internal/cron` -> `Test_nameFromKey` 8/8
  pass; whole cron + serialize packages pass. RED on the old `LastIndex` algo
  (`foo||bar`->`bar`, `a||b||c`->`c`, `myjob||` dropped), GREEN after.
- Integration (in-process, no Docker):
  `go test -tags=integration ./tests/integration --focus '(daprd/jobs|actors/reminders)/specialchars'`
  passes; RED for the right reason when cron.go is reverted to the old logic
  (reminder fired as `.../remind/now`; job callback `job/job@name`).
- Lint: golangci-lint pinned to v2.10.1 (the version the Makefile pins; the
  machine default is v2.12.2) -> 0 issues on the cron package and both
  integration packages (`--build-tags=integration`). `go vet` clean, `gofmt -l`
  clean on all 4 files.
- Correctness: `key == prefix + name` byte-for-byte because `buildJobName` and
  `PrefixFromMetadata` build the same leading segments (incl. the id segment) via
  the same `joinStrings`; `TrimPrefix` recovers `name` exactly, even with `||`
  inside. Confirmed `req.GetName()` in `triggerHandler` is the composed key
  WITHOUT the `<ns>/jobs/` prefix (go-etcd-cron informer sets it via
  `key.JobName`, which strips the namespace), so `nameFromKey` correctly does not
  strip a leading `/` (unlike the ListJobs read path).
