### PR TITLE
fix(pubsub): make DeliverBulk empty status fallthru consistent with Deliver

### DIFF
--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -303,8 +303,12 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 			if _, ok := (*bscData.EntryIdIndexMap)[response.EntryId]; ok {
 				switch response.Status {
 				case "":
-					// When statusCode 2xx, Consider empty status field OR not receiving status for an item as retry
+					// Consider empty status field as success, consistent with Deliver.
 					fallthrough
+				case contribpubsub.Success:
+					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Success)]++
+					entryRespReceived[response.EntryId] = true
+					todo.AddBulkResponseEntry(&bsrr.Entries, response.EntryId, nil)
 				case contribpubsub.Retry:
 					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Retry)]++
 					entryRespReceived[response.EntryId] = true
@@ -312,10 +316,6 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 						fmt.Errorf("RETRY required while processing bulk subscribe event for entry id: %v", response.EntryId))
 
 					hasAnyError = true
-				case contribpubsub.Success:
-					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Success)]++
-					entryRespReceived[response.EntryId] = true
-					todo.AddBulkResponseEntry(&bsrr.Entries, response.EntryId, nil)
 				case contribpubsub.Drop:
 					bscData.BulkSubDiag.StatusWiseDiag[string(contribpubsub.Drop)]++
 					entryRespReceived[response.EntryId] = true


### PR DESCRIPTION
## Description

In the HTTP postman, `Deliver` treats an empty status string as success (fallthrough to `Success` case), but `DeliverBulk` treated it as retry (fallthrough to `Retry` case). This inconsistency meant that an app returning an empty status would succeed in single-message delivery but retry indefinitely in bulk delivery.

## Fix

Change `DeliverBulk` to treat empty status as success, consistent with `Deliver`. An uninitialized/empty status is a safe default to treat as success since the app didn't explicitly request retry or drop.

The change in `pkg/runtime/subscription/postman/http/http.go`:
- **Before**: `case "":` fell through to `Retry`
- **After**: `case "":` falls through to `Success`

This is consistent with:
1. `Deliver` in the same file (line 132-137)
2. gRPC postman where uninitialized protobuf status defaults to `SUCCESS`

## Related issue(s)

Fixes #8737

## Checklist

- [x] Code compiles correctly
- [x] Unit tests passing
- [ ] End-to-end tests passing

## Release Note

RELEASE NOTE: **FIX** PubSub bulk subscribe now treats empty status responses as success, consistent with single-message delivery.