### PR TITLE
workflow: fix stalled workflows left unrecoverable

### DIFF
--- a/docs/release_notes/v1.17.13.md
+++ b/docs/release_notes/v1.17.13.md
@@ -1,0 +1,33 @@
+# Dapr 1.17.13
+
+This update contains the following bug fixes:
+- [Stalled workflows permanently stuck after the last workflow worker disconnects](#stalled-workflows-permanently-stuck-after-the-last-workflow-worker-disconnects)
+
+## Stalled workflows permanently stuck after the last workflow worker disconnects
+
+### Problem
+
+A workflow that entered the `STALLED` state (version not available, patch mismatch, or payload size exceeded) could become permanently stuck if the last connected workflow worker disconnected while the workflow was stalled.
+Reconnecting workers, including workers registering the exact workflow version the stall was waiting for, did not resume it: status queries kept reporting `STALLED` and the only recovery was restarting daprd.
+When it occurred, the sidecar logged:
+
+```
+error while disconnecting work item stream: failed to deactivate workflow '<id>': actor is stalled
+```
+
+### Impact
+
+Stalling exists precisely so that a workflow survives its workers going away and resumes once capable workers return, most commonly a rolling upgrade where the old application version disconnects and the new version reconnects.
+You were affected if you use workflow versioning, patching, or a configured `--max-body-size`, and all workflow workers of an application disconnected while a workflow was stalled; for example during application restarts, rolling upgrades, scale-to-zero, or behind a load balancer with `WorkflowsClusteredDeployment` enabled.
+
+### Root Cause
+
+A stalled workflow actor parks its execution in-process, holding the execution reminder in flight until its context is cancelled, and marks its lock as stalled.
+When the last workflow worker disconnects, daprd unregisters the workflow actor types and deactivates all workflow actors, but deactivation begins by acquiring the actor's lock, and the lock rejects acquisition while the actor is stalled.
+Whether the workflow could later recover came down to a race: if the scheduler's reminder stream teardown cancelled the parked execution before deactivation reached the actor, deactivation succeeded and the unacknowledged reminder was redelivered when workers reconnected; if deactivation won the race, it failed with `actor is stalled`, leaving the actor activated and holding the reminder in flight, so reconnecting workers had nothing to redeliver and the workflow never re-executed.
+
+### Solution
+
+Deactivating a stalled workflow actor now wakes the parked execution instead of failing: the held execution returns immediately, leaving the execution reminder unacknowledged, and deactivation completes.
+When workflow workers reconnect, the reminder is redelivered and the workflow re-executes, resuming and completing once the connected workers satisfy the stall condition (for example the required workflow version is registered, or daprd was restarted with a larger `--max-body-size`).
+Recovery from a stall no longer depends on timing, and a daprd restart is no longer required.

--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -11,6 +11,7 @@ This update contains the following bug fixes:
 - [MCPServer left unusable when its endpoint was briefly unavailable at startup](#mcpserver-left-unusable-when-its-endpoint-was-briefly-unavailable-at-startup)
 - [Crash when delivering a pub/sub message with a non-string trace field over HTTP](#crash-when-delivering-a-pubsub-message-with-a-non-string-trace-field-over-http)
 - [Workflow `continue_as_new` iterations sharing a single unbounded trace](#workflow-continue_as_new-iterations-sharing-a-single-unbounded-trace)
+- [Stalled workflows permanently stuck after the last workflow worker disconnects](#stalled-workflows-permanently-stuck-after-the-last-workflow-worker-disconnects)
 
 ## Actor state store components cannot be hot reloaded
 
@@ -272,3 +273,33 @@ Each iteration's orchestration span was therefore parented off the original trac
 When the prior iteration was traced, each `continue_as_new` transition now generates a fresh W3C root trace context (new random trace and span IDs) for the new iteration, so every iteration produces its own bounded, independently queryable trace.
 Activity spans and spans created inside the application continue to join their own iteration's trace as before.
 A workflow that was not being traced stays untraced across the transition.
+
+## Stalled workflows permanently stuck after the last workflow worker disconnects
+
+### Problem
+
+A workflow that entered the `STALLED` state (version not available, patch mismatch, or payload size exceeded) could become permanently stuck if the last connected workflow worker disconnected while the workflow was stalled.
+Reconnecting workers, including workers registering the exact workflow version the stall was waiting for, did not resume it: status queries kept reporting `STALLED` and the only recovery was restarting daprd.
+When it occurred, the sidecar logged:
+
+```
+error while disconnecting work item stream: failed to deactivate workflow '<id>': actor is stalled
+```
+
+### Impact
+
+Stalling exists so that a workflow survives its workers going away and resumes once capable workers return, most commonly a rolling upgrade where the old application version disconnects and the new version reconnects.
+You were affected if you use workflow versioning, patching, or a configured `--max-body-size`, and all workflow workers of an application disconnected while a workflow was stalled; for example during application restarts, rolling upgrades, scale-to-zero.
+
+### Root Cause
+
+A stalled workflow actor parks its execution in-process, holding the execution reminder in flight until its context is cancelled, and marks its lock as stalled.
+When the last workflow worker disconnects, daprd unregisters the workflow actor types and deactivates all workflow actors, but deactivation begins by acquiring the actor's lock, and the lock rejects acquisition while the actor is stalled.
+Whether the workflow could later recover came down to a race: if the scheduler's reminder stream teardown cancelled the parked execution before deactivation reached the actor, deactivation succeeded and the unacknowledged reminder was redelivered when workers reconnected.
+If deactivation won the race, it failed with `actor is stalled`, leaving the actor activated and holding the reminder in flight, so reconnecting workers had nothing to redeliver and the workflow never re-executed.
+
+### Solution
+
+Deactivating a stalled workflow actor now wakes the parked execution instead of failing: the held execution returns immediately, leaving the execution reminder unacknowledged, and deactivation completes.
+When workflow workers reconnect, the reminder is redelivered and the workflow re-executes, resuming and completing once the connected workers satisfy the stall condition (for example the required workflow version is registered, or daprd was restarted with a larger `--max-body-size`).
+Recovery from a stall no longer depends on timing, and a daprd restart is no longer required.

--- a/pkg/actors/targets/workflow/common/lock/stallable.go
+++ b/pkg/actors/targets/workflow/common/lock/stallable.go
@@ -15,30 +15,35 @@ package lock
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 
 	"github.com/dapr/dapr/pkg/actors/targets/errors"
 )
 
 type Stallable struct {
 	*Lock
-	stalledCh atomic.Pointer[chan struct{}]
+	mu        sync.Mutex
+	stalledCh chan struct{}
+	releaseCh chan struct{}
 }
 
 func NewStallable() *Stallable {
 	return &Stallable{
 		Lock:      New(),
-		stalledCh: atomic.Pointer[chan struct{}]{},
+		stalledCh: make(chan struct{}),
 	}
 }
 
 func (l *Stallable) ContextLock(ctx context.Context) (context.CancelFunc, error) {
-	stalledCh := l.stalledCh.Load()
+	l.mu.Lock()
+	stalledCh := l.stalledCh
+	l.mu.Unlock()
+
 	select {
 	case l.ch <- struct{}{}:
 	case <-l.closeCh:
 		return nil, errors.NewClosed("lock")
-	case <-*stalledCh:
+	case <-stalledCh:
 		return nil, errors.NewStalled()
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -49,19 +54,52 @@ func (l *Stallable) ContextLock(ctx context.Context) (context.CancelFunc, error)
 
 func (l *Stallable) Init() {
 	l.Lock.Init()
-	l.resetStalledChannel()
+	l.mu.Lock()
+	l.stalledCh = make(chan struct{})
+	l.releaseCh = nil
+	l.mu.Unlock()
 }
 
-func (l *Stallable) Stall() context.CancelFunc {
-	stalledCh := l.stalledCh.Load()
+// Stall marks the lock as stalled and returns a channel which is closed by
+// ReleaseStall to wake the stall holder, plus a cancel func which resets the
+// stalled state.
+func (l *Stallable) Stall() (<-chan struct{}, context.CancelFunc) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	select {
-	case <-*stalledCh:
+	case <-l.stalledCh:
 	default:
-		close(*stalledCh)
+		close(l.stalledCh)
 	}
-	return l.resetStalledChannel
+
+	release := make(chan struct{})
+	l.releaseCh = release
+
+	return release, func() {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		l.stalledCh = make(chan struct{})
+		if l.releaseCh == release {
+			l.releaseCh = nil
+		}
+	}
 }
 
-func (l *Stallable) resetStalledChannel() {
-	l.stalledCh.Store(new(make(chan struct{})))
+// ReleaseStall resets the stalled state and wakes the stall holder, if any,
+// so the actor holding the stall can be deactivated.
+func (l *Stallable) ReleaseStall() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	select {
+	case <-l.stalledCh:
+		l.stalledCh = make(chan struct{})
+	default:
+	}
+
+	if l.releaseCh != nil {
+		close(l.releaseCh)
+		l.releaseCh = nil
+	}
 }

--- a/pkg/actors/targets/workflow/common/lock/stallable_test.go
+++ b/pkg/actors/targets/workflow/common/lock/stallable_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/actors/targets/errors"
+)
+
+func TestStallableReleaseStall(t *testing.T) {
+	t.Parallel()
+
+	l := NewStallable()
+
+	unlock, err := l.ContextLock(t.Context())
+	require.NoError(t, err)
+
+	releaseCh, unstall := l.Stall()
+
+	_, err = l.ContextLock(t.Context())
+	require.True(t, errors.IsStalled(err))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		<-releaseCh
+		unstall()
+		unlock()
+	}()
+
+	l.ReleaseStall()
+
+	unlock, err = l.ContextLock(t.Context())
+	require.NoError(t, err)
+	unlock()
+	<-done
+}
+
+func TestStallableReleaseStallNoHolder(t *testing.T) {
+	t.Parallel()
+
+	l := NewStallable()
+	l.ReleaseStall()
+
+	unlock, err := l.ContextLock(t.Context())
+	require.NoError(t, err)
+	unlock()
+}
+
+func TestStallableUnstallResetsStalledState(t *testing.T) {
+	t.Parallel()
+
+	l := NewStallable()
+
+	unlock, err := l.ContextLock(t.Context())
+	require.NoError(t, err)
+
+	_, unstall := l.Stall()
+	_, err = l.ContextLock(t.Context())
+	require.True(t, errors.IsStalled(err))
+
+	unstall()
+	unlock()
+
+	unlock, err = l.ContextLock(t.Context())
+	require.NoError(t, err)
+	unlock()
+}

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -115,6 +115,12 @@ func (o *orchestrator) InvokeStream(ctx context.Context, req *internalsv1pb.Inte
 // DeactivateActor implements actors.InternalActor
 func (o *orchestrator) Deactivate(ctx context.Context) error {
 	unlock, err := o.lock.ContextLock(ctx)
+	if targeterrors.IsStalled(err) {
+		// The actor is parked in the stall hold; wake it so its invocation
+		// returns and releases the lock, then take the lock to deactivate.
+		o.lock.ReleaseStall()
+		unlock, err = o.lock.ContextLock(ctx)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to deactivate workflow '%s': %w", o.actorID, err)
 	}

--- a/pkg/actors/targets/workflow/orchestrator/versioning.go
+++ b/pkg/actors/targets/workflow/orchestrator/versioning.go
@@ -94,13 +94,16 @@ func (o *orchestrator) stallWorkflow(ctx context.Context, state *wfenginestate.S
 	}
 	log.Infof("Workflow actor '%s': workflow is stalled; holding execution until context is canceled", o.actorID)
 
-	unlock := o.lock.Stall()
+	releaseCh, unlock := o.lock.Stall()
 	defer unlock()
 
 	// Clear in-memory state to save resources as stalling is indefinite.
 	o.invalidateCachedState()
 
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-releaseCh:
+	}
 
 	return api.ErrStalled
 }

--- a/tests/integration/framework/process/workflow/clustered.go
+++ b/tests/integration/framework/process/workflow/clustered.go
@@ -1,11 +1,9 @@
 /*
-Copyright 2025 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
-	http://wwb.apache.org/licenses/LICENSE-2.0
-
+    http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package loadbalance
+package workflow
 
 import (
 	"testing"
@@ -22,12 +20,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
-	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 )
 
-func newClusteredDeployment(t *testing.T, daprds int) *workflow.Workflow {
-	wopts := make([]workflow.Option, 0, 1+daprds)
-	wopts = append(wopts, workflow.WithDaprds(daprds))
+// NewClustered returns a Workflow whose daprds share a single app ID with
+// WorkflowsClusteredDeployment enabled, representing a clustered deployment
+// behind a load balancer.
+func NewClustered(t *testing.T, daprds int, extraDaprdOpts ...daprd.Option) *Workflow {
+	t.Helper()
+
+	wopts := make([]Option, 0, 1+daprds)
+	wopts = append(wopts, WithDaprds(daprds))
 	config := `
 apiVersion: dapr.io/v1alpha1
 kind: Configuration
@@ -38,13 +40,13 @@ spec:
     - name: WorkflowsClusteredDeployment
       enabled: true
 `
-	// use the same appID for all daprds so they represent a cluster of daprds
 	uid, err := uuid.NewRandom()
 	require.NoError(t, err)
 	appID := uid.String()
 
 	for i := range daprds {
-		wopts = append(wopts, workflow.WithDaprdOptions(i, daprd.WithAppID(appID), daprd.WithConfigManifests(t, config)))
+		dopts := append([]daprd.Option{daprd.WithAppID(appID), daprd.WithConfigManifests(t, config)}, extraDaprdOpts...)
+		wopts = append(wopts, WithDaprdOptions(i, dopts...))
 	}
-	return workflow.New(t, wopts...)
+	return New(t, wopts...)
 }

--- a/tests/integration/framework/process/workflow/stalled/clustered.go
+++ b/tests/integration/framework/process/workflow/stalled/clustered.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+// PermutationOptions configures the worker client placement for a
+// Permutation. Each phase's slice lists the daprd index each worker client
+// connects to; duplicates mean multiple clients on the same daprd.
+type PermutationOptions struct {
+	Daprds   int
+	V1       []int
+	V2       []int
+	Recovery []int
+}
+
+// Permutation is a clustered deployment process which drives the
+// stall-and-recover scenario for a given placement of worker clients.
+type Permutation struct {
+	workflow *workflow.Workflow
+	opts     PermutationOptions
+}
+
+func NewPermutation(t *testing.T, opts PermutationOptions) *Permutation {
+	t.Helper()
+	return &Permutation{
+		workflow: workflow.NewClustered(t, opts.Daprds),
+		opts:     opts,
+	}
+}
+
+func (p *Permutation) Run(t *testing.T, ctx context.Context) {
+	t.Helper()
+	p.workflow.Run(t, ctx)
+}
+
+func (p *Permutation) Cleanup(t *testing.T) {
+	t.Helper()
+	p.workflow.Cleanup(t)
+}
+
+func (p *Permutation) Execute(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	p.workflow.WaitUntilRunning(t, ctx)
+
+	var completed atomic.Bool
+
+	observers := make([]*client.TaskHubGrpcClient, p.opts.Daprds)
+	for i := range observers {
+		observers[i] = client.NewTaskHubGrpcClient(p.workflow.DaprN(i).GRPCConn(t, ctx), logger.New(t))
+	}
+
+	newWorkers := func(t *testing.T, ctx context.Context, version string, idxs []int) {
+		t.Helper()
+		expected := make(map[int]int)
+		for _, idx := range idxs {
+			registry := task.NewTaskRegistry()
+			require.NoError(t, registry.AddVersionedWorkflowN("workflow", version, true, func(ctx *task.WorkflowContext) (any, error) {
+				if err := ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+					return nil, err
+				}
+				completed.Store(true)
+				return nil, nil
+			}))
+			worker := client.NewTaskHubGrpcClient(p.workflow.DaprN(idx).GRPCConn(t, ctx), logger.New(t))
+			require.NoError(t, worker.StartWorkItemListener(ctx, registry))
+			expected[idx]++
+		}
+
+		for idx, count := range expected {
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				md := p.workflow.DaprN(idx).GetMetadata(c, ctx)
+				if !assert.NotNil(c, md) || !assert.NotNil(c, md.Workflows) {
+					return
+				}
+				assert.GreaterOrEqual(c, md.Workflows.ConnectedWorkers, count)
+			}, time.Second*30, time.Millisecond*10)
+		}
+	}
+
+	disconnectWorkers := func(t *testing.T, ctx context.Context, cancel context.CancelFunc) {
+		t.Helper()
+		cancel()
+		for i := range p.opts.Daprds {
+			p.workflow.WaitForNoConnectedWorkersN(t, ctx, i)
+		}
+	}
+
+	workerCtx, cancelWorkers := context.WithCancel(ctx)
+	newWorkers(t, workerCtx, "v1", p.opts.V1)
+	id, err := observers[0].ScheduleNewWorkflow(ctx, "workflow")
+	require.NoError(t, err)
+	wf.WaitForWorkflowStartedEvent(t, ctx, observers[0], id)
+
+	disconnectWorkers(t, ctx, cancelWorkers)
+	workerCtx, cancelWorkers = context.WithCancel(ctx)
+	newWorkers(t, workerCtx, "v2", p.opts.V2)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, observers[p.opts.Daprds-1].RaiseEvent(ctx, id, "Continue"))
+	}, time.Second*20, time.Millisecond*10)
+
+	for i := range observers {
+		wf.WaitForRuntimeStatus(t, ctx, observers[i], id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED)
+		lastEvent := wf.GetLastHistoryEventOfType[protos.HistoryEvent_ExecutionStalled](t, ctx, observers[i], id)
+		require.NotNil(t, lastEvent)
+		require.Equal(t, protos.StalledReason_VERSION_NOT_AVAILABLE, lastEvent.GetExecutionStalled().GetReason())
+		require.Equal(t, "Version not available: v1", lastEvent.GetExecutionStalled().GetDescription())
+	}
+	require.False(t, completed.Load())
+
+	disconnectWorkers(t, ctx, cancelWorkers)
+	workerCtx, cancelWorkers = context.WithCancel(ctx)
+	t.Cleanup(cancelWorkers)
+	newWorkers(t, workerCtx, "v1", p.opts.Recovery)
+
+	for i := range observers {
+		wf.WaitForRuntimeStatus(t, ctx, observers[i], id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED)
+	}
+	require.True(t, completed.Load())
+}

--- a/tests/integration/framework/process/workflow/stalled/stalled.go
+++ b/tests/integration/framework/process/workflow/stalled/stalled.go
@@ -108,6 +108,18 @@ func (f *Stalled) RestartAsReplica(t *testing.T, ctx context.Context, name strin
 	f.restart(t, ctx)
 }
 
+// ReconnectAsReplica switches the workflow replica by disconnecting the
+// current client and connecting a new one, without restarting daprd.
+func (f *Stalled) ReconnectAsReplica(t *testing.T, ctx context.Context, name string) {
+	t.Helper()
+	f.runWorkflowReplica = name
+	f.currentClientCancel()
+	f.workflows.WaitForNoConnectedWorkers(t, ctx)
+	clientCtx, cancel := context.WithCancel(ctx)
+	f.currentClientCancel = cancel
+	f.CurrentClient = f.workflows.BackendClient(t, clientCtx)
+}
+
 func (f *Stalled) restart(t *testing.T, ctx context.Context) {
 	t.Helper()
 	f.currentClientCancel()

--- a/tests/integration/suite/daprd/workflow/loadbalance/activity.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/activity.go
@@ -40,7 +40,7 @@ type activity struct {
 }
 
 func (a *activity) Setup(t *testing.T) []framework.Option {
-	a.workflow = newClusteredDeployment(t, 2)
+	a.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(a.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/canorphan.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/canorphan.go
@@ -46,7 +46,7 @@ type canorphan struct {
 }
 
 func (c *canorphan) Setup(t *testing.T) []framework.Option {
-	c.workflow = newClusteredDeployment(t, 2)
+	c.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(c.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/continueasnew.go
@@ -40,7 +40,7 @@ type continueasnew struct {
 }
 
 func (c *continueasnew) Setup(t *testing.T) []framework.Option {
-	c.workflow = newClusteredDeployment(t, 2)
+	c.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(c.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/keycollision.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/keycollision.go
@@ -41,7 +41,7 @@ type keycollision struct {
 }
 
 func (k *keycollision) Setup(t *testing.T) []framework.Option {
-	k.workflow = newClusteredDeployment(t, 2)
+	k.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(k.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/loadbalance.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/loadbalance.go
@@ -1,0 +1,5 @@
+package loadbalance
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/loadbalance/stalled"
+)

--- a/tests/integration/suite/daprd/workflow/loadbalance/loadbalance.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/loadbalance.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package loadbalance
 
 import (

--- a/tests/integration/suite/daprd/workflow/loadbalance/raise.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/raise.go
@@ -40,7 +40,7 @@ type raise struct {
 }
 
 func (r *raise) Setup(t *testing.T) []framework.Option {
-	r.workflow = newClusteredDeployment(t, 2)
+	r.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(r.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/routes.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/routes.go
@@ -50,7 +50,7 @@ type routes struct {
 }
 
 func (r *routes) Setup(t *testing.T) []framework.Option {
-	r.workflow = newClusteredDeployment(t, 2)
+	r.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(r.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalled/base.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalled/base.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow/stalled"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(base))
+}
+
+// base verifies a workflow stalls and recovers in a clustered deployment with
+// one worker client on each daprd.
+type base struct {
+	stalled *stalled.Permutation
+}
+
+func (b *base) Setup(t *testing.T) []framework.Option {
+	b.stalled = stalled.NewPermutation(t, stalled.PermutationOptions{
+		Daprds:   2,
+		V1:       []int{0, 1},
+		V2:       []int{0, 1},
+		Recovery: []int{0, 1},
+	})
+
+	return []framework.Option{
+		framework.WithProcesses(b.stalled),
+	}
+}
+
+func (b *base) Run(t *testing.T, ctx context.Context) {
+	b.stalled.Execute(t, ctx)
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalled/manyclients.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalled/manyclients.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow/stalled"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(manyclients))
+}
+
+// manyclients stalls and recovers on a two daprd cluster with two worker
+// clients per daprd.
+type manyclients struct {
+	stalled *stalled.Permutation
+}
+
+func (m *manyclients) Setup(t *testing.T) []framework.Option {
+	m.stalled = stalled.NewPermutation(t, stalled.PermutationOptions{
+		Daprds:   2,
+		V1:       []int{0, 0, 1, 1},
+		V2:       []int{0, 0, 1, 1},
+		Recovery: []int{0, 0, 1, 1},
+	})
+
+	return []framework.Option{
+		framework.WithProcesses(m.stalled),
+	}
+}
+
+func (m *manyclients) Run(t *testing.T, ctx context.Context) {
+	m.stalled.Execute(t, ctx)
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalled/maxbodysize.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalled/maxbodysize.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(maxbodysize))
+}
+
+// maxbodysize verifies a workflow stalls with PAYLOAD_SIZE_EXCEEDED in a
+// clustered deployment and completes after the cluster is rolled to a larger
+// --max-body-size.
+type maxbodysize struct {
+	workflow *workflow.Workflow
+}
+
+func (m *maxbodysize) Setup(t *testing.T) []framework.Option {
+	m.workflow = workflow.NewClustered(t, 2, daprd.WithMaxBodySize("1Mi"))
+
+	return []framework.Option{
+		framework.WithProcesses(m.workflow),
+	}
+}
+
+func (m *maxbodysize) Run(t *testing.T, ctx context.Context) {
+	m.workflow.WaitUntilRunning(t, ctx)
+
+	// 4 chunks of 250 KiB cross the 95% stall threshold of the 1 MiB limit.
+	const chunkSize = 250 * 1024
+	const numActivities = 4
+	chunk := strings.Repeat("x", chunkSize)
+
+	newWorkers := func(t *testing.T, ctx context.Context) []*client.TaskHubGrpcClient {
+		t.Helper()
+		clients := make([]*client.TaskHubGrpcClient, 2)
+		for i := range clients {
+			registry := task.NewTaskRegistry()
+			require.NoError(t, registry.AddWorkflowN("growing-history", func(wctx *task.WorkflowContext) (any, error) {
+				for range numActivities {
+					var out string
+					if err := wctx.CallActivity("emit-chunk").Await(&out); err != nil {
+						return nil, err
+					}
+				}
+				return nil, nil
+			}))
+			require.NoError(t, registry.AddActivityN("emit-chunk", func(task.ActivityContext) (any, error) {
+				return chunk, nil
+			}))
+			clients[i] = client.NewTaskHubGrpcClient(m.workflow.DaprN(i).GRPCConn(t, ctx), logger.New(t))
+			require.NoError(t, clients[i].StartWorkItemListener(ctx, registry))
+		}
+		return clients
+	}
+
+	clients := newWorkers(t, ctx)
+	id, err := clients[0].ScheduleNewWorkflow(ctx, "growing-history")
+	require.NoError(t, err)
+
+	for i := range clients {
+		wf.WaitForRuntimeStatus(t, ctx, clients[i], id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED)
+		lastEvent := wf.GetLastHistoryEventOfType[protos.HistoryEvent_ExecutionStalled](t, ctx, clients[i], id)
+		require.NotNil(t, lastEvent)
+		require.Equal(t, protos.StalledReason_PAYLOAD_SIZE_EXCEEDED, lastEvent.GetExecutionStalled().GetReason())
+		require.Contains(t, lastEvent.GetExecutionStalled().GetDescription(), "exceeds")
+	}
+
+	for i := range 2 {
+		m.workflow.DaprN(i).ReplaceArg(t, "max-body-size", "16Mi")
+		m.workflow.DaprN(i).Restart(t, ctx)
+	}
+	m.workflow.WaitUntilRunning(t, ctx)
+
+	clients = newWorkers(t, ctx)
+	for i := range clients {
+		wf.WaitForRuntimeStatus(t, ctx, clients[i], id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED)
+	}
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalled/workermigrate.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalled/workermigrate.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow/stalled"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(workermigrate))
+}
+
+// workermigrate stalls and recovers on a three daprd cluster where the worker
+// moves to a different daprd on every reconnect.
+type workermigrate struct {
+	stalled *stalled.Permutation
+}
+
+func (w *workermigrate) Setup(t *testing.T) []framework.Option {
+	w.stalled = stalled.NewPermutation(t, stalled.PermutationOptions{
+		Daprds:   3,
+		V1:       []int{0},
+		V2:       []int{1},
+		Recovery: []int{2},
+	})
+
+	return []framework.Option{
+		framework.WithProcesses(w.stalled),
+	}
+}
+
+func (w *workermigrate) Run(t *testing.T, ctx context.Context) {
+	w.stalled.Execute(t, ctx)
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalled/workersubset.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalled/workersubset.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow/stalled"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(workersubset))
+}
+
+// workersubset stalls and recovers on a three daprd cluster where only daprd
+// 0 ever hosts a worker.
+type workersubset struct {
+	stalled *stalled.Permutation
+}
+
+func (w *workersubset) Setup(t *testing.T) []framework.Option {
+	w.stalled = stalled.NewPermutation(t, stalled.PermutationOptions{
+		Daprds:   3,
+		V1:       []int{0},
+		V2:       []int{0},
+		Recovery: []int{0},
+	})
+
+	return []framework.Option{
+		framework.WithProcesses(w.stalled),
+	}
+}
+
+func (w *workersubset) Run(t *testing.T, ctx context.Context) {
+	w.stalled.Execute(t, ctx)
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/suborchestration.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/suborchestration.go
@@ -40,7 +40,7 @@ type suborchestration struct {
 }
 
 func (s *suborchestration) Setup(t *testing.T) []framework.Option {
-	s.workflow = newClusteredDeployment(t, 2)
+	s.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(s.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/timer.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/timer.go
@@ -40,7 +40,7 @@ type timer struct {
 }
 
 func (i *timer) Setup(t *testing.T) []framework.Option {
-	i.workflow = newClusteredDeployment(t, 2)
+	i.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(i.workflow),

--- a/tests/integration/suite/daprd/workflow/loadbalance/workerlb.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/workerlb.go
@@ -48,7 +48,7 @@ type workerlb struct {
 }
 
 func (w *workerlb) Setup(t *testing.T) []framework.Option {
-	w.workflow = newClusteredDeployment(t, 2)
+	w.workflow = workflow.NewClustered(t, 2)
 
 	return []framework.Option{
 		framework.WithProcesses(w.workflow),

--- a/tests/integration/suite/daprd/workflow/patching/stalled/recoverclient.go
+++ b/tests/integration/suite/daprd/workflow/patching/stalled/recoverclient.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow/stalled"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(recoverclient))
+}
+
+// recoverclient verifies a workflow stalled on a patch mismatch resumes and
+// completes once a client running the patched replica reconnects, without
+// restarting daprd.
+type recoverclient struct {
+	fw *stalled.Stalled
+}
+
+func (r *recoverclient) Setup(t *testing.T) []framework.Option {
+	r.fw = stalled.New(t,
+		stalled.WithInitialReplica("new"),
+		stalled.WithNamedWorkflowReplica("new", func(ctx *task.WorkflowContext) (any, error) {
+			if ctx.IsPatched("patch1") {
+				if err := ctx.CallActivity("activity2").Await(nil); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := ctx.CallActivity("activity1").Await(nil); err != nil {
+					return nil, err
+				}
+			}
+			if err := ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}),
+		stalled.WithNamedWorkflowReplica("old", func(ctx *task.WorkflowContext) (any, error) {
+			if err := ctx.CallActivity("activity1").Await(nil); err != nil {
+				return nil, err
+			}
+			if err := ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}),
+		stalled.WithActivity("activity1", func(ctx task.ActivityContext) (any, error) {
+			return "", nil
+		}),
+		stalled.WithActivity("activity2", func(ctx task.ActivityContext) (any, error) {
+			return "", nil
+		}),
+	)
+	return []framework.Option{
+		framework.WithProcesses(r.fw),
+	}
+}
+
+func (r *recoverclient) Run(t *testing.T, ctx context.Context) {
+	id := r.fw.ScheduleWorkflow(t, ctx)
+	r.fw.WaitForNumberOfOrchestrationStartedEvents(t, ctx, id, 2)
+
+	r.fw.ReconnectAsReplica(t, ctx, "old")
+
+	require.NoError(t, r.fw.CurrentClient.RaiseEvent(ctx, id, "Continue"))
+
+	stalledEvent := r.fw.WaitForStalled(t, ctx, id)
+	require.Equal(t, protos.StalledReason_PATCH_MISMATCH, stalledEvent.GetReason())
+
+	r.fw.ReconnectAsReplica(t, ctx, "new")
+	r.fw.WaitForCompleted(t, ctx, id)
+}

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/recoverclient.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/recoverclient.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(recoverclient))
+}
+
+// recoverclient verifies a stalled workflow resumes and completes once a worker
+// with the required version reconnects, without restarting daprd.
+type recoverclient struct {
+	workflow *workflow.Workflow
+}
+
+func (r *recoverclient) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *recoverclient) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	r.workflow.Registry().AddVersionedWorkflowN("workflow", "v1", true, func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+
+	clientCtx, cancelClient := context.WithCancel(ctx)
+	client := r.workflow.BackendClient(t, clientCtx)
+	id, err := client.ScheduleNewWorkflow(ctx, "workflow")
+	require.NoError(t, err)
+
+	wf.WaitForWorkflowStartedEvent(t, ctx, client, id)
+
+	r.workflow.ResetRegistry(t)
+	cancelClient()
+	r.workflow.WaitForNoConnectedWorkers(t, ctx)
+
+	r.workflow.Registry().AddVersionedWorkflowN("workflow", "v2", true, func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	clientCtx, cancelClient = context.WithCancel(ctx)
+	client = r.workflow.BackendClient(t, clientCtx)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, client.RaiseEvent(ctx, id, "Continue"))
+	}, time.Second*20, time.Millisecond*10)
+
+	wf.WaitForRuntimeStatus(t, ctx, client, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED)
+	lastEvent := wf.GetLastHistoryEventOfType[protos.HistoryEvent_ExecutionStalled](t, ctx, client, id)
+	require.NotNil(t, lastEvent)
+	require.Equal(t, protos.StalledReason_VERSION_NOT_AVAILABLE, lastEvent.GetExecutionStalled().GetReason())
+
+	r.workflow.ResetRegistry(t)
+	cancelClient()
+	r.workflow.WaitForNoConnectedWorkers(t, ctx)
+
+	r.workflow.Registry().AddVersionedWorkflowN("workflow", "v1", true, func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("Continue", -1).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	clientCtx, cancelClient = context.WithCancel(ctx)
+	t.Cleanup(cancelClient)
+	client = r.workflow.BackendClient(t, clientCtx)
+
+	wf.WaitForRuntimeStatus(t, ctx, client, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED)
+}


### PR DESCRIPTION
A stalled workflow actor parks its execution in-process, holding the execution reminder in flight until its context is cancelled, and marks its lock as stalled. When the last workflow worker disconnects, daprd halts all workflow actors, but Deactivate begins with ContextLock, which rejects acquisition while the actor is stalled. Recovery then came down to a race: if the scheduler reminder stream teardown cancelled the parked execution first, deactivation succeeded and the unacknowledged reminder was redelivered on worker reconnect; if HaltAll won, deactivation failed with "actor is stalled", the actor stayed activated holding the reminder, and the workflow remained STALLED until daprd restarted.

Fix: Stallable.Stall now returns a release channel and ReleaseStall resets the stalled state and wakes the holder. The stall hold selects on the release channel as well as its context, and Deactivate releases the stall and reacquires the lock when it finds the actor stalled, so halting always succeeds and the reminder is redelivered once workers reconnect.