### PR TITLE
actors: survive transient state store outage

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -16,6 +16,7 @@ This update contains the following bug fixes:
 - [Fixes orphaned workflow activity-result reminders retrying forever](#fixes-orphaned-workflow-activity-result-reminders-retrying-forever)
 - [Pub/sub delivery to a gRPC app failing with "use of closed network connection"](#pubsub-delivery-to-a-grpc-app-failing-with-use-of-closed-network-connection)
 - [Azure component authentication halting at the SPIFFE credential instead of falling back](#azure-component-authentication-halting-at-the-spiffe-credential-instead-of-falling-back)
+- [Sidecars unable to restart while the actor state store's database is unavailable](#sidecars-unable-to-restart-while-the-actor-state-stores-database-is-unavailable)
 
 ## Actor state store components cannot be hot reloaded
 

--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -428,3 +428,34 @@ The SPIFFE credential returned a plain error when the context carried no JWT SVI
 
 The SPIFFE credential now reports itself as unavailable when no JWT SVID source is present, before any token request is made, which is exactly what `ChainedTokenCredential` requires to continue to the next credential in the chain.
 Both the default chain and explicitly ordered `azureAuthMethods` lists now fall through as expected, and behavior when a SPIFFE source is configured is unchanged.
+
+## Sidecars unable to restart while the actor state store's database is unavailable
+
+### Problem
+
+A component whose initialization fails is fatal to daprd: the runtime logs `Error processing component, daprd will exit gracefully` and exits.
+That is the intended behaviour for a misconfigured component, but the actor state store's initialization also fails when its backing database is merely unreachable, and the two cases are indistinguishable to the runtime.
+
+A sidecar that starts, or restarts for any reason, while the actor state store's database is down therefore cannot complete boot.
+Under Kubernetes the container is restarted, fails initialization again, and keeps crash-looping until the database returns, instead of waiting for its dependency and coming up when it recovers.
+
+### Impact
+
+The issue impacts users on Dapr 1.18.x-1.18.2 hosting actors or workflows with an actor state store backed by an external database, whenever a sidecar restarts during a database outage.
+Restarts that land in that window are routine: a deployment rollout, a node drain, an eviction, an OOM kill, a failed liveness probe, or the application container restarting.
+
+The effect is a seconds-long dependency blip amplified into a crash-loop that lasts as long as the outage.
+
+Sidecars that do not restart during the outage are not affected by this issue: the actor state store is resolved per call, so they recover on their own once the database returns.
+
+### Root cause
+
+`processComponents` in `pkg/runtime/processor/components.go` treats any non-ignored component initialization failure as terminal and propagates it out of the runtime's `Run`, ending the process.
+Failing fast is the right response to a component that can never work, such as one with an invalid connection string, but the same path is taken when initialization failed only because the component's backing service was momentarily unreachable.
+Nothing distinguishes a permanent configuration error from a transient dependency failure, and nothing retries.
+
+### Solution
+
+A failed initialization of the component marked as the actor state store is now retried with a jittered backoff (500ms base, 10s cap) rather than being recorded as a fatal error.
+Each attempt runs through the normal component initialization path with the same per-attempt timeout, and the caller stays blocked while retrying, so daprd stays alive and keeps reporting not ready for the whole outage.
+Every other component keeps the existing fail-fast behaviour, as does the actor state store itself when `ignoreErrors` is set.

--- a/pkg/actors/targets/workflow/common/backoff.go
+++ b/pkg/actors/targets/workflow/common/backoff.go
@@ -19,6 +19,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/dapr/dapr/pkg/backoff"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 )
 
@@ -29,35 +30,12 @@ const (
 	RetryBackoffCap  = 2 * time.Second
 )
 
-// JitterBackoff is decorrelated exponential jitter (next = uniform(base,
-// min(cap, prev*3))): under overload, concurrent retries spread out instead of
-// re-colliding on a fixed interval.
-type JitterBackoff struct {
-	base time.Duration
-	cap  time.Duration
-	prev time.Duration
-}
+// JitterBackoff is the decorrelated exponential jitter from pkg/backoff,
+// aliased here for the workflow-internal call sites.
+type JitterBackoff = backoff.Jitter
 
 func NewJitterBackoff(base, cap time.Duration) *JitterBackoff {
-	return &JitterBackoff{
-		base: base,
-		cap:  cap,
-		prev: base,
-	}
-}
-
-func (j *JitterBackoff) Reset() {
-	j.prev = j.base
-}
-
-func (j *JitterBackoff) NextBackOff() time.Duration {
-	hi := min(j.prev*3, j.cap)
-	next := j.base
-	if hi > j.base {
-		next += rand.N(hi - j.base) //nolint:gosec // retry jitter, not security sensitive
-	}
-	j.prev = next
-	return next
+	return backoff.NewJitter(base, cap)
 }
 
 // RetryForeverPolicy returns the failure policy for one-shot workflow

--- a/pkg/backoff/jitter.go
+++ b/pkg/backoff/jitter.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// Jitter is decorrelated exponential jitter
+// (next = uniform(base, min(cap, prev*3))): under overload, concurrent
+// retries spread out instead of re-colliding on a fixed interval.
+type Jitter struct {
+	base time.Duration
+	cap  time.Duration
+	prev time.Duration
+}
+
+func NewJitter(base, cap time.Duration) *Jitter {
+	return &Jitter{
+		base: base,
+		cap:  cap,
+		prev: base,
+	}
+}
+
+func (j *Jitter) Reset() {
+	j.prev = j.base
+}
+
+func (j *Jitter) NextBackOff() time.Duration {
+	hi := min(j.prev*3, j.cap)
+	next := j.base
+	if hi > j.base {
+		next += rand.N(hi - j.base) //nolint:gosec // retry jitter, not security sensitive
+	}
+	j.prev = next
+	return next
+}

--- a/pkg/backoff/jitter_test.go
+++ b/pkg/backoff/jitter_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backoff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Jitter(t *testing.T) {
+	t.Parallel()
+
+	const (
+		base = 50 * time.Millisecond
+		cap  = 2 * time.Second
+	)
+
+	j := NewJitter(base, cap)
+
+	prev := base
+	for range 100 {
+		d := j.NextBackOff()
+		assert.GreaterOrEqual(t, d, base)
+		assert.Less(t, d, cap)
+		// Decorrelated growth: each draw is bounded by three times the
+		// previous draw (capped), never more.
+		assert.Less(t, d, min(prev*3, cap)+1)
+		prev = d
+	}
+
+	j.Reset()
+	first := j.NextBackOff()
+	assert.GreaterOrEqual(t, first, base)
+	assert.Less(t, first, 3*base)
+}

--- a/pkg/runtime/compstore/components.go
+++ b/pkg/runtime/compstore/components.go
@@ -20,6 +20,10 @@ import (
 	compsv1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 )
 
+// ErrComponentAlreadyExists signals an init of a component name which is
+// already installed. Matchable with errors.Is by init retry loops.
+var ErrComponentAlreadyExists = errors.New("already exists")
+
 func (c *ComponentStore) GetComponent(name string) (compsv1alpha1.Component, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
@@ -46,7 +50,7 @@ func (c *ComponentStore) AddPendingComponentForCommit(component compsv1alpha1.Co
 	for _, existing := range c.components {
 		if existing.Name == component.Name {
 			c.compPendingLock.Unlock()
-			return fmt.Errorf("component %s already exists", existing.Name)
+			return fmt.Errorf("component %s %w", existing.Name, ErrComponentAlreadyExists)
 		}
 	}
 

--- a/pkg/runtime/hotreload/reconciler/components.go
+++ b/pkg/runtime/hotreload/reconciler/components.go
@@ -42,9 +42,6 @@ type components struct {
 	// out-of-order create-before-delete rename delivered by an event stream.
 	skippedActorStore     *compapi.Component
 	skippedActorStoreLock sync.Mutex
-
-	// wg tracks the async init-result consumers; see update.
-	wg sync.WaitGroup
 }
 
 func NewComponents(opts Options[compapi.Component]) *Reconciler[compapi.Component] {
@@ -85,15 +82,7 @@ func (c *components) update(ctx context.Context, comp compapi.Component) error {
 	// the actor state store actually changed. Notifying after both the close
 	// and re-init of an updated component means the actor runtime never
 	// observes the transient store-less state in the middle of an update.
-	// The async consumer below owns the notification when it takes the
-	// result.
-	notify := c.notifyActorStateStoreChanged()
-	notifyAsync := false
-	defer func() {
-		if !notifyAsync {
-			notify()
-		}
-	}()
+	defer c.notifyActorStateStoreChanged()()
 
 	oldComp, exists := c.store.GetComponent(comp.Name)
 	_, _ = c.proc.Secret().ProcessResource(ctx, comp)
@@ -131,32 +120,13 @@ func (c *components) update(ctx context.Context, comp compapi.Component) error {
 
 	log.Infof("Adding Component for processing: %s", comp.LogName())
 
-	res := c.proc.AddPendingComponent(ctx, comp)
+	// EarlyResult: the actor state store retries a failed init in place, so
+	// waiting for its final result could starve later component events,
+	// including the fix for this very spec. The first attempt's outcome is
+	// enough here: a failure keeps retrying in the root loop, which kicks the
+	// actor runtime itself when a background retry eventually succeeds.
+	res := c.proc.AddPendingComponentEarlyResult(ctx, comp)
 	if res == nil {
-		return nil
-	}
-
-	// The actor state store retries its init in place, so its result can
-	// take arbitrarily long. Blocking here would starve later component
-	// events, including the fix for this very spec. Its failures are
-	// superseded-or-abandoned by construction, never fatal.
-	if isMarkedActorStateStore(comp) && !comp.Spec.IgnoreErrors {
-		notifyAsync = true
-		c.wg.Go(func() {
-			defer notify()
-			select {
-			case <-ctx.Done():
-			case err := <-res:
-				if err == nil {
-					log.Infof("Component updated: %s", comp.LogName())
-					if rerr := c.replaySkippedActorStore(ctx); rerr != nil {
-						log.Errorf("Error replaying skipped actor state store: %s", rerr)
-					}
-					return
-				}
-				log.Errorf("Error processing actor state store component %s (superseded or abandoned; not fatal): %s", comp.Name, err)
-			}
-		})
 		return nil
 	}
 
@@ -173,6 +143,10 @@ func (c *components) update(ctx context.Context, comp compapi.Component) error {
 		err = fmt.Errorf("process component %s error: %s", comp.Name, err)
 		if comp.Spec.IgnoreErrors {
 			log.Errorf("Ignoring error processing component: %s", err)
+			return nil
+		}
+		if isMarkedActorStateStore(comp) {
+			log.Errorf("Error initializing actor state store %s, init keeps retrying in the background: %s", comp.Name, err)
 			return nil
 		}
 		log.Warnf("Error processing component, daprd will exit gracefully: %s", err)

--- a/pkg/runtime/hotreload/reconciler/components.go
+++ b/pkg/runtime/hotreload/reconciler/components.go
@@ -42,6 +42,9 @@ type components struct {
 	// out-of-order create-before-delete rename delivered by an event stream.
 	skippedActorStore     *compapi.Component
 	skippedActorStoreLock sync.Mutex
+
+	// wg tracks the async init-result consumers; see update.
+	wg sync.WaitGroup
 }
 
 func NewComponents(opts Options[compapi.Component]) *Reconciler[compapi.Component] {
@@ -82,7 +85,15 @@ func (c *components) update(ctx context.Context, comp compapi.Component) error {
 	// the actor state store actually changed. Notifying after both the close
 	// and re-init of an updated component means the actor runtime never
 	// observes the transient store-less state in the middle of an update.
-	defer c.notifyActorStateStoreChanged()()
+	// The async consumer below owns the notification when it takes the
+	// result.
+	notify := c.notifyActorStateStoreChanged()
+	notifyAsync := false
+	defer func() {
+		if !notifyAsync {
+			notify()
+		}
+	}()
 
 	oldComp, exists := c.store.GetComponent(comp.Name)
 	_, _ = c.proc.Secret().ProcessResource(ctx, comp)
@@ -124,6 +135,31 @@ func (c *components) update(ctx context.Context, comp compapi.Component) error {
 	if res == nil {
 		return nil
 	}
+
+	// The actor state store retries its init in place, so its result can
+	// take arbitrarily long. Blocking here would starve later component
+	// events, including the fix for this very spec. Its failures are
+	// superseded-or-abandoned by construction, never fatal.
+	if isMarkedActorStateStore(comp) && !comp.Spec.IgnoreErrors {
+		notifyAsync = true
+		c.wg.Go(func() {
+			defer notify()
+			select {
+			case <-ctx.Done():
+			case err := <-res:
+				if err == nil {
+					log.Infof("Component updated: %s", comp.LogName())
+					if rerr := c.replaySkippedActorStore(ctx); rerr != nil {
+						log.Errorf("Error replaying skipped actor state store: %s", rerr)
+					}
+					return
+				}
+				log.Errorf("Error processing actor state store component %s (superseded or abandoned; not fatal): %s", comp.Name, err)
+			}
+		})
+		return nil
+	}
+
 	select {
 	case <-ctx.Done():
 		return nil

--- a/pkg/runtime/processor/components.go
+++ b/pkg/runtime/processor/components.go
@@ -39,6 +39,20 @@ func (p *Processor) AddPendingComponent(ctx context.Context, comp compapi.Compon
 	return res
 }
 
+// AddPendingComponentEarlyResult is AddPendingComponent, except Result
+// receives the first init attempt's outcome even when the init keeps
+// retrying in the background (the actor state store). The hot reload
+// reconciler uses this so a retrying init cannot starve later component
+// events, including the one which fixes the failing spec.
+func (p *Processor) AddPendingComponentEarlyResult(ctx context.Context, comp compapi.Component) <-chan error {
+	if p.closed.Load() || ctx.Err() != nil {
+		return nil
+	}
+	res := make(chan error, 1)
+	p.rootLoop.Loop().Enqueue(&loops.Init{Component: comp, Result: res, EarlyResult: true})
+	return res
+}
+
 // Init synchronously initialises a component. If Process is running, the
 // init is routed through the loop hierarchy and waits for the result;
 // otherwise the init runs inline. Tests that drive the processor without

--- a/pkg/runtime/processor/loops/component.go
+++ b/pkg/runtime/processor/loops/component.go
@@ -33,6 +33,9 @@ type Init struct {
 	Result    chan<- error
 	Internal  bool
 	Timeout   time.Duration
+	// EarlyResult delivers the first init attempt's outcome to Result even
+	// when the init keeps retrying in the background.
+	EarlyResult bool
 }
 
 // Close asks the named instance to close a component. Result receives one

--- a/pkg/runtime/processor/loops/root/component.go
+++ b/pkg/runtime/processor/loops/root/component.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
-	wfcommon "github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/pkg/backoff"
 	"github.com/dapr/dapr/pkg/components"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/processor/loops"
@@ -181,15 +181,21 @@ func shouldRetryInit(comp compapi.Component) bool {
 // category loop like the original one, with the same per-attempt timeout.
 // Returns the final error and whether the loop was abandoned by shutdown.
 func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compapi.Component, timeout time.Duration, firstErr error) (error, bool) {
-	backoff := wfcommon.NewJitterBackoff(initRetryBackoffBase, initRetryBackoffCap)
+	retryBackoff := backoff.NewJitter(initRetryBackoffBase, initRetryBackoffCap)
 	err := firstErr
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
 	for {
-		delay := backoff.NextBackOff()
+		delay := retryBackoff.NextBackOff()
 		log.Warnf("Retrying init of actor state store %s in %s after error: %s", comp.LogName(), delay, err)
+		timer.Reset(delay)
 		select {
 		case <-r.runCtx.Done():
 			return err, true
-		case <-time.After(delay):
+		case <-timer.C:
 		}
 
 		res := make(chan error, 1)

--- a/pkg/runtime/processor/loops/root/component.go
+++ b/pkg/runtime/processor/loops/root/component.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dapr/dapr/pkg/components"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
+	"github.com/dapr/dapr/pkg/runtime/hotreload/differ"
 	"github.com/dapr/dapr/pkg/runtime/processor/loops"
 	procstate "github.com/dapr/dapr/pkg/runtime/processor/state"
 	"github.com/dapr/kit/events/loop"
@@ -36,48 +37,51 @@ import (
 // processor's inline (test) init path applies the same default.
 const DefaultComponentInitTimeout = time.Second * 5
 
-// registerInitRetry arms a supersession signal for an init retry loop on
-// name, cancelling any previous loop for the same name.
-func (r *Root) registerInitRetry(name string) chan struct{} {
+// initRetryEntry is an armed supersession signal together with the desired
+// spec it was armed for. deleted marks a Close of the component while its
+// init was in flight, distinguishing a delete from a completed successor.
+type initRetryEntry struct {
+	ch      chan struct{}
+	comp    compapi.Component
+	deleted bool
+}
+
+// registerInitRetry arms a supersession signal for an init retry loop on the
+// component's name, cancelling any previous loop for the same name.
+func (r *Root) registerInitRetry(comp compapi.Component) chan struct{} {
 	r.initRetryMu.Lock()
 	defer r.initRetryMu.Unlock()
-	if prev, ok := r.initRetryCancels[name]; ok {
-		close(prev)
+	if prev, ok := r.initRetryCancels[comp.Name]; ok && !prev.deleted {
+		close(prev.ch)
 	}
 	ch := make(chan struct{})
-	r.initRetryCancels[name] = ch
+	r.initRetryCancels[comp.Name] = &initRetryEntry{ch: ch, comp: comp}
 	return ch
 }
 
 func (r *Root) unregisterInitRetry(name string, ch chan struct{}) {
 	r.initRetryMu.Lock()
 	defer r.initRetryMu.Unlock()
-	if cur, ok := r.initRetryCancels[name]; ok && cur == ch {
+	if cur, ok := r.initRetryCancels[name]; ok && cur.ch == ch {
 		delete(r.initRetryCancels, name)
 	}
 }
 
+// cancelInitRetry stops an in-flight init retry loop for name. The entry is
+// kept as a tombstone (cleared by the loop's own unregister, or replaced by
+// a new registration) so the loop's finalizer can tell a delete apart from a
+// completed successor init.
 func (r *Root) cancelInitRetry(name string) {
 	r.initRetryMu.Lock()
 	defer r.initRetryMu.Unlock()
-	if ch, ok := r.initRetryCancels[name]; ok {
-		close(ch)
-		delete(r.initRetryCancels, name)
+	if entry, ok := r.initRetryCancels[name]; ok && !entry.deleted {
+		close(entry.ch)
+		entry.deleted = true
 	}
 }
 
 func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 	comp := ev.Component
-
-	// A new configuration supersedes any in-flight retry loop for this name.
-	// The signal is armed before the first attempt so a Close or re-create
-	// landing mid-attempt is never lost. Retry attempts bypass this handler.
-	var superseded chan struct{}
-	if shouldRetryInit(comp) {
-		superseded = r.registerInitRetry(comp.Name)
-	} else {
-		r.cancelInitRetry(comp.Name)
-	}
 
 	// Preprocess: resolve secret refs on the component, detect unresolved
 	// secret-store dependencies.
@@ -134,6 +138,18 @@ func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 	timeout, err := time.ParseDuration(comp.Spec.InitTimeout)
 	if err != nil || timeout <= 0 {
 		timeout = DefaultComponentInitTimeout
+	}
+
+	// A new configuration supersedes any in-flight retry loop for this name.
+	// The signal is armed before the first attempt so a Close or re-create
+	// landing mid-attempt is never lost, and after secret resolution so the
+	// registered spec is the resolved one (a parked component registers when
+	// it is flushed, not while parked). Retry attempts bypass this handler.
+	var superseded chan struct{}
+	if shouldRetryInit(comp) {
+		superseded = r.registerInitRetry(comp)
+	} else {
+		r.cancelInitRetry(comp.Name)
 	}
 
 	// Intercept the Result so we can flush dependents on a successful secret
@@ -297,12 +313,23 @@ func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compa
 
 var errSupersededInit = errors.New("superseded by a newer component configuration during init")
 
-// rollbackStaleInit closes the just-committed component if its configuration
-// was superseded or deleted while the successful init attempt was in flight.
+// rollbackStaleInit closes the just-committed component if it was deleted or
+// superseded by a DIFFERENT spec while the successful init attempt was in
+// flight. A duplicate init of an identical spec (a flushed parked component
+// racing the reconciler's re-create) is not a supersession: the commit
+// matches the desired state and must stay, whether the duplicate is still
+// registered or already completed and unregistered.
 func (r *Root) rollbackStaleInit(catLoop loop.Interface[loops.EventCategory], comp compapi.Component, superseded <-chan struct{}) bool {
 	select {
 	case <-superseded:
 	default:
+		return false
+	}
+	r.initRetryMu.Lock()
+	entry, ok := r.initRetryCancels[comp.Name]
+	stale := ok && (entry.deleted || !differ.AreSame(entry.comp, comp))
+	r.initRetryMu.Unlock()
+	if !stale {
 		return false
 	}
 	log.Warnf("Init of %s succeeded after its configuration was superseded or removed; closing the stale component", comp.LogName())

--- a/pkg/runtime/processor/loops/root/component.go
+++ b/pkg/runtime/processor/loops/root/component.go
@@ -34,8 +34,48 @@ import (
 // processor's inline (test) init path applies the same default.
 const DefaultComponentInitTimeout = time.Second * 5
 
+// registerInitRetry arms a supersession signal for an init retry loop on
+// name, cancelling any previous loop for the same name.
+func (r *Root) registerInitRetry(name string) chan struct{} {
+	r.initRetryMu.Lock()
+	defer r.initRetryMu.Unlock()
+	if prev, ok := r.initRetryCancels[name]; ok {
+		close(prev)
+	}
+	ch := make(chan struct{})
+	r.initRetryCancels[name] = ch
+	return ch
+}
+
+func (r *Root) unregisterInitRetry(name string, ch chan struct{}) {
+	r.initRetryMu.Lock()
+	defer r.initRetryMu.Unlock()
+	if cur, ok := r.initRetryCancels[name]; ok && cur == ch {
+		delete(r.initRetryCancels, name)
+	}
+}
+
+func (r *Root) cancelInitRetry(name string) {
+	r.initRetryMu.Lock()
+	defer r.initRetryMu.Unlock()
+	if ch, ok := r.initRetryCancels[name]; ok {
+		close(ch)
+		delete(r.initRetryCancels, name)
+	}
+}
+
 func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 	comp := ev.Component
+
+	// A new configuration supersedes any in-flight retry loop for this name.
+	// The signal is armed before the first attempt so a Close or re-create
+	// landing mid-attempt is never lost. Retry attempts bypass this handler.
+	var superseded chan struct{}
+	if shouldRetryInit(comp) {
+		superseded = r.registerInitRetry(comp.Name)
+	} else {
+		r.cancelInitRetry(comp.Name)
+	}
 
 	// Preprocess: resolve secret refs on the component, detect unresolved
 	// secret-store dependencies.
@@ -121,8 +161,17 @@ func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 		// database returns. The caller stays blocked while retrying, so
 		// readiness keeps reporting the degraded state.
 		var abandoned bool
-		if innerErr != nil && shouldRetryInit(comp) {
-			innerErr, abandoned = r.retryInit(catLoop, comp, timeout, innerErr)
+		if superseded != nil {
+			defer r.unregisterInitRetry(comp.Name, superseded)
+		}
+		if innerErr != nil && superseded != nil {
+			select {
+			case <-superseded:
+				innerErr = fmt.Errorf("superseded by a newer component configuration during init retry: %w", innerErr)
+				abandoned = true
+			default:
+				innerErr, abandoned = r.retryInit(catLoop, comp, timeout, innerErr, superseded)
+			}
 		}
 		if innerErr != nil {
 			log.Errorf("Failed to init component %s: %s", comp.LogName(), innerErr)
@@ -177,10 +226,9 @@ func shouldRetryInit(comp compapi.Component) bool {
 }
 
 // retryInit re-attempts a failed component init with jittered backoff until
-// it succeeds or the runtime shuts down. Each attempt goes through the
-// category loop like the original one, with the same per-attempt timeout.
-// Returns the final error and whether the loop was abandoned by shutdown.
-func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compapi.Component, timeout time.Duration, firstErr error) (error, bool) {
+// it succeeds, the runtime shuts down, or the configuration is superseded.
+// Returns the final error and whether the loop was abandoned.
+func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compapi.Component, timeout time.Duration, firstErr error, superseded <-chan struct{}) (error, bool) {
 	retryBackoff := backoff.NewJitter(initRetryBackoffBase, initRetryBackoffCap)
 	err := firstErr
 	timer := time.NewTimer(0)
@@ -195,6 +243,9 @@ func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compa
 		select {
 		case <-r.runCtx.Done():
 			return err, true
+		case <-superseded:
+			log.Infof("Stopping init retry of %s: configuration superseded", comp.LogName())
+			return fmt.Errorf("superseded by a newer component configuration during init retry: %w", err), true
 		case <-timer.C:
 		}
 
@@ -219,6 +270,8 @@ func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compa
 
 func (r *Root) handleClose(_ context.Context, ev *loops.Close) {
 	comp := ev.Component
+
+	r.cancelInitRetry(comp.Name)
 	cat := r.category(comp)
 	if cat == "" {
 		sendResult(ev.Result, fmt.Errorf("incorrect type %s", comp.Spec.Type))

--- a/pkg/runtime/processor/loops/root/component.go
+++ b/pkg/runtime/processor/loops/root/component.go
@@ -15,6 +15,7 @@ package root
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/backoff"
 	"github.com/dapr/dapr/pkg/components"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/processor/loops"
 	procstate "github.com/dapr/dapr/pkg/runtime/processor/state"
@@ -180,6 +182,12 @@ func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 				innerErr, abandoned = r.retryInit(catLoop, comp, timeout, innerErr, superseded)
 			}
 		}
+		// A success which raced a newer spec or a delete has committed a stale
+		// component: roll it back so the newer event converges.
+		if innerErr == nil && superseded != nil && r.rollbackStaleInit(catLoop, comp, superseded) {
+			innerErr = errSupersededInit
+			abandoned = true
+		}
 		if innerErr != nil {
 			log.Errorf("Failed to init component %s: %s", comp.LogName(), innerErr)
 			wrapped := rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), innerErr)
@@ -272,7 +280,34 @@ func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compa
 		if err == nil {
 			return nil, false
 		}
+		// A stale commit from a superseded attempt can occupy the slot; close
+		// it so the next attempt of this (current) configuration can install.
+		// Guarded on the supersession signal: a superseded loop must never
+		// close the newer component, so it abandons at the top of the loop.
+		if errors.Is(err, compstore.ErrComponentAlreadyExists) {
+			select {
+			case <-superseded:
+			default:
+				log.Warnf("Closing stale component occupying the slot of %s before retrying init", comp.LogName())
+				catLoop.Enqueue(&loops.Close{Component: comp})
+			}
+		}
 	}
+}
+
+var errSupersededInit = errors.New("superseded by a newer component configuration during init")
+
+// rollbackStaleInit closes the just-committed component if its configuration
+// was superseded or deleted while the successful init attempt was in flight.
+func (r *Root) rollbackStaleInit(catLoop loop.Interface[loops.EventCategory], comp compapi.Component, superseded <-chan struct{}) bool {
+	select {
+	case <-superseded:
+	default:
+		return false
+	}
+	log.Warnf("Init of %s succeeded after its configuration was superseded or removed; closing the stale component", comp.LogName())
+	catLoop.Enqueue(&loops.Close{Component: comp})
+	return true
 }
 
 func (r *Root) handleClose(_ context.Context, ev *loops.Close) {

--- a/pkg/runtime/processor/loops/root/component.go
+++ b/pkg/runtime/processor/loops/root/component.go
@@ -16,12 +16,17 @@ package root
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	wfcommon "github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	"github.com/dapr/dapr/pkg/components"
 	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
 	"github.com/dapr/dapr/pkg/runtime/processor/loops"
+	procstate "github.com/dapr/dapr/pkg/runtime/processor/state"
+	"github.com/dapr/kit/events/loop"
+	kitstrings "github.com/dapr/kit/strings"
 )
 
 // DefaultComponentInitTimeout is the init deadline applied to a component
@@ -108,6 +113,17 @@ func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 		// callers stay blocked until the component's Init returns, even when it
 		// overruns its deadline.
 		innerErr := <-intercept
+		// The actor state store retries in place of failing fatally: a
+		// transient outage of its backing database (for example Postgres
+		// restarting) must leave the runtime alive and unready rather than
+		// crash it, which under Kubernetes turns a seconds-long database blip
+		// into a crash-restart cycle of every replica that lasts until the
+		// database returns. The caller stays blocked while retrying, so
+		// readiness keeps reporting the degraded state.
+		var abandoned bool
+		if innerErr != nil && shouldRetryInit(comp) {
+			innerErr, abandoned = r.retryInit(catLoop, comp, timeout, innerErr)
+		}
 		if innerErr != nil {
 			log.Errorf("Failed to init component %s: %s", comp.LogName(), innerErr)
 			wrapped := rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), innerErr)
@@ -115,8 +131,10 @@ func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 			// A non-ignored init failure is fatal to the runtime. Record it so
 			// Run surfaces it on a path the runtime's init-context cancellation
 			// cannot mask (the legacy processComponents runner did this), so a
-			// failure that races with shutdown still propagates out of Run.
-			if !comp.Spec.IgnoreErrors {
+			// failure that races with shutdown still propagates out of Run. A
+			// retry loop abandoned by shutdown is not a failure and is not
+			// recorded.
+			if !comp.Spec.IgnoreErrors && !abandoned {
 				r.recordFatalInitError(fmt.Errorf("process component %s error: %w", comp.Name, wrapped))
 			}
 		} else {
@@ -133,6 +151,64 @@ func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 			Err:      innerErr,
 		})
 	})
+}
+
+const (
+	// initRetryBackoffBase and initRetryBackoffCap bound the jittered backoff
+	// between init attempts of a retriable component.
+	initRetryBackoffBase = 500 * time.Millisecond
+	initRetryBackoffCap  = 10 * time.Second
+)
+
+// shouldRetryInit reports whether a failed init of comp is retried in place
+// of being recorded as fatal. Only the component marked as the actor state
+// store qualifies: its availability is a runtime dependency (workflows,
+// actors) whose transient loss must degrade the runtime, not kill it.
+func shouldRetryInit(comp compapi.Component) bool {
+	if comp.Spec.IgnoreErrors || !strings.HasPrefix(comp.Spec.Type, "state.") {
+		return false
+	}
+	for _, m := range comp.Spec.Metadata {
+		if strings.EqualFold(m.Name, procstate.PropertyKeyActorStateStore) {
+			return kitstrings.IsTruthy(m.Value.String())
+		}
+	}
+	return false
+}
+
+// retryInit re-attempts a failed component init with jittered backoff until
+// it succeeds or the runtime shuts down. Each attempt goes through the
+// category loop like the original one, with the same per-attempt timeout.
+// Returns the final error and whether the loop was abandoned by shutdown.
+func (r *Root) retryInit(catLoop loop.Interface[loops.EventCategory], comp compapi.Component, timeout time.Duration, firstErr error) (error, bool) {
+	backoff := wfcommon.NewJitterBackoff(initRetryBackoffBase, initRetryBackoffCap)
+	err := firstErr
+	for {
+		delay := backoff.NextBackOff()
+		log.Warnf("Retrying init of actor state store %s in %s after error: %s", comp.LogName(), delay, err)
+		select {
+		case <-r.runCtx.Done():
+			return err, true
+		case <-time.After(delay):
+		}
+
+		res := make(chan error, 1)
+		catLoop.Enqueue(&loops.Init{
+			Component: comp,
+			Result:    res,
+			Timeout:   timeout,
+		})
+		select {
+		case err = <-res:
+		case <-r.runCtx.Done():
+			// The category loop may already be closed and the enqueued event
+			// dropped, so do not wait on res unconditionally.
+			return err, true
+		}
+		if err == nil {
+			return nil, false
+		}
+	}
 }
 
 func (r *Root) handleClose(_ context.Context, ev *loops.Close) {

--- a/pkg/runtime/processor/loops/root/component.go
+++ b/pkg/runtime/processor/loops/root/component.go
@@ -170,6 +170,13 @@ func (r *Root) handleInit(ctx context.Context, ev *loops.Init) {
 				innerErr = fmt.Errorf("superseded by a newer component configuration during init retry: %w", innerErr)
 				abandoned = true
 			default:
+				// An EarlyResult caller (the hot reload reconciler) must not
+				// stay blocked behind the retry loop: hand it the first
+				// attempt's error before retrying.
+				if ev.EarlyResult {
+					sendResult(ev.Result, rterrors.NewInit(rterrors.InitComponentFailure, comp.LogName(), innerErr))
+					ev.Result = nil
+				}
 				innerErr, abandoned = r.retryInit(catLoop, comp, timeout, innerErr, superseded)
 			}
 		}

--- a/pkg/runtime/processor/loops/root/root.go
+++ b/pkg/runtime/processor/loops/root/root.go
@@ -82,8 +82,9 @@ type Root struct {
 	unregisterMCPServer func(name string)
 
 	// initRetryCancels tracks in-flight init retry loops by component name
-	// so a newer configuration supersedes them.
-	initRetryCancels map[string]chan struct{}
+	// so a newer configuration supersedes them. The desired spec is kept so
+	// a duplicate init of an identical spec is not treated as a stale commit.
+	initRetryCancels map[string]*initRetryEntry
 	initRetryMu      sync.Mutex
 
 	// fatalErr retains the first non-ignored component init failure seen by a
@@ -145,7 +146,7 @@ func New(opts Options) *Root {
 		registerMCPServer:   opts.RegisterMCPServer,
 		unregisterMCPServer: opts.UnregisterMCPServer,
 		pendingDependents:   make(map[string][]compapi.Component),
-		initRetryCancels:    make(map[string]chan struct{}),
+		initRetryCancels:    make(map[string]*initRetryEntry),
 		mcpServers:          make(map[string]loop.Interface[loops.EventMCPServer]),
 		httpEndpoints:       make(map[string]loop.Interface[loops.EventHTTPEndpoint]),
 	}

--- a/pkg/runtime/processor/loops/root/root.go
+++ b/pkg/runtime/processor/loops/root/root.go
@@ -81,6 +81,11 @@ type Root struct {
 	registerMCPServer   func(ctx context.Context, s mcpserverapi.MCPServer) error
 	unregisterMCPServer func(name string)
 
+	// initRetryCancels tracks in-flight init retry loops by component name
+	// so a newer configuration supersedes them.
+	initRetryCancels map[string]chan struct{}
+	initRetryMu      sync.Mutex
+
 	// fatalErr retains the first non-ignored component init failure seen by a
 	// finalizer. Run returns it after the finalizers drain, so a failure that
 	// races with shutdown still propagates out (the runtime's init path masks
@@ -140,6 +145,7 @@ func New(opts Options) *Root {
 		registerMCPServer:   opts.RegisterMCPServer,
 		unregisterMCPServer: opts.UnregisterMCPServer,
 		pendingDependents:   make(map[string][]compapi.Component),
+		initRetryCancels:    make(map[string]chan struct{}),
 		mcpServers:          make(map[string]loop.Interface[loops.EventMCPServer]),
 		httpEndpoints:       make(map[string]loop.Interface[loops.EventHTTPEndpoint]),
 	}

--- a/pkg/runtime/processor/loops_test.go
+++ b/pkg/runtime/processor/loops_test.go
@@ -246,6 +246,73 @@ func TestProcessorNonActorStateStoreInitStillFatal(t *testing.T) {
 	}
 }
 
+// TestProcessorActorStateStoreInitDuplicateIdenticalSpec: two racing inits
+// of an IDENTICAL retriable spec (a flushed parked component racing the hot
+// reload reconciler's re-create) must both succeed and leave the component
+// installed: the duplicate is not a supersession and must not trigger the
+// stale-commit rollback.
+func TestProcessorActorStateStoreInitDuplicateIdenticalSpec(t *testing.T) {
+	proc, reg := newTestProc()
+
+	mockStore := new(daprt.MockStateStore)
+	reg.StateStores().RegisterComponent(
+		func(logger.Logger) contribstate.Store { return mockStore },
+		"mockState",
+	)
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	mockStore.On("Init", mock.Anything).Run(func(mock.Arguments) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+	}).Return(nil)
+	mockStore.On("Close").Maybe().Return(nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- proc.Process(ctx) }()
+
+	comp := actorStateStoreComp("mystore")
+	ch1 := proc.AddPendingComponent(ctx, comp)
+	require.NotNil(t, ch1)
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the first init to start")
+	}
+	ch2 := proc.AddPendingComponent(ctx, comp)
+	require.NotNil(t, ch2)
+	close(release)
+
+	for i, ch := range []<-chan error{ch1, ch2} {
+		select {
+		case err := <-ch:
+			require.NoError(t, err, "init %d of an identical spec must succeed", i+1)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for init %d", i+1)
+		}
+	}
+	_, ok := proc.compStore.GetComponent("mystore")
+	require.True(t, ok)
+	time.Sleep(time.Second)
+	_, ok = proc.compStore.GetComponent("mystore")
+	assert.True(t, ok, "a duplicate identical init must not roll back the installed component")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the processor to stop")
+	}
+}
+
 // TestProcessorActorStateStoreInitRetryStaleCommitRollback: a retriable init
 // whose success races a newer spec (phase 1) or a delete (phase 2) must not
 // leave the stale component installed: the commit is rolled back and the

--- a/pkg/runtime/processor/loops_test.go
+++ b/pkg/runtime/processor/loops_test.go
@@ -246,6 +246,136 @@ func TestProcessorNonActorStateStoreInitStillFatal(t *testing.T) {
 	}
 }
 
+// TestProcessorActorStateStoreInitRetryStaleCommitRollback: a retriable init
+// whose success races a newer spec (phase 1) or a delete (phase 2) must not
+// leave the stale component installed: the commit is rolled back and the
+// newest event wins, without a fatal init error.
+func TestProcessorActorStateStoreInitRetryStaleCommitRollback(t *testing.T) {
+	proc, reg := newTestProc()
+
+	mockStore := new(daprt.MockStateStore)
+	reg.StateStores().RegisterComponent(
+		func(logger.Logger) contribstate.Store { return mockStore },
+		"mockState",
+	)
+
+	genOf := func(g string) any {
+		return mock.MatchedBy(func(md contribstate.Metadata) bool {
+			return md.Properties["generation"] == g
+		})
+	}
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	mockStore.On("Init", genOf("1")).Run(func(mock.Arguments) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+	}).Return(nil)
+	mockStore.On("Init", genOf("2")).Return(nil)
+	enteredDel := make(chan struct{}, 1)
+	releaseDel := make(chan struct{})
+	mockStore.On("Init", genOf("d1")).Run(func(mock.Arguments) {
+		select {
+		case enteredDel <- struct{}{}:
+		default:
+		}
+		<-releaseDel
+	}).Return(nil)
+	mockStore.On("Close").Maybe().Return(nil)
+
+	withGen := func(name, g string) componentsapi.Component {
+		comp := actorStateStoreComp(name)
+		comp.Spec.Metadata = append(comp.Spec.Metadata, commonapi.NameValuePair{
+			Name: "generation",
+			Value: commonapi.DynamicValue{
+				JSON: apiextv1.JSON{Raw: []byte(`"` + g + `"`)},
+			},
+		})
+		return comp
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- proc.Process(ctx) }()
+
+	// Phase 1: gen 1 blocks mid-init, gen 2 arrives, then gen 1 succeeds.
+	ch1 := proc.AddPendingComponent(ctx, withGen("mystore", "1"))
+	require.NotNil(t, ch1)
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the gen 1 init to start")
+	}
+	ch2 := proc.AddPendingComponent(ctx, withGen("mystore", "2"))
+	require.NotNil(t, ch2)
+	close(release)
+
+	select {
+	case err := <-ch2:
+		require.NoError(t, err, "the newest spec must install")
+	case <-time.After(20 * time.Second):
+		t.Fatal("timed out waiting for the gen 2 init")
+	}
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		comp, ok := proc.compStore.GetComponent("mystore")
+		if !assert.True(c, ok) {
+			return
+		}
+		for _, md := range comp.Spec.Metadata {
+			if md.Name == "generation" {
+				assert.Contains(c, string(md.Value.Raw), "2",
+					"the stale gen 1 commit must not survive")
+			}
+		}
+	}, 10*time.Second, 10*time.Millisecond)
+	select {
+	case err := <-ch1:
+		if err != nil {
+			require.ErrorContains(t, err, "superseded")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the gen 1 result")
+	}
+
+	// Phase 2: the init blocks, a delete lands, then the init succeeds. The
+	// stale commit must be rolled back so the component stays deleted.
+	delComp := withGen("delstore", "d1")
+	chD := proc.AddPendingComponent(ctx, delComp)
+	require.NotNil(t, chD)
+	select {
+	case <-enteredDel:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the delstore init to start")
+	}
+	closeErrCh := make(chan error, 1)
+	go func() { closeErrCh <- proc.Close(ctx, delComp) }()
+	close(releaseDel)
+	select {
+	case err := <-closeErrCh:
+		require.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("timed out waiting for the delete to complete")
+	}
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, ok := proc.compStore.GetComponent("delstore")
+		assert.False(c, ok, "a deleted component must not be re-created by a stale init success")
+	}, 10*time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled,
+				"a rolled-back stale init must not surface as a fatal error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the processor to stop")
+	}
+}
+
 // TestProcessorActorStateStoreInitRetrySuperseded: a re-create of the same
 // name supersedes the old retry loop (phase 1), a delete supersedes the
 // successor (phase 2); superseded loops release their caller and are not

--- a/pkg/runtime/processor/loops_test.go
+++ b/pkg/runtime/processor/loops_test.go
@@ -14,15 +14,20 @@ limitations under the License.
 package processor
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/dapr/components-contrib/pubsub"
 	"github.com/dapr/components-contrib/secretstores"
+	contribstate "github.com/dapr/components-contrib/state"
 	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	componentsapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	rtmock "github.com/dapr/dapr/pkg/runtime/mock"
@@ -105,4 +110,138 @@ func TestProcessorSecretStoreDependentReenqueue(t *testing.T) {
 
 	_, ok = proc.compStore.GetComponent("needs-secret")
 	assert.True(t, ok, "dependent must be processed once its secret store initialises")
+}
+
+func actorStateStoreComp(name string) componentsapi.Component {
+	return componentsapi.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: componentsapi.ComponentSpec{
+			Type:    "state.mockState",
+			Version: "v1",
+			Metadata: []commonapi.NameValuePair{{
+				Name: "actorStateStore",
+				Value: commonapi.DynamicValue{
+					JSON: apiextv1.JSON{Raw: []byte(`"true"`)},
+				},
+			}},
+		},
+	}
+}
+
+// TestProcessorActorStateStoreInitRetry asserts that a transiently failing
+// actor state store init is retried with backoff instead of being recorded
+// as a fatal runtime error: the component commits once its backing store
+// recovers and the processor loop stays alive throughout (chaos campaign
+// 10/08/2026 S6: a 25s state store outage crash-looped every sidecar).
+func TestProcessorActorStateStoreInitRetry(t *testing.T) {
+	proc, reg := newTestProc()
+	startProc(t, proc)
+
+	mockStore := new(daprt.MockStateStore)
+	reg.StateStores().RegisterComponent(
+		func(logger.Logger) contribstate.Store { return mockStore },
+		"mockState",
+	)
+	mockStore.On("Init", mock.Anything, mock.Anything).Return(errors.New("connection refused")).Twice()
+	mockStore.On("Init", mock.Anything, mock.Anything).Return(nil)
+	mockStore.On("Features").Return(nil)
+
+	ch := proc.AddPendingComponent(t.Context(), actorStateStoreComp("mystore"))
+	require.NotNil(t, ch)
+
+	select {
+	case err := <-ch:
+		require.NoError(t, err, "init must succeed after the store recovers")
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the actor state store init to recover")
+	}
+
+	_, ok := proc.compStore.GetComponent("mystore")
+	assert.True(t, ok, "component must be committed once init recovers")
+	mockStore.AssertNumberOfCalls(t, "Init", 3)
+}
+
+// TestProcessorActorStateStoreInitRetryShutdown asserts that shutting the
+// processor down while the actor state store init is still retrying stops
+// the retry loop promptly and is treated as a clean shutdown, not a fatal
+// component init failure.
+func TestProcessorActorStateStoreInitRetryShutdown(t *testing.T) {
+	proc, reg := newTestProc()
+
+	mockStore := new(daprt.MockStateStore)
+	reg.StateStores().RegisterComponent(
+		func(logger.Logger) contribstate.Store { return mockStore },
+		"mockState",
+	)
+	firstFailure := make(chan struct{}, 1)
+	mockStore.On("Init", mock.Anything, mock.Anything).Run(func(mock.Arguments) {
+		select {
+		case firstFailure <- struct{}{}:
+		default:
+		}
+	}).Return(errors.New("connection refused"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- proc.Process(ctx) }()
+
+	ch := proc.AddPendingComponent(ctx, actorStateStoreComp("mystore"))
+	require.NotNil(t, ch)
+
+	select {
+	case <-firstFailure:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the first init failure")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled, "an abandoned retry must not surface as a fatal init error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the processor to stop")
+	}
+}
+
+// TestProcessorNonActorStateStoreInitStillFatal guards the pre-existing
+// behavior for every other component: a non-ignored init failure is not
+// retried and still surfaces as a fatal error out of Process.
+func TestProcessorNonActorStateStoreInitStillFatal(t *testing.T) {
+	proc, reg := newTestProc()
+
+	mockStore := new(daprt.MockStateStore)
+	reg.StateStores().RegisterComponent(
+		func(logger.Logger) contribstate.Store { return mockStore },
+		"mockState",
+	)
+	mockStore.On("Init", mock.Anything, mock.Anything).Return(errors.New("connection refused"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- proc.Process(ctx) }()
+
+	comp := actorStateStoreComp("plainstore")
+	comp.Spec.Metadata = nil
+
+	ch := proc.AddPendingComponent(ctx, comp)
+	require.NotNil(t, ch)
+	select {
+	case err := <-ch:
+		require.ErrorContains(t, err, "connection refused")
+		mockStore.AssertNumberOfCalls(t, "Init", 1)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the init failure")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "process component plainstore error")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the processor to stop")
+	}
 }

--- a/pkg/runtime/processor/loops_test.go
+++ b/pkg/runtime/processor/loops_test.go
@@ -245,3 +245,79 @@ func TestProcessorNonActorStateStoreInitStillFatal(t *testing.T) {
 		t.Fatal("timed out waiting for the processor to stop")
 	}
 }
+
+// TestProcessorActorStateStoreInitRetrySuperseded: a re-create of the same
+// name supersedes the old retry loop (phase 1), a delete supersedes the
+// successor (phase 2); superseded loops release their caller and are not
+// fatal. One shared processor lifecycle: constructing a processor right
+// after a component close trips a pre-existing kit loop-segment race under
+// -race.
+func TestProcessorActorStateStoreInitRetrySuperseded(t *testing.T) {
+	proc, reg := newTestProc()
+
+	mockStore := new(daprt.MockStateStore)
+	reg.StateStores().RegisterComponent(
+		func(logger.Logger) contribstate.Store { return mockStore },
+		"mockState",
+	)
+	initAttempt := make(chan struct{}, 1)
+	mockStore.On("Init", mock.Anything, mock.Anything).Run(func(mock.Arguments) {
+		select {
+		case initAttempt <- struct{}{}:
+		default:
+		}
+	}).Return(errors.New("connection refused"))
+	mockStore.On("Close").Maybe().Return(nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- proc.Process(ctx) }()
+
+	comp := actorStateStoreComp("mystore")
+
+	// Phase 1: re-create supersedes the old loop.
+	oldCh := proc.AddPendingComponent(ctx, comp)
+	require.NotNil(t, oldCh)
+
+	select {
+	case <-initAttempt:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the first init failure")
+	}
+
+	newCh := proc.AddPendingComponent(ctx, comp)
+	require.NotNil(t, newCh)
+
+	select {
+	case err := <-oldCh:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "superseded",
+			"the old configuration's retry must stop when a new configuration arrives")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the old retry to be superseded")
+	}
+
+	// Phase 2: delete supersedes the surviving loop.
+	require.NoError(t, proc.Close(ctx, comp))
+
+	select {
+	case err := <-newCh:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "superseded",
+			"the pending init must be released as superseded on delete, not left retrying")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the deleted component's retry to release its caller")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled,
+				"a superseded retry must not surface as a fatal init error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the processor to stop")
+	}
+}

--- a/pkg/runtime/processor/processor_test.go
+++ b/pkg/runtime/processor/processor_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dapr/dapr/pkg/components"
 	"github.com/dapr/dapr/pkg/config"
 	"github.com/dapr/dapr/pkg/modes"
+	outboxfake "github.com/dapr/dapr/pkg/outbox/fake"
 	operatorv1 "github.com/dapr/dapr/pkg/proto/operator/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/channels"
@@ -75,6 +76,7 @@ func newTestProc(setters ...newTestProcOptions) (*Processor, *registry.Registry)
 		ID:             "id",
 		Namespace:      "test",
 		Registry:       reg,
+		Outbox:         outboxfake.New(),
 		ComponentStore: compstore.New(),
 		Meta: meta.New(meta.Options{
 			ID:        "id",

--- a/tests/integration/suite/daprd/hotreload/hotreload.go
+++ b/tests/integration/suite/daprd/hotreload/hotreload.go
@@ -16,5 +16,6 @@ package hotreload
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/operator"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/selfhosted/actorstate"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/hotreload/sighup"
 )

--- a/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/initretry.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/initretry.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actorstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	contribstate "github.com/dapr/components-contrib/state"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
+	frameworkos "github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/logline"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(initretry))
+}
+
+// initretry hot-reloads a healthy actor state store to a broken
+// spec (init retries in place), then to a corrected spec. The fix must
+// supersede the stale retry loop, which requires the component reconciler
+// to not block on the broken init's result. Boot-time failures are out of
+// scope: the hot reloader only starts after initial component processing.
+type initretry struct {
+	daprd             *daprd.Daprd
+	store             *gatedInitStore
+	loglineRetry      *logline.LogLine
+	loglineSuperseded *logline.LogLine
+	resDir            string
+	componentManifest string
+}
+
+// gatedInitStore fails Init only for generation=2, decoupling the broken
+// spec from retry timing.
+type gatedInitStore struct {
+	*inmemory.WrappedTransactionalMultiMaxSize
+
+	attempts atomic.Int32
+}
+
+func (s *gatedInitStore) Init(ctx context.Context, md contribstate.Metadata) error {
+	s.attempts.Add(1)
+	if md.Properties["generation"] == "2" {
+		return errors.New("connection refused: state store down")
+	}
+	return s.WrappedTransactionalMultiMaxSize.Init(ctx, md)
+}
+
+func (a *initretry) Setup(t *testing.T) []framework.Option {
+	frameworkos.SkipWindows(t)
+
+	a.store = &gatedInitStore{
+		WrappedTransactionalMultiMaxSize: inmemory.NewTransactionalMultiMaxSize(t).(*inmemory.WrappedTransactionalMultiMaxSize),
+	}
+
+	sock := socket.New(t)
+	ss := statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(a.store),
+	)
+
+	a.componentManifest = fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+  - name: generation
+    value: "%%s"
+`, ss.SocketName())
+
+	a.resDir = t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(a.resDir, "state.yaml"),
+		fmt.Appendf(nil, a.componentManifest, "1"), 0o600))
+
+	a.loglineRetry = logline.New(t, logline.WithStdoutLineContains(
+		"Retrying init of actor state store mystore",
+	))
+	a.loglineSuperseded = logline.New(t, logline.WithStdoutLineContains(
+		"Stopping init retry of mystore",
+	))
+
+	a.daprd = daprd.New(t,
+		daprd.WithSocket(t, sock),
+		daprd.WithResourcesDir(a.resDir),
+		daprd.WithExecOptions(
+			exec.WithStdout(iowriter.NewMultiWriteCloser(
+				iowriter.New(t, "daprd"),
+				a.loglineRetry.Stdout(),
+				a.loglineSuperseded.Stdout(),
+			)),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(ss, a.loglineRetry, a.loglineSuperseded, a.daprd),
+	}
+}
+
+func (a *initretry) Run(t *testing.T, ctx context.Context) {
+	a.daprd.WaitUntilRunning(t, ctx)
+	require.GreaterOrEqual(t, a.store.attempts.Load(), int32(1))
+
+	// Hot reload to a broken spec: init retries in place.
+	require.NoError(t, os.WriteFile(filepath.Join(a.resDir, "state.yaml"),
+		fmt.Appendf(nil, a.componentManifest, "2"), 0o600))
+	a.loglineRetry.EventuallyFoundAll(t)
+
+	// The corrected spec must supersede the retry and initialize.
+	require.NoError(t, os.WriteFile(filepath.Join(a.resDir, "state.yaml"),
+		fmt.Appendf(nil, a.componentManifest, "3"), 0o600))
+
+	a.loglineSuperseded.EventuallyFoundAll(t)
+
+	a.daprd.WaitUntilRunning(t, ctx)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		comps := a.daprd.GetMetaRegisteredComponents(c, ctx)
+		found := false
+		for _, comp := range comps {
+			if comp.GetName() == "mystore" {
+				found = true
+			}
+		}
+		assert.True(c, found, "the corrected actor state store must be committed")
+	}, time.Second*10, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/remove.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/remove.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package selfhosted
+package actorstate
 
 import (
 	"context"
@@ -45,7 +45,7 @@ import (
 )
 
 func init() {
-	suite.Register(new(actorstate))
+	suite.Register(new(remove))
 }
 
 const actorStateStoreComp = `
@@ -61,17 +61,17 @@ spec:
    value: "true"
 `
 
-// actorstate ensures that removing the actor state store via hot reload shuts
+// remove ensures that removing the actor state store via hot reload shuts
 // down actor hosting in-process - hosted actors are deactivated and the actor
 // and workflow APIs error - and that hosting and the workflow APIs recover
 // when the actor state store is hot reloaded back.
-type actorstate struct {
+type remove struct {
 	daprd         *daprd.Daprd
 	resDir        string
 	deactivatedCh chan string
 }
 
-func (a *actorstate) Setup(t *testing.T) []framework.Option {
+func (a *remove) Setup(t *testing.T) []framework.Option {
 	a.deactivatedCh = make(chan string, 10)
 
 	handler := chi.NewRouter()
@@ -109,7 +109,7 @@ func (a *actorstate) Setup(t *testing.T) []framework.Option {
 	}
 }
 
-func (a *actorstate) Run(t *testing.T, ctx context.Context) {
+func (a *remove) Run(t *testing.T, ctx context.Context) {
 	a.daprd.WaitUntilRunning(t, ctx)
 
 	httpClient := client.HTTP(t)

--- a/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/secret.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/secret.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package selfhosted
+package actorstate
 
 import (
 	"context"
@@ -41,16 +41,16 @@ import (
 )
 
 func init() {
-	suite.Register(new(actorstatesecret))
+	suite.Register(new(secret))
 }
 
-type actorstatesecret struct {
+type secret struct {
 	daprd   *daprd.Daprd
 	logline *logline.LogLine
 	resDir  string
 }
 
-func (a *actorstatesecret) Setup(t *testing.T) []framework.Option {
+func (a *secret) Setup(t *testing.T) []framework.Option {
 	sched := scheduler.New(t)
 	place := placement.New(t)
 
@@ -74,7 +74,7 @@ func (a *actorstatesecret) Setup(t *testing.T) []framework.Option {
 	}
 }
 
-func (a *actorstatesecret) Run(t *testing.T, ctx context.Context) {
+func (a *secret) Run(t *testing.T, ctx context.Context) {
 	a.daprd.WaitUntilRunning(t, ctx)
 
 	reg := task.NewTaskRegistry()

--- a/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/stalereminder.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/stalereminder.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package selfhosted
+package actorstate
 
 import (
 	"context"
@@ -39,17 +39,17 @@ import (
 )
 
 func init() {
-	suite.Register(new(actorstatestalereminder))
+	suite.Register(new(stalereminder))
 }
 
-type actorstatestalereminder struct {
+type stalereminder struct {
 	daprd   *daprd.Daprd
 	sched   *scheduler.Scheduler
 	logline *logline.LogLine
 	resDir  string
 }
 
-func (a *actorstatestalereminder) Setup(t *testing.T) []framework.Option {
+func (a *stalereminder) Setup(t *testing.T) []framework.Option {
 	a.sched = scheduler.New(t)
 	place := placement.New(t)
 
@@ -73,7 +73,7 @@ func (a *actorstatestalereminder) Setup(t *testing.T) []framework.Option {
 	}
 }
 
-func (a *actorstatestalereminder) Run(t *testing.T, ctx context.Context) {
+func (a *stalereminder) Run(t *testing.T, ctx context.Context) {
 	a.daprd.WaitUntilRunning(t, ctx)
 
 	// Connect a workflow worker before any actor state store exists.

--- a/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/update.go
+++ b/tests/integration/suite/daprd/hotreload/selfhosted/actorstate/update.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package selfhosted
+package actorstate
 
 import (
 	"context"
@@ -40,10 +40,10 @@ import (
 )
 
 func init() {
-	suite.Register(new(actorstateupdate))
+	suite.Register(new(update))
 }
 
-type actorstateupdate struct {
+type update struct {
 	daprd            *daprd.Daprd
 	loglineUpdate    *logline.LogLine
 	loglineDuplicate *logline.LogLine
@@ -51,7 +51,7 @@ type actorstateupdate struct {
 	deactivatedCh    chan string
 }
 
-func (a *actorstateupdate) Setup(t *testing.T) []framework.Option {
+func (a *update) Setup(t *testing.T) []framework.Option {
 	a.deactivatedCh = make(chan string, 10)
 
 	handler := chi.NewRouter()
@@ -100,7 +100,7 @@ func (a *actorstateupdate) Setup(t *testing.T) []framework.Option {
 	}
 }
 
-func (a *actorstateupdate) Run(t *testing.T, ctx context.Context) {
+func (a *update) Run(t *testing.T, ctx context.Context) {
 	a.daprd.WaitUntilRunning(t, ctx)
 
 	httpClient := client.HTTP(t)

--- a/tests/integration/suite/daprd/workflow/chaos/initretry.go
+++ b/tests/integration/suite/daprd/workflow/chaos/initretry.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/components-contrib/state"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/inmemory"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(initretry))
+}
+
+type initretry struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *initFailStore
+}
+
+type initFailStore struct {
+	*inmemory.WrappedTransactionalMultiMaxSize
+
+	lock     sync.Mutex
+	allow    bool
+	attempts atomic.Int32
+}
+
+func (s *initFailStore) Init(ctx context.Context, md state.Metadata) error {
+	s.attempts.Add(1)
+	s.lock.Lock()
+	allow := s.allow
+	s.lock.Unlock()
+	if !allow {
+		return errors.New("connection refused: state store down")
+	}
+	return s.WrappedTransactionalMultiMaxSize.Init(ctx, md)
+}
+
+func (s *initFailStore) release() {
+	s.lock.Lock()
+	s.allow = true
+	s.lock.Unlock()
+}
+
+func (i *initretry) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	i.store = &initFailStore{
+		WrappedTransactionalMultiMaxSize: inmemory.NewTransactionalMultiMaxSize(t).(*inmemory.WrappedTransactionalMultiMaxSize),
+	}
+
+	sock := socket.New(t)
+	i.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(i.store),
+	)
+
+	i.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, i.ss.SocketName())),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(i.ss, i.workflow),
+	}
+}
+
+func (i *initretry) Run(t *testing.T, ctx context.Context) {
+	assert.Eventually(t, func() bool {
+		return i.store.attempts.Load() >= 2
+	}, 30*time.Second, 10*time.Millisecond)
+
+	i.store.release()
+	i.workflow.WaitUntilRunning(t, ctx)
+
+	r := i.workflow.Registry()
+	require.NoError(t, r.AddActivityN("act", func(task.ActivityContext) (any, error) {
+		return "ok", nil
+	}))
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		var out string
+		if err := octx.CallActivity("act").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	i.workflow.BackendClient(t, ctx)
+
+	const wfID = "initretry-wf"
+	gclient := i.workflow.GRPCClient(t, ctx)
+	_, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "wf",
+		InstanceId:        wfID,
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(co *assert.CollectT) {
+		resp, gerr := gclient.GetWorkflowBeta1(ctx, &rtv1.GetWorkflowRequest{
+			InstanceId:        wfID,
+			WorkflowComponent: "dapr",
+		})
+		if assert.NoError(co, gerr) {
+			assert.Equal(co, "COMPLETED", resp.GetRuntimeStatus())
+		}
+	}, 30*time.Second, 10*time.Millisecond)
+
+	assert.GreaterOrEqual(t, i.store.attempts.Load(), int32(3))
+}


### PR DESCRIPTION
A failed init of the component marked as the actor state store is now retried with jittered backoff (base 500ms, cap 10s) instead of being recorded as a fatal init error. Each attempt goes through the normal category/instance init path with the same per-attempt timeout, the caller stays blocked so runtime readiness keeps reporting not-ready, and shutdown cancels the loop cleanly (an abandoned retry is not recorded as fatal). All other components keep the existing fail-fast behavior, as does the actor state store when IgnoreErrors is set.

Branched from https://github.com/dapr/dapr/pull/10344
