### PR TITLE
fix(wfengine/state): retry read-only workflow state loads on transient inbox/history key race

### DIFF
--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -50,6 +50,7 @@ import (
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	wfstateerrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/state/list"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/dapr/utils"
@@ -704,6 +705,14 @@ func (abe *Actors) String() string {
 	return "dapr.actors/v1"
 }
 
+// loadInternalStateMaxRetries bounds how many times loadInternalState
+// re-reads workflow state after a wfstateerrors.TransientReadError. The
+// metadata Get and the inbox/history GetBulk are two separate state-store
+// calls, so a concurrent actor write landing between them can make metadata
+// declare a key the bulk read doesn't (yet) see; this self-heals on the next
+// read, typically within tens of milliseconds.
+const loadInternalStateMaxRetries = 3
+
 func (abe *Actors) loadInternalState(ctx context.Context, id api.InstanceID) (*state.State, error) {
 	astate, err := abe.actors.State(ctx)
 	if err != nil {
@@ -717,13 +726,26 @@ func (abe *Actors) loadInternalState(ctx context.Context, id api.InstanceID) (*s
 	// terminal failed event) is the orchestrator actor's responsibility, not
 	// the read path's — readers surface the verification error to clients
 	// and let them detect it.
-	wstate, err := state.LoadWorkflowState(ctx, astate, string(id), state.Options{
-		AppID:             abe.appID,
-		Namespace:         abe.namespace,
-		WorkflowActorType: abe.workflowActorType,
-		ActivityActorType: abe.activityActorType,
-		Signer:            abe.signer,
-	})
+	var wstate *state.State
+	err = backoff.Retry(func() error {
+		var lerr error
+		wstate, lerr = state.LoadWorkflowState(ctx, astate, string(id), state.Options{
+			AppID:             abe.appID,
+			Namespace:         abe.namespace,
+			WorkflowActorType: abe.workflowActorType,
+			ActivityActorType: abe.activityActorType,
+			Signer:            abe.signer,
+		})
+		if lerr == nil {
+			return nil
+		}
+
+		var transientErr *wfstateerrors.TransientReadError
+		if errors.As(lerr, &transientErr) {
+			return lerr
+		}
+		return backoff.Permanent(lerr)
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(25*time.Millisecond), loadInternalStateMaxRetries), ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -857,21 +879,7 @@ func (abe *Actors) ListInstanceIDs(ctx context.Context, req *protos.ListInstance
 }
 
 func (abe *Actors) GetInstanceHistory(ctx context.Context, req *protos.GetInstanceHistoryRequest) (*protos.GetInstanceHistoryResponse, error) {
-	ss, err := abe.actors.State(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if ss == nil {
-		return nil, messages.ErrActorRuntimeNotFound
-	}
-
-	resp, err := state.LoadWorkflowState(ctx, ss, req.GetInstanceId(), state.Options{
-		AppID:             abe.appID,
-		Namespace:         abe.namespace,
-		WorkflowActorType: abe.workflowActorType,
-		ActivityActorType: abe.activityActorType,
-		Signer:            abe.signer,
-	})
+	resp, err := abe.loadInternalState(ctx, api.InstanceID(req.GetInstanceId()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runtime/wfengine/backends/actors/actors_test.go
+++ b/pkg/runtime/wfengine/backends/actors/actors_test.go
@@ -15,6 +15,7 @@ package actors
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -134,5 +135,69 @@ func TestLoadInternalState_RetriesTransientReadError(t *testing.T) {
 
 		var transientErr *wfstateerrors.TransientReadError
 		require.ErrorAs(t, err, &transientErr)
+	})
+
+	t.Run("does not retry a non-transient error", func(t *testing.T) {
+		t.Parallel()
+
+		metaBytes, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
+			InboxLength: 1,
+			Generation:  1,
+		})
+		require.NoError(t, err)
+
+		var calls atomic.Int32
+		store := statefake.New().
+			WithGetFn(func(_ context.Context, req *actorsapi.GetStateRequest, _ bool) (*actorsapi.StateResponse, error) {
+				return &actorsapi.StateResponse{Data: metaBytes}, nil
+			}).
+			WithGetBulkFn(func(_ context.Context, req *actorsapi.GetBulkStateRequest, _ bool) (actorsapi.BulkStateResponse, error) {
+				calls.Add(1)
+				return nil, errors.New("boom: permanent state store failure")
+			})
+
+		abe := newActors(store)
+
+		wstate, err := abe.loadInternalState(t.Context(), api.InstanceID("wf-1"))
+		require.Error(t, err)
+		assert.Nil(t, wstate)
+		assert.Equal(t, int32(1), calls.Load(), "a non-transient error must not be retried")
+
+		var transientErr *wfstateerrors.TransientReadError
+		assert.False(t, errors.As(err, &transientErr))
+	})
+
+	t.Run("stops retrying once the context is canceled mid-retry", func(t *testing.T) {
+		t.Parallel()
+
+		metaBytes, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
+			InboxLength: 1,
+			Generation:  1,
+		})
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		var calls atomic.Int32
+		store := statefake.New().
+			WithGetFn(func(_ context.Context, req *actorsapi.GetStateRequest, _ bool) (*actorsapi.StateResponse, error) {
+				return &actorsapi.StateResponse{Data: metaBytes}, nil
+			}).
+			WithGetBulkFn(func(_ context.Context, req *actorsapi.GetBulkStateRequest, _ bool) (actorsapi.BulkStateResponse, error) {
+				// Simulate the caller's context being canceled (e.g. the
+				// client disconnected) immediately after observing the
+				// transient mismatch on the first attempt, before any
+				// further retry can run.
+				calls.Add(1)
+				cancel()
+				return actorsapi.BulkStateResponse{}, nil
+			})
+
+		abe := newActors(store)
+
+		wstate, err := abe.loadInternalState(ctx, api.InstanceID("wf-1"))
+		require.Error(t, err)
+		assert.Nil(t, wstate)
+		assert.Equal(t, int32(1), calls.Load(), "backoff must stop once the context is canceled instead of exhausting the retry budget")
+		assert.ErrorIs(t, err, context.Canceled, "a mid-retry cancellation must surface as context.Canceled, not be masked or retried further")
 	})
 }

--- a/pkg/runtime/wfengine/backends/actors/actors_test.go
+++ b/pkg/runtime/wfengine/backends/actors/actors_test.go
@@ -164,7 +164,7 @@ func TestLoadInternalState_RetriesTransientReadError(t *testing.T) {
 		assert.Equal(t, int32(1), calls.Load(), "a non-transient error must not be retried")
 
 		var transientErr *wfstateerrors.TransientReadError
-		assert.False(t, errors.As(err, &transientErr))
+		assert.NotErrorAs(t, err, &transientErr)
 	})
 
 	t.Run("stops retrying once the context is canceled mid-retry", func(t *testing.T) {

--- a/pkg/runtime/wfengine/backends/actors/actors_test.go
+++ b/pkg/runtime/wfengine/backends/actors/actors_test.go
@@ -14,11 +14,22 @@ limitations under the License.
 package actors
 
 import (
+	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	actorsapi "github.com/dapr/dapr/pkg/actors/api"
+	actorsfake "github.com/dapr/dapr/pkg/actors/fake"
+	actorsstate "github.com/dapr/dapr/pkg/actors/state"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
+	wfstateerrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
 )
 
 func TestUniqueEventTimestamp(t *testing.T) {
@@ -55,5 +66,73 @@ func TestUniqueEventTimestamp(t *testing.T) {
 			require.False(t, dup, "duplicate timestamp issued: %d", v)
 			seen[v] = struct{}{}
 		}
+	})
+}
+
+func TestLoadInternalState_RetriesTransientReadError(t *testing.T) {
+	t.Parallel()
+
+	// Metadata declares one inbox entry throughout; the bulk read of
+	// inbox-000000 fails to observe it for the first failCount calls before
+	// "self-healing" and returning it, simulating a concurrent actor write
+	// racing the metadata Get and the inbox GetBulk.
+	newStore := func(failCount int32) *statefake.Fake {
+		metaBytes, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
+			InboxLength: 1,
+			Generation:  1,
+		})
+		require.NoError(t, err)
+
+		eventBytes, err := proto.Marshal(&backend.HistoryEvent{EventId: 0})
+		require.NoError(t, err)
+
+		var calls atomic.Int32
+
+		return statefake.New().
+			WithGetFn(func(_ context.Context, req *actorsapi.GetStateRequest, _ bool) (*actorsapi.StateResponse, error) {
+				return &actorsapi.StateResponse{Data: metaBytes}, nil
+			}).
+			WithGetBulkFn(func(_ context.Context, req *actorsapi.GetBulkStateRequest, _ bool) (actorsapi.BulkStateResponse, error) {
+				out := actorsapi.BulkStateResponse{}
+				if calls.Add(1) <= failCount {
+					return out, nil
+				}
+				out["inbox-000000"] = actorsapi.BulkStateEntry{Data: eventBytes}
+				return out, nil
+			})
+	}
+
+	newActors := func(store *statefake.Fake) *Actors {
+		return &Actors{
+			workflowActorType: "workflow",
+			activityActorType: "activity",
+			actors: actorsfake.New().WithState(func(context.Context) (actorsstate.Interface, error) {
+				return store, nil
+			}),
+		}
+	}
+
+	t.Run("succeeds once the retry budget observes the healed read", func(t *testing.T) {
+		t.Parallel()
+
+		abe := newActors(newStore(loadInternalStateMaxRetries))
+
+		wstate, err := abe.loadInternalState(t.Context(), api.InstanceID("wf-1"))
+		require.NoError(t, err)
+		require.NotNil(t, wstate)
+		assert.Len(t, wstate.Inbox, 1)
+	})
+
+	t.Run("gives up as a TransientReadError once the retry budget is exhausted", func(t *testing.T) {
+		t.Parallel()
+
+		abe := newActors(newStore(loadInternalStateMaxRetries + 1))
+
+		wstate, err := abe.loadInternalState(t.Context(), api.InstanceID("wf-1"))
+		require.Error(t, err)
+		assert.Nil(t, wstate)
+
+		var transientErr *wfstateerrors.TransientReadError
+		require.ErrorAs(t, err, &transientErr)
 	})
 }

--- a/pkg/runtime/wfengine/state/errors/errors.go
+++ b/pkg/runtime/wfengine/state/errors/errors.go
@@ -64,3 +64,27 @@ func (e *ConfigurationError) Error() string {
 func (e *ConfigurationError) Unwrap() error {
 	return e.err
 }
+
+// TransientReadError is returned by LoadWorkflowState when metadata declares
+// an inbox or history key that the bulk read didn't observe. The metadata
+// Get and the inbox/history GetBulk are two separate state-store calls, so a
+// concurrent actor write landing between them can produce this mismatch even
+// though the persisted state itself is intact; the condition clears on the
+// next load. Callers on read-only query paths (GetInstance,
+// GetWorkflowMetadata) should retry a bounded number of times before
+// surfacing the error.
+type TransientReadError struct {
+	err error
+}
+
+func NewTransientReadError(err error) *TransientReadError {
+	return &TransientReadError{err}
+}
+
+func (e *TransientReadError) Error() string {
+	return e.err.Error()
+}
+
+func (e *TransientReadError) Unwrap() error {
+	return e.err
+}

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -840,7 +840,9 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetInboxLength() {
 		key = getMultiEntryKeyName(inboxKeyPrefix, i)
 		if bulkRes[key].Data == nil {
-			return nil, fmt.Errorf("workflow '%s': inbox key '%s' declared in metadata (inboxLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetInboxLength())
+			return nil, wferrors.NewTransientReadError(
+				fmt.Errorf("workflow '%s': inbox key '%s' declared in metadata (inboxLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetInboxLength()),
+			)
 		}
 
 		var hist backend.HistoryEvent
@@ -855,7 +857,9 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetHistoryLength() {
 		key = getMultiEntryKeyName(historyKeyPrefix, i)
 		if bulkRes[key].Data == nil {
-			return nil, fmt.Errorf("workflow '%s': history key '%s' declared in metadata (historyLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetHistoryLength())
+			return nil, wferrors.NewTransientReadError(
+				fmt.Errorf("workflow '%s': history key '%s' declared in metadata (historyLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetHistoryLength()),
+			)
 		}
 
 		var hist backend.HistoryEvent

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -717,6 +717,68 @@ func TestLoadWorkflowState_SetsPersistedFlagsFromETag(t *testing.T) {
 	}
 }
 
+func TestLoadWorkflowState_MissingInboxOrHistoryKeyReturnsTransientReadError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		inboxLength   uint64
+		historyLength uint64
+		missingKey    string
+	}{
+		{
+			name:        "missing inbox key",
+			inboxLength: 1,
+			missingKey:  "inbox-000000",
+		},
+		{
+			name:          "missing history key",
+			historyLength: 1,
+			missingKey:    "history-000000",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const actorID = "wf-missing-key"
+
+			metaBytes, err := proto.Marshal(&backend.BackendWorkflowStateMetadata{
+				InboxLength:   tc.inboxLength,
+				HistoryLength: tc.historyLength,
+				Generation:    1,
+			})
+			require.NoError(t, err)
+
+			store := statefake.New().
+				WithGetFn(func(_ context.Context, req *api.GetStateRequest, _ bool) (*api.StateResponse, error) {
+					if req.Key == MetadataKey {
+						return &api.StateResponse{Data: metaBytes}, nil
+					}
+					return &api.StateResponse{}, nil
+				}).
+				WithGetBulkFn(func(_ context.Context, req *api.GetBulkStateRequest, _ bool) (api.BulkStateResponse, error) {
+					// Simulate the declared key not (yet) being visible to the
+					// bulk read, as happens when a concurrent write races the
+					// metadata Get and the inbox/history GetBulk.
+					return api.BulkStateResponse{}, nil
+				})
+
+			got, err := LoadWorkflowState(t.Context(), store, actorID, Options{
+				WorkflowActorType: "workflow",
+				ActivityActorType: "activity",
+			})
+			require.Nil(t, got)
+			require.Error(t, err)
+
+			var transientErr *wferrors.TransientReadError
+			require.ErrorAs(t, err, &transientErr, "error must be a TransientReadError so read-path callers can retry")
+			assert.Contains(t, err.Error(), tc.missingKey)
+		})
+	}
+}
+
 func TestGetSaveRequest_MetadataIncludesSigningLengths(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Motivation:

GetInstance / GetWorkflowMetadata / GetInstanceHistory intermittently fail
with a gRPC Unknown error:

  workflow '<id>': inbox key 'inbox-000000' declared in metadata
  (inboxLength=1) but missing from state store (transient store read
  failure or partial save?)

LoadWorkflowState reads the metadata row and the inbox/history entries as
two separate state-store calls (Get, then GetBulk). A concurrent actor
write landing between the two calls can make metadata declare a key that
the bulk read doesn't yet observe, even though nothing is actually
corrupted on disk. This condition is transient and self-healing: the
reporter of dapr/dapr#10242 (a re-filed copy of the original #10226, which
was briefly transferred to dapr/dotnet-sdk#1876 and bounced back to the
runtime) observed the very next poll for the same instance succeeding, and
found no persisted metadata/inbox disagreement when sampling the state
table during the race.

Approach:

- Add a TransientReadError wrapper type in pkg/runtime/wfengine/state/errors
  so LoadWorkflowState's two "declared in metadata ... but missing" error
  sites (inbox, history) can be distinguished from other load failures
  (e.g. tamper-detection VerificationError) without callers string-matching
  the error text.
- In pkg/runtime/wfengine/backends/actors/actors.go, loadInternalState now
  retries LoadWorkflowState up to 3 additional times (25ms constant
  backoff, so 4 attempts spanning up to ~75ms) specifically when the error
  is a TransientReadError; any other error returns immediately with no
  retry. loadInternalState backs GetWorkflowMetadata and
  GetWorkflowRuntimeState, and GetInstanceHistory (which previously called
  LoadWorkflowState directly, bypassing the retry) now routes through it
  too.

This does not change what's persisted, and it does not guarantee the race
never surfaces: if the underlying write hasn't settled within the ~75ms
retry window, the error still reaches the caller — the issue's own logs
show one instance where two failures landed ~120ms apart, outside this
window. The fix only reduces how often the transient mismatch is visible
to callers, by requiring it to reproduce across up to 4 reads of the same
instance instead of 1.

Validation:

go build ./pkg/... && go test ./pkg/runtime/wfengine/... ./pkg/actors/...

All packages pass, including two new tests: state_test.go asserts both the
missing-inbox-key and missing-history-key paths return a TransientReadError,
and actors_test.go asserts loadInternalState both recovers within the retry
budget and gives up with a TransientReadError once the budget is exhausted.

Fixes #10226
Fixes #10242

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>