### PR TITLE
scheduler: preserve delivery seniority in the pool pending drain

### DIFF
--- a/pkg/scheduler/server/internal/pool/loops/connections/concurrency.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/concurrency.go
@@ -88,6 +88,15 @@ func (g *concurrencyGate) dequeue() *loops.TriggerRequest {
 	return req
 }
 
+// requeueFront returns skipped requests to the front of the pending queue in
+// their original order, preserving their seniority over later arrivals.
+func (g *concurrencyGate) requeueFront(reqs []*loops.TriggerRequest) {
+	if len(reqs) == 0 {
+		return
+	}
+	g.pending = append(reqs, g.pending...)
+}
+
 func (g *concurrencyGate) pendingLen() int {
 	return len(g.pending)
 }

--- a/pkg/scheduler/server/internal/pool/loops/connections/concurrency_test.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/concurrency_test.go
@@ -22,6 +22,8 @@ import (
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/loops"
+	"github.com/dapr/dapr/pkg/scheduler/server/internal/pool/loops/connections/store"
+	loopfake "github.com/dapr/kit/events/loop/fake"
 )
 
 func TestLocalLimitFromGlobal(t *testing.T) {
@@ -282,4 +284,57 @@ func makeTriggerRequest(actorType, actorID, concurrencyKey string) *loops.Trigge
 			Metadata: meta,
 		},
 	}
+}
+
+// TestDrainPending_PreservesSeniority asserts that a pending trigger skipped
+// by the drain scan (blocked on a secondary gate) keeps its position at the
+// front of the queue rather than being rotated behind fresher arrivals.
+func TestDrainPending_PreservesSeniority(t *testing.T) {
+	t.Parallel()
+
+	const actorType = "dapr.internal.default.myapp.workflow"
+
+	var dispatched []loops.EventStream
+	streamLoop := loopfake.New[loops.EventStream]().WithEnqueue(func(e loops.EventStream) {
+		dispatched = append(dispatched, e)
+	})
+
+	pool := store.New()
+	pool.Add(store.Options{
+		Loop:       streamLoop,
+		ActorTypes: []string{actorType},
+	})
+
+	primary := &concurrencyGate{globalLimit: 5}
+	named := &concurrencyGate{globalLimit: 1, current: 1}
+
+	c := &connections{
+		streamPool: pool,
+		concurrencyGates: map[string]*concurrencyGate{
+			actorType:          primary,
+			actorType + ":act": named,
+		},
+		streamGateKeys: make(map[uint64][]string),
+		schedulerCount: 1,
+	}
+
+	elder := makeTriggerRequest(actorType, "a1", "act")
+	mid := makeTriggerRequest(actorType, "a2", "")
+	fresh := makeTriggerRequest(actorType, "a3", "")
+
+	require.True(t, primary.enqueue(elder))
+	require.True(t, primary.enqueue(mid))
+	require.True(t, primary.enqueue(fresh))
+
+	c.drainPending(actorType, primary)
+
+	require.Len(t, dispatched, 1)
+	assert.Same(t, mid, dispatched[0].(*loops.TriggerRequest))
+
+	require.Equal(t, 2, primary.pendingLen())
+	assert.Same(t, elder, primary.dequeue(), "skipped elder must stay at the front of the pending queue")
+	assert.Same(t, fresh, primary.dequeue())
+
+	assert.Equal(t, uint32(1), primary.current, "only the dispatched trigger holds the primary gate")
+	assert.Equal(t, uint32(1), named.current, "partial acquisition must be rolled back")
 }

--- a/pkg/scheduler/server/internal/pool/loops/connections/connections.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/connections.go
@@ -328,37 +328,48 @@ func (c *connections) handleConcurrencyRelease(rel *loops.ConcurrencyRelease) {
 // drainPending scans the pending queue to find a trigger that can acquire all
 // required gates. This avoids head-of-line blocking when the first pending
 // trigger is blocked on a different gate than the one that just released.
+// Requests skipped by the scan are returned to the front of the queue in
+// their original order, so an elder trigger is never rotated behind fresher
+// arrivals.
 func (c *connections) drainPending(key string, gate *concurrencyGate) {
 	defer monitoring.RecordConcurrencyPending(key, int64(gate.pendingLen()))
 
 	n := gate.pendingLen()
+	var skipped []*loops.TriggerRequest
 	for range n {
 		next := gate.dequeue()
 		if next == nil {
-			return
+			break
 		}
 
-		if c.tryDispatchPending(next) {
-			return
+		dispatched, consumed := c.tryDispatchPending(next)
+		if !consumed {
+			skipped = append(skipped, next)
+		}
+		if dispatched {
+			break
 		}
 	}
+
+	gate.requeueFront(skipped)
 }
 
-// tryDispatchPending attempts to dispatch a single pending trigger. On gate
-// acquisition failure it re-queues the request (or fails it if the queue is
-// full) and releases any partially-acquired gates via defer. Returns true iff
-// the trigger was dispatched.
-func (c *connections) tryDispatchPending(next *loops.TriggerRequest) bool {
+// tryDispatchPending attempts to dispatch a single pending trigger. Returns
+// dispatched=true iff the trigger was handed to a stream loop, and
+// consumed=true when the caller no longer owns the request (dispatched, or
+// resolved undeliverable). On gate acquisition failure the request stays with
+// the caller to requeue at its original position, and partially-acquired
+// gates are released via defer.
+func (c *connections) tryDispatchPending(next *loops.TriggerRequest) (dispatched, consumed bool) {
 	streamLoop, ok := c.getStreamLoop(next.Job.GetMetadata())
 	if !ok {
 		next.ResultFn(api.TriggerResponseResult_UNDELIVERABLE)
-		return false
+		return false, true
 	}
 
 	gateKeys := c.gateKeysForTrigger(next)
 
 	var acquired []string
-	dispatched := false
 	defer func() {
 		if !dispatched {
 			c.releaseGates(acquired)
@@ -368,16 +379,11 @@ func (c *connections) tryDispatchPending(next *loops.TriggerRequest) bool {
 	var gotAll bool
 	acquired, gotAll = c.acquireGates(gateKeys)
 	if !gotAll {
-		primaryGate := c.concurrencyGates[gateKeys[0]]
-		if !primaryGate.enqueue(next) {
-			next.ResultFn(api.TriggerResponseResult_FAILED)
-		}
-		return false
+		return false, false
 	}
 
 	c.dispatchWithGates(streamLoop, next, gateKeys)
-	dispatched = true
-	return true
+	return true, true
 }
 
 // handleCloseStream handles a close stream request.

--- a/pkg/scheduler/server/internal/pool/loops/connections/connections.go
+++ b/pkg/scheduler/server/internal/pool/loops/connections/connections.go
@@ -332,7 +332,9 @@ func (c *connections) handleConcurrencyRelease(rel *loops.ConcurrencyRelease) {
 // their original order, so an elder trigger is never rotated behind fresher
 // arrivals.
 func (c *connections) drainPending(key string, gate *concurrencyGate) {
-	defer monitoring.RecordConcurrencyPending(key, int64(gate.pendingLen()))
+	defer func() {
+		monitoring.RecordConcurrencyPending(key, int64(gate.pendingLen()))
+	}()
 
 	n := gate.pendingLen()
 	var skipped []*loops.TriggerRequest

--- a/tests/integration/suite/scheduler/concurrency/seniority.go
+++ b/tests/integration/suite/scheduler/concurrency/seniority.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrency
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	schedulerv1 "github.com/dapr/dapr/pkg/proto/scheduler/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/kit/ptr"
+)
+
+func init() {
+	suite.Register(new(seniority))
+}
+
+// seniority verifies the pending-queue drain preserves delivery seniority.
+type seniority struct {
+	scheduler *scheduler.Scheduler
+}
+
+func (s *seniority) Setup(t *testing.T) []framework.Option {
+	s.scheduler = scheduler.New(t)
+	return []framework.Option{
+		framework.WithProcesses(s.scheduler),
+	}
+}
+
+func (s *seniority) Run(t *testing.T, ctx context.Context) {
+	s.scheduler.WaitUntilRunning(t, ctx)
+
+	client := s.scheduler.Client(t, ctx)
+
+	stream, err := client.WatchJobs(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&schedulerv1.WatchJobsRequest{
+		WatchJobRequestType: &schedulerv1.WatchJobsRequest_Initial{
+			Initial: &schedulerv1.WatchJobsRequestInitial{
+				AppId:      "myapp",
+				Namespace:  "default",
+				ActorTypes: []string{"mytype"},
+				AcceptJobTypes: []schedulerv1.JobTargetType{
+					schedulerv1.JobTargetType_JOB_TARGET_TYPE_ACTOR_REMINDER,
+				},
+				ConcurrencyLimits: []*schedulerv1.ConcurrencyLimit{
+					{
+						Target: &schedulerv1.ConcurrencyLimit_Actor{
+							Actor: &schedulerv1.ConcurrencyLimitActor{Type: "mytype"},
+						},
+						MaxConcurrent: 2,
+					},
+					{
+						Target: &schedulerv1.ConcurrencyLimit_Actor{
+							Actor: &schedulerv1.ConcurrencyLimitActor{Type: "mytype"},
+						},
+						Name:          ptr.Of("hot"),
+						MaxConcurrent: 1,
+					},
+				},
+			},
+		},
+	}))
+
+	type recvResult struct {
+		resp *schedulerv1.WatchJobsResponse
+		err  error
+	}
+	recvCh := make(chan recvResult, 10)
+	go func() {
+		for {
+			resp, rerr := stream.Recv()
+			recvCh <- recvResult{resp, rerr}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	schedule := func(name, key string) {
+		req := s.scheduler.JobNowActor(name, "default", "myapp", "mytype", name)
+		if key != "" {
+			req.Metadata.ConcurrencyKey = ptr.Of(key)
+		}
+		_, serr := client.ScheduleJob(ctx, req)
+		require.NoError(t, serr)
+	}
+
+	recv := func(msg string) *schedulerv1.WatchJobsResponse {
+		t.Helper()
+		select {
+		case r := <-recvCh:
+			require.NoError(t, r.err)
+			return r.resp
+		case <-time.After(time.Second * 10):
+			t.Fatal("timed out waiting for trigger: " + msg)
+			return nil
+		}
+	}
+
+	ack := func(resp *schedulerv1.WatchJobsResponse) {
+		require.NoError(t, stream.Send(&schedulerv1.WatchJobsRequest{
+			WatchJobRequestType: &schedulerv1.WatchJobsRequest_Result{
+				Result: &schedulerv1.WatchJobsRequestResult{
+					Id:     resp.GetId(),
+					Status: schedulerv1.WatchJobsRequestResultStatus_SUCCESS,
+				},
+			},
+		}))
+	}
+
+	waitPending := func(n int) {
+		t.Helper()
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			ms := s.scheduler.Metrics(c, ctx).MatchMetric(
+				"dapr_scheduler_concurrency_pending", "concurrency_key:mytype")
+			if assert.Len(c, ms, 1) {
+				assert.Equal(c, n, int(ms[0].Value))
+			}
+		}, time.Second*10, time.Millisecond*10)
+	}
+
+	schedule("hold-hot", "hot")
+	holdHot := recv("hold-hot")
+	require.Equal(t, "hold-hot", holdHot.GetName())
+	schedule("hold-type", "")
+	holdType := recv("hold-type")
+	require.Equal(t, "hold-type", holdType.GetName())
+
+	schedule("w1", "hot")
+	waitPending(1)
+	schedule("f1", "")
+	waitPending(2)
+	schedule("w2", "hot")
+	waitPending(3)
+
+	ack(holdType)
+	f1 := recv("f1 after hold-type ack")
+	require.Equal(t, "f1", f1.GetName())
+
+	ack(holdHot)
+	ack(f1)
+	first := recv("first hot waiter")
+	assert.Equal(t, "w1", first.GetName(),
+		"gate-blocked elder lost its place in the pending queue to a fresher arrival")
+
+	ack(first)
+	schedule("f2", "")
+	f2 := recv("f2")
+	require.Equal(t, "f2", f2.GetName())
+	ack(f2)
+	second := recv("second hot waiter")
+	assert.Equal(t, "w2", second.GetName())
+	ack(second)
+}


### PR DESCRIPTION
The scheduler pool's pending-queue drain scans for a trigger that can acquire all of its gates, so a trigger blocked on a secondary concurrency gate is dequeued, fails acquisition, and is re-enqueued at the TAIL of the pending queue; on the way out it also emits a spurious FAILED nack via the queue-full arm of the re-enqueue. Under backlog that rotation runs on every dispatch pass, so the oldest waiters systematically lose their place to every fresh arrival and starve indefinitely while the queue as a whole keeps draining.

tryDispatchPending now reports dispatched and consumed separately: on gate-acquisition failure the request stays with drainPending, which collects skipped requests and returns them, in their original relative order, to the FRONT of the pending queue. Partially acquired gates are still released via the existing defer, and the spurious FAILED nack is gone: a trigger that merely lost a gate race is not a delivery failure. Only the genuinely undeliverable case (no stream for the target) still resolves the request.