### PR TITLE
test(service invocation): cover multiple Set-Cookie headers

### DIFF
--- a/tests/apps/service_invocation/app.go
+++ b/tests/apps/service_invocation/app.go
@@ -443,6 +443,8 @@ func retrieveRequestObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("DaprTest-Response-2", "DaprTest-Response-Value-2")
 	w.Header().Add("DaprTest-Response-Multi", "DaprTest-Response-Multi-1")
 	w.Header().Add("DaprTest-Response-Multi", "DaprTest-Response-Multi-2")
+	w.Header().Add("Set-Cookie", "cookie1=value1; Path=/")
+	w.Header().Add("Set-Cookie", "cookie2=value2; Path=/")
 
 	if val, ok := headers["Daprtest-Traceid"]; ok {
 		// val[0] is client app given trace id

--- a/tests/e2e/service_invocation/service_invocation_test.go
+++ b/tests/e2e/service_invocation/service_invocation_test.go
@@ -1288,6 +1288,11 @@ func verifyHTTPToHTTP(t *testing.T, hostIP string, hostname string, url string, 
 		assert.Equal(t, "DaprTest-Response-Value-2", responseHeaders["Daprtest-Response-2"][0])
 	_ = assert.NotEmpty(t, responseHeaders["Daprtest-Response-Multi"]) &&
 		assert.Equal(t, []string{"DaprTest-Response-Multi-1", "DaprTest-Response-Multi-2"}, responseHeaders["Daprtest-Response-Multi"])
+	_ = assert.NotEmpty(t, responseHeaders["Set-Cookie"]) &&
+		assert.Equal(t, []string{
+			"cookie1=value1; Path=/",
+			"cookie2=value2; Path=/",
+		}, responseHeaders["Set-Cookie"])
 	_ = assert.NotEmpty(t, responseHeaders["Traceparent"]) &&
 		assert.NotNil(t, responseHeaders["Traceparent"][0])
 }


### PR DESCRIPTION
# Description

Adds explicit end-to-end regression coverage for preserving multiple `Set-Cookie` response header fields during HTTP service invocation.

The existing response-header fixture now emits two distinct cookies, and the HTTP-to-HTTP checks assert that both values arrive as separate header entries through both the `/v1.0/invoke` route and the `dapr-app-id` header route. This is test-only and does not change production behavior.

Local validation:

- `make test`
- `go test ./tests/apps/service_invocation`
- `go test -c -tags=e2e ./tests/e2e/service_invocation`
- `go vet ./tests/apps/service_invocation`
- `go vet -tags=e2e ./tests/e2e/service_invocation`
- `go test ./pkg/messaging/v1 ./pkg/channel/http`
- `go test -tags=unit,allcomponents ./pkg/channel/http/...`
- `go test -tags=unit,allcomponents ./pkg/api/http/...`
- `make lint`

Manual process-level validation used the `daprd` binary built from this PR, two standalone sidecars, and a separate HTTP application that returned two distinct `Set-Cookie` fields. An external `curl` client invoked the app five times through `/v1.0/invoke/<app-id>/method/...` and five times through the `dapr-app-id` header route. Every response preserved both cookie fields as separate headers.

The Kubernetes E2E suite was not run locally because it requires a configured cluster and image registry; the tagged E2E package was compiled successfully.

## Issue reference

Closes #6409

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing — requires the configured Kubernetes E2E environment
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: not applicable to this test-only change
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: not applicable to this test-only change
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: not applicable to this test-only change

