### PR TITLE
Fix gRPC MaxHeaderListSize magnitude (drop redundant ReadBufferSize<<10 shift)

### DIFF
--- a/pkg/actors/internal/scheduler/scheduler.go
+++ b/pkg/actors/internal/scheduler/scheduler.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -139,9 +140,11 @@ func scheduleFromPeriod(period string) (*string, *uint32, error) {
 
 	var repeats *uint32
 	if repetition > 0 {
-		//TODO: fix types
-		//nolint:gosec
-		repeats = new(uint32(repetition))
+		r := uint32(repetition) //nolint:gosec // round-trip checked below
+		if int64(r) != int64(repetition) {
+			return nil, nil, fmt.Errorf("unsupported repetition count: %d exceeds maximum of %d", repetition, math.MaxUint32)
+		}
+		repeats = &r
 	}
 
 	return new("@every " + duration.String()), repeats, nil

--- a/pkg/api/grpc/server.go
+++ b/pkg/api/grpc/server.go
@@ -353,12 +353,17 @@ func (s *server) getGRPCServer() (*grpcGo.Server, error) {
 		opts = append(opts, s.grpcServerOpts...)
 	}
 
-	// TODO: fix types
-	//nolint:gosec
+	// MaxRequestBodySize is already in bytes, so no unit conversion is needed
+	// for MaxRecvMsgSize/MaxSendMsgSize. The ReadBufferSize<<10 conversion for
+	// MaxHeaderListSize is round-trip checked before the narrowing conversion.
+	maxHeaderListSize := uint32(s.config.ReadBufferSize << 10) //nolint:gosec // round-trip checked below
+	if int64(maxHeaderListSize) != int64(s.config.ReadBufferSize<<10) {
+		return nil, fmt.Errorf("read buffer size %d is out of range for gRPC max header list size", s.config.ReadBufferSize)
+	}
 	opts = append(opts,
 		grpcGo.MaxRecvMsgSize(s.config.MaxRequestBodySize),
 		grpcGo.MaxSendMsgSize(s.config.MaxRequestBodySize),
-		grpcGo.MaxHeaderListSize(uint32(s.config.ReadBufferSize<<10)),
+		grpcGo.MaxHeaderListSize(maxHeaderListSize),
 	)
 
 	if s.sec == nil {
@@ -417,8 +422,8 @@ func (s *server) printAPILog(ctx context.Context, method string, duration time.D
 	}
 	// Report duration in milliseconds
 	fields["duration"] = duration.Milliseconds()
-	// TODO: fix types
-	//nolint:gosec
-	fields["code"] = int32(code)
+	// grpcCodes.Code is a small, well-known enum (currently 0-16), so the
+	// narrowing conversion to int32 for the log field cannot overflow.
+	fields["code"] = int32(code) //nolint:gosec // bounded enum, see comment above
 	s.infoLogger.WithFields(fields).Info("gRPC API Called")
 }

--- a/pkg/api/grpc/server.go
+++ b/pkg/api/grpc/server.go
@@ -353,11 +353,11 @@ func (s *server) getGRPCServer() (*grpcGo.Server, error) {
 		opts = append(opts, s.grpcServerOpts...)
 	}
 
-	// MaxRequestBodySize is already in bytes, so no unit conversion is needed
-	// for MaxRecvMsgSize/MaxSendMsgSize. The ReadBufferSize<<10 conversion for
-	// MaxHeaderListSize is round-trip checked before the narrowing conversion.
-	maxHeaderListSize := uint32(s.config.ReadBufferSize << 10) //nolint:gosec // round-trip checked below
-	if int64(maxHeaderListSize) != int64(s.config.ReadBufferSize<<10) {
+	// MaxRequestBodySize and ReadBufferSize are both already in bytes, so no
+	// unit conversion is needed here. ReadBufferSize is round-trip checked
+	// before the narrowing conversion for MaxHeaderListSize.
+	maxHeaderListSize := uint32(s.config.ReadBufferSize) //nolint:gosec // round-trip checked below
+	if int64(maxHeaderListSize) != int64(s.config.ReadBufferSize) {
 		return nil, fmt.Errorf("read buffer size %d is out of range for gRPC max header list size", s.config.ReadBufferSize)
 	}
 	opts = append(opts,


### PR DESCRIPTION
## Why

Fixes #10272.

`getGRPCServer()` in `pkg/api/grpc/server.go` sets the gRPC server's max header list size via:

```go
grpcGo.MaxHeaderListSize(uint32(s.config.ReadBufferSize<<10)),
```

`ReadBufferSize` (`pkg/api/grpc/config.go:25`) is documented and consistently used as **bytes** everywhere else in the codebase (`cmd/daprd/options.go`, `pkg/runtime/config.go`, `pkg/api/http/server.go`). The `<<10` shift multiplies it by 1024 a second time, so with the default `ReadBufferSize` of 4096 bytes, `MaxHeaderListSize` was being set to `4194304` (~4 MB) instead of the evidently intended `4096` (~4 KB).

`git log -L 355,362:pkg/api/grpc/server.go` traces this to commit `c920e2667` ("Standardize max-body-size and read-buffer-size flags", Feb 2024), which converted this field from KB to bytes but only dropped the equivalent `<<20` shift on the adjacent `MaxRequestBodySize` line, not this one — see #10272 for full details.

## What

Drops the redundant `<<10` shift. The narrowing conversion to `uint32` is unchanged from #10271 (round-trip checked, returns an error instead of silently truncating on an out-of-range value).

## Note on scope

This branch is stacked on #10271 (the diff will show both commits until that one merges — this PR's actual change is a single 5-line diff removing the `<<10` shift). Opening as a separate PR intentionally, since this is a behavior change on a stable code path and deserves its own review/discussion rather than being bundled into the type-safety cleanup in #10271.

## Test plan
- [x] `go build ./pkg/api/grpc/...`
- [x] `go vet --tags=unit,allcomponents ./pkg/api/grpc/...`
- [x] `go test --tags=unit,allcomponents ./pkg/api/grpc/...`
- [x] `golangci-lint run --build-tags=allcomponents,subtlecrypto ./pkg/api/grpc/...` (0 issues)