### PR TITLE
scheduler: retry client creation instead of fatal exit

### DIFF
--- a/cmd/scheduler/app/app.go
+++ b/cmd/scheduler/app/app.go
@@ -16,8 +16,10 @@ package app
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/dapr/dapr/cmd/scheduler/options"
+	wfcommon "github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	"github.com/dapr/dapr/pkg/buildinfo"
 	"github.com/dapr/dapr/pkg/healthz"
 	healthzserver "github.com/dapr/dapr/pkg/healthz/server"
@@ -149,20 +151,9 @@ func Run() {
 				return server, nil
 			}
 
-			for {
-				server, gerr := getServer()
-				if gerr != nil {
-					return gerr
-				}
-
-				if gerr = server.Run(ctx); gerr != nil {
-					return gerr
-				}
-
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-			}
+			return runServerLoop(ctx, func() (serverRunner, error) {
+				return getServer()
+			})
 		},
 	).Run(ctx)
 	if err != nil {
@@ -170,4 +161,53 @@ func Run() {
 	}
 
 	log.Info("Scheduler service shut down gracefully")
+}
+
+// serverRunner is the subset of *server.Server that runServerLoop drives.
+type serverRunner interface {
+	Run(ctx context.Context) error
+}
+
+const (
+	// serverRetryBackoffBase and serverRetryBackoffCap bound the jittered
+	// backoff between scheduler server incarnations after a runtime failure.
+	serverRetryBackoffBase = 500 * time.Millisecond
+	serverRetryBackoffCap  = 10 * time.Second
+)
+
+// runServerLoop runs scheduler server incarnations until ctx is cancelled. A
+// server that stops with a runtime error (for example the backing store
+// becoming unavailable) is recreated after a jittered backoff instead of
+// crashing the process: a transient dependency blip must not be fatal to an
+// HA fleet, whose members would otherwise all crash-restart together.
+// Healthz reports not-ready between incarnations, so orchestration still
+// observes the outage. Errors from getServer are configuration failures and
+// remain fatal.
+func runServerLoop(ctx context.Context, getServer func() (serverRunner, error)) error {
+	backoff := wfcommon.NewJitterBackoff(serverRetryBackoffBase, serverRetryBackoffCap)
+	for {
+		server, err := getServer()
+		if err != nil {
+			return err
+		}
+
+		err = server.Run(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err == nil {
+			// A nil return with a live context is a server-requested restart:
+			// recreate immediately and reset the failure backoff.
+			backoff.Reset()
+			continue
+		}
+
+		delay := backoff.NextBackOff()
+		log.Errorf("Scheduler server failed, recreating in %s: %s", delay, err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
 }

--- a/cmd/scheduler/app/app.go
+++ b/cmd/scheduler/app/app.go
@@ -82,7 +82,23 @@ func Run() {
 		log.Fatal(err)
 	}
 
-	err = concurrency.NewRunnerManager(
+	// The controller is long-lived and runs at the top level, not inside a
+	// server incarnation: controller-runtime managers cannot be restarted, so
+	// the recreate loop below must not tear it down with a failed server. It
+	// follows each incarnation's cron via SetCron.
+	var ctrl *server.Controller
+	if modes.DaprMode(opts.Mode) == modes.KubernetesMode {
+		var cerr error
+		ctrl, cerr = server.NewController(server.ControllerOptions{
+			KubeConfig: opts.KubeConfig,
+			Healthz:    healthz,
+		})
+		if cerr != nil {
+			log.Fatalf("Fatal error creating scheduler controller: %v", cerr)
+		}
+	}
+
+	runners := []concurrency.Runner{
 		healthzserver.New(healthzserver.Options{
 			Log:     log,
 			Port:    opts.HealthzPort,
@@ -94,17 +110,6 @@ func Run() {
 			secHandler, serr := secProvider.Handler(ctx)
 			if serr != nil {
 				return serr
-			}
-			var ctrl *server.Controller
-			if modes.DaprMode(opts.Mode) == modes.KubernetesMode {
-				var cerr error
-				ctrl, cerr = server.NewController(server.ControllerOptions{
-					KubeConfig: opts.KubeConfig,
-					Healthz:    healthz,
-				})
-				if cerr != nil {
-					return cerr
-				}
 			}
 
 			getServer := func() (*server.Server, error) {
@@ -155,7 +160,12 @@ func Run() {
 				return getServer()
 			})
 		},
-	).Run(ctx)
+	}
+	if ctrl != nil {
+		runners = append(runners, ctrl.Run)
+	}
+
+	err = concurrency.NewRunnerManager(runners...).Run(ctx)
 	if err != nil {
 		log.Fatalf("Fatal error running scheduler: %v", err)
 	}

--- a/cmd/scheduler/app/app.go
+++ b/cmd/scheduler/app/app.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/dapr/dapr/cmd/scheduler/options"
-	wfcommon "github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	"github.com/dapr/dapr/pkg/backoff"
 	"github.com/dapr/dapr/pkg/buildinfo"
 	"github.com/dapr/dapr/pkg/healthz"
 	healthzserver "github.com/dapr/dapr/pkg/healthz/server"
@@ -184,8 +184,14 @@ const (
 // observes the outage. Errors from getServer are configuration failures and
 // remain fatal.
 func runServerLoop(ctx context.Context, getServer func() (serverRunner, error)) error {
-	backoff := wfcommon.NewJitterBackoff(serverRetryBackoffBase, serverRetryBackoffCap)
+	retryBackoff := backoff.NewJitter(serverRetryBackoffBase, serverRetryBackoffCap)
 	for {
+		// A shutdown signal can land between iterations: do not construct a
+		// fresh server just to tear it down.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		server, err := getServer()
 		if err != nil {
 			return err
@@ -198,16 +204,18 @@ func runServerLoop(ctx context.Context, getServer func() (serverRunner, error)) 
 		if err == nil {
 			// A nil return with a live context is a server-requested restart:
 			// recreate immediately and reset the failure backoff.
-			backoff.Reset()
+			retryBackoff.Reset()
 			continue
 		}
 
-		delay := backoff.NextBackOff()
+		delay := retryBackoff.NextBackOff()
 		log.Errorf("Scheduler server failed, recreating in %s: %s", delay, err)
+		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
-		case <-time.After(delay):
+		case <-timer.C:
 		}
 	}
 }

--- a/cmd/scheduler/app/app_test.go
+++ b/cmd/scheduler/app/app_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeServer struct {
+	run func(ctx context.Context) error
+}
+
+func (f *fakeServer) Run(ctx context.Context) error {
+	return f.run(ctx)
+}
+
+func Test_runServerLoop(t *testing.T) {
+	t.Parallel()
+
+	t.Run("getServer error is fatal", func(t *testing.T) {
+		t.Parallel()
+
+		fatal := errors.New("bad config")
+		err := runServerLoop(t.Context(), func() (serverRunner, error) {
+			return nil, fatal
+		})
+		require.ErrorIs(t, err, fatal)
+	})
+
+	t.Run("runtime failures are retried until the server recovers", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var runs int
+		recovered := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			done <- runServerLoop(ctx, func() (serverRunner, error) {
+				return &fakeServer{run: func(ctx context.Context) error {
+					runs++
+					if runs < 3 {
+						return errors.New("connecting to embedded etcd: no route to host")
+					}
+					close(recovered)
+					<-ctx.Done()
+					return ctx.Err()
+				}}, nil
+			})
+		}()
+
+		select {
+		case <-recovered:
+		case err := <-done:
+			t.Fatalf("loop exited instead of retrying: %v", err)
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for the server to recover")
+		}
+		assert.Equal(t, 3, runs)
+
+		cancel()
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the loop to stop")
+		}
+	})
+
+	t.Run("context cancellation stops the retry backoff wait", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		failing := make(chan struct{}, 1)
+		done := make(chan error, 1)
+		go func() {
+			done <- runServerLoop(ctx, func() (serverRunner, error) {
+				return &fakeServer{run: func(context.Context) error {
+					select {
+					case failing <- struct{}{}:
+					default:
+					}
+					return errors.New("still down")
+				}}, nil
+			})
+		}()
+
+		select {
+		case <-failing:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the first failure")
+		}
+		cancel()
+
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the loop to stop after cancellation")
+		}
+	})
+
+	t.Run("nil run result recreates the server without backoff", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		var runs int
+		done := make(chan error, 1)
+		go func() {
+			done <- runServerLoop(ctx, func() (serverRunner, error) {
+				return &fakeServer{run: func(ctx context.Context) error {
+					runs++
+					if runs < 3 {
+						return nil
+					}
+					cancel()
+					return ctx.Err()
+				}}, nil
+			})
+		}()
+
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the loop to stop")
+		}
+		assert.Equal(t, 3, runs)
+	})
+}

--- a/pkg/actors/targets/workflow/common/backoff.go
+++ b/pkg/actors/targets/workflow/common/backoff.go
@@ -19,6 +19,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/dapr/dapr/pkg/backoff"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 )
 
@@ -29,35 +30,12 @@ const (
 	RetryBackoffCap  = 2 * time.Second
 )
 
-// JitterBackoff is decorrelated exponential jitter (next = uniform(base,
-// min(cap, prev*3))): under overload, concurrent retries spread out instead of
-// re-colliding on a fixed interval.
-type JitterBackoff struct {
-	base time.Duration
-	cap  time.Duration
-	prev time.Duration
-}
+// JitterBackoff is the decorrelated exponential jitter from pkg/backoff,
+// aliased here for the workflow-internal call sites.
+type JitterBackoff = backoff.Jitter
 
 func NewJitterBackoff(base, cap time.Duration) *JitterBackoff {
-	return &JitterBackoff{
-		base: base,
-		cap:  cap,
-		prev: base,
-	}
-}
-
-func (j *JitterBackoff) Reset() {
-	j.prev = j.base
-}
-
-func (j *JitterBackoff) NextBackOff() time.Duration {
-	hi := min(j.prev*3, j.cap)
-	next := j.base
-	if hi > j.base {
-		next += rand.N(hi - j.base) //nolint:gosec // retry jitter, not security sensitive
-	}
-	j.prev = next
-	return next
+	return backoff.NewJitter(base, cap)
 }
 
 // RetryForeverPolicy returns the failure policy for one-shot workflow

--- a/pkg/backoff/jitter.go
+++ b/pkg/backoff/jitter.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// Jitter is decorrelated exponential jitter (next = uniform(base, min(cap,
+// prev*3))): under overload, concurrent retries spread out instead of
+// re-colliding on a fixed interval.
+type Jitter struct {
+	base time.Duration
+	cap  time.Duration
+	prev time.Duration
+}
+
+func NewJitter(base, cap time.Duration) *Jitter {
+	return &Jitter{
+		base: base,
+		cap:  cap,
+		prev: base,
+	}
+}
+
+func (j *Jitter) Reset() {
+	j.prev = j.base
+}
+
+func (j *Jitter) NextBackOff() time.Duration {
+	hi := min(j.prev*3, j.cap)
+	next := j.base
+	if hi > j.base {
+		next += rand.N(hi - j.base) //nolint:gosec // retry jitter, not security sensitive
+	}
+	j.prev = next
+	return next
+}

--- a/pkg/backoff/jitter_test.go
+++ b/pkg/backoff/jitter_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Jitter(t *testing.T) {
+	t.Parallel()
+
+	const (
+		base = 50 * time.Millisecond
+		cap  = 2 * time.Second
+	)
+
+	j := NewJitter(base, cap)
+
+	prev := base
+	for range 100 {
+		d := j.NextBackOff()
+		assert.GreaterOrEqual(t, d, base)
+		assert.Less(t, d, cap)
+		// Decorrelated growth: each draw is bounded by three times the
+		// previous draw (capped), never more.
+		assert.Less(t, d, min(prev*3, cap)+1)
+		prev = d
+	}
+
+	j.Reset()
+	first := j.NextBackOff()
+	assert.GreaterOrEqual(t, first, base)
+	assert.Less(t, first, 3*base)
+}

--- a/pkg/scheduler/server/server.go
+++ b/pkg/scheduler/server/server.go
@@ -100,7 +100,6 @@ type Server struct {
 	serializer *serialize.Serializer
 	cron       cron.Interface
 	etcd       etcd.Interface
-	controller *controller.Controller
 
 	hzAPIServer healthz.Target
 
@@ -176,7 +175,6 @@ func New(ctx context.Context, opts Options) (*Server, error) {
 		port:          opts.Port,
 		listenAddress: opts.ListenAddress,
 		sec:           opts.Security,
-		controller:    opts.Controller,
 		cron:          cron,
 		etcd:          etcdServer,
 		serializer: serialize.New(serialize.Options{
@@ -211,10 +209,6 @@ func (s *Server) Run(ctx context.Context) error {
 			close(s.closeCh)
 			return nil
 		},
-	}
-
-	if s.controller != nil {
-		runners = append(runners, s.controller.Run)
 	}
 
 	if s.etcd != nil {

--- a/tests/integration/framework/process/grpc/operator/operator.go
+++ b/tests/integration/framework/process/grpc/operator/operator.go
@@ -395,6 +395,15 @@ func (o *Operator) SetMCPServers(servers ...mcpserverapi.MCPServer) {
 
 func (o *Operator) MCPServerUpdateEvent(t *testing.T, ctx context.Context, event *MCPServerUpdateEvent) {
 	t.Helper()
+
+	// daprd's watch stream registers asynchronously to its readiness; fanning
+	// out to zero subscribers would silently drop the event.
+	require.Eventually(t, func() bool {
+		o.lock.Lock()
+		defer o.lock.Unlock()
+		return len(o.srvMCPUpdateCh) > 0
+	}, time.Second*10, time.Millisecond*10, "no MCPServerUpdate stream subscribed")
+
 	o.lock.Lock()
 	defer o.lock.Unlock()
 

--- a/tests/integration/suite/scheduler/embed/retry.go
+++ b/tests/integration/suite/scheduler/embed/retry.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package embed
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	schedulerv1 "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(retry))
+}
+
+// retry verifies the scheduler run loop survives a runtime failure of a server
+// incarnation instead of exiting the process.
+type retry struct {
+	scheduler *scheduler.Scheduler
+	logline   *logline.LogLine
+	ln        net.Listener
+	ln6       net.Listener
+}
+
+func (r *retry) Setup(t *testing.T) []framework.Option {
+	fp := ports.Reserve(t, 1)
+	r.ln = fp.Listener(t)
+	port := r.ln.Addr().(*net.TCPAddr).Port
+	if ln6, err := net.Listen("tcp", net.JoinHostPort("::1", strconv.Itoa(port))); err == nil {
+		r.ln6 = ln6
+		t.Cleanup(func() { r.ln6.Close() })
+	}
+
+	r.logline = logline.New(t, logline.WithStdoutLineContains(
+		"Scheduler server failed, recreating in",
+	))
+
+	r.scheduler = scheduler.New(t,
+		scheduler.WithEtcdClientPort(port),
+		scheduler.WithLogLineStdout(r.logline),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.logline, r.scheduler),
+	}
+}
+
+func (r *retry) Run(t *testing.T, ctx context.Context) {
+	r.logline.EventuallyFoundAll(t)
+
+	httpClient := client.HTTP(t)
+	healthzURL := fmt.Sprintf("http://127.0.0.1:%d/healthz", r.scheduler.HealthzPort())
+	for end := time.Now().Add(3 * time.Second); time.Now().Before(end); {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthzURL, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err, "scheduler process must stay alive while etcd cannot bind")
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Release the port: the next incarnation starts etcd and recovers.
+	require.NoError(t, r.ln.Close())
+	if r.ln6 != nil {
+		require.NoError(t, r.ln6.Close())
+	}
+
+	r.scheduler.WaitUntilRunning(t, ctx)
+
+	_, err := r.scheduler.Client(t, ctx).ScheduleJob(ctx, &schedulerv1.ScheduleJobRequest{
+		Name: "test",
+		Job: &schedulerv1.Job{
+			Schedule: new("@every 20s"),
+		},
+		Metadata: &schedulerv1.JobMetadata{
+			AppId:     "appid",
+			Namespace: "namespace",
+			Target: &schedulerv1.JobTargetMetadata{
+				Type: new(schedulerv1.JobTargetMetadata_Job),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, r.scheduler.EtcdJobs(t, ctx), 1)
+}

--- a/tests/integration/suite/scheduler/embed/retry.go
+++ b/tests/integration/suite/scheduler/embed/retry.go
@@ -52,8 +52,12 @@ func (r *retry) Setup(t *testing.T) []framework.Option {
 	port := r.ln.Addr().(*net.TCPAddr).Port
 	if ln6, err := net.Listen("tcp", net.JoinHostPort("::1", strconv.Itoa(port))); err == nil {
 		r.ln6 = ln6
-		t.Cleanup(func() { r.ln6.Close() })
 	}
+	// Release-on-abort: if the test fails before Run reaches the deliberate
+	// release below, the bound port must not leak. closeListeners is
+	// idempotent (fields are nil-ed on close) so the double invocation on the
+	// happy path is a no-op.
+	t.Cleanup(r.closeListeners)
 
 	r.logline = logline.New(t, logline.WithStdoutLineContains(
 		"Scheduler server failed, recreating in",
@@ -66,6 +70,19 @@ func (r *retry) Setup(t *testing.T) []framework.Option {
 
 	return []framework.Option{
 		framework.WithProcesses(r.logline, r.scheduler),
+	}
+}
+
+// closeListeners releases the squatted etcd client port(s). Safe to call
+// more than once.
+func (r *retry) closeListeners() {
+	if r.ln != nil {
+		r.ln.Close()
+		r.ln = nil
+	}
+	if r.ln6 != nil {
+		r.ln6.Close()
+		r.ln6 = nil
 	}
 }
 
@@ -85,10 +102,7 @@ func (r *retry) Run(t *testing.T, ctx context.Context) {
 	}
 
 	// Release the port: the next incarnation starts etcd and recovers.
-	require.NoError(t, r.ln.Close())
-	if r.ln6 != nil {
-		require.NoError(t, r.ln6.Close())
-	}
+	r.closeListeners()
 
 	r.scheduler.WaitUntilRunning(t, ctx)
 

--- a/tests/integration/suite/scheduler/kubernetes/retry.go
+++ b/tests/integration/suite/scheduler/kubernetes/retry.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/ports"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/dapr/utils"
+)
+
+func init() {
+	suite.Register(new(retry))
+}
+
+type retry struct {
+	sentry    *sentry.Sentry
+	scheduler *scheduler.Scheduler
+	kubeapi   *kubernetes.Kubernetes
+	logline   *logline.LogLine
+	ln        net.Listener
+	ln6       net.Listener
+}
+
+func (r *retry) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	tld, err := utils.GetKubeClusterDomain()
+	require.NoError(t, err)
+
+	r.sentry = sentry.New(t,
+		sentry.WithTrustDomain(tld),
+	)
+
+	r.kubeapi = kubernetes.New(t,
+		kubernetes.WithClusterNamespaceList(t, &corev1.NamespaceList{
+			Items: []corev1.Namespace{{
+				TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			}},
+		}),
+	)
+
+	fp := ports.Reserve(t, 1)
+	r.ln = fp.Listener(t)
+	port := r.ln.Addr().(*net.TCPAddr).Port
+	if ln6, lerr := net.Listen("tcp", net.JoinHostPort("::1", strconv.Itoa(port))); lerr == nil {
+		r.ln6 = ln6
+	}
+	t.Cleanup(r.closeListeners)
+
+	r.logline = logline.New(t, logline.WithStdoutLineContains(
+		"Scheduler server failed, recreating in",
+	))
+
+	r.scheduler = scheduler.New(t,
+		scheduler.WithSentry(r.sentry),
+		scheduler.WithKubeconfig(r.kubeapi.KubeconfigPath(t)),
+		scheduler.WithMode("kubernetes"),
+		scheduler.WithID("dapr-scheduler-server-0"),
+		scheduler.WithEtcdClientPort(port),
+		scheduler.WithLogLineStdout(r.logline),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.sentry, r.kubeapi, r.logline, r.scheduler),
+	}
+}
+
+func (r *retry) Run(t *testing.T, ctx context.Context) {
+	r.sentry.WaitUntilRunning(t, ctx)
+	r.logline.EventuallyFoundAll(t)
+
+	r.closeListeners()
+	r.scheduler.WaitUntilRunning(t, ctx)
+
+	client := r.scheduler.ClientMTLS(t, ctx, "myapp")
+	_, err := client.ScheduleJob(ctx, &schedulerv1pb.ScheduleJobRequest{
+		Name: "testJob",
+		Job:  &schedulerv1pb.Job{Schedule: new("@daily")},
+		Metadata: &schedulerv1pb.JobMetadata{
+			AppId:     "myapp",
+			Namespace: "default",
+			Target: &schedulerv1pb.JobTargetMetadata{
+				Type: &schedulerv1pb.JobTargetMetadata_Job{
+					Job: new(schedulerv1pb.TargetJob),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	etcdClient := r.scheduler.ETCDClient(t, ctx).KV
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, gerr := etcdClient.Get(ctx, "dapr/jobs/", clientv3.WithPrefix())
+		require.NoError(c, gerr)
+		assert.Len(c, resp.Kvs, 1)
+	}, time.Second*10, 10*time.Millisecond)
+}
+
+func (r *retry) closeListeners() {
+	if r.ln != nil {
+		r.ln.Close()
+		r.ln = nil
+	}
+	if r.ln6 != nil {
+		r.ln6.Close()
+		r.ln6 = nil
+	}
+}


### PR DESCRIPTION
The scheduler run loop now recreates the server after a jittered backoff (base 500ms, cap 10s) when a server incarnation stops with a runtime error, instead of exiting the process. Context cancellation still stops the loop, and errors from server construction remain fatal (they are configuration failures). Healthz reports not-ready between incarnations, so Kubernetes probes still observe the outage truthfully.

Branched from https://github.com/dapr/dapr/pull/10344