### PR TITLE
PubSub: Fix panic in HTTP delivery on non-string trace field

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -8,6 +8,7 @@ This update contains the following bug fixes:
 - [Workflow GetInstance intermittently failing while the workflow is running](#workflow-getinstance-intermittently-failing-while-the-workflow-is-running)
 - [Input bindings not activated when the app is slow to answer the subscription discovery probe](#input-bindings-not-activated-when-the-app-is-slow-to-answer-the-subscription-discovery-probe)
 - [MCPServer left unusable when its endpoint was briefly unavailable at startup](#mcpserver-left-unusable-when-its-endpoint-was-briefly-unavailable-at-startup)
+- [Crash when delivering a pub/sub message with a non-string trace field over HTTP](#crash-when-delivering-a-pubsub-message-with-a-non-string-trace-field-over-http)
 
 ## Scheduler embedded etcd metrics missing from the metrics endpoint
 
@@ -192,3 +193,27 @@ Both left the server listed in metadata and unusable.
 MCPServer registration now runs under Dapr's built-in initialization retry policy, the same one used elsewhere for resource initialization: exponential backoff starting at 500ms, up to 3 retries within a 10 second budget.
 An endpoint that becomes reachable inside that window is registered normally and its tools work as expected.
 A genuinely unreachable endpoint behaves as before once the retries are exhausted, and `ignoreErrors: true` continues to keep daprd running.
+
+## Crash when delivering a pub/sub message with a non-string trace field over HTTP
+
+### Problem
+
+Delivering a pub/sub message to a subscriber over HTTP crashed the daprd process when the message's CloudEvent carried a non-string `traceparent` or `traceid` field, for example a JSON number, boolean, or object instead of a string.
+
+### Impact
+
+Any client permitted to publish to a subscribed topic could crash the sidecar with a single message.
+A publisher controls the CloudEvent trace fields: publishing with content type `application/cloudevents+json` and a body such as `{"specversion":"1.0", ..., "traceid":12345}` preserves the non-string value all the way through to delivery.
+The HTTP delivery path runs in a background goroutine with no panic recovery, so the failure terminated the whole process rather than dropping the single message.
+The gRPC delivery path was not affected.
+In a highly available deployment this manifested as sidecars crash-looping whenever the offending message was redelivered.
+
+### Root Cause
+
+The HTTP pub/sub delivery path (`Deliver` and `DeliverBulk` in `pkg/runtime/subscription/postman/http`) read the trace field from the CloudEvent and performed an unchecked type assertion to `string`.
+The CloudEvent is deserialized from publisher-controlled bytes into a `map[string]any`, so a non-string trace field became a `float64`, `bool`, or map, and the assertion panicked.
+
+### Solution
+
+The HTTP delivery path now uses a checked type assertion, matching the gRPC delivery path: a non-string trace field is ignored (tracing is skipped for that message) instead of crashing the process.
+Messages carrying a malformed trace field are now delivered to the subscriber normally.

--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -85,10 +85,11 @@ func (h *http) Deliver(ctx context.Context, msg *pubsub.SubscribedMessage) error
 		iTraceID = cloudEvent[contribpubsub.TraceIDField]
 	}
 
-	if iTraceID != nil {
-		traceID := iTraceID.(string)
+	if traceID, ok := iTraceID.(string); ok {
 		sc, _ := diag.SpanContextFromW3CString(traceID)
 		ctx, span = diag.StartInternalCallbackSpan(ctx, "pubsub/"+msg.Topic, sc, h.tracingSpec)
+	} else if iTraceID != nil {
+		log.Debugf("skipping tracing for pub/sub event %v: non-string trace id of type %T", cloudEvent[contribpubsub.IDField], iTraceID)
 	}
 
 	start := time.Now()
@@ -243,8 +244,7 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 			iTraceID = cloudEvent[contribpubsub.TraceIDField]
 		}
 
-		if iTraceID != nil {
-			traceID := iTraceID.(string)
+		if traceID, ok := iTraceID.(string); ok {
 			sc, _ := diag.SpanContextFromW3CString(traceID)
 
 			var span trace.Span
@@ -254,6 +254,8 @@ func (h *http) DeliverBulk(ctx context.Context, req *postman.DeliverBulkRequest)
 				spans[n] = span
 				n++
 			}
+		} else if iTraceID != nil {
+			log.Debugf("skipping tracing for pub/sub event %v: non-string trace id of type %T", cloudEvent[contribpubsub.IDField], iTraceID)
 		}
 	}
 

--- a/pkg/runtime/subscription/postman/http/http_test.go
+++ b/pkg/runtime/subscription/postman/http/http_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/channels"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
+	"github.com/dapr/dapr/pkg/runtime/subscription/postman"
+	"github.com/dapr/dapr/pkg/runtime/subscription/todo"
 	"github.com/dapr/kit/logger"
 )
 
@@ -437,4 +439,122 @@ func TestOnNewPublishedMessage(t *testing.T) {
 		assert.Equal(t, expectedClientError.Error(), err.Error())
 		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 	})
+}
+
+// A publisher fully controls the CloudEvent trace fields. When they deserialize
+// to a non-string type (number, bool, object), delivery must not panic; the
+// trace context is simply skipped. See the matching gRPC postman behaviour.
+func TestDeliverNonStringTraceID(t *testing.T) {
+	matchContextInterface := func(v any) bool {
+		_, ok := v.(context.Context)
+		return ok
+	}
+
+	cases := map[string]struct {
+		field string
+		value any
+	}{
+		"float64 traceparent": {contribpubsub.TraceParentField, float64(12345)},
+		"bool traceparent":    {contribpubsub.TraceParentField, true},
+		"object traceparent":  {contribpubsub.TraceParentField, map[string]any{"x": 1}},
+		"float64 traceid":     {contribpubsub.TraceIDField, float64(12345)},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mockAppChannel := new(channelt.MockAppChannel)
+			h := New(Options{
+				Channels: new(channels.Channels).WithAppChannel(mockAppChannel),
+			})
+
+			var buf bytes.Buffer
+			require.NoError(t, json.NewEncoder(&buf).Encode(contribpubsub.AppResponse{Status: contribpubsub.Success}))
+			fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).WithRawData(&buf)
+			defer fakeResp.Close()
+
+			mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(fakeResp, nil)
+
+			msg := &runtimePubsub.SubscribedMessage{
+				CloudEvent: map[string]any{
+					contribpubsub.IDField: "1",
+					tc.field:              tc.value,
+				},
+				Topic: "topic1",
+				Data:  []byte("data"),
+				Path:  "topic1",
+			}
+
+			require.NotPanics(t, func() {
+				require.NoError(t, h.Deliver(t.Context(), msg))
+			})
+			mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
+		})
+	}
+}
+
+func TestDeliverBulkNonStringTraceID(t *testing.T) {
+	matchContextInterface := func(v any) bool {
+		_, ok := v.(context.Context)
+		return ok
+	}
+
+	mockAppChannel := new(channelt.MockAppChannel)
+	h := New(Options{
+		Channels: new(channels.Channels).WithAppChannel(mockAppChannel),
+	})
+
+	const entryID = "entry-1"
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(contribpubsub.AppBulkResponse{
+		AppResponses: []contribpubsub.AppBulkResponseEntry{{EntryId: entryID, Status: contribpubsub.Success}},
+	}))
+	fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).WithRawData(&buf).WithContentType("application/json")
+	defer fakeResp.Close()
+
+	mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), mock.Anything).Return(fakeResp, nil)
+
+	entryIdIndexMap := map[string]int{entryID: 0} //nolint:stylecheck
+	bulkResponses := make([]contribpubsub.BulkSubscribeResponseEntry, 1)
+	bulkSubDiag := todo.NewBulkSubIngressDiagnostics()
+
+	bscData := todo.BulkSubscribeCallData{
+		BulkResponses:   &bulkResponses,
+		BulkSubDiag:     &bulkSubDiag,
+		EntryIdIndexMap: &entryIdIndexMap,
+		PsName:          "testpubsub",
+		Topic:           "topic1",
+	}
+
+	entry := contribpubsub.BulkMessageEntry{EntryId: entryID, Event: []byte("data"), ContentType: "text/plain"}
+	psm := todo.BulkSubscribedMessage{
+		PubSubMessages: []todo.Message{{
+			CloudEvent: map[string]any{
+				contribpubsub.IDField:          "1",
+				contribpubsub.TraceParentField: float64(12345),
+			},
+			RawData: &runtimePubsub.BulkSubscribeMessageItem{EntryId: entryID},
+			Entry:   &entry,
+		}},
+		Topic:  "topic1",
+		Pubsub: "testpubsub",
+		Path:   "topic1",
+		Length: 1,
+	}
+
+	bsrr := todo.BulkSubscribeResiliencyRes{
+		Entries:  make([]contribpubsub.BulkSubscribeResponseEntry, 0),
+		Envelope: map[string]any{},
+	}
+
+	req := &postman.DeliverBulkRequest{
+		BulkSubCallData:      &bscData,
+		BulkSubMsg:           &psm,
+		BulkSubResiliencyRes: &bsrr,
+	}
+
+	require.NotPanics(t, func() {
+		require.NoError(t, h.DeliverBulk(t.Context(), req))
+	})
+	mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 }

--- a/tests/integration/suite/daprd/pubsub/grpc/nonstringtrace.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/nonstringtrace.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(nonstringtrace))
+}
+
+// nonstringtrace verifies that a published CloudEvent whose trace fields
+// (traceid/traceparent) are not strings is delivered over gRPC without crashing
+// daprd. The gRPC postman already guards its trace-field assertion with a
+// checked conversion; this locks that behaviour in, mirroring the HTTP case.
+type nonstringtrace struct {
+	daprd     *daprd.Daprd
+	deliverCh chan struct{}
+}
+
+func (n *nonstringtrace) Setup(t *testing.T) []framework.Option {
+	n.deliverCh = make(chan struct{}, 1)
+
+	app := app.New(t,
+		app.WithOnTopicEventFn(func(ctx context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			select {
+			case n.deliverCh <- struct{}{}:
+			default:
+			}
+			return &rtv1.TopicEventResponse{Status: rtv1.TopicEventResponse_SUCCESS}, nil
+		}),
+		app.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{{
+					PubsubName: "mypub",
+					Topic:      "test-topic",
+					Routes:     &rtv1.TopicRoutes{Default: "/test-topic"},
+				}},
+			}, nil
+		}),
+	)
+
+	n.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(app, n.daprd),
+	}
+}
+
+func (n *nonstringtrace) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+	client := n.daprd.GRPCClient(t, ctx)
+
+	for name, payload := range map[string]string{
+		"numeric traceid":     `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceid":12345}`,
+		"numeric traceparent": `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceparent":12345}`,
+		"object traceparent":  `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceparent":{"x":1}}`,
+		"bool traceid":        `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceid":true}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+				PubsubName:      "mypub",
+				Topic:           "test-topic",
+				Data:            []byte(payload),
+				DataContentType: "application/cloudevents+json",
+			})
+			require.NoError(t, err)
+
+			select {
+			case <-n.deliverCh:
+			case <-time.After(10 * time.Second):
+				assert.Fail(t, "timed out waiting for pubsub delivery; daprd may have crashed")
+			}
+
+			n.daprd.WaitUntilRunning(t, ctx)
+		})
+	}
+}

--- a/tests/integration/suite/daprd/pubsub/http/nonstringtrace.go
+++ b/tests/integration/suite/daprd/pubsub/http/nonstringtrace.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	nethttp "net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(nonstringtrace))
+}
+
+type nonstringtrace struct {
+	daprd     *daprd.Daprd
+	deliverCh chan struct{}
+}
+
+func (n *nonstringtrace) Setup(t *testing.T) []framework.Option {
+	n.deliverCh = make(chan struct{}, 1)
+
+	app := app.New(t,
+		app.WithHandlerFunc("/test-topic", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			select {
+			case n.deliverCh <- struct{}{}:
+			default:
+			}
+			w.WriteHeader(nethttp.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"status": "SUCCESS"})
+		}),
+		app.WithHandlerFunc("/dapr/subscribe", func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"pubsubname": "mypub", "topic": "test-topic", "route": "/test-topic"},
+			})
+		}),
+	)
+
+	n.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithAppProtocol("http"),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypub
+spec:
+  type: pubsub.in-memory
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(app, n.daprd),
+	}
+}
+
+func (n *nonstringtrace) Run(t *testing.T, ctx context.Context) {
+	n.daprd.WaitUntilRunning(t, ctx)
+
+	for name, payload := range map[string]string{
+		"numeric traceid":     `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceid":12345}`,
+		"numeric traceparent": `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceparent":12345}`,
+		"object traceparent":  `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceparent":{"x":1}}`,
+		"bool traceid":        `{"specversion":"1.0","id":"a","source":"b","type":"c","datacontenttype":"text/plain","data":"hello","traceid":true}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			n.daprd.HTTPPost(t, ctx, "v1.0/publish/mypub/test-topic",
+				strings.NewReader(payload), nethttp.StatusNoContent,
+				"Content-Type", "application/cloudevents+json")
+
+			select {
+			case <-n.deliverCh:
+			case <-time.After(10 * time.Second):
+				assert.Fail(t, "timed out waiting for pubsub delivery; daprd may have crashed")
+			}
+
+			n.daprd.WaitUntilRunning(t, ctx)
+		})
+	}
+}


### PR DESCRIPTION
A publisher fully controls the CloudEvent traceparent/traceid fields. The

The HTTP postman delivery path read the traceparent/traceid fields with an unchecked `iTraceID.(string)` assertion. A CloudEvent published as application/cloudevents+json with a non-string trace field (a JSON number, bool, or object) deserializes into the CloudEvent map as float64/bool/map, so the assertion panicked. A single malformed message crashed the daprd process. Any client permitted to publish to a subscribed topic could take down the sidecar.

Use the checked comma-ok form in both Deliver and DeliverBulk. A non-string trace field is now logged and skipped (tracing omitted for that message) and the message is delivered normally.