### PR TITLE
feat(runtime): support custom app API token headers

### DIFF
--- a/pkg/api/grpc/manager/manager.go
+++ b/pkg/api/grpc/manager/manager.go
@@ -59,6 +59,7 @@ type AppChannelConfig struct {
 	ReadBufferSize     int // In bytes
 	BaseAddress        string
 	AppAPIToken        string
+	AppAPITokenHeader  string
 }
 
 // Manager is a wrapper around gRPC connection pooling.
@@ -109,6 +110,7 @@ func (g *Manager) GetAppChannel() (channel.AppChannel, error) {
 		g.channelConfig.ReadBufferSize,
 		g.channelConfig.BaseAddress,
 		g.channelConfig.AppAPIToken,
+		g.channelConfig.AppAPITokenHeader,
 	)
 	return ch, nil
 }
@@ -277,13 +279,29 @@ func nopTeardown(destroy bool) {
 	// Nop
 }
 
-// AddAppTokenToContext appends the app API token to outgoing gRPC context.
+// AddAppTokenToContext sets the app API token on the outgoing gRPC context.
 func (g *Manager) AddAppTokenToContext(ctx context.Context) context.Context {
 	if g == nil || g.channelConfig == nil {
 		return ctx
 	}
-	if g.channelConfig.AppAPIToken != "" {
-		return md.AppendToOutgoingContext(ctx, securityConsts.APITokenHeader, g.channelConfig.AppAPIToken)
+	header := g.channelConfig.AppAPITokenHeader
+	if header == "" {
+		header = securityConsts.APITokenHeader
 	}
-	return ctx
+
+	outMD, ok := md.FromOutgoingContext(ctx)
+	if !ok {
+		if g.channelConfig.AppAPIToken == "" {
+			return ctx
+		}
+		outMD = md.MD{}
+	} else {
+		outMD = outMD.Copy()
+	}
+	outMD.Delete(securityConsts.APITokenHeader)
+	outMD.Delete(header)
+	if g.channelConfig.AppAPIToken != "" {
+		outMD.Set(header, g.channelConfig.AppAPIToken)
+	}
+	return md.NewOutgoingContext(ctx, outMD)
 }

--- a/pkg/api/grpc/manager/manager_test.go
+++ b/pkg/api/grpc/manager/manager_test.go
@@ -14,12 +14,14 @@ limitations under the License.
 package manager
 
 import (
+	"context"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/modes"
@@ -37,6 +39,34 @@ func TestNewManager(t *testing.T) {
 		assert.NotNil(t, m)
 		assert.Equal(t, modes.KubernetesMode, m.mode)
 	})
+}
+
+func TestAddAppTokenToContext(t *testing.T) {
+	for name, test := range map[string]struct {
+		header string
+		want   string
+	}{
+		"default header": {want: "dapr-api-token"},
+		"custom header":  {header: "x-api-key", want: "x-api-key"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := NewManager(nil, modes.StandaloneMode, &AppChannelConfig{
+				AppAPIToken:       "token1",
+				AppAPITokenHeader: test.header,
+			})
+			ctx := metadata.NewOutgoingContext(context.Background(), metadata.MD{
+				"dapr-api-token": {"default-oldtoken"},
+				"x-api-key":      {"custom-oldtoken"},
+			})
+			ctx = m.AddAppTokenToContext(ctx)
+			md, ok := metadata.FromOutgoingContext(ctx)
+			require.True(t, ok)
+			assert.Equal(t, []string{"token1"}, md.Get(test.want))
+			if test.want != "dapr-api-token" {
+				assert.Empty(t, md.Get("dapr-api-token"))
+			}
+		})
+	}
 }
 
 func TestGetAppClient_Scaling(t *testing.T) {

--- a/pkg/channel/grpc/grpc_channel.go
+++ b/pkg/channel/grpc/grpc_channel.go
@@ -45,25 +45,27 @@ type ConnFn func() (*grpc.ClientConn, func(bool), error)
 
 // Channel is a concrete AppChannel implementation for interacting with gRPC based user code.
 type Channel struct {
-	connFn              ConnFn
-	actorCallbackStream *callbackstream.Manager
-	baseAddress         string
-	ch                  chan struct{}
-	tracingSpec         config.TracingSpec
-	appMetadataToken    string
-	maxRequestBodySize  int
-	appHealth           *apphealth.AppHealth
+	connFn               ConnFn
+	actorCallbackStream  *callbackstream.Manager
+	baseAddress          string
+	ch                   chan struct{}
+	tracingSpec          config.TracingSpec
+	appMetadataToken     string
+	appMetadataTokenName string
+	maxRequestBodySize   int
+	appHealth            *apphealth.AppHealth
 }
 
 // CreateLocalChannel creates a gRPC connection with user code.
-func CreateLocalChannel(port, maxConcurrency int, connFn ConnFn, spec config.TracingSpec, maxRequestBodySize int, readBufferSize int, baseAddress string, appAPIToken string) *Channel {
+func CreateLocalChannel(port, maxConcurrency int, connFn ConnFn, spec config.TracingSpec, maxRequestBodySize int, readBufferSize int, baseAddress, appAPIToken, appAPITokenHeader string) *Channel {
 	// readBufferSize is unused
 	c := &Channel{
-		connFn:             connFn,
-		baseAddress:        net.JoinHostPort(baseAddress, strconv.Itoa(port)),
-		tracingSpec:        spec,
-		appMetadataToken:   appAPIToken,
-		maxRequestBodySize: maxRequestBodySize,
+		connFn:               connFn,
+		baseAddress:          net.JoinHostPort(baseAddress, strconv.Itoa(port)),
+		tracingSpec:          spec,
+		appMetadataToken:     appAPIToken,
+		appMetadataTokenName: appAPITokenHeader,
+		maxRequestBodySize:   maxRequestBodySize,
 	}
 	if maxConcurrency > 0 {
 		c.ch = make(chan struct{}, maxConcurrency)
@@ -209,10 +211,7 @@ func (g *Channel) invokeMethodV1(ctx context.Context, req *invokev1.InvokeMethod
 	}
 
 	md := invokev1.InternalMetadataToGrpcMetadata(ctx, pd.GetMetadata(), true)
-
-	if g.appMetadataToken != "" {
-		md.Set(securityConsts.APITokenHeader, g.appMetadataToken)
-	}
+	g.setAppTokenMetadata(md)
 
 	// Prepare gRPC Metadata
 	ctx = grpcMetadata.NewOutgoingContext(context.Background(), md)
@@ -299,8 +298,31 @@ func (g *Channel) SetAppHealth(ah *apphealth.AppHealth) {
 // AddAppTokenToContext adds the app API token to the outgoing gRPC context using the
 // token captured at channel creation time
 func (g *Channel) AddAppTokenToContext(ctx context.Context) context.Context {
-	if g.appMetadataToken != "" {
-		return grpcMetadata.AppendToOutgoingContext(ctx, securityConsts.APITokenHeader, g.appMetadataToken)
+	md, ok := grpcMetadata.FromOutgoingContext(ctx)
+	if !ok {
+		if g.appMetadataToken == "" {
+			return ctx
+		}
+		md = grpcMetadata.MD{}
+	} else {
+		md = md.Copy()
 	}
-	return ctx
+	g.setAppTokenMetadata(md)
+	return grpcMetadata.NewOutgoingContext(ctx, md)
+}
+
+func (g *Channel) appTokenMetadataName() string {
+	if g.appMetadataTokenName != "" {
+		return g.appMetadataTokenName
+	}
+	return securityConsts.APITokenHeader
+}
+
+func (g *Channel) setAppTokenMetadata(md grpcMetadata.MD) {
+	header := g.appTokenMetadataName()
+	md.Delete(securityConsts.APITokenHeader)
+	md.Delete(header)
+	if g.appMetadataToken != "" {
+		md.Set(header, g.appMetadataToken)
+	}
 }

--- a/pkg/channel/grpc/grpc_channel_test.go
+++ b/pkg/channel/grpc/grpc_channel_test.go
@@ -123,6 +123,27 @@ func TestInvokeMethod(t *testing.T) {
 		assert.Equal(t, "param1=val1&param2=val2", actual["querystring"])
 	})
 
+	t.Run("successful request with custom token metadata", func(t *testing.T) {
+		customChannel := c
+		customChannel.appMetadataTokenName = "x-api-key"
+		req := invokev1.NewInvokeMethodRequest("method").
+			WithHTTPExtension(http.MethodPost, "").
+			WithMetadata(map[string][]string{
+				securityConsts.APITokenHeader: {"default-oldtoken"},
+				"x-api-key":                   {"custom-oldtoken"},
+			})
+		defer req.Close()
+
+		response, err := customChannel.InvokeMethod(ctx, req, "")
+		require.NoError(t, err)
+		defer response.Close()
+
+		actual := map[string]string{}
+		require.NoError(t, json.NewDecoder(response.RawData()).Decode(&actual))
+		assert.Equal(t, "token1", actual["x-api-key"])
+		assert.Empty(t, actual[securityConsts.APITokenHeader])
+	})
+
 	t.Run("request body stream errors", func(t *testing.T) {
 		req := invokev1.NewInvokeMethodRequest("method").
 			WithHTTPExtension(http.MethodPost, "param1=val1&param2=val2").
@@ -174,6 +195,6 @@ func TestHealthProbe(t *testing.T) {
 }
 
 func TestCreateLocalChannelWithBaseAddress(t *testing.T) {
-	ch := CreateLocalChannel(8080, 1, nil, config.TracingSpec{}, 1024, 1, "my.app", "")
+	ch := CreateLocalChannel(8080, 1, nil, config.TracingSpec{}, 1024, 1, "my.app", "", "")
 	assert.Equal(t, "my.app:8080", ch.baseAddress)
 }

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -77,6 +77,7 @@ type Channel struct {
 	compStore           *compstore.ComponentStore
 	tracingSpec         *config.TracingSpec
 	appHeaderToken      string
+	appHeaderTokenName  string
 	maxResponseBodySize int
 	appHealthCheckPath  string
 	appHealth           *apphealth.AppHealth
@@ -97,6 +98,7 @@ type ChannelConfiguration struct {
 	TLSRootCA          string
 	TLSRenegotiation   string
 	AppAPIToken        string
+	AppAPITokenHeader  string
 }
 
 // CreateHTTPChannel creates an HTTP AppChannel.
@@ -108,6 +110,7 @@ func CreateHTTPChannel(config ChannelConfiguration) (channel.AppChannel, error) 
 		baseAddress:         config.Endpoint,
 		tracingSpec:         config.TracingSpec,
 		appHeaderToken:      config.AppAPIToken,
+		appHeaderTokenName:  config.AppAPITokenHeader,
 		maxResponseBodySize: config.MaxRequestBodySize,
 	}
 
@@ -232,9 +235,7 @@ func (h *Channel) constructJobRequest(ctx context.Context, name string, data *an
 	}
 
 	// Set any additional headers or tokens required
-	if h.appHeaderToken != "" {
-		channelReq.Header.Set(securityConsts.APITokenHeader, h.appHeaderToken)
-	}
+	h.setAppToken(channelReq.Header)
 
 	return channelReq, nil
 }
@@ -644,11 +645,23 @@ func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMeth
 		channelReq.Header.Set("tracestate", ts)
 	}
 
-	if h.appHeaderToken != "" {
-		channelReq.Header.Set(securityConsts.APITokenHeader, h.appHeaderToken)
-	}
+	h.setAppToken(channelReq.Header)
 
 	return channelReq, nil
+}
+
+func (h *Channel) setAppToken(header http.Header) {
+	headerName := h.appHeaderTokenName
+	if headerName == "" {
+		headerName = securityConsts.APITokenHeader
+	}
+	header.Del(securityConsts.APITokenHeader)
+	header.Del(headerName)
+
+	if h.appHeaderToken == "" {
+		return
+	}
+	header.Set(headerName, h.appHeaderToken)
 }
 
 func (h *Channel) parseChannelResponse(channelResp *http.Response) (*invokev1.InvokeMethodResponse, error) {

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -819,6 +819,39 @@ func TestAppToken(t *testing.T) {
 		testServer.Close()
 	})
 
+	t.Run("custom token header present", func(t *testing.T) {
+		ctx := t.Context()
+		testServer := httptest.NewServer(&testHandlerHeaders{})
+		defer testServer.Close()
+		c := Channel{
+			baseAddress:        testServer.URL,
+			client:             http.DefaultClient,
+			appHeaderToken:     "token1",
+			appHeaderTokenName: "x-api-key",
+			compStore:          compstore.New(),
+			middleware:         httpMiddleware.New().BuildPipelineFromSpec("test", nil),
+		}
+
+		req := invokev1.NewInvokeMethodRequest("method").
+			WithHTTPExtension(http.MethodPost, "").
+			WithMetadata(map[string][]string{
+				"dapr-api-token": {"default-oldtoken"},
+				"x-api-key":      {"custom-oldtoken"},
+			})
+		defer req.Close()
+
+		resp, err := c.InvokeMethod(ctx, req, "")
+		require.NoError(t, err)
+		defer resp.Close()
+		body, err := resp.RawDataFull()
+		require.NoError(t, err)
+
+		actual := map[string]string{}
+		require.NoError(t, json.Unmarshal(body, &actual))
+		assert.Empty(t, actual["Dapr-Api-Token"])
+		assert.Equal(t, "token1", actual["X-Api-Key"])
+	})
+
 	t.Run("token not present", func(t *testing.T) {
 		ctx := t.Context()
 		testServer := httptest.NewServer(&testHandlerHeaders{})

--- a/pkg/injector/annotations/annotations.go
+++ b/pkg/injector/annotations/annotations.go
@@ -28,6 +28,7 @@ const (
 	KeyLogLevel                         = "dapr.io/log-level"
 	KeyAPITokenSecret                   = "dapr.io/api-token-secret" /* #nosec */
 	KeyAppTokenSecret                   = "dapr.io/app-token-secret" /* #nosec */
+	KeyAppTokenHeader                   = "dapr.io/app-token-header" /* #nosec */
 	KeyLogAsJSON                        = "dapr.io/log-as-json"
 	KeyAppMaxConcurrency                = "dapr.io/app-max-concurrency"
 	KeyEnableMetrics                    = "dapr.io/enable-metrics"

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -70,6 +70,7 @@ type SidecarConfig struct {
 	LogLevel                            string  `annotation:"dapr.io/log-level" default:"info"`
 	APITokenSecret                      string  `annotation:"dapr.io/api-token-secret"`
 	AppTokenSecret                      string  `annotation:"dapr.io/app-token-secret"`
+	AppTokenHeader                      string  `annotation:"dapr.io/app-token-header"`
 	LogAsJSON                           bool    `annotation:"dapr.io/log-as-json"`
 	AppMaxConcurrency                   *int    `annotation:"dapr.io/app-max-concurrency"`
 	EnableMetrics                       bool    `annotation:"dapr.io/enable-metrics" default:"true"`

--- a/pkg/injector/patcher/sidecar_container.go
+++ b/pkg/injector/patcher/sidecar_container.go
@@ -413,6 +413,13 @@ func (c *SidecarConfig) getSidecarContainer(opts getSidecarContainerOpts) (*core
 		})
 	}
 
+	if c.AppTokenHeader != "" {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  securityConsts.AppAPITokenHeaderEnvVar,
+			Value: c.AppTokenHeader,
+		})
+	}
+
 	// Resources for the container
 	resources, err := c.getResourceRequirements()
 	if err != nil {

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -571,6 +571,7 @@ func TestGetSidecarContainer(t *testing.T) {
 					annotations.KeyLogAsJSON:      "true",
 					annotations.KeyAPITokenSecret: "secret",
 					annotations.KeyAppTokenSecret: "appsecret",
+					annotations.KeyAppTokenHeader: "x-api-key",
 				},
 			},
 		})
@@ -616,7 +617,7 @@ func TestGetSidecarContainer(t *testing.T) {
 
 		// Command should be empty, image's entrypoint to be used.
 		assert.Empty(t, container.Command)
-		assertEqualJSON(t, container.Env, `[{"name":"NAMESPACE","value":"dapr-system"},{"name":"DAPR_TRUST_ANCHORS"},{"name":"POD_NAME","valueFrom":{"fieldRef":{"fieldPath":"metadata.name"}}},{"name":"DAPR_CONTROLPLANE_NAMESPACE","value":"my-namespace"},{"name":"DAPR_CONTROLPLANE_TRUST_DOMAIN","value":"test.example.com"},{"name":"DAPR_API_TOKEN","valueFrom":{"secretKeyRef":{"name":"secret","key":"token"}}},{"name":"APP_API_TOKEN","valueFrom":{"secretKeyRef":{"name":"appsecret","key":"token"}}}]`)
+		assertEqualJSON(t, container.Env, `[{"name":"NAMESPACE","value":"dapr-system"},{"name":"DAPR_TRUST_ANCHORS"},{"name":"POD_NAME","valueFrom":{"fieldRef":{"fieldPath":"metadata.name"}}},{"name":"DAPR_CONTROLPLANE_NAMESPACE","value":"my-namespace"},{"name":"DAPR_CONTROLPLANE_TRUST_DOMAIN","value":"test.example.com"},{"name":"DAPR_API_TOKEN","valueFrom":{"secretKeyRef":{"name":"secret","key":"token"}}},{"name":"APP_API_TOKEN","valueFrom":{"secretKeyRef":{"name":"appsecret","key":"token"}}},{"name":"DAPR_APP_API_TOKEN_HEADER","value":"x-api-key"}]`)
 		// default image
 		assert.Equal(t, "daprio/dapr", container.Image)
 		assert.Equal(t, expectedArgs, container.Args)

--- a/pkg/injector/patcher/sidecar_patcher_test.go
+++ b/pkg/injector/patcher/sidecar_patcher_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/injector/annotations"
 	injectorConsts "github.com/dapr/dapr/pkg/injector/consts"
+	securityConsts "github.com/dapr/dapr/pkg/security/consts"
 )
 
 func TestAddDaprEnvVarsToContainers(t *testing.T) {
@@ -381,6 +382,22 @@ func TestPatching(t *testing.T) {
 				require.Len(t, pod.Spec.InitContainers, 1)
 				args := strings.Join(pod.Spec.InitContainers[0].Args, " ")
 				assert.Contains(t, args, "--dapr-graceful-shutdown-seconds 30")
+			},
+		},
+		{
+			name: "app token header does not require app token secret",
+			podModifierFn: func(pod *corev1.Pod) {
+				pod.Annotations[annotations.KeyAppTokenHeader] = "x-api-key"
+			},
+			assertFn: func(t *testing.T, pod *corev1.Pod) {
+				require.Len(t, pod.Spec.Containers, 2)
+				assert.Contains(t, pod.Spec.Containers[1].Env, corev1.EnvVar{
+					Name:  securityConsts.AppAPITokenHeaderEnvVar,
+					Value: "x-api-key",
+				})
+				for _, env := range pod.Spec.Containers[1].Env {
+					assert.NotEqual(t, securityConsts.AppAPITokenEnvVar, env.Name)
+				}
 			},
 		},
 		{

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -148,8 +148,8 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 		}
 
 		mdCopy := md.Copy()
-		delete(mdCopy, securityConsts.APITokenHeader)
-		delete(mdCopy, p.appAPITokenHeader)
+		mdCopy.Delete(securityConsts.APITokenHeader)
+		mdCopy.Delete(p.appAPITokenHeader)
 		outCtx := metadata.NewOutgoingContext(ctx, mdCopy)
 		if p.appendAppTokenFn != nil {
 			outCtx = p.appendAppTokenFn(outCtx)

--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -49,6 +49,7 @@ type proxy struct {
 	remoteAppFn        func(ctx context.Context, appID string) (remoteApp, error)
 	telemetryFn        func(context.Context) context.Context
 	appendAppTokenFn   func(context.Context) context.Context
+	appAPITokenHeader  string
 	acl                *config.AccessControlList
 	resiliency         resiliency.Provider
 	maxRequestBodySize int
@@ -63,6 +64,7 @@ type ProxyOpts struct {
 	Resiliency         resiliency.Provider
 	MaxRequestBodySize int
 	AppendAppTokenFn   func(context.Context) context.Context
+	AppAPITokenHeader  string
 }
 
 // NewProxy returns a new proxy.
@@ -72,6 +74,7 @@ func NewProxy(opts ProxyOpts) Proxy {
 		appID:              opts.AppID,
 		connectionFactory:  opts.ConnectionFactory,
 		appendAppTokenFn:   opts.AppendAppTokenFn,
+		appAPITokenHeader:  opts.AppAPITokenHeader,
 		acl:                opts.ACL,
 		resiliency:         opts.Resiliency,
 		maxRequestBodySize: opts.MaxRequestBodySize,
@@ -146,6 +149,7 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 
 		mdCopy := md.Copy()
 		delete(mdCopy, securityConsts.APITokenHeader)
+		delete(mdCopy, p.appAPITokenHeader)
 		outCtx := metadata.NewOutgoingContext(ctx, mdCopy)
 		if p.appendAppTokenFn != nil {
 			outCtx = p.appendAppTokenFn(outCtx)

--- a/pkg/messaging/grpc_proxy_test.go
+++ b/pkg/messaging/grpc_proxy_test.go
@@ -206,6 +206,41 @@ func TestIntercept(t *testing.T) {
 		assert.Equal(t, "token1", md[securityConsts.APITokenHeader][0])
 	})
 
+	t.Run("proxy to the app with custom token metadata", func(t *testing.T) {
+		const customHeader = "x-api-key"
+		p := NewProxy(ProxyOpts{
+			ConnectionFactory: connectionFn,
+			AppClientFn:       appClientFn,
+			AppID:             "a",
+			Resiliency:        resiliency.New(nil),
+			AppAPITokenHeader: customHeader,
+			AppendAppTokenFn: func(ctx context.Context) context.Context {
+				return metadata.AppendToOutgoingContext(ctx, customHeader, "token1")
+			},
+		})
+		p.SetTelemetryFn(func(ctx context.Context) context.Context {
+			return ctx
+		})
+		p.SetRemoteAppFn(func(_ context.Context, s string) (remoteApp, error) {
+			return remoteApp{id: "a"}, nil
+		})
+
+		ctx := metadata.NewIncomingContext(t.Context(), metadata.MD{
+			diagConsts.GRPCProxyAppIDKey:  []string{"a"},
+			securityConsts.APITokenHeader: []string{"default-oldtoken"},
+			customHeader:                  []string{"custom-oldtoken"},
+		})
+		proxy := p.(*proxy)
+		ctx, conn, _, teardown, err := proxy.intercept(ctx, "/test")
+		defer teardown(true)
+
+		require.NoError(t, err)
+		assert.NotNil(t, conn)
+		md, _ := metadata.FromOutgoingContext(ctx)
+		assert.Empty(t, md[securityConsts.APITokenHeader])
+		assert.Equal(t, []string{"token1"}, md[customHeader])
+	})
+
 	t.Run("proxy to a remote app", func(t *testing.T) {
 		p := NewProxy(ProxyOpts{
 			ConnectionFactory: connectionFn,

--- a/pkg/messaging/grpc_proxy_test.go
+++ b/pkg/messaging/grpc_proxy_test.go
@@ -207,7 +207,10 @@ func TestIntercept(t *testing.T) {
 	})
 
 	t.Run("proxy to the app with custom token metadata", func(t *testing.T) {
-		const customHeader = "x-api-key"
+		const (
+			customHeader       = "X-API-Key"
+			normalizedMetadata = "x-api-key"
+		)
 		p := NewProxy(ProxyOpts{
 			ConnectionFactory: connectionFn,
 			AppClientFn:       appClientFn,
@@ -225,11 +228,11 @@ func TestIntercept(t *testing.T) {
 			return remoteApp{id: "a"}, nil
 		})
 
-		ctx := metadata.NewIncomingContext(t.Context(), metadata.MD{
-			diagConsts.GRPCProxyAppIDKey:  []string{"a"},
-			securityConsts.APITokenHeader: []string{"default-oldtoken"},
-			customHeader:                  []string{"custom-oldtoken"},
-		})
+		ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs(
+			diagConsts.GRPCProxyAppIDKey, "a",
+			securityConsts.APITokenHeader, "default-oldtoken",
+			normalizedMetadata, "custom-oldtoken",
+		))
 		proxy := p.(*proxy)
 		ctx, conn, _, teardown, err := proxy.intercept(ctx, "/test")
 		defer teardown(true)
@@ -238,7 +241,7 @@ func TestIntercept(t *testing.T) {
 		assert.NotNil(t, conn)
 		md, _ := metadata.FromOutgoingContext(ctx)
 		assert.Empty(t, md[securityConsts.APITokenHeader])
-		assert.Equal(t, []string{"token1"}, md[customHeader])
+		assert.Equal(t, []string{"token1"}, md[normalizedMetadata])
 	})
 
 	t.Run("proxy to a remote app", func(t *testing.T) {

--- a/pkg/runtime/channels/channels.go
+++ b/pkg/runtime/channels/channels.go
@@ -69,8 +69,9 @@ type Options struct {
 	// ReadBufferSize is the read buffer size, in bytes
 	ReadBufferSize int
 
-	GRPC        *manager.Manager
-	AppAPIToken string
+	GRPC              *manager.Manager
+	AppAPIToken       string
+	AppAPITokenHeader string
 
 	// ActorCallbackStream is the runtime-owned stream manager attached to
 	// the gRPC app channel, if any. Its event loop is driven by the
@@ -90,11 +91,12 @@ type Channels struct {
 	grpc                *manager.Manager
 	actorCallbackStream *callbackstream.Manager
 
-	appAPIToken     string
-	appChannel      channel.AppChannel
-	endpChannels    map[string]channel.HTTPEndpointAppChannel
-	httpEndpChannel channel.AppChannel
-	lock            sync.RWMutex
+	appAPIToken       string
+	appAPITokenHeader string
+	appChannel        channel.AppChannel
+	endpChannels      map[string]channel.HTTPEndpointAppChannel
+	httpEndpChannel   channel.AppChannel
+	lock              sync.RWMutex
 }
 
 func New(opts Options) *Channels {
@@ -109,6 +111,7 @@ func New(opts Options) *Channels {
 		grpc:                opts.GRPC,
 		actorCallbackStream: opts.ActorCallbackStream,
 		appAPIToken:         opts.AppAPIToken,
+		appAPITokenHeader:   opts.AppAPITokenHeader,
 		httpClient:          appHTTPClient(opts.AppConnectionConfig, opts.GlobalConfig, opts.ReadBufferSize),
 		endpChannels:        make(map[string]channel.HTTPEndpointAppChannel),
 	}
@@ -227,6 +230,7 @@ func (c *Channels) appHTTPChannelConfig() channelhttp.ChannelConfiguration {
 	conf.Endpoint = c.AppHTTPEndpoint()
 	conf.Client = c.httpClient
 	conf.AppAPIToken = c.appAPIToken
+	conf.AppAPITokenHeader = c.appAPITokenHeader
 
 	return conf
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -98,6 +98,7 @@ type DaprRuntime struct {
 	accessControlList      *config.AccessControlList
 	grpc                   *manager.Manager
 	channels               *channels.Channels
+	appAPITokenHeader      string
 	appConfig              config.ApplicationConfig
 	directMessaging        invokev1.DirectMessaging
 	actors                 actors.Interface
@@ -205,7 +206,8 @@ func newDaprRuntime(ctx context.Context,
 	}
 
 	appAPIToken := security.GetAppToken()
-	grpc := createGRPCManager(sec, runtimeConfig, globalConfig, appAPIToken)
+	appAPITokenHeader := security.GetAppTokenHeader()
+	grpc := createGRPCManager(sec, runtimeConfig, globalConfig, appAPIToken, appAPITokenHeader)
 
 	authz := authorizer.New(authorizer.Options{
 		ID:           runtimeConfig.id,
@@ -228,6 +230,7 @@ func newDaprRuntime(ctx context.Context,
 		GRPC:                grpc,
 		AppMiddleware:       httpMiddlewareApp,
 		AppAPIToken:         appAPIToken,
+		AppAPITokenHeader:   appAPITokenHeader,
 		ActorCallbackStream: actorCallbackStream,
 	})
 
@@ -389,6 +392,7 @@ func newDaprRuntime(ctx context.Context,
 		meta:                   meta,
 		operatorClient:         operatorClient,
 		channels:               channels,
+		appAPITokenHeader:      appAPITokenHeader,
 		sec:                    sec,
 		processor:              processor,
 		jobsManager:            jobsManager,
@@ -1046,6 +1050,7 @@ func (a *DaprRuntime) initProxy() {
 		Resiliency:         a.resiliency,
 		MaxRequestBodySize: a.runtimeConfig.maxRequestBodySize,
 		AppendAppTokenFn:   a.grpc.AddAppTokenToContext,
+		AppAPITokenHeader:  a.appAPITokenHeader,
 	})
 }
 
@@ -1478,7 +1483,7 @@ func featureTypeToString(features any) []string {
 	return featureStr
 }
 
-func createGRPCManager(sec security.Handler, runtimeConfig *internalConfig, globalConfig *config.Configuration, appAPIToken string) *manager.Manager {
+func createGRPCManager(sec security.Handler, runtimeConfig *internalConfig, globalConfig *config.Configuration, appAPIToken, appAPITokenHeader string) *manager.Manager {
 	grpcAppChannelConfig := &manager.AppChannelConfig{}
 	if globalConfig != nil {
 		grpcAppChannelConfig.TracingSpec = globalConfig.GetTracingSpec()
@@ -1494,6 +1499,7 @@ func createGRPCManager(sec security.Handler, runtimeConfig *internalConfig, glob
 	}
 
 	grpcAppChannelConfig.AppAPIToken = appAPIToken
+	grpcAppChannelConfig.AppAPITokenHeader = appAPITokenHeader
 	m := manager.NewManager(sec, runtimeConfig.mode, grpcAppChannelConfig)
 	m.StartCollector()
 

--- a/pkg/security/consts/consts.go
+++ b/pkg/security/consts/consts.go
@@ -20,6 +20,9 @@ const (
 	// AppAPITokenEnvVar is the environment variable for the app API token.
 	//nolint:gosec
 	AppAPITokenEnvVar = "APP_API_TOKEN"
+	// AppAPITokenHeaderEnvVar is the environment variable for the HTTP header or gRPC metadata name for the app API token.
+	//nolint:gosec
+	AppAPITokenHeaderEnvVar = "DAPR_APP_API_TOKEN_HEADER"
 	// APITokenHeader is header name for HTTP/gRPC calls to hold the token.
 	//nolint:gosec
 	APITokenHeader = "dapr-api-token"

--- a/pkg/security/token.go
+++ b/pkg/security/token.go
@@ -16,6 +16,7 @@ package security
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dapr/dapr/pkg/security/consts"
 )
@@ -39,7 +40,7 @@ func GetAppToken() string {
 
 // GetAppTokenHeader returns the HTTP header or gRPC metadata name for the app API token.
 func GetAppTokenHeader() string {
-	if header := os.Getenv(consts.AppAPITokenHeaderEnvVar); header != "" {
+	if header := strings.ToLower(strings.TrimSpace(os.Getenv(consts.AppAPITokenHeaderEnvVar))); header != "" {
 		return header
 	}
 	return consts.APITokenHeader

--- a/pkg/security/token.go
+++ b/pkg/security/token.go
@@ -37,6 +37,14 @@ func GetAppToken() string {
 	return os.Getenv(consts.AppAPITokenEnvVar)
 }
 
+// GetAppTokenHeader returns the HTTP header or gRPC metadata name for the app API token.
+func GetAppTokenHeader() string {
+	if header := os.Getenv(consts.AppAPITokenHeaderEnvVar); header != "" {
+		return header
+	}
+	return consts.APITokenHeader
+}
+
 // getKubernetesIdentityToken returns the value of the Kubernetes identity
 // token.
 func getKubernetesIdentityToken() (string, error) {

--- a/pkg/security/token_test.go
+++ b/pkg/security/token_test.go
@@ -59,15 +59,34 @@ func TestAppToken(t *testing.T) {
 }
 
 func TestAppTokenHeader(t *testing.T) {
-	t.Run("existing header", func(t *testing.T) {
-		t.Setenv(consts.AppAPITokenHeaderEnvVar, "x-api-key")
-		assert.Equal(t, "x-api-key", GetAppTokenHeader())
-	})
+	tests := map[string]struct {
+		header string
+		want   string
+	}{
+		"existing header": {
+			header: "x-api-key",
+			want:   "x-api-key",
+		},
+		"normalizes padded mixed-case header": {
+			header: " \tX-API-Key\n",
+			want:   "x-api-key",
+		},
+		"non-existent header": {
+			header: "",
+			want:   consts.APITokenHeader,
+		},
+		"whitespace-only header": {
+			header: " \t\n",
+			want:   consts.APITokenHeader,
+		},
+	}
 
-	t.Run("non-existent header", func(t *testing.T) {
-		t.Setenv(consts.AppAPITokenHeaderEnvVar, "")
-		assert.Equal(t, consts.APITokenHeader, GetAppTokenHeader())
-	})
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(consts.AppAPITokenHeaderEnvVar, test.header)
+			assert.Equal(t, test.want, GetAppTokenHeader())
+		})
+	}
 }
 
 func TestGetKubernetesIdentityToken(t *testing.T) {

--- a/pkg/security/token_test.go
+++ b/pkg/security/token_test.go
@@ -58,6 +58,18 @@ func TestAppToken(t *testing.T) {
 	})
 }
 
+func TestAppTokenHeader(t *testing.T) {
+	t.Run("existing header", func(t *testing.T) {
+		t.Setenv(consts.AppAPITokenHeaderEnvVar, "x-api-key")
+		assert.Equal(t, "x-api-key", GetAppTokenHeader())
+	})
+
+	t.Run("non-existent header", func(t *testing.T) {
+		t.Setenv(consts.AppAPITokenHeaderEnvVar, "")
+		assert.Equal(t, consts.APITokenHeader, GetAppTokenHeader())
+	})
+}
+
 func TestGetKubernetesIdentityToken(t *testing.T) {
 	tests := map[string]struct {
 		kubeToken  *string

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -350,6 +350,12 @@ func WithAppAPIToken(t *testing.T, token string) Option {
 	))
 }
 
+func WithAppAPITokenHeader(t *testing.T, header string) Option {
+	return WithExecOptions(exec.WithEnvVars(t,
+		"DAPR_APP_API_TOKEN_HEADER", header,
+	))
+}
+
 func WithDaprAPIToken(t *testing.T, token string) Option {
 	return WithExecOptions(exec.WithEnvVars(t,
 		"DAPR_API_TOKEN", token,

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/appapitoken/customheader.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/appapitoken/customheader.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appapitoken
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	runtimev1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	testpb "github.com/dapr/dapr/tests/integration/framework/process/grpc/app/proto"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(customheader))
+}
+
+type customheader struct {
+	daprd *daprd.Daprd
+	ch    chan metadata.MD
+}
+
+func (c *customheader) Setup(t *testing.T) []framework.Option {
+	c.ch = make(chan metadata.MD, 2)
+	app := app.New(t,
+		app.WithOnInvokeFn(func(ctx context.Context, _ *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
+			md, ok := metadata.FromIncomingContext(ctx)
+			require.True(t, ok)
+			c.ch <- md
+			return new(commonv1.InvokeResponse), nil
+		}),
+		app.WithPingFn(func(ctx context.Context, _ *testpb.PingRequest) (*testpb.PingResponse, error) {
+			md, _ := metadata.FromIncomingContext(ctx)
+			c.ch <- md
+			return new(testpb.PingResponse), nil
+		}),
+	)
+
+	c.daprd = daprd.New(t,
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppAPIToken(t, "abc"),
+		daprd.WithAppAPITokenHeader(t, "x-api-key"),
+		daprd.WithAppPort(app.Port(t)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, c.daprd),
+	}
+}
+
+func (c *customheader) Run(t *testing.T, ctx context.Context) {
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	client := testpb.NewTestServiceClient(c.daprd.GRPCConn(t, ctx))
+	pingCtx := metadata.AppendToOutgoingContext(ctx,
+		"dapr-app-id", c.daprd.AppID(),
+		"dapr-api-token", "default-oldtoken",
+		"x-api-key", "custom-oldtoken",
+	)
+	_, err := client.Ping(pingCtx, new(testpb.PingRequest))
+	require.NoError(t, err)
+	c.assertMetadata(t)
+
+	_, err = c.daprd.GRPCClient(t, ctx).InvokeService(ctx, &runtimev1.InvokeServiceRequest{
+		Id: c.daprd.AppID(),
+		Message: &commonv1.InvokeRequest{
+			Method:        "helloworld",
+			Data:          new(anypb.Any),
+			HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+		},
+	})
+	require.NoError(t, err)
+	c.assertMetadata(t)
+}
+
+func (c *customheader) assertMetadata(t *testing.T) {
+	t.Helper()
+	select {
+	case md := <-c.ch:
+		assert.Empty(t, md.Get("dapr-api-token"))
+		assert.Equal(t, []string{"abc"}, md.Get("x-api-key"))
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timed out waiting for custom token metadata")
+	}
+}

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/appapitoken/customheader.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/appapitoken/customheader.go
@@ -37,12 +37,13 @@ func init() {
 }
 
 type customheader struct {
-	daprd *daprd.Daprd
-	ch    chan metadata.MD
+	withToken *daprd.Daprd
+	noToken   *daprd.Daprd
+	ch        chan metadata.MD
 }
 
 func (c *customheader) Setup(t *testing.T) []framework.Option {
-	c.ch = make(chan metadata.MD, 2)
+	c.ch = make(chan metadata.MD, 4)
 	app := app.New(t,
 		app.WithOnInvokeFn(func(ctx context.Context, _ *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
 			md, ok := metadata.FromIncomingContext(ctx)
@@ -57,49 +58,67 @@ func (c *customheader) Setup(t *testing.T) []framework.Option {
 		}),
 	)
 
-	c.daprd = daprd.New(t,
+	c.withToken = daprd.New(t,
 		daprd.WithAppProtocol("grpc"),
 		daprd.WithAppAPIToken(t, "abc"),
-		daprd.WithAppAPITokenHeader(t, "x-api-key"),
+		daprd.WithAppAPITokenHeader(t, " X-API-Key "),
+		daprd.WithAppPort(app.Port(t)),
+	)
+	c.noToken = daprd.New(t,
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppAPITokenHeader(t, " X-API-Key "),
 		daprd.WithAppPort(app.Port(t)),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(app, c.daprd),
+		framework.WithProcesses(app, c.withToken, c.noToken),
 	}
 }
 
 func (c *customheader) Run(t *testing.T, ctx context.Context) {
-	c.daprd.WaitUntilRunning(t, ctx)
+	c.withToken.WaitUntilRunning(t, ctx)
+	c.noToken.WaitUntilRunning(t, ctx)
 
-	client := testpb.NewTestServiceClient(c.daprd.GRPCConn(t, ctx))
-	pingCtx := metadata.AppendToOutgoingContext(ctx,
-		"dapr-app-id", c.daprd.AppID(),
-		"dapr-api-token", "default-oldtoken",
-		"x-api-key", "custom-oldtoken",
-	)
-	_, err := client.Ping(pingCtx, new(testpb.PingRequest))
-	require.NoError(t, err)
-	c.assertMetadata(t)
+	exercise := func(daprdProcess *daprd.Daprd, expectedToken string) {
+		t.Helper()
 
-	_, err = c.daprd.GRPCClient(t, ctx).InvokeService(ctx, &runtimev1.InvokeServiceRequest{
-		Id: c.daprd.AppID(),
-		Message: &commonv1.InvokeRequest{
-			Method:        "helloworld",
-			Data:          new(anypb.Any),
-			HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
-		},
-	})
-	require.NoError(t, err)
-	c.assertMetadata(t)
+		requestCtx := metadata.AppendToOutgoingContext(ctx,
+			"dapr-app-id", daprdProcess.AppID(),
+			"dapr-api-token", "default-oldtoken",
+			"x-api-key", "custom-oldtoken",
+		)
+
+		client := testpb.NewTestServiceClient(daprdProcess.GRPCConn(t, ctx))
+		_, err := client.Ping(requestCtx, new(testpb.PingRequest))
+		require.NoError(t, err)
+		c.assertMetadata(t, expectedToken)
+
+		_, err = daprdProcess.GRPCClient(t, ctx).InvokeService(requestCtx, &runtimev1.InvokeServiceRequest{
+			Id: daprdProcess.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method:        "helloworld",
+				Data:          new(anypb.Any),
+				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+			},
+		})
+		require.NoError(t, err)
+		c.assertMetadata(t, expectedToken)
+	}
+
+	exercise(c.withToken, "abc")
+	exercise(c.noToken, "")
 }
 
-func (c *customheader) assertMetadata(t *testing.T) {
+func (c *customheader) assertMetadata(t *testing.T, expectedToken string) {
 	t.Helper()
 	select {
 	case md := <-c.ch:
 		assert.Empty(t, md.Get("dapr-api-token"))
-		assert.Equal(t, []string{"abc"}, md.Get("x-api-key"))
+		if expectedToken == "" {
+			assert.Empty(t, md.Get("x-api-key"))
+		} else {
+			assert.Equal(t, []string{expectedToken}, md.Get("x-api-key"))
+		}
 	case <-time.After(5 * time.Second):
 		assert.Fail(t, "timed out waiting for custom token metadata")
 	}

--- a/tests/integration/suite/daprd/serviceinvocation/http/appapitoken/customheader.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/appapitoken/customheader.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appapitoken
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	runtimev1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(customheader))
+}
+
+type customheader struct {
+	withToken *daprd.Daprd
+	noToken   *daprd.Daprd
+	ch        chan http.Header
+}
+
+func (c *customheader) Setup(t *testing.T) []framework.Option {
+	c.ch = make(chan http.Header, 2)
+	app := app.New(t,
+		app.WithHandlerFunc("/helloworld", func(w http.ResponseWriter, r *http.Request) {
+			c.ch <- r.Header
+		}),
+	)
+
+	c.withToken = daprd.New(t,
+		daprd.WithAppAPIToken(t, "abc"),
+		daprd.WithAppAPITokenHeader(t, "x-api-key"),
+		daprd.WithAppPort(app.Port()),
+	)
+	c.noToken = daprd.New(t,
+		daprd.WithAppAPITokenHeader(t, "x-api-key"),
+		daprd.WithAppPort(app.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, c.withToken, c.noToken),
+	}
+}
+
+func (c *customheader) Run(t *testing.T, ctx context.Context) {
+	c.withToken.WaitUntilRunning(t, ctx)
+	c.noToken.WaitUntilRunning(t, ctx)
+
+	invoke := func(daprdProcess *daprd.Daprd) {
+		t.Helper()
+		invokeCtx := metadata.AppendToOutgoingContext(ctx,
+			"dapr-api-token", "default-oldtoken",
+			"x-api-key", "custom-oldtoken",
+		)
+		_, err := daprdProcess.GRPCClient(t, ctx).InvokeService(invokeCtx, &runtimev1.InvokeServiceRequest{
+			Id: daprdProcess.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method:        "helloworld",
+				Data:          new(anypb.Any),
+				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	invoke(c.withToken)
+	select {
+	case header := <-c.ch:
+		assert.Empty(t, header.Values("dapr-api-token"))
+		assert.Equal(t, "abc", header.Get("x-api-key"))
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timed out waiting for custom token header")
+	}
+
+	invoke(c.noToken)
+	select {
+	case header := <-c.ch:
+		assert.Empty(t, header.Values("dapr-api-token"))
+		assert.Empty(t, header.Values("x-api-key"))
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timed out waiting for header without a token")
+	}
+}

--- a/tests/integration/suite/daprd/serviceinvocation/http/appapitoken/customheader.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/appapitoken/customheader.go
@@ -52,11 +52,11 @@ func (c *customheader) Setup(t *testing.T) []framework.Option {
 
 	c.withToken = daprd.New(t,
 		daprd.WithAppAPIToken(t, "abc"),
-		daprd.WithAppAPITokenHeader(t, "x-api-key"),
+		daprd.WithAppAPITokenHeader(t, " X-API-Key "),
 		daprd.WithAppPort(app.Port()),
 	)
 	c.noToken = daprd.New(t,
-		daprd.WithAppAPITokenHeader(t, "x-api-key"),
+		daprd.WithAppAPITokenHeader(t, " X-API-Key "),
 		daprd.WithAppPort(app.Port()),
 	)
 


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->

Add support for choosing the HTTP header or gRPC metadata name used to send the app API token:

- read `DAPR_APP_API_TOKEN_HEADER`, falling back to `dapr-api-token` when unset, empty, or whitespace-only
- trim surrounding whitespace and normalize the configured name to lowercase
- use replacement semantics across HTTP callbacks, gRPC callbacks, jobs, bindings, subscriptions, and the transparent gRPC proxy
- delete caller-supplied default and configured gRPC metadata keys case-insensitively before adding the trusted app token
- inject the custom name from the `dapr.io/app-token-header` Kubernetes annotation
- cover token and no-token behavior over HTTP, transparent gRPC, and public `InvokeService`

The configured name replaces `dapr-api-token`; Dapr does not send both. If `APP_API_TOKEN` is unset, neither reserved name is forwarded. This uses the `DAPR_` namespace requested by maintainers in #7190.

Companion documentation: dapr/docs#5256.

Validation at commit `60aac419899ae21e110e830e3ed9b46b48604545`:

- `make lint` with the repository-pinned golangci-lint v2.10.1
- `go test -count=1 -tags=unit,allcomponents ./pkg/security ./pkg/messaging ./pkg/api/grpc/manager ./pkg/channel/grpc ./pkg/channel/http ./pkg/runtime/... ./pkg/injector/...`
- `go test ./tests/integration -timeout=5m -count=1 -v -tags=integration -integration-parallel=false -focus='^daprd/serviceinvocation/(http|grpc)/appapitoken/customheader$'`
- Manual process validation built an exact-SHA, cgo-disabled, all-components `daprd` and used external HTTP and gRPC applications. Six configurations covered padded mixed-case custom names with and without a token, plus whitespace-only fallback, over HTTP, transparent gRPC, and public `InvokeService`. App-observed headers proved trusted-token replacement, removal when no token is configured, fallback to the default name, and preservation of an unrelated custom header. All processes shut down with no listener leaks.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: Closes #7147

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [x] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#5256
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_

Focused Dapr integration scenarios and manual process validation pass. The full Kubernetes end-to-end suite was not run. No specification change or standalone sample is required; the companion documentation includes configuration examples.
