### PR TITLE
placement: report stream closure exactly once

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -2,6 +2,7 @@
 
 This update contains the following bug fixes:
 - [Actor state store components cannot be hot reloaded](#actor-state-store-components-cannot-be-hot-reloaded)
+- [All sidecars in a namespace disconnected from Placement when a single sidecar disconnected mid-dissemination](#all-sidecars-in-a-namespace-disconnected-from-placement-when-a-single-sidecar-disconnected-mid-dissemination)
 - [Scheduler embedded etcd metrics missing from the metrics endpoint](#scheduler-embedded-etcd-metrics-missing-from-the-metrics-endpoint)
 - [Scheduler hanging on shutdown and failing to redeliver jobs after client disconnects](#scheduler-hanging-on-shutdown-and-failing-to-redeliver-jobs-after-client-disconnects)
 - [Scheduler crash when scheduling a job with a malformed timezone-prefixed schedule](#scheduler-crash-when-scheduling-a-job-with-a-malformed-timezone-prefixed-schedule)
@@ -40,6 +41,31 @@ Two further consistency fixes ride along with this change:
 
 - Actor types are now only advertised to placement while an actor state store is configured. Previously an app declaring actor entities with no actor state store at all would still receive actor invocations, despite actor state, reminders, and workflows being non-functional, contradicting the documented requirement and the `actor hosting disabled` log.
 - Hot loading a second component marked as the actor state store is skipped with an error log naming the existing actor state store, instead of the duplicate silently corrupting the component store bookkeeping.
+
+## All sidecars in a namespace disconnected from Placement when a single sidecar disconnected mid-dissemination
+
+### Problem
+
+Periodically, the Placement server closed every sidecar stream in a namespace within the same millisecond, and all sidecars reconnected at once.
+On reconnect each sidecar halts its local actors, so actors mid-call were interrupted on hosts that were perfectly healthy.
+The dissemination version restarted from scratch after each occurrence.
+
+### Impact
+
+You were affected if you ran actor-hosting sidecars, most visibly in namespaces with many sidecars and frequent deployment rollouts.
+Each sidecar disconnecting while a dissemination round was in flight brought the namespace one step closer to a mass disconnect, so large, frequently rolled clusters could see every sidecar in a namespace dropped every few minutes.
+Actors mid-invocation on unaffected hosts were interrupted each time.
+
+### Root Cause
+
+A single failing Placement stream could report its closure twice: once from its receive loop unwinding, and once from a failed dissemination send on the same connection.
+The per-namespace connection counter was decremented for both reports, leaving it one below the real number of live connections after each such event.
+Once the accumulated drift reached zero, the namespace's dissemination loop was shut down while live streams were still attached, closing all of them and resetting the dissemination version.
+
+### Solution
+
+A stream closure is now reported exactly once: a failed dissemination send cancels the stream's context, preserving the send error as the close cause, and the receive loop unwinding is the single place a closure is reported from.
+The namespace connection counter now always matches the number of live streams, so a healthy namespace is never torn down by one sidecar's disconnect.
 
 ## Scheduler embedded etcd metrics missing from the metrics endpoint
 

--- a/pkg/placement/internal/loops/stream/stream.go
+++ b/pkg/placement/internal/loops/stream/stream.go
@@ -114,10 +114,13 @@ func (s *stream) Handle(ctx context.Context, event loops.EventStream) error {
 
 	if err != nil {
 		log.Errorf("Error handling stream event %T on %s: %v", event, s.addr, err)
-		s.nsLoop.Enqueue(&loops.ConnCloseStream{
-			StreamIDx: s.idx,
-			Namespace: s.ns,
-		})
+		// Cancel the stream context rather than enqueueing a ConnCloseStream
+		// directly. recvLoop unwinds on the cancellation and reports the close,
+		// making it the single emission point. Enqueueing here as well would
+		// deliver two ConnCloseStream events for the same connection,
+		// underflowing the namespace connection counter and tearing down the
+		// disseminator while healthy streams are still attached.
+		s.cancel(err)
 	}
 
 	return nil

--- a/tests/integration/suite/placement/dissemination/doubleclose.go
+++ b/tests/integration/suite/placement/dissemination/doubleclose.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dissemination
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(doubleclose))
+}
+
+type doubleclose struct {
+	place   *placement.Placement
+	logline *logline.LogLine
+}
+
+func (d *doubleclose) Setup(t *testing.T) []framework.Option {
+	d.logline = logline.New(t, logline.WithCaptureAll())
+
+	d.place = placement.New(t,
+		placement.WithDisseminateTimeout(time.Second*10),
+		placement.WithDisseminateCoalesceWindow(time.Second),
+		placement.WithExecOptions(
+			exec.WithStdout(d.logline.Stdout()),
+			exec.WithStderr(d.logline.Stderr()),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(d.logline, d.place),
+	}
+}
+
+func (d *doubleclose) Run(t *testing.T, ctx context.Context) {
+	d.place.WaitUntilRunning(t, ctx)
+
+	assert.Eventually(t, func() bool {
+		return d.place.IsLeader(t, ctx)
+	}, time.Second*10, time.Millisecond*10)
+
+	client := d.place.Client(t, ctx)
+
+	hostA := &v1pb.Host{
+		Name: "a", Port: 1001, Entities: []string{"actorA"},
+		Id: "a", Namespace: "default",
+	}
+
+	a, err := client.ReportDaprStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, a.Send(hostA))
+
+	for _, op := range []string{"lock", "update", "unlock"} {
+		r, rerr := a.Recv()
+		require.NoError(t, rerr)
+		require.Equal(t, op, r.GetOperation())
+		require.NoError(t, a.Send(hostA))
+	}
+
+	bctx, bcancel := context.WithCancel(ctx)
+	b, err := client.ReportDaprStatus(bctx)
+	require.NoError(t, err)
+	require.NoError(t, b.Send(&v1pb.Host{
+		Name: "b", Port: 1002, Entities: []string{"actorB"},
+		Id: "b", Namespace: "default",
+	}))
+
+	d.logline.EventuallyContains(t,
+		"Received status report connection from new namespace=default id=b",
+		time.Second*5, time.Millisecond*10)
+	bcancel()
+
+	sawFinalUpdate := false
+	for range 30 {
+		r, rerr := a.Recv()
+		require.NoError(t, rerr,
+			"healthy stream was closed after another connection aborted (dapr/dapr#10323)")
+
+		if r.GetOperation() == "update" {
+			entries := r.GetTables().GetEntries()
+			_, hasB := entries["actorB"]
+			_, hasA := entries["actorA"]
+			sawFinalUpdate = hasA && !hasB
+		}
+
+		require.NoError(t, a.Send(hostA))
+
+		if sawFinalUpdate && r.GetOperation() == "unlock" {
+			break
+		}
+	}
+	require.True(t, sawFinalUpdate,
+		"expected a dissemination round whose table contains actorA but not actorB")
+
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		table := d.place.PlacementTables(t, ctx)
+		if !assert.NotNil(col, table.Tables["default"]) {
+			return
+		}
+		if assert.Len(col, table.Tables["default"].Hosts, 1) {
+			assert.Equal(col, "a", table.Tables["default"].Hosts[0].Name)
+		}
+	}, time.Second*10, time.Millisecond*10)
+}


### PR DESCRIPTION
A stream could emit ConnCloseStream twice for the same connection: once from recvLoop unwinding, and once from Handle when a dissemination Send fails. namespaces.handleCloseStream decrements its per-namespace connection counter unconditionally, so each duplicate pair left the counter one below the real number of live streams. Once the drift reached zero, the namespace disseminator was shut down and cached while healthy streams were still attached, closing every sidecar stream in the namespace and restarting the dissemination version from scratch.

Make recvLoop the single emission point: on a Send failure, cancel the stream context with the error instead of enqueueing a second event. recvLoop then unwinds and reports the close exactly once, preserving the real error as the close cause.

Fixes #10323