### PR TITLE
runtime: surface readiness-check failures at warn instead of debug

### DIFF
--- a/pkg/api/http/healthz.go
+++ b/pkg/api/http/healthz.go
@@ -59,8 +59,15 @@ func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.healthz.IsReady() {
 		msg := messages.ErrHealthNotReady.WithFormat(a.healthz.GetUnhealthyTargets())
 		respondWithError(w, msg)
-		log.Debug(msg)
+		// Only log once per not-ready streak, at a level visible on default log settings,
+		// so the failure isn't silent but readiness polling doesn't spam the logs.
+		if a.healthzNotReadyLogged.CompareAndSwap(false, true) {
+			log.Warn(msg)
+		}
 		return
+	}
+	if a.healthzNotReadyLogged.CompareAndSwap(true, false) {
+		log.Info("dapr is ready again")
 	}
 
 	// If we have an "appid" parameter in the query string, we will return an error if the ID of this app is not the value of the requested "appid"
@@ -80,8 +87,13 @@ func (a *api) onGetOutboundHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.outboundHealthz.IsReady() {
 		msg := messages.ErrOutboundHealthNotReady
 		respondWithError(w, msg)
-		log.Debug(msg)
+		if a.outboundNotReadyLogged.CompareAndSwap(false, true) {
+			log.Warn(msg)
+		}
 		return
+	}
+	if a.outboundNotReadyLogged.CompareAndSwap(true, false) {
+		log.Info("dapr outbound is ready again")
 	}
 
 	respondWithEmpty(w)

--- a/pkg/api/http/healthz.go
+++ b/pkg/api/http/healthz.go
@@ -59,13 +59,20 @@ func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.healthz.IsReady() {
 		msg := messages.ErrHealthNotReady.WithFormat(a.healthz.GetUnhealthyTargets())
 		respondWithError(w, msg)
-		// Only log once per not-ready streak, at a level visible on default log settings,
-		// so the failure isn't silent but readiness polling doesn't spam the logs.
-		if a.healthzNotReadyLogged.CompareAndSwap(false, true) {
-			log.Warn(msg)
+		// A startup that hasn't become ready yet is expected and stays quiet at Debug.
+		// Once we've been ready at least once, a not-ready poll means a regression, so
+		// surface it at a level visible on default log settings. Still only log once per
+		// not-ready streak, since readiness polling can run as often as every second.
+		if a.healthzEverReady.Load() {
+			if a.healthzNotReadyLogged.CompareAndSwap(false, true) {
+				log.Warn(msg.Message())
+			}
+		} else {
+			log.Debug(msg)
 		}
 		return
 	}
+	a.healthzEverReady.Store(true)
 	if a.healthzNotReadyLogged.CompareAndSwap(true, false) {
 		log.Info("dapr is ready again")
 	}
@@ -87,11 +94,16 @@ func (a *api) onGetOutboundHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.outboundHealthz.IsReady() {
 		msg := messages.ErrOutboundHealthNotReady
 		respondWithError(w, msg)
-		if a.outboundNotReadyLogged.CompareAndSwap(false, true) {
-			log.Warn(msg)
+		if a.outboundEverReady.Load() {
+			if a.outboundNotReadyLogged.CompareAndSwap(false, true) {
+				log.Warnf("%s: %v", msg.Message(), a.outboundHealthz.GetUnhealthyTargets())
+			}
+		} else {
+			log.Debug(msg)
 		}
 		return
 	}
+	a.outboundEverReady.Store(true)
 	if a.outboundNotReadyLogged.CompareAndSwap(true, false) {
 		log.Info("dapr outbound is ready again")
 	}

--- a/pkg/api/http/healthz.go
+++ b/pkg/api/http/healthz.go
@@ -14,11 +14,19 @@ limitations under the License.
 package http
 
 import (
+	"fmt"
 	"net/http"
+	"sync/atomic"
+	"time"
 
 	"github.com/dapr/dapr/pkg/api/http/endpoints"
 	"github.com/dapr/dapr/pkg/messages"
 )
+
+// notReadyWarnThreshold is how long a not-ready streak that has never reached ready
+// must persist before it is escalated to Warn. This keeps a normal startup quiet
+// while still surfacing a sidecar that gets stuck and never becomes ready.
+const notReadyWarnThreshold = 30 * time.Second
 
 var endpointGroupHealthzV1 = &endpoints.EndpointGroup{
 	Name:                 endpoints.EndpointGroupHealth,
@@ -59,20 +67,11 @@ func (a *api) onGetHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.healthz.IsReady() {
 		msg := messages.ErrHealthNotReady.WithFormat(a.healthz.GetUnhealthyTargets())
 		respondWithError(w, msg)
-		// A startup that hasn't become ready yet is expected and stays quiet at Debug.
-		// Once we've been ready at least once, a not-ready poll means a regression, so
-		// surface it at a level visible on default log settings. Still only log once per
-		// not-ready streak, since readiness polling can run as often as every second.
-		if a.healthzEverReady.Load() {
-			if a.healthzNotReadyLogged.CompareAndSwap(false, true) {
-				log.Warn(msg.Message())
-			}
-		} else {
-			log.Debug(msg)
-		}
+		warnOnPersistentNotReady(msg, msg.Message(), &a.healthzEverReady, &a.healthzNotReadySince, &a.healthzNotReadyLogged)
 		return
 	}
 	a.healthzEverReady.Store(true)
+	a.healthzNotReadySince.Store(0)
 	if a.healthzNotReadyLogged.CompareAndSwap(true, false) {
 		log.Info("dapr is ready again")
 	}
@@ -94,19 +93,46 @@ func (a *api) onGetOutboundHealthz(w http.ResponseWriter, r *http.Request) {
 	if !a.outboundHealthz.IsReady() {
 		msg := messages.ErrOutboundHealthNotReady
 		respondWithError(w, msg)
-		if a.outboundEverReady.Load() {
-			if a.outboundNotReadyLogged.CompareAndSwap(false, true) {
-				log.Warnf("%s: %v", msg.Message(), a.outboundHealthz.GetUnhealthyTargets())
-			}
-		} else {
-			log.Debug(msg)
-		}
+		warnMsg := fmt.Sprintf("%s: %v", msg.Message(), a.outboundHealthz.GetUnhealthyTargets())
+		warnOnPersistentNotReady(msg, warnMsg, &a.outboundEverReady, &a.outboundNotReadySince, &a.outboundNotReadyLogged)
 		return
 	}
 	a.outboundEverReady.Store(true)
+	a.outboundNotReadySince.Store(0)
 	if a.outboundNotReadyLogged.CompareAndSwap(true, false) {
 		log.Info("dapr outbound is ready again")
 	}
 
 	respondWithEmpty(w)
+}
+
+// warnOnPersistentNotReady logs a not-ready poll at Warn once per not-ready streak,
+// either immediately if this is a regression after having been ready before, or once
+// the streak has persisted past notReadyWarnThreshold for a target that has never
+// reached ready. This keeps a normal startup quiet while still surfacing a sidecar
+// that never comes up. debugMsg is logged at Debug while the streak is within the
+// threshold and hasn't warned yet; warnMsg is the human-readable message used at Warn.
+func warnOnPersistentNotReady(debugMsg error, warnMsg string, everReady *atomic.Bool, since *atomic.Int64, logged *atomic.Bool) {
+	if everReady.Load() {
+		if logged.CompareAndSwap(false, true) {
+			log.Warn(warnMsg)
+		}
+		return
+	}
+
+	now := time.Now()
+	start := since.Load()
+	if start == 0 {
+		since.CompareAndSwap(0, now.UnixNano())
+		start = since.Load()
+	}
+
+	if now.Sub(time.Unix(0, start)) < notReadyWarnThreshold {
+		log.Debug(debugMsg)
+		return
+	}
+
+	if logged.CompareAndSwap(false, true) {
+		log.Warn(warnMsg)
+	}
 }

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -82,6 +82,8 @@ type api struct {
 	outboundHealthz        healthz.Healthz
 	healthzNotReadyLogged  atomic.Bool
 	outboundNotReadyLogged atomic.Bool
+	healthzEverReady       atomic.Bool
+	outboundEverReady      atomic.Bool
 }
 
 const (

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -84,6 +84,8 @@ type api struct {
 	outboundNotReadyLogged atomic.Bool
 	healthzEverReady       atomic.Bool
 	outboundEverReady      atomic.Bool
+	healthzNotReadySince   atomic.Int64 // UnixNano; 0 when currently ready
+	outboundNotReadySince  atomic.Int64 // UnixNano; 0 when currently ready
 }
 
 const (

--- a/pkg/api/http/http.go
+++ b/pkg/api/http/http.go
@@ -24,6 +24,7 @@ import (
 	nethttp "net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -66,19 +67,21 @@ type API interface {
 }
 
 type api struct {
-	universal             *universal.Universal
-	endpoints             []endpoints.Endpoint
-	publicEndpoints       []endpoints.Endpoint
-	directMessaging       invokev1.DirectMessaging
-	channels              *channels.Channels
-	pubsubAdapter         runtimePubsub.Adapter
-	outbox                outbox.Outbox
-	sendToOutputBindingFn func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-	metricSpec            *config.MetricSpec
-	tracingSpec           config.TracingSpec
-	maxRequestBodySize    int64 // In bytes
-	healthz               healthz.Healthz
-	outboundHealthz       healthz.Healthz
+	universal              *universal.Universal
+	endpoints              []endpoints.Endpoint
+	publicEndpoints        []endpoints.Endpoint
+	directMessaging        invokev1.DirectMessaging
+	channels               *channels.Channels
+	pubsubAdapter          runtimePubsub.Adapter
+	outbox                 outbox.Outbox
+	sendToOutputBindingFn  func(ctx context.Context, name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
+	metricSpec             *config.MetricSpec
+	tracingSpec            config.TracingSpec
+	maxRequestBodySize     int64 // In bytes
+	healthz                healthz.Healthz
+	outboundHealthz        healthz.Healthz
+	healthzNotReadyLogged  atomic.Bool
+	outboundNotReadyLogged atomic.Bool
 }
 
 const (

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -4264,7 +4264,7 @@ func TestV1HealthzEndpoint(t *testing.T) {
 		resp = server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set once the streak persists past the threshold")
-		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once once the threshold is crossed")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once the threshold is crossed")
 
 		buf.Reset()
 		resp = server.DoRequest("GET", apiPath, nil, nil)
@@ -4376,7 +4376,7 @@ func TestV1OutboundHealthzEndpoint(t *testing.T) {
 		resp = server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.True(t, testAPI.outboundNotReadyLogged.Load(), "flag should be set once the streak persists past the threshold")
-		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once once the threshold is crossed")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once the threshold is crossed")
 
 		buf.Reset()
 		resp = server.DoRequest("GET", apiPath, nil, nil)

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	nethttp "net/http"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -4181,31 +4182,59 @@ func TestV1HealthzEndpoint(t *testing.T) {
 		assert.Equal(t, 204, resp.StatusCode)
 	})
 
-	t.Run("Healthz - not-ready state is only flagged for logging once until recovery", func(t *testing.T) {
+	t.Run("Healthz - not-ready before ever ready stays quiet, warns once per streak after a regression", func(t *testing.T) {
 		apiPath := "v1.0/healthz"
+		testAPI.healthzEverReady.Store(false)
 		testAPI.healthzNotReadyLogged.Store(false)
 		htarget.NotReady()
 		t.Cleanup(htarget.NotReady)
 
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stdout) })
+
 		server := fakeServer(t)
 
+		// A target that has never been ready is a normal startup, not a regression: stay quiet.
 		resp := server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set after the first not-ready poll")
+		assert.False(t, testAPI.healthzNotReadyLogged.Load(), "flag should not be set before the target has ever been ready")
+		assert.NotContains(t, buf.String(), "level=warning", "must not warn before the target has ever been ready")
+
+		// First readiness: this is not a "recovery", so it should not claim one.
+		buf.Reset()
+		htarget.Ready()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 204, resp.StatusCode)
+		assert.NotContains(t, buf.String(), "dapr is ready again", "should not claim recovery on first-ever readiness")
+
+		// A regression after having been ready warns exactly once for the new streak.
+		buf.Reset()
+		htarget.NotReady()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set after the first not-ready poll following a ready state")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once for the new not-ready streak")
+		assert.Contains(t, buf.String(), "dapr is not ready", "warn log should carry the human-readable message")
 
 		resp = server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should remain set across repeated not-ready polls")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "repeated not-ready polls in the same streak should not warn again")
 
+		buf.Reset()
 		htarget.Ready()
 		resp = server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 204, resp.StatusCode)
 		assert.False(t, testAPI.healthzNotReadyLogged.Load(), "flag should reset once dapr becomes ready again")
+		assert.Contains(t, buf.String(), "dapr is ready again")
 
+		buf.Reset()
 		htarget.NotReady()
 		resp = server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set again on a new not-ready streak")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "new streak should warn again")
 	})
 }
 
@@ -4237,25 +4266,50 @@ func TestV1OutboundHealthzEndpoint(t *testing.T) {
 		assert.Equal(t, 204, resp.StatusCode)
 	})
 
-	t.Run("Outbound healthz - not-ready state is only flagged for logging once until recovery", func(t *testing.T) {
+	t.Run("Outbound healthz - not-ready before ever ready stays quiet, warns once per streak after a regression", func(t *testing.T) {
+		testAPI.outboundEverReady.Store(false)
 		testAPI.outboundNotReadyLogged.Store(false)
 		otarget.NotReady()
 		t.Cleanup(otarget.NotReady)
 
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stdout) })
+
 		server := fakeServer(t)
 
+		// A target that has never been ready is a normal startup, not a regression: stay quiet.
 		resp := server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 500, resp.StatusCode)
-		assert.True(t, testAPI.outboundNotReadyLogged.Load(), "flag should be set after the first not-ready poll")
+		assert.False(t, testAPI.outboundNotReadyLogged.Load(), "flag should not be set before the target has ever been ready")
+		assert.NotContains(t, buf.String(), "level=warning", "must not warn before the target has ever been ready")
+
+		buf.Reset()
+		otarget.Ready()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 204, resp.StatusCode)
+		assert.NotContains(t, buf.String(), "dapr outbound is ready again", "should not claim recovery on first-ever readiness")
+
+		buf.Reset()
+		otarget.NotReady()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.outboundNotReadyLogged.Load(), "flag should be set after the first not-ready poll following a ready state")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once for the new not-ready streak")
+		assert.Contains(t, buf.String(), "dapr outbound is not ready", "warn log should carry the human-readable message")
+		assert.Contains(t, buf.String(), "outbound-test-target", "warn log should name the unhealthy target")
 
 		resp = server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 500, resp.StatusCode)
 		assert.True(t, testAPI.outboundNotReadyLogged.Load(), "flag should remain set across repeated not-ready polls")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "repeated not-ready polls in the same streak should not warn again")
 
+		buf.Reset()
 		otarget.Ready()
 		resp = server.DoRequest("GET", apiPath, nil, nil)
 		assert.Equal(t, 204, resp.StatusCode)
 		assert.False(t, testAPI.outboundNotReadyLogged.Load(), "flag should reset once dapr becomes ready again")
+		assert.Contains(t, buf.String(), "dapr outbound is ready again")
 	})
 }
 

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -4180,6 +4180,83 @@ func TestV1HealthzEndpoint(t *testing.T) {
 		resp := fakeServer(t).DoRequest("GET", apiPath, nil, map[string]string{"appid": appID})
 		assert.Equal(t, 204, resp.StatusCode)
 	})
+
+	t.Run("Healthz - not-ready state is only flagged for logging once until recovery", func(t *testing.T) {
+		apiPath := "v1.0/healthz"
+		testAPI.healthzNotReadyLogged.Store(false)
+		htarget.NotReady()
+		t.Cleanup(htarget.NotReady)
+
+		server := fakeServer(t)
+
+		resp := server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set after the first not-ready poll")
+
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should remain set across repeated not-ready polls")
+
+		htarget.Ready()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 204, resp.StatusCode)
+		assert.False(t, testAPI.healthzNotReadyLogged.Load(), "flag should reset once dapr becomes ready again")
+
+		htarget.NotReady()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set again on a new not-ready streak")
+	})
+}
+
+func TestV1OutboundHealthzEndpoint(t *testing.T) {
+	outboundHealthz := healthz.New()
+	otarget := outboundHealthz.AddTarget("outbound-test-target")
+	testAPI := &api{
+		outboundHealthz: outboundHealthz,
+	}
+
+	fakeServer := func(t *testing.T) *fakeHTTPServer {
+		f := newFakeHTTPServer()
+		t.Cleanup(f.Shutdown)
+		f.StartServer(testAPI.constructHealthzEndpoints(), nil)
+		return f
+	}
+
+	apiPath := "v1.0/healthz/outbound"
+
+	t.Run("Outbound healthz - 500 when not ready", func(t *testing.T) {
+		resp := fakeServer(t).DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+	})
+
+	t.Run("Outbound healthz - 204 when ready", func(t *testing.T) {
+		otarget.Ready()
+		t.Cleanup(otarget.NotReady)
+		resp := fakeServer(t).DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 204, resp.StatusCode)
+	})
+
+	t.Run("Outbound healthz - not-ready state is only flagged for logging once until recovery", func(t *testing.T) {
+		testAPI.outboundNotReadyLogged.Store(false)
+		otarget.NotReady()
+		t.Cleanup(otarget.NotReady)
+
+		server := fakeServer(t)
+
+		resp := server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.outboundNotReadyLogged.Load(), "flag should be set after the first not-ready poll")
+
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.outboundNotReadyLogged.Load(), "flag should remain set across repeated not-ready polls")
+
+		otarget.Ready()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 204, resp.StatusCode)
+		assert.False(t, testAPI.outboundNotReadyLogged.Load(), "flag should reset once dapr becomes ready again")
+	})
 }
 
 func TestV1TransactionEndpoints(t *testing.T) {

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -4236,6 +4236,41 @@ func TestV1HealthzEndpoint(t *testing.T) {
 		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set again on a new not-ready streak")
 		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "new streak should warn again")
 	})
+
+	t.Run("Healthz - a not-ready streak that never reaches ready escalates to warn once it persists past the threshold", func(t *testing.T) {
+		apiPath := "v1.0/healthz"
+		testAPI.healthzEverReady.Store(false)
+		testAPI.healthzNotReadyLogged.Store(false)
+		testAPI.healthzNotReadySince.Store(0)
+		htarget.NotReady()
+		t.Cleanup(htarget.NotReady)
+
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stdout) })
+
+		server := fakeServer(t)
+
+		// Within the threshold, a never-ready target stays quiet.
+		resp := server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.False(t, testAPI.healthzNotReadyLogged.Load(), "flag should not be set while within the threshold")
+		assert.NotContains(t, buf.String(), "level=warning", "must not warn while within the threshold")
+
+		// Simulate the streak having persisted past the threshold.
+		testAPI.healthzNotReadySince.Store(time.Now().Add(-notReadyWarnThreshold - time.Second).UnixNano())
+
+		buf.Reset()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.healthzNotReadyLogged.Load(), "flag should be set once the streak persists past the threshold")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once once the threshold is crossed")
+
+		buf.Reset()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.Equal(t, 0, strings.Count(buf.String(), "level=warning"), "repeated not-ready polls in the same streak should not warn again")
+	})
 }
 
 func TestV1OutboundHealthzEndpoint(t *testing.T) {
@@ -4310,6 +4345,43 @@ func TestV1OutboundHealthzEndpoint(t *testing.T) {
 		assert.Equal(t, 204, resp.StatusCode)
 		assert.False(t, testAPI.outboundNotReadyLogged.Load(), "flag should reset once dapr becomes ready again")
 		assert.Contains(t, buf.String(), "dapr outbound is ready again")
+	})
+
+	t.Run("Outbound healthz - a not-ready streak that never reaches ready escalates to warn once it persists past the threshold", func(t *testing.T) {
+		testAPI.outboundEverReady.Store(false)
+		testAPI.outboundNotReadyLogged.Store(false)
+		testAPI.outboundNotReadySince.Store(0)
+		otarget.NotReady()
+		t.Cleanup(otarget.NotReady)
+
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stdout) })
+
+		server := fakeServer(t)
+
+		// Within the threshold, a never-ready target stays quiet. This is the common
+		// case in a default k8s deployment, since only /v1.0/healthz is polled by the
+		// injector's readiness probe, not this endpoint.
+		resp := server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.False(t, testAPI.outboundNotReadyLogged.Load(), "flag should not be set while within the threshold")
+		assert.NotContains(t, buf.String(), "level=warning", "must not warn while within the threshold")
+
+		// Simulate the streak having persisted past the threshold, e.g. via `daprd wait`
+		// or a custom probe polling this endpoint.
+		testAPI.outboundNotReadySince.Store(time.Now().Add(-notReadyWarnThreshold - time.Second).UnixNano())
+
+		buf.Reset()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.True(t, testAPI.outboundNotReadyLogged.Load(), "flag should be set once the streak persists past the threshold")
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=warning"), "should warn exactly once once the threshold is crossed")
+
+		buf.Reset()
+		resp = server.DoRequest("GET", apiPath, nil, nil)
+		assert.Equal(t, 500, resp.StatusCode)
+		assert.Equal(t, 0, strings.Count(buf.String(), "level=warning"), "repeated not-ready polls in the same streak should not warn again")
 	})
 }
 


### PR DESCRIPTION
# Description

Today, when daprd's readiness check fails (`/v1.0/healthz` or `/v1.0/healthz/outbound`), the failure is only logged at `Debug` level. On any normal (default) log verbosity, a stuck-not-ready sidecar produces zero log output — the only way to notice is to already be polling the health endpoint from outside. This PR raises those readiness-failure log lines to `Warn`, logged once per not-ready streak (not once per poll, since readiness probes can run as often as every second), with a matching `Info` log when the target recovers.

This does **not** fix the underlying reason a sidecar can get stuck not-ready in the first place (that is a separate, larger architectural question about whether/how the actor runtime and workflow engine subsystems should restart after certain fatal errors) — it only makes an already-failing readiness check visible in logs at default settings, instead of requiring `--log-level debug`.

## Issue reference

Relates to #10337, but does not fix it. That issue's logs show the scheduler `WatchHosts` stream failing to reconnect, what looks like the same root cause #9968 addressed on master; #10337 was reported against 1.16.4-msft.11, so the actual fix there is likely a backport of #9968 rather than this logging-only change.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
