### PR TITLE
feat(kubernetes): add appProtocol to Dapr Kubernetes Services for Istio protocol detection

### DIFF
--- a/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
+++ b/charts/dapr/charts/dapr_operator/templates/dapr_operator_service.yaml
@@ -27,6 +27,7 @@ spec:
     port: {{ .Values.ports.port }}
     targetPort: {{ .Values.ports.targetPort }}
     name: grpc
+    appProtocol: {{ if .Values.global.mtls.enabled }}grpcs{{ else }}grpc{{ end }}
 # Added for backwards compatibility where previous clients will attempt to
 # connect on port 80.
 # TOOD: @joshvanl: remove in v1.14
@@ -35,12 +36,14 @@ spec:
     port: 80
     targetPort: {{ .Values.ports.targetPort }}
     name: legacy
+    appProtocol: {{ if .Values.global.mtls.enabled }}grpcs{{ else }}grpc{{ end }}
 {{ end }}
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
     targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
+    appProtocol: http
 {{- end}}
 ---
 apiVersion: v1
@@ -59,8 +62,10 @@ metadata:
 spec:
   type: {{ .Values.webhookService.type }}
   ports:
-  - port: 443
+  - name: https
+    port: 443
     targetPort: 19443
     protocol: TCP
+    appProtocol: https
   selector:
     app: dapr-operator

--- a/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
+++ b/charts/dapr/charts/dapr_placement/templates/dapr_placement_service.yaml
@@ -29,13 +29,16 @@ spec:
   ports:
   - name: api
     port: {{ .Values.ports.apiPort }}
+    appProtocol: {{ if .Values.global.mtls.enabled }}grpcs{{ else }}grpc{{ end }}
   - name: raft-node
     port: {{ .Values.ports.raftRPCPort }}
+    appProtocol: tcp
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
     targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
+    appProtocol: http
 {{- end}}
   clusterIP: None
 {{- end }}

--- a/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
+++ b/charts/dapr/charts/dapr_scheduler/templates/dapr_scheduler_service.yaml
@@ -30,15 +30,19 @@ spec:
   - name: api
     port: 443
     targetPort: 50006
+    appProtocol: {{ if .Values.global.mtls.enabled }}grpcs{{ else }}grpc{{ end }}
   - name: etcd-client
     port: {{ .Values.ports.etcdGRPCClientPort }}
+    appProtocol: tcp
   - name: etcd-peer
     port: {{ .Values.ports.etcdGRPCPeerPort }}
+    appProtocol: tcp
   {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
     targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
+    appProtocol: http
   {{- end}}
   type: ClusterIP
 {{- end }}
@@ -74,15 +78,19 @@ spec:
   ports:
   - name: api
     port: 50006
+    appProtocol: {{ if .Values.global.mtls.enabled }}grpcs{{ else }}grpc{{ end }}
   - name: etcd-client
     port: {{ .Values.ports.etcdGRPCClientPort }}
+    appProtocol: tcp
   - name: etcd-peer
     port: {{ .Values.ports.etcdGRPCPeerPort }}
+    appProtocol: tcp
   {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
     targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
+    appProtocol: http
   {{- end}}
   clusterIP: None # make the service headless
 {{- end }}

--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_service.yaml
@@ -27,15 +27,18 @@ spec:
     port: {{ .Values.ports.port }}
     targetPort: {{ .Values.ports.targetPort }}
     name: grpc
+    appProtocol: {{ if .Values.global.mtls.enabled }}grpcs{{ else }}grpc{{ end }}
 {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
     targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
+    appProtocol: http
 {{- end}}
 {{- if .Values.oidc.enabled }}
   - name: oidc
     port: {{ .Values.oidc.server.port }}
     targetPort: 9080
     protocol: TCP
+    appProtocol: http
 {{- end }}

--- a/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
+++ b/charts/dapr/charts/dapr_sidecar_injector/templates/dapr_sidecar_injector_service.yaml
@@ -28,10 +28,12 @@ spec:
     targetPort: https
     protocol: TCP
     name: https
+    appProtocol: https
   {{- if eq .Values.global.prometheus.enabled true }}
   - name: metrics
     port: {{ .Values.global.prometheus.port }}
     targetPort: {{ .Values.global.prometheus.port }}
     protocol: TCP
+    appProtocol: http
   {{- end}}
 {{- end }}


### PR DESCRIPTION
## Description

This PR adds the `appProtocol` field to all Dapr Kubernetes Service templates to explicitly define the application protocol for each Service port.

Adding `appProtocol` allows Istio, Envoy, and other service meshes to correctly identify protocols without relying on protocol sniffing, improving protocol detection and interoperability.

### Changes
- Added `appProtocol` to all Dapr control plane Kubernetes Services.
- Configured gRPC endpoints to use `grpcs` when control plane mTLS is enabled and `grpc` otherwise.
- Configured webhook endpoints to use `https`.
- Configured Prometheus metrics endpoints to use `http`.
- Configured internal Raft and etcd communication ports to use `tcp`.
- Added an explicit port name (`https`) for the `dapr-webhook` Service where required.

## Why

Explicitly defining `appProtocol` improves compatibility with service meshes such as Istio by eliminating protocol ambiguity and reducing reliance on protocol sniffing.

Fixes #10231

## Testing

- Reviewed all modified Helm templates.
- Verified that only the intended Service templates were modified.
- Confirmed the `appProtocol` values are appropriate for each Service port.
- Automated validation (`go test` and `helm template`) could not be executed in the local environment because the required binaries were unavailable. The changes are expected to be validated by the project's CI pipeline.

## Checklist

- [x] Follows the project's coding conventions
- [x] Only the intended Helm Service templates were modified
- [x] No unrelated changes included
- [x] References the associated issue