### PR TITLE
Propagate pubsub baggage

### DIFF
--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -191,6 +191,7 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 	data := body
 	span := diagUtils.SpanFromContext(ctx)
 	traceID, traceState := diag.TraceIDAndStateFromSpan(span)
+	baggage := otelbaggage.FromContext(ctx).String()
 	md := maps.Clone(in.GetMetadata())
 	if !rawPayload {
 		envelope, err := runtimePubsub.NewCloudEvent(&runtimePubsub.CloudEvent{
@@ -200,6 +201,7 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 			Data:            body,
 			TraceID:         traceID,
 			TraceState:      traceState,
+			Baggage:         baggage,
 			Pubsub:          in.GetPubsubName(),
 		}, in.GetMetadata())
 		if err != nil {
@@ -224,6 +226,9 @@ func (a *api) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequ
 	} else {
 		md[pubsub.TraceIDField] = traceID
 		md[pubsub.TraceStateField] = traceState
+		if baggage != "" {
+			md[diagConsts.BaggageHeader] = baggage
+		}
 	}
 
 	req := pubsub.PublishRequest{
@@ -430,6 +435,7 @@ func (a *api) bulkPublishEvent(ctx context.Context, in *runtimev1pb.BulkPublishR
 				Data:            entries[i].Event,
 				TraceID:         traceID,
 				TraceState:      traceState,
+				Baggage:         otelbaggage.FromContext(ctx).String(),
 				Pubsub:          pubsubName,
 			}, entries[i].Metadata)
 			if err != nil {
@@ -451,6 +457,17 @@ func (a *api) bulkPublishEvent(ctx context.Context, in *runtimev1pb.BulkPublishR
 				apiServerLogger.Debug(nerr)
 				closeChildSpans(ctx, nerr)
 				return &runtimev1pb.BulkPublishResponse{}, nerr
+			}
+		}
+	}
+	if rawPayload {
+		baggage := otelbaggage.FromContext(ctx)
+		if baggage.Len() > 0 {
+			for i := range entries {
+				if entries[i].Metadata == nil {
+					entries[i].Metadata = map[string]string{}
+				}
+				entries[i].Metadata[diagConsts.BaggageHeader] = baggage.String()
 			}
 		}
 	}

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -1137,6 +1137,7 @@ func (a *api) onPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 	if !rawPayload {
 		span := diagUtils.SpanFromContext(r.Context())
 		traceID, traceState := diag.TraceIDAndStateFromSpan(span)
+		baggage := otelBaggage.FromContext(r.Context()).String()
 		envelope, err := runtimePubsub.NewCloudEvent(&runtimePubsub.CloudEvent{
 			Source:          a.universal.AppID(),
 			Topic:           topic,
@@ -1144,6 +1145,7 @@ func (a *api) onPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 			Data:            body,
 			TraceID:         traceID,
 			TraceState:      traceState,
+			Baggage:         baggage,
 			Pubsub:          pubsubName,
 		}, metadata)
 		if err != nil {
@@ -1168,6 +1170,8 @@ func (a *api) onPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 			log.Debug(nerr)
 			return
 		}
+	} else if baggage := otelBaggage.FromContext(r.Context()); baggage.Len() > 0 {
+		metadata[diagConsts.BaggageHeader] = baggage.String()
 	}
 
 	req := pubsub.PublishRequest{
@@ -1302,6 +1306,7 @@ func (a *api) onBulkPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 				Data:            entries[i].Event,
 				TraceID:         traceID,
 				TraceState:      traceState,
+				Baggage:         otelBaggage.FromContext(r.Context()).String(),
 				Pubsub:          pubsubName,
 			}, entries[i].Metadata)
 			if err != nil {
@@ -1333,6 +1338,8 @@ func (a *api) onBulkPublish(w nethttp.ResponseWriter, r *nethttp.Request) {
 				return
 			}
 		}
+	} else if baggage := otelBaggage.FromContext(r.Context()); baggage.Len() > 0 {
+		metadata[diagConsts.BaggageHeader] = baggage.String()
 	}
 
 	req := pubsub.BulkPublishRequest{

--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/baggage"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -39,6 +40,7 @@ import (
 	"github.com/dapr/dapr/pkg/channel"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 	diagUtils "github.com/dapr/dapr/pkg/diagnostics/utils"
 	"github.com/dapr/dapr/pkg/messages"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
@@ -644,6 +646,9 @@ func (h *Channel) constructRequest(ctx context.Context, req *invokev1.InvokeMeth
 	ts := diag.TraceStateToW3CString(span.SpanContext())
 	if ts != "" {
 		channelReq.Header.Set("tracestate", ts)
+	}
+	if b := baggage.FromContext(ctx); b.Len() > 0 {
+		channelReq.Header.Set(diagConsts.BaggageHeader, b.String())
 	}
 
 	if h.appHeaderToken != "" {

--- a/pkg/channel/http/http_channel_test.go
+++ b/pkg/channel/http/http_channel_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
@@ -919,4 +920,19 @@ func TestNoInvalidTraceContext(t *testing.T) {
 		assert.NotEqual(t, "00-00000000000000000000000000000000-0000000000000000-00", traceparent)
 	}
 	testServer.Close()
+}
+
+func TestConstructRequestInjectsBaggage(t *testing.T) {
+	bag, err := baggage.Parse("key=value")
+	require.NoError(t, err)
+
+	ctx := baggage.ContextWithBaggage(t.Context(), bag)
+
+	c := Channel{baseAddress: "http://localhost", compStore: compstore.New()}
+	req := invokev1.NewInvokeMethodRequest("method").WithHTTPExtension(http.MethodPost, "")
+	defer req.Close()
+
+	channelReq, err := c.constructRequest(ctx, req, "")
+	require.NoError(t, err)
+	assert.Equal(t, "key=value", channelReq.Header.Get("baggage"))
 }

--- a/pkg/runtime/pubsub/cloudevents.go
+++ b/pkg/runtime/pubsub/cloudevents.go
@@ -18,6 +18,7 @@ import (
 
 	contribContenttype "github.com/dapr/components-contrib/contenttype"
 	contribPubsub "github.com/dapr/components-contrib/pubsub"
+	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 )
 
 // CloudEvent is a request object to create a Dapr compliant cloudevent.
@@ -30,6 +31,7 @@ type CloudEvent struct {
 	DataContentType string `mapstructure:"-"` // cannot be overridden
 	TraceID         string `mapstructure:"cloudevent.traceid"`
 	TraceState      string `mapstructure:"cloudevent.tracestate"`
+	Baggage         string `mapstructure:"cloudevent.baggage"`
 	Source          string `mapstructure:"cloudevent.source"`
 	Type            string `mapstructure:"cloudevent.type"`
 	TraceParent     string `mapstructure:"cloudevent.traceparent"`
@@ -54,6 +56,11 @@ func NewCloudEvent(req *CloudEvent, metadata map[string]string) (map[string]any,
 		req.TraceID = req.TraceParent
 	}
 
-	return contribPubsub.NewCloudEventsEnvelope(req.ID, req.Source, req.Type,
-		req.Subject, req.Topic, req.Pubsub, req.DataContentType, req.Data, req.TraceID, req.TraceState), nil
+	envelope := contribPubsub.NewCloudEventsEnvelope(req.ID, req.Source, req.Type,
+		req.Subject, req.Topic, req.Pubsub, req.DataContentType, req.Data, req.TraceID, req.TraceState)
+	if req.Baggage != "" {
+		envelope[diagConsts.BaggageHeader] = req.Baggage
+	}
+
+	return envelope, nil
 }

--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -23,12 +23,14 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/dapr/components-contrib/contenttype"
 	contribpubsub "github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/channels"
@@ -89,6 +91,11 @@ func (h *http) Deliver(ctx context.Context, msg *pubsub.SubscribedMessage) error
 		traceID := iTraceID.(string)
 		sc, _ := diag.SpanContextFromW3CString(traceID)
 		ctx, span = diag.StartInternalCallbackSpan(ctx, "pubsub/"+msg.Topic, sc, h.tracingSpec)
+	}
+	if baggageString, ok := cloudEvent[diagConsts.BaggageHeader].(string); ok && baggageString != "" {
+		if parsedBaggage, err := baggage.Parse(baggageString); err == nil {
+			ctx = baggage.ContextWithBaggage(ctx, parsedBaggage)
+		}
 	}
 
 	start := time.Now()
@@ -253,6 +260,11 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 			if span != nil {
 				spans[n] = span
 				n++
+			}
+		}
+		if baggageString, ok := cloudEvent[diagConsts.BaggageHeader].(string); ok && baggageString != "" {
+			if parsedBaggage, err := baggage.Parse(baggageString); err == nil {
+				ctx = baggage.ContextWithBaggage(ctx, parsedBaggage)
 			}
 		}
 	}

--- a/pkg/runtime/subscription/postman/http/http_test.go
+++ b/pkg/runtime/subscription/postman/http/http_test.go
@@ -25,10 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
 
 	"github.com/dapr/components-contrib/contenttype"
 	contribpubsub "github.com/dapr/components-contrib/pubsub"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
+	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/runtime/channels"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
@@ -153,6 +155,29 @@ func TestErrorPublishedNonCloudEventHTTP(t *testing.T) {
 
 		assert.Equal(t, runtimePubsub.ErrMessageDropped, h.Deliver(t.Context(), testPubSubMessage))
 	})
+}
+
+func TestDeliverRestoresBaggage(t *testing.T) {
+	cloudEvent := contribpubsub.NewCloudEventsEnvelope("", "", contribpubsub.DefaultCloudEventType, "", "topic",
+		"pubsub", "", []byte("message"), "", "")
+	cloudEvent[diagConsts.BaggageHeader] = "key=value"
+	message := &runtimePubsub.SubscribedMessage{
+		CloudEvent: cloudEvent,
+		Topic:      "topic",
+		Data:       []byte("message"),
+		Path:       "topic",
+	}
+
+	response := invokev1.NewInvokeMethodResponse(200, "OK", nil).WithRawDataString(`{"status":"SUCCESS"}`)
+	defer response.Close()
+	mockAppChannel := new(channelt.MockAppChannel)
+	mockAppChannel.On("InvokeMethod", mock.MatchedBy(func(ctx context.Context) bool {
+		return baggage.FromContext(ctx).String() == "key=value"
+	}), mock.Anything).Return(response, nil)
+
+	h := New(Options{Channels: new(channels.Channels).WithAppChannel(mockAppChannel)})
+	require.NoError(t, h.Deliver(t.Context(), message))
+	mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 }
 
 func TestOnNewPublishedMessage(t *testing.T) {

--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -29,6 +29,7 @@ import (
 	pluggablepubsub "github.com/dapr/dapr/pkg/components/pubsub"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	diagConsts "github.com/dapr/dapr/pkg/diagnostics/consts"
 	"github.com/dapr/dapr/pkg/resiliency"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	rtpubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
@@ -234,6 +235,10 @@ func New(opts Options) (*Subscription, error) {
 				cloudEvent[contribpubsub.TraceStateField] = tracestate
 			}
 
+			if baggage, ok := msg.Metadata[diagConsts.BaggageHeader]; ok {
+				cloudEvent[diagConsts.BaggageHeader] = baggage
+			}
+
 			data, err = json.Marshal(cloudEvent)
 			if err != nil {
 				log.Errorf("error serializing cloud event in pubsub %s and topic %s: %s", name, msgTopic, err)
@@ -301,6 +306,12 @@ func New(opts Options) (*Subscription, error) {
 			if _, ok := cloudEvent[contribpubsub.TraceStateField]; !ok {
 				if tracestate, ok := msg.Metadata[contribpubsub.TraceStateField]; ok {
 					cloudEvent[contribpubsub.TraceStateField] = tracestate
+				}
+			}
+
+			if _, ok := cloudEvent[diagConsts.BaggageHeader]; !ok {
+				if baggage, ok := msg.Metadata[diagConsts.BaggageHeader]; ok {
+					cloudEvent[diagConsts.BaggageHeader] = baggage
 				}
 			}
 		}


### PR DESCRIPTION
This pull request adds support for propagating OpenTelemetry baggage through Dapr's pub/sub system, ensuring that baggage is included in CloudEvents and HTTP headers, and is restored on the receiving side. This enables distributed context propagation for cross-cutting concerns such as feature flags, user identifiers, or custom metadata. The changes affect both gRPC and HTTP APIs, CloudEvents generation, and subscription delivery, and include new tests for baggage propagation.

The most important changes are:

**Baggage propagation in publish APIs:**
* Extracts baggage from the context in both gRPC (`pkg/api/grpc/grpc.go`) and HTTP (`pkg/api/http/http.go`) publish and bulk publish methods, adds it to CloudEvent envelopes and/or metadata, and ensures it is sent with messages. [[1]](diffhunk://#diff-473161725d4a741e0d28f7ff3f1f8d4eeb201faec147cb1fd31453a7c148c200R194) [[2]](diffhunk://#diff-473161725d4a741e0d28f7ff3f1f8d4eeb201faec147cb1fd31453a7c148c200R204) [[3]](diffhunk://#diff-473161725d4a741e0d28f7ff3f1f8d4eeb201faec147cb1fd31453a7c148c200R229-R231) [[4]](diffhunk://#diff-473161725d4a741e0d28f7ff3f1f8d4eeb201faec147cb1fd31453a7c148c200R438) [[5]](diffhunk://#diff-473161725d4a741e0d28f7ff3f1f8d4eeb201faec147cb1fd31453a7c148c200R463-R473) [[6]](diffhunk://#diff-63b2a64b50912ff4a12cba3e1c98b8ebdc0e47a449e48ef7296e54b666868a4bR1140-R1148) [[7]](diffhunk://#diff-63b2a64b50912ff4a12cba3e1c98b8ebdc0e47a449e48ef7296e54b666868a4bR1173-R1174) [[8]](diffhunk://#diff-63b2a64b50912ff4a12cba3e1c98b8ebdc0e47a449e48ef7296e54b666868a4bR1309) [[9]](diffhunk://#diff-63b2a64b50912ff4a12cba3e1c98b8ebdc0e47a449e48ef7296e54b666868a4bR1341-R1342)

**CloudEvents baggage support:**
* Adds a `Baggage` field to the `CloudEvent` struct and ensures it is included in the CloudEvents envelope if present. [[1]](diffhunk://#diff-743bbf07ae27eb655bc6849c12459c29d0789aa5009c628ad6c67925b02c54ffR34) [[2]](diffhunk://#diff-743bbf07ae27eb655bc6849c12459c29d0789aa5009c628ad6c67925b02c54ffL57-R65)

**Baggage propagation in HTTP channel:**
* Injects baggage from the context as an HTTP header when invoking methods on the app via the HTTP channel.
* Adds a test to ensure baggage is correctly injected into HTTP requests.

**Baggage restoration on subscription delivery:**
* Restores baggage from CloudEvent metadata into the context before invoking the app on message delivery, for both single and bulk deliveries. [[1]](diffhunk://#diff-9bfb5d012b67adb648ffa577786f2b703b5027707344f0677026b9ea955b0d16R95-R99) [[2]](diffhunk://#diff-9bfb5d012b67adb648ffa577786f2b703b5027707344f0677026b9ea955b0d16R265-R269)
* Adds a test to verify baggage restoration in the app channel.

**Subscription message enrichment:**
* Ensures that baggage from pubsub message metadata is added to CloudEvents when delivering messages to subscribers. [[1]](diffhunk://#diff-f26b497e34b8a3c9c08ff5c0959fff0e2fbb697a7cc61747322957fca5d3462cR238-R241) [[2]](diffhunk://#diff-f26b497e34b8a3c9c08ff5c0959fff0e2fbb697a7cc61747322957fca5d3462cR311-R316)

These changes collectively enable seamless end-to-end propagation of OpenTelemetry baggage through Dapr's pub/sub and service invocation mechanisms.# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
