### PR TITLE
e2e: drain pubsub redelivery backlog before reset

### DIFF
--- a/tests/e2e/pubsub/pubsub_test.go
+++ b/tests/e2e/pubsub/pubsub_test.go
@@ -312,6 +312,14 @@ func testDropToDeadLetter(t *testing.T, publisherExternalURL, subscriberExternal
 	err := utils.HealthCheckApps(publisherExternalURL)
 	require.NoError(t, err, "Health check failed for publisher")
 
+	// Flush any redelivery backlog left by earlier scenarios (notably the
+	// resiliency-exhaustion scenario, whose erroring subscriber builds one
+	// up) before resetting the received sets. Stragglers arriving after the
+	// reset land on topics B/C and break the empty-topic assertions below
+	// (observed as 8/0 on topic B and 31/0 on topic C on the pluggable
+	// suite, whose redis component redelivers on a 1s interval).
+	drainSubscriberBacklog(t, publisherExternalURL, subscriberAppName, protocol, podEndpoints)
+
 	setDesiredResponse(t, subscriberAppName, "drop", publisherExternalURL, protocol)
 	callInitialize(t, subscriberAppName, publisherExternalURL, protocol)
 
@@ -345,6 +353,11 @@ func testResiliencyExhaustion(t *testing.T, publisherExternalURL, subscriberExte
 	log.Printf("Test resiliency exhaustion - messages should be dropped after retries exhausted")
 	err := utils.HealthCheckApps(publisherExternalURL)
 	require.NoError(t, err, "Health check failed for publisher")
+
+	// Flush any redelivery backlog from the previous scenario before
+	// resetting the received sets: this scenario asserts nothing is
+	// delivered, so a single straggler recorded after the reset fails it.
+	drainSubscriberBacklog(t, publisherExternalURL, subscriberAppName, protocol, podEndpoints)
 
 	callInitialize(t, subscriberAppName, publisherExternalURL, protocol)
 	setDesiredResponse(t, subscriberAppName, "error", publisherExternalURL, protocol)


### PR DESCRIPTION
TestPubSubHTTP subtests share one subscriber app. Scenarios that hold the subscriber in a failing state (error, resiliency exhaustion) build up a broker redelivery backlog; the pluggable suite's redis component redelivers on a 1s interval, so stragglers can arrive after a later subtest has reset the received sets and inflate its counts.

Call the existing drainSubscriberBacklog helper before resetting the received sets in testDropToDeadLetter and testResiliencyExhaustion, matching what testValidateRedeliveryOrEmptyJSON already does. Both scenarios assert empty topics after the reset, so a single straggler recorded after initialize fails them.