### PR TITLE
workflows: fresh trace roots on ContinueAsNew

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -9,6 +9,7 @@ This update contains the following bug fixes:
 - [Input bindings not activated when the app is slow to answer the subscription discovery probe](#input-bindings-not-activated-when-the-app-is-slow-to-answer-the-subscription-discovery-probe)
 - [MCPServer left unusable when its endpoint was briefly unavailable at startup](#mcpserver-left-unusable-when-its-endpoint-was-briefly-unavailable-at-startup)
 - [Crash when delivering a pub/sub message with a non-string trace field over HTTP](#crash-when-delivering-a-pubsub-message-with-a-non-string-trace-field-over-http)
+- [Workflow `continue_as_new` iterations sharing a single unbounded trace](#workflow-continue_as_new-iterations-sharing-a-single-unbounded-trace)
 
 ## Scheduler embedded etcd metrics missing from the metrics endpoint
 
@@ -217,3 +218,27 @@ The CloudEvent is deserialized from publisher-controlled bytes into a `map[strin
 
 The HTTP delivery path now uses a checked type assertion, matching the gRPC delivery path: a non-string trace field is ignored (tracing is skipped for that message) instead of crashing the process.
 Messages carrying a malformed trace field are now delivered to the subscriber normally.
+
+## Workflow `continue_as_new` iterations sharing a single unbounded trace
+
+### Problem
+
+When a workflow restarted itself with `continue_as_new`, the new iteration inherited the previous iteration's trace context instead of starting a trace of its own.
+Every iteration of an eternal workflow therefore joined the trace of the very first iteration, sharing one trace ID indefinitely.
+
+### Impact
+
+You were affected if you ran eternal or polling workflows built on `continue_as_new` with distributed tracing enabled (OTLP or Zipkin exporter to any backend, such as Jaeger, Azure Monitor, or Geneva).
+A workflow iterating over hours or days produced a single trace accumulating thousands of spans.
+Workflows running without tracing enabled were unaffected.
+
+### Root Cause
+
+On a `continue_as_new` completion, the durable task engine built the new iteration's execution-started event by copying the previous iteration's parent trace context verbatim.
+Each iteration's orchestration span was therefore parented off the original trace, and the trace grew without bound.
+
+### Solution
+
+When the prior iteration was traced, each `continue_as_new` transition now generates a fresh W3C root trace context (new random trace and span IDs) for the new iteration, so every iteration produces its own bounded, independently queryable trace.
+Activity spans and spans created inside the application continue to join their own iteration's trace as before.
+A workflow that was not being traced stays untraced across the transition.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.18.1
-	github.com/dapr/durabletask-go v0.12.2-0.20260720151349-fd4e0626bbd3
+	github.com/dapr/durabletask-go v0.12.2-0.20260803222509-354104514c67
 	github.com/dapr/kit v0.18.3-0.20260727141402-dd127582d044
 	github.com/diagridio/go-etcd-cron v0.12.7
 	github.com/evanphx/json-patch/v5 v5.9.0

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/dapr/components-contrib v1.18.1 h1:GgPuh60eBkVltg0Q+rsstHyzHvmk7XxUC/
 github.com/dapr/components-contrib v1.18.1/go.mod h1:QRNh9OQcdDN2hzDNzlImLI4pnWfqTIIg1vX9yRsLHV8=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf h1:vRT6BytcXSseSg+VZthVm93niltGVOFbhLeRXbwyWKI=
 github.com/dapr/components-contrib/tests/certification v0.0.0-20260219105038-d0cf89ba8acf/go.mod h1:NawmfMN065wKn8Jk39E1iwwgWe3kti/MfHBy1jQmSZs=
-github.com/dapr/durabletask-go v0.12.2-0.20260720151349-fd4e0626bbd3 h1:Iv6h1te2Ha8ADf7lRke3cAO9USf28QvCsirrtbJ9QwI=
-github.com/dapr/durabletask-go v0.12.2-0.20260720151349-fd4e0626bbd3/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
+github.com/dapr/durabletask-go v0.12.2-0.20260803222509-354104514c67 h1:4/gSFNoWdW49awHAsfVfgfBSuylqSbMyQxP6kI+QCh0=
+github.com/dapr/durabletask-go v0.12.2-0.20260803222509-354104514c67/go.mod h1:+8ABEQn9JvRPRvPr1QNVxdkdLPgJgpJwcpie5ZDt7nk=
 github.com/dapr/kit v0.18.3-0.20260727141402-dd127582d044 h1:++C9fyLCEIZr5k8lnlWJo+Zmyalk7Y1mMVwLZpkfB88=
 github.com/dapr/kit v0.18.3-0.20260727141402-dd127582d044/go.mod h1:2v02LZdXzPmOadxoT6EMEt0bsEYe6h1fn2ndYWmylCg=
 github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=

--- a/pkg/api/universal/workflow_test.go
+++ b/pkg/api/universal/workflow_test.go
@@ -401,7 +401,7 @@ func newGetWorkflowAPI(metadata *backend.WorkflowMetadata, metadataErr error) *U
 		logger:     logger.NewLogger("test"),
 		resiliency: resiliency.New(nil),
 		workflowEngine: fake.New().WithClient(func() backend.TaskHubClient {
-			return fake.NewClient().WithFetchWorkflowMetadata(func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
+			return fake.NewClient().WithFetchWorkflowMetadata(func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error) {
 				return metadata, metadataErr
 			})
 		}),

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -405,7 +405,11 @@ func (abe *Actors) CreateWorkflowInstance(ctx context.Context, e *backend.Histor
 }
 
 // GetWorkflowMetadata implements backend.Backend
-func (abe *Actors) GetWorkflowMetadata(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
+func (abe *Actors) GetWorkflowMetadata(ctx context.Context, id api.InstanceID, router *protos.TaskRouter) (*backend.WorkflowMetadata, error) {
+	if target := router.GetTargetAppID(); target != "" && target != abe.appID {
+		return nil, errors.New("cross-app workflow metadata reads are not supported by the actors backend")
+	}
+
 	wstate, err := abe.loadInternalState(ctx, id)
 	if err != nil {
 		return nil, err
@@ -588,8 +592,12 @@ func (abe *Actors) GetWorkflowRuntimeState(ctx context.Context, owi *backend.Wor
 	return runtimeState, nil
 }
 
-func (abe *Actors) WatchWorkflowRuntimeStatus(ctx context.Context, id api.InstanceID, condition func(*backend.WorkflowMetadata) bool) error {
+func (abe *Actors) WatchWorkflowRuntimeStatus(ctx context.Context, id api.InstanceID, taskRouter *protos.TaskRouter, condition func(*backend.WorkflowMetadata) bool) error {
 	log.Debugf("Actor backend streaming WorkflowRuntimeStatus %s", id)
+
+	if target := taskRouter.GetTargetAppID(); target != "" && target != abe.appID {
+		return errors.New("cross-app workflow status watches are not supported by the actors backend")
+	}
 
 	router, err := abe.actors.Router(ctx)
 	if err != nil {
@@ -629,7 +637,11 @@ func (abe *Actors) WatchWorkflowRuntimeStatus(ctx context.Context, id api.Instan
 // workflow actor recursively handles its own subtree and returns the count.
 // Mirrors the "each app handles its own subtree" model that recursive
 // terminate already uses.
-func (abe *Actors) PurgeWorkflowState(ctx context.Context, id api.InstanceID, router *protos.TaskRouter, force bool) (int, error) {
+//
+// The recursive flag is only ever set together with a foreign router (the
+// driver walks local descendants itself), so the remote delegation path
+// above already covers it and it needs no separate handling here.
+func (abe *Actors) PurgeWorkflowState(ctx context.Context, id api.InstanceID, router *protos.TaskRouter, recursive bool, force bool) (int, error) {
 	start := time.Now()
 
 	count, err := abe.purgeWorkflowState(ctx, id, router, force)

--- a/pkg/runtime/wfengine/fake/client.go
+++ b/pkg/runtime/wfengine/fake/client.go
@@ -24,9 +24,9 @@ import (
 
 type FakeClient struct {
 	scheduleNewWorkflowFn       func(ctx context.Context, workflow any, opts ...api.NewWorkflowOptions) (api.InstanceID, error)
-	fetchWorkflowMetadataFn     func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error)
-	waitForWorkflowStartFn      func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error)
-	waitForWorkflowCompletionFn func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error)
+	fetchWorkflowMetadataFn     func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error)
+	waitForWorkflowStartFn      func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error)
+	waitForWorkflowCompletionFn func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error)
 	terminateWorkflowFn         func(ctx context.Context, id api.InstanceID, opts ...api.TerminateOptions) error
 	raiseEventFn                func(ctx context.Context, id api.InstanceID, eventName string, opts ...api.RaiseEventOptions) error
 	suspendWorkflowFn           func(ctx context.Context, id api.InstanceID, reason string) error
@@ -40,13 +40,13 @@ func NewClient() *FakeClient {
 		scheduleNewWorkflowFn: func(ctx context.Context, workflow any, opts ...api.NewWorkflowOptions) (api.InstanceID, error) {
 			return api.EmptyInstanceID, nil
 		},
-		fetchWorkflowMetadataFn: func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
+		fetchWorkflowMetadataFn: func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error) {
 			return &backend.WorkflowMetadata{InstanceId: string(id)}, nil
 		},
-		waitForWorkflowStartFn: func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
+		waitForWorkflowStartFn: func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error) {
 			return &backend.WorkflowMetadata{InstanceId: string(id)}, nil
 		},
-		waitForWorkflowCompletionFn: func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
+		waitForWorkflowCompletionFn: func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error) {
 			return &backend.WorkflowMetadata{InstanceId: string(id)}, nil
 		},
 		terminateWorkflowFn: func(ctx context.Context, id api.InstanceID, opts ...api.TerminateOptions) error { return nil },
@@ -67,17 +67,17 @@ func (f *FakeClient) WithScheduleNewWorkflow(fn func(ctx context.Context, workfl
 	return f
 }
 
-func (f *FakeClient) WithFetchWorkflowMetadata(fn func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error)) *FakeClient {
+func (f *FakeClient) WithFetchWorkflowMetadata(fn func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error)) *FakeClient {
 	f.fetchWorkflowMetadataFn = fn
 	return f
 }
 
-func (f *FakeClient) WithWaitForWorkflowStart(fn func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error)) *FakeClient {
+func (f *FakeClient) WithWaitForWorkflowStart(fn func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error)) *FakeClient {
 	f.waitForWorkflowStartFn = fn
 	return f
 }
 
-func (f *FakeClient) WithWaitForWorkflowCompletion(fn func(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error)) *FakeClient {
+func (f *FakeClient) WithWaitForWorkflowCompletion(fn func(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error)) *FakeClient {
 	f.waitForWorkflowCompletionFn = fn
 	return f
 }
@@ -116,16 +116,16 @@ func (f *FakeClient) ScheduleNewWorkflow(ctx context.Context, workflow any, opts
 	return f.scheduleNewWorkflowFn(ctx, workflow, opts...)
 }
 
-func (f *FakeClient) FetchWorkflowMetadata(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
-	return f.fetchWorkflowMetadataFn(ctx, id)
+func (f *FakeClient) FetchWorkflowMetadata(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error) {
+	return f.fetchWorkflowMetadataFn(ctx, id, opts...)
 }
 
-func (f *FakeClient) WaitForWorkflowStart(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
-	return f.waitForWorkflowStartFn(ctx, id)
+func (f *FakeClient) WaitForWorkflowStart(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error) {
+	return f.waitForWorkflowStartFn(ctx, id, opts...)
 }
 
-func (f *FakeClient) WaitForWorkflowCompletion(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
-	return f.waitForWorkflowCompletionFn(ctx, id)
+func (f *FakeClient) WaitForWorkflowCompletion(ctx context.Context, id api.InstanceID, opts ...api.FetchWorkflowMetadataOptions) (*backend.WorkflowMetadata, error) {
+	return f.waitForWorkflowCompletionFn(ctx, id, opts...)
 }
 
 func (f *FakeClient) TerminateWorkflow(ctx context.Context, id api.InstanceID, opts ...api.TerminateOptions) error {
@@ -136,11 +136,11 @@ func (f *FakeClient) RaiseEvent(ctx context.Context, id api.InstanceID, eventNam
 	return f.raiseEventFn(ctx, id, eventName, opts...)
 }
 
-func (f *FakeClient) SuspendWorkflow(ctx context.Context, id api.InstanceID, reason string) error {
+func (f *FakeClient) SuspendWorkflow(ctx context.Context, id api.InstanceID, reason string, opts ...api.SuspendOptions) error {
 	return f.suspendWorkflowFn(ctx, id, reason)
 }
 
-func (f *FakeClient) ResumeWorkflow(ctx context.Context, id api.InstanceID, reason string) error {
+func (f *FakeClient) ResumeWorkflow(ctx context.Context, id api.InstanceID, reason string, opts ...api.ResumeOptions) error {
 	return f.resumeWorkflowFn(ctx, id, reason)
 }
 

--- a/tests/integration/suite/daprd/workflow/tracing/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/tracing/continueasnew.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/otel"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(continueasnew))
+}
+
+type continueasnew struct {
+	wf        *workflow.Workflow
+	collector *otel.Collector
+}
+
+func (c *continueasnew) Setup(t *testing.T) []framework.Option {
+	c.collector = otel.New(t)
+
+	c.wf = workflow.New(t,
+		workflow.WithDaprdOptions(0,
+			c.collector.GRPCDaprdConfiguration(t),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.collector, c.wf),
+	}
+}
+
+func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
+	c.wf.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	reg.AddWorkflowN("can", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		var input string
+		require.NoError(t, ctx.GetInput(&input))
+		require.NoError(t, ctx.CallActivity("bar").Await(nil))
+		if input == "first" {
+			ctx.ContinueAsNew("second")
+		}
+		return nil, nil
+	})
+	reg.AddActivityN("bar", func(ctx dworkflow.ActivityContext) (any, error) {
+		return nil, nil
+	})
+
+	client := dworkflow.NewClient(c.wf.Dapr().GRPCConn(t, ctx))
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "can",
+		dworkflow.WithInstanceID("canid"),
+		dworkflow.WithInput("first"),
+	)
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		var orchestrations []*v1.Span
+		activities := make(map[string]int)
+		var startTraceID string
+		for _, span := range c.collector.GetSpans() {
+			for _, scopeSpan := range span.GetScopeSpans() {
+				for _, span := range scopeSpan.GetSpans() {
+					switch span.GetName() {
+					case "orchestration||can":
+						orchestrations = append(orchestrations, span)
+					case "activity||bar":
+						activities[hex.EncodeToString(span.GetTraceId())]++
+					case "create_orchestration||can":
+						startTraceID = hex.EncodeToString(span.GetTraceId())
+					}
+				}
+			}
+		}
+
+		if !assert.Len(col, orchestrations, 2, "expected an orchestration span per generation") {
+			return
+		}
+
+		gen1 := hex.EncodeToString(orchestrations[0].GetTraceId())
+		gen2 := hex.EncodeToString(orchestrations[1].GetTraceId())
+		assert.NotEqual(col, gen1, gen2,
+			"each ContinueAsNew generation must be rooted in its own trace")
+
+		gens := map[string]bool{gen1: true, gen2: true}
+		assert.True(col, gens[startTraceID],
+			"one generation must belong to the scheduling client's trace")
+
+		assert.Equal(col, 1, activities[gen1], "first generation's activity must share its trace")
+		assert.Equal(col, 1, activities[gen2], "second generation's activity must share its trace")
+	}, time.Second*10, time.Millisecond*10)
+}


### PR DESCRIPTION
Rach generation of a ContinueAsNew workflow previously copied the prior generation's ParentTraceContext, so every iteration of an eternal workflow re-parented onto the first generation's trace and produced a single unbounded trace. Each traced generation now starts from a fresh W3C root trace context; untraced workflows stay untraced.

Fixes #10064