### PR TITLE
[1.18] cherrypick fix(runtime): make binding OPTIONS probe timeout configurable (#10220)

### DIFF
--- a/cmd/daprd/app/app.go
+++ b/cmd/daprd/app/app.go
@@ -209,6 +209,7 @@ func runWithContext(ctx context.Context, opts *options.Options) error {
 				EnableAPILogging:              opts.EnableAPILogging,
 				Config:                        opts.Config,
 				DisableInitEndpoints:          opts.DisableInitEndpoints,
+				AppBindingOptionsTimeout:      opts.AppBindingOptionsTimeout,
 				Metrics: metrics.Options{
 					Enabled:       opts.Metrics.Enabled(),
 					Log:           log,

--- a/cmd/daprd/options/options.go
+++ b/cmd/daprd/options/options.go
@@ -88,6 +88,7 @@ type Options struct {
 	Logger                        logger.Options
 	Metrics                       *metrics.FlagOptions
 	DisableInitEndpoints          []string
+	AppBindingOptionsTimeout      time.Duration
 }
 
 func New(origArgs []string) (*Options, error) {
@@ -180,6 +181,7 @@ func New(origArgs []string) (*Options, error) {
 	fs.UintVar(&opts.SchedulerJobStreams, "scheduler-job-streams", 3, "The number of active job streams to connect to the Scheduler service")
 	fs.DurationVar(&opts.ActorsDisseminationTimeout, "actors-disseminate-timeout", runtime.DefaultActorsDisseminationTimeout, "Timeout for the daprd-side actor placement dissemination round; if exceeded, daprd resets its placement stream and halts hosted actors. Should be greater than the placement service --disseminate-timeout (default 8s).")
 	fs.DurationVar(&opts.HotReloadReconcileInterval, "hot-reload-reconcile-interval", 0, "Period of the hot-reload backup reconcile that lists resources and reconciles any the event watch missed, e.g. '30s'. Zero uses the default (60s)")
+	fs.DurationVar(&opts.AppBindingOptionsTimeout, "app-binding-options-timeout", config.DefaultAppBindingOptionsTimeout, "Timeout for input binding subscription discovery requests to the app (HTTP OPTIONS or gRPC ListInputBindings). Increase for apps with slow startup (e.g. JVM/JIT workloads). Non-positive values use the default.")
 
 	// DEPRECATED.
 	fs.StringVar(&opts.RemindersService, "reminders-service", "", "Type and address of the reminders service, in the format 'type:address'")

--- a/docs/release_notes/v1.16.18.md
+++ b/docs/release_notes/v1.16.18.md
@@ -1,0 +1,33 @@
+# Dapr 1.16.18
+
+This update contains the following bug fix:
+- [Input bindings not activated when the app is slow to answer the subscription discovery probe](#input-bindings-not-activated-when-the-app-is-slow-to-answer-the-subscription-discovery-probe)
+
+## Input bindings not activated when the app is slow to answer the subscription discovery probe
+
+### Problem
+
+Before it starts reading from an input binding, daprd asks the application whether it subscribes to that binding: an HTTP `OPTIONS` request to the binding's route, or a gRPC `ListInputBindings` call.
+This request was given a hardcoded 3 second budget with no way to change it.
+An application that had not finished warming up within those 3 seconds never answered in time, so daprd treated the binding as unsubscribed and never activated it.
+
+### Impact
+
+You were affected if your application is slow to serve its first request after startup — JVM or JIT warmup, large dependency-injection graphs, or resource-constrained nodes — and you declared an input binding without an explicit `direction: input` metadata entry.
+
+The binding component itself initialized correctly and appeared in the sidecar's metadata endpoint, so the component looked healthy while no events were ever delivered.
+On the HTTP channel a failed probe also aborted the remaining bindings, leaving every input binding on that sidecar inactive; the only trace was a `failed to read from bindings` warning in the sidecar log.
+On the gRPC channel the probe failure was silent.
+
+### Root Cause
+
+The subscription discovery deadline was hardcoded to 3 seconds in the binding processor and built from a background context.
+It could neither be tuned for applications with slow startup nor cancelled when the runtime shut down while a probe was still in flight.
+
+### Solution
+
+The timeout is now configurable through the new daprd `--app-binding-options-timeout` flag, which applies to both the HTTP `OPTIONS` probe and the gRPC `ListInputBindings` probe.
+The default remains 3 seconds, so existing deployments are unchanged, and non-positive values fall back to that default.
+The probe is now derived from the runtime's context, so it is cancelled promptly on shutdown instead of running to its full deadline.
+
+Setting `direction: input` on the binding component continues to skip the probe entirely.

--- a/docs/release_notes/v1.17.12.md
+++ b/docs/release_notes/v1.17.12.md
@@ -1,0 +1,52 @@
+# Dapr 1.17.12
+
+This update contains the following changes:
+- [Update Go to 1.26.5](#update-go-to-1265)
+- [Input bindings not activated when the app is slow to answer the subscription discovery probe](#input-bindings-not-activated-when-the-app-is-slow-to-answer-the-subscription-discovery-probe)
+
+## Update Go to 1.26.5
+
+### Problem
+
+Dapr was built with Go 1.26.4, which `govulncheck` reported as affected by known vulnerabilities in the Go standard library and toolchain.
+
+### Impact
+
+Users running Dapr 1.17.11 or earlier are affected. The exposure depends on which standard library packages the reported vulnerabilities cover; see the [Go 1.26.5 release notes](https://go.dev/doc/devel/release#go1.26) for the specific issues fixed.
+
+### Root Cause
+
+The issues originated in the Go standard library and toolchain rather than in Dapr code.
+
+### Solution
+
+The Go version used to build Dapr has been updated from 1.26.4 to 1.26.5 across the runtime, build tooling, and container images.
+
+## Input bindings not activated when the app is slow to answer the subscription discovery probe
+
+### Problem
+
+Before it starts reading from an input binding, daprd asks the application whether it subscribes to that binding: an HTTP `OPTIONS` request to the binding's route, or a gRPC `ListInputBindings` call.
+This request was given a hardcoded 3 second budget with no way to change it.
+An application that had not finished warming up within those 3 seconds never answered in time, so daprd treated the binding as unsubscribed and never activated it.
+
+### Impact
+
+You were affected if your application is slow to serve its first request after startup — JVM or JIT warmup, large dependency-injection graphs, or resource-constrained nodes — and you declared an input binding without an explicit `direction: input` metadata entry.
+
+The binding component itself initialized correctly and appeared in the sidecar's metadata endpoint, so the component looked healthy while no events were ever delivered.
+On the HTTP channel a failed probe also aborted the remaining bindings, leaving every input binding on that sidecar inactive; the only trace was a `failed to read from bindings` warning in the sidecar log.
+On the gRPC channel the probe failure was silent.
+
+### Root Cause
+
+The subscription discovery deadline was hardcoded to 3 seconds in the binding processor and built from a background context.
+It could neither be tuned for applications with slow startup nor cancelled when the runtime shut down while a probe was still in flight.
+
+### Solution
+
+The timeout is now configurable through the new daprd `--app-binding-options-timeout` flag, which applies to both the HTTP `OPTIONS` probe and the gRPC `ListInputBindings` probe.
+The default remains 3 seconds, so existing deployments are unchanged, and non-positive values fall back to that default.
+The probe is now derived from the runtime's context, so it is cancelled promptly on shutdown instead of running to its full deadline.
+
+Setting `direction: input` on the binding component continues to skip the probe entirely.

--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -6,6 +6,7 @@ This update contains the following bug fixes:
 - [Scheduler crash when scheduling a job with a malformed timezone-prefixed schedule](#scheduler-crash-when-scheduling-a-job-with-a-malformed-timezone-prefixed-schedule)
 - [Timezone prefix silently ignored on `@every` job schedules](#timezone-prefix-silently-ignored-on-every-job-schedules)
 - [Workflow GetInstance intermittently failing while the workflow is running](#workflow-getinstance-intermittently-failing-while-the-workflow-is-running)
+- [Input bindings not activated when the app is slow to answer the subscription discovery probe](#input-bindings-not-activated-when-the-app-is-slow-to-answer-the-subscription-discovery-probe)
 
 ## Scheduler embedded etcd metrics missing from the metrics endpoint
 
@@ -134,3 +135,32 @@ This torn read was reported as a hard error to the caller.
 The workflow state load now detects this mismatch and retries the whole load with freshly read metadata, up to 5 attempts spaced 15 ms apart.
 The metadata ETag is compared between attempts: a changed ETag proves a concurrent save landed between the reads (retry), while an unchanged ETag proves the entries are genuinely missing from the store, in which case the original error is still returned.
 Status queries racing an active workflow now return consistent results instead of transient `Unknown` errors.
+
+## Input bindings not activated when the app is slow to answer the subscription discovery probe
+
+### Problem
+
+Before it starts reading from an input binding, daprd asks the application whether it subscribes to that binding: an HTTP `OPTIONS` request to the binding's route, or a gRPC `ListInputBindings` call.
+This request was given a hardcoded 3 second budget with no way to change it.
+An application that had not finished warming up within those 3 seconds never answered in time, so daprd treated the binding as unsubscribed and never activated it.
+
+### Impact
+
+You were affected if your application is slow to serve its first request after startup — JVM or JIT warmup, large dependency-injection graphs, or resource-constrained nodes — and you declared an input binding without an explicit `direction: input` metadata entry.
+
+The binding component itself initialized correctly and appeared in the sidecar's metadata endpoint, so the component looked healthy while no events were ever delivered.
+On the HTTP channel a failed probe also aborted the remaining bindings, leaving every input binding on that sidecar inactive; the only trace was a `failed to read from bindings` warning in the sidecar log.
+On the gRPC channel the probe failure was silent.
+
+### Root Cause
+
+The subscription discovery deadline was hardcoded to 3 seconds in the binding processor and built from a background context.
+It could neither be tuned for applications with slow startup nor cancelled when the runtime shut down while a probe was still in flight.
+
+### Solution
+
+The timeout is now configurable through the new daprd `--app-binding-options-timeout` flag, which applies to both the HTTP `OPTIONS` probe and the gRPC `ListInputBindings` probe.
+The default remains 3 seconds, so existing deployments are unchanged, and non-positive values fall back to that default.
+The probe is now derived from the runtime's context, so it is cancelled promptly on shutdown instead of running to its full deadline.
+
+Setting `direction: input` on the binding component continues to skip the probe entirely.

--- a/pkg/config/app_connection.go
+++ b/pkg/config/app_connection.go
@@ -26,6 +26,10 @@ const (
 	AppHealthConfigDefaultProbeTimeout = 500 * time.Millisecond
 	// AppHealthConfigDefaultThreshold is the default threshold for determining failures in app health checks.
 	AppHealthConfigDefaultThreshold = int32(3)
+	// DefaultAppBindingOptionsTimeout is the default timeout for the subscription discovery request
+	// sent to the app for input bindings (HTTP OPTIONS or gRPC ListInputBindings).
+	// Apps with slow startup (JVM, JIT, resource-constrained) may need a larger value.
+	DefaultAppBindingOptionsTimeout = 3 * time.Second
 )
 
 // AppHealthConfig is the configuration object for the app health probes.

--- a/pkg/injector/annotations/annotations.go
+++ b/pkg/injector/annotations/annotations.go
@@ -69,6 +69,7 @@ const (
 	KeyAppHealthProbeInterval           = "dapr.io/app-health-probe-interval"
 	KeyAppHealthProbeTimeout            = "dapr.io/app-health-probe-timeout"
 	KeyAppHealthThreshold               = "dapr.io/app-health-threshold"
+	KeyAppBindingOptionsTimeout         = "dapr.io/app-binding-options-timeout"
 	KeyPlacementHostAddresses           = "dapr.io/placement-host-address"
 	KeyActorsDisseminateTimeout         = "dapr.io/actors-disseminate-timeout"
 	KeySchedulerHostAddresses           = "dapr.io/scheduler-host-address"

--- a/pkg/injector/patcher/sidecar.go
+++ b/pkg/injector/patcher/sidecar.go
@@ -111,6 +111,7 @@ type SidecarConfig struct {
 	AppHealthProbeInterval              int32   `annotation:"dapr.io/app-health-probe-interval" default:"5"`  // In seconds
 	AppHealthProbeTimeout               int32   `annotation:"dapr.io/app-health-probe-timeout" default:"500"` // In milliseconds
 	AppHealthThreshold                  int32   `annotation:"dapr.io/app-health-threshold" default:"3"`
+	AppBindingOptionsTimeout            *string `annotation:"dapr.io/app-binding-options-timeout"`
 	PlacementAddress                    string  `annotation:"dapr.io/placement-host-address"`
 	ActorsDisseminateTimeout            *string `annotation:"dapr.io/actors-disseminate-timeout"`
 	SchedulerAddress                    *string `annotation:"dapr.io/scheduler-host-address"`

--- a/pkg/injector/patcher/sidecar_container.go
+++ b/pkg/injector/patcher/sidecar_container.go
@@ -143,6 +143,10 @@ func (c *SidecarConfig) getSidecarContainer(opts getSidecarContainerOpts) (*core
 		)
 	}
 
+	if c.AppBindingOptionsTimeout != nil {
+		args = append(args, "--app-binding-options-timeout", *c.AppBindingOptionsTimeout)
+	}
+
 	if c.LogAsJSON {
 		args = append(args, "--log-as-json")
 	}

--- a/pkg/injector/patcher/sidecar_container_test.go
+++ b/pkg/injector/patcher/sidecar_container_test.go
@@ -901,6 +901,27 @@ func TestGetSidecarContainer(t *testing.T) {
 		},
 	}))
 
+	t.Run("app binding options timeout", testSuiteGenerator([]testCase{
+		{
+			name:        "default to empty",
+			annotations: map[string]string{},
+			assertFn: func(t *testing.T, container *corev1.Container) {
+				args := strings.Join(container.Args, " ")
+				assert.NotContains(t, args, "--app-binding-options-timeout")
+			},
+		},
+		{
+			name: "add an app binding options timeout",
+			annotations: map[string]string{
+				annotations.KeyAppBindingOptionsTimeout: "30s",
+			},
+			assertFn: func(t *testing.T, container *corev1.Container) {
+				args := strings.Join(container.Args, " ")
+				assert.Contains(t, args, "--app-binding-options-timeout 30s")
+			},
+		},
+	}))
+
 	t.Run("sidecar image", testSuiteGenerator([]testCase{
 		{
 			name:        "no annotation",

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -139,6 +139,10 @@ type Config struct {
 	// HotReloadReconcileInterval overrides the hot-reload backup reconcile
 	// period. Zero uses the reconciler default (60s).
 	HotReloadReconcileInterval time.Duration
+	// AppBindingOptionsTimeout overrides the timeout for the subscription discovery
+	// request sent to the app for input bindings (HTTP OPTIONS or gRPC ListInputBindings).
+	// Non-positive values use config.DefaultAppBindingOptionsTimeout (3s).
+	AppBindingOptionsTimeout time.Duration
 }
 
 type internalConfig struct {
@@ -179,6 +183,7 @@ type internalConfig struct {
 	workflowEventSink            orchestrator.EventSink
 	disableInitEndpoints         []string
 	hotReloadReconcileInterval   time.Duration
+	appBindingOptionsTimeout     time.Duration
 }
 
 func (i internalConfig) SchedulerEnabled() bool {
@@ -378,6 +383,7 @@ func (c *Config) toInternal() (*internalConfig, error) {
 		actorsService:              c.ActorsService,
 		actorsDisseminationTimeout: c.ActorsDisseminationTimeout,
 		hotReloadReconcileInterval: c.HotReloadReconcileInterval,
+		appBindingOptionsTimeout:   c.AppBindingOptionsTimeout,
 		remindersService:           c.RemindersService,
 		schedulerAddress:           c.SchedulerAddress,
 		schedulerStreams:           c.SchedulerStreams,

--- a/pkg/runtime/processor/binding/binding.go
+++ b/pkg/runtime/processor/binding/binding.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/dapr/pkg/api/grpc/manager"
@@ -51,13 +52,14 @@ var log = logger.NewLogger("dapr.runtime.processor.binding")
 type Options struct {
 	IsHTTP bool
 
-	Registry       *compbindings.Registry
-	ComponentStore *compstore.ComponentStore
-	Meta           *meta.Meta
-	Resiliency     resiliency.Provider
-	GRPC           *manager.Manager
-	TracingSpec    *config.TracingSpec
-	Channels       *channels.Channels
+	Registry                 *compbindings.Registry
+	ComponentStore           *compstore.ComponentStore
+	Meta                     *meta.Meta
+	Resiliency               resiliency.Provider
+	GRPC                     *manager.Manager
+	TracingSpec              *config.TracingSpec
+	Channels                 *channels.Channels
+	AppBindingOptionsTimeout time.Duration
 }
 
 type binding struct {
@@ -75,22 +77,28 @@ type binding struct {
 	readingBindings bool
 	stopForever     bool
 
-	subscribeBindingList []string
-	activeInputs         map[string]*input.Input
-	wg                   sync.WaitGroup
+	subscribeBindingList     []string
+	activeInputs             map[string]*input.Input
+	wg                       sync.WaitGroup
+	appBindingOptionsTimeout time.Duration
 }
 
 func New(opts Options) *binding {
+	appBindingOptionsTimeout := opts.AppBindingOptionsTimeout
+	if appBindingOptionsTimeout <= 0 {
+		appBindingOptionsTimeout = config.DefaultAppBindingOptionsTimeout
+	}
 	return &binding{
-		registry:     opts.Registry,
-		compStore:    opts.ComponentStore,
-		meta:         opts.Meta,
-		isHTTP:       opts.IsHTTP,
-		resiliency:   opts.Resiliency,
-		tracingSpec:  opts.TracingSpec,
-		grpc:         opts.GRPC,
-		channels:     opts.Channels,
-		activeInputs: make(map[string]*input.Input),
+		registry:                 opts.Registry,
+		compStore:                opts.ComponentStore,
+		meta:                     opts.Meta,
+		isHTTP:                   opts.IsHTTP,
+		resiliency:               opts.Resiliency,
+		tracingSpec:              opts.TracingSpec,
+		grpc:                     opts.GRPC,
+		channels:                 opts.Channels,
+		activeInputs:             make(map[string]*input.Input),
+		appBindingOptionsTimeout: appBindingOptionsTimeout,
 	}
 }
 
@@ -204,7 +212,7 @@ func (b *binding) initInputBinding(ctx context.Context, comp compapi.Component) 
 	diag.DefaultMonitoring.ComponentInitialized(comp.Spec.Type)
 
 	if b.readingBindings {
-		return b.startInputBinding(comp, binding)
+		return b.startInputBinding(ctx, comp, binding)
 	}
 
 	return nil

--- a/pkg/runtime/processor/binding/send.go
+++ b/pkg/runtime/processor/binding/send.go
@@ -81,7 +81,7 @@ func (b *binding) StartReadingFromBindings(ctx context.Context) error {
 	}
 
 	for name, bind := range b.compStore.ListInputBindings() {
-		err := b.startInputBinding(bindings[name], bind)
+		err := b.startInputBinding(ctx, bindings[name], bind)
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func (b *binding) StartReadingFromBindings(ctx context.Context) error {
 	return nil
 }
 
-func (b *binding) startInputBinding(comp componentsV1alpha1.Component, binding bindings.InputBinding) error {
+func (b *binding) startInputBinding(ctx context.Context, comp componentsV1alpha1.Component, binding bindings.InputBinding) error {
 	var isSubscribed bool
 
 	meta, err := b.meta.ToBaseMetadata(comp)
@@ -103,10 +103,10 @@ func (b *binding) startInputBinding(comp componentsV1alpha1.Component, binding b
 	if isBindingOfExplicitDirection(ComponentTypeInput, m) {
 		isSubscribed = true
 	} else {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		probeCtx, cancel := context.WithTimeout(ctx, b.appBindingOptionsTimeout)
 		defer cancel()
 
-		isSubscribed, err = b.isAppSubscribedToBinding(ctx, comp.Name)
+		isSubscribed, err = b.isAppSubscribedToBinding(probeCtx, comp.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/runtime/processor/binding/send_test.go
+++ b/pkg/runtime/processor/binding/send_test.go
@@ -31,6 +31,7 @@ import (
 	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	componentsV1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	channelt "github.com/dapr/dapr/pkg/channel/testing"
+	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/healthz"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	"github.com/dapr/dapr/pkg/modes"
@@ -176,6 +177,65 @@ func TestStartReadingFromBindings(t *testing.T) {
 	})
 }
 
+func TestBindingOptionsTimeout(t *testing.T) {
+	t.Run("zero value falls back to default timeout", func(t *testing.T) {
+		b := New(Options{
+			IsHTTP:                   true,
+			Resiliency:               resiliency.New(log),
+			ComponentStore:           compstore.New(),
+			Meta:                     meta.New(meta.Options{}),
+			AppBindingOptionsTimeout: 0, // should use config.DefaultAppBindingOptionsTimeout
+		})
+		assert.Equal(t, config.DefaultAppBindingOptionsTimeout, b.appBindingOptionsTimeout)
+	})
+
+	t.Run("custom timeout is stored and respected", func(t *testing.T) {
+		customTimeout := 10 * time.Second
+		b := New(Options{
+			IsHTTP:                   true,
+			Resiliency:               resiliency.New(log),
+			ComponentStore:           compstore.New(),
+			Meta:                     meta.New(meta.Options{}),
+			AppBindingOptionsTimeout: customTimeout,
+		})
+		assert.Equal(t, customTimeout, b.appBindingOptionsTimeout)
+	})
+
+	t.Run("very short timeout causes OPTIONS probe to fail with deadline exceeded", func(t *testing.T) {
+		// Set up a mock channel whose InvokeMethod returns a deadline exceeded error,
+		// simulating a slow-starting app that exceeds the probe timeout.
+		probeTimeout := 500 * time.Millisecond
+		mockAppChannel := new(channelt.MockAppChannel)
+		b := New(Options{
+			IsHTTP:                   true,
+			Resiliency:               resiliency.New(log),
+			ComponentStore:           compstore.New(),
+			Meta:                     meta.New(meta.Options{}),
+			AppBindingOptionsTimeout: probeTimeout,
+		})
+		b.channels = new(channels.Channels).WithAppChannel(mockAppChannel)
+
+		mockAppChannel.On(
+			"InvokeMethod",
+			mock.MatchedBy(func(ctx context.Context) bool {
+				d, ok := ctx.Deadline()
+				if !ok {
+					return false
+				}
+				remaining := time.Until(d)
+				return remaining > 0 && remaining <= probeTimeout
+			}),
+			mock.Anything,
+		).Return(nil, context.DeadlineExceeded)
+		m := &rtmock.Binding{}
+		b.compStore.AddInputBinding("slow-app", m)
+
+		err := b.StartReadingFromBindings(t.Context())
+		require.Error(t, err, "expected OPTIONS probe to fail when app is slow to respond")
+		mockAppChannel.AssertExpectations(t)
+	})
+}
+
 func TestGetSubscribedBindingsGRPC(t *testing.T) {
 	secP, err := security.New(t.Context(), security.Options{
 		TrustAnchors:            []byte("test"),
@@ -281,7 +341,7 @@ func TestReadInputBindings(t *testing.T) {
 				Name: testInputBindingName,
 			},
 		}
-		b.startInputBinding(comp, &mockBinding)
+		b.startInputBinding(t.Context(), comp, &mockBinding)
 
 		assert.False(t, <-ch)
 	})
@@ -330,7 +390,7 @@ func TestReadInputBindings(t *testing.T) {
 				Name: testInputBindingName,
 			},
 		}
-		b.startInputBinding(comp, &mockBinding)
+		b.startInputBinding(t.Context(), comp, &mockBinding)
 
 		assert.True(t, <-ch)
 	})
@@ -380,7 +440,7 @@ func TestReadInputBindings(t *testing.T) {
 				Name: testInputBindingName,
 			},
 		}
-		b.startInputBinding(comp, &mockBinding)
+		b.startInputBinding(t.Context(), comp, &mockBinding)
 
 		assert.Equal(t, string(rtmock.TestInputBindingData), mockBinding.Data)
 	})
@@ -420,7 +480,7 @@ func TestReadInputBindings(t *testing.T) {
 			},
 		}
 		b.compStore.AddInputBinding(testInputBindingName, mockBinding)
-		b.startInputBinding(comp, mockBinding)
+		b.startInputBinding(t.Context(), comp, mockBinding)
 
 		time.Sleep(80 * time.Millisecond)
 

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -111,6 +111,7 @@ type Options struct {
 
 	// ProgrammaticSubscriptionEnabled indicates whether programmatic subscriptions are active.
 	ProgrammaticSubscriptionEnabled bool
+	AppBindingOptionsTimeout        time.Duration
 }
 
 // Processor manages the lifecycle of all components categories.
@@ -198,14 +199,15 @@ func New(opts Options) *Processor {
 	})
 
 	binding := binding.New(binding.Options{
-		Registry:       opts.Registry.Bindings(),
-		ComponentStore: opts.ComponentStore,
-		Meta:           opts.Meta,
-		IsHTTP:         opts.IsHTTP,
-		Resiliency:     opts.Resiliency,
-		GRPC:           opts.GRPC,
-		TracingSpec:    opts.GlobalConfig.Spec.TracingSpec,
-		Channels:       opts.Channels,
+		Registry:                 opts.Registry.Bindings(),
+		ComponentStore:           opts.ComponentStore,
+		Meta:                     opts.Meta,
+		IsHTTP:                   opts.IsHTTP,
+		Resiliency:               opts.Resiliency,
+		GRPC:                     opts.GRPC,
+		TracingSpec:              opts.GlobalConfig.Spec.TracingSpec,
+		Channels:                 opts.Channels,
+		AppBindingOptionsTimeout: opts.AppBindingOptionsTimeout,
 	})
 
 	// ensure a default no-op reporter

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -300,6 +300,7 @@ func newDaprRuntime(ctx context.Context,
 		Adapter:                         pubsubAdapter,
 		AdapterStreamer:                 pubsubAdapterStreamer,
 		Reporter:                        runtimeConfig.registry.Reporter(),
+		AppBindingOptionsTimeout:        runtimeConfig.appBindingOptionsTimeout,
 	})
 
 	var reloader *hotreload.Reloader

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -158,6 +158,9 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	if opts.hotReloadReconcileInterval != nil {
 		args = append(args, "--hot-reload-reconcile-interval="+opts.hotReloadReconcileInterval.String())
 	}
+	if opts.appBindingOptionsTimeout != nil {
+		args = append(args, "--app-binding-options-timeout="+opts.appBindingOptionsTimeout.String())
+	}
 	if len(opts.schedulerAddresses) > 0 {
 		args = append(args, "--scheduler-host-address="+strings.Join(opts.schedulerAddresses, ","))
 	}

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -68,6 +68,7 @@ type options struct {
 	actorsDisseminateTimeout   *time.Duration
 	hotReloadReconcileInterval *time.Duration
 	controlPlaneTrustDomain    *string
+	appBindingOptionsTimeout   *time.Duration
 	schedulerAddresses         []string
 	disableInitEndpoints       []string
 	maxBodySize                *string
@@ -329,6 +330,12 @@ func WithActorsDisseminateTimeout(timeout time.Duration) Option {
 func WithHotReloadReconcileInterval(interval time.Duration) Option {
 	return func(o *options) {
 		o.hotReloadReconcileInterval = &interval
+	}
+}
+
+func WithAppBindingOptionsTimeout(timeout time.Duration) Option {
+	return func(o *options) {
+		o.appBindingOptionsTimeout = &timeout
 	}
 }
 

--- a/tests/integration/suite/daprd/binding/input/grpc/optionstimeout.go
+++ b/tests/integration/suite/daprd/binding/input/grpc/optionstimeout.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(optionstimeout))
+}
+
+// optionstimeout checks --app-binding-options-timeout bounds the gRPC discovery
+// probe, which uses ListInputBindings instead of HTTP OPTIONS.
+//
+// Each daprd gets its own app because OnBindingEvent carries no daprd identity.
+type optionstimeout struct {
+	failApp   *app.App
+	customApp *app.App
+
+	daprdFail   *daprd.Daprd
+	daprdCustom *daprd.Daprd
+
+	bindingCalledFail   atomic.Int64
+	bindingCalledCustom atomic.Int64
+}
+
+func (o *optionstimeout) Setup(t *testing.T) []framework.Option {
+	const (
+		// Stands in for a slow-starting app, ex: a JVM/JIT workload.
+		optionsDelay = 2 * time.Second
+
+		failTimeout   = optionsDelay / 2 // probe gives up first
+		customTimeout = 5 * optionsDelay // app answers first
+	)
+
+	// direction is omitted so daprd runs the probe instead of skipping it.
+	const bindingResource = `
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mybinding
+spec:
+  type: bindings.cron
+  version: v1
+  metadata:
+  - name: schedule
+    value: "@every 1s"
+`
+
+	listInputBindings := func(delay time.Duration) func(context.Context, *emptypb.Empty) (*rtv1.ListInputBindingsResponse, error) {
+		return func(context.Context, *emptypb.Empty) (*rtv1.ListInputBindingsResponse, error) {
+			time.Sleep(delay)
+			return &rtv1.ListInputBindingsResponse{Bindings: []string{"mybinding"}}, nil
+		}
+	}
+
+	o.failApp = app.New(t,
+		app.WithListInputBindings(listInputBindings(optionsDelay)),
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			o.bindingCalledFail.Add(1)
+			return new(rtv1.BindingEventResponse), nil
+		}),
+	)
+
+	o.customApp = app.New(t,
+		app.WithListInputBindings(listInputBindings(optionsDelay)),
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			o.bindingCalledCustom.Add(1)
+			return new(rtv1.BindingEventResponse), nil
+		}),
+	)
+
+	// A failed gRPC probe reads as an empty subscription list, so daprd keeps
+	// running with the binding inactive.
+	o.daprdFail = daprd.New(t,
+		daprd.WithAppPort(o.failApp.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppBindingOptionsTimeout(failTimeout),
+		daprd.WithResourceFiles(bindingResource),
+	)
+
+	o.daprdCustom = daprd.New(t,
+		daprd.WithAppPort(o.customApp.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithAppBindingOptionsTimeout(customTimeout),
+		daprd.WithResourceFiles(bindingResource),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(o.failApp, o.customApp, o.daprdFail, o.daprdCustom),
+	}
+}
+
+func (o *optionstimeout) Run(t *testing.T, ctx context.Context) {
+	// The probe runs during startup, so by the time daprd is up it has already
+	// timed out or succeeded.
+	o.daprdFail.WaitUntilRunning(t, ctx)
+	o.daprdCustom.WaitUntilRunning(t, ctx)
+
+	gclientFail := o.daprdFail.GRPCClient(t, ctx)
+	gclientCustom := o.daprdCustom.GRPCClient(t, ctx)
+
+	// Registered either way, a failed probe only stops it reading.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := gclientFail.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		assert.NoError(c, err)
+		assert.Len(c, resp.GetRegisteredComponents(), 1)
+	}, time.Second*5, 10*time.Millisecond)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := gclientCustom.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		assert.NoError(c, err)
+		assert.Len(c, resp.GetRegisteredComponents(), 1)
+	}, time.Second*5, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return o.bindingCalledCustom.Load() > 0
+	}, 5*time.Second, 100*time.Millisecond, "binding should fire: probe had time to succeed")
+
+	assert.Equal(t, int64(0), o.bindingCalledFail.Load(),
+		"binding should not fire: probe timed out")
+}

--- a/tests/integration/suite/daprd/binding/input/http/optionstimeout.go
+++ b/tests/integration/suite/daprd/binding/input/http/optionstimeout.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(optionstimeout))
+}
+
+// optionstimeout verifies that --app-binding-options-timeout controls when daprd
+// gives up waiting for an HTTP app to respond to the OPTIONS subscription
+// discovery probe.
+//
+// Scenario:
+//   - Both apps delay their OPTIONS response by 2 s to simulate a slow-starting
+//     JVM/JIT workload.
+//   - The default timeout is 3 s.
+//     This test exercises the failure case by configuring daprdFail with 1 s and
+//     the success case with 10 s.
+//     daprdFail uses a 1 s timeout — shorter than the 2 s app delay — so its
+//     OPTIONS probe times out and the binding is NOT activated.
+//   - daprdCustom uses a 10 s timeout: well beyond the 2 s app delay, so its
+//     OPTIONS probe always succeeds and the binding IS activated.
+//
+// Each daprd instance gets its own dedicated app so binding POST events are
+// counted independently. The HTTP channel does NOT set dapr-app-id on outbound
+// binding event POSTs, so header-based routing would not work.
+type optionstimeout struct {
+	// failApp is the app paired with daprdFail (1 s configured timeout < 2 s delay).
+	failApp *app.App
+	// customApp is the app paired with daprdCustom (10 s configured timeout > 2 s delay).
+	customApp *app.App
+
+	// daprdFail uses a 1 s OPTIONS probe timeout (shorter than the app's 2 s delay).
+	daprdFail *daprd.Daprd
+	// daprdCustom uses a 10 s OPTIONS probe timeout (longer than the app's 2 s delay).
+	daprdCustom *daprd.Daprd
+
+	// bindingCalledFail counts binding events delivered to failApp.
+	bindingCalledFail atomic.Int64
+	// bindingCalledCustom counts binding events delivered to customApp.
+	bindingCalledCustom atomic.Int64
+}
+
+func (o *optionstimeout) Setup(t *testing.T) []framework.Option {
+	const (
+		// optionsDelay is the time the slow app takes to respond to the OPTIONS probe,
+		// simulating a slow-starting JVM/JIT workload.
+		optionsDelay = 2 * time.Second
+
+		// failTimeout is shorter than optionsDelay so the probe times out and the
+		// binding is NOT activated.
+		failTimeout = optionsDelay / 2 // 1 s
+
+		// customTimeout is much longer than optionsDelay so the probe always succeeds
+		// and the binding IS activated.
+		customTimeout = 5 * optionsDelay // 10 s
+	)
+
+	// A cron input binding that fires every second. The direction is intentionally
+	// omitted so that daprd performs the OPTIONS probe rather than bypassing it.
+	const bindingResource = `
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mybinding
+spec:
+  type: bindings.cron
+  version: v1
+  metadata:
+  - name: schedule
+    value: "@every 1s"
+`
+
+	// Each daprd gets its own app instance so binding POST events are counted
+	// independently — no header-based routing required.
+	o.failApp = app.New(t,
+		app.WithHandlerFunc("/mybinding", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			switch r.Method {
+			case nethttp.MethodOptions:
+				// Simulate a slow-starting application that exceeds the configured timeout.
+				time.Sleep(optionsDelay)
+				w.WriteHeader(nethttp.StatusOK)
+			case nethttp.MethodPost:
+				o.bindingCalledFail.Add(1)
+				w.WriteHeader(nethttp.StatusOK)
+			default:
+				w.WriteHeader(nethttp.StatusMethodNotAllowed)
+			}
+		}),
+	)
+
+	o.customApp = app.New(t,
+		app.WithHandlerFunc("/mybinding", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			switch r.Method {
+			case nethttp.MethodOptions:
+				// Same delay — but daprdCustom's 10 s timeout gives it room to succeed.
+				time.Sleep(optionsDelay)
+				w.WriteHeader(nethttp.StatusOK)
+			case nethttp.MethodPost:
+				o.bindingCalledCustom.Add(1)
+				w.WriteHeader(nethttp.StatusOK)
+			default:
+				w.WriteHeader(nethttp.StatusMethodNotAllowed)
+			}
+		}),
+	)
+
+	// daprdFail: failTimeout < optionsDelay, so the OPTIONS probe times out.
+	// StartReadingFromBindings returns an error logged as a warning; daprd
+	// continues running but the binding is not activated.
+	o.daprdFail = daprd.New(t,
+		daprd.WithAppPort(o.failApp.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppBindingOptionsTimeout(failTimeout),
+		daprd.WithResourceFiles(bindingResource),
+	)
+
+	// daprdCustom: customTimeout >> optionsDelay, so the OPTIONS probe succeeds.
+	// StartReadingFromBindings activates the cron binding, which fires every second.
+	o.daprdCustom = daprd.New(t,
+		daprd.WithAppPort(o.customApp.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppBindingOptionsTimeout(customTimeout),
+		daprd.WithResourceFiles(bindingResource),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(o.failApp, o.customApp, o.daprdFail, o.daprdCustom),
+	}
+}
+
+func (o *optionstimeout) Run(t *testing.T, ctx context.Context) {
+	// StartReadingFromBindings is called synchronously during daprd startup, so
+	// WaitUntilRunning returns only after the OPTIONS probe has either timed out
+	// (daprdFail, ~1 s) or succeeded (daprdCustom, ~2 s). At this point the
+	// cron binding is already active for daprdCustom.
+	o.daprdFail.WaitUntilRunning(t, ctx)
+	o.daprdCustom.WaitUntilRunning(t, ctx)
+
+	gclientFail := o.daprdFail.GRPCClient(t, ctx)
+	gclientCustom := o.daprdCustom.GRPCClient(t, ctx)
+
+	// Both daprd instances must have registered the cron component even if the
+	// probe failed — the component is initialized, just not actively reading.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := gclientFail.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		assert.NoError(c, err)
+		assert.Len(c, resp.GetRegisteredComponents(), 1)
+	}, time.Second*5, 10*time.Millisecond)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := gclientCustom.GetMetadata(ctx, new(rtv1.GetMetadataRequest))
+		assert.NoError(c, err)
+		assert.Len(c, resp.GetRegisteredComponents(), 1)
+	}, time.Second*5, 10*time.Millisecond)
+
+	// daprdCustom's OPTIONS probe succeeded (10 s > 2 s app delay),
+	// so the binding SHOULD have fired at least once.
+	require.Eventually(t, func() bool {
+		return o.bindingCalledCustom.Load() > 0
+	}, 5*time.Second, 100*time.Millisecond, "10 s timeout: binding should fire because OPTIONS probe succeeded")
+
+	// daprdFail's OPTIONS probe timed out (1 s < 2 s app delay),
+	// so the binding should NOT have been activated.
+	assert.Equal(t, int64(0), o.bindingCalledFail.Load(),
+		"1 s timeout: binding should NOT fire because OPTIONS probe timed out")
+}

--- a/tests/integration/suite/injector/bindingoptionstimeout.go
+++ b/tests/integration/suite/injector/bindingoptionstimeout.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package injector
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	procinjector "github.com/dapr/dapr/tests/integration/framework/process/injector"
+	procsentry "github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(bindingoptionstimeout))
+}
+
+// bindingoptionstimeout verifies the injector turns the
+// dapr.io/app-binding-options-timeout annotation into the matching daprd flag,
+// and passes no flag at all when the annotation is absent.
+type bindingoptionstimeout struct {
+	injector *procinjector.Injector
+}
+
+func (b *bindingoptionstimeout) Setup(t *testing.T) []framework.Option {
+	sentry := procsentry.New(t,
+		procsentry.WithTrustDomain("integration.test.dapr.io"),
+		procsentry.WithNamespace("dapr-system"),
+	)
+	b.injector = procinjector.New(t,
+		procinjector.WithNamespace("dapr-system"),
+		procinjector.WithSentry(sentry),
+	)
+	return []framework.Option{
+		framework.WithProcesses(sentry, b.injector),
+	}
+}
+
+func (b *bindingoptionstimeout) Run(t *testing.T, ctx context.Context) {
+	b.injector.WaitUntilRunning(t, ctx)
+
+	t.Run("annotation set", func(t *testing.T) {
+		args := b.daprdArgs(t, ctx, map[string]string{
+			"dapr.io/enabled":                     "true",
+			"dapr.io/app-id":                      "dapr-app",
+			"dapr.io/app-binding-options-timeout": "30s",
+		})
+		assert.Contains(t, strings.Join(args, " "), "--app-binding-options-timeout 30s")
+	})
+
+	t.Run("annotation absent", func(t *testing.T) {
+		args := b.daprdArgs(t, ctx, map[string]string{
+			"dapr.io/enabled": "true",
+			"dapr.io/app-id":  "dapr-app",
+		})
+		assert.NotContains(t, strings.Join(args, " "), "--app-binding-options-timeout")
+	})
+}
+
+// daprdArgs runs the pod through the injector and returns the args of the
+// injected daprd container.
+func (b *bindingoptionstimeout) daprdArgs(t *testing.T, ctx context.Context, annotations map[string]string) []string {
+	t.Helper()
+
+	podBytes := buildPod("dapr-app", annotations)
+	review := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       uuid.NewUUID(),
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			Name:      "dapr-app",
+			Namespace: "dapr-system",
+			Operation: "CREATE",
+			UserInfo:  authenticationv1.UserInfo{Groups: []string{"system:masters"}},
+			Object:    runtime.RawExtension{Raw: podBytes},
+		},
+	}
+
+	ar := b.injector.SendAdmission(t, ctx, review)
+	require.NotNil(t, ar.Response)
+	require.True(t, ar.Response.Allowed)
+	require.NotEmpty(t, ar.Response.Patch, "should contain sidecar patch")
+
+	patch, err := jsonpatch.DecodePatch(ar.Response.Patch)
+	require.NoError(t, err)
+	patched, err := patch.Apply(podBytes)
+	require.NoError(t, err)
+
+	var pod corev1.Pod
+	require.NoError(t, json.Unmarshal(patched, &pod))
+
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "daprd" {
+			return c.Args
+		}
+	}
+
+	require.Fail(t, "patched pod has no daprd container")
+
+	return nil
+}


### PR DESCRIPTION
[supersede this PR](https://github.com/dapr/dapr/pull/10297)