### PR TITLE
workflow: ack activity-result reminders for purged instances

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -13,6 +13,7 @@ This update contains the following bug fixes:
 - [Crash when delivering a pub/sub message with a non-string trace field over HTTP](#crash-when-delivering-a-pubsub-message-with-a-non-string-trace-field-over-http)
 - [Workflow `continue_as_new` iterations sharing a single unbounded trace](#workflow-continue_as_new-iterations-sharing-a-single-unbounded-trace)
 - [Stalled workflows permanently stuck after the last workflow worker disconnects](#stalled-workflows-permanently-stuck-after-the-last-workflow-worker-disconnects)
+- [Fixes orphaned workflow activity-result reminders retrying forever](#fixes-orphaned-workflow-activity-result-reminders-retrying-forever)
 
 ## Actor state store components cannot be hot reloaded
 
@@ -329,3 +330,26 @@ If deactivation won the race, it failed with `actor is stalled`, leaving the act
 Deactivating a stalled workflow actor now wakes the parked execution instead of failing: the held execution returns immediately, leaving the execution reminder unacknowledged, and deactivation completes.
 When workflow workers reconnect, the reminder is redelivered and the workflow re-executes, resuming and completing once the connected workers satisfy the stall condition (for example the required workflow version is registered, or daprd was restarted with a larger `--max-body-size`).
 Recovery from a stall no longer depends on timing, and a daprd restart is no longer required.
+
+## Fixes orphaned workflow activity-result reminders retrying forever
+
+### Problem
+
+When a workflow activity completes but its parent workflow actor is unreachable (for example during placement rebalancing or a host restart), the activity actor durably queues the result as an `activity-result` reminder on the workflow actor so the outcome is delivered once the workflow is reachable again.
+If the workflow instance is purged before that reminder fires, the reminder becomes an orphan: it targets an instance that no longer exists.
+
+### Impact
+
+The issue impacts users on Dapr 1.18.0-1.18.2 running workflows with activities where instances are purged (explicitly, or via a state retention policy) while activity results are still in flight, particularly across placement churn such as rolling restarts or scale events.
+
+Each orphaned reminder adds a permanent one-invocation-per-second load on the daprd hosting the workflow actor type.
+
+### Root cause
+
+The workflow actor's `activity-result` reminder handler forwarded the instance-not-found error to the reminder system without classifying it as terminal.
+The scheduler treats any error as a failed invocation and applies the reminder's failure policy, which for this reminder type is a constant one-second retry with no retry limit.
+
+### Solution
+
+The `activity-result` reminder handler now treats instance-not-found as a successful delivery outcome:
+At-least-once delivery for live instances is unchanged as the fix only affects reminders whose target instance has been purged.

--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -344,7 +344,7 @@ The issue impacts users on Dapr 1.18.0-1.18.2 running workflows with activities 
 
 Each orphaned reminder adds a permanent one-invocation-per-second load on the daprd hosting the workflow actor type.
 
-### Root cause
+### Root Cause
 
 The workflow actor's `activity-result` reminder handler forwarded the instance-not-found error to the reminder system without classifying it as terminal.
 The scheduler treats any error as a failed invocation and applies the reminder's failure policy, which for this reminder type is a constant one-second retry with no retry limit.

--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dapr/dapr/pkg/resiliency"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/backend"
 )
 
@@ -136,7 +137,18 @@ func (o *orchestrator) handleReminder(ctx context.Context, reminder *actorapi.Re
 		if err := proto.Unmarshal(reminder.Data.GetValue(), &ev); err != nil {
 			return fmt.Errorf("failed to unmarshal activity-result HistoryEvent: %w", err)
 		}
-		return o.addWorkflowEvent(ctx, &ev)
+		err := o.addWorkflowEvent(ctx, &ev)
+		if errors.Is(err, api.ErrInstanceNotFound) {
+			// The instance is gone (purged or never existed): ack so the scheduler
+			// deletes this one-shot reminder. It is created with a retry-forever
+			// failure policy, so an unclassified error here refires it every second
+			// indefinitely; a batch of such orphans (activities completing across an
+			// instance purge under placement churn) measurably degrades the whole
+			// host.
+			log.Warnf("Workflow actor '%s': dropping activity-result reminder '%s' for a purged instance", o.actorID, reminder.Name)
+			return nil
+		}
+		return err
 
 	default:
 		return fmt.Errorf("unable to handle reminder '%s' for workflow actor '%s': unknown reminder type", reminder.Name, o.actorID)

--- a/tests/integration/suite/daprd/workflow/crossapp/resultreminder/orphan.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/resultreminder/orphan.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resultreminder
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(orphan))
+}
+
+type orphan struct {
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+}
+
+func (o *orphan) Setup(t *testing.T) []framework.Option {
+	o.place = placement.New(t)
+	o.scheduler = procscheduler.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(o.place, o.scheduler),
+	}
+}
+
+func (o *orphan) Run(t *testing.T, ctx context.Context) {
+	o.scheduler.WaitUntilRunning(t, ctx)
+	o.place.WaitUntilRunning(t, ctx)
+
+	appA := uuid.New().String()
+	appB := uuid.New().String()
+
+	newDaprd := func(appID string) *daprd.Daprd {
+		return daprd.New(t,
+			daprd.WithAppID(appID),
+			daprd.WithInMemoryActorStateStore("statestore"),
+			daprd.WithPlacementAddresses(o.place.Address()),
+			daprd.WithSchedulerAddresses(o.scheduler.Address()),
+		)
+	}
+
+	daprdA := newDaprd(appA)
+	daprdB := newDaprd(appB)
+	daprdA.Run(t, ctx)
+	daprdB.Run(t, ctx)
+	t.Cleanup(func() { daprdB.Cleanup(t) })
+	daprdA.WaitUntilRunning(t, ctx)
+	daprdB.WaitUntilRunning(t, ctx)
+
+	regA := task.NewTaskRegistry()
+	require.NoError(t, regA.AddWorkflowN("Orphaned", func(c *task.WorkflowContext) (any, error) {
+		var out string
+		err := c.CallActivity("Slow",
+			task.WithActivityInput("x"),
+			task.WithActivityAppID(appB),
+		).Await(&out)
+		return out, err
+	}))
+
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	started := make(chan struct{}, 1)
+	regB := task.NewTaskRegistry()
+	require.NoError(t, regB.AddActivityN("Slow", func(c task.ActivityContext) (any, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-block
+		return "done", nil
+	}))
+
+	clientA := client.NewTaskHubGrpcClient(daprdA.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, clientA.StartWorkItemListener(ctx, regA))
+	clientB := client.NewTaskHubGrpcClient(daprdB.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, clientB.StartWorkItemListener(ctx, regB))
+
+	_, err := daprdA.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "Orphaned",
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "timed out waiting for the activity to start")
+	}
+
+	daprdA.Cleanup(t)
+	block <- struct{}{}
+
+	activityResultJobCount := func(t *testing.T, ctx context.Context, s *procscheduler.Scheduler) int {
+		t.Helper()
+		var count int
+		for _, key := range s.ListAllKeys(t, ctx, "dapr/jobs") {
+			if strings.Contains(key, "activity-result") {
+				count++
+			}
+		}
+		return count
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, activityResultJobCount(t, ctx, o.scheduler), 1,
+			"the undeliverable result must be queued as an activity-result reminder")
+	}, time.Second*30, time.Millisecond*10)
+
+	daprdA2 := newDaprd(appA)
+	daprdA2.Run(t, ctx)
+	t.Cleanup(func() { daprdA2.Cleanup(t) })
+	daprdA2.WaitUntilRunning(t, ctx)
+
+	clientA2 := client.NewTaskHubGrpcClient(daprdA2.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, clientA2.StartWorkItemListener(ctx, regA))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Zero(c, activityResultJobCount(t, ctx, o.scheduler),
+			"an activity-result reminder for a missing instance must be acked and deleted, not retried")
+	}, time.Second*30, time.Millisecond*10)
+}


### PR DESCRIPTION
An activity-result reminder (the remote-activity fallback delivery path) that fires against a purged or never-existing workflow instance returns ErrInstanceNotFound unclassified, which the scheduler treats as a failed invocation. Because these reminders are created with a retry-forever constant one-second failure policy, every such orphan refires every second indefinitely.

Orphans are minted in bulk whenever activities complete across an instance purge under placement churn: the activity actor cannot reach the workflow actor, falls back to creating the durable activity-result reminder, and the instance is then purged before it fires.

Treat `ErrInstanceNotFound` as an ack for this reminder arm so the scheduler deletes the one-shot, mirroring the self-cleaning semantics of the other reminder arms: the instance can never accept the result, so redelivery is pure load.