### PR TITLE
Bound injector admission request body size to prevent unbounded reads

### DIFF
--- a/pkg/injector/service/handler.go
+++ b/pkg/injector/service/handler.go
@@ -48,7 +48,7 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
-		log.Error("Empty body")
+		log.Errorf("Failed to read request body: %v", err)
 		http.Error(w, "empty body", http.StatusBadRequest)
 		return
 	}
@@ -107,7 +107,7 @@ func readRequestBody(r *http.Request) ([]byte, error) {
 		if errors.Is(err, streams.ErrStreamTooLarge) {
 			return nil, err
 		}
-		return nil, errors.New("empty body")
+		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}
 	if len(body) == 0 {
 		return nil, errors.New("empty body")

--- a/pkg/injector/service/handler.go
+++ b/pkg/injector/service/handler.go
@@ -29,13 +29,25 @@ import (
 
 	"github.com/dapr/dapr/pkg/injector/annotations"
 	"github.com/dapr/dapr/utils"
+	"github.com/dapr/kit/streams"
 )
+
+// maxAdmissionRequestBodySize is the maximum size, in bytes, of an admission
+// request body the injector will read. AdmissionReview payloads embed the
+// full Pod object, which is normally small, so this is a generous ceiling
+// meant to bound memory use against oversized or malicious requests.
+const maxAdmissionRequestBodySize = 4 << 20 // 4 MiB
 
 func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 	RecordSidecarInjectionRequestsCount()
 
 	body, err := readRequestBody(r)
 	if err != nil {
+		if errors.Is(err, streams.ErrStreamTooLarge) {
+			log.Errorf("Request body exceeds the %d byte limit", maxAdmissionRequestBodySize)
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		log.Error("Empty body")
 		http.Error(w, "empty body", http.StatusBadRequest)
 		return
@@ -81,15 +93,23 @@ func (i *injector) handleRequest(w http.ResponseWriter, r *http.Request) {
 	i.writeAdmissionResponse(w, ar, gvk, patchOps, err)
 }
 
-// readRequestBody reads the full request body and returns it. Returns an error
-// if the body is nil, unreadable, or empty.
+// readRequestBody reads the request body, up to maxAdmissionRequestBodySize,
+// and returns it. Returns an error if the body is nil, unreadable, empty, or
+// exceeds maxAdmissionRequestBodySize (streams.ErrStreamTooLarge).
 func readRequestBody(r *http.Request) ([]byte, error) {
 	if r.Body == nil {
 		return nil, errors.New("empty body")
 	}
-	defer r.Body.Close()
-	body, err := io.ReadAll(r.Body)
-	if err != nil || len(body) == 0 {
+	limited := streams.LimitReadCloser(r.Body, maxAdmissionRequestBodySize)
+	defer limited.Close()
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		if errors.Is(err, streams.ErrStreamTooLarge) {
+			return nil, err
+		}
+		return nil, errors.New("empty body")
+	}
+	if len(body) == 0 {
 		return nil, errors.New("empty body")
 	}
 	return body, nil

--- a/pkg/injector/service/handler_test.go
+++ b/pkg/injector/service/handler_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/dapr/dapr/pkg/client/clientset/versioned/fake"
 	"github.com/dapr/dapr/pkg/healthz"
+	"github.com/dapr/kit/streams"
 )
 
 func TestHandleRequest(t *testing.T) {
@@ -602,4 +603,70 @@ func TestHandleRequestWithGlobPatterns(t *testing.T) {
 			assert.Equal(t, tc.expectPatched, len(ar.Response.Patch) > 0)
 		})
 	}
+}
+
+func TestReadRequestBody(t *testing.T) {
+	t.Run("body within limit is read fully", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), 1024)
+		req := httptest.NewRequest(http.MethodPost, "/mutate", bytes.NewReader(payload))
+
+		body, err := readRequestBody(req)
+		require.NoError(t, err)
+		assert.Equal(t, payload, body)
+	})
+
+	t.Run("empty body returns error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mutate", bytes.NewReader(nil))
+
+		_, err := readRequestBody(req)
+		require.Error(t, err)
+	})
+
+	t.Run("nil body returns error", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mutate", nil)
+		req.Body = nil
+
+		_, err := readRequestBody(req)
+		require.Error(t, err)
+	})
+
+	t.Run("body exceeding the limit is rejected", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), maxAdmissionRequestBodySize+1)
+		req := httptest.NewRequest(http.MethodPost, "/mutate", bytes.NewReader(payload))
+
+		body, err := readRequestBody(req)
+		require.ErrorIs(t, err, streams.ErrStreamTooLarge)
+		assert.Nil(t, body)
+	})
+}
+
+func TestHandleRequestRejectsOversizedBody(t *testing.T) {
+	i, err := NewInjector(Options{
+		Config: Config{
+			SidecarImage:            "test-image",
+			Namespace:               "test-ns",
+			ControlPlaneTrustDomain: "test-trust-domain",
+		},
+		DaprClient: fake.NewSimpleClientset(),
+		KubeClient: kubernetesfake.NewSimpleClientset(),
+		Healthz:    healthz.New(),
+	})
+	require.NoError(t, err)
+
+	injector := i.(*injector)
+	injector.currentTrustAnchors = func(context.Context) ([]byte, error) {
+		return nil, nil
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(injector.handleRequest))
+	t.Cleanup(ts.Close)
+
+	// Exceed the limit by a wide margin (rather than by a single byte) so the
+	// assertion isn't sensitive to how the underlying connection chunks reads.
+	oversized := bytes.Repeat([]byte("a"), maxAdmissionRequestBodySize+1024*1024)
+	resp, err := http.Post(ts.URL, runtime.ContentTypeJSON, bytes.NewReader(oversized))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
 }


### PR DESCRIPTION
Motivation:
The injector's admission webhook handler (pkg/injector/service/handler.go)
read the entire HTTP request body via io.ReadAll(r.Body) with no size
limit. The server sets ReadHeaderTimeout but nothing bounds the size of
the body itself, so a client able to reach this endpoint could send an
arbitrarily large request and force the injector to buffer it all into
memory. This is a resource-exhaustion hardening gap in an admission
webhook handler, not a demonstrated crash or outage.

Approach:
Wrap r.Body with the existing github.com/dapr/kit/streams.LimitReadCloser
helper (already used by pkg/api/http/middlewares.go's MaxBodySizeMiddleware
and pkg/channel/http/http_channel.go for the same purpose) before reading
it, capping reads at a new maxAdmissionRequestBodySize constant (4 MiB,
matching runtime.DefaultMaxRequestBodySize, Dapr's own existing HTTP body
size default). When the limit is exceeded, readRequestBody now returns
streams.ErrStreamTooLarge, and handleRequest responds with 413 Request
Entity Too Large instead of falling through to the generic "empty body"
400 response. AdmissionReview payloads embed a single Pod object, which
is normally well under this ceiling (Kubernetes' own default etcd object
size limit is ~1.5 MiB), so this should not affect legitimate traffic.

Validation:
- go build ./...
- go test ./pkg/injector/... (all packages pass)
- golangci-lint run ./pkg/injector/service/... — 0 new findings; the 8
  pre-existing goconst findings in this package are unchanged from master
- Added TestReadRequestBody, a table test exercising readRequestBody
  directly for within-limit, empty, nil, and over-limit bodies
- Added TestHandleRequestRejectsOversizedBody, an end-to-end test that
  POSTs an oversized body through a real httptest.NewServer connection
  and asserts the handler now responds 413 instead of reading the full
  body

Fixes #10310

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>