### PR TITLE
State API: enrich the state GET error with the rich error model

### DIFF
--- a/pkg/api/errors/state.go
+++ b/pkg/api/errors/state.go
@@ -153,6 +153,22 @@ func (s *StateStoreError) QueryFailed(detail string) error {
 	)
 }
 
+/**** Store Operations ****/
+
+func (s *StateStoreError) Get(key string, msg string) error {
+	return s.build(
+		errors.NewBuilder(
+			codes.Internal,
+			http.StatusInternalServerError,
+			fmt.Sprintf("fail to get %s from state store %s: %s", key, s.name, msg),
+			errorcodes.StateGet.Code,
+			string(errorcodes.StateGet.Category),
+		),
+		errorcodes.StateGet.GrpcCode,
+		nil,
+	)
+}
+
 func (s *StateStoreError) build(err *errors.ErrorBuilder, errCode string, metadata map[string]string) error {
 	if !s.skipResourceInfo {
 		err = err.WithResourceInfo("state", s.name, "", "")

--- a/pkg/api/errors/state.go
+++ b/pkg/api/errors/state.go
@@ -160,7 +160,7 @@ func (s *StateStoreError) Get(key string, msg string) error {
 		errors.NewBuilder(
 			codes.Internal,
 			http.StatusInternalServerError,
-			fmt.Sprintf("fail to get %s from state store %s: %s", key, s.name, msg),
+			fmt.Sprintf("failed to get %s from state store %s: %s", key, s.name, msg),
 			errorcodes.StateGet.Code,
 			string(errorcodes.StateGet.Category),
 		),

--- a/pkg/api/errors/state_test.go
+++ b/pkg/api/errors/state_test.go
@@ -34,5 +34,5 @@ func TestStateStoreGet(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, kerr.HTTPStatusCode())
 	require.Equal(t, codes.Internal, kerr.GrpcStatusCode())
 	require.Equal(t, errorcodes.StateGet.Code, kerr.ErrorCode())
-	require.Contains(t, kerr.Error(), "fail to get mykey from state store mystore: connection refused")
+	require.Contains(t, kerr.Error(), "failed to get mykey from state store mystore: connection refused")
 }

--- a/pkg/api/errors/state_test.go
+++ b/pkg/api/errors/state_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	kiterrors "github.com/dapr/kit/errors"
+)
+
+func TestStateStoreGet(t *testing.T) {
+	err := StateStore("mystore").Get("mykey", "connection refused")
+	require.Error(t, err)
+
+	kerr, ok := kiterrors.FromError(err)
+	require.True(t, ok)
+
+	require.Equal(t, http.StatusInternalServerError, kerr.HTTPStatusCode())
+	require.Equal(t, codes.Internal, kerr.GrpcStatusCode())
+	require.Equal(t, errorcodes.StateGet.Code, kerr.ErrorCode())
+	require.Contains(t, kerr.Error(), "fail to get mykey from state store mystore: connection refused")
+}

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -693,7 +693,7 @@ func (a *api) GetState(ctx context.Context, in *runtimev1pb.GetStateRequest) (*r
 		if ok {
 			err = kerr.GRPCStatus().Err()
 		} else {
-			err = apierrors.Basic(codes.Internal, http.StatusInternalServerError, errorcodes.StateGet, fmt.Sprintf(messages.ErrStateGet, in.GetKey(), in.GetStoreName(), err.Error()))
+			err = apierrors.StateStore(in.GetStoreName()).Get(in.GetKey(), err.Error())
 		}
 
 		a.logger.Debug(err)
@@ -706,7 +706,7 @@ func (a *api) GetState(ctx context.Context, in *runtimev1pb.GetStateRequest) (*r
 	if encryption.EncryptedStateStore(in.GetStoreName()) {
 		val, err := encryption.TryDecryptValue(in.GetStoreName(), getResponse.Data)
 		if err != nil {
-			err = apierrors.Basic(codes.Internal, http.StatusInternalServerError, errorcodes.StateGet, fmt.Sprintf(messages.ErrStateGet, in.GetKey(), in.GetStoreName(), err.Error()))
+			err = apierrors.StateStore(in.GetStoreName()).Get(in.GetKey(), err.Error())
 			a.logger.Debug(err)
 			return &runtimev1pb.GetStateResponse{}, err
 		}

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -663,13 +663,13 @@ func (a *api) onGetState(w nethttp.ResponseWriter, r *nethttp.Request) {
 	diag.DefaultComponentMonitoring.StateInvoked(context.Background(), storeName, diag.Get, err == nil, elapsed)
 
 	if err != nil {
-		code := nethttp.StatusInternalServerError
-		kerr, ok := kiterrors.FromError(err)
-		if ok {
-			code = kerr.HTTPStatusCode()
+		if kerr, ok := kiterrors.FromError(err); ok {
+			respondWithError(w, kerr)
+			log.Debug(kerr)
+			return
 		}
 
-		resp := messages.NewAPIErrorHTTP(fmt.Sprintf(messages.ErrStateGet, key, storeName, err.Error()), errorcodes.StateGet, code)
+		resp := apierrors.StateStore(storeName).Get(key, err.Error())
 		respondWithError(w, resp)
 		log.Debug(resp)
 		return
@@ -683,7 +683,7 @@ func (a *api) onGetState(w nethttp.ResponseWriter, r *nethttp.Request) {
 	if encryption.EncryptedStateStore(storeName) {
 		val, err := encryption.TryDecryptValue(storeName, resp.Data)
 		if err != nil {
-			resp := messages.NewAPIErrorHTTP(fmt.Sprintf(messages.ErrStateGet, key, storeName, err.Error()), errorcodes.StateGet, nethttp.StatusInternalServerError)
+			resp := apierrors.StateStore(storeName).Get(key, err.Error())
 			respondWithError(w, resp)
 			log.Debug(resp)
 			return

--- a/pkg/messages/errorcodes/errorcodes.go
+++ b/pkg/messages/errorcodes/errorcodes.go
@@ -86,7 +86,7 @@ var (
 	// ### State management API
 	StateTransaction                   = ErrorCode{"ERR_STATE_TRANSACTION", "", CategoryState}                                                 // Error in state transaction
 	StateSave                          = ErrorCode{"ERR_STATE_SAVE", "", CategoryState}                                                        // Error saving state
-	StateGet                           = ErrorCode{"ERR_STATE_GET", "", CategoryState}                                                         // Error getting state
+	StateGet                           = ErrorCode{"ERR_STATE_GET", "DAPR_STATE_GET", CategoryState}                                           // Error getting state
 	StateDelete                        = ErrorCode{"ERR_STATE_DELETE", "", CategoryState}                                                      // Error deleting state
 	StateBulkDelete                    = ErrorCode{"ERR_STATE_BULK_DELETE", "", CategoryState}                                                 // Error deleting state in bulk
 	StateBulkGet                       = ErrorCode{"ERR_STATE_BULK_GET", "", CategoryState}                                                    // Error getting state in bulk


### PR DESCRIPTION
# Description

The state `GET` error was still built from the legacy predefined message (`messages.ErrStateGet`) via `apierrors.Basic` and `messages.NewAPIErrorHTTP`. This adds a `StateStore.Get` rich error and uses it in the HTTP and gRPC handlers, following the same pattern as the already-migrated state errors (`NotFound`, `NotConfigured`, `QueryFailed`, ...).

The HTTP `500` status, gRPC `Internal` code and `ERR_STATE_GET` error code are all unchanged, so the response contract stays the same. In the HTTP handler the block is aligned with the gRPC handler: an underlying kit error is now surfaced directly instead of being wrapped in a generic message.

This is a focused, incremental step for the State API error standardization; happy to follow up with the remaining store operations (save, delete, bulk delete) in separate PRs.

## Issue reference

Part of #7481

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo
