### PR TITLE
grpc: give the app connection realistic connect budget

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -14,6 +14,7 @@ This update contains the following bug fixes:
 - [Workflow `continue_as_new` iterations sharing a single unbounded trace](#workflow-continue_as_new-iterations-sharing-a-single-unbounded-trace)
 - [Stalled workflows permanently stuck after the last workflow worker disconnects](#stalled-workflows-permanently-stuck-after-the-last-workflow-worker-disconnects)
 - [Fixes orphaned workflow activity-result reminders retrying forever](#fixes-orphaned-workflow-activity-result-reminders-retrying-forever)
+- [Pub/sub delivery to a gRPC app failing with "use of closed network connection"](#pubsub-delivery-to-a-grpc-app-failing-with-use-of-closed-network-connection)
 
 ## Actor state store components cannot be hot reloaded
 
@@ -353,3 +354,44 @@ The scheduler treats any error as a failed invocation and applies the reminder's
 
 The `activity-result` reminder handler now treats instance-not-found as a successful delivery outcome:
 At-least-once delivery for live instances is unchanged as the fix only affects reminders whose target instance has been purged.
+
+## Pub/sub delivery to a gRPC app failing with "use of closed network connection"
+
+### Problem
+
+Delivering a pub/sub message to an application connected over gRPC intermittently failed before the application ever saw the message, and the sidecar logged:
+
+```
+error returned from app while processing pub/sub event <id>: retriable error occurred: rpc error: code = Unavailable desc = connection error: desc = "error reading server preface: read tcp 127.0.0.1:56264->127.0.0.1:14208: use of closed network connection"
+```
+
+The application was healthy and listening throughout, and the same message was delivered successfully on a later attempt or after a sidecar restart.
+
+### Impact
+
+You were affected if you ran an application with `--app-protocol grpc` (or `grpcs`) subscribing to topics, and had upgraded to 1.18.
+The failures were most visible on subscriptions receiving sporadic traffic, and on hosts where the application is slow to accept a new connection, for example a busy thread pool or a garbage collection pause.
+
+Every affected delivery was reported to the broker as a retriable failure, so the message was either redelivered by the broker (RabbitMQ, Kafka, and other components with redelivery) or dropped for components without it.
+The same connection handling is used for service invocation into a gRPC application, input binding delivery, and job triggers, so those paths could fail the same way.
+Applications using `--app-protocol http` were not affected.
+
+### Root Cause
+
+daprd dialed the application with a `MinConnectTimeout` of one second.
+In gRPC that value is the budget for an entire connection attempt, covering the TCP connect and the HTTP/2 handshake, not just the TCP connect: when it expires, gRPC hard-closes the socket, and a request already riding on that connection fails with `error reading server preface: use of closed network connection`.
+
+Up to 1.17 this was almost never reachable, because daprd held a single application connection for the lifetime of the process and only ever dialed at startup.
+In 1.18 the application connection moved into the same pool used for sidecar-to-sidecar connections, so connections are established on demand while messages are being delivered, and each new connection had one second to complete its handshake before the delivery riding on it failed.
+
+The pool made this far more frequent than it needed to be.
+The pool is configured to keep one warm connection to the application, but once that connection had been idle for longer than the pool's three minute idle window it was neither handed out again (it was treated as expired) nor closed (it was the connection being kept warm).
+It was stuck in the pool, unusable and open, so every request arriving after an idle period dialed a brand new connection rather than reusing the warm one.
+
+### Solution
+
+A connection attempt to the application is now given gRPC's default budget of 20 seconds instead of one second, matching what daprd already used for sidecar-to-sidecar connections.
+This does not change how long a request waits for an unreachable application: a refused connection still fails immediately, and how long a request waits remains governed by the caller's context and resiliency policy.
+
+Connections the pool holds to satisfy its warm connection minimum are also no longer expired out.
+The application connection established at startup now stays in use for the life of the sidecar, so a subscription that receives one message an hour no longer re-dials the application for every message.

--- a/pkg/api/grpc/manager/manager.go
+++ b/pkg/api/grpc/manager/manager.go
@@ -44,6 +44,12 @@ const (
 	grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
 	dialTimeout       = 30 * time.Second
 	maxConnIdle       = 3 * time.Minute
+
+	// appConnectTimeout is the budget gRPC gives a single connection attempt to
+	// the app, covering the TCP connect and the HTTP/2 handshake. This matches
+	// gRPC's own default; it does not bound how long a request waits, which
+	// remains governed by the caller's context.
+	appConnectTimeout = 20 * time.Second
 )
 
 // ConnCreatorFn is a function that returns a gRPC connection
@@ -162,7 +168,7 @@ func (g *Manager) createLocalConnection(parentCtx context.Context, port int, ena
 	}
 	opts = append(opts, grpc.WithConnectParams(grpc.ConnectParams{
 		Backoff:           backoff.DefaultConfig,
-		MinConnectTimeout: 1 * time.Second,
+		MinConnectTimeout: appConnectTimeout,
 	}))
 
 	dialPrefix := GetDialAddressPrefix(g.mode)

--- a/pkg/api/grpc/manager/pool.go
+++ b/pkg/api/grpc/manager/pool.go
@@ -126,7 +126,12 @@ func (p *ConnectionPool) doShare() grpc.ClientConnInterface {
 		// Check if the connection is still valid first
 		// First we check if the referenceCount is 0, and then we check if the connection has expired
 		// This should be safe for concurrent use
-		if atomic.LoadInt32(&p.connections[i].referenceCount) == 0 && p.connections[i].Expired(p.maxConnIdle) {
+		// Connections held to satisfy minActiveConns are exempt: they are the pool's warm connections,
+		// which Purge keeps for the same reason. Expiring them here would leave them in the pool
+		// unusable and unclosed, and force a fresh dial for every request that follows an idle period.
+		if i >= p.minActiveConns &&
+			atomic.LoadInt32(&p.connections[i].referenceCount) == 0 &&
+			p.connections[i].Expired(p.maxConnIdle) {
 			continue
 		}
 

--- a/pkg/api/grpc/manager/pool_test.go
+++ b/pkg/api/grpc/manager/pool_test.go
@@ -331,29 +331,108 @@ func TestConnectionPool(t *testing.T) {
 			require.Equal(t, idleStart, *(cp.connections[0].idleSince.Load()))
 
 			// Wait 15 seconds (more than expiration time)
-			// Share should return nil because the connection has expired
 			clockMock.Step(15 * time.Second)
-			conn = cp.Share()
-			require.Nil(t, conn)
-			require.Equal(t, int32(0), cp.connections[0].referenceCount)
 
-			// Now the first connection should be purged if minActiveConns == 0 only
+			if minActiveConns == 0 {
+				// Share should return nil because the connection has expired
+				conn = cp.Share()
+				require.Nil(t, conn)
+				require.Equal(t, int32(0), cp.connections[0].referenceCount)
+
+				// Now the first connection should be purged
+				clockMock.Step(15 * time.Second)
+				cp.Purge()
+
+				require.Empty(t, cp.connections)
+				return
+			}
+
+			// Connections kept to satisfy minActiveConns are the pool's warm
+			// connections, so they are never expired out: Share keeps handing
+			// them out and Purge keeps them.
+			conn = cp.Share()
+			require.Equal(t, conns[0], conn)
+			require.Equal(t, int32(1), cp.connections[0].referenceCount)
+
+			cp.Release(conns[0])
+			require.Equal(t, int32(0), cp.connections[0].referenceCount)
+			require.Equal(t, clock.Now(), *(cp.connections[0].idleSince.Load()))
+
 			clockMock.Step(15 * time.Second)
 			cp.Purge()
 
-			if minActiveConns == 0 {
-				require.Empty(t, cp.connections)
-			} else {
-				require.Len(t, cp.connections, 1)
-				require.Equal(t, conns[0], cp.connections[0].conn)
-				require.Equal(t, int32(0), cp.connections[0].referenceCount)
-				require.Equal(t, idleStart, *(cp.connections[0].idleSince.Load()))
-			}
+			require.Len(t, cp.connections, 1)
+			require.Equal(t, conns[0], cp.connections[0].conn)
+			require.Equal(t, int32(0), cp.connections[0].referenceCount)
 		}
 	}
 
 	t.Run("expired connection", testExpiredConn(0))
 	t.Run("expired connection with 1 min", testExpiredConn(1))
+}
+
+// TestConnectionPoolWarmConnection covers the pool half of
+// https://github.com/dapr/dapr/issues/10335 for the local app pool, which is
+// created with minActiveConns == 1 so that a warm connection to the app is
+// always kept around.
+//
+// That connection used to be stuck once it had been idle for longer than
+// maxConnIdle: Get no longer handed it out (doShare skipped expired
+// connections) while Purge refused to close it (it is below minActiveConns).
+// Every request arriving after an idle gap therefore dialled a brand new
+// connection, and each of those had to complete a handshake inside gRPC's
+// one-shot connect budget before the request riding on it could proceed.
+func TestConnectionPoolWarmConnection(t *testing.T) {
+	clockMock := testingclock.NewFakeClock(time.Now())
+	clock = clockMock
+	t.Cleanup(func() {
+		clock = &kclock.RealClock{}
+	})
+
+	const maxConnIdle = 3 * time.Minute
+
+	// Same shape as the local app connection pool in NewManager.
+	cp := NewConnectionPool(maxConnIdle, 1)
+
+	var created []*mockConnection
+	createFn := func() (grpc.ClientConnInterface, error) {
+		conn := new(mockConnection)
+		created = append(created, conn)
+		return conn, nil
+	}
+
+	// First request establishes the app connection.
+	first, err := cp.Get(createFn)
+	require.NoError(t, err)
+	require.Len(t, created, 1)
+	cp.Release(first)
+
+	// A second request inside the idle window reuses it, as expected.
+	second, err := cp.Get(createFn)
+	require.NoError(t, err)
+	require.Len(t, created, 1)
+	require.Same(t, first, second)
+	cp.Release(second)
+
+	// Three more requests, each arriving after an idle gap longer than
+	// maxConnIdle, as a sporadic pub/sub subscription would. Every one of them
+	// reuses the warm connection instead of dialing.
+	for range 3 {
+		clockMock.Step(maxConnIdle + time.Second)
+		cp.Purge()
+
+		conn, err := cp.Get(createFn)
+		require.NoError(t, err)
+		cp.Release(conn)
+
+		require.Len(t, created, 1)
+		require.Same(t, first, conn)
+	}
+
+	// The connection is still the only one in the pool, and still open.
+	require.Len(t, cp.connections, 1)
+	require.Same(t, created[0], cp.connections[0].conn)
+	assert.False(t, created[0].Closed)
 }
 
 // Mock that implements grpc.ClientConnInterface and the Close method

--- a/tests/integration/framework/listener/stall.go
+++ b/tests/integration/framework/listener/stall.go
@@ -61,13 +61,15 @@ func (s *Stall) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	if stall := s.stall.Load(); stall > 0 {
-		time.Sleep(time.Duration(stall))
-	}
-
+	// Record before stalling, so a connection which is still being held is
+	// dropped by CloseAccepted like any other.
 	s.lock.Lock()
 	s.accepted = append(s.accepted, conn)
 	s.lock.Unlock()
+
+	if stall := s.stall.Load(); stall > 0 {
+		time.Sleep(time.Duration(stall))
+	}
 
 	return conn, nil
 }

--- a/tests/integration/framework/listener/stall.go
+++ b/tests/integration/framework/listener/stall.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package listener
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Stall wraps a net.Listener and holds on to accepted connections before
+// handing them to the server, simulating an application which is slow to
+// complete its protocol handshake, for example a busy app whose accept loop is
+// starved. It also keeps hold of the connections it has accepted so a test can
+// drop them on demand and force the client to dial again.
+type Stall struct {
+	net.Listener
+
+	stall atomic.Int64
+
+	lock     sync.Mutex
+	accepted []net.Conn
+}
+
+// New returns a Stall wrapping the given listener.
+func New(ln net.Listener) *Stall {
+	return &Stall{Listener: ln}
+}
+
+// SetStall sets how long Accept holds a connection before returning it. Zero
+// disables stalling.
+func (s *Stall) SetStall(d time.Duration) {
+	s.stall.Store(int64(d))
+}
+
+// CloseAccepted closes every connection accepted so far.
+func (s *Stall) CloseAccepted() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	for _, conn := range s.accepted {
+		conn.Close()
+	}
+	s.accepted = nil
+}
+
+func (s *Stall) Accept() (net.Conn, error) {
+	conn, err := s.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	if stall := s.stall.Load(); stall > 0 {
+		time.Sleep(time.Duration(stall))
+	}
+
+	s.lock.Lock()
+	s.accepted = append(s.accepted, conn)
+	s.lock.Unlock()
+
+	return conn, nil
+}

--- a/tests/integration/suite/daprd/binding/input/grpc/appconnredial.go
+++ b/tests/integration/suite/daprd/binding/input/grpc/appconnredial.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/listener"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	procgrpc "github.com/dapr/dapr/tests/integration/framework/process/grpc"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(appconnredial))
+}
+
+type appconnredial struct {
+	daprd    *daprd.Daprd
+	listener *listener.Stall
+	logs     *log.Log
+	eventCh  chan struct{}
+}
+
+func (a *appconnredial) Setup(t *testing.T) []framework.Option {
+	a.eventCh = make(chan struct{}, 100)
+	a.logs = log.New()
+	a.listener = listener.New(ports.Reserve(t, 1).Listener(t))
+
+	srv := app.New(t,
+		app.WithGRPCOptions(procgrpc.WithListener(func() (net.Listener, error) {
+			return a.listener, nil
+		})),
+		app.WithOnBindingEventFn(func(context.Context, *rtv1.BindingEventRequest) (*rtv1.BindingEventResponse, error) {
+			select {
+			case a.eventCh <- struct{}{}:
+			default:
+			}
+			return new(rtv1.BindingEventResponse), nil
+		}),
+	)
+
+	a.daprd = daprd.New(t,
+		daprd.WithAppPort(srv.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithExecOptions(exec.WithStdout(a.logs), exec.WithStderr(a.logs)),
+		daprd.WithResourceFiles(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mybinding
+spec:
+  type: bindings.cron
+  version: v1
+  metadata:
+  - name: schedule
+    value: "@every 1s"
+  - name: direction
+    value: input
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(srv, a.daprd),
+	}
+}
+
+func (a *appconnredial) Run(t *testing.T, ctx context.Context) {
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	waitForEvent := func(t require.TestingT, timeout time.Duration) {
+		select {
+		case <-a.eventCh:
+		case <-time.After(timeout):
+			require.Fail(t, "timed out waiting for a binding event")
+		}
+	}
+
+	waitForEvent(t, time.Second*10)
+
+	a.listener.SetStall(time.Second * 2)
+	a.listener.CloseAccepted()
+
+	for len(a.eventCh) > 0 {
+		<-a.eventCh
+	}
+
+	waitForEvent(t, time.Second*20)
+
+	assert.False(t, a.logs.Contains("error reading server preface"),
+		"app connection was closed mid handshake")
+}

--- a/tests/integration/suite/daprd/pubsub/grpc/appconnredial.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/appconnredial.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/listener"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	procgrpc "github.com/dapr/dapr/tests/integration/framework/process/grpc"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(appconnredial))
+}
+
+type appconnredial struct {
+	daprd     *daprd.Daprd
+	listener  *listener.Stall
+	logs      *log.Log
+	topicChan chan string
+}
+
+func (a *appconnredial) Setup(t *testing.T) []framework.Option {
+	a.topicChan = make(chan string, 10)
+	a.logs = log.New()
+	a.listener = listener.New(ports.Reserve(t, 1).Listener(t))
+
+	srv := app.New(t,
+		app.WithGRPCOptions(procgrpc.WithListener(func() (net.Listener, error) {
+			return a.listener, nil
+		})),
+		app.WithOnTopicEventFn(func(_ context.Context, in *rtv1.TopicEventRequest) (*rtv1.TopicEventResponse, error) {
+			a.topicChan <- in.GetPath()
+			return new(rtv1.TopicEventResponse), nil
+		}),
+		app.WithListTopicSubscriptions(func(context.Context, *emptypb.Empty) (*rtv1.ListTopicSubscriptionsResponse, error) {
+			return &rtv1.ListTopicSubscriptionsResponse{
+				Subscriptions: []*rtv1.TopicSubscription{
+					{PubsubName: "mypubsub", Topic: "mytopic", Routes: &rtv1.TopicRoutes{Default: "/myroute"}},
+				},
+			}, nil
+		}),
+	)
+
+	a.daprd = daprd.New(t,
+		daprd.WithAppPort(srv.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithExecOptions(exec.WithStdout(a.logs), exec.WithStderr(a.logs)),
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mypubsub
+spec:
+  type: pubsub.in-memory
+  version: v1`),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, a.daprd),
+	}
+}
+
+func (a *appconnredial) Run(t *testing.T, ctx context.Context) {
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	client := a.daprd.GRPCClient(t, ctx)
+
+	publish := func() {
+		_, err := client.PublishEvent(ctx, &rtv1.PublishEventRequest{
+			PubsubName: "mypubsub",
+			Topic:      "mytopic",
+			Data:       []byte(`{"status": "completed"}`),
+		})
+		require.NoError(t, err)
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		publish()
+		select {
+		case path := <-a.topicChan:
+			assert.Equal(c, "/myroute", path)
+		case <-time.After(time.Second):
+			assert.Fail(c, "message not delivered")
+		}
+	}, time.Second*10, time.Millisecond*100)
+
+	a.listener.SetStall(time.Second * 2)
+	a.listener.CloseAccepted()
+
+	publish()
+
+	select {
+	case path := <-a.topicChan:
+		assert.Equal(t, "/myroute", path)
+	case <-time.After(time.Second * 20):
+		assert.Fail(t, "message not delivered after re-dialing the app")
+	}
+
+	assert.False(t, a.logs.Contains("error reading server preface"),
+		"app connection was closed mid handshake")
+}

--- a/tests/integration/suite/daprd/pubsub/grpc/appconnredial.go
+++ b/tests/integration/suite/daprd/pubsub/grpc/appconnredial.go
@@ -113,14 +113,19 @@ func (a *appconnredial) Run(t *testing.T, ctx context.Context) {
 	a.listener.SetStall(time.Second * 2)
 	a.listener.CloseAccepted()
 
-	publish()
-
-	select {
-	case path := <-a.topicChan:
-		assert.Equal(t, "/myroute", path)
-	case <-time.After(time.Second * 20):
-		assert.Fail(t, "message not delivered after re-dialing the app")
+	for len(a.topicChan) > 0 {
+		<-a.topicChan
 	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		publish()
+		select {
+		case path := <-a.topicChan:
+			assert.Equal(c, "/myroute", path)
+		case <-time.After(time.Second * 3):
+			assert.Fail(c, "message not delivered after re-dialing the app")
+		}
+	}, time.Second*30, time.Millisecond*100)
 
 	assert.False(t, a.logs.Contains("error reading server preface"),
 		"app connection was closed mid handshake")

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/appconnredial.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/appconnredial.go
@@ -78,7 +78,7 @@ func (a *appconnredial) Run(t *testing.T, ctx context.Context) {
 
 	client := a.daprd.GRPCClient(t, ctx)
 
-	invoke := func(t require.TestingT) {
+	invoke := func() (string, error) {
 		resp, err := client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
 			Id: a.daprd.AppID(),
 			Message: &commonv1.InvokeRequest{
@@ -86,17 +86,37 @@ func (a *appconnredial) Run(t *testing.T, ctx context.Context) {
 				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
 			},
 		})
-		require.NoError(t, err)
-		require.Equal(t, "pong", string(resp.GetData().GetValue()))
+		if err != nil {
+			return "", err
+		}
+		return string(resp.GetData().GetValue()), nil
 	}
 
-	invoke(t)
+	data, err := invoke()
+	require.NoError(t, err)
+	require.Equal(t, "pong", data)
 
 	a.listener.SetStall(time.Second * 2)
 	a.listener.CloseAccepted()
 
-	invoke(t)
+	var (
+		lastErr error
+		invoked bool
+	)
+	for start := time.Now(); time.Since(start) < time.Second*30; {
+		var data string
+		data, lastErr = invoke()
+		if lastErr == nil {
+			assert.Equal(t, "pong", data)
+			invoked = true
+			break
+		}
 
-	assert.False(t, a.logs.Contains("error reading server preface"),
-		"app connection was closed mid handshake")
+		require.NotContains(t, lastErr.Error(), "error reading server preface",
+			"app connection was closed mid handshake")
+
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	require.True(t, invoked, "app never became reachable again: %v", lastErr)
 }

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/appconnredial.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/appconnredial.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/listener"
+	"github.com/dapr/dapr/tests/integration/framework/log"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	procgrpc "github.com/dapr/dapr/tests/integration/framework/process/grpc"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(appconnredial))
+}
+
+type appconnredial struct {
+	daprd    *daprd.Daprd
+	listener *listener.Stall
+	logs     *log.Log
+}
+
+func (a *appconnredial) Setup(t *testing.T) []framework.Option {
+	a.logs = log.New()
+	a.listener = listener.New(ports.Reserve(t, 1).Listener(t))
+
+	srv := app.New(t,
+		app.WithGRPCOptions(procgrpc.WithListener(func() (net.Listener, error) {
+			return a.listener, nil
+		})),
+		app.WithOnInvokeFn(func(_ context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
+			return &commonv1.InvokeResponse{
+				Data:        &anypb.Any{Value: []byte("pong")},
+				ContentType: "text/plain",
+			}, nil
+		}),
+	)
+
+	a.daprd = daprd.New(t,
+		daprd.WithAppPort(srv.Port(t)),
+		daprd.WithAppProtocol("grpc"),
+		daprd.WithExecOptions(exec.WithStdout(a.logs), exec.WithStderr(a.logs)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, a.daprd),
+	}
+}
+
+func (a *appconnredial) Run(t *testing.T, ctx context.Context) {
+	a.daprd.WaitUntilRunning(t, ctx)
+
+	client := a.daprd.GRPCClient(t, ctx)
+
+	invoke := func(t require.TestingT) {
+		resp, err := client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
+			Id: a.daprd.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method:        "ping",
+				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_GET},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "pong", string(resp.GetData().GetValue()))
+	}
+
+	invoke(t)
+
+	a.listener.SetStall(time.Second * 2)
+	a.listener.CloseAccepted()
+
+	invoke(t)
+
+	assert.False(t, a.logs.Contains("error reading server preface"),
+		"app connection was closed mid handshake")
+}


### PR DESCRIPTION
Pub/sub delivery to a gRPC app intermittently failed before the app saw the message, with:

```
  error returned from app while processing pub/sub event <id>: retriable
  error occurred: rpc error: code = Unavailable desc = connection error:
  desc = "error reading server preface: read tcp ...: use of closed
  network connection"
```

daprd dialed the app with a MinConnectTimeout of one second. In gRPC that is the budget for an entire connection attempt, covering the TCP connect and the HTTP/2 handshake, not just the TCP connect. When it expires gRPC hard-closes the socket, so a request already riding on that connection fails while reading the server preface.

Up to 1.17 this was almost never reachable: daprd held a single app connection for the lifetime of the process and only dialed at startup. Since #9492 the app connection lives in the same pool used for sidecar-to-sidecar connections, so connections are established on demand while messages are being delivered, and each new one had one second to complete its handshake.

The pool made this more frequent than it needed to be. It keeps one warm connection to the app, but once that connection had been idle longer than the pool's idle window it was neither handed out again (treated as expired) nor closed (it was the connection being kept warm). It sat in the pool unusable and open, so every request after an idle period dialed a new connection instead of reusing the warm one.

Give a connection attempt to the app gRPC's default 20 second budget, matching what daprd already used for sidecar-to-sidecar connections, and stop expiring out connections the pool holds to satisfy its warm connection minimum. This does not change how long a request waits for an unreachable app: a refused connection still fails immediately, and the wait remains governed by the caller's context and resiliency policy.

Fixes #10335