### PR TITLE
Attach SVID context when doing secret resolution

### DIFF
--- a/cmd/daprd/components/secretstores_spiffeprobe.go
+++ b/cmd/daprd/components/secretstores_spiffeprobe.go
@@ -1,0 +1,83 @@
+//go:build secretstores_spiffeprobe
+
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	contribsecret "github.com/dapr/components-contrib/secretstores"
+	"github.com/dapr/components-contrib/secretstores/local/env"
+	secretstoresLoader "github.com/dapr/dapr/pkg/components/secretstores"
+	spiffecontext "github.com/dapr/kit/crypto/spiffe/context"
+	"github.com/dapr/kit/logger"
+)
+
+// SpiffeProbeResolutionReportKey is the reserved secret name that reads back
+// what the probe observed, instead of recording a new observation.
+const SpiffeProbeResolutionReportKey = "__resolution__"
+
+// spiffeProbeSecretStore is an integration-test-only secret store that records
+// whether the workload's SPIFFE identity (the X.509 and JWT SVID sources)
+// reached the context the runtime resolves secretKeyRef entries on.
+//
+// Secret resolution happens while a component is being loaded, not on an API
+// call, so there is nothing for a test to observe in-band. The store therefore
+// records what it saw and reports it back on a later read of the reserved
+// SpiffeProbeResolutionReportKey. That read travels the data plane path and
+// carries an SVID context of its own, so it is served before anything is
+// recorded and can never overwrite what resolution saw.
+//
+// It is gated behind the secretstores_spiffeprobe build tag, set only for the
+// integration-test daprd binary and never for a released flavor, so it is never
+// shipped. It embeds the env secret store to satisfy the full
+// secretstores.SecretStore interface for free, overriding only GetSecret.
+type spiffeProbeSecretStore struct {
+	contribsecret.SecretStore
+
+	lock     sync.Mutex
+	recorded bool
+	hasX509  bool
+	hasJWT   bool
+}
+
+func (s *spiffeProbeSecretStore) GetSecret(ctx context.Context, req contribsecret.GetSecretRequest) (contribsecret.GetSecretResponse, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if req.Name == SpiffeProbeResolutionReportKey {
+		return contribsecret.GetSecretResponse{Data: map[string]string{
+			"recorded": strconv.FormatBool(s.recorded),
+			"x509":     strconv.FormatBool(s.hasX509),
+			"jwt":      strconv.FormatBool(s.hasJWT),
+		}}, nil
+	}
+
+	_, s.hasX509 = spiffecontext.X509From(ctx)
+	_, s.hasJWT = spiffecontext.JWTFrom(ctx)
+	s.recorded = true
+
+	// Resolve to a fixed value so the referencing component's metadata is
+	// populated and it loads as normal.
+	return contribsecret.GetSecretResponse{Data: map[string]string{req.Name: "resolved"}}, nil
+}
+
+func init() {
+	secretstoresLoader.DefaultRegistry.RegisterComponent(func(log logger.Logger) contribsecret.SecretStore {
+		return &spiffeProbeSecretStore{SecretStore: env.NewEnvSecretStore(log)}
+	}, "spiffeprobe")
+}

--- a/pkg/runtime/processor/processor.go
+++ b/pkg/runtime/processor/processor.go
@@ -204,6 +204,7 @@ func New(opts Options) *Processor {
 		ComponentStore: opts.ComponentStore,
 		Meta:           opts.Meta,
 		OperatorClient: opts.OperatorClient,
+		Security:       opts.Security,
 	})
 
 	bindingProc := binding.New(binding.Options{

--- a/pkg/runtime/processor/secret/secret.go
+++ b/pkg/runtime/processor/secret/secret.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/meta"
+	"github.com/dapr/dapr/pkg/security"
 	"github.com/dapr/dapr/pkg/security/consts"
 	"github.com/dapr/kit/logger"
 )
@@ -40,6 +41,7 @@ type Options struct {
 	ComponentStore *compstore.ComponentStore
 	Meta           *meta.Meta
 	OperatorClient operatorv1pb.OperatorClient
+	Security       security.Handler
 }
 
 type secret struct {
@@ -47,6 +49,7 @@ type secret struct {
 	compStore      *compstore.ComponentStore
 	meta           *meta.Meta
 	operatorClient operatorv1pb.OperatorClient
+	security       security.Handler
 	lock           sync.Mutex
 }
 
@@ -56,6 +59,7 @@ func New(opts Options) *secret {
 		compStore:      opts.ComponentStore,
 		meta:           opts.Meta,
 		operatorClient: opts.OperatorClient,
+		security:       opts.Security,
 	}
 }
 
@@ -110,7 +114,12 @@ func (s *secret) Close(comp compapi.Component) error {
 
 // Returns the component or HTTP endpoint updated with the secrets applied.
 // If the resource references a secret store that hasn't been loaded yet, it returns the name of the secret store component as second returned value.
+//
+// Resolving a secretKeyRef invokes GetSecret on the referenced secret store, so
+// the workload's SPIFFE identity is attached here.
 func (s *secret) ProcessResource(ctx context.Context, resource meta.Resource) (updated bool, secretStoreName string) {
+	ctx = s.withSVIDContext(ctx)
+
 	cache := map[string]secretstores.GetSecretResponse{}
 
 	secretStoreName = s.meta.AuthSecretStoreOrDefault(resource)
@@ -198,6 +207,17 @@ func (s *secret) ProcessResource(ctx context.Context, resource meta.Resource) (u
 	}
 
 	return updated, ""
+}
+
+// withSVIDContext attaches the workload's SPIFFE identity (X.509 and JWT SVID
+// sources) to ctx so a secret store can use it to authenticate to the underlying
+// secret provider.
+func (s *secret) withSVIDContext(ctx context.Context) context.Context {
+	if s.security == nil {
+		return ctx
+	}
+
+	return s.security.WithSVIDContext(ctx)
 }
 
 func isEnvVarAllowed(key string) bool {

--- a/pkg/runtime/processor/secret/svidcontext_test.go
+++ b/pkg/runtime/processor/secret/svidcontext_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/dapr/components-contrib/secretstores"
+	commonapi "github.com/dapr/dapr/pkg/apis/common"
+	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/modes"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/dapr/pkg/runtime/meta"
+	"github.com/dapr/dapr/pkg/runtime/registry"
+	"github.com/dapr/dapr/pkg/security"
+	securityfake "github.com/dapr/dapr/pkg/security/fake"
+	spiffecontext "github.com/dapr/kit/crypto/spiffe/context"
+	"github.com/dapr/kit/logger"
+)
+
+// fakeX509Source is a sentinel x509svid.Source. The test only checks that the
+// source reference reaches the secret store, so the methods are stubs.
+type fakeX509Source struct{}
+
+func (fakeX509Source) GetX509SVID() (*x509svid.SVID, error) {
+	return nil, errors.New("not implemented")
+}
+
+// fakeJWTSource is a sentinel jwtsvid.Source.
+type fakeJWTSource struct{}
+
+func (fakeJWTSource) FetchJWTSVID(context.Context, jwtsvid.Params) (*jwtsvid.SVID, error) {
+	return nil, errors.New("not implemented")
+}
+
+// capturingSecretStore records the context that GetSecret was invoked with, so
+// a test can assert what the store observes during secret resolution.
+type capturingSecretStore struct {
+	secretstores.SecretStore
+
+	lock sync.Mutex
+	ctx  context.Context
+}
+
+func (c *capturingSecretStore) Init(context.Context, secretstores.Metadata) error {
+	return nil
+}
+
+func (c *capturingSecretStore) GetSecret(ctx context.Context, _ secretstores.GetSecretRequest) (secretstores.GetSecretResponse, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.ctx = ctx
+
+	return secretstores.GetSecretResponse{Data: map[string]string{"key1": "value1"}}, nil
+}
+
+func (c *capturingSecretStore) operationContext(t *testing.T) context.Context {
+	t.Helper()
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	require.NotNil(t, c.ctx, "GetSecret was not called")
+
+	return c.ctx
+}
+
+// TestProcessResourceSVIDContext asserts that resolving a secretKeyRef calls
+// the referenced secret store with the workload's SPIFFE identity attached.
+// Resolution happens before a component is initialised, on a context that the
+// caller (the root loop, the http endpoint and MCP server loops, or the hot
+// reload reconciler) has not decorated, so the sub-processor must attach it.
+func TestProcessResourceSVIDContext(t *testing.T) {
+	newProbe := func(t *testing.T, sec security.Handler) (*secret, *capturingSecretStore) {
+		t.Helper()
+
+		store := new(capturingSecretStore)
+
+		s := New(Options{
+			Registry:       registry.New(registry.NewOptions()).SecretStores(),
+			ComponentStore: compstore.New(),
+			Meta: meta.New(meta.Options{
+				ID:   "test",
+				Mode: modes.StandaloneMode,
+			}),
+			Security: sec,
+		})
+
+		s.registry.RegisterComponent(
+			func(logger.Logger) secretstores.SecretStore { return store },
+			"svidprobe",
+		)
+
+		require.NoError(t, s.Init(t.Context(), componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{Name: "svidprobe-store"},
+			Spec: componentsapi.ComponentSpec{
+				Type:    "secretstores.svidprobe",
+				Version: "v1",
+			},
+		}))
+
+		return s, store
+	}
+
+	// A resource whose metadata value must be resolved from svidprobe-store.
+	newResource := func() *componentsapi.Component {
+		comp := &componentsapi.Component{
+			ObjectMeta: metav1.ObjectMeta{Name: "mockBinding"},
+			Spec: componentsapi.ComponentSpec{
+				Type:    "bindings.mock",
+				Version: "v1",
+				Metadata: []commonapi.NameValuePair{{
+					Name: "a",
+					SecretKeyRef: commonapi.SecretKeyRef{
+						Key:  "key1",
+						Name: "name1",
+					},
+				}},
+			},
+		}
+		comp.SecretStore = "svidprobe-store"
+		return comp
+	}
+
+	t.Run("the secret store sees the SVID sources when security is wired", func(t *testing.T) {
+		// The fake attaches the X.509 and JWT SVID sources exactly as the real
+		// handler's spiffecontext.WithSpiffe does when mTLS is enabled.
+		sec := securityfake.New().WithSVIDContextFn(func(ctx context.Context) context.Context {
+			ctx = spiffecontext.WithX509(ctx, fakeX509Source{})
+			return spiffecontext.WithJWT(ctx, fakeJWTSource{})
+		})
+
+		s, store := newProbe(t, sec)
+
+		comp := newResource()
+		updated, unready := s.ProcessResource(t.Context(), comp)
+		require.True(t, updated)
+		require.Empty(t, unready)
+		assert.Equal(t, "value1", comp.Spec.Metadata[0].Value.String())
+
+		ctx := store.operationContext(t)
+		_, ok := spiffecontext.X509From(ctx)
+		assert.True(t, ok, "GetSecret context should carry the X.509 SVID source")
+		_, ok = spiffecontext.JWTFrom(ctx)
+		assert.True(t, ok, "GetSecret context should carry the JWT SVID source")
+	})
+
+	t.Run("the secret store sees no SVID sources when mTLS is disabled", func(t *testing.T) {
+		// WithSVIDContext returns ctx untouched when SPIFFE is not configured
+		// (the fake's default). Negative control proving the assertion above is
+		// not vacuous: nothing leaks into the context by default.
+		s, store := newProbe(t, securityfake.New())
+
+		comp := newResource()
+		updated, unready := s.ProcessResource(t.Context(), comp)
+		require.True(t, updated)
+		require.Empty(t, unready)
+
+		ctx := store.operationContext(t)
+		_, ok := spiffecontext.X509From(ctx)
+		assert.False(t, ok, "X.509 SVID source should be absent when mTLS is disabled")
+		_, ok = spiffecontext.JWTFrom(ctx)
+		assert.False(t, ok, "JWT SVID source should be absent when mTLS is disabled")
+	})
+
+	t.Run("no security handler is not fatal", func(t *testing.T) {
+		// Unit tests construct the sub-processor without a handler; resolution
+		// must still work rather than nil panic.
+		s, store := newProbe(t, nil)
+
+		comp := newResource()
+		updated, unready := s.ProcessResource(t.Context(), comp)
+		require.True(t, updated)
+		require.Empty(t, unready)
+		assert.Equal(t, "value1", comp.Spec.Metadata[0].Value.String())
+
+		_, ok := spiffecontext.X509From(store.operationContext(t))
+		assert.False(t, ok)
+	})
+}

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -45,6 +45,11 @@ var buildTags = []string{
 	// reports whether the SPIFFE identity reached the component operation
 	// context. Never set for released daprd flavors.
 	"state_spiffeprobe",
+	// secretstores_spiffeprobe compiles in an integration-test-only secret
+	// store that reports whether the SPIFFE identity reached the context that
+	// secretKeyRef entries are resolved on. Never set for released daprd
+	// flavors.
+	"secretstores_spiffeprobe",
 }
 
 func BuildAll(t *testing.T) {

--- a/tests/integration/suite/daprd/mtls/standalone/svidcontext.go
+++ b/tests/integration/suite/daprd/mtls/standalone/svidcontext.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,12 +42,20 @@ func init() {
 // runtime injects the workload's SPIFFE identity (X.509 and JWT SVID sources)
 // into the context of building-block component operations.
 //
-// It relies on the `state.spiffeprobe` state store, an integration-only
-// component compiled into the test daprd via the `state_spiffeprobe` build tag
-// (see tests/integration/framework/binary and cmd/daprd/components), whose Get
-// reports which SVID sources were present in its operation context. We drive it
-// through the normal state API so the request travels the real path:
-// gRPC server -> universal API -> resiliency runner -> component.
+// It covers two distinct paths, which are wired independently:
+//
+//   - Data plane operations, via the `state.spiffeprobe` state store whose Get
+//     reports which SVID sources were present in its operation context. Driven
+//     through the normal state API so the request travels the real path:
+//     gRPC server -> universal API -> resiliency runner -> component.
+//   - Secret resolution, via the `secretstores.spiffeprobe` secret store which
+//     records the sources present when the runtime resolved another component's
+//     secretKeyRef. That happens while components are loading, so the probe
+//     reports what it saw on a later read of a reserved key.
+//
+// Both probes are integration-only components compiled into the test daprd via
+// the `state_spiffeprobe` and `secretstores_spiffeprobe` build tags (see
+// tests/integration/framework/binary and cmd/daprd/components).
 type svidcontext struct {
 	mtlsDaprd  *daprd.Daprd
 	plainDaprd *daprd.Daprd
@@ -63,6 +72,42 @@ spec:
   type: state.spiffeprobe
   version: v1
 `
+
+//nolint:gosec // G101: component YAML, not a credential.
+const spiffeProbeSecretStore = `apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: spiffeprobe-secrets
+spec:
+  type: secretstores.spiffeprobe
+  version: v1
+`
+
+// secretRefComponent resolves a metadata value out of spiffeprobe-secrets. The
+// runtime calls that store's GetSecret while loading this component, before its
+// Init, which is the context the probe records.
+//
+//nolint:gosec // G101: component YAML, not a credential.
+const secretRefComponent = `apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: secretref-store
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: probe
+    secretKeyRef:
+      name: probe-secret
+auth:
+  secretStore: spiffeprobe-secrets
+`
+
+// resolutionReportKey mirrors SpiffeProbeResolutionReportKey in
+// cmd/daprd/components/secretstores_spiffeprobe.go. It is duplicated rather
+// than imported because every file in that package is behind a build tag, so
+// the package has no Go files from the integration suite's point of view.
+const resolutionReportKey = "__resolution__"
 
 func (s *svidcontext) Setup(t *testing.T) []framework.Option {
 	s.sentry = sentry.New(t)
@@ -92,7 +137,7 @@ func (s *svidcontext) Setup(t *testing.T) []framework.Option {
 		daprd.WithPlacementAddresses(s.placement.Address()),
 		daprd.WithSchedulerAddresses(s.scheduler.Address()),
 		daprd.WithEnableMTLS(true),
-		daprd.WithResourceFiles(spiffeProbeComponent),
+		daprd.WithResourceFiles(spiffeProbeComponent, spiffeProbeSecretStore, secretRefComponent),
 	)
 
 	// mTLS disabled: WithSVIDContext is a no-op, so component operations must not
@@ -100,7 +145,7 @@ func (s *svidcontext) Setup(t *testing.T) []framework.Option {
 	// assertion is not vacuous.
 	s.plainDaprd = daprd.New(t,
 		daprd.WithAppID("plain-app"),
-		daprd.WithResourceFiles(spiffeProbeComponent),
+		daprd.WithResourceFiles(spiffeProbeComponent, spiffeProbeSecretStore, secretRefComponent),
 	)
 
 	return []framework.Option{
@@ -128,6 +173,40 @@ func (s *svidcontext) Run(t *testing.T, ctx context.Context) {
 		return got
 	}
 
+	// resolutionProbe reads back which SVID sources the secret store saw while
+	// the runtime resolved secretref-store's secretKeyRef. The referencing
+	// component is parked until its secret store loads, so wait for the probe to
+	// have been called before reading the report.
+	resolutionProbe := func(t *testing.T, d *daprd.Daprd) map[string]string {
+		t.Helper()
+		client := d.GRPCClient(t, ctx)
+		report := func() (map[string]string, error) {
+			resp, err := client.GetSecret(ctx, &rtv1.GetSecretRequest{
+				StoreName: "spiffeprobe-secrets",
+				Key:       resolutionReportKey,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp.GetData(), nil
+		}
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			data, err := report()
+			if !assert.NoError(c, err) {
+				return
+			}
+			assert.Equal(c, "true", data["recorded"],
+				"secret resolution has not called the probe secret store yet")
+		}, time.Second*15, time.Millisecond*100)
+
+		// Recorded once during load and never rewritten, so a plain read now is
+		// stable.
+		data, err := report()
+		require.NoError(t, err)
+		return data
+	}
+
 	t.Run("with mTLS the component sees the SVID sources", func(t *testing.T) {
 		got := probe(t, s.mtlsDaprd)
 		assert.True(t, got["x509"], "X.509 SVID source should be in the component operation context")
@@ -138,5 +217,17 @@ func (s *svidcontext) Run(t *testing.T, ctx context.Context) {
 		got := probe(t, s.plainDaprd)
 		assert.False(t, got["x509"], "X.509 SVID source should be absent when mTLS is disabled")
 		assert.False(t, got["jwt"], "JWT SVID source should be absent when mTLS is disabled")
+	})
+
+	t.Run("with mTLS the secret store sees the SVID sources during secret resolution", func(t *testing.T) {
+		got := resolutionProbe(t, s.mtlsDaprd)
+		assert.Equal(t, "true", got["x509"], "X.509 SVID source should be in the secret resolution context")
+		assert.Equal(t, "true", got["jwt"], "JWT SVID source should be in the secret resolution context")
+	})
+
+	t.Run("without mTLS the secret store sees no SVID sources during secret resolution", func(t *testing.T) {
+		got := resolutionProbe(t, s.plainDaprd)
+		assert.Equal(t, "false", got["x509"], "X.509 SVID source should be absent when mTLS is disabled")
+		assert.Equal(t, "false", got["jwt"], "JWT SVID source should be absent when mTLS is disabled")
 	})
 }


### PR DESCRIPTION
Signed-off-by: Joni Collinge <joni@diagrid.io>

# Description
When using the dapr workload identity to authenticate to a secret store that is used for secret references in other components it currently fails as the SVID is not available on the context. This PR fixes that.
<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
