### PR TITLE
Standardize Configuration API errors with the rich error model

### DIFF
--- a/pkg/api/errors/configuration.go
+++ b/pkg/api/errors/configuration.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/pkg/messages/errorcodes"
+	"github.com/dapr/kit/errors"
+)
+
+// ConfigurationError builds rich errors for the Configuration API following the
+// gRPC richer error model.
+type ConfigurationError struct {
+	name             string
+	skipResourceInfo bool
+}
+
+// Configuration returns a builder for Configuration API errors for the given store name.
+func Configuration(name string) *ConfigurationError {
+	return &ConfigurationError{
+		name: name,
+	}
+}
+
+// NotConfigured is returned when no configuration stores are configured.
+func (c *ConfigurationError) NotConfigured() error {
+	c.skipResourceInfo = true
+	return c.build(
+		errors.NewBuilder(
+			codes.FailedPrecondition,
+			http.StatusInternalServerError,
+			"configuration stores not configured",
+			errorcodes.ConfigurationStoreNotConfigured.Code,
+			string(errorcodes.ConfigurationStoreNotConfigured.Category),
+		),
+		errorcodes.ConfigurationStoreNotConfigured.GrpcCode,
+		nil,
+	)
+}
+
+// NotFound is returned when the requested configuration store does not exist.
+func (c *ConfigurationError) NotFound() error {
+	c.skipResourceInfo = true
+	return c.build(
+		errors.NewBuilder(
+			codes.InvalidArgument,
+			http.StatusBadRequest,
+			fmt.Sprintf("configuration store %s not found", c.name),
+			errorcodes.ConfigurationStoreNotFound.Code,
+			string(errorcodes.ConfigurationStoreNotFound.Category),
+		),
+		errorcodes.ConfigurationStoreNotFound.GrpcCode,
+		nil,
+	)
+}
+
+// GetFailed is returned when reading configuration items from the store fails.
+func (c *ConfigurationError) GetFailed(keys []string, reason string) error {
+	return c.build(
+		errors.NewBuilder(
+			codes.Internal,
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to get %v from Configuration store %s: %s", keys, c.name, reason),
+			errorcodes.ConfigurationGet.Code,
+			string(errorcodes.ConfigurationGet.Category),
+		),
+		errorcodes.ConfigurationGet.GrpcCode,
+		nil,
+	)
+}
+
+// SubscribeFailed is returned when subscribing to configuration updates fails.
+func (c *ConfigurationError) SubscribeFailed(keys []string, reason string) error {
+	return c.build(
+		errors.NewBuilder(
+			codes.InvalidArgument,
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to subscribe %v from Configuration store %s: %s", keys, c.name, reason),
+			errorcodes.ConfigurationSubscribe.Code,
+			string(errorcodes.ConfigurationSubscribe.Category),
+		),
+		errorcodes.ConfigurationSubscribe.GrpcCode,
+		nil,
+	)
+}
+
+// UnsubscribeFailed is returned when cancelling a configuration subscription fails.
+func (c *ConfigurationError) UnsubscribeFailed(subscribeID string, reason string) error {
+	return c.build(
+		errors.NewBuilder(
+			codes.InvalidArgument,
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to unsubscribe to configuration request %s: %s", subscribeID, reason),
+			errorcodes.ConfigurationUnsubscribe.Code,
+			string(errorcodes.ConfigurationUnsubscribe.Category),
+		),
+		errorcodes.ConfigurationUnsubscribe.GrpcCode,
+		nil,
+	)
+}
+
+func (c *ConfigurationError) build(err *errors.ErrorBuilder, errCode string, metadata map[string]string) error {
+	if !c.skipResourceInfo {
+		err = err.WithResourceInfo("configuration", c.name, "", "")
+	}
+	return err.
+		WithErrorInfo(errCode, metadata).
+		Build()
+}

--- a/pkg/api/errors/configuration_test.go
+++ b/pkg/api/errors/configuration_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kiterrors "github.com/dapr/kit/errors"
+)
+
+func TestConfigurationErrors(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantHTTPCode int
+		wantMsgPart  string
+	}{
+		{"NotConfigured", Configuration("mystore").NotConfigured(), http.StatusInternalServerError, "not configured"},
+		{"NotFound", Configuration("mystore").NotFound(), http.StatusBadRequest, "mystore"},
+		{"GetFailed", Configuration("mystore").GetFailed([]string{"key1"}, "boom"), http.StatusInternalServerError, "failed to get"},
+		{"SubscribeFailed", Configuration("mystore").SubscribeFailed([]string{"key1"}, "boom"), http.StatusInternalServerError, "failed to subscribe"},
+		{"UnsubscribeFailed", Configuration("mystore").UnsubscribeFailed("sub-1", "boom"), http.StatusInternalServerError, "failed to unsubscribe"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Error(t, tc.err)
+
+			kitErr, ok := kiterrors.FromError(tc.err)
+			require.True(t, ok, "expected a standardized kit error")
+
+			assert.Equal(t, tc.wantHTTPCode, kitErr.HTTPStatusCode())
+			assert.Contains(t, kitErr.Error(), tc.wantMsgPart)
+		})
+	}
+}

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -1251,13 +1251,13 @@ func stringValueOrEmpty(value *string) string {
 
 func (a *api) getConfigurationStore(name string) (configuration.Store, error) {
 	if a.CompStore().ConfigurationsLen() == 0 {
-		err := apierrors.Basic(codes.FailedPrecondition, http.StatusInternalServerError, errorcodes.ConfigurationStoreNotConfigured, messages.ErrConfigurationStoresNotConfigured)
+		err := apierrors.Configuration(name).NotConfigured()
 		return nil, err
 	}
 
 	conf, ok := a.CompStore().GetConfiguration(name)
 	if !ok {
-		err := apierrors.Basic(codes.InvalidArgument, http.StatusInternalServerError, errorcodes.ConfigurationStoreNotFound, fmt.Sprintf(messages.ErrConfigurationStoreNotFound, name))
+		err := apierrors.Configuration(name).NotFound()
 		return nil, err
 	}
 	return conf, nil
@@ -1289,7 +1289,7 @@ func (a *api) GetConfiguration(ctx context.Context, in *runtimev1pb.GetConfigura
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(ctx, in.GetStoreName(), diag.Get, err == nil, elapsed)
 
 	if err != nil {
-		richError := apierrors.Basic(codes.Internal, http.StatusInternalServerError, errorcodes.ConfigurationGet, fmt.Sprintf(messages.ErrConfigurationGet, req.Keys, in.GetStoreName(), err.Error()))
+		richError := apierrors.Configuration(in.GetStoreName()).GetFailed(req.Keys, err.Error())
 		apiServerLogger.Debug(richError)
 		return response, richError
 	}
@@ -1442,7 +1442,7 @@ func (a *api) subscribeConfiguration(ctx context.Context, request *runtimev1pb.S
 	diag.DefaultComponentMonitoring.ConfigurationInvoked(context.Background(), request.GetStoreName(), diag.ConfigurationSubscribe, err == nil, elapsed)
 
 	if err != nil {
-		richError := apierrors.Basic(codes.InvalidArgument, http.StatusInternalServerError, errorcodes.ConfigurationSubscribe, fmt.Sprintf(messages.ErrConfigurationSubscribe, componentReq.Keys, request.GetStoreName(), err))
+		richError := apierrors.Configuration(request.GetStoreName()).SubscribeFailed(componentReq.Keys, err.Error())
 		apiServerLogger.Debug(richError)
 		return "", richError
 	}

--- a/pkg/messages/errorcodes/errorcodes.go
+++ b/pkg/messages/errorcodes/errorcodes.go
@@ -100,11 +100,11 @@ var (
 	StateMalformedRequest              = ErrorCode{"ERR_MALFORMED_REQUEST", "DAPR_STATE_ILLEGAL_KEY", CategoryState}                           // Invalid key
 
 	// ### Configuration API
-	ConfigurationGet                = ErrorCode{"ERR_CONFIGURATION_GET", "", CategoryConfiguration}                  // Error getting configuration
-	ConfigurationStoreNotConfigured = ErrorCode{"ERR_CONFIGURATION_STORE_NOT_CONFIGURED", "", CategoryConfiguration} // Configuration store not configured
-	ConfigurationStoreNotFound      = ErrorCode{"ERR_CONFIGURATION_STORE_NOT_FOUND", "", CategoryConfiguration}      // Configuration store not found
-	ConfigurationSubscribe          = ErrorCode{"ERR_CONFIGURATION_SUBSCRIBE", "", CategoryConfiguration}            // Error subscribing to configuration
-	ConfigurationUnsubscribe        = ErrorCode{"ERR_CONFIGURATION_UNSUBSCRIBE", "", CategoryConfiguration}          // Error unsubscribing from configuration
+	ConfigurationGet                = ErrorCode{"ERR_CONFIGURATION_GET", "DAPR_CONFIGURATION_GET_FAILED", CategoryConfiguration}                  // Error getting configuration
+	ConfigurationStoreNotConfigured = ErrorCode{"ERR_CONFIGURATION_STORE_NOT_CONFIGURED", "DAPR_CONFIGURATION_NOT_CONFIGURED", CategoryConfiguration} // Configuration store not configured
+	ConfigurationStoreNotFound      = ErrorCode{"ERR_CONFIGURATION_STORE_NOT_FOUND", "DAPR_CONFIGURATION_NOT_FOUND", CategoryConfiguration}      // Configuration store not found
+	ConfigurationSubscribe          = ErrorCode{"ERR_CONFIGURATION_SUBSCRIBE", "DAPR_CONFIGURATION_SUBSCRIBE_FAILED", CategoryConfiguration}            // Error subscribing to configuration
+	ConfigurationUnsubscribe        = ErrorCode{"ERR_CONFIGURATION_UNSUBSCRIBE", "DAPR_CONFIGURATION_UNSUBSCRIBE_FAILED", CategoryConfiguration}          // Error unsubscribing from configuration
 
 	// ### Crypto API
 	Crypto                       = ErrorCode{"ERR_CRYPTO", "", CategoryCrypto}                          // Error in crypto operation


### PR DESCRIPTION
Migrates the Configuration API errors to the gRPC richer error model, following the pattern in `pkg/api/errors/state.go`.

Part of #7485.

### What this does
- Adds `pkg/api/errors/configuration.go` with a `ConfigurationError` builder covering `NotConfigured`, `NotFound`, `GetFailed`, `SubscribeFailed` and `UnsubscribeFailed`.
- Fills in the previously empty gRPC reason codes for the Configuration error codes (`DAPR_CONFIGURATION_*`) in `pkg/messages/errorcodes/errorcodes.go`.
- Updates the gRPC handlers in `pkg/api/grpc/grpc.go` to use the new builders instead of the generic `apierrors.Basic(...)` calls.
- Adds unit tests for the builders.

### Scope / follow-up
This covers the gRPC side. The HTTP handlers in `pkg/api/http/http.go` still use the older `NewAPIErrorHTTP` flow. I'm happy to migrate those in this PR or a follow-up, whichever you prefer. I'm also happy to adjust the `DAPR_CONFIGURATION_*` reason names if there's a preferred convention.
