### PR TITLE
version-skew: Fix master

### DIFF
--- a/.github/scripts/version-skew-test-patches/integration/release-1.18/control-plane-master/001-fake-informer-periodic-relist.patch
+++ b/.github/scripts/version-skew-test-patches/integration/release-1.18/control-plane-master/001-fake-informer-periodic-relist.patch
@@ -1,0 +1,382 @@
+diff --git a/tests/integration/framework/process/kubernetes/informer/informer.go b/tests/integration/framework/process/kubernetes/informer/informer.go
+index fe393ce9..d96784a2 100644
+--- a/tests/integration/framework/process/kubernetes/informer/informer.go
++++ b/tests/integration/framework/process/kubernetes/informer/informer.go
+@@ -17,6 +17,7 @@ import (
+ 	"bytes"
+ 	"context"
+ 	"encoding/json"
++	"errors"
+ 	"math/rand/v2"
+ 	"net/http"
+ 	"strings"
+@@ -33,6 +34,8 @@ import (
+ 	"k8s.io/apimachinery/pkg/runtime/schema"
+ 	"k8s.io/apimachinery/pkg/watch"
+ 
++	"github.com/dapr/kit/events/loop"
++
+ 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+ 	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
+ 	httpendapi "github.com/dapr/dapr/pkg/apis/httpEndpoint/v1alpha1"
+@@ -42,19 +45,70 @@ import (
+ 	wfaclapi "github.com/dapr/dapr/pkg/apis/workflowaccesspolicy/v1alpha1"
+ )
+ 
+-// Informer is a fake informer that adds events to the Kubernetes API server to
+-// send events to clients.
++// informedSendTimeout is how long inform() waits when notifying
++// test-side observers (e.g. DeleteWait) before failing the test.
++const informedSendTimeout = 3 * time.Second
++
++// rotateInterval is how long a /watch connection is held open before the
++// fake informer closes it to force the K8s reflector on the other end to
++// reconnect and re-LIST. See the comment on the close goroutine inside
++// Handler for why this exists.
++const rotateInterval = 200 * time.Millisecond
++
++// streamFactory pools queue segments across all active /watch handlers.
++// The segment size is small because most watchers process events as fast
++// as they arrive; the loop grows additional segments on demand when a
++// burst exceeds one segment.
++var streamFactory = loop.New[streamEvent](16)
++
++// streamEvent is the event type for the per-watcher event loop. A non-nil
++// payload is a watch event to deliver; closed=true is the shutdown
++// sentinel emitted on disconnect so the loop drains and exits.
++type streamEvent struct {
++	payload []byte
++	closed  bool
++}
++
++// Informer is a fake informer that pushes events to Kubernetes watch
++// clients over a single long-lived chunked HTTP response.
++//
++// Previously each call to /watch popped one queued event and closed the
++// connection, forcing the K8s reflector inside the operator to reconnect
++// for every event with exponential backoff. That made every event cost
++// seconds of test wall time. Now the handler holds the connection open
++// for the lifetime of the request and streams events out as they arrive,
++// so the reflector observes a steady-state watch and never needs to
++// backoff between events. The per-watcher queue is a dapr/kit/events/loop
++// so we never have to bound the in-flight buffer.
+ type Informer struct {
+-	lock   sync.Mutex
+-	active map[string][][]byte
++	lock sync.Mutex
++
++	// backlog is per-GVK events emitted while no watcher was connected
++	// for that GVK. Drained on the next /watch connection.
++	backlog map[string][][]byte
++
++	// streams is per-GVK loops held by currently-active /watch handlers.
++	// inform() fans events out to every loop.
++	streams map[string][]loop.Interface[streamEvent]
+ 
+-	informed map[uint64]chan *metav1.WatchEvent
++	// informed is test-side observation channels (DeleteWait & co.).
++	// Fired when an event is actually delivered to a watcher.
++	informed map[uint64]*informedSub
++}
++
++// informedSub is a single test-side observer. done is closed when the observer
++// stops reading ch, so senders select on it rather than risk sending on a
++// channel the observer has abandoned.
++type informedSub struct {
++	ch   chan *metav1.WatchEvent
++	done chan struct{}
+ }
+ 
+ func New() *Informer {
+ 	return &Informer{
+-		active:   make(map[string][][]byte),
+-		informed: make(map[uint64]chan *metav1.WatchEvent),
++		backlog:  make(map[string][][]byte),
++		streams:  make(map[string][]loop.Interface[streamEvent]),
++		informed: make(map[uint64]*informedSub),
+ 	}
+ }
+ 
+@@ -65,58 +119,141 @@ func (i *Informer) Handler(t *testing.T, wrapped http.Handler) http.HandlerFunc
+ 			return
+ 		}
+ 
+-		i.lock.Lock()
+-		defer i.lock.Unlock()
+-
+-		path := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/apis/"), "/api/")
+-
+-		var gvk schema.GroupVersionKind
+-		split := strings.Split(path, "/")
+-		if !assert.GreaterOrEqual(t, len(split), 2, "invalid path: %s", path) {
++		gvk, ok := parseGVK(t, r.URL.Path)
++		if !ok {
+ 			return
+ 		}
+-		if split[0] == "v1" {
+-			gvk = schema.GroupVersionKind{Group: "", Version: "v1"}
+-			split = split[1:]
+-		} else {
+-			gvk = schema.GroupVersionKind{Group: strings.Split(path, "/")[0], Version: strings.Split(path, "/")[1]}
+-			split = split[2:]
+-		}
+-		if split[0] == "namespaces" {
+-			// namespace resources are special cased in the Kubernetes CRUD resource
+-			// URL, so we need to handle them differently.
+-			if len(split) > 1 {
+-				split = split[2:]
+-				gvk.Kind = split[0]
+-			} else {
+-				gvk.Kind = "namespaces"
+-			}
+-		} else {
+-			gvk.Kind = split[0]
+-		}
++		gvkKey := gvk.String()
+ 
+ 		w.Header().Add("Transfer-Encoding", "chunked")
+ 		w.Header().Add("Content-Type", "application/json")
+ 		w.WriteHeader(http.StatusOK)
++		flusher, _ := w.(http.Flusher)
+ 
+-		if len(i.active[gvk.String()]) > 0 {
+-			var event metav1.WatchEvent
+-			assert.NoError(t, json.Unmarshal(i.active[gvk.String()][0], &event))
+-			w.Write(i.active[gvk.String()][0])
+-			i.active[gvk.String()] = i.active[gvk.String()][1:]
+-
+-			for _, ch := range i.informed {
+-				select {
+-				case ch <- &event:
+-				case <-time.After(3 * time.Second):
+-					t.Errorf("failed to send informed event to subscriber")
+-				}
++		// Build the per-watcher loop. Its Handle method writes events to
++		// this response; on Write failure it returns errClientGone and
++		// Run unwinds, which we treat as "client disconnected, drain and
++		// stop".
++		h := &streamHandler{
++			informer: i,
++			t:        t,
++			w:        w,
++			flusher:  flusher,
++		}
++		l := streamFactory.NewLoop(h)
++
++		// Register the loop under this GVK and atomically pick up any
++		// backlog so subsequent inform() calls go through us.
++		i.lock.Lock()
++		backlog := i.backlog[gvkKey]
++		i.backlog[gvkKey] = nil
++		i.streams[gvkKey] = append(i.streams[gvkKey], l)
++		i.lock.Unlock()
++
++		// Pre-load backlog onto the loop; Run will process them before
++		// blocking on new events.
++		for _, b := range backlog {
++			l.Enqueue(streamEvent{payload: b})
++		}
++
++		// Cancel the loop when the client disconnects, or after the
++		// rotateInterval window, whichever comes first.
++		//
++		// The periodic close mirrors master's behaviour without the per-
++		// event reconnect penalty: holding /watch open lets bursts of
++		// explicit Informer().Add events stream back-to-back, while the
++		// rotation forces the reflector to do a fresh LIST every few
++		// hundred ms. That fresh LIST is what makes store-only mutations
++		// (tests that call store.Add without a paired Informer().Add)
++		// observable to consumers like the operator, and it lets typed
++		// TypeMeta survive the trip through controller-runtime's cache,
++		// which we have seen get stripped when the same item arrives via
++		// the watch decode path instead of the list decode path.
++		//
++		// The disconnect goroutine reads loop internals via l.Close, so
++		// we must wait for it to fully exit before recycling the loop,
++		// otherwise the next NewLoop on the recycled instance races with
++		// this Close.
++		runCtx, cancel := context.WithCancel(r.Context())
++		closerDone := make(chan struct{})
++		go func() {
++			defer close(closerDone)
++			select {
++			case <-runCtx.Done():
++			case <-time.After(rotateInterval):
++			}
++			l.Close(streamEvent{closed: true})
++		}()
++
++		runErr := l.Run(runCtx)
++
++		// Unregister before triggering Close so no further inform() calls
++		// can enqueue onto a loop that's about to be recycled.
++		i.lock.Lock()
++		for j, c := range i.streams[gvkKey] {
++			if c == l {
++				i.streams[gvkKey] = append(i.streams[gvkKey][:j], i.streams[gvkKey][j+1:]...)
++				break
+ 			}
+ 		}
+-		w.(http.Flusher).Flush()
++		i.lock.Unlock()
++
++		cancel()
++		<-closerDone
++		streamFactory.CacheLoop(l)
++		_ = runErr
+ 	}
+ }
+ 
++// streamHandler is the per-watcher loop.Handler[streamEvent] that writes
++// events to one HTTP response.
++type streamHandler struct {
++	informer *Informer
++	t        *testing.T
++	w        http.ResponseWriter
++	flusher  http.Flusher
++}
++
++var errClientGone = errors.New("informer: client disconnected")
++
++// Handle writes one streamEvent. Returns errClientGone if the HTTP write
++// fails (the client closed its end), which exits the per-watcher loop.
++func (h *streamHandler) Handle(_ context.Context, ev streamEvent) error {
++	if ev.closed {
++		return errClientGone
++	}
++	var event metav1.WatchEvent
++	if err := json.Unmarshal(ev.payload, &event); err != nil {
++		assert.NoError(h.t, err)
++		return errClientGone
++	}
++	if _, err := h.w.Write(ev.payload); err != nil {
++		return errClientGone
++	}
++	if h.flusher != nil {
++		h.flusher.Flush()
++	}
++
++	// Snapshot informed subscribers under the lock, then notify outside
++	// the lock so a slow subscriber cannot wedge inform() callers.
++	h.informer.lock.Lock()
++	subs := make([]*informedSub, 0, len(h.informer.informed))
++	for _, c := range h.informer.informed {
++		subs = append(subs, c)
++	}
++	h.informer.lock.Unlock()
++
++	for _, c := range subs {
++		select {
++		case c.ch <- &event:
++		case <-c.done:
++		case <-time.After(informedSendTimeout):
++			h.t.Errorf("failed to send informed event to subscriber")
++		}
++	}
++	return nil
++}
++
+ func (i *Informer) Add(t *testing.T, obj runtime.Object) {
+ 	t.Helper()
+ 	i.inform(t, obj, string(watch.Added))
+@@ -138,15 +275,18 @@ func (i *Informer) DeleteWait(t *testing.T, ctx context.Context, obj runtime.Obj
+ 	i.lock.Lock()
+ 	//nolint:gosec
+ 	ui := rand.Uint64()
+-	ch := make(chan *metav1.WatchEvent)
+-	i.informed[ui] = ch
++	sub := &informedSub{
++		ch:   make(chan *metav1.WatchEvent),
++		done: make(chan struct{}),
++	}
++	i.informed[ui] = sub
+ 	i.lock.Unlock()
+ 
+ 	defer func() {
+ 		i.lock.Lock()
+-		close(ch)
+ 		delete(i.informed, ui)
+ 		i.lock.Unlock()
++		close(sub.done)
+ 	}()
+ 
+ 	i.Delete(t, obj)
+@@ -159,7 +299,7 @@ func (i *Informer) DeleteWait(t *testing.T, ctx context.Context, obj runtime.Obj
+ 		case <-ctx.Done():
+ 			assert.Fail(t, "failed to wait for delete event to occur")
+ 			return
+-		case e := <-ch:
++		case e := <-sub.ch:
+ 			if e.Type != string(watch.Deleted) {
+ 				continue
+ 			}
+@@ -175,9 +315,6 @@ func (i *Informer) DeleteWait(t *testing.T, ctx context.Context, obj runtime.Obj
+ 
+ func (i *Informer) inform(t *testing.T, obj runtime.Object, event string) {
+ 	t.Helper()
+-	i.lock.Lock()
+-	defer i.lock.Unlock()
+-
+ 	gvk := i.objToGVK(t, obj)
+ 
+ 	watchObjB, err := json.Marshal(obj)
+@@ -188,7 +325,58 @@ func (i *Informer) inform(t *testing.T, obj runtime.Object, event string) {
+ 		Object: runtime.RawExtension{Raw: watchObjB, Object: obj},
+ 	})
+ 	require.NoError(t, err)
+-	i.active[gvk.String()] = append(i.active[gvk.String()], watchEvent)
++
++	i.lock.Lock()
++	defer i.lock.Unlock()
++
++	streams := i.streams[gvk.String()]
++	if len(streams) == 0 {
++		// No connected watcher: stash until one connects.
++		i.backlog[gvk.String()] = append(i.backlog[gvk.String()], watchEvent)
++		return
++	}
++	for _, l := range streams {
++		// Enqueue is non-blocking and the loop's queue is unbounded.
++		l.Enqueue(streamEvent{payload: watchEvent})
++	}
++}
++
++// parseGVK pulls the GroupVersionKind out of a Kubernetes watch URL of the
++// form /apis/<group>/<version>/[namespaces/<ns>/]<kind> or
++// /api/v1/[namespaces/<ns>/]<kind>.
++func parseGVK(t *testing.T, urlPath string) (schema.GroupVersionKind, bool) {
++	t.Helper()
++	path := strings.TrimPrefix(strings.TrimPrefix(urlPath, "/apis/"), "/api/")
++	split := strings.Split(path, "/")
++	if !assert.GreaterOrEqual(t, len(split), 2, "invalid path: %s", path) {
++		return schema.GroupVersionKind{}, false
++	}
++
++	var gvk schema.GroupVersionKind
++	if split[0] == "v1" {
++		gvk = schema.GroupVersionKind{Group: "", Version: "v1"}
++		split = split[1:]
++	} else {
++		gvk = schema.GroupVersionKind{Group: split[0], Version: split[1]}
++		split = split[2:]
++	}
++	if !assert.NotEmpty(t, split, "invalid path: %s", path) {
++		return schema.GroupVersionKind{}, false
++	}
++	if split[0] == "namespaces" {
++		switch {
++		case len(split) == 1:
++			gvk.Kind = "namespaces"
++		case len(split) >= 3:
++			gvk.Kind = split[2]
++		default:
++			assert.Fail(t, "invalid path: missing kind", path)
++			return schema.GroupVersionKind{}, false
++		}
++	} else {
++		gvk.Kind = split[0]
++	}
++	return gvk, true
+ }
+ 
+ func (i *Informer) objToGVK(t *testing.T, obj runtime.Object) schema.GroupVersionKind {

--- a/.github/scripts/version-skew-test-patches/integration/release-1.18/control-plane-master/002-operator-pod-config-resolution.patch
+++ b/.github/scripts/version-skew-test-patches/integration/release-1.18/control-plane-master/002-operator-pod-config-resolution.patch
@@ -1,0 +1,96 @@
+diff --git a/tests/integration/framework/process/kubernetes/options.go b/tests/integration/framework/process/kubernetes/options.go
+index b61a2e73..c05c59eb 100644
+--- a/tests/integration/framework/process/kubernetes/options.go
++++ b/tests/integration/framework/process/kubernetes/options.go
+@@ -156,6 +156,10 @@ func WithSecretList(t *testing.T, secrets *corev1.SecretList) Option {
+ 	return handleClusterListResource(t, "/api/v1/secrets", secrets)
+ }
+ 
++func WithClusterSecretListFromStore(t *testing.T, store *store.Store) Option {
++	return handleClusterListResourceFromStore(t, "/api/v1/secrets", store)
++}
++
+ func WithDaprResiliencyGet(t *testing.T, ns, name string, res *resapi.Resiliency) Option {
+ 	return handleGetResource(t, "/apis/dapr.io/v1alpha1", "resiliencies", ns, name, res)
+ }
+@@ -177,6 +181,7 @@ func WithBaseOperatorAPI(t *testing.T, td spiffeid.TrustDomain, ns string, sentr
+ 					},
+ 				},
+ 			}),
++			WithClusterPodList(t, &corev1.PodList{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PodList"}}),
+ 			WithClusterServiceList(t, &corev1.ServiceList{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceList"}}),
+ 			WithClusterStatefulSetList(t, &appsv1.StatefulSetList{TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSetList"}}),
+ 			WithClusterDeploymentList(t, &appsv1.DeploymentList{TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "DeploymentList"}}),
+diff --git a/tests/integration/framework/process/kubernetes/store/store.go b/tests/integration/framework/process/kubernetes/store/store.go
+index 88a861ca..43e8d311 100644
+--- a/tests/integration/framework/process/kubernetes/store/store.go
++++ b/tests/integration/framework/process/kubernetes/store/store.go
+@@ -78,8 +78,15 @@ func (s *Store) Objects() map[string]any {
+ 		objs = nil
+ 	}
+ 
++	// Core group resources (e.g. v1 Secrets) have an empty group and their
++	// apiVersion is just the version.
++	apiVersion := s.gvk.Version
++	if s.gvk.Group != "" {
++		apiVersion = s.gvk.Group + "/" + s.gvk.Version
++	}
++
+ 	return map[string]any{
+-		"apiVersion": s.gvk.Group + "/" + s.gvk.Version,
++		"apiVersion": apiVersion,
+ 		"kind":       s.gvk.Kind + "List",
+ 		"items":      objs,
+ 	}
+diff --git a/tests/integration/suite/operator/api/configurationupdate/basic.go b/tests/integration/suite/operator/api/configurationupdate/basic.go
+index e9f220d2..edc81344 100644
+--- a/tests/integration/suite/operator/api/configurationupdate/basic.go
++++ b/tests/integration/suite/operator/api/configurationupdate/basic.go
+@@ -22,9 +22,12 @@ import (
+ 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+ 	"github.com/stretchr/testify/assert"
+ 	"github.com/stretchr/testify/require"
++	corev1 "k8s.io/api/core/v1"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 
+ 	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
++	"github.com/dapr/dapr/pkg/injector/annotations"
++	injectorconsts "github.com/dapr/dapr/pkg/injector/consts"
+ 	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
+ 	"github.com/dapr/dapr/tests/integration/framework"
+ 	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+@@ -54,6 +57,23 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
+ 		Version: "v1alpha1",
+ 		Kind:    "Configuration",
+ 	})
++	// The operator resolves the configuration assigned to "myapp" from its pod's
++	// dapr.io/config annotation, and only streams updates for that configuration.
++	pod := &corev1.Pod{
++		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
++		ObjectMeta: metav1.ObjectMeta{
++			Name:      "myapp",
++			Namespace: "default",
++			Labels:    map[string]string{injectorconsts.SidecarInjectedLabel: "true"},
++			Annotations: map[string]string{
++				annotations.KeyEnabled: "true",
++				annotations.KeyAppID:   "myapp",
++				annotations.KeyConfig:  "myconfig",
++			},
++		},
++		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "daprd"}}},
++	}
++
+ 	b.kubeapi = kubernetes.New(t,
+ 		kubernetes.WithBaseOperatorAPI(t,
+ 			spiffeid.RequireTrustDomainFromString("integration.test.dapr.io"),
+@@ -61,6 +81,10 @@ func (b *basic) Setup(t *testing.T) []framework.Option {
+ 			b.sentry.Port(),
+ 		),
+ 		kubernetes.WithClusterDaprConfigurationListFromStore(t, b.store),
++		kubernetes.WithClusterPodList(t, &corev1.PodList{
++			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PodList"},
++			Items:    []corev1.Pod{*pod},
++		}),
+ 	)
+ 
+ 	b.operator = operator.New(t,

--- a/.github/scripts/version-skew-test-patches/integration/release-1.18/dapr-sidecar-master/001-mcpserver-error-wrapping-log.patch
+++ b/.github/scripts/version-skew-test-patches/integration/release-1.18/dapr-sidecar-master/001-mcpserver-error-wrapping-log.patch
@@ -1,0 +1,52 @@
+diff --git a/tests/integration/suite/daprd/hotreload/selfhosted/mcpserverignoreerrors.go b/tests/integration/suite/daprd/hotreload/selfhosted/mcpserverignoreerrors.go
+index 941a7fa6..6ff50bca 100644
+--- a/tests/integration/suite/daprd/hotreload/selfhosted/mcpserverignoreerrors.go
++++ b/tests/integration/suite/daprd/hotreload/selfhosted/mcpserverignoreerrors.go
+@@ -33,6 +33,22 @@ func init() {
+ 	suite.Register(new(mcpserverignoreerrors))
+ }
+ 
++// mcpserverignoreerrors mirrors the components ignoreerrors suite for
++// MCPServer hot-reload. It exercises:
++//
++//  1. Hot-reload update on an existing server with a spec that fails
++//     security validation under IgnoreErrors=true: the old server is closed
++//     (DeleteMCPServer side) and the new one is rejected, so compstore ends
++//     up empty.
++//  2. After IgnoreErrors=true failure, switching back to a valid spec
++//     re-registers the server.
++//  3. A hot-reload update that fails validation with IgnoreErrors=false
++//     surfaces the error through the reconciler and shuts down daprd.
++//
++// All servers in this test use IgnoreErrors=true (except the final exit
++// case) so the workflow-registration step against example.com can fail
++// without crashing daprd; we are exercising the reconciler error-policy
++// machinery, not real MCP traffic.
+ type mcpserverignoreerrors struct {
+ 	daprd   *daprd.Daprd
+ 	logline *logline.LogLine
+@@ -42,8 +58,13 @@ type mcpserverignoreerrors struct {
+ func (m *mcpserverignoreerrors) Setup(t *testing.T) []framework.Option {
+ 	m.logline = logline.New(t,
+ 		logline.WithStdoutLineContains(
+-			`Ignoring error processing MCPServer: MCPServer \"a\" failed security validation:`,
+-			`Error processing MCPServer, daprd will exit gracefully: MCPServer \"a\" failed security validation:`,
++			// daprd writes the message field in logrus's quoted form, so
++			// MCPServer "a" appears in the line as MCPServer \"a\".
++			// Update with ignoreErrors=true and a bad scheme: logged then
++			// ignored, server is not re-added.
++			`Ignoring error processing MCPServer: process MCPServer a error: MCPServer \"a\" failed security validation:`,
++			// Final update with ignoreErrors=false: daprd exits gracefully.
++			`Error processing MCPServer, daprd will exit gracefully: process MCPServer a error: MCPServer \"a\" failed security validation:`,
+ 		),
+ 	)
+ 
+@@ -95,6 +116,8 @@ spec:
+     streamableHTTP:
+       url: ftp://example.com/mcp
+ `), 0o600))
++		// Reconciler runs DeleteMCPServer (close) then AddPendingMCPServer
++		// (rejected by security validation). End state: empty compstore.
+ 		require.EventuallyWithT(t, func(t *assert.CollectT) {
+ 			assert.Empty(t, m.daprd.GetMetaMCPServers(t, ctx))
+ 		}, time.Second*5, time.Millisecond*10)

--- a/.github/scripts/version-skew-test-patches/integration/release-1.18/dapr-sidecar-master/002-circuitbreaker-gauge-closed.patch
+++ b/.github/scripts/version-skew-test-patches/integration/release-1.18/dapr-sidecar-master/002-circuitbreaker-gauge-closed.patch
@@ -1,0 +1,35 @@
+diff --git a/tests/integration/suite/daprd/resiliency/apps/defaultcircuitbreaker.go b/tests/integration/suite/daprd/resiliency/apps/defaultcircuitbreaker.go
+index 1160f084..4176c8e1 100644
+--- a/tests/integration/suite/daprd/resiliency/apps/defaultcircuitbreaker.go
++++ b/tests/integration/suite/daprd/resiliency/apps/defaultcircuitbreaker.go
+@@ -175,11 +175,13 @@ func (d *defaultcircuitbreaker) Run(t *testing.T, ctx context.Context) {
+ 		assert.Equal(t, http.StatusOK, resp.StatusCode)
+ 		require.NoError(t, resp.Body.Close())
+ 
+-		// make sure gauge is half open
++		// The gauge must immediately update to "closed" once the probe succeeds
++		// (fix for #10113: the gauge previously stayed stuck at "half-open" until
++		// the next policy instantiation).
+ 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+ 			mtc := d.daprdClient.Metrics(c, ctx).All()
+-			assert.InDelta(c, float64(0), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:open|target:app_server"], 0)
+-			assert.InDelta(c, float64(1), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:half-open|target:app_server"], 0)
++			assert.InDelta(c, float64(0), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:half-open|target:app_server"], 0)
++			assert.InDelta(c, float64(1), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:closed|target:app_server"], 0)
+ 		}, time.Second*4, 10*time.Millisecond)
+ 
+ 		// Subsequent calls should succeed
+@@ -190,13 +192,6 @@ func (d *defaultcircuitbreaker) Run(t *testing.T, ctx context.Context) {
+ 		assert.Equal(t, http.StatusOK, resp.StatusCode)
+ 		require.NoError(t, resp.Body.Close())
+ 
+-		// make sure gauge is closed
+-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+-			mtc := d.daprdClient.Metrics(c, ctx).All()
+-			assert.InDelta(c, float64(0), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:half-open|target:app_server"], 0)
+-			assert.InDelta(c, float64(1), mtc["dapr_resiliency_cb_state|app_id:client|flow_direction:outbound|name:myresiliency|namespace:|policy:circuitbreaker|status:closed|target:app_server"], 0)
+-		}, time.Second*4, 10*time.Millisecond)
+-
+ 		// Verify the total number of calls made to the server
+ 		assert.Equal(t, int32(5), d.callCount2.Load())
+ 	})

--- a/.github/workflows/version-skew.yaml
+++ b/.github/workflows/version-skew.yaml
@@ -61,8 +61,31 @@ jobs:
         - dapr-sidecar-master
     steps:
     - name: Set up for Dapr lastest release
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        echo "DAPR_PREV_VERSION=$(curl -s https://api.github.com/repos/dapr/dapr/releases/latest | jq -r '.tag_name' | cut -c 2-)" >> $GITHUB_ENV
+        set -euo pipefail
+        # Authenticate the API call (anonymous requests are aggressively rate
+        # limited and would otherwise return an error body with no tag_name,
+        # silently yielding a bogus ref like "vull" and failing the checkout).
+        tag=""
+        for i in 1 2 3 4 5; do
+          tag="$(curl -sSf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/dapr/dapr/releases/latest \
+            | jq -r '.tag_name // empty')"
+          if [ -n "$tag" ]; then
+            break
+          fi
+          echo "Attempt $i: could not resolve latest Dapr release tag, retrying..." >&2
+          sleep $((i * 5))
+        done
+        if [ -z "$tag" ]; then
+          echo "Failed to resolve the latest Dapr release tag" >&2
+          exit 1
+        fi
+        echo "DAPR_PREV_VERSION=${tag#v}" >> $GITHUB_ENV
     - name: Set up for master
       if: github.event_name != 'repository_dispatch'
       run: |
@@ -243,8 +266,31 @@ jobs:
         - dapr-sidecar-master
     steps:
     - name: Set up for Dapr lastest release
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        echo "DAPR_PREV_VERSION=$(curl -s https://api.github.com/repos/dapr/dapr/releases/latest | jq -r '.tag_name' | cut -c 2-)" >> $GITHUB_ENV
+        set -euo pipefail
+        # Authenticate the API call (anonymous requests are aggressively rate
+        # limited and would otherwise return an error body with no tag_name,
+        # silently yielding a bogus ref like "vull" and failing the checkout).
+        tag=""
+        for i in 1 2 3 4 5; do
+          tag="$(curl -sSf \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/dapr/dapr/releases/latest \
+            | jq -r '.tag_name // empty')"
+          if [ -n "$tag" ]; then
+            break
+          fi
+          echo "Attempt $i: could not resolve latest Dapr release tag, retrying..." >&2
+          sleep $((i * 5))
+        done
+        if [ -z "$tag" ]; then
+          echo "Failed to resolve the latest Dapr release tag" >&2
+          exit 1
+        fi
+        echo "DAPR_PREV_VERSION=${tag#v}" >> $GITHUB_ENV
     - name: Set up for master
       if: github.event_name != 'repository_dispatch'
       run: |


### PR DESCRIPTION
control-plane-master:
- 001-fake-informer-periodic-relist: backport the fake Kubernetes informer rewrite so /watch connections rotate and force the reflector to re-LIST. The master operator now suppresses CREATED events emitted during the informer initial sync (to avoid spurious sidecar restarts) and relies on that periodic re-LIST to surface store mutations. Fixes the operator configurationupdate, subscription and component hot-reload tests.
- 002-operator-pod-config-resolution: the master operator resolves an app's Configuration from its pod's dapr.io/config annotation, so serve a Pod list from the fake API and add the annotated Pod to the configurationupdate test.

dapr-sidecar-master:
- 001-mcpserver-error-wrapping-log: master wraps the MCPServer processing error as "process MCPServer a error: ..." so update the expected log lines.
- 002-circuitbreaker-gauge-closed: master (dapr#10113) updates the circuit breaker gauge to "closed" as soon as the probe succeeds instead of leaving it "half-open", so assert the corrected gauge state.