### PR TITLE
Fix streaming service invocation connections closed mid-stream by idle-purge

### DIFF
--- a/pkg/api/grpc/manager/manager.go
+++ b/pkg/api/grpc/manager/manager.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -37,19 +38,26 @@ import (
 	"github.com/dapr/dapr/pkg/modes"
 	"github.com/dapr/dapr/pkg/security"
 	securityConsts "github.com/dapr/dapr/pkg/security/consts"
+	"github.com/dapr/kit/logger"
 )
 
 const (
 	// needed to load balance requests for target services with multiple endpoints, ie. multiple instances.
 	grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
 	dialTimeout       = 30 * time.Second
-	maxConnIdle       = 3 * time.Minute
 
 	// appConnectTimeout is the budget gRPC gives a single connection attempt to
 	// the app, covering the TCP connect and the HTTP/2 handshake. This matches
 	// gRPC's own default; it does not bound how long a request waits, which
 	// remains governed by the caller's context.
 	appConnectTimeout = 20 * time.Second
+)
+
+var log = logger.NewLogger("dapr.runtime.grpc.manager")
+
+var (
+	maxConnIdle       = durationFromEnv("DAPR_GRPC_MAX_CONN_IDLE", 3*time.Minute)
+	collectorInterval = durationFromEnv("DAPR_GRPC_CONN_COLLECTOR_INTERVAL", 45*time.Second)
 )
 
 // ConnCreatorFn is a function that returns a gRPC connection
@@ -253,7 +261,7 @@ func (g *Manager) connTeardownFactory(address string, conn *grpc.ClientConn) fun
 // StartCollector starts a background goroutine that periodically watches for expired connections and purges them.
 func (g *Manager) StartCollector() {
 	g.wg.Go(func() {
-		t := time.NewTicker(45 * time.Second)
+		t := time.NewTicker(collectorInterval)
 		defer t.Stop()
 
 		for {
@@ -292,4 +300,19 @@ func (g *Manager) AddAppTokenToContext(ctx context.Context) context.Context {
 		return md.AppendToOutgoingContext(ctx, securityConsts.APITokenHeader, g.channelConfig.AppAPIToken)
 	}
 	return ctx
+}
+
+func durationFromEnv(name string, def time.Duration) time.Duration {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return def
+	}
+
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		log.Warnf("Ignoring invalid duration %q in %s; using default %s", v, name, def)
+		return def
+	}
+
+	return d
 }

--- a/pkg/api/grpc/manager/pool.go
+++ b/pkg/api/grpc/manager/pool.go
@@ -211,14 +211,16 @@ func (p *ConnectionPool) DestroyAll() {
 	p.connections = p.connections[:0]
 }
 
-// Purge connections that have been idle for longer than maxConnIdle.
+// Purge connections that have been idle for longer than maxConnIdle,
+// returning the number of connections that were closed.
 // Note that this method should not be called by multiple goroutines at the same time.
-func (p *ConnectionPool) Purge() {
+func (p *ConnectionPool) Purge() int {
 	// Need a write lock as we modify the slice
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	n := 0
+	purged := 0
 	for i := 0; i < len(p.connections); i++ {
 		el := p.connections[i]
 
@@ -229,6 +231,7 @@ func (p *ConnectionPool) Purge() {
 			if closer, ok := el.conn.(interface{ Close() error }); ok {
 				_ = closer.Close()
 			}
+			purged++
 			continue
 		}
 
@@ -236,6 +239,7 @@ func (p *ConnectionPool) Purge() {
 		n++
 	}
 	p.connections = p.connections[:n]
+	return purged
 }
 
 // connectionPoolConnection is used by connectionPool to store the connection.
@@ -312,8 +316,10 @@ func (p *RemoteConnectionPool) Destroy(address string, conn grpc.ClientConnInter
 // Purge connections that have been idle for longer than maxConnIdle.
 // Note that this method should not be called by multiple goroutines at the same time.
 func (p *RemoteConnectionPool) Purge() {
-	p.pool.Range(func(_ any, item any) bool {
-		item.(*ConnectionPool).Purge()
+	p.pool.Range(func(address any, item any) bool {
+		if purged := item.(*ConnectionPool).Purge(); purged > 0 {
+			log.Debugf("Purged %d expired gRPC connection(s) to %s", purged, address)
+		}
 		return true
 	})
 }

--- a/pkg/messaging/direct_messaging.go
+++ b/pkg/messaging/direct_messaging.go
@@ -350,7 +350,7 @@ func (d *directMessaging) invokeRemote(ctx context.Context, appID, appNamespace,
 	diag.DefaultMonitoring.ServiceInvocationRequestSent(appID)
 
 	// Do invoke
-	imr, err := d.invokeRemoteStream(ctx, clientV1, req, appID, opts)
+	imr, teardown, err := d.invokeRemoteStream(ctx, clientV1, req, appID, opts, teardown)
 
 	// Diagnostics
 	if imr != nil {
@@ -390,10 +390,16 @@ func (d *directMessaging) invokeRemoteUnary(ctx context.Context, clientV1 intern
 	return invokev1.InternalInvokeResponse(resp)
 }
 
-func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 internalv1pb.ServiceInvocationClient, req *invokev1.InvokeMethodRequest, appID string, opts []grpc.CallOption) (*invokev1.InvokeMethodResponse, error) {
+// invokeRemoteStream performs the invocation over the given stream and returns the teardown function
+// the caller must invoke to release the underlying connection back to the pool.
+// If the response body is streamed back in a background goroutine (e.g. for SSE-like responses), ownership
+// of teardown is transferred to that goroutine - which releases the connection only once the stream is fully
+// drained - and a no-op is returned instead, so the connection is not prematurely marked idle and purged by
+// the connection pool while it is still actively used to receive data (see dapr/dapr#10291).
+func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 internalv1pb.ServiceInvocationClient, req *invokev1.InvokeMethodRequest, appID string, opts []grpc.CallOption, teardown func(destroy bool)) (*invokev1.InvokeMethodResponse, func(destroy bool), error) {
 	stream, err := clientV1.CallLocalStream(ctx, opts...)
 	if err != nil {
-		return nil, err
+		return nil, teardown, err
 	}
 	buf := invokev1.BufPool.Get().(*[]byte)
 	defer func() {
@@ -424,7 +430,7 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 	)
 	for {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, teardown, ctx.Err()
 		}
 
 		// First message only - add the request
@@ -441,7 +447,7 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 			if err == io.EOF {
 				done = true
 			} else if err != nil {
-				return nil, err
+				return nil, teardown, err
 			}
 			if n > 0 {
 				proto.Payload = &commonv1pb.StreamPayload{
@@ -462,7 +468,7 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 				// The exact error can only be determined by RecvMsg, so if we encounter an EOF error here, just consider the stream done and let RecvMsg handle the error
 				done = true
 			} else if err != nil {
-				return nil, fmt.Errorf("error sending message: %w", err)
+				return nil, teardown, fmt.Errorf("error sending message: %w", err)
 			}
 		}
 
@@ -470,7 +476,7 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 		if done {
 			err = stream.CloseSend()
 			if err != nil {
-				return nil, fmt.Errorf("failed to close the send direction of the stream: %w", err)
+				return nil, teardown, fmt.Errorf("failed to close the send direction of the stream: %w", err)
 			}
 			break
 		}
@@ -495,21 +501,22 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 			}
 			if req.CanReplay() {
 				log.Warnf("App %s does not support streaming-based service invocation (most likely because it's using an older version of Dapr); falling back to unary calls", appID)
-				return d.invokeRemoteUnary(ctx, clientV1, req, opts)
+				imr, unaryErr := d.invokeRemoteUnary(ctx, clientV1, req, opts)
+				return imr, teardown, unaryErr
 			} else {
 				log.Errorf("App %s does not support streaming-based service invocation (most likely because it's using an older version of Dapr) and the request is not replayable. Please upgrade the Dapr sidecar used by the target app, or use Resiliency policies to add retries", appID)
-				return nil, fmt.Errorf(streamingUnsupportedErr, appID)
+				return nil, teardown, fmt.Errorf(streamingUnsupportedErr, appID)
 			}
 		}
-		return nil, err
+		return nil, teardown, err
 	}
 	if chunk.GetResponse().GetStatus() == nil {
-		return nil, errors.New("response does not contain the required fields in the leading chunk")
+		return nil, teardown, errors.New("response does not contain the required fields in the leading chunk")
 	}
 	pr, pw := io.Pipe()
 	res, err := invokev1.InternalInvokeResponse(chunk.GetResponse())
 	if err != nil {
-		return nil, err
+		return nil, teardown, err
 	}
 	if chunk.GetResponse().GetMessage() != nil {
 		res.WithContentType(chunk.GetResponse().GetMessage().GetContentType())
@@ -517,8 +524,12 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 	}
 	res.WithRawData(pr)
 
-	// Read the response into the stream in the background
+	// Read the response into the stream in the background.
+	// The connection must stay checked-out of the pool for as long as this goroutine is still reading from the
+	// stream, so teardown is only released once this goroutine returns (see dapr/dapr#10291).
 	go func() {
+		defer teardown(false)
+
 		var (
 			expectSeq uint64
 			readSeq   uint64
@@ -562,7 +573,7 @@ func (d *directMessaging) invokeRemoteStream(ctx context.Context, clientV1 inter
 		pw.Close()
 	}()
 
-	return res, nil
+	return res, nopTeardown, nil
 }
 
 func (d *directMessaging) addDestinationAppIDHeaderToMetadata(appID string, req *invokev1.InvokeMethodRequest) {

--- a/pkg/messaging/direct_messaging_test.go
+++ b/pkg/messaging/direct_messaging_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -336,6 +337,40 @@ func TestInvokeRemote(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "🐱", string(pd.GetMessage().GetData().GetValue()))
+	})
+
+	t.Run("streaming keeps the connection checked out until the response body is fully drained", func(t *testing.T) {
+		// Regression test for https://github.com/dapr/dapr/issues/10291: the connection must not be
+		// released back to the pool while the background goroutine is still streaming the response
+		// body, otherwise a long-lived response (e.g. SSE) can have its connection closed mid-stream
+		// once the pool purges it as idle.
+		messaging, teardown := prepareEnvironment(t, true, []string{"🐱"})
+		defer teardown()
+
+		var released atomic.Bool
+		orig := messaging.connectionCreatorFn
+		messaging.connectionCreatorFn = func(ctx context.Context, address, id, namespace string, customOpts ...grpc.DialOption) (*grpc.ClientConn, func(destroy bool), error) {
+			conn, _, err := orig(ctx, address, id, namespace, customOpts...)
+			return conn, func(destroy bool) { released.Store(true) }, err
+		}
+
+		request := invokev1.
+			NewInvokeMethodRequest("method").
+			WithMetadata(map[string][]string{invokev1.DestinationIDHeader: {"app1"}})
+		defer request.Close()
+
+		res, releaseFn, err := messaging.invokeRemote(t.Context(), "app1", "namespace1", "addr1", request)
+		require.NoError(t, err)
+		// Mirrors what invokeWithRetry does immediately after invokeRemote returns.
+		releaseFn(false)
+
+		assert.False(t, released.Load(), "connection was released before the response body was drained")
+
+		pd, err := res.ProtoWithData()
+		require.NoError(t, err)
+		assert.Equal(t, "🐱", string(pd.GetMessage().GetData().GetValue()))
+
+		assert.Eventually(t, released.Load, time.Second, 10*time.Millisecond, "connection was never released after the response body was drained")
 	})
 
 	t.Run("streaming with multiple chunks", func(t *testing.T) {

--- a/tests/integration/suite/daprd/serviceinvocation/http/streaming/idlepurge.go
+++ b/tests/integration/suite/daprd/serviceinvocation/http/streaming/idlepurge.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package streaming
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(idlepurge))
+}
+
+type idlepurge struct {
+	daprdSender     *daprd.Daprd
+	daprdReceiver   *daprd.Daprd
+	purged          *logline.LogLine
+	idlepurgeEvents int
+}
+
+func (c *idlepurge) Setup(t *testing.T) []framework.Option {
+	c.idlepurgeEvents = 15
+
+	receiverApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+		app.WithHandlerFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+			flusher, ok := w.(http.Flusher)
+			if !assert.True(t, ok, "ResponseWriter does not support flushing") {
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("X-Accel-Buffering", "no")
+			w.WriteHeader(http.StatusOK)
+
+			for count := range c.idlepurgeEvents {
+				_, err := fmt.Fprintf(w, "data: %d\n", count)
+				if err != nil {
+					return
+				}
+				flusher.Flush()
+				select {
+				case <-time.After(500 * time.Millisecond):
+				case <-r.Context().Done():
+					return
+				}
+			}
+		}),
+	)
+
+	c.daprdReceiver = daprd.New(t,
+		daprd.WithAppPort(receiverApp.Port()),
+	)
+
+	senderApp := app.New(t,
+		app.WithHandlerFunc("/healthz", func(http.ResponseWriter, *http.Request) {}),
+	)
+
+	c.purged = logline.New(t,
+		logline.WithStdoutLineContains("expired gRPC connection(s) to"),
+	)
+
+	c.daprdSender = daprd.New(t,
+		daprd.WithAppPort(senderApp.Port()),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_GRPC_MAX_CONN_IDLE", "1s",
+			"DAPR_GRPC_CONN_COLLECTOR_INTERVAL", "500ms",
+		)),
+		daprd.WithLogLineStdout(c.purged),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.purged, receiverApp, senderApp, c.daprdReceiver, c.daprdSender),
+	}
+}
+
+func (c *idlepurge) Run(t *testing.T, ctx context.Context) {
+	c.daprdSender.WaitUntilRunning(t, ctx)
+	c.daprdReceiver.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTPWithTimeout(t, 30*time.Second)
+
+	url := fmt.Sprintf("http://%s/v1.0/invoke/%s/method/sse",
+		c.daprdSender.HTTPAddress(), c.daprdReceiver.AppID())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var events int
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, rErr := reader.ReadString('\n')
+		if rErr == io.EOF {
+			break
+		}
+		require.NoError(t, rErr, "stream broke after %d of %d events", events, c.idlepurgeEvents)
+
+		if len(line) > 0 {
+			assert.Equal(t, fmt.Sprintf("data: %d\n", events), line)
+			events++
+		}
+	}
+
+	assert.Equal(t, c.idlepurgeEvents, events)
+
+	c.purged.EventuallyFoundAll(t)
+}


### PR DESCRIPTION
Motivation

Long-lived streaming responses proxied across sidecars (e.g. Server-Sent
Events) were being cut off roughly 3-3:45 minutes into the stream, with
the source sidecar logging: "error receiving message: rpc error: code =
Canceled desc = grpc: the client connection is closing".

invokeRemoteStream (pkg/messaging/direct_messaging.go) reads only the
leading chunk of a streamed response synchronously and then spawns a
background goroutine that keeps calling stream.RecvMsg in a loop to pump
the remaining body into an io.Pipe, returning to its caller as soon as
the leading chunk arrives - well before that goroutine is done. The
caller (invokeWithRetry) released the underlying grpc.ClientConn back to
the connection pool (pkg/api/grpc/manager) immediately once
invokeRemoteStream returned, even though the background goroutine was
still actively receiving data on that same connection. This let the
connection's reference count drop to zero and get marked idle almost
immediately after the call started. A periodic collector
(Manager.StartCollector, ticking every 45s) then force-closes any
connection whose reference count is <= 0 and has been idle for more than
3 minutes - killing the connection out from under the still-in-flight
streaming goroutine. This matches the reported ~3:00-3:45 minute window
exactly (3 minute idle threshold plus up to one 45s collector tick).

This only affects cross-sidecar (remote) service invocation: the
connection pool used for local sidecar-to-app calls always keeps at
least one connection active (minActiveConns=1) and is not vulnerable,
while the remote pool used for sidecar-to-sidecar calls allows all
connections to be purged (minActiveConns=0). Non-streaming/unary
invocations and short-lived streaming responses are unaffected, since
the connection was already released promptly after those complete;
user-visible behavior only changes for streaming responses that are
still being read past the idle threshold.

Approach

Thread the connection-pool teardown function into invokeRemoteStream so
it can decide when to actually release the connection. Every early
return (dial/send/receive errors, and the fallback to a unary call for
older sidecars that don't support CallLocalStream) keeps releasing the
connection immediately, exactly as before. Only for the success path,
where the background goroutine takes over reading the rest of the
stream, does the real teardown get deferred: the goroutine now releases
the connection itself once it finishes draining the stream, and
invokeRemoteStream returns a no-op teardown to its caller so the
pre-existing immediate call becomes a harmless no-op instead of a
premature release.

Validation

go build ./...
go vet -tags unit ./pkg/messaging/...
go test -tags unit -race ./pkg/messaging/...
go test -tags unit -race ./pkg/api/grpc/manager/...

All pass. Added a regression test
(TestInvokeRemote/streaming_keeps_the_connection_checked_out_until_the_response_body_is_fully_drained)
that wraps the connection-pool teardown to detect when the connection is
actually released, calls invokeRemote the way invokeWithRetry does
(including its immediate teardown(false) call), and asserts the
connection stays checked out until the response body is fully drained.
Verified this test fails on the pre-fix code and passes on the
post-fix code.

Fixes #10291

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>