### PR TITLE
Fix devcontainer image rebuild trigger

### DIFF
--- a/.github/workflows/dapr-dev-container.yml
+++ b/.github/workflows/dapr-dev-container.yml
@@ -15,6 +15,22 @@ name: dapr-dev-container
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
+      - release-*
+    paths:
+      - '.github/workflows/dapr-dev-container.yml'
+      - 'docker/**'
+      - '.devcontainer/**'
+  pull_request:
+    branches:
+      - master
+      - release-*
+    paths:
+      - '.github/workflows/dapr-dev-container.yml'
+      - 'docker/**'
+      - '.devcontainer/**'
   schedule:
     # Run weekly on Tuesdays
     - cron: "22 03 * * 2"

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -2,7 +2,7 @@
 
 # [Choice] Go version: 1, 1.26.5, etc
 ARG GOVERSION=1.26.5
-FROM golang:${GOVERSION}-bullseye
+FROM golang:${GOVERSION}-bookworm
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"


### PR DESCRIPTION
## Description

Updated the devcontainer publishing workflow to automatically run on changes to the devcontainer configuration, Docker files, or the workflow itself. This ensures the published devcontainer image is rebuilt when relevant changes are made and prevents the image from becoming stale.

## Issue reference

Please reference the issue this PR will close: #10313
