### PR TITLE
scheduler: bound shutdown drain, survive dead WatchJobs streams

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -2,6 +2,7 @@
 
 This update contains the following bug fixes:
 - [Scheduler embedded etcd metrics missing from the metrics endpoint](#scheduler-embedded-etcd-metrics-missing-from-the-metrics-endpoint)
+- [Scheduler hanging on shutdown and failing to redeliver jobs after client disconnects](#scheduler-hanging-on-shutdown-and-failing-to-redeliver-jobs-after-client-disconnects)
 
 ## Scheduler embedded etcd metrics missing from the metrics endpoint
 
@@ -25,3 +26,36 @@ Embedded etcd registers all of its collectors on the global default registry dur
 The metrics endpoint now gathers from both the private registry and the global default registry.
 Nothing is ever registered on the default registry by the exporter itself, so in-process restarts remain safe and the original panic cannot reoccur.
 All `etcd_*` metrics are emitted on the Scheduler metrics endpoint again, and other metrics registered on the default registry by linked libraries (such as `grpc_server_*` and `grpc_client_*`) are restored to their 1.17 behavior across Dapr binaries.
+
+## Scheduler hanging on shutdown and failing to redeliver jobs after client disconnects
+
+### Problem
+
+Two related failure modes in the Scheduler:
+
+1. A Scheduler instance could hang forever during shutdown, remaining as a zombie process: its gRPC transport stayed alive and its health endpoint kept returning 200, but no handler was serving.
+   Connected daprd sidecars hung on in-flight calls to the zombie instead of failing over.
+2. After a daprd sidecar disconnected abruptly, the Scheduler could stop delivering jobs and actor reminders for that sidecar's entire namespace, in some cases for minutes, even though other healthy sidecars remained connected.
+
+### Impact
+
+A Scheduler restart or crash under load could escalate into a cluster-wide outage window: job and actor reminder delivery stalled until pods were manually restarted or clients reconnected and re-registered.
+You were affected if you run the Scheduler in HA with actively connected sidecars, most visibly under high job or workflow throughput.
+
+### Root Cause
+
+Shutdown used an unbounded gRPC `GracefulStop()`, which waits for every open stream.
+A `WatchJobs` stream whose client had connected but never sent, or had stopped reading, left its handler blocked in its initial `Recv` (or a flow-control blocked `Send`), so the drain never completed and the process never exited.
+Readiness was only failed after the drain completed, so health probes never detected the zombie.
+
+Separately, a dead `WatchJobs` stream emitted duplicate close events (one from its receive loop plus one per failed send), while the per-namespace connection counter was decremented once per event.
+Duplicates could drive the count to zero while live streams remained, deleting the namespace and dropping every stream and deliverable job prefix in it.
+Failed sends also held their job's completion callback until the stream was fully reaped, so the scheduling engine could not promptly redeliver those jobs to healthy streams.
+A data race in the connection event-loop object recycling could additionally corrupt loop state under connection churn.
+
+### Solution
+
+Scheduler shutdown now fails readiness before draining and bounds the graceful drain to 5 seconds before forcing the gRPC server to stop, guaranteeing process exit.
+Dead streams are now closed exactly once: the close cancels the stream at detection time, promptly deregisters its deliverable prefixes, and resolves in-flight jobs as undeliverable so the engine immediately redelivers them to healthy streams.
+Namespace deletion is now confirmed by the connection tracking loop that owns the authoritative stream set, so duplicate or stray close events can no longer tear down a namespace that still has live streams.
+The event-loop object recycling race was removed.

--- a/pkg/runtime/scheduler/internal/clients/clients.go
+++ b/pkg/runtime/scheduler/internal/clients/clients.go
@@ -16,7 +16,6 @@ package clients
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -38,16 +37,13 @@ type Options struct {
 type Clients struct {
 	security security.Handler
 
-	clients     []schedulerv1pb.SchedulerClient
-	closeFns    []context.CancelFunc
-	lastUsedIdx atomic.Uint64
-
-	disabled     chan struct{}
+	gen          *generation
+	lastUsedIdx  atomic.Uint64
 	currentAddrs []string
 
-	wg      sync.WaitGroup
-	lock    sync.RWMutex
-	hasInit chan struct{}
+	disabled chan struct{}
+	lock     sync.RWMutex
+	hasInit  chan struct{}
 }
 
 func New(opts Options) *Clients {
@@ -62,41 +58,49 @@ func (c *Clients) Disable() {
 	close(c.disabled)
 }
 
+// Reload dials the new address set and atomically swaps it in. It never
+// blocks on borrowers of the previous generation: the old connections are
+// closed asynchronously, which aborts any RPCs still hung against dead
+// schedulers. On dial failure the current (working) generation is preserved.
 func (c *Clients) Reload(ctx context.Context, addresses []string) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	c.currentAddrs = []string{}
-	c.close()
-
-	c.clients = make([]schedulerv1pb.SchedulerClient, 0, len(addresses))
-	c.closeFns = make([]context.CancelFunc, 0, len(addresses))
+	newGen := &generation{
+		clients:  make([]schedulerv1pb.SchedulerClient, 0, len(addresses)),
+		closeFns: make([]context.CancelFunc, 0, len(addresses)),
+	}
 
 	for _, address := range addresses {
 		log.Debugf("Attempting to connect to Scheduler at address: %s", address)
 
-		client, closeFn, err := client.New(ctx, address, c.security)
+		cl, closeFn, err := client.New(ctx, address, c.security)
 		if err != nil {
-			c.close()
-			return fmt.Errorf("scheduler client not initialized for address %s: %s", address, err)
+			newGen.close()
+			return errors.New("scheduler client not initialized for address " + address + ": " + err.Error())
 		}
 
 		log.Infof("Scheduler client initialized for address: %s", address)
 
-		c.clients = append(c.clients, client)
-		c.closeFns = append(c.closeFns, closeFn)
+		newGen.clients = append(newGen.clients, cl)
+		newGen.closeFns = append(newGen.closeFns, closeFn)
 	}
 
-	if len(c.clients) > 0 {
+	if len(newGen.clients) > 0 {
 		log.Info("Scheduler clients initialized")
 	}
 
+	c.lock.Lock()
+	old := c.gen
+	c.gen = newGen
 	c.currentAddrs = addresses
 
 	select {
 	case <-c.hasInit:
 	default:
 		close(c.hasInit)
+	}
+	c.lock.Unlock()
+
+	if old != nil {
+		go old.close()
 	}
 
 	return nil
@@ -115,13 +119,14 @@ func (c *Clients) Next(ctx context.Context) (schedulerv1pb.SchedulerClient, cont
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	if len(c.clients) == 0 {
+	gen := c.gen
+	if gen == nil || len(gen.clients) == 0 {
 		return nil, nil, errors.New("no scheduler client initialized")
 	}
 
-	c.wg.Add(1)
+	gen.wg.Add(1)
 	//nolint:gosec
-	return c.clients[int(c.lastUsedIdx.Add(1))%len(c.clients)], c.wg.Done, nil
+	return gen.clients[int(c.lastUsedIdx.Add(1))%len(gen.clients)], gen.wg.Done, nil
 }
 
 func (c *Clients) Addresses() []string {
@@ -129,20 +134,4 @@ func (c *Clients) Addresses() []string {
 	defer c.lock.RUnlock()
 
 	return c.currentAddrs
-}
-
-func (c *Clients) close() {
-	c.wg.Wait()
-
-	var wg sync.WaitGroup
-	wg.Add(len(c.closeFns))
-
-	for _, closeFn := range c.closeFns {
-		go func() {
-			closeFn()
-			wg.Done()
-		}()
-	}
-
-	wg.Wait()
 }

--- a/pkg/runtime/scheduler/internal/clients/clients_test.go
+++ b/pkg/runtime/scheduler/internal/clients/clients_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	securityfake "github.com/dapr/dapr/pkg/security/fake"
+)
+
+// Reload must never block on borrowers of the previous generation: an
+// in-flight RPC against a scheduler that died mid-shutdown can hang
+// indefinitely (the transport still ACKs keepalives), and blocking Reload
+// while holding the write lock wedges every scheduler operation in the
+// runtime permanently.
+func Test_ReloadDoesNotBlockOnBorrowers(t *testing.T) {
+	t.Parallel()
+
+	c := New(Options{Security: securityfake.New()})
+	ctx := t.Context()
+
+	// gRPC dials are lazy, so unreachable addresses still produce clients.
+	require.NoError(t, c.Reload(ctx, []string{"127.0.0.1:1"}))
+
+	// Borrow a client and do NOT release it (simulates a hung RPC).
+	_, done, err := c.Next(ctx)
+	require.NoError(t, err)
+
+	reloaded := make(chan error, 1)
+	go func() {
+		reloaded <- c.Reload(ctx, []string{"127.0.0.1:2", "127.0.0.1:3"})
+	}()
+
+	select {
+	case err = <-reloaded:
+		require.NoError(t, err)
+	case <-time.After(time.Second * 5):
+		t.Fatal("Reload blocked on an unreleased borrower from the previous generation")
+	}
+
+	assert.Equal(t, []string{"127.0.0.1:2", "127.0.0.1:3"}, c.Addresses())
+
+	// Next must serve from the new generation while the old borrow is live.
+	_, done2, err := c.Next(ctx)
+	require.NoError(t, err)
+	done2()
+
+	// Releasing the stale borrow after the swap must not panic.
+	done()
+}
+
+func Test_NextRoundRobin(t *testing.T) {
+	t.Parallel()
+
+	c := New(Options{Security: securityfake.New()})
+	ctx := t.Context()
+
+	require.NoError(t, c.Reload(ctx, []string{"127.0.0.1:1", "127.0.0.1:2"}))
+
+	cl1, done1, err := c.Next(ctx)
+	require.NoError(t, err)
+	cl2, done2, err := c.Next(ctx)
+	require.NoError(t, err)
+	assert.NotSame(t, cl1, cl2)
+	done1()
+	done2()
+}

--- a/pkg/runtime/scheduler/internal/clients/generation.go
+++ b/pkg/runtime/scheduler/internal/clients/generation.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"context"
+	"sync"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+)
+
+// generation is one immutable set of scheduler clients. Borrowers taken via
+// Next hold a reference on the generation they borrowed from, so a Reload can
+// swap in a new generation without waiting for (possibly hung) in-flight
+// calls against the old one.
+type generation struct {
+	clients  []schedulerv1pb.SchedulerClient
+	closeFns []context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+// close force-closes the generation's connections first, aborting any
+// in-flight RPCs (a scheduler that died mid-shutdown can hold streams open
+// and ACK keepalives without ever answering, so waiting for borrowers before
+// closing can block forever), then waits for borrowers to release.
+func (g *generation) close() {
+	var wg sync.WaitGroup
+	wg.Add(len(g.closeFns))
+	for _, closeFn := range g.closeFns {
+		go func() {
+			closeFn()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	g.wg.Wait()
+}

--- a/pkg/runtime/scheduler/internal/clients/wrapper/wrapper.go
+++ b/pkg/runtime/scheduler/internal/clients/wrapper/wrapper.go
@@ -15,12 +15,14 @@ package wrapper
 
 import (
 	"context"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	v1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/pkg/retry"
 	"github.com/dapr/dapr/pkg/runtime/scheduler/client"
 	"github.com/dapr/dapr/pkg/runtime/scheduler/internal/clients"
 )
@@ -168,8 +170,16 @@ func (w *wrapper) call(ctx context.Context, fn apiFn) error {
 
 		done()
 
+		// A scheduler shutting down cancels in-flight RPCs; retry against the
+		// next client, with backoff so a cluster-wide restart does not turn
+		// this loop into a hot spin.
 		status, ok := status.FromError(err)
-		if ok && status.Code() == codes.Canceled {
+		if ok && status.Code() == codes.Canceled && ctx.Err() == nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(retry.Jitter(time.Second/4, time.Second/8)):
+			}
 			continue
 		}
 

--- a/pkg/runtime/scheduler/internal/watchhosts/watchhosts.go
+++ b/pkg/runtime/scheduler/internal/watchhosts/watchhosts.go
@@ -91,7 +91,17 @@ func (w *WatchHosts) Run(ctx context.Context) error {
 		resp, err := stream.Recv()
 		if status.Code(err) == codes.Unimplemented {
 			if err = w.clients.Reload(ctx, w.allAddrs); err != nil {
-				return err
+				closeCon()
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				log.Errorf("Failed to reload scheduler clients, retrying: %s", err)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(retry.Jitter(time.Second, time.Second/2)):
+					continue
+				}
 			}
 
 			// Ignore unimplemented error code as we are talking to an old server.
@@ -128,7 +138,17 @@ func (w *WatchHosts) Run(ctx context.Context) error {
 		log.Infof("Connected and received scheduler hosts addresses: %v", gotAddrs)
 
 		if err = w.clients.Reload(ctx, gotAddrs); err != nil {
-			return err
+			closeCon()
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Errorf("Failed to reload scheduler clients, retrying: %s", err)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(retry.Jitter(time.Second, time.Second/2)):
+				continue
+			}
 		}
 
 		w.loop.Enqueue(&loops.ReloadClients{

--- a/pkg/scheduler/server/internal/pool/loops/connections/connections.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/connections.go
@@ -15,7 +15,6 @@ package connections
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -28,7 +27,10 @@ import (
 	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/loops/connections/store"
 	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/loops/stream"
 	"github.com/dapr/kit/events/loop"
+	"github.com/dapr/kit/logger"
 )
+
+var log = logger.NewLogger("dapr.scheduler.server.pool.loops.connections")
 
 var (
 	loopFactory = loop.New[loops.EventConn](1024)
@@ -379,10 +381,14 @@ func (c *connections) tryDispatchPending(next *loops.TriggerRequest) bool {
 }
 
 // handleCloseStream handles a close stream request.
-func (c *connections) handleCloseStream(closeStream *loops.ConnCloseStream) error {
+func (c *connections) handleCloseStream(closeStream *loops.ConnCloseStream) {
 	cancel, ok := c.streams[closeStream.StreamIDx]
 	if !ok {
-		return errors.New("catastrophic state machine error: lost connection stream reference")
+		// Close events are deduplicated at the stream, so an unknown index is
+		// unexpected, but it must never take down this loop: that tears down
+		// every stream in the namespace. Log loudly and tolerate.
+		log.Errorf("Ignoring close for unknown stream connection %d in namespace %s", closeStream.StreamIDx, closeStream.Namespace)
+		return
 	}
 
 	delete(c.streams, closeStream.StreamIDx)
@@ -391,7 +397,14 @@ func (c *connections) handleCloseStream(closeStream *loops.ConnCloseStream) erro
 
 	c.removeOrphanedGates()
 
-	return nil
+	// This loop owns the authoritative stream set: confirm emptiness to the
+	// namespaces loop so it can delete the namespace. Deleting on the
+	// namespaces loop's own counting alone is unsafe against stray events.
+	if len(c.streams) == 0 {
+		c.nsLoop.Enqueue(&loops.ConnCloseNamespace{
+			Namespace: closeStream.Namespace,
+		})
+	}
 }
 
 // handleShutdown handles the shutdown of the connections.
@@ -412,7 +425,10 @@ func (c *connections) handleShutdown() {
 	clear(c.concurrencyGates)
 	clear(c.streamGateKeys)
 
-	loopFactory.CacheLoop(c.loop)
+	// The loop object is deliberately NOT returned to the factory cache:
+	// this handler runs inside the loop's own drain, before Close observes
+	// completion, so a recycled loop could be reused and rewritten while the
+	// closer still reads it (data race, and a lost close signal).
 	connsCache.Put(c)
 }
 

--- a/pkg/scheduler/server/internal/pool/loops/loops.go
+++ b/pkg/scheduler/server/internal/pool/loops/loops.go
@@ -72,6 +72,16 @@ type ConnCloseStream struct {
 	Namespace string
 }
 
+// ConnCloseNamespace is sent by a namespace's connections loop when its last
+// stream has been removed. The connections loop owns the authoritative stream
+// set, so namespace deletion is driven by this confirmation rather than by
+// per-event counting alone, which a stray or duplicate close event could
+// otherwise corrupt into deleting a namespace that still has live streams.
+type ConnCloseNamespace struct {
+	*nsbase
+	Namespace string
+}
+
 type ConcurrencyRelease struct {
 	*connbase
 	GateKeys []string

--- a/pkg/scheduler/server/internal/pool/loops/namespaces/duplicateclose_test.go
+++ b/pkg/scheduler/server/internal/pool/loops/namespaces/duplicateclose_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespaces
+
+import (
+	"testing"
+	"time"
+
+	"github.com/diagridio/go-etcd-cron/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/loops"
+)
+
+// Test_NamespaceDuplicateCloseStream injects duplicate close events for one
+// stream and asserts the namespace survives with its remaining live stream
+// intact. A stray duplicate close must not double-decrement the namespace
+// connection count: that deletes the namespace while live streams remain,
+// dropping every stream and deliverable prefix in it (the mechanism behind
+// the minutes-long reminder-delivery outage after a scheduler restart).
+func Test_NamespaceDuplicateCloseStream(t *testing.T) {
+	t.Parallel()
+
+	suite := newSuite(t)
+
+	sc1 := newClientServer(t)
+	sc2 := newClientServer(t)
+
+	suite.connLoop.Enqueue(&loops.ConnAdd{
+		Channel: sc1.serverstream,
+		Cancel:  sc1.closeserver,
+		Request: &schedulerv1pb.WatchJobsRequestInitial{
+			AppId:     "app1",
+			Namespace: "ns1",
+		},
+	})
+	suite.connLoop.Enqueue(&loops.ConnAdd{
+		Channel: sc2.serverstream,
+		Cancel:  sc2.closeserver,
+		Request: &schedulerv1pb.WatchJobsRequestInitial{
+			AppId:     "app2",
+			Namespace: "ns1",
+		},
+	})
+
+	// Both adds processed once both app prefixes are registered.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		suite.prefixesMu.Lock()
+		defer suite.prefixesMu.Unlock()
+		assert.ElementsMatch(c, []string{
+			"app||ns1||app1||", "app||ns1||app2||",
+		}, *suite.prefixes)
+	}, time.Second*5, time.Millisecond*10)
+
+	// Duplicate close for app1's stream (idx 0): in production both the recv
+	// loop exit and every failed Send raced to emit one, and any future
+	// regression must not collapse the namespace.
+	suite.connLoop.Enqueue(&loops.ConnCloseStream{StreamIDx: 0, Namespace: "ns1"})
+	suite.connLoop.Enqueue(&loops.ConnCloseStream{StreamIDx: 0, Namespace: "ns1"})
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, sc1.serverclosed.Load())
+	}, time.Second*5, time.Millisecond*10)
+
+	// app2's live stream must survive the duplicate close.
+	recvCh := make(chan error, 1)
+	go func() {
+		_, err := sc2.clientstream.Recv()
+		recvCh <- err
+	}()
+
+	suite.connLoop.Enqueue(&loops.TriggerRequest{
+		ResultFn: func(r api.TriggerResponseResult) {},
+		Job: &internalsv1pb.JobEvent{
+			Key:  "app||ns1||app2||job1",
+			Name: "job1",
+			Metadata: &schedulerv1pb.JobMetadata{
+				AppId:     "app2",
+				Namespace: "ns1",
+				Target: &schedulerv1pb.JobTargetMetadata{
+					Type: &schedulerv1pb.JobTargetMetadata_Job{
+						Job: new(schedulerv1pb.TargetJob),
+					},
+				},
+			},
+		},
+	})
+
+	select {
+	case err := <-recvCh:
+		require.NoError(t, err, "live stream was torn down by the duplicate close for its sibling")
+	case <-time.After(time.Second * 5):
+		t.Fatal("trigger was not delivered: namespace routing lost after duplicate close")
+	}
+
+	require.False(t, sc2.serverclosed.Load(), "live stream closed by duplicate close event")
+	require.Nil(t, suite.cancelCalled.Load(), "duplicate close escalated to pool teardown")
+
+	suite.connLoop.Close(new(loops.Shutdown))
+}

--- a/pkg/scheduler/server/internal/pool/loops/namespaces/namespaces.go
+++ b/pkg/scheduler/server/internal/pool/loops/namespaces/namespaces.go
@@ -79,6 +79,8 @@ func (n *namespaces) Handle(ctx context.Context, event loops.EventNS) error {
 		return n.handleAdd(ctx, e)
 	case *loops.ConnCloseStream:
 		return n.handleCloseStream(e)
+	case *loops.ConnCloseNamespace:
+		return n.handleCloseNamespace(e)
 	case *loops.TriggerRequest:
 		return n.handleTriggerRequest(e)
 	case *loops.SchedulerInfoUpdate:
@@ -147,13 +149,31 @@ func (n *namespaces) handleCloseStream(closeStream *loops.ConnCloseStream) error
 		return nil
 	}
 
-	connLoop.connections--
+	// Guard against a stray duplicate close event: an unguarded decrement can
+	// wrap the counter. Namespace deletion is NOT decided here: the
+	// connections loop owns the authoritative stream set and confirms
+	// emptiness with a ConnCloseNamespace event, so a stray or duplicate
+	// close cannot delete a namespace that still has live streams.
+	if connLoop.connections > 0 {
+		connLoop.connections--
+	}
 	connLoop.loop.Enqueue(closeStream)
 
-	if connLoop.connections == 0 {
-		delete(n.connections, closeStream.Namespace)
-		connLoop.loop.Close(new(loops.Shutdown))
+	return nil
+}
+
+// handleCloseNamespace deletes a namespace once its connections loop has
+// confirmed its last stream is gone AND no add has arrived since (the
+// connection count covers the window between the confirmation being enqueued
+// and processed).
+func (n *namespaces) handleCloseNamespace(closeNS *loops.ConnCloseNamespace) error {
+	connLoop, ok := n.connections[closeNS.Namespace]
+	if !ok || connLoop.connections != 0 {
+		return nil
 	}
+
+	delete(n.connections, closeNS.Namespace)
+	connLoop.loop.Close(new(loops.Shutdown))
 
 	return nil
 }

--- a/pkg/scheduler/server/internal/pool/loops/stream/stream.go
+++ b/pkg/scheduler/server/internal/pool/loops/stream/stream.go
@@ -55,6 +55,14 @@ type stream struct {
 	loop    loop.Interface[loops.EventStream]
 	cancel  context.CancelCauseFunc
 
+	// closeStream closes the stream exactly once: it cancels the stream
+	// (deregistering its deliverable prefixes and unblocking the WatchJobs
+	// handler) and notifies the namespace loop exactly once. Both the recv
+	// loop and every failed Send race to close the same stream; duplicate
+	// ConnCloseStream events for one stream corrupt the per-namespace
+	// connection accounting and tear down live streams.
+	closeStream func(error)
+
 	// triggerIDx is the uuid of a triggered job. We can use a simple counter as
 	// there are no privacy/time attack concerns as this counter is scoped to a
 	// single client.
@@ -78,9 +86,30 @@ func New(ctx context.Context, opts Options) (loop.Interface[loops.EventStream], 
 	stream.ns = opts.Add.Request.GetNamespace()
 	stream.appID = opts.Add.Request.GetAppId()
 	stream.triggerIDx = 0
+	// The cron prefix deregistration returned by handleAdd is not idempotent:
+	// a second invocation releases a reference which may belong to a
+	// reconnected stream's fresh registration, marking a live app's prefixes
+	// undeliverable. Guard the combined cancel so every path through cancel
+	// and closeStream deregisters exactly once.
+	var cancelOnce sync.Once
 	stream.cancel = func(err error) {
-		opts.Add.Cancel(err)
-		cancel(err)
+		cancelOnce.Do(func() {
+			opts.Add.Cancel(err)
+			cancel(err)
+		})
+	}
+	var closeOnce sync.Once
+	stream.closeStream = func(err error) {
+		closeOnce.Do(func() {
+			// Cancel at detection time rather than when the connections loop
+			// reaps the stream: this promptly deregisters the dead stream's
+			// deliverable prefixes and aborts any Send parked on flow control.
+			stream.cancel(err)
+			stream.nsLoop.Enqueue(&loops.ConnCloseStream{
+				StreamIDx: stream.idx,
+				Namespace: stream.ns,
+			})
+		})
 	}
 
 	stream.loop = streamLoopFactory.NewLoop(stream)
@@ -88,10 +117,7 @@ func New(ctx context.Context, opts Options) (loop.Interface[loops.EventStream], 
 	stream.wg.Go(func() {
 		stream.recvLoop()
 		log.Debugf("Closed receive stream to %s/%s", stream.ns, stream.appID)
-		stream.nsLoop.Enqueue(&loops.ConnCloseStream{
-			StreamIDx: stream.idx,
-			Namespace: stream.ns,
-		})
+		stream.closeStream(errStreamShutdown)
 	})
 
 	return stream.loop, nil
@@ -126,10 +152,13 @@ func (s *stream) handleTriggerRequest(req *loops.TriggerRequest) {
 	if err := s.channel.Send(job); err != nil {
 		log.Warnf("Error sending job to stream %s/%s: %s", s.ns, s.appID, err)
 		monitoring.RecordSidecarSendError()
-		s.nsLoop.Enqueue(&loops.ConnCloseStream{
-			StreamIDx: s.idx,
-			Namespace: s.ns,
-		})
+		// Resolve the trigger promptly so the cron engine redelivers it to a
+		// live stream instead of parking it until this stream is reaped.
+		// LoadAndDelete guarantees the shutdown drain cannot double-resolve.
+		if fn, ok := s.inflight.LoadAndDelete(s.triggerIDx); ok {
+			fn.(func(api.TriggerResponseResult))(api.TriggerResponseResult_UNDELIVERABLE)
+		}
+		s.closeStream(err)
 	}
 }
 
@@ -147,6 +176,9 @@ func (s *stream) handleShutdown() {
 		return true
 	})
 	s.inflight.Clear()
-	streamLoopFactory.CacheLoop(s.loop)
+	// The loop object is deliberately NOT returned to the factory cache:
+	// this handler runs inside the loop's own drain, before Close observes
+	// completion, so a recycled loop could be reused and rewritten while the
+	// closer still reads it (data race, and a lost close signal).
 	streamCache.Put(s)
 }

--- a/pkg/scheduler/server/internal/pool/loops/stream/streamclose_test.go
+++ b/pkg/scheduler/server/internal/pool/loops/stream/streamclose_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/diagridio/go-etcd-cron/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/loops"
+)
+
+// Test_StreamDeadSendClose covers the dead-stream close path: a failed Send
+// must resolve the trigger's result promptly as UNDELIVERABLE (so the cron
+// engine redelivers to a live stream instead of parking the trigger until the
+// stream is reaped), and the stream must emit exactly one ConnCloseStream no
+// matter how many sends fail after death. Duplicate close events corrupt the
+// per-namespace connection accounting and tear down live streams.
+func Test_StreamDeadSendClose(t *testing.T) {
+	t.Parallel()
+
+	suite := newSuite(t)
+
+	// Kill the server side of the stream: the recv loop exits and emits the
+	// stream's single close event.
+	suite.closeserver()
+	suite.expectEvent(t, &loops.ConnCloseStream{
+		StreamIDx: 123,
+		Namespace: "ns",
+	})
+
+	// Triggers routed to the dead stream fail their Send.
+	var calls1, calls2 atomic.Int32
+	var res1, res2 atomic.Pointer[api.TriggerResponseResult]
+	suite.streamLoop.Enqueue(&loops.TriggerRequest{
+		Job: &internalsv1pb.JobEvent{
+			Key: "job-key-1", Name: "job-name-1",
+		},
+		ResultFn: func(res api.TriggerResponseResult) {
+			calls1.Add(1)
+			res1.Store(&res)
+		},
+	})
+	suite.streamLoop.Enqueue(&loops.TriggerRequest{
+		Job: &internalsv1pb.JobEvent{
+			Key: "job-key-2", Name: "job-name-2",
+		},
+		ResultFn: func(res api.TriggerResponseResult) {
+			calls2.Add(1)
+			res2.Store(&res)
+		},
+	})
+
+	// The failed sends must resolve UNDELIVERABLE promptly, well before the
+	// stream is shut down by the connections loop.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		ptr1, ptr2 := res1.Load(), res2.Load()
+		if !assert.NotNil(c, ptr1, "trigger 1 not resolved after failed send") ||
+			!assert.NotNil(c, ptr2, "trigger 2 not resolved after failed send") {
+			return
+		}
+		assert.Equal(c, api.TriggerResponseResult_UNDELIVERABLE, *ptr1)
+		assert.Equal(c, api.TriggerResponseResult_UNDELIVERABLE, *ptr2)
+	}, time.Second*5, time.Millisecond*10)
+
+	// No further close events: the recv-loop exit and every failed send race
+	// to close the same stream and must dedupe to the single event above.
+	select {
+	case ev := <-suite.nsLoop.Events():
+		t.Fatalf("unexpected duplicate close event for dead stream: %#v", ev)
+	case <-time.After(time.Second):
+	}
+
+	suite.streamLoop.Close(new(loops.StreamShutdown))
+
+	// The shutdown drain must not double-resolve the already-resolved
+	// triggers.
+	require.Equal(t, int32(1), calls1.Load(), "trigger 1 resolved more than once")
+	require.Equal(t, int32(1), calls2.Load(), "trigger 2 resolved more than once")
+}

--- a/pkg/scheduler/server/server.go
+++ b/pkg/scheduler/server/server.go
@@ -264,9 +264,38 @@ func (s *Server) runServer(ctx context.Context) error {
 		},
 		func(ctx context.Context) error {
 			<-ctx.Done()
-			srv.GracefulStop()
+			// Fail readiness before draining so probes go unhealthy during
+			// shutdown rather than only after the drain completes (the defer
+			// at the top of runServer cannot run until GracefulStop returns).
+			s.hzAPIServer.NotReady()
+
+			// Bounded drain: GracefulStop waits for every open stream, but a
+			// WatchJobs handler can be parked in its initial stream Recv (and
+			// a WatchHosts handler in a Send to a hung client), never
+			// reaching its closeCh select. An unbounded GracefulStop then
+			// waits forever and the process becomes a zombie: the gRPC
+			// transport keeps ACKing keepalives and healthz stays serving
+			// while every handler is dead. Scheduler streams are infinite
+			// watches, so a drain either completes almost immediately via
+			// closeCh or never will: force the stop after the grace period.
+			stopped := make(chan struct{})
+			go func() {
+				srv.GracefulStop()
+				close(stopped)
+			}()
+			select {
+			case <-stopped:
+			case <-time.After(gracefulShutdownTimeout):
+				log.Warnf("Graceful shutdown timed out after %s, forcing stop", gracefulShutdownTimeout)
+				srv.Stop()
+				<-stopped
+			}
 			log.Info("Scheduler GRPC server stopped")
 			return nil
 		},
 	).Run(ctx)
 }
+
+// gracefulShutdownTimeout bounds how long the scheduler waits for open
+// streams to drain on shutdown before forcing the gRPC server to stop.
+const gracefulShutdownTimeout = time.Second * 5

--- a/tests/integration/suite/actors/reminders/restartdelivery.go
+++ b/tests/integration/suite/actors/reminders/restartdelivery.go
@@ -27,6 +27,7 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -56,6 +57,8 @@ type restartdelivery struct {
 }
 
 func (r *restartdelivery) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
 	handler := http.NewServeMux()
 	handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`{"entities": ["myactortype"]}`))

--- a/tests/integration/suite/actors/reminders/restartdelivery.go
+++ b/tests/integration/suite/actors/reminders/restartdelivery.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(restartdelivery))
+}
+
+// restartdelivery asserts that reminder DELIVERY resumes within seconds of a
+// scheduler restart under active reminder load. Recovery regressions on
+// either side of the stream (server pool routing to dead streams, client
+// reconnect stalls) historically showed up as multi-minute delivery outages
+// after the scheduler came back healthy, so the resume bound is the
+// regression assertion. The restart is graceful: a hard kill leaves the
+// previous process's cron leadership lease in the persisted etcd data and
+// the restarted engine must wait out the lease TTL, which would swamp the
+// bound this test exists to enforce.
+type restartdelivery struct {
+	daprd *daprd.Daprd
+	place *placement.Placement
+	sched *scheduler.Scheduler
+
+	called atomic.Int64
+}
+
+func (r *restartdelivery) Setup(t *testing.T) []framework.Option {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/dapr/config", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"entities": ["myactortype"]}`))
+	})
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler.HandleFunc("/actors/myactortype/myactorid", func(http.ResponseWriter, *http.Request) {})
+	handler.HandleFunc("/actors/myactortype/myactorid/method/remind/tick", func(http.ResponseWriter, *http.Request) {
+		r.called.Add(1)
+	})
+	handler.HandleFunc("/actors/myactortype/myactorid/method/foo", func(http.ResponseWriter, *http.Request) {})
+
+	srv := prochttp.New(t, prochttp.WithHandler(handler))
+	r.place = placement.New(t)
+	r.sched = scheduler.New(t)
+	r.daprd = daprd.New(t,
+		daprd.WithInMemoryActorStateStore("mystore"),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithAppPort(srv.Port()),
+		daprd.WithScheduler(r.sched),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.place, srv),
+	}
+}
+
+func (r *restartdelivery) Run(t *testing.T, ctx context.Context) {
+	// The scheduler and daprd are run here rather than as framework processes
+	// so the test owns the scheduler's lifecycle and daprd starts against a
+	// live scheduler.
+	r.sched.Run(t, ctx)
+	t.Cleanup(func() { r.sched.Kill(t) })
+	r.sched.WaitUntilRunning(t, ctx)
+	r.place.WaitUntilRunning(t, ctx)
+
+	r.daprd.Run(t, ctx)
+	t.Cleanup(func() { r.daprd.Cleanup(t) })
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+	daprdURL := "http://localhost:" + strconv.Itoa(r.daprd.HTTPPort()) + "/v1.0/actors/myactortype/myactorid"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, daprdURL+"/method/foo", nil)
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, rErr := httpClient.Do(req)
+		if assert.NoError(c, rErr) {
+			assert.NoError(c, resp.Body.Close())
+			assert.Equal(c, http.StatusOK, resp.StatusCode)
+		}
+	}, 10*time.Second, 10*time.Millisecond, "actor not ready in time")
+
+	_, err = r.daprd.GRPCClient(t, ctx).RegisterActorReminder(ctx, &rtv1.RegisterActorReminderRequest{
+		ActorType: "myactortype",
+		ActorId:   "myactorid",
+		Name:      "tick",
+		DueTime:   "0s",
+		Period:    "1s",
+	})
+	require.NoError(t, err)
+
+	// Steady state: the reminder is firing every second.
+	require.Eventually(t, func() bool {
+		return r.called.Load() >= 3
+	}, 15*time.Second, 10*time.Millisecond, "reminder never reached steady delivery")
+
+	before := r.called.Load()
+	r.sched.RestartGraceful(t, ctx)
+	r.sched.WaitUntilRunning(t, ctx)
+
+	// The regression bound: delivery must resume within seconds of the
+	// scheduler being healthy again, not minutes.
+	require.Eventually(t, func() bool {
+		return r.called.Load() > before
+	}, 15*time.Second, 10*time.Millisecond,
+		"reminder delivery did not resume within 15s of the scheduler restart")
+}

--- a/tests/integration/suite/scheduler/api/api.go
+++ b/tests/integration/suite/scheduler/api/api.go
@@ -16,4 +16,5 @@ package api
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/api/list"
 	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/api/watchhosts"
+	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/api/watchjobs"
 )

--- a/tests/integration/suite/scheduler/api/watchjobs/deadstream.go
+++ b/tests/integration/suite/scheduler/api/watchjobs/deadstream.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchjobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(deadstream))
+}
+
+// deadstream verifies that an abruptly dead WatchJobs stream cannot take down
+// its namespace. Job payloads larger than the per-stream flow-control window
+// are sent to a client that never reads, parking the server's Send; when that
+// client dies, the parked send and every queued trigger fail at once. The
+// resulting burst of close events for the one stream must dedupe: duplicate
+// events double-decrement the namespace connection count, deleting the
+// namespace while live streams remain and dropping every stream and
+// deliverable prefix in it. The failed triggers must also resolve promptly as
+// undeliverable so the cron engine redelivers them to the surviving stream.
+type deadstream struct {
+	scheduler *scheduler.Scheduler
+}
+
+func (d *deadstream) Setup(t *testing.T) []framework.Option {
+	d.scheduler = scheduler.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(d.scheduler),
+	}
+}
+
+func (d *deadstream) Run(t *testing.T, ctx context.Context) {
+	d.scheduler.WaitUntilRunning(t, ctx)
+
+	// Live client: reads and ACKs every job.
+	live := d.scheduler.WatchJobsSuccess(t, ctx, &schedulerv1pb.WatchJobsRequestInitial{
+		AppId: "appid", Namespace: "default",
+	})
+
+	// Doomed client: connects, registers, then never reads.
+	conn, err := grpc.NewClient(d.scheduler.Address(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	doomedCtx, doomedCancel := context.WithCancel(ctx)
+	t.Cleanup(doomedCancel)
+	doomed, err := schedulerv1pb.NewSchedulerClient(conn).WatchJobs(doomedCtx)
+	require.NoError(t, err)
+	require.NoError(t, doomed.Send(&schedulerv1pb.WatchJobsRequest{
+		WatchJobRequestType: &schedulerv1pb.WatchJobsRequest_Initial{
+			Initial: &schedulerv1pb.WatchJobsRequestInitial{
+				AppId: "appid", Namespace: "default",
+			},
+		},
+	}))
+
+	d.scheduler.WaitUntilSidecarsConnected(t, ctx, 2)
+
+	// Payloads larger than the default 64KiB per-stream flow-control window:
+	// the doomed stream's first Send parks, and the round-robin half of the
+	// remaining triggers queue up behind it.
+	payload, err := anypb.New(wrapperspb.Bytes(make([]byte, 128*1024)))
+	require.NoError(t, err)
+
+	const jobs = 20
+	client := d.scheduler.Client(t, ctx)
+	for i := range jobs {
+		_, err = client.ScheduleJob(ctx, &schedulerv1pb.ScheduleJobRequest{
+			Name: fmt.Sprintf("fat-%d", i),
+			Job: &schedulerv1pb.Job{
+				DueTime: new(time.Now().Format(time.RFC3339)),
+				Data:    payload,
+			},
+			Metadata: &schedulerv1pb.JobMetadata{
+				AppId: "appid", Namespace: "default",
+				Target: &schedulerv1pb.JobTargetMetadata{
+					Type: &schedulerv1pb.JobTargetMetadata_Job{
+						Job: new(schedulerv1pb.TargetJob),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	seen := make(map[string]bool)
+	drain := func(bound time.Duration, want int) {
+		timeout := time.After(bound)
+		for len(seen) < want {
+			select {
+			case name := <-live:
+				seen[name] = true
+			case <-timeout:
+				return
+			}
+		}
+	}
+
+	// The live stream receives its round-robin half while the doomed stream
+	// blocks the rest.
+	drain(15*time.Second, jobs/2)
+	require.GreaterOrEqual(t, len(seen), jobs/2,
+		"live stream did not receive its share of jobs: got %d", len(seen))
+
+	// Kill the doomed client: the parked send and all queued triggers fail.
+	// Every one of their jobs must be redelivered to the live stream, which
+	// must itself survive.
+	doomedCancel()
+
+	drain(15*time.Second, jobs)
+	require.Len(t, seen, jobs,
+		"jobs routed to the dead stream were not redelivered to the live stream")
+
+	// The namespace must still be intact: exactly one connected sidecar and a
+	// fresh job still delivers.
+	d.scheduler.WaitUntilSidecarsConnected(t, ctx, 1)
+
+	_, err = client.ScheduleJob(ctx, &schedulerv1pb.ScheduleJobRequest{
+		Name: "final",
+		Job: &schedulerv1pb.Job{
+			DueTime: new(time.Now().Format(time.RFC3339)),
+		},
+		Metadata: &schedulerv1pb.JobMetadata{
+			AppId: "appid", Namespace: "default",
+			Target: &schedulerv1pb.JobTargetMetadata{
+				Type: &schedulerv1pb.JobTargetMetadata_Job{
+					Job: new(schedulerv1pb.TargetJob),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	select {
+	case name := <-live:
+		require.Equal(t, "final", name)
+	case <-time.After(10 * time.Second):
+		t.Fatal("job scheduled after dead-stream cleanup was not delivered: namespace routing lost")
+	}
+}

--- a/tests/integration/suite/scheduler/scheduler.go
+++ b/tests/integration/suite/scheduler/scheduler.go
@@ -23,5 +23,6 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/kubernetes"
 	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/metrics"
 	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/quorum"
+	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/shutdown"
 	_ "github.com/dapr/dapr/tests/integration/suite/scheduler/staging"
 )

--- a/tests/integration/suite/scheduler/shutdown/stalledwatch.go
+++ b/tests/integration/suite/scheduler/shutdown/stalledwatch.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shutdown
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(stalledwatch))
+}
+
+// stalledwatch verifies the scheduler exits within a bounded time on shutdown
+// even when a WatchJobs stream is parked in its initial Recv. Such a handler
+// never reaches its closeCh select, so an unbounded GracefulStop waits on it
+// forever: the process becomes a zombie that ACKs gRPC keepalives and serves
+// healthz 200 while every handler is dead, turning an engine failure into a
+// cluster-wide outage window.
+type stalledwatch struct {
+	scheduler *scheduler.Scheduler
+}
+
+func (s *stalledwatch) Setup(t *testing.T) []framework.Option {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on windows which relies on unix process signals")
+	}
+
+	s.scheduler = scheduler.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(),
+	}
+}
+
+func (s *stalledwatch) Run(t *testing.T, ctx context.Context) {
+	s.scheduler.Run(t, ctx)
+	s.scheduler.WaitUntilRunning(t, ctx)
+
+	// Open a WatchJobs stream but never send the initial request: the server
+	// handler parks in its first Recv. Keep the connection alive for the
+	// whole shutdown so the transport keeps ACKing keepalives.
+	conn, err := grpc.NewClient(s.scheduler.Address(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	t.Cleanup(streamCancel)
+	stream, err := schedulerv1pb.NewSchedulerClient(conn).WatchJobs(streamCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = stream
+
+	// Give the RPC time to reach the server and park in Recv.
+	time.Sleep(time.Second)
+
+	done := make(chan struct{})
+	go func() {
+		s.scheduler.Cleanup(t)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second * 15):
+		t.Fatal("scheduler did not exit within 15s of SIGINT while a WatchJobs stream was parked in its initial Recv")
+	}
+}


### PR DESCRIPTION
1. Zombie shutdown (infinite drain). The scheduler shut down with an unbounded srv.GracefulStop(), which waits for every open stream. A WatchJobs handler can be parked in its initial stream Recv (serialize.FromWatch) and a WatchHosts handler in a Send to a hung client; neither ever reaches its closeCh select, so the process hung forever as a zombie: the gRPC transport kept ACKing keepalives and healthz stayed 200 while every handler was dead. Clients hung on the zombie instead of failing over, turning an engine failure into a cluster-wide outage window. The kit RunnerCloserManager grace period cannot help: its watchdog only arms after all runners return, and the stuck drain IS a runner.

Fix: readiness is failed before the drain starts, and GracefulStop is bounded (5s) with a forced srv.Stop() fallback. Scheduler streams are infinite watches: a drain either completes almost immediately via closeCh or never will.

2. Dead-stream close storms. A dead WatchJobs stream emitted one ConnCloseStream from its recv loop AND one per failed Send, while the namespace loop blindly decremented its per-namespace connection counter per event and deleted the namespace at zero. Duplicate closes for one stream could therefore delete a namespace while live streams remained, dropping every stream and deliverable prefix in it; recovery then depended entirely on client re-registration (minutes-long reminder delivery outages after scheduler restarts). Failed sends also parked their trigger's ResultFn in the inflight map until the stream was reaped, so the cron engine could not redeliver those jobs promptly, and the cron prefix-deregistration cancel is not idempotent, so racing closers could release a reconnected stream's fresh registration.

Fix: a stream closes exactly once (single guarded path shared by the recv loop and failed sends) and cancels at detection time, promptly deregistering its prefixes and aborting sends parked on flow control; a failed send resolves its trigger UNDELIVERABLE immediately so the engine redelivers to a live stream; the combined stream cancel is once-guarded; an unknown close in the connections loop is tolerated and logged instead of being a "catastrophic state machine error" (which, if ever wired through the currently-discarded return, would tear down the whole pool); and namespace deletion is now confirmed by the connections loop, which owns the authoritative stream set (new ConnCloseNamespace event), instead of being decided by per-event counting that stray events can corrupt.

3. Loop factory recycling race. connections.handleShutdown and stream.handleShutdown returned their loop objects to the global factory caches from INSIDE the loop's own drain, before Close observes completion: a concurrently created loop could reuse and rewrite the object (including its closeCh) while the closer still reads it. The loop objects are no longer recycled; the handler structs still are (safe: nothing reads them after the drain).