### PR TITLE
fix: use tick-local CollectT in subscriptions hot-reload test to stop hard-failing on transient errors

### DIFF
--- a/tests/integration/suite/daprd/hotreload/operator/informer/subscriptions.go
+++ b/tests/integration/suite/daprd/hotreload/operator/informer/subscriptions.go
@@ -173,7 +173,7 @@ func (s *subscriptions) Run(t *testing.T, ctx context.Context) {
 	s.kubeapi.Informer().Modify(t, &sub2)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		resp, err := s.daprd.GRPCClient(t, ctx).GetMetadata(ctx, new(rtv1.GetMetadataRequest))
-		require.NoError(t, err)
+		require.NoError(c, err)
 		if assert.Len(c, resp.GetSubscriptions(), 2) {
 			assert.Equal(c, "a", resp.GetSubscriptions()[0].GetTopic())
 			assert.Equal(c, "c", resp.GetSubscriptions()[1].GetTopic())


### PR DESCRIPTION
Motivation

Issue dapr/dapr#9692 reports flakiness in
Test_Integration/daprd/hotreload/operator/informer/subscriptions/run,
observed on Windows CI with a GetMetadata call failing with
"context deadline exceeded" followed by "Condition never satisfied".

Approach

In one of the assert.EventuallyWithT retry blocks in this test, the
GetMetadata error check used require.NoError(t, err), passing the
outer *testing.T instead of the tick-local *assert.CollectT (c) that
testify supplies to the callback. testify runs each retry tick's
condition function in its own goroutine, and only considers a tick
"failed" if the tick-local CollectT recorded an error. Because
require.NoError(t, err) fails on the real *testing.T, a single
transient error on any one tick calls t.FailNow(), which Goexits that
goroutine and permanently marks the whole test as failed immediately,
rather than letting assert.EventuallyWithT retry within its 40s
budget as the other blocks in this same test correctly do (they
thread c through, e.g. assert.Len(c, s.daprd.GetMetaSubscriptions(c,
ctx), 2)).

This plausibly explains (not certainly proves, since it can't be
reproduced without the exact CI timing conditions on Windows) the
reported flakiness: a single slow/transient metadata request would
hard-fail the test instead of being retried. User-visible behavior of
a genuinely broken/permanently-failing case is unchanged: every tick
would still fail and assert.EventuallyWithT still reports failure
after the 40s timeout. The fix is to pass the tick-local c instead of
t, matching the pattern already used elsewhere in this file.

Validation

go build ./tests/integration/...
go vet ./tests/integration/suite/daprd/hotreload/operator/informer/...
go test -tags=integration ./tests/integration/ -run '^Test_Integration$' \
  -focus '^daprd/hotreload/operator/informer/subscriptions$' -v -timeout=300s

All passed. Ran the focused test 3 times locally; each run passed in
~3-4s.

Fixes #9692

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
