### PR TITLE
fix(pubsub): prevent slice mutation during iteration and unsafe type assertion

### DIFF
--- a/pkg/runtime/pubsub/outbox.go
+++ b/pkg/runtime/pubsub/outbox.go
@@ -169,21 +169,27 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 
 	projections := map[string]state.SetRequest{}
 
-	for i, op := range operations {
+	var filteredOps []state.TransactionalStateOperation
+	for _, op := range operations {
 		sr, ok := op.(state.SetRequest)
-
 		if ok {
+			isProjection := false
 			for k, v := range sr.Metadata {
 				if k == "outbox.projection" && kitstrings.IsTruthy(v) {
 					projections[sr.Key] = sr
-
-					operations = append(operations[:i], operations[i+1:]...)
+					isProjection = true
+					break
 				}
 			}
+			if !isProjection {
+				filteredOps = append(filteredOps, op)
+			}
+		} else {
+			filteredOps = append(filteredOps, op)
 		}
 	}
 
-	for _, op := range operations {
+	for _, op := range filteredOps {
 		sr, ok := op.(state.SetRequest)
 		if ok {
 			tr, err := transaction()
@@ -260,11 +266,11 @@ func (o *outboxImpl) PublishInternal(ctx context.Context, stateStore string, ope
 				return nil, err
 			}
 
-			operations = append(operations, tr)
+			filteredOps = append(filteredOps, tr)
 		}
 	}
 
-	return operations, nil
+	return filteredOps, nil
 }
 
 func outboxTopic(appID, topic, namespace string) string {
@@ -349,7 +355,10 @@ func (o *outboxImpl) SubscribeToInternalTopics(ctx context.Context, appID string
 				return err
 			}
 
-			contentType := cloudEvent[contribPubsub.DataContentTypeField].(string)
+			var contentType string
+			if ct, ok := cloudEvent[contribPubsub.DataContentTypeField].(string); ok {
+				contentType = ct
+			}
 
 			err = o.publisher.Publish(ctx, &contribPubsub.PublishRequest{
 				PubsubName:  c.publishPubSub,

--- a/pkg/runtime/pubsub/outbox_test.go
+++ b/pkg/runtime/pubsub/outbox_test.go
@@ -590,6 +590,187 @@ func TestPublishInternal(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("projection operation excluded from returned operations", func(t *testing.T) {
+		o := newTestOutbox(func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
+			var cloudEvent map[string]any
+			err := json.Unmarshal(pr.Data, &cloudEvent)
+			require.NoError(t, err)
+
+			assert.Equal(t, "projection-value", cloudEvent["data"])
+
+			return nil
+		}).(*outboxImpl)
+
+		o.AddOrUpdateOutbox(v1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v1alpha1.ComponentSpec{
+				Metadata: []common.NameValuePair{
+					{
+						Name: outboxPublishPubsubKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("a"),
+							},
+						},
+					},
+					{
+						Name: outboxPublishTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("1"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		trs, err := o.PublishInternal(t.Context(), "test", []state.TransactionalStateOperation{
+			state.SetRequest{
+				Key:   "key",
+				Value: "original-value",
+			},
+			state.SetRequest{
+				Key:      "key",
+				Value:    "projection-value",
+				Metadata: map[string]string{"outbox.projection": "true"},
+			},
+		}, "testapp", "", "")
+
+		require.NoError(t, err)
+
+		assert.Len(t, trs, 2, "expected 1 original op + 1 transaction marker")
+
+		setReq, ok := trs[0].(state.SetRequest)
+		require.True(t, ok)
+		assert.Equal(t, "key", setReq.Key)
+		assert.Equal(t, "original-value", setReq.Value, "returned op should have the original value, not the projection value")
+	})
+
+	t.Run("multiple projections in same batch excluded from returned operations", func(t *testing.T) {
+		var publishedData []any
+		o := newTestOutbox(func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
+			var cloudEvent map[string]any
+			err := json.Unmarshal(pr.Data, &cloudEvent)
+			require.NoError(t, err)
+			publishedData = append(publishedData, cloudEvent["data"])
+			return nil
+		}).(*outboxImpl)
+
+		o.AddOrUpdateOutbox(v1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v1alpha1.ComponentSpec{
+				Metadata: []common.NameValuePair{
+					{
+						Name: outboxPublishPubsubKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("a"),
+							},
+						},
+					},
+					{
+						Name: outboxPublishTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("1"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		trs, err := o.PublishInternal(t.Context(), "test", []state.TransactionalStateOperation{
+			state.SetRequest{
+				Key:   "keyA",
+				Value: "valA",
+			},
+			state.SetRequest{
+				Key:      "keyA",
+				Value:    "projA",
+				Metadata: map[string]string{"outbox.projection": "true"},
+			},
+			state.SetRequest{
+				Key:   "keyB",
+				Value: "valB",
+			},
+			state.SetRequest{
+				Key:      "keyB",
+				Value:    "projB",
+				Metadata: map[string]string{"outbox.projection": "true"},
+			},
+		}, "testapp", "", "")
+
+		require.NoError(t, err)
+
+		originalCount := 0
+		for _, op := range trs {
+			if sr, ok := op.(state.SetRequest); ok {
+				if sr.Key == "keyA" || sr.Key == "keyB" {
+					originalCount++
+					_, hasProj := sr.Metadata["outbox.projection"]
+					assert.False(t, hasProj, "returned operation should not have outbox.projection metadata")
+				}
+			}
+		}
+		assert.Equal(t, 2, originalCount, "expected 2 original ops in returned operations (plus transaction markers)")
+	})
+
+	t.Run("no projection preserves original value in returned operations", func(t *testing.T) {
+		o := newTestOutbox(func(ctx context.Context, pr *contribPubsub.PublishRequest) error {
+			var cloudEvent map[string]any
+			err := json.Unmarshal(pr.Data, &cloudEvent)
+			require.NoError(t, err)
+			assert.Equal(t, "my-value", cloudEvent["data"])
+			return nil
+		}).(*outboxImpl)
+
+		o.AddOrUpdateOutbox(v1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: v1alpha1.ComponentSpec{
+				Metadata: []common.NameValuePair{
+					{
+						Name: outboxPublishPubsubKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("a"),
+							},
+						},
+					},
+					{
+						Name: outboxPublishTopicKey,
+						Value: common.DynamicValue{
+							JSON: v1.JSON{
+								Raw: []byte("1"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		trs, err := o.PublishInternal(t.Context(), "test", []state.TransactionalStateOperation{
+			state.SetRequest{
+				Key:   "key",
+				Value: "my-value",
+			},
+		}, "testapp", "", "")
+
+		require.NoError(t, err)
+		require.Len(t, trs, 2, "expected 1 original op + 1 transaction marker")
+
+		setReq, ok := trs[0].(state.SetRequest)
+		require.True(t, ok)
+		assert.Equal(t, "my-value", setReq.Value)
+	})
+
 	t.Run("missing state store", func(t *testing.T) {
 		o := newTestOutbox(nil).(*outboxImpl)
 


### PR DESCRIPTION
## Summary

Two fixes in the outbox implementation (`pkg/runtime/pubsub/outbox.go`):

### 1. Slice mutation during range iteration (line 172)

In `PublishInternal`, the projection extraction loop was mutating the `operations` slice during a `range` iteration using `append(operations[:i], operations[i+1:]...)`. This is undefined behavior in Go — elements can be skipped or processed twice depending on the runtime.

**Fix**: Build a separate `filteredOps` slice instead of mutating the original. The original `operations` slice is now treated as read-only.

### 2. Unconditional type assertion (line 358)

The `cloudEvent[contribPubsub.DataContentTypeField]` was accessed with an unconditional type assertion (`.(string)`). If the field is missing from the cloud event map or is not a string, this panics.

**Fix**: Changed to a comma-ok assertion with a fallback to empty string.