### PR TITLE
[Backport release-1.18] fix: preserve sub-millisecond latency precision

### DIFF
--- a/docs/release_notes/v1.18.2.md
+++ b/docs/release_notes/v1.18.2.md
@@ -14,6 +14,7 @@ This update contains the following bug fixes:
 - [gRPC streaming actor applications could not host actors without opening an app port](#grpc-streaming-actor-applications-could-not-host-actors-without-opening-an-app-port)
 - [go-chi updated to v5.2.4 for CVE-2025-69725](#go-chi-updated-to-v524-for-cve-2025-69725)
 - [mongo-driver updated to v1.17.7 for CVE-2026-2303](#mongo-driver-updated-to-v1177-for-cve-2026-2303)
+- [Sub-millisecond latencies are omitted from latency metrics](#sub-millisecond-latencies-are-omitted-from-latency-metrics)
 
 ## SPIFFE SVID component operation propagation
 
@@ -317,3 +318,21 @@ The `go.mongodb.org/mongo-driver` dependency predated the upstream fix released 
 ### Solution
 
 `go.mongodb.org/mongo-driver` is updated to v1.17.7, and the `github.com/dapr/components-contrib` dependency is bumped to v1.18.3 to carry the same driver update on the component side. Both resolve CVE-2026-2303. The upgrade stays within the driver's v1 line, so it is a dependency-only change with no behavioral impact.
+
+## Sub-millisecond latencies are omitted from latency metrics
+
+### Problem
+
+Latency measurements below one millisecond were omitted from latency histograms.
+
+### Impact
+
+Operations completing in less than one millisecond were not represented in the affected latency histograms, causing low-latency observations to be undercounted.
+
+### Root Cause
+
+`ElapsedSince` divided `time.Duration` values before converting the result to `float64`, truncating sub-millisecond durations to zero. Existing positive-latency guards then skipped those observations.
+
+### Solution
+
+`ElapsedSince` now converts durations to floating-point milliseconds before division, preserving fractional milliseconds and allowing sub-millisecond latency observations to be recorded.

--- a/pkg/diagnostics/component_monitoring.go
+++ b/pkg/diagnostics/component_monitoring.go
@@ -488,7 +488,12 @@ func (c *componentMetrics) jobTriggered(ctx context.Context, operation string, s
 	}
 }
 
-// ElapsedSince returns the given time in milliseconds.
+// ElapsedSince returns the elapsed duration since start in milliseconds,
+// including fractional milliseconds.
 func ElapsedSince(start time.Time) float64 {
-	return float64(time.Since(start) / time.Millisecond)
+	return durationInMilliseconds(time.Since(start))
+}
+
+func durationInMilliseconds(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
 }

--- a/pkg/diagnostics/component_monitoring_test.go
+++ b/pkg/diagnostics/component_monitoring_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats/view"
 
 	"github.com/dapr/dapr/pkg/config"
@@ -324,4 +325,34 @@ func TestElapsedSince(t *testing.T) {
 
 	elapsed := ElapsedSince(start)
 	assert.GreaterOrEqual(t, elapsed, float64(1000))
+}
+
+func TestDurationInMilliseconds(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected float64
+	}{
+		{
+			name:     "sub-millisecond",
+			duration: 500 * time.Microsecond,
+			expected: 0.5,
+		},
+		{
+			name:     "multiple milliseconds",
+			duration: 1500 * time.Microsecond,
+			expected: 1.5,
+		},
+		{
+			name:     "zero",
+			duration: 0,
+			expected: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.InDelta(t, test.expected, durationInMilliseconds(test.duration), 1e-9)
+		})
+	}
 }


### PR DESCRIPTION
Backport of #10215 to release-1.18