### PR TITLE
fix(workflow): use CANCELED status for engine-initiated validation fa…

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -480,6 +480,8 @@ func executionStatusForRuntimeStatus(status api.OrchestrationStatus) string {
 		return diag.StatusSuccess
 	case api.RUNTIME_STATUS_TERMINATED:
 		return diag.StatusTerminated
+	case api.RUNTIME_STATUS_CANCELED:
+		return diag.StatusCanceled
 	default:
 		return diag.StatusFailed
 	}

--- a/pkg/actors/targets/workflow/orchestrator/run_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/run_test.go
@@ -597,7 +597,7 @@ func Test_executionStatusForRuntimeStatus(t *testing.T) {
 		{"completed", api.RUNTIME_STATUS_COMPLETED, diag.StatusSuccess},
 		{"terminated", api.RUNTIME_STATUS_TERMINATED, diag.StatusTerminated},
 		{"failed", api.RUNTIME_STATUS_FAILED, diag.StatusFailed},
-		{"canceled falls back to failed", api.RUNTIME_STATUS_CANCELED, diag.StatusFailed},
+		{"canceled", api.RUNTIME_STATUS_CANCELED, diag.StatusCanceled},
 	}
 
 	for _, tt := range tests {

--- a/pkg/actors/targets/workflow/orchestrator/signing/tombstone.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing/tombstone.go
@@ -22,15 +22,15 @@ import (
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 )
 
-// Tombstone appends an unsigned ExecutionCompleted(FAILED) tamper marker to
+// Tombstone appends an unsigned ExecutionCompleted(CANCELED) tamper marker to
 // the workflow's history (see [wfenginestate.MarkAsTamperFailed]) so it
-// surfaces as terminally FAILED on every subsequent load, then deletes the
+// surfaces as terminally CANCELED on every subsequent load, then deletes the
 // actor's reminders so no further activations fire against the dead workflow.
 // The original (untrusted) history, inbox, signatures, and certs are left
-// intact for forensics. Returns the new (failed) state; the caller is
+// intact for forensics. Returns the new (canceled) state; the caller is
 // responsible for refreshing any cached views (state, rstate, ometa).
 func (s *Signing) Tombstone(ctx context.Context, actorState state.Interface, opts wfenginestate.Options, prior *wfenginestate.State, cause error) (*wfenginestate.State, error) {
-	log.Warnf("Workflow actor '%s': tampering detected, marking workflow as FAILED: %s", s.ActorID, cause)
+	log.Warnf("Workflow actor '%s': tampering detected, marking workflow as CANCELED: %s", s.ActorID, cause)
 
 	failed, err := wfenginestate.MarkAsTamperFailed(ctx, actorState, s.ActorID, opts, prior, cause)
 	if err != nil {
@@ -44,7 +44,7 @@ func (s *Signing) Tombstone(ctx context.Context, actorState state.Interface, opt
 // failSignatureVerification deletes all reminders for this workflow to
 // prevent endless retries when signature verification has failed. The
 // workflow state is left untouched; the tamper marker inserted by
-// Tombstone is what surfaces the FAILED status on subsequent loads.
+// Tombstone is what surfaces the CANCELED status on subsequent loads.
 func (s *Signing) failSignatureVerification(ctx context.Context) {
 	log.Warnf("Workflow actor '%s': signature verification failed, deleting reminders to stop retries", s.ActorID)
 

--- a/pkg/diagnostics/workflow_monitoring.go
+++ b/pkg/diagnostics/workflow_monitoring.go
@@ -35,6 +35,7 @@ const (
 	StatusSuccess     = "success"
 	StatusFailed      = "failed"
 	StatusTerminated  = "terminated"
+	StatusCanceled    = "canceled"
 	StatusRecoverable = "recoverable"
 	CreateWorkflow    = "create_workflow"
 	GetWorkflow       = "get_workflow"

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -1019,7 +1019,7 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 // IsTamperMarker reports whether e is the well-known terminal event written
 // by [MarkAsTamperFailed] to record that the workflow's persisted state was
 // detected as tampered. It is identified by an ExecutionCompleted with
-// status FAILED and FailureDetails.ErrorType set to
+// status CANCELED and FailureDetails.ErrorType set to
 // [wferrors.ErrorTypeHistoryTampered]. Loaders use this check to bypass
 // signature verification on workflows that have already been terminally
 // failed by tamper detection — without the bypass, the broken signature
@@ -1032,7 +1032,9 @@ func IsTamperMarker(e *backend.HistoryEvent) bool {
 	if ec == nil {
 		return false
 	}
-	if ec.GetWorkflowStatus() != protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED {
+	status := ec.GetWorkflowStatus()
+	if status != protos.OrchestrationStatus_ORCHESTRATION_STATUS_CANCELED &&
+		status != protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED {
 		return false
 	}
 	fd := ec.GetFailureDetails()
@@ -1063,13 +1065,13 @@ func (s *State) HasTamperMarker() bool {
 	return hasTamperMarker(s)
 }
 
-// MarkAsTamperFailed appends a single terminal ExecutionCompleted(FAILED) event to
+// MarkAsTamperFailed appends a single terminal ExecutionCompleted(CANCELED) event to
 // the workflow's history to record that its persisted state was detected as
 // tampered. The original (untrusted) history, inbox, signatures, and certs
 // are left intact for forensics — only the marker event is added, and it is
 // not signed. Subsequent loads detect the marker via [IsTamperMarker] and
 // bypass signature verification, so the workflow surfaces as terminally
-// FAILED with [wferrors.ErrorTypeHistoryTampered] in its FailureDetails.
+// CANCELED with [wferrors.ErrorTypeHistoryTampered] in its FailureDetails.
 //
 // MarkAsTamperFailed is idempotent: if prior already ends in a tamper marker the
 // state is returned unchanged with no store write.
@@ -1088,7 +1090,7 @@ func MarkAsTamperFailed(ctx context.Context, astate state.Interface, actorID str
 		Timestamp: timestamppb.Now(),
 		EventType: &protos.HistoryEvent_ExecutionCompleted{
 			ExecutionCompleted: &protos.ExecutionCompletedEvent{
-				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_CANCELED,
 				FailureDetails: &protos.TaskFailureDetails{
 					ErrorType:    wferrors.ErrorTypeHistoryTampered,
 					ErrorMessage: cause.Error(),

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -816,7 +816,7 @@ func tamperMarkerEvent() *backend.HistoryEvent {
 		Timestamp: timestamppb.Now(),
 		EventType: &protos.HistoryEvent_ExecutionCompleted{
 			ExecutionCompleted: &protos.ExecutionCompletedEvent{
-				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_CANCELED,
 				FailureDetails: &protos.TaskFailureDetails{
 					ErrorType:    wferrors.ErrorTypeHistoryTampered,
 					ErrorMessage: "boom",

--- a/tests/integration/framework/workflow/httpapi/httpapi.go
+++ b/tests/integration/framework/workflow/httpapi/httpapi.go
@@ -33,6 +33,7 @@ var (
 	StatusCompleted  = helpers.ToRuntimeStatusString(protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED)
 	StatusFailed     = helpers.ToRuntimeStatusString(protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED)
 	StatusTerminated = helpers.ToRuntimeStatusString(protos.OrchestrationStatus_ORCHESTRATION_STATUS_TERMINATED)
+	StatusCanceled   = helpers.ToRuntimeStatusString(protos.OrchestrationStatus_ORCHESTRATION_STATUS_CANCELED)
 )
 
 // Status mirrors the JSON the dapr workflow HTTP API returns for a single
@@ -44,7 +45,7 @@ type Status struct {
 
 // IsTerminal reports whether the runtime status is a terminal workflow state.
 func IsTerminal(s string) bool {
-	return s == StatusCompleted || s == StatusFailed || s == StatusTerminated
+	return s == StatusCompleted || s == StatusFailed || s == StatusTerminated || s == StatusCanceled
 }
 
 // Start starts the named workflow via the HTTP API and returns the new

--- a/tests/integration/suite/daprd/workflow/attestation/mixedparenton.go
+++ b/tests/integration/suite/daprd/workflow/attestation/mixedparenton.go
@@ -72,7 +72,7 @@ func (m *mixedParentOn) Run(t *testing.T, ctx context.Context) {
 
 	meta, err := parentClient.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
-	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED, meta.GetRuntimeStatus())
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_CANCELED, meta.GetRuntimeStatus())
 	assert.Equal(t, errors.ErrorTypeHistoryTampered, meta.GetFailureDetails().GetErrorType())
 
 	assert.Equal(t, 0, fworkflow.ExtSigCertCount(t, ctx, m.workflow.DB(), string(id)))

--- a/tests/integration/suite/daprd/workflow/propagation/signed/emptyappid.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/emptyappid.go
@@ -112,7 +112,7 @@ func (s *emptyappid) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"empty appId on chunk must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/emptychunkwithsigs.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/emptychunkwithsigs.go
@@ -116,7 +116,7 @@ func (s *emptychunkwithsigs) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"empty chunk with attached signatures must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/extrarawevents.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/extrarawevents.go
@@ -112,7 +112,7 @@ func (s *extrarawevents) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"appending an unsigned rawEvent must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/missingcerts.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/missingcerts.go
@@ -113,7 +113,7 @@ func (s *missingcerts) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"missing signingCertChains on chunk must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/mixedchunks.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/mixedchunks.go
@@ -134,7 +134,7 @@ func (s *mixedchunks) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client2.FetchWorkflowMetadata(ctx, api.InstanceID(leafID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"any tampered chunk in a multi-chunk lineage must tombstone the receiver")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/outofbounds.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/outofbounds.go
@@ -118,7 +118,7 @@ func (s *outofbounds) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"truncating a chunk's rawEvents must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/tamperedappid.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/tamperedappid.go
@@ -118,7 +118,7 @@ func (s *tamperedappid) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"chunk-appid mismatch must tombstone the child workflow")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/tamperedcert.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/tamperedcert.go
@@ -130,7 +130,7 @@ func (s *tamperedcert) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"swapped signing cert must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/tamperedevent.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/tamperedevent.go
@@ -127,11 +127,11 @@ func (s *tamperedevent) Run(t *testing.T, ctx context.Context) {
 	// path runs first; tamper detection trumps the event delivery.
 	require.NoError(t, client1.RaiseEvent(ctx, api.InstanceID(childID), "continue", api.WithEventPayload("real-event")))
 
-	// Tampered child workflow must surface as FAILED.
+	// Tampered child workflow must surface as CANCELED.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"tampered propagated-history must tombstone the child workflow")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/tamperednamespace.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/tamperednamespace.go
@@ -116,7 +116,7 @@ func (s *tamperednamespace) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"signing cert with mismatched namespace must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/propagation/signed/tamperedsig.go
+++ b/tests/integration/suite/daprd/workflow/propagation/signed/tamperedsig.go
@@ -118,7 +118,7 @@ func (s *tamperedsig) Run(t *testing.T, ctx context.Context) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		meta, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
 		assert.NoError(c, err)
-		assert.Equal(c, api.RUNTIME_STATUS_FAILED, meta.GetRuntimeStatus(),
+		assert.Equal(c, api.RUNTIME_STATUS_CANCELED, meta.GetRuntimeStatus(),
 			"missing rawSignatures on chunk must tombstone the child")
 	}, 20*time.Second, 10*time.Millisecond)
 }

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -169,7 +169,7 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 		if !assert.NotNil(c, meta) {
 			return
 		}
-		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
+		if !assert.Equal(c, dworkflow.StatusCanceled, meta.RuntimeStatus) {
 			return
 		}
 		if !assert.NotNil(c, meta.FailureDetails) {

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -170,7 +170,7 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 			return
 		}
 
-		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
+		if !assert.Equal(c, dworkflow.StatusCanceled, meta.RuntimeStatus) {
 			return
 		}
 

--- a/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
+++ b/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
@@ -134,7 +134,7 @@ func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
 		if !assert.NotNil(c, meta) {
 			return
 		}
-		if !assert.Equal(c, dworkflow.StatusFailed, meta.RuntimeStatus) {
+		if !assert.Equal(c, dworkflow.StatusCanceled, meta.RuntimeStatus) {
 			return
 		}
 		if !assert.NotNil(c, meta.FailureDetails) {


### PR DESCRIPTION
## Description

This PR updates engine-initiated workflow validation failures to use `ORCHESTRATION_STATUS_CANCELED` instead of `ORCHESTRATION_STATUS_FAILED`.

The change also preserves backward compatibility by allowing legacy `FAILED` tamper markers to continue to be recognized.

## Issue reference

Closes #10219

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] All tests passed locally