### PR TITLE
Fix pubsub tracestate propagation

### DIFF
--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -88,6 +88,9 @@ func (h *http) Deliver(ctx context.Context, msg *pubsub.SubscribedMessage) error
 	if iTraceID != nil {
 		traceID := iTraceID.(string)
 		sc, _ := diag.SpanContextFromW3CString(traceID)
+		if traceState, ok := cloudEvent[contribpubsub.TraceStateField].(string); ok && traceState != "" {
+			sc = sc.WithTraceState(*diag.TraceStateFromW3CString(traceState))
+		}
 		ctx, span = diag.StartInternalCallbackSpan(ctx, "pubsub/"+msg.Topic, sc, h.tracingSpec)
 	}
 
@@ -246,6 +249,9 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 		if iTraceID != nil {
 			traceID := iTraceID.(string)
 			sc, _ := diag.SpanContextFromW3CString(traceID)
+			if traceState, ok := cloudEvent[contribpubsub.TraceStateField].(string); ok && traceState != "" {
+				sc = sc.WithTraceState(*diag.TraceStateFromW3CString(traceState))
+			}
 
 			var span trace.Span
 

--- a/pkg/runtime/subscription/postman/http/http_test.go
+++ b/pkg/runtime/subscription/postman/http/http_test.go
@@ -25,10 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/dapr/components-contrib/contenttype"
 	contribpubsub "github.com/dapr/components-contrib/pubsub"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
+	"github.com/dapr/dapr/pkg/config"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/runtime/channels"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
@@ -153,6 +155,41 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 
 		assert.Equal(t, runtimePubsub.ErrMessageDropped, h.Deliver(t.Context(), testPubSubMessage))
 	})
+}
+
+func TestDeliverRestoresTraceState(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("00112233445566778899aabbccddeeff")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0011223344556677")
+	require.NoError(t, err)
+	traceState, err := trace.ParseTraceState("vendor=value")
+	require.NoError(t, err)
+
+	cloudEvent := contribpubsub.NewCloudEventsEnvelope("", "", contribpubsub.DefaultCloudEventType, "", "topic",
+		"pubsub", "", []byte("message"), "00-00112233445566778899aabbccddeeff-0011223344556677-01", traceState.String())
+	message := &runtimePubsub.SubscribedMessage{
+		CloudEvent: cloudEvent,
+		Topic:      "topic",
+		Data:       []byte("message"),
+		Path:       "topic",
+	}
+
+	response := invokev1.NewInvokeMethodResponse(200, "OK", nil).WithRawDataString(`{"status":"SUCCESS"}`)
+	defer response.Close()
+	mockAppChannel := new(channelt.MockAppChannel)
+	mockAppChannel.On("InvokeMethod", mock.MatchedBy(func(ctx context.Context) bool {
+		spanContext := trace.SpanContextFromContext(ctx)
+		return spanContext.TraceID() == traceID && spanContext.SpanID() == spanID &&
+			spanContext.TraceState().String() == traceState.String()
+	}), mock.Anything).Return(response, nil)
+
+	h := New(Options{
+		Channels: new(channels.Channels).WithAppChannel(mockAppChannel),
+		Tracing:  &config.TracingSpec{SamplingRate: "1"},
+	})
+
+	require.NoError(t, h.Deliver(t.Context(), message))
+	mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 }
 
 func TestOnNewPublishedMessage(t *testing.T) {


### PR DESCRIPTION
This pull request enhances distributed tracing support by ensuring that the trace state is correctly restored and propagated when delivering messages via HTTP in the pub/sub runtime. It also adds a unit test to verify this behavior.

**Distributed Tracing Improvements:**

* Updated both `Deliver` and `DeliverBulk` methods in `http.go` to restore the trace state from the CloudEvent envelope and attach it to the span context, ensuring trace continuity across services. [[1]](diffhunk://#diff-9bfb5d012b67adb648ffa577786f2b703b5027707344f0677026b9ea955b0d16R91-R93) [[2]](diffhunk://#diff-9bfb5d012b67adb648ffa577786f2b703b5027707344f0677026b9ea955b0d16R252-R254)

**Testing Enhancements:**

* Added the `TestDeliverRestoresTraceState` unit test in `http_test.go` to verify that the trace state is correctly restored and included in the context when messages are delivered.
* Added necessary imports for tracing and configuration to support the new test.# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
