### PR TITLE
workflows: fix lost completion rendezvous

### DIFF
--- a/pkg/actors/fake/fake.go
+++ b/pkg/actors/fake/fake.go
@@ -17,8 +17,10 @@ import (
 	"context"
 
 	"github.com/dapr/dapr/pkg/actors"
+	"github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/hostconfig"
 	"github.com/dapr/dapr/pkg/actors/internal/placement"
+	placementfake "github.com/dapr/dapr/pkg/actors/internal/placement/fake"
 	"github.com/dapr/dapr/pkg/actors/reminders"
 	remindersfake "github.com/dapr/dapr/pkg/actors/reminders/fake"
 	"github.com/dapr/dapr/pkg/actors/router"
@@ -124,6 +126,20 @@ func (f *Fake) WithReminders(fn func(context.Context) (reminders.Interface, erro
 
 func (f *Fake) WithPlacement(fn func(context.Context) (placement.Interface, error)) *Fake {
 	f.fnPlacement = fn
+	return f
+}
+
+// WithPlacementLookupActor configures the fake's placement to answer
+// LookupActor with the given function. Unlike WithPlacement, callers outside
+// the actors tree can use this without importing the internal placement
+// package.
+func (f *Fake) WithPlacementLookupActor(fn func(context.Context, *api.LookupActorRequest) (*api.LookupActorResponse, error)) *Fake {
+	f.fnPlacement = func(context.Context) (placement.Interface, error) {
+		return placementfake.New().WithLookupActor(func(ctx context.Context, req *api.LookupActorRequest) (*api.LookupActorResponse, context.Context, context.CancelCauseFunc, error) {
+			lar, err := fn(ctx, req)
+			return lar, ctx, func(error) {}, err
+		}), nil
+	}
 	return f
 }
 

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -50,6 +50,15 @@ type executor struct {
 
 	watchLock chan struct{}
 
+	// displaced holds a parked completion of the colliding other task type
+	// that a claim drained from completeCh. It cannot be put back on the
+	// channel: a completer blocked on a full channel (the only sender
+	// outside mu) can refill the freed slot first, and the non-blocking
+	// put-back would silently drop the payload. Guarded by mu; consumed by
+	// the first matching claim or watch stream. While it is non-nil the
+	// actor must not deactivate, or the payload would be stranded.
+	displaced *internalsv1pb.InternalInvokeResponse
+
 	// mu serializes each side's check-then-act pair of the rendezvous:
 	// complete's pending-map miss followed by its channel park, cancel's map
 	// miss followed by closing cancelCh, claim's drain of both, and close on
@@ -114,8 +123,11 @@ func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvo
 		case e.completeCh <- d:
 		default:
 		}
+		deactivate := e.displaced == nil
 		e.mu.Unlock()
-		e.tryDeactivate()
+		if deactivate {
+			e.tryDeactivate()
+		}
 		return nil
 	}
 
@@ -185,66 +197,102 @@ func (e *executor) claim(req *internalsv1pb.InternalInvokeRequest) *internalsv1p
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	select {
-	case d := <-e.completeCh:
-		// A parked completion of the colliding other task type (a workflow
-		// instance ID equal to an activity actor ID) belongs to a different
-		// waiter: put it back for its own watcher or claimer, and keep the
-		// actor alive for it.
-		if v, ok := d.GetHeaders()[MetadataTaskType]; ok && len(v.GetValues()) > 0 && v.GetValues()[0] != claimType {
-			select {
-			case e.completeCh <- d:
-			default:
-			}
-			return &internalsv1pb.InternalInvokeResponse{
-				Status: &internalsv1pb.Status{Code: int32(codes.NotFound)},
-			}
-		}
+	// A completion of this type displaced by an earlier claim of the
+	// colliding other task type is checked first: it is older than anything
+	// still in the channel.
+	if d := e.displaced; d != nil && parkedTaskType(d) == claimType {
+		e.displaced = nil
+		return e.claimed(d)
+	}
 
-		// A stale watch stream from a superseded attempt may still be parked
-		// on this actor; feed it a copy so it terminates promptly. Duplicate
-		// deliveries are discarded by the workflow-side dedup guards.
-		if len(e.watchLock) > 0 {
-			select {
-			case e.completeCh <- d:
-			default:
-			}
-		} else {
-			e.tryDeactivate()
+	// Drain parked completions. One of the colliding other task type (a
+	// workflow instance ID equal to an activity actor ID) belongs to a
+	// different waiter and is moved to the displaced slot rather than put
+	// back: a completer blocked on a full channel (the only sender outside
+	// mu) can refill the slot the drain freed, and a non-blocking put-back
+	// would silently drop the payload. A same-type duplicate overwrites the
+	// slot, which the workflow-side dedup guards make safe.
+	for {
+		var d *internalsv1pb.InternalInvokeResponse
+		select {
+		case d = <-e.completeCh:
+		default:
 		}
-		return d
-	default:
+		if d == nil {
+			break
+		}
+		if pt := parkedTaskType(d); pt != "" && pt != claimType {
+			e.displaced = d
+			continue
+		}
+		return e.claimed(d)
 	}
 
 	select {
 	case <-e.cancelCh:
-		e.tryDeactivate()
+		if e.displaced == nil {
+			e.tryDeactivate()
+		}
 		return &internalsv1pb.InternalInvokeResponse{
 			Status: &internalsv1pb.Status{Code: int32(codes.Aborted)},
 		}
 	default:
 	}
 
-	// Nothing parked: the waiter rendezvouses through the pending map, which
-	// completions arriving on this daprd reach without touching this actor,
-	// so don't leave an idle entry in the table (a later remote forward
-	// simply re-creates it). A completion racing this deactivation either
-	// finds the still-registered waiter in the map, or observes the closed
-	// actor (the close and complete's closed-check are both under mu) and is
-	// redelivered by the caller's retry onto a fresh actor. A park can only
-	// slip in before the close after the waiter deregistered, where the
-	// durable reminder retry already owns redelivery.
-	e.tryDeactivate()
+	// Nothing parked for this type: the waiter rendezvouses through the
+	// pending map, which completions arriving on this daprd reach without
+	// touching this actor, so don't leave an idle entry in the table (a
+	// later remote forward simply re-creates it), unless a displaced
+	// completion still needs the actor alive for its own waiter. A
+	// completion racing this deactivation either finds the still-registered
+	// waiter in the map, or observes the closed actor (the close and
+	// complete's closed-check are both under mu) and is redelivered by the
+	// caller's retry onto a fresh actor. A park can only slip in before the
+	// close after the waiter deregistered, where the durable reminder retry
+	// already owns redelivery.
+	if e.displaced == nil {
+		e.tryDeactivate()
+	}
 	return &internalsv1pb.InternalInvokeResponse{
 		Status: &internalsv1pb.Status{Code: int32(codes.NotFound)},
 	}
 }
 
+// claimed finalizes a successful claim under mu: a stale watch stream from a
+// superseded attempt is fed a copy so it terminates promptly (duplicates are
+// discarded by the workflow-side dedup guards), and the actor deactivates
+// when no watcher is parked and nothing displaced remains for the colliding
+// other task type.
+func (e *executor) claimed(d *internalsv1pb.InternalInvokeResponse) *internalsv1pb.InternalInvokeResponse {
+	if len(e.watchLock) > 0 {
+		select {
+		case e.completeCh <- d:
+		default:
+		}
+	} else if e.displaced == nil {
+		e.tryDeactivate()
+	}
+	return d
+}
+
+// parkedTaskType reads the task type a parked completion was stamped with by
+// complete; "" only for payloads parked by builds predating the stamp, which
+// any claimer may take.
+func parkedTaskType(d *internalsv1pb.InternalInvokeResponse) string {
+	if v, ok := d.GetHeaders()[MetadataTaskType]; ok && len(v.GetValues()) > 0 {
+		return v.GetValues()[0]
+	}
+	return ""
+}
+
 func (e *executor) cancel(req *internalsv1pb.InternalInvokeRequest) error {
 	e.mu.Lock()
 	if e.pending != nil && e.pending.Cancel(PendingKey(taskTypeOf(req, e.actorID), e.actorID)) {
+		deactivate := e.displaced == nil
 		e.mu.Unlock()
-		e.tryDeactivate()
+		if deactivate {
+			e.tryDeactivate()
+		}
 		return nil
 	}
 
@@ -303,15 +351,22 @@ func (e *executor) InvokeStream(ctx context.Context,
 
 	switch req.GetMessage().GetMethod() {
 	case MethodWatchComplete:
-		return e.watchComplete(ctx, stream)
+		return e.watchComplete(ctx, req, stream)
 	default:
 		return errors.New("unknown method: " + req.GetMessage().GetMethod())
 	}
 }
 
-func (e *executor) watchComplete(ctx context.Context, stream func(*internalsv1pb.InternalInvokeResponse) (bool, error)) error {
+func (e *executor) watchComplete(ctx context.Context, req *internalsv1pb.InternalInvokeRequest, stream func(*internalsv1pb.InternalInvokeResponse) (bool, error)) error {
 	defer func() {
-		e.deactivateCh <- e
+		// A displaced completion still needs the actor alive for its own
+		// waiter; skip deactivation until it is consumed.
+		e.mu.Lock()
+		displaced := e.displaced != nil
+		e.mu.Unlock()
+		if !displaced {
+			e.deactivateCh <- e
+		}
 	}()
 
 	select {
@@ -324,6 +379,25 @@ func (e *executor) watchComplete(ctx context.Context, stream func(*internalsv1pb
 	defer func() {
 		<-e.watchLock
 	}()
+
+	// A completion displaced by a wrong-type claim never reaches the channel
+	// select below: hand it to the first watcher whose advertised type
+	// matches. A watcher advertising no type (a pre-upgrade daprd) takes
+	// whatever is held and applies its own type check stream-side.
+	watchType := ""
+	if v, ok := req.GetMetadata()[MetadataTaskType]; ok && len(v.GetValues()) > 0 {
+		watchType = v.GetValues()[0]
+	}
+	e.mu.Lock()
+	if d := e.displaced; d != nil {
+		if pt := parkedTaskType(d); watchType == "" || pt == "" || pt == watchType {
+			e.displaced = nil
+			e.mu.Unlock()
+			_, err := stream(d)
+			return err
+		}
+	}
+	e.mu.Unlock()
 
 	select {
 	case <-ctx.Done():

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -144,13 +144,16 @@ func (e *executor) claim(req *internalsv1pb.InternalInvokeRequest) *internalsv1p
 	case d := <-e.completeCh:
 		// A parked completion of the colliding other task type (a workflow
 		// instance ID equal to an activity actor ID) belongs to a different
-		// waiter: put it back for its own watcher or claimer.
+		// waiter: put it back for its own watcher or claimer, and keep the
+		// actor alive for it.
 		if v, ok := d.GetHeaders()[MetadataTaskType]; ok && len(v.GetValues()) > 0 && v.GetValues()[0] != claimType {
 			select {
 			case e.completeCh <- d:
 			default:
 			}
-			break
+			return &internalsv1pb.InternalInvokeResponse{
+				Status: &internalsv1pb.Status{Code: int32(codes.NotFound)},
+			}
 		}
 
 		// A stale watch stream from a superseded attempt may still be parked
@@ -177,6 +180,12 @@ func (e *executor) claim(req *internalsv1pb.InternalInvokeRequest) *internalsv1p
 	default:
 	}
 
+	// Nothing parked: the waiter rendezvouses through the pending map, which
+	// completions arriving on this daprd reach without touching this actor,
+	// so don't leave an idle entry in the table (a later remote forward
+	// simply re-creates it). A completion parked concurrently with the
+	// deactivation is redelivered by the caller's closed-actor retry.
+	e.tryDeactivate()
 	return &internalsv1pb.InternalInvokeResponse{
 		Status: &internalsv1pb.Status{Code: int32(codes.NotFound)},
 	}

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -50,6 +50,14 @@ type executor struct {
 
 	watchLock chan struct{}
 
+	// mu serializes each side's check-then-act pair of the rendezvous:
+	// complete's pending-map miss followed by its channel park, cancel's map
+	// miss followed by closing cancelCh, claim's drain of both, and close on
+	// deactivation. Without it a waiter's whole Register+Claim can land
+	// between a completer's miss and its park, with each side missing the
+	// other. Every section held under it is non-blocking.
+	mu sync.Mutex
+
 	closed       atomic.Bool
 	cancelClosed atomic.Bool
 	wg           sync.WaitGroup
@@ -92,7 +100,11 @@ func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvo
 	// The waiter for this task normally lives on this host (it shares this
 	// actor's ID, so placement co-locates them) and is registered in the
 	// process-local pending map: deliver in-process. The channel park below
-	// remains for waiters that fell back to a WatchComplete stream.
+	// remains for waiters that fell back to a WatchComplete stream and for
+	// waiters whose Register+Claim has not happened yet. The miss and the
+	// park are one critical section: a claim can never observe the channel
+	// empty after the map was checked but before the park lands.
+	e.mu.Lock()
 	if e.pending != nil && e.pending.Deliver(PendingKey(taskType, e.actorID), req.GetMessage().GetData().GetValue()) {
 		// A stale watch stream from a superseded attempt may still be
 		// parked on this actor; feed it a copy so it terminates promptly
@@ -102,9 +114,30 @@ func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvo
 		case e.completeCh <- d:
 		default:
 		}
+		e.mu.Unlock()
 		e.tryDeactivate()
 		return nil
 	}
+
+	// A concurrent claim may have found nothing and requested deactivation;
+	// the close happens under mu, so this check is race-free: parking into a
+	// closed actor would strand the payload, erroring instead makes the
+	// caller's closed-actor retry redeliver onto a fresh actor.
+	select {
+	case <-e.closeCh:
+		e.mu.Unlock()
+		return targeterrors.NewClosed("executor")
+	default:
+	}
+
+	parked := false
+	select {
+	case e.completeCh <- d:
+		parked = true
+	default:
+	}
+	forward := taskType == TaskTypeActivity && !isForwarded(req) && len(e.watchLock) == 0
+	e.mu.Unlock()
 
 	// No waiter is registered on this host. If no watch stream is parked on
 	// this actor either, and this call was not itself forwarded, forward once
@@ -113,10 +146,17 @@ func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvo
 	// activity keys have sibling forms, so workflow completions never
 	// forward (a workflow instance ID that happens to look like an activity
 	// key must not be rewritten).
-	if taskType == TaskTypeActivity && !isForwarded(req) && len(e.watchLock) == 0 {
+	if forward {
 		e.forwardSibling(ctx, req.GetMessage().GetData().GetValue())
 	}
 
+	if parked {
+		return nil
+	}
+
+	// The channel already holds an earlier parked completion (a superseded
+	// attempt): block outside the critical section until a consumer or
+	// lifecycle event resolves it.
 	select {
 	case e.completeCh <- d:
 		return nil
@@ -132,13 +172,18 @@ func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvo
 // claim hands a parked completion to a co-located waiter whose pending-map
 // registration lost the race with the completion RPC: complete() found no
 // waiter and parked the payload in completeCh, which the pending map never
-// consults. The waiter registers first and claims second, pairing with
-// complete()'s deliver-then-park, so whichever side loses the race, the
-// completion is observed by the other. Non-blocking: no parked completion
-// means the waiter goes back to its pending-map channel, where any later
-// completion is delivered directly.
+// consults. The waiter registers first and claims second; complete()'s
+// map-miss and park form one mu critical section and this whole drain is
+// another, so the two sides cannot interleave: a completer that missed the
+// map has parked before any later claim runs, and a claim that found nothing
+// ran before the completer's map check, which then finds the registered
+// waiter. Non-blocking: no parked completion means the waiter goes back to
+// its pending-map channel, where any later completion is delivered directly.
 func (e *executor) claim(req *internalsv1pb.InternalInvokeRequest) *internalsv1pb.InternalInvokeResponse {
 	claimType := taskTypeOf(req, e.actorID)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
 	select {
 	case d := <-e.completeCh:
@@ -183,8 +228,12 @@ func (e *executor) claim(req *internalsv1pb.InternalInvokeRequest) *internalsv1p
 	// Nothing parked: the waiter rendezvouses through the pending map, which
 	// completions arriving on this daprd reach without touching this actor,
 	// so don't leave an idle entry in the table (a later remote forward
-	// simply re-creates it). A completion parked concurrently with the
-	// deactivation is redelivered by the caller's closed-actor retry.
+	// simply re-creates it). A completion racing this deactivation either
+	// finds the still-registered waiter in the map, or observes the closed
+	// actor (the close and complete's closed-check are both under mu) and is
+	// redelivered by the caller's retry onto a fresh actor. A park can only
+	// slip in before the close after the waiter deregistered, where the
+	// durable reminder retry already owns redelivery.
 	e.tryDeactivate()
 	return &internalsv1pb.InternalInvokeResponse{
 		Status: &internalsv1pb.Status{Code: int32(codes.NotFound)},
@@ -192,16 +241,21 @@ func (e *executor) claim(req *internalsv1pb.InternalInvokeRequest) *internalsv1p
 }
 
 func (e *executor) cancel(req *internalsv1pb.InternalInvokeRequest) error {
+	e.mu.Lock()
 	if e.pending != nil && e.pending.Cancel(PendingKey(taskTypeOf(req, e.actorID), e.actorID)) {
+		e.mu.Unlock()
 		e.tryDeactivate()
 		return nil
 	}
 
 	// Cancels are at-least-once (stream disconnect cleanup and executor
-	// shutdown can both cancel the same task); only the first closes.
+	// shutdown can both cancel the same task); only the first closes. The
+	// miss and the close are one mu critical section, mirroring complete's
+	// miss-then-park, so a claim can never run between them.
 	if e.cancelClosed.CompareAndSwap(false, true) {
 		close(e.cancelCh)
 	}
+	e.mu.Unlock()
 	return nil
 }
 
@@ -229,8 +283,13 @@ func (e *executor) Deactivate(_ context.Context) error {
 		return nil
 	}
 
+	// Close under mu so complete's closed-check-then-park cannot straddle
+	// the close and strand a payload in a deactivated actor. wg.Wait stays
+	// outside: in-flight invocations hold wg and may be waiting on mu.
+	e.mu.Lock()
 	close(e.closeCh)
 	e.table.Delete(e.actorID)
+	e.mu.Unlock()
 	e.wg.Wait()
 	return nil
 }

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -35,6 +35,7 @@ var log = logger.NewLogger("dapr.runtime.actors.targets.executor")
 const (
 	MethodComplete      = "Complete"
 	MethodCancel        = "Cancel"
+	MethodClaim         = "Claim"
 	MethodWatchComplete = "WatchComplete"
 )
 
@@ -63,6 +64,8 @@ func (e *executor) InvokeMethod(ctx context.Context, req *internalsv1pb.Internal
 		return nil, e.complete(ctx, req)
 	case MethodCancel:
 		return nil, e.cancel(req)
+	case MethodClaim:
+		return e.claim(req), nil
 	default:
 		return nil, errors.New("unknown method: " + req.GetMessage().GetMethod())
 	}
@@ -123,6 +126,59 @@ func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvo
 		return targeterrors.NewClosed("executor")
 	case <-ctx.Done():
 		return errors.New("context cancelled before completion result was sent")
+	}
+}
+
+// claim hands a parked completion to a co-located waiter whose pending-map
+// registration lost the race with the completion RPC: complete() found no
+// waiter and parked the payload in completeCh, which the pending map never
+// consults. The waiter registers first and claims second, pairing with
+// complete()'s deliver-then-park, so whichever side loses the race, the
+// completion is observed by the other. Non-blocking: no parked completion
+// means the waiter goes back to its pending-map channel, where any later
+// completion is delivered directly.
+func (e *executor) claim(req *internalsv1pb.InternalInvokeRequest) *internalsv1pb.InternalInvokeResponse {
+	claimType := taskTypeOf(req, e.actorID)
+
+	select {
+	case d := <-e.completeCh:
+		// A parked completion of the colliding other task type (a workflow
+		// instance ID equal to an activity actor ID) belongs to a different
+		// waiter: put it back for its own watcher or claimer.
+		if v, ok := d.GetHeaders()[MetadataTaskType]; ok && len(v.GetValues()) > 0 && v.GetValues()[0] != claimType {
+			select {
+			case e.completeCh <- d:
+			default:
+			}
+			break
+		}
+
+		// A stale watch stream from a superseded attempt may still be parked
+		// on this actor; feed it a copy so it terminates promptly. Duplicate
+		// deliveries are discarded by the workflow-side dedup guards.
+		if len(e.watchLock) > 0 {
+			select {
+			case e.completeCh <- d:
+			default:
+			}
+		} else {
+			e.tryDeactivate()
+		}
+		return d
+	default:
+	}
+
+	select {
+	case <-e.cancelCh:
+		e.tryDeactivate()
+		return &internalsv1pb.InternalInvokeResponse{
+			Status: &internalsv1pb.Status{Code: int32(codes.Aborted)},
+		}
+	default:
+	}
+
+	return &internalsv1pb.InternalInvokeResponse{
+		Status: &internalsv1pb.Status{Code: int32(codes.NotFound)},
 	}
 }
 

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -360,12 +360,14 @@ func (e *executor) InvokeStream(ctx context.Context,
 func (e *executor) watchComplete(ctx context.Context, req *internalsv1pb.InternalInvokeRequest, stream func(*internalsv1pb.InternalInvokeResponse) (bool, error)) error {
 	defer func() {
 		// A displaced completion still needs the actor alive for its own
-		// waiter; skip deactivation until it is consumed.
+		// waiter; skip deactivation until it is consumed. Non-blocking: a
+		// blocking send can deadlock when the queue is full and its consumer
+		// is waiting on this actor's wait group, which this stream holds.
 		e.mu.Lock()
 		displaced := e.displaced != nil
 		e.mu.Unlock()
 		if !displaced {
-			e.deactivateCh <- e
+			e.tryDeactivate()
 		}
 	}()
 

--- a/pkg/actors/targets/workflow/executor/executor_test.go
+++ b/pkg/actors/targets/workflow/executor/executor_test.go
@@ -193,6 +193,76 @@ func Test_claim(t *testing.T) {
 		assert.Equal(t, []byte("payload"), res.GetMessage().GetData().GetValue())
 	})
 
+	t.Run("displaced completion is claimed before the channel", func(t *testing.T) {
+		t.Parallel()
+		e, _ := newClaimTestExecutor(t)
+
+		_, err := e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("first")))
+		require.NoError(t, err)
+
+		// The wrong-type claim moves "first" to the displaced slot, freeing
+		// the channel for "second".
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeActivity))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.NotFound), res.GetStatus().GetCode())
+
+		_, err = e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("second")))
+		require.NoError(t, err)
+
+		for _, want := range [][]byte{[]byte("first"), []byte("second")} {
+			res, err = e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+			require.NoError(t, err)
+			assert.Equal(t, int32(codes.OK), res.GetStatus().GetCode())
+			assert.Equal(t, want, res.GetMessage().GetData().GetValue())
+		}
+	})
+
+	t.Run("no completion is lost to a concurrent blocked completer", func(t *testing.T) {
+		t.Parallel()
+		e, f := newClaimTestExecutor(t)
+
+		// Fill the channel slot with a workflow-type completion, then block an
+		// activity-type completer on the full channel: the moment a claim
+		// drains the slot this sender refills it, which is exactly the window
+		// where a channel put-back would drop the drained payload. The two
+		// payloads are of different task types, so neither may ever be lost.
+		_, err := e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("wf")))
+		require.NoError(t, err)
+		blockedDone := make(chan error, 1)
+		go func() {
+			_, berr := e.InvokeMethod(t.Context(), completeReq(TaskTypeActivity, []byte("act")))
+			blockedDone <- berr
+		}()
+
+		// The activity claim displaces "wf"; depending on whether the blocked
+		// sender has refilled the slot yet it returns "act" or not-found.
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeActivity))
+		require.NoError(t, err)
+		gotAct := res.GetStatus().GetCode() == int32(codes.OK)
+		if gotAct {
+			assert.Equal(t, []byte("act"), res.GetMessage().GetData().GetValue())
+		}
+		assert.Empty(t, f.deactivateCh, "a displaced completion must keep the actor alive")
+
+		res, err = e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.OK), res.GetStatus().GetCode())
+		assert.Equal(t, []byte("wf"), res.GetMessage().GetData().GetValue())
+
+		if !gotAct {
+			assert.EventuallyWithT(t, func(col *assert.CollectT) {
+				cres, cerr := e.InvokeMethod(t.Context(), claimReq(TaskTypeActivity))
+				if !assert.NoError(col, cerr) {
+					return
+				}
+				if assert.Equal(col, int32(codes.OK), cres.GetStatus().GetCode()) {
+					assert.Equal(col, []byte("act"), cres.GetMessage().GetData().GetValue())
+				}
+			}, time.Second*5, time.Millisecond)
+		}
+		require.NoError(t, <-blockedDone)
+	})
+
 	t.Run("delivers to registered waiter instead of parking", func(t *testing.T) {
 		t.Parallel()
 		e, f := newClaimTestExecutor(t)

--- a/pkg/actors/targets/workflow/executor/executor_test.go
+++ b/pkg/actors/targets/workflow/executor/executor_test.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +62,57 @@ func cancelReq(taskType string) *internalsv1pb.InternalInvokeRequest {
 		WithActor("dapr.internal.default.test.executor", "abc").
 		WithContentType(invokev1.ProtobufContentType).
 		WithMetadata(map[string][]string{MetadataTaskType: {taskType}})
+}
+
+// Test_claimCompleteRace hammers the interleaving where a waiter's whole
+// Register+Claim lands between a completer's pending-map miss and its channel
+// park: without the executor's rendezvous mutex the claim can observe an
+// empty channel, the park lands afterwards with no reader, and the waiter
+// hangs. The window is a few instructions wide, so this cannot reliably
+// reproduce the unsynchronized bug; the guarantee is the mu critical
+// sections in complete/claim. This keeps regression pressure on the
+// invariant: every iteration must resolve the waiter via either the claim or
+// the pending map, whichever side wins the race.
+func Test_claimCompleteRace(t *testing.T) {
+	t.Parallel()
+
+	for range 10_000 {
+		f := &factory{
+			actorType:    "dapr.internal.default.test.executor",
+			deactivateCh: make(chan *executor, 10),
+			pending:      pending.New(),
+		}
+		e, ok := f.GetOrCreate("abc").(*executor)
+		require.True(t, ok)
+
+		completerDone := make(chan error, 1)
+		go func() {
+			_, err := e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("payload")))
+			completerDone <- err
+		}()
+
+		waitCh, deregister := f.pending.Register(PendingKey(TaskTypeWorkflow, "abc"))
+
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+
+		switch res.GetStatus().GetCode() {
+		case int32(codes.OK):
+			assert.Equal(t, []byte("payload"), res.GetMessage().GetData().GetValue())
+		case int32(codes.NotFound):
+			select {
+			case pres := <-waitCh:
+				assert.Equal(t, []byte("payload"), pres.Data)
+			case <-time.After(time.Second * 5):
+				t.Fatal("completion neither claimed nor delivered to the pending map waiter")
+			}
+		default:
+			t.Fatalf("unexpected claim status %d", res.GetStatus().GetCode())
+		}
+
+		deregister()
+		require.NoError(t, <-completerDone)
+	}
 }
 
 func Test_claim(t *testing.T) {

--- a/pkg/actors/targets/workflow/executor/executor_test.go
+++ b/pkg/actors/targets/workflow/executor/executor_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/executor/pending"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+)
+
+// newClaimTestExecutor builds an executor without the factory goroutines so
+// deactivation requests can be asserted on the buffered channel directly. The
+// workflow-shaped actor ID has no sibling rendezvous form, keeping complete()
+// off the forwarding path, which needs a live actor router.
+func newClaimTestExecutor(t *testing.T) (*executor, *factory) {
+	t.Helper()
+	f := &factory{
+		actorType:    "dapr.internal.default.test.executor",
+		deactivateCh: make(chan *executor, 10),
+		pending:      pending.New(),
+	}
+	e, ok := f.GetOrCreate("abc").(*executor)
+	require.True(t, ok)
+	return e, f
+}
+
+func claimReq(taskType string) *internalsv1pb.InternalInvokeRequest {
+	return internalsv1pb.NewInternalInvokeRequest(MethodClaim).
+		WithActor("dapr.internal.default.test.executor", "abc").
+		WithContentType(invokev1.ProtobufContentType).
+		WithMetadata(map[string][]string{MetadataTaskType: {taskType}})
+}
+
+func completeReq(taskType string, data []byte) *internalsv1pb.InternalInvokeRequest {
+	return internalsv1pb.NewInternalInvokeRequest(MethodComplete).
+		WithActor("dapr.internal.default.test.executor", "abc").
+		WithData(data).
+		WithContentType(invokev1.ProtobufContentType).
+		WithMetadata(map[string][]string{MetadataTaskType: {taskType}})
+}
+
+func cancelReq(taskType string) *internalsv1pb.InternalInvokeRequest {
+	return internalsv1pb.NewInternalInvokeRequest(MethodCancel).
+		WithActor("dapr.internal.default.test.executor", "abc").
+		WithContentType(invokev1.ProtobufContentType).
+		WithMetadata(map[string][]string{MetadataTaskType: {taskType}})
+}
+
+func Test_claim(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not found when nothing parked, actor deactivates", func(t *testing.T) {
+		t.Parallel()
+		e, f := newClaimTestExecutor(t)
+
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.NotFound), res.GetStatus().GetCode())
+		assert.Len(t, f.deactivateCh, 1)
+	})
+
+	t.Run("returns completion parked before registration", func(t *testing.T) {
+		t.Parallel()
+		e, f := newClaimTestExecutor(t)
+
+		_, err := e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("payload")))
+		require.NoError(t, err)
+
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.OK), res.GetStatus().GetCode())
+		assert.Equal(t, []byte("payload"), res.GetMessage().GetData().GetValue())
+		assert.Equal(t, TaskTypeWorkflow, res.GetHeaders()[MetadataTaskType].GetValues()[0])
+		assert.Len(t, f.deactivateCh, 1)
+
+		res, err = e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.NotFound), res.GetStatus().GetCode())
+	})
+
+	t.Run("aborted when cancellation parked before registration", func(t *testing.T) {
+		t.Parallel()
+		e, f := newClaimTestExecutor(t)
+
+		_, err := e.InvokeMethod(t.Context(), cancelReq(TaskTypeActivity))
+		require.NoError(t, err)
+
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeActivity))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.Aborted), res.GetStatus().GetCode())
+		assert.Len(t, f.deactivateCh, 1)
+	})
+
+	t.Run("parked completion takes precedence over cancellation", func(t *testing.T) {
+		t.Parallel()
+		e, _ := newClaimTestExecutor(t)
+
+		_, err := e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("payload")))
+		require.NoError(t, err)
+		_, err = e.InvokeMethod(t.Context(), cancelReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.OK), res.GetStatus().GetCode())
+		assert.Equal(t, []byte("payload"), res.GetMessage().GetData().GetValue())
+	})
+
+	t.Run("other task type's completion is put back, not claimed", func(t *testing.T) {
+		t.Parallel()
+		e, f := newClaimTestExecutor(t)
+
+		_, err := e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("payload")))
+		require.NoError(t, err)
+
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeActivity))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.NotFound), res.GetStatus().GetCode())
+		assert.Empty(t, f.deactivateCh, "put-back must keep the actor alive for its own waiter")
+
+		res, err = e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.OK), res.GetStatus().GetCode())
+		assert.Equal(t, []byte("payload"), res.GetMessage().GetData().GetValue())
+	})
+
+	t.Run("delivers to registered waiter instead of parking", func(t *testing.T) {
+		t.Parallel()
+		e, f := newClaimTestExecutor(t)
+
+		waitCh, deregister := f.pending.Register(PendingKey(TaskTypeWorkflow, "abc"))
+		defer deregister()
+
+		_, err := e.InvokeMethod(t.Context(), completeReq(TaskTypeWorkflow, []byte("payload")))
+		require.NoError(t, err)
+
+		select {
+		case res := <-waitCh:
+			assert.Equal(t, []byte("payload"), res.Data)
+		default:
+			t.Fatal("completion was not delivered to the registered waiter")
+		}
+
+		// A successful delivery also parks a copy for stale watch streams;
+		// a subsequent claim drains that copy (duplicates are discarded by
+		// the workflow-side dedup guards).
+		res, err := e.InvokeMethod(t.Context(), claimReq(TaskTypeWorkflow))
+		require.NoError(t, err)
+		assert.Equal(t, int32(codes.OK), res.GetStatus().GetCode())
+		assert.Equal(t, []byte("payload"), res.GetMessage().GetData().GetValue())
+	})
+}

--- a/pkg/runtime/wfengine/backends/actors/clustertasks.go
+++ b/pkg/runtime/wfengine/backends/actors/clustertasks.go
@@ -293,8 +293,13 @@ func (be *ClusterTasksBackend) claimParked(ctx context.Context, taskType, key st
 		return true, proto.Unmarshal(res.GetMessage().GetData().GetValue(), resp)
 	case int32(codes.Aborted):
 		return true, api.ErrTaskCancelled
-	default:
+	case int32(codes.NotFound):
 		return false, nil
+	default:
+		// An unexpected status must settle the wait rather than leave the
+		// waiter parked on the pending map: the work item is abandoned and
+		// the durable retry converges.
+		return false, fmt.Errorf("unexpected claim status %d for task %q", res.GetStatus().GetCode(), key)
 	}
 }
 
@@ -331,10 +336,14 @@ func (be *ClusterTasksBackend) watchCompletion(ctx context.Context, taskType, ke
 		return err
 	}
 
+	// Advertising the task type lets the executor actor hand a displaced
+	// completion only to a watcher of its own type; the stream-side check
+	// below stays as the guard for untyped deliveries.
 	sreq := internalsv1pb.
 		NewInternalInvokeRequest(executor.MethodWatchComplete).
 		WithActor(be.executorActorType, key).
-		WithContentType(invokev1.ProtobufContentType)
+		WithContentType(invokev1.ProtobufContentType).
+		WithMetadata(map[string][]string{executor.MetadataTaskType: {taskType}})
 
 	return router.CallStream(ctx, sreq, func(res *internalsv1pb.InternalInvokeResponse) (bool, error) {
 		if res == nil {

--- a/pkg/runtime/wfengine/backends/actors/clustertasks.go
+++ b/pkg/runtime/wfengine/backends/actors/clustertasks.go
@@ -220,6 +220,20 @@ func (be *ClusterTasksBackend) waitForCompletion(taskType, key string) func(cont
 		if be.executorLocal(ctx, key) {
 			diag.DefaultWorkflowMonitoring.WorkflowCompletionRoute(ctx, taskType, diag.CompletionRouteWaitLocal)
 
+			// The completion RPC can win the race with the Register above:
+			// finding no waiter, it parks the payload on the co-located
+			// executor actor, which the pending map never consults, and the
+			// select below would block forever (the durable reminder retry
+			// cannot redispatch, because the reminder invocation is this
+			// blocked call chain). Register-then-claim pairs with the
+			// executor actor's deliver-then-park so whichever order the race
+			// resolves in, one side observes the other. A claim error is
+			// returned rather than waited out: the work item is abandoned and
+			// the durable retry converges.
+			if done, err := be.claimParked(ctx, taskType, key, resp); done || err != nil {
+				return err
+			}
+
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -248,6 +262,38 @@ func (be *ClusterTasksBackend) waitForCompletion(taskType, key string) func(cont
 		diag.DefaultWorkflowMonitoring.WorkflowCompletionRoute(ctx, taskType, diag.CompletionRouteWaitWatch)
 
 		return be.watchCompletion(ctx, taskType, key, resp)
+	}
+}
+
+// claimParked drains a completion or cancellation for key that was parked on
+// the co-located executor actor before the waiter registered in the pending
+// map. It reports whether the wait is settled: a claimed completion is
+// unmarshalled into resp, a parked cancellation surfaces as ErrTaskCancelled.
+// Not-found (the steady state) leaves the waiter on its pending-map channel.
+func (be *ClusterTasksBackend) claimParked(ctx context.Context, taskType, key string, resp proto.Message) (bool, error) {
+	router, err := be.actors.Router(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	req := internalsv1pb.
+		NewInternalInvokeRequest(executor.MethodClaim).
+		WithActor(be.executorActorType, key).
+		WithContentType(invokev1.ProtobufContentType).
+		WithMetadata(map[string][]string{executor.MetadataTaskType: {taskType}})
+
+	res, err := router.Call(ctx, req)
+	if err != nil {
+		return false, err
+	}
+
+	switch res.GetStatus().GetCode() {
+	case int32(codes.OK):
+		return true, proto.Unmarshal(res.GetMessage().GetData().GetValue(), resp)
+	case int32(codes.Aborted):
+		return true, api.ErrTaskCancelled
+	default:
+		return false, nil
 	}
 }
 

--- a/pkg/runtime/wfengine/backends/actors/clustertasks.go
+++ b/pkg/runtime/wfengine/backends/actors/clustertasks.go
@@ -201,10 +201,11 @@ func (be *ClusterTasksBackend) WaitForWorkflowTaskCompletion(req *protos.Workflo
 // constructing the waiter and invoking it (context cancellation during
 // dispatch), and an entry registered eagerly would leak and swallow a later
 // completion for the same key. The window this opens (a completion reported
-// before the returned function runs) is bounded by a full application round
-// trip racing the next statement in the caller; if it is ever lost, the
-// completion parks on the co-located executor actor and the durable reminder
-// retry redispatches the work item.
+// before the returned function runs) is real: the work item is dispatched
+// before the returned function runs, so a fast application round trip can
+// report the completion first. Such a completion parks on the co-located
+// executor actor and is drained by the claim call made right after
+// registration on the wait_local path below.
 //
 // The pending map is only consulted by completions arriving on this daprd or
 // forwarded here by the executor actor, so blocking on it is only correct

--- a/pkg/runtime/wfengine/backends/actors/clustertasks.go
+++ b/pkg/runtime/wfengine/backends/actors/clustertasks.go
@@ -299,7 +299,7 @@ func (be *ClusterTasksBackend) claimParked(ctx context.Context, taskType, key st
 		// An unexpected status must settle the wait rather than leave the
 		// waiter parked on the pending map: the work item is abandoned and
 		// the durable retry converges.
-		return false, fmt.Errorf("unexpected claim status %d for task %q", res.GetStatus().GetCode(), key)
+		return true, fmt.Errorf("unexpected claim status %d for task %q", res.GetStatus().GetCode(), key)
 	}
 }
 

--- a/pkg/runtime/wfengine/backends/actors/clustertasks_test.go
+++ b/pkg/runtime/wfengine/backends/actors/clustertasks_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package actors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	actorsapi "github.com/dapr/dapr/pkg/actors/api"
+	actorsfake "github.com/dapr/dapr/pkg/actors/fake"
+	"github.com/dapr/dapr/pkg/actors/router"
+	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
+	"github.com/dapr/dapr/pkg/actors/targets"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/executor"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/executor/pending"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+// newClusterTasksTestBackend wires a ClusterTasksBackend to a real executor
+// actor factory through fakes: the router invokes executor actors in-process
+// and placement always resolves the executor actor locally, mirroring the
+// co-located steady state under WorkflowsClusteredDeployment.
+func newClusterTasksTestBackend(t *testing.T) *ClusterTasksBackend {
+	t.Helper()
+
+	const executorType = "dapr.internal.default.test.executor"
+	p := pending.New()
+
+	var execFactory targets.Factory
+	routerFake := routerfake.New().WithCallFn(func(ctx context.Context, req *internalsv1pb.InternalInvokeRequest) (*internalsv1pb.InternalInvokeResponse, error) {
+		return execFactory.GetOrCreate(req.GetActor().GetActorId()).InvokeMethod(ctx, req)
+	})
+	actorsFake := actorsfake.New().
+		WithRouter(func(context.Context) (router.Interface, error) {
+			return routerFake, nil
+		}).
+		WithPlacementLookupActor(func(context.Context, *actorsapi.LookupActorRequest) (*actorsapi.LookupActorResponse, error) {
+			return &actorsapi.LookupActorResponse{Local: true}, nil
+		})
+
+	var err error
+	execFactory, err = executor.New(t.Context(), executor.Options{
+		Actors:    actorsFake,
+		ActorType: executorType,
+		Pending:   p,
+	})
+	require.NoError(t, err)
+
+	be, err := NewClusterTasksBackend(ClusterTasksBackendOptions{
+		Actors:            actorsFake,
+		ExecutorActorType: executorType,
+		Pending:           p,
+	})
+	require.NoError(t, err)
+	return be
+}
+
+// Test_waitForCompletionClaimsParkedResults is the regression test for the
+// register-then-claim race: the completion RPC can arrive before the waiter
+// registers in the pending map, in which case it parks on the co-located
+// executor actor. The wait must drain it via Claim instead of blocking
+// forever on the pending map.
+func Test_waitForCompletionClaimsParkedResults(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
+	t.Cleanup(cancel)
+
+	t.Run("activity completion before registration", func(t *testing.T) {
+		t.Parallel()
+		be := newClusterTasksTestBackend(t)
+
+		wait := be.WaitForActivityCompletion(&protos.ActivityRequest{
+			WorkflowInstance: &protos.WorkflowInstance{InstanceId: "i1"},
+			TaskId:           0,
+		})
+
+		require.NoError(t, be.CompleteActivityTask(ctx, &protos.ActivityResponse{
+			InstanceId: "i1",
+			TaskId:     0,
+			Result:     wrapperspb.String("ok"),
+		}))
+
+		resp, err := wait(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp.GetResult().GetValue())
+	})
+
+	t.Run("workflow completion before registration", func(t *testing.T) {
+		t.Parallel()
+		be := newClusterTasksTestBackend(t)
+
+		wait := be.WaitForWorkflowTaskCompletion(&protos.WorkflowRequest{
+			InstanceId: "w1",
+		})
+
+		require.NoError(t, be.CompleteWorkflowTask(ctx, &protos.WorkflowResponse{
+			InstanceId: "w1",
+		}))
+
+		resp, err := wait(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "w1", resp.GetInstanceId())
+	})
+
+	t.Run("activity cancellation before registration", func(t *testing.T) {
+		t.Parallel()
+		be := newClusterTasksTestBackend(t)
+
+		wait := be.WaitForActivityCompletion(&protos.ActivityRequest{
+			WorkflowInstance: &protos.WorkflowInstance{InstanceId: "i2"},
+			TaskId:           0,
+		})
+
+		require.NoError(t, be.CancelActivityTask(ctx, "i2", 0))
+
+		_, err := wait(ctx)
+		require.ErrorIs(t, err, api.ErrTaskCancelled)
+	})
+
+	t.Run("completion after registration is delivered via the pending map", func(t *testing.T) {
+		t.Parallel()
+		be := newClusterTasksTestBackend(t)
+
+		wait := be.WaitForActivityCompletion(&protos.ActivityRequest{
+			WorkflowInstance: &protos.WorkflowInstance{InstanceId: "i3"},
+			TaskId:           0,
+		})
+
+		resCh := make(chan *protos.ActivityResponse, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			resp, err := wait(ctx)
+			errCh <- err
+			resCh <- resp
+		}()
+
+		assert.EventuallyWithT(t, func(col *assert.CollectT) {
+			assert.Equal(col, 1, be.pending.Len())
+		}, time.Second*5, time.Millisecond)
+
+		require.NoError(t, be.CompleteActivityTask(ctx, &protos.ActivityResponse{
+			InstanceId: "i3",
+			TaskId:     0,
+			Result:     wrapperspb.String("ok"),
+		}))
+
+		require.NoError(t, <-errCh)
+		assert.Equal(t, "ok", (<-resCh).GetResult().GetValue())
+	})
+}


### PR DESCRIPTION
Under WorkflowsClusteredDeployment, the pending-map waiter registers when the wait function is invoked, which happens after the work item has been dispatched to the worker. A fast worker can report the completion before the waiter registers: the completion finds no pending-map entry, is forwarded to the co-located executor actor, finds no entry there either, and is parked in the actor's channel, which the wait_local path never consults. The waiter then registers and blocks on the pending map forever. The durable reminder retry cannot redispatch the work item because the reminder invocation is the very call chain that is blocked, so the workflow hangs permanently.

Fix with register-then-claim: after registering in the pending map on the wait_local path, the waiter makes one non-blocking Claim call to the co-located executor actor to drain a completion or cancellation parked before registration. Claim pairs with complete()'s deliver-then-park: whichever side loses the race, one side always observes the other. A parked completion of the colliding other task type is put back for its own waiter, and a stale watch stream is fed a copy on claim, mirroring the existing deliver-success behaviour. A claim error is returned rather than waited out so the work item is abandoned and the durable retry converges.


Fixes https://github.com/dapr/dapr/issues/10305