### PR TITLE
Workflow: Fix transient GetInstance failure

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -3,6 +3,7 @@
 This update contains the following bug fixes:
 - [Scheduler embedded etcd metrics missing from the metrics endpoint](#scheduler-embedded-etcd-metrics-missing-from-the-metrics-endpoint)
 - [Scheduler hanging on shutdown and failing to redeliver jobs after client disconnects](#scheduler-hanging-on-shutdown-and-failing-to-redeliver-jobs-after-client-disconnects)
+- [Workflow GetInstance intermittently failing while the workflow is running](#workflow-getinstance-intermittently-failing-while-the-workflow-is-running)
 
 ## Scheduler embedded etcd metrics missing from the metrics endpoint
 
@@ -59,3 +60,33 @@ Scheduler shutdown now fails readiness before draining and bounds the graceful d
 Dead streams are now closed exactly once: the close cancels the stream at detection time, promptly deregisters its deliverable prefixes, and resolves in-flight jobs as undeliverable so the engine immediately redelivers them to healthy streams.
 Namespace deletion is now confirmed by the connection tracking loop that owns the authoritative stream set, so duplicate or stray close events can no longer tear down a namespace that still has live streams.
 The event-loop object recycling race was removed.
+
+## Workflow GetInstance intermittently failing while the workflow is running
+
+### Problem
+
+A read-only workflow status query (`GetInstance` / `GetWorkflowMetadata`, or the equivalent SDK calls such as `GetWorkflowStateAsync`) could intermittently fail with a gRPC `Unknown` error while the queried workflow was running normally:
+
+```
+Status(StatusCode="Unknown", Detail="workflow '<id>': inbox key 'inbox-000000' declared in metadata (inboxLength=1) but missing from state store (transient store read failure or partial save?)")
+```
+
+The failure was transient and self-healing: the next poll for the same instance succeeded, and the workflow itself completed successfully.
+
+### Impact
+
+You were affected if you polled workflow status while workflows were making progress, most visibly under high activity concurrency (for example a fan-out of many parallel activities polled by several concurrent clients), although a single activity transition could also trigger it.
+Callers received a terminal-looking error for a healthy workflow, so clients without their own retry logic surfaced spurious failures.
+The persisted workflow state was never actually inconsistent.
+
+### Root Cause
+
+Loading workflow state reads the `metadata` row and the `inbox-*`/`history-*` entry rows in two separate state store calls, and the status query path performs these reads without holding the workflow actor's lock.
+A workflow actor save is a single atomic transaction that deletes consumed inbox entries and writes updated metadata, so a save committing between the reader's two calls produced a torn read: the old metadata still declared inbox entries that the second read no longer found.
+This torn read was reported as a hard error to the caller.
+
+### Solution
+
+The workflow state load now detects this mismatch and retries the whole load with freshly read metadata, up to 5 attempts spaced 15 ms apart.
+The metadata ETag is compared between attempts: a changed ETag proves a concurrent save landed between the reads (retry), while an unchanged ETag proves the entries are genuinely missing from the store, in which case the original error is still returned.
+Status queries racing an active workflow now return consistent results instead of transient `Unknown` errors.

--- a/pkg/runtime/wfengine/state/load.go
+++ b/pkg/runtime/wfengine/state/load.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dapr/dapr/pkg/actors/state"
+)
+
+const (
+	// loadStateMaxAttempts and loadStateRetryDelay bound the reload retries when
+	// a load observes metadata and entry rows from different committed snapshots
+	// (a save landing between the metadata Get and the bulk Get).
+	loadStateMaxAttempts = 5
+	loadStateRetryDelay  = 15 * time.Millisecond
+)
+
+// LoadWorkflowState loads the workflow state from the actor state store. The
+// metadata row and the inbox/history entry rows are read in two separate
+// state-store calls, so a concurrent actor save committing between them can
+// delete entry rows the just-read metadata still declares. That torn read is
+// transient: retry the whole load with fresh metadata. If the metadata ETag is
+// unchanged between two attempts no save landed in between, so the data is
+// genuinely missing and the error is surfaced.
+func LoadWorkflowState(ctx context.Context, astate state.Interface, actorID string, opts Options) (*State, error) {
+	var prevETag *string
+	var havePrev bool
+	for attempt := 1; ; attempt++ {
+		s, err := loadWorkflowStateOnce(ctx, astate, actorID, opts)
+		var mErr *transientKeyMismatchError
+		if err == nil || !errors.As(err, &mErr) {
+			return s, err
+		}
+		if havePrev && prevETag != nil && mErr.etag != nil && *prevETag == *mErr.etag {
+			return nil, mErr.err
+		}
+		if attempt >= loadStateMaxAttempts {
+			return nil, mErr.err
+		}
+		prevETag, havePrev = mErr.etag, true
+		wfLogger.Debugf("workflow '%s': load raced a concurrent save (attempt %d/%d), retrying: %s",
+			actorID, attempt, loadStateMaxAttempts, mErr.err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(loadStateRetryDelay):
+		}
+	}
+}
+
+// transientKeyMismatchError marks a load that observed metadata declaring an
+// inbox or history key which the bulk read did not return. It carries the
+// metadata ETag of the failed attempt so the retry loop can distinguish a
+// concurrent save (metadata changed) from genuinely missing data.
+type transientKeyMismatchError struct {
+	err  error
+	etag *string
+}
+
+func (e *transientKeyMismatchError) Error() string { return e.err.Error() }
+func (e *transientKeyMismatchError) Unwrap() error { return e.err }

--- a/pkg/runtime/wfengine/state/load_test.go
+++ b/pkg/runtime/wfengine/state/load_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/pkg/actors/api"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/kit/ptr"
+)
+
+func TestLoadWorkflowState_ConcurrentSaveMismatch(t *testing.T) {
+	t.Parallel()
+
+	const actorID = "wf-load-race"
+
+	marshalMeta := func(t *testing.T, meta *backend.BackendWorkflowStateMetadata) []byte {
+		t.Helper()
+		b, err := proto.Marshal(meta)
+		require.NoError(t, err)
+		return b
+	}
+
+	type attempt struct {
+		meta *backend.BackendWorkflowStateMetadata
+		etag *string
+		bulk map[string]api.BulkStateEntry
+	}
+
+	newStore := func(t *testing.T, attempts []attempt, gets *int) *statefake.Fake {
+		t.Helper()
+		return statefake.New().
+			WithGetFn(func(_ context.Context, req *api.GetStateRequest, _ bool) (*api.StateResponse, error) {
+				require.Equal(t, MetadataKey, req.Key)
+				require.Less(t, *gets, len(attempts), "more load attempts than scripted")
+				a := attempts[*gets]
+				*gets++
+				return &api.StateResponse{Data: marshalMeta(t, a.meta), ETag: a.etag}, nil
+			}).
+			WithGetBulkFn(func(_ context.Context, req *api.GetBulkStateRequest, _ bool) (api.BulkStateResponse, error) {
+				a := attempts[*gets-1]
+				out := api.BulkStateResponse{}
+				for _, k := range req.Keys {
+					out[k] = a.bulk[k]
+				}
+				return out, nil
+			})
+	}
+
+	histBytes, err := proto.Marshal(testEvent(0))
+	require.NoError(t, err)
+	inboxBytes, err := proto.Marshal(testEvent(1))
+	require.NoError(t, err)
+
+	t.Run("inbox mismatch with changed etag retries and succeeds", func(t *testing.T) {
+		t.Parallel()
+		var gets int
+		store := newStore(t, []attempt{
+			{
+				meta: &backend.BackendWorkflowStateMetadata{InboxLength: 1, Generation: 1},
+				etag: ptr.Of("e1"),
+				bulk: map[string]api.BulkStateEntry{},
+			},
+			{
+				meta: &backend.BackendWorkflowStateMetadata{HistoryLength: 1, Generation: 1},
+				etag: ptr.Of("e2"),
+				bulk: map[string]api.BulkStateEntry{"history-000000": {Data: histBytes}},
+			},
+		}, &gets)
+
+		got, lerr := LoadWorkflowState(t.Context(), store, actorID, testOpts())
+		require.NoError(t, lerr)
+		require.NotNil(t, got)
+		assert.Empty(t, got.Inbox)
+		assert.Len(t, got.History, 1)
+		assert.Equal(t, 2, gets)
+	})
+
+	t.Run("history mismatch with changed etag retries and succeeds", func(t *testing.T) {
+		t.Parallel()
+		var gets int
+		store := newStore(t, []attempt{
+			{
+				meta: &backend.BackendWorkflowStateMetadata{HistoryLength: 2, Generation: 1},
+				etag: ptr.Of("e1"),
+				bulk: map[string]api.BulkStateEntry{"history-000000": {Data: histBytes}},
+			},
+			{
+				meta: &backend.BackendWorkflowStateMetadata{HistoryLength: 1, InboxLength: 1, Generation: 1},
+				etag: ptr.Of("e2"),
+				bulk: map[string]api.BulkStateEntry{
+					"history-000000": {Data: histBytes},
+					"inbox-000000":   {Data: inboxBytes},
+				},
+			},
+		}, &gets)
+
+		got, lerr := LoadWorkflowState(t.Context(), store, actorID, testOpts())
+		require.NoError(t, lerr)
+		require.NotNil(t, got)
+		assert.Len(t, got.Inbox, 1)
+		assert.Len(t, got.History, 1)
+		assert.Equal(t, 2, gets)
+	})
+
+	t.Run("unchanged etag is a hard error without further retries", func(t *testing.T) {
+		t.Parallel()
+		var gets int
+		missing := attempt{
+			meta: &backend.BackendWorkflowStateMetadata{InboxLength: 1, Generation: 1},
+			etag: ptr.Of("e1"),
+			bulk: map[string]api.BulkStateEntry{},
+		}
+		store := newStore(t, []attempt{missing, missing}, &gets)
+
+		got, lerr := LoadWorkflowState(t.Context(), store, actorID, testOpts())
+		require.ErrorContains(t, lerr, "declared in metadata")
+		assert.Nil(t, got)
+		assert.Equal(t, 2, gets)
+	})
+
+	t.Run("changing etags retry until the attempt cap", func(t *testing.T) {
+		t.Parallel()
+		var gets int
+		attempts := make([]attempt, loadStateMaxAttempts)
+		for i := range attempts {
+			attempts[i] = attempt{
+				meta: &backend.BackendWorkflowStateMetadata{InboxLength: 1, Generation: 1},
+				etag: ptr.Of(strconv.Itoa(i)),
+				bulk: map[string]api.BulkStateEntry{},
+			}
+		}
+		store := newStore(t, attempts, &gets)
+
+		got, lerr := LoadWorkflowState(t.Context(), store, actorID, testOpts())
+		require.ErrorContains(t, lerr, "declared in metadata")
+		assert.Nil(t, got)
+		assert.Equal(t, loadStateMaxAttempts, gets)
+	})
+
+	t.Run("nil etags retry until the attempt cap", func(t *testing.T) {
+		t.Parallel()
+		var gets int
+		missing := attempt{
+			meta: &backend.BackendWorkflowStateMetadata{InboxLength: 1, Generation: 1},
+			bulk: map[string]api.BulkStateEntry{},
+		}
+		attempts := make([]attempt, loadStateMaxAttempts)
+		for i := range attempts {
+			attempts[i] = missing
+		}
+		store := newStore(t, attempts, &gets)
+
+		got, lerr := LoadWorkflowState(t.Context(), store, actorID, testOpts())
+		require.ErrorContains(t, lerr, "declared in metadata")
+		assert.Nil(t, got)
+		assert.Equal(t, loadStateMaxAttempts, gets)
+	})
+
+	t.Run("signing certificate verification error does not retry", func(t *testing.T) {
+		t.Parallel()
+		var gets int
+		store := newStore(t, []attempt{{
+			meta: &backend.BackendWorkflowStateMetadata{HistoryLength: 1, SigningCertificateLength: 1, Generation: 1},
+			etag: ptr.Of("e1"),
+			bulk: map[string]api.BulkStateEntry{"history-000000": {Data: histBytes}},
+		}}, &gets)
+
+		_, lerr := LoadWorkflowState(t.Context(), store, actorID, testOpts())
+		var verifyErr *wferrors.VerificationError
+		require.ErrorAs(t, lerr, &verifyErr)
+		assert.Equal(t, 1, gets)
+	})
+}

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -695,7 +695,7 @@ func addPurgeStateOperations(req *api.TransactionalRequest, keyPrefix string, co
 	}
 }
 
-func LoadWorkflowState(ctx context.Context, state state.Interface, actorID string, opts Options) (*State, error) {
+func loadWorkflowStateOnce(ctx context.Context, state state.Interface, actorID string, opts Options) (*State, error) {
 	loadStartTime := time.Now()
 
 	// Load metadata
@@ -840,7 +840,10 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetInboxLength() {
 		key = getMultiEntryKeyName(inboxKeyPrefix, i)
 		if bulkRes[key].Data == nil {
-			return nil, fmt.Errorf("workflow '%s': inbox key '%s' declared in metadata (inboxLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetInboxLength())
+			return nil, &transientKeyMismatchError{
+				err:  fmt.Errorf("workflow '%s': inbox key '%s' declared in metadata (inboxLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetInboxLength()),
+				etag: res.ETag,
+			}
 		}
 
 		var hist backend.HistoryEvent
@@ -855,7 +858,10 @@ func LoadWorkflowState(ctx context.Context, state state.Interface, actorID strin
 	for i := range metadata.GetHistoryLength() {
 		key = getMultiEntryKeyName(historyKeyPrefix, i)
 		if bulkRes[key].Data == nil {
-			return nil, fmt.Errorf("workflow '%s': history key '%s' declared in metadata (historyLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetHistoryLength())
+			return nil, &transientKeyMismatchError{
+				err:  fmt.Errorf("workflow '%s': history key '%s' declared in metadata (historyLength=%d) but missing from state store (transient store read failure or partial save?)", actorID, key, metadata.GetHistoryLength()),
+				etag: res.ETag,
+			}
 		}
 
 		var hist backend.HistoryEvent

--- a/tests/integration/framework/process/statestore/fault/fault.go
+++ b/tests/integration/framework/process/statestore/fault/fault.go
@@ -45,6 +45,20 @@ type Store struct {
 	failedCount      atomic.Int32
 
 	multiObserver func(*state.TransactionalStateRequest)
+
+	multiDeleteHold *holdSpec
+	bulkGetHold     *holdSpec
+}
+
+// holdSpec is a one-shot arm-able hold on a store operation matching a key
+// substring. arrived is closed when the operation is captured; the operation
+// then blocks until releaseCh is closed (or the request context is done);
+// done, when non-nil, is closed after the delegated operation returns.
+type holdSpec struct {
+	sub       string
+	arrived   chan struct{}
+	releaseCh chan struct{}
+	done      chan struct{}
 }
 
 // SetMultiObserver registers a callback invoked synchronously on every Multi
@@ -96,6 +110,44 @@ func (s *Store) armWith(keySubstring string, n int, err error, notify chan struc
 // by this Store since it was constructed.
 func (s *Store) FailedCount() int { return int(s.failedCount.Load()) }
 
+// ArmMultiDeleteHold arms a one-shot hold on the next Multi containing a
+// Delete operation whose key contains sub. arrived is closed when the Multi
+// is captured; the Multi blocks until release is called (or its context is
+// done); done is closed after the delegated Multi returns. release is
+// idempotent, so it is safe to register with t.Cleanup.
+func (s *Store) ArmMultiDeleteHold(sub string) (arrived <-chan struct{}, release func(), done <-chan struct{}) {
+	spec := &holdSpec{
+		sub:       sub,
+		arrived:   make(chan struct{}),
+		releaseCh: make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	s.mu.Lock()
+	s.multiDeleteHold = spec
+	s.mu.Unlock()
+
+	var once sync.Once
+	return spec.arrived, func() { once.Do(func() { close(spec.releaseCh) }) }, spec.done
+}
+
+// ArmBulkGetHold arms a one-shot hold on the next BulkGet touching a key
+// containing sub. arrived is closed when the BulkGet is captured; the call
+// blocks until release is called (or its context is done). release is
+// idempotent, so it is safe to register with t.Cleanup.
+func (s *Store) ArmBulkGetHold(sub string) (arrived <-chan struct{}, release func()) {
+	spec := &holdSpec{
+		sub:       sub,
+		arrived:   make(chan struct{}),
+		releaseCh: make(chan struct{}),
+	}
+	s.mu.Lock()
+	s.bulkGetHold = spec
+	s.mu.Unlock()
+
+	var once sync.Once
+	return spec.arrived, func() { once.Do(func() { close(spec.releaseCh) }) }
+}
+
 // Multi implements state.TransactionalStore. If the store is armed and the
 // request touches a key containing the armed substring, the request is failed
 // with the armed error; otherwise the request is delegated to the underlying
@@ -142,7 +194,52 @@ func (s *Store) Multi(ctx context.Context, req *state.TransactionalStateRequest)
 		}
 		return err
 	}
+
+	s.mu.Lock()
+	var hold *holdSpec
+	if s.multiDeleteHold != nil && anyDeleteHasSubstring(req.Operations, s.multiDeleteHold.sub) {
+		hold = s.multiDeleteHold
+		s.multiDeleteHold = nil
+	}
+	s.mu.Unlock()
+
+	if hold != nil {
+		close(hold.arrived)
+		select {
+		case <-hold.releaseCh:
+		case <-ctx.Done():
+		}
+		defer close(hold.done)
+	}
+
 	return s.Wrapped.Store.(state.TransactionalStore).Multi(ctx, req)
+}
+
+// BulkGet shadows the promoted in-memory implementation so an armed hold can
+// block the read between a caller's metadata Get and its bulk entry read.
+func (s *Store) BulkGet(ctx context.Context, req []state.GetRequest, opts state.BulkGetOpts) ([]state.BulkGetResponse, error) {
+	s.mu.Lock()
+	var hold *holdSpec
+	if s.bulkGetHold != nil {
+		for _, r := range req {
+			if strings.Contains(r.Key, s.bulkGetHold.sub) {
+				hold = s.bulkGetHold
+				s.bulkGetHold = nil
+				break
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	if hold != nil {
+		close(hold.arrived)
+		select {
+		case <-hold.releaseCh:
+		case <-ctx.Done():
+		}
+	}
+
+	return s.Store.BulkGet(ctx, req, opts)
 }
 
 // MultiMaxSize advertises no per-transaction key limit so the test can freely
@@ -152,6 +249,15 @@ func (s *Store) MultiMaxSize() int { return -1 }
 func anyHasSubstring(keys []string, sub string) bool {
 	for _, k := range keys {
 		if strings.Contains(k, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyDeleteHasSubstring(ops []state.TransactionalStateOperation, sub string) bool {
+	for _, op := range ops {
+		if del, ok := op.(state.DeleteRequest); ok && strings.Contains(del.Key, sub) {
 			return true
 		}
 	}

--- a/tests/integration/suite/daprd/workflow/chaos/loadretry.go
+++ b/tests/integration/suite/daprd/workflow/chaos/loadretry.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(loadretry))
+}
+
+type loadretry struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *fault.Store
+	sched    *scheduler.Scheduler
+}
+
+func (l *loadretry) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	l.store = fault.New(t)
+
+	sock := socket.New(t)
+	l.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(l.store),
+	)
+
+	l.sched = scheduler.New(t)
+
+	l.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithSchedulerInstance(l.sched),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, l.ss.SocketName())),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(l.sched, l.ss, l.workflow),
+	}
+}
+
+func (l *loadretry) Run(t *testing.T, ctx context.Context) {
+	l.workflow.WaitUntilRunning(t, ctx)
+
+	const wfID = "loadretry-wf"
+
+	r := l.workflow.Registry()
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		octx.WaitForSingleEvent("go", time.Minute).Await(nil)
+		return nil, nil
+	}))
+
+	client := l.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewWorkflow(ctx, "wf", api.WithInstanceID(wfID))
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	// RUNNING implies the start event was consumed and its save committed, so
+	// the committed metadata now declares inboxLength=0.
+	saveArrived, saveRelease, saveDone := l.store.ArmMultiDeleteHold(wfID + "||inbox-000000")
+	t.Cleanup(saveRelease)
+
+	// The event save is Sets-only (inbox-000000 upsert + metadata inboxLength=1)
+	// so it passes the Delete-only matcher and commits. The orchestrator then
+	// consumes the event and its completion save, which deletes inbox-000000, is
+	// captured and held.
+	require.NoError(t, client.RaiseEvent(ctx, id, "go"))
+
+	select {
+	case <-saveArrived:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "inbox-consuming save never arrived")
+	}
+
+	// The orchestrator is blocked inside its save with all its reads done
+	// (its state is cached while active), so the next BulkGet touching the
+	// inbox key can only come from the metadata read below.
+	readArrived, readRelease := l.store.ArmBulkGetHold(wfID + "||inbox-000000")
+	t.Cleanup(readRelease)
+
+	type fetchResult struct {
+		meta *backend.WorkflowMetadata
+		err  error
+	}
+	fetchCh := make(chan fetchResult, 1)
+	go func() {
+		meta, ferr := client.FetchWorkflowMetadata(ctx, id)
+		fetchCh <- fetchResult{meta: meta, err: ferr}
+	}()
+
+	select {
+	case <-readArrived:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "metadata read never reached the inbox bulk get")
+	}
+
+	// The reader has observed metadata declaring inboxLength=1 and is now frozen
+	// before its bulk read. Commit the held save so inbox-000000 is deleted,
+	// then let the reader proceed into the torn view.
+	saveRelease()
+	select {
+	case <-saveDone:
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "inbox-consuming save never committed")
+	}
+	readRelease()
+
+	select {
+	case res := <-fetchCh:
+		require.NoError(t, res.err)
+		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", res.meta.GetRuntimeStatus().String())
+	case <-time.After(15 * time.Second):
+		require.Fail(t, "metadata fetch never returned")
+	}
+}

--- a/tests/integration/suite/daprd/workflow/chaos/loadretry.go
+++ b/tests/integration/suite/daprd/workflow/chaos/loadretry.go
@@ -93,7 +93,9 @@ func (l *loadretry) Run(t *testing.T, ctx context.Context) {
 
 	r := l.workflow.Registry()
 	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
-		octx.WaitForSingleEvent("go", time.Minute).Await(nil)
+		if err := octx.WaitForSingleEvent("go", time.Minute).Await(nil); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}))
 


### PR DESCRIPTION
GetWorkflowMetadata loads workflow state with two non-atomic reads: a Get of the metadata row followed by a GetBulk of the inbox and history entry rows, without holding the orchestrator actor lock. An actor save committing between the two reads deletes consumed inbox rows that the just-read metadata still declares, so the load failed with:

```
  workflow '<id>': inbox key 'inbox-000000' declared in metadata
  (inboxLength=1) but missing from state store
```

which surfaced to callers as a terminal gRPC Unknown error even though the workflow was healthy and the persisted state was never inconsistent.

LoadWorkflowState now retries the whole load with freshly read metadata when it observes this mismatch, up to 5 attempts 15ms apart. The metadata ETag is compared between attempts: a changed ETag proves a concurrent save landed between the reads, so the load retries, while an unchanged ETag proves the entries are genuinely missing and the original error is returned. Signing verification errors are not retried. All LoadWorkflowState callers (GetWorkflowMetadata, GetInstanceHistory, purge, and the orchestrator load path) benefit without signature changes.

Fixes #10242