### PR TITLE
Resolve TODO: fix types in gRPC server and scheduler

### DIFF
--- a/pkg/actors/internal/scheduler/scheduler.go
+++ b/pkg/actors/internal/scheduler/scheduler.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -139,9 +140,11 @@ func scheduleFromPeriod(period string) (*string, *uint32, error) {
 
 	var repeats *uint32
 	if repetition > 0 {
-		//TODO: fix types
-		//nolint:gosec
-		repeats = new(uint32(repetition))
+		r := uint32(repetition) //nolint:gosec // round-trip checked below
+		if int64(r) != int64(repetition) {
+			return nil, nil, fmt.Errorf("unsupported repetition count: %d exceeds maximum of %d", repetition, math.MaxUint32)
+		}
+		repeats = &r
 	}
 
 	return new("@every " + duration.String()), repeats, nil

--- a/pkg/api/grpc/server.go
+++ b/pkg/api/grpc/server.go
@@ -353,12 +353,17 @@ func (s *server) getGRPCServer() (*grpcGo.Server, error) {
 		opts = append(opts, s.grpcServerOpts...)
 	}
 
-	// TODO: fix types
-	//nolint:gosec
+	// MaxRequestBodySize is already in bytes, so no unit conversion is needed
+	// for MaxRecvMsgSize/MaxSendMsgSize. The ReadBufferSize<<10 conversion for
+	// MaxHeaderListSize is round-trip checked before the narrowing conversion.
+	maxHeaderListSize := uint32(s.config.ReadBufferSize << 10) //nolint:gosec // round-trip checked below
+	if int64(maxHeaderListSize) != int64(s.config.ReadBufferSize<<10) {
+		return nil, fmt.Errorf("read buffer size %d is out of range for gRPC max header list size", s.config.ReadBufferSize)
+	}
 	opts = append(opts,
 		grpcGo.MaxRecvMsgSize(s.config.MaxRequestBodySize),
 		grpcGo.MaxSendMsgSize(s.config.MaxRequestBodySize),
-		grpcGo.MaxHeaderListSize(uint32(s.config.ReadBufferSize<<10)),
+		grpcGo.MaxHeaderListSize(maxHeaderListSize),
 	)
 
 	if s.sec == nil {
@@ -417,8 +422,8 @@ func (s *server) printAPILog(ctx context.Context, method string, duration time.D
 	}
 	// Report duration in milliseconds
 	fields["duration"] = duration.Milliseconds()
-	// TODO: fix types
-	//nolint:gosec
-	fields["code"] = int32(code)
+	// grpcCodes.Code is a small, well-known enum (currently 0-16), so the
+	// narrowing conversion to int32 for the log field cannot overflow.
+	fields["code"] = int32(code) //nolint:gosec // bounded enum, see comment above
 	s.infoLogger.WithFields(fields).Info("gRPC API Called")
 }


### PR DESCRIPTION
## Why

Three call sites carried a `TODO: fix types` comment next to a blanket `//nolint:gosec` suppression, silently hiding unchecked integer conversions instead of resolving them:

- `pkg/api/grpc/server.go` `printAPILog()`: `int32(grpcCodes.Code)` — safe in practice since `codes.Code` is a small, bounded enum (~17 defined values), but the suppression gave no indication why.
- `pkg/api/grpc/server.go` `getGRPCServer()`: the whole `nolint` covered three option calls, but `MaxRecvMsgSize`/`MaxSendMsgSize` take `s.config.MaxRequestBodySize`, which is already an `int` — no conversion happens there at all. Only `MaxHeaderListSize(uint32(s.config.ReadBufferSize<<10))` has a real narrowing conversion, and it was unchecked.
- `pkg/actors/internal/scheduler/scheduler.go` `scheduleFromPeriod()`: `uint32(repetition)` had no upper-bound check, so a reminder period string with an extreme repetition count would silently wrap instead of failing clearly.

## What

- Replaced the `int32(code)` suppression with a comment explaining why it's safe (bounded enum), rather than leaving it as an unexplained TODO.
- Removed the suppression on `MaxRecvMsgSize`/`MaxSendMsgSize` since they need no conversion.
- Added a round-trip bounds check before the `MaxHeaderListSize` conversion, returning an error instead of silently truncating on an out-of-range value.
- Added the same round-trip bounds check for `repetition` before narrowing to `uint32`, returning a clear error instead of silently truncating.

No behavior changes for any currently valid input — this is purely resolving the "fix types" TODOs with either a real fix or a documented justification. (While investigating this, I found a separate, real magnitude bug in the same `ReadBufferSize<<10` expression — that's tracked and will be submitted as its own follow-up PR after discussion, since it's a behavior change and deserves its own scrutiny rather than being bundled here.)

## Test plan
- [x] `go build ./pkg/api/grpc/... ./pkg/actors/internal/scheduler/...`
- [x] `go vet --tags=unit,allcomponents ./pkg/api/grpc/... ./pkg/actors/internal/scheduler/...`
- [x] `go test --tags=unit,allcomponents ./pkg/api/grpc/... ./pkg/actors/internal/scheduler/...`
- [x] `golangci-lint run --build-tags=allcomponents,subtlecrypto ./pkg/api/grpc/... ./pkg/actors/internal/scheduler/...` (0 issues)