### PR TITLE
fix(placement): prevent nil pointer dereference and infinite loop in consistent hash

### DIFF
--- a/pkg/placement/hashing/consistent_hash.go
+++ b/pkg/placement/hashing/consistent_hash.go
@@ -24,7 +24,6 @@ package hashing
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"maps"
 	"math"
 	"slices"
@@ -291,7 +290,7 @@ func (c *Consistent) GetLeast(key string) (string, error) {
 	idx := c.search(h)
 
 	i := idx
-	for {
+	for range len(c.hosts) {
 		host := c.hosts[c.sortedSet[i]]
 		if c.loadOK(host) {
 			return host, nil
@@ -301,6 +300,8 @@ func (c *Consistent) GetLeast(key string) (string, error) {
 			i = 0
 		}
 	}
+
+	return "", ErrNoHosts
 }
 
 func (c *Consistent) search(key uint64) int {
@@ -334,6 +335,9 @@ func (c *Consistent) Inc(host string) {
 	c.Lock()
 	defer c.Unlock()
 
+	if _, ok := c.loadMap[host]; !ok {
+		return
+	}
 	atomic.AddInt64(&c.loadMap[host].Load, 1)
 	atomic.AddInt64(&c.totalLoad, 1)
 }
@@ -395,6 +399,9 @@ func (c *Consistent) GetLoads() map[string]int64 {
 // for more info:
 // https://research.googleblog.com/2017/04/consistent-hashing-with-bounded-loads.html
 func (c *Consistent) MaxLoad() int64 {
+	if len(c.loadMap) == 0 {
+		return 1
+	}
 	if c.totalLoad == 0 {
 		c.totalLoad = 1
 	}
@@ -422,7 +429,7 @@ func (c *Consistent) loadOK(host string) bool {
 
 	bhost, ok := c.loadMap[host]
 	if !ok {
-		panic(fmt.Sprintf("given host(%s) not in loadsMap", bhost.Name))
+		return false
 	}
 
 	if float64(bhost.Load)+1 <= avgLoadPerNode {

--- a/pkg/placement/hashing/consistent_hash_test.go
+++ b/pkg/placement/hashing/consistent_hash_test.go
@@ -149,6 +149,62 @@ func TestHostEqual(t *testing.T) {
 	}
 }
 
+func TestGetLeastBoundedLoad(t *testing.T) {
+	t.Run("returns ErrNoHosts on empty ring", func(t *testing.T) {
+		c := NewFromExisting(map[string]*Host{}, 100, NewVirtualNodesCache())
+		_, err := c.GetLeast("any-key")
+		assert.ErrorIs(t, err, ErrNoHosts)
+	})
+
+	t.Run("returns ErrNoHosts when all hosts exceed load", func(t *testing.T) {
+		loadMap := map[string]*Host{
+			"host1": NewHost("host1", "id1", 100, 1),
+			"host2": NewHost("host2", "id2", 100, 1),
+		}
+		c := NewFromExisting(loadMap, 100, NewVirtualNodesCache())
+		_, err := c.GetLeast("any-key")
+		assert.ErrorIs(t, err, ErrNoHosts)
+	})
+
+	t.Run("returns a host when at least one is under load", func(t *testing.T) {
+		loadMap := map[string]*Host{
+			"host1": NewHost("host1", "id1", 0, 1),
+			"host2": NewHost("host2", "id2", 100, 1),
+		}
+		c := NewFromExisting(loadMap, 100, NewVirtualNodesCache())
+		host, err := c.GetLeast("any-key")
+		require.NoError(t, err)
+		assert.Equal(t, "host1", host)
+	})
+}
+
+func TestIncMissingHost(t *testing.T) {
+	loadMap := map[string]*Host{
+		"host1": NewHost("host1", "id1", 0, 1),
+	}
+	c := NewFromExisting(loadMap, 100, NewVirtualNodesCache())
+
+	// Should not panic when incrementing a host that doesn't exist
+	assert.NotPanics(t, func() {
+		c.Inc("nonexistent-host")
+	})
+}
+
+func TestMaxLoadEmptyRing(t *testing.T) {
+	c := NewFromExisting(map[string]*Host{}, 100, NewVirtualNodesCache())
+	assert.Equal(t, int64(1), c.MaxLoad())
+}
+
+func TestLoadOKRemovedHost(t *testing.T) {
+	loadMap := map[string]*Host{
+		"host1": NewHost("host1", "id1", 0, 1),
+	}
+	c := NewFromExisting(loadMap, 100, NewVirtualNodesCache())
+
+	// Should return false, not panic, when host has been removed
+	assert.False(t, c.loadOK("removed-host"))
+}
+
 func TestConsistentEqual(t *testing.T) {
 	cache := NewVirtualNodesCache()
 	mk := func(loadMap map[string]*Host, rf int64) *Consistent {


### PR DESCRIPTION
## Summary

Fixes multiple safety issues in the consistent hash ring implementation (`pkg/placement/hashing/consistent_hash.go`):

### 1. Infinite loop in `GetLeast` (line 293)

The `for` loop iterating through hosts had no termination condition. If no host passed `loadOK()` (e.g., all hosts were above the load threshold), this would loop forever. Added a bounded iteration (`for range len(c.hosts)`) and returns `ErrNoHosts` if no suitable host is found.

### 2. Nil pointer dereference in `Inc` (line 337)

`Inc()` directly accessed `c.loadMap[host].Load` without checking if the host exists. If a host was removed between the call to `GetLeast` and `Inc`, this would panic. Added the same nil guard that `Done()` already has.

### 3. Panic in `loadOK` on removed host (line 423)

When `loadOK` was called with a host that had been removed from `loadMap`, it panicked with an error message. Changed to `return false` so the caller can try the next host gracefully.

### 4. Divide-by-zero in `MaxLoad` (line 402)

`MaxLoad()` divides `c.totalLoad` by `len(c.loadMap)` without checking if `loadMap` is empty. Added an early return of 1 when there are no hosts.